### PR TITLE
docs: batch registration form, per-account access, public live view

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -34,8 +34,11 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    Jawa Barat.
 3. Diadakan rutin setiap tahun, biasanya Februari atau Maret.
 4. Skala peserta konsisten di kisaran 300 regu, dengan batas atas sekitar 500.
-5. Pengguna sistem untuk saat ini **hanya panitia**. Belum ada akses peserta
-   maupun publik.
+5. Sistem terbagi menjadi **dua wajah yang terpisah**:
+   - **Aplikasi panitia** — satu link yang sama untuk semua panitia, dengan
+     akses yang dibedakan per akun (bagian 8.8).
+   - **Tampilan live untuk peserta** — halaman publik tanpa login. Apa saja
+     isinya dan kapan dibuka masih perlu diputuskan (bagian 13).
 
 ## 2. Satuan lomba dan identitas
 
@@ -49,24 +52,54 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Penggalang PA (SMP, putra)
    - Penggalang PI (SMP, putri)
 4. Sebuah regu memakai **dua identitas secara berurutan**:
-   - **Kode pembayaran** — terbit setelah pembayaran diverifikasi. Menjadi ID
-     yang disebutkan regu saat daftar ulang.
-   - **Nomor dada** — diberikan saat daftar ulang. Menjadi nomor peserta dan
-     dipakai sebagai kunci di seluruh tahap berikutnya.
+   - **Kode pembayaran** — terbit **saat pendaftaran** dan terikat pada seluruh
+     regu dalam satu batch (bagian 3). Menjadi referensi saat membayar, lalu —
+     setelah pembayaran diverifikasi — menjadi ID yang disebutkan saat daftar
+     ulang. Satu kode mencakup semua regu yang didaftarkan bersama.
+   - **Nomor dada** — diberikan saat daftar ulang, satu per regu. Menjadi nomor
+     peserta dan dipakai sebagai kunci di seluruh tahap berikutnya.
 
 ## 3. Pendaftaran
 
-1. Regu mendaftar secara online dan mengisi identitas.
-2. Formulir menanyakan **"apakah memerlukan tempat menginap?"**. Jawaban ya
-   memasukkan regu ke skema penempatan barak (bagian 11).
-3. Regu melakukan pembayaran.
-4. Panitia memverifikasi pembayaran, lalu regu menerima **kwitansi** dan
-   **kode pembayaran**.
-5. Pendaftaran online dan offline memakai **link yang sama**. Regu yang belum
-   mendaftar dapat mendaftar di lokasi lewat HP atau laptop di meja pendaftaran
-   offline, lalu membayar tunai atau transfer ke rekening panitia.
-6. **Tidak ada pengembalian dana.** Regu yang batal setelah membayar tidak
+1. **Satuan pendaftaran tetap regu** — tetapi form-nya dibuat satu per sekolah
+   sebagai kemudahan: sekolah yang mengirim 10 regu tidak perlu mengisi form 10
+   kali. Satu pengisian mendaftarkan beberapa regu sekaligus dalam satu batch,
+   dan sistem tetap memperlakukan tiap regu sebagai baris tersendiri (poin 3).
+2. Urutan pertanyaan di form:
+   1. **Asal sekolah.** Ketikan dicocokkan ke database sekolah — jika sekolahnya
+      dikenal, muncul sebagai pilihan dropdown otomatis; jika tidak ada, diisi
+      manual (dan sekolah baru itu masuk ke database).
+   2. **Konfirmasi alamat.** Jika sekolah dipilih dari database, alamatnya
+      ditampilkan agar pendaftar memastikan sekolah yang dimaksud benar —
+      penting karena banyak sekolah bernama sama di kota berbeda.
+   3. **Butuh penginapan?** Jawaban ya memasukkan seluruh batch ke skema
+      penempatan barak (bagian 11).
+   4. **Mendaftarkan berapa regu?**
+   5. **Rincian golongan** yang jumlahnya harus sama dengan total — misal 5
+      regu = 3 Penegak PA + 1 Penegak PI + 1 Penggalang PA. Form memvalidasi
+      penjumlahannya.
+   6. **Untuk setiap regu:** nama regu dan nama ketua.
+   7. **Satu kontak person WA** untuk keseluruhan batch.
+3. Setelah dikirim, sistem **memecah batch menjadi satu baris per regu** —
+   5 regu menjadi 5 baris — yang tetap terikat pada satu tagihan bersama.
+4. Begitu form dikirim, terbit **kode pembayaran yang terikat pada regu-regu
+   dalam batch itu**. Sekolah membayar **sekaligus untuk seluruh batch** dengan
+   kode itu sebagai referensi. Setelah panitia memverifikasi, **seluruh regu
+   dalam batch menjadi valid bersama** dan menerima kwitansi, siap lanjut ke
+   daftar ulang.
+5. **Pembayaran sebagian tidak dilayani** — batch bersifat semua-atau-tidak,
+   karena pembayaran parsial membuat sistem rumit. Sekolah yang hanya sanggup
+   membayar sebagian cukup **mendaftar ulang** dengan batch yang lebih kecil
+   sesuai kemampuannya.
+6. Pendaftaran online dan offline memakai **link yang sama**. Sekolah yang
+   belum mendaftar dapat mendaftar di lokasi lewat HP atau laptop di meja
+   pendaftaran offline, lalu membayar tunai atau transfer ke rekening panitia.
+7. **Tidak ada pengembalian dana.** Regu yang batal setelah membayar tidak
    digantikan, dan kloternya tetap berjalan dengan jumlah regu berkurang.
