### PR TITLE
docs: record live-view decisions, Sheets-as-window analysis, CDN choice

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -37,8 +37,12 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 5. Sistem terbagi menjadi **dua wajah yang terpisah**:
    - **Aplikasi panitia** — satu link yang sama untuk semua panitia, dengan
      akses yang dibedakan per akun (bagian 8.8).
-   - **Tampilan live untuk peserta** — halaman publik tanpa login. Apa saja
-     isinya dan kapan dibuka masih perlu diputuskan (bagian 13).
+   - **Tampilan live untuk peserta** — halaman publik tanpa login, berisi
+     **klasemen penuh empat golongan**, dibuka **bertahap**: selama lomba
+     hanya progres tanpa angka (regu X sudah melewati pos Y), nilai dan
+     peringkat lengkap baru tampil setelah closing. Halaman ini **disajikan
+     statis dan diperbarui berkala**, tidak pernah membaca database langsung —
+     ratusan HP penonton tidak boleh bisa membebani jalur input panitia.
 
 ## 2. Satuan lomba dan identitas
 
@@ -78,7 +82,9 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    5. **Rincian golongan** yang jumlahnya harus sama dengan total — misal 5
       regu = 3 Penegak PA + 1 Penegak PI + 1 Penggalang PA. Form memvalidasi
       penjumlahannya.
-   6. **Untuk setiap regu:** nama regu dan nama ketua.
+   6. **Untuk setiap regu:** nama regu dan nama ketua. **Nama empat anggota
+      lain tidak diminta** — untuk sekarang sistem tidak mencatatnya;
+      kelengkapan 5 orang dicek fisik di akhir lomba (bagian 10.9).
    7. **Satu kontak person WA** untuk keseluruhan batch.
 3. Setelah dikirim, sistem **memecah batch menjadi satu baris per regu** —
    5 regu menjadi 5 baris — yang tetap terikat pada satu tagihan bersama.
@@ -395,25 +401,11 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
      yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
      Dokumen ini mengasumsikan per orang.
-5. **Nama anggota selain ketua.** Form pendaftaran hanya mencatat nama regu +
-   nama ketua. Empat anggota lain dicatat di mana — saat daftar ulang, atau
-   tidak dicatat sama sekali (pengecekan kelengkapan di akhir bersifat hitung
-   fisik, bagian 10.9)?
-   *(Dua pertanyaan lain dari skema batch sudah terjawab: pembayaran sebagian
-   tidak dilayani — semua-atau-tidak, daftar ulang saja dengan batch lebih
-   kecil; dan kode pembayaran terbit saat pendaftaran, satu kode per batch.)*
-6. **Isi tampilan live peserta (bagian 1.5).** Yang belum diputuskan:
-   - Apa yang dilihat peserta — klasemen penuh empat golongan, hanya status
-     regunya sendiri, atau keduanya?
-   - Kapan dibuka — live sepanjang lomba (regu bisa melihat posisinya di
-     tengah rute) atau baru setelah closing? Ini keputusan lomba, bukan
-     teknis: klasemen yang terlihat di tengah lomba bisa mengubah perilaku
-     peserta.
-   - Konsekuensi teknis yang sudah pasti: penonton bisa ratusan HP sekaligus,
-     sehingga tampilan publik **wajib disajikan dari jalur terpisah yang
-     murah** (halaman statis yang diperbarui berkala), tidak boleh membaca
-     database secara langsung — supaya penonton tidak pernah bisa membebani
-     jalur input panitia.
-7. **Teknologi yang dipakai.** Sengaja ditunda sampai alur ini disepakati.
-   Empat kandidat arsitektur gratis beserta rekomendasinya sudah ditawarkan di
-   `desain-sistem.md`.
+5. **Teknologi yang dipakai.** Empat kandidat arsitektur gratis beserta
+   rekomendasinya sudah ditawarkan di `desain-sistem.md`; Kandidat A (Google
+   Sheets) telah dicoret panitia, pilihan mengerucut ke B melawan D.
+   *(Pertanyaan-pertanyaan lain di bagian ini yang sudah terjawab dan pindah ke
+   badan dokumen: pembayaran sebagian tidak dilayani — bagian 3.5; kode
+   pembayaran per batch terbit saat pendaftaran — bagian 3.4; nama anggota
+   selain ketua tidak dicatat untuk sekarang — bagian 3.2; isi dan waktu
+   tampilan live — bagian 1.5.)*

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -327,6 +327,50 @@ benar baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
 4. **Kandidat C gugur** — satu-satunya yang bisa mati justru karena acaranya
    ramai.
 
