### PR TITLE
docs: document the no-ff merge convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,16 @@ git commit -m "<type>: <what changed>"
 git push -u origin HEAD
 gh pr create --fill
 ```
+
+### Merging
+
+PRs are merged with a **merge commit** (`--no-ff`), never squashed or rebased, so
+every PR stays a distinct merge point in `main`'s history. The merge commit
+subject is the PR title followed by the PR number:
+
+```bash
+gh pr merge <number> --merge --subject "<PR title> (#<number>)" --delete-branch
+```
+
+Omitting `--subject` lets GitHub write `Merge pull request #N from <branch>`
+instead, which buries the title — so always pass it.


### PR DESCRIPTION
## What

Adds a **Merging** subsection to the README's contributing guide, recording that PRs land as `--no-ff` merge commits with the subject `<PR title> (#<number>)`.

## Why

PR #1 was squash-merged before this convention was set. Writing it down means the next person (or agent) does not have to guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)