+8. Konsekuensi bagi sistem: perlu **master data sekolah** (nama + alamat) yang
+   tumbuh dari tahun ke tahun — sumber dropdown otomatis di form, dan sekaligus
+   kunci penyebaran kloter per sekolah (bagian 5) serta penempatan barak
+   (bagian 11).
 
 ## 4. Daftar ulang
 
@@ -206,9 +239,20 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
 7. Sebuah **server pemantau** menampilkan status kelengkapan input — pos mana
    yang sudah menyetor dan pos mana yang belum.
-8. **Setiap pos memiliki link input sendiri**, yang hanya dapat dibuka dengan
-   akun dan password khusus pos tersebut. Operator sebuah pos tidak dapat
-   menyentuh nilai pos lain.
+8. **Satu link untuk semua panitia, akses dibedakan per akun.** Setiap akun
+   hanya melihat dan menyentuh bagiannya sendiri:
+
+   | Contoh akun | Akses |
+   | --- | --- |
+   | `pos1hrcd37` | Hanya input nilai Pos 1 |
+   | `pos2hrcd37` | Hanya input nilai Pos 2 |
+   | `admin.ciradyka` | Semua bagian sistem |
+
+   Akun hanya diberikan kepada admin tiap pos dan tim IT. Operator sebuah pos
+   tidak dapat menyentuh nilai pos lain — ditegakkan oleh sistem, bukan sekadar
+   disembunyikan dari layar.
+9. Pola nama akun mengikuti edisi (`hrcd37` = edisi ke-37), sehingga akun dan
+   password dapat diganti bersih setiap tahun tanpa membongkar sistem.
 9. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap
    dicatat**: siapa memasukkan atau mengubah nilai apa, dan kapan. Tujuannya
    bukan mengawasi orang, melainkan agar setiap angka dapat ditelusuri kembali
@@ -351,4 +395,25 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
      yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
      Dokumen ini mengasumsikan per orang.
-5. **Teknologi yang dipakai.** Sengaja ditunda sampai alur ini disepakati.
+5. **Nama anggota selain ketua.** Form pendaftaran hanya mencatat nama regu +
+   nama ketua. Empat anggota lain dicatat di mana — saat daftar ulang, atau
+   tidak dicatat sama sekali (pengecekan kelengkapan di akhir bersifat hitung
+   fisik, bagian 10.9)?
+   *(Dua pertanyaan lain dari skema batch sudah terjawab: pembayaran sebagian
+   tidak dilayani — semua-atau-tidak, daftar ulang saja dengan batch lebih
+   kecil; dan kode pembayaran terbit saat pendaftaran, satu kode per batch.)*
+6. **Isi tampilan live peserta (bagian 1.5).** Yang belum diputuskan:
+   - Apa yang dilihat peserta — klasemen penuh empat golongan, hanya status
+     regunya sendiri, atau keduanya?
+   - Kapan dibuka — live sepanjang lomba (regu bisa melihat posisinya di
+     tengah rute) atau baru setelah closing? Ini keputusan lomba, bukan
+     teknis: klasemen yang terlihat di tengah lomba bisa mengubah perilaku
+     peserta.
+   - Konsekuensi teknis yang sudah pasti: penonton bisa ratusan HP sekaligus,
+     sehingga tampilan publik **wajib disajikan dari jalur terpisah yang
+     murah** (halaman statis yang diperbarui berkala), tidak boleh membaca
+     database secara langsung — supaya penonton tidak pernah bisa membebani
+     jalur input panitia.
+7. **Teknologi yang dipakai.** Sengaja ditunda sampai alur ini disepakati.
+   Empat kandidat arsitektur gratis beserta rekomendasinya sudah ditawarkan di
+   `desain-sistem.md`.

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -280,7 +280,35 @@ Semua kandidat berbagi satu batas yang sama pada R7: lima bentuk konversi yang
 sudah dienumerasi bisa diubah panitia sendiri, tetapi bentuk rumus yang **benar-
 benar baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
 