+### 8.1 Tujuh tahun Google Sheets — jendela, bukan mesin
+
+1. Panitia memakai Google Sheets selama 7 tahun karena tampilan Excel-nya
+   mudah. Itu bukti nyata yang tidak boleh dibuang: **kepercayaan panitia ada
+   pada tampilan tabel** — memeriksa data, merekap, membuka arsip lama.
+2. Tapi pisahkan dua peran yang selama ini menempel: Sheets sebagai **tampilan
+   baca** (di situ ia unggul) dan Sheets sebagai **mesin sistem** (di situ ia
+   gagal untuk skema sekarang: akses per akun tidak bisa ditegakkan, form
+   dinamis canggung, kuota 30 eksekusi dibagi semua orang).
+3. Soal era AI: AI **menguatkan B, bukan menyelamatkan A**. Yang membuat A
+   gugur adalah fakta platform — batas eksekusi, semua request berjalan sebagai
+   pemilik, restore seluruh file — dan AI tidak bisa mengubah fakta platform.
+   Sebaliknya, kelemahan terbesar B ("pelajar tidak bisa debug SQL sendirian")
+   justru persis jenis masalah yang AI bantu: menjelaskan error, membaca
+   policy, menambal query.
+4. Maka rancangan yang tepat adalah **hybrid peran**: Supabase menjadi mesin
+   (penegakan akses, transaksi, riwayat), dan Sheets tetap hidup sebagai
+   jendela — setiap tabel dan klasemen bisa di-export CSV/Sheets sekali klik,
+   input massal memang sudah masuk lewat paste dari Excel (R6), dan arsip
+   tahunan disimpan sebagai spreadsheet yang bisa dibuka selamanya tanpa
+   sistem berjalan. Panitia tidak kehilangan tampilan Excel-nya; mereka hanya
+   berhenti menjadikannya tempat kebenaran data.
+
+### 8.2 Cloudflare vs Vercel untuk frontend statis
+
+| Aspek | Cloudflare (Pages/Workers) | Vercel (Hobby) |
+| --- | --- | --- |
+| Bandwidth gratis | **Tak terbatas** | 100 GB/bulan |
+| Syarat pemakaian | Tanpa klausul komersial | Khusus non-komersial (acara sekolah aman) |
+| Cron gratis (keep-alive Supabase) | ✅ Workers cron | Terbatas (2 cron, 1×/hari) |
+| Kartu kredit | Tidak perlu | Tidak perlu |
+| Kenyamanan deploy | Baik | **Paling nyaman** |
+| Catatan | Pages berstatus maintenance; jalur baru = Workers static assets (tetap gratis) | Batas soft bisa berubah |
+
+1. **Pilihan: Cloudflare.** Alasan penentunya tampilan live publik: ratusan HP
+   penonton me-refresh klasemen adalah lalu lintas yang tidak bisa diprediksi,
+   dan hanya Cloudflare yang menjawabnya dengan "tak terbatas" alih-alih
+   kuota bulanan.
+2. Alasan kedua: keep-alive Supabase butuh cron, dan Workers cron gratis
+   menyediakannya di akun yang sama — satu vendor lebih sedikit.
+3. Vercel tetap alternatif sah bila kenyamanan deploy dinilai lebih penting;
+   untuk beban acara ini 100 GB/bulan kemungkinan besar cukup, hanya saja
+   "kemungkinan besar cukup" kalah dengan "tidak ada batas".
+
 ## 9. Keputusan yang menunggu panitia
 
 1. Pilih kandidat (bagian 8).


### PR DESCRIPTION
## What

**Decisions recorded in the spec (`alur-lomba.md`):**
- Public live page = full four-golongan klasemen, opened **in stages**: progress-only (regu X passed pos Y, no numbers) during the race; full scores and rankings after closing. Served as periodically regenerated static content.
- The four non-ketua member names are **not collected for now** — the physical count at the finish (§10.9) covers completeness.
- §13 shrinks: everything answered moves into the document body.

**Analyses added to `desain-sistem.md`:**

§8.1 — *Seven years of Google Sheets: window, not engine.* The panitia's trust is in the table view, which is worth keeping — as a read surface. One-click CSV/Sheets export, Excel-paste input (already required by R6), and spreadsheet archives keep the Excel experience; Supabase keeps enforcement where writes happen. On AI: it strengthens B rather than rescuing A — A's failures (execution ceiling, execute-as-owner, whole-file restore) are platform facts no assistant can change, while B's biggest weakness (students debugging SQL alone) is precisely what AI helps with.

§8.2 — *Cloudflare over Vercel* for the static frontend: unlimited free bandwidth answers unpredictable spectator traffic better than a 100 GB/month quota, and Workers cron covers the Supabase keep-alive in the same account. Vercel remains a legitimate alternative if deploy comfort is weighted higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)