### PR TITLE
chore: add .gitignore and expand README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# JetBrains IDEs (IntelliJ IDEA / PhpStorm)
+.idea/
+*.iml
+
+# OS cruft
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+logs/
+
+# Dependencies & build output
+node_modules/
+vendor/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# hrcd-rekap
+# HRCD Rekap
+
+> Status: scaffolding. The project's scope and stack are not yet decided.
+
+## Getting started
+
+Not applicable yet — no application code has been added.
+
+## Repository layout
+
+```
+.
+├── .gitignore
+└── README.md
+```
+
+## Contributing
+
+Work happens on branches off `main` and lands via pull request.
+
+```bash
+git checkout -b <type>/<short-description>
+# ...make changes...
+git commit -m "<type>: <what changed>"
+git push -u origin HEAD
+gh pr create --fill
+```


### PR DESCRIPTION
## What

- Adds a root `.gitignore` covering JetBrains IDE files (`.idea/`, `*.iml`), OS cruft, `.env` files, logs, and dependency/build output.
- Expands `README.md` with a repository layout and the branch/PR workflow.

## Why

`.idea/` was showing up as untracked in `git status` on a fresh clone. The README was a single heading.

## Notes

Project scope and stack are still undecided, so the README is explicit about that rather than describing an application that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)