+### 7.1 Dua kebutuhan yang ditambahkan setelah dokumen ini ditulis
+
+1. **Form pendaftaran dinamis** (alur-lomba.md bagian 3): autocomplete sekolah
+   dari database + konfirmasi alamat + blok per-regu yang jumlahnya mengikuti
+   jawaban. **Google Form polos tidak bisa mengekspresikan ini** — semua
+   kandidat butuh form custom. Akibat per kandidat: B dan C tidak terpengaruh
+   (form custom memang rencananya); A tetap bisa (form jadi halaman web app,
+   bukan Google Form); **D paling terpukul** — trik "jendela pendaftaran
+   dititipkan ke Google Form" gugur, sehingga D butuh tempat hosting form
+   custom yang selalu hidup, yang justru masalah yang dihindarinya.
+2. **Tampilan live publik untuk peserta** (alur-lomba.md bagian 1.5): penonton
+   bisa ratusan HP. Aturan desainnya sama untuk semua kandidat — **tampilan
+   publik disajikan statis dan diperbarui berkala, tidak pernah membaca
+   database langsung.** A: sheet "publish to web" (gratis, tanpa memakan kuota
+   eksekusi). B: file statis di Cloudflare Pages yang di-regenerate berkala
+   (bandwidth gratis tak terbatas — pola paling alami). C: inilah yang
+   membunuhnya — listener publik langsung menghantam kuota baca. D: halaman
+   statis di tunnel yang sama (menambah beban uplink laptop) atau dititipkan
+   ke Pages.
+
 ## 8. Rekomendasi
+
+> **Keputusan panitia (Agustus 2026): Kandidat A dicoret.** Dengan skema form
+> pendaftaran dinamis, akses per akun di satu link (`pos1hrcd37` vs
+> `admin.ciradyka`), dan tampilan live publik, Google Sheets dinilai bukan
+> pilihan yang tepat — pembatasan akses di Apps Script hanya bisa berupa
+> konvensi aplikasi, bukan penegakan server, dan seluruh beban form dinamis
+> jatuh ke bagian platform yang paling canggung. Pilihan mengerucut ke
+> **B melawan D**.
 
 1. **Rekomendasi utama: Kandidat B (Supabase + Cloudflare Pages).**
    Alasannya satu kalimat: **tiga kebutuhan yang paling berbahaya kalau salah


### PR DESCRIPTION
## What

Four clarifications from the panitia, recorded across `alur-lomba.md` and `desain-sistem.md`:

**Registration form (§3)** — the unit stays the regu, but the form is one per school: autocomplete from a schools master table with address confirmation, barak question, regu count, golongan breakdown validated to sum, nama regu + ketua per regu, one WA contact. Submit splits into one row per regu under one bill; **kode pembayaran is issued at registration and covers the batch**. **No partial payment** — all-or-nothing; pay for fewer regu by registering a smaller batch.

**Access model (§8)** — one shared link for all panitia; access differs per account (`pos1hrcd37` → Pos 1 only, `admin.ciradyka` → everything), enforced server-side, edition-suffixed names rotating yearly.

**Public live view (§1, §13)** — the system now has two faces. The peserta-facing page must be served as periodically regenerated static content, never direct DB reads: spectators can be hundreds of phones and must never be able to load the panitia input path. Content/opening time remain open (§13.6).

**Candidate A eliminated (desain-sistem §8)** — panitia's call: Apps Script cannot *enforce* the per-account model (convention only), and the dynamic form lands on its clumsiest part. Field narrows to **B vs D**; §7.1 maps both new requirements onto all candidates — the dynamic form also kills D's "Google Form carries the registration window" trick.

## Notes

Two of the three §13.5 open questions are now answered and folded into the spec; the remaining one: where are the four non-ketua member names recorded, if anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)