### PR TITLE
docs: lock candidate B as the decided architecture

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -401,10 +401,11 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
      yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
      Dokumen ini mengasumsikan per orang.
-5. **Teknologi yang dipakai.** Empat kandidat arsitektur gratis beserta
-   rekomendasinya sudah ditawarkan di `desain-sistem.md`; belum ada yang
-   dikunci. Ujian jujur Kandidat A (Google Sheets) terhadap permintaan
-   terbaru ada di bagian 8.3 dokumen itu.
+5. **Teknologi yang dipakai: SUDAH DIPUTUSKAN.** Panitia memilih Kandidat B —
+   Supabase + frontend statis di Cloudflare, dengan Google Sheets tetap
+   sebagai jendela baca — dengan syarat keras UI/UX harus mudah diajarkan.
+   Perbandingan lengkap dan alasan di `desain-sistem.md` bagian 8; rancangan
+   detail di `rancangan-b.md`.
    *(Pertanyaan-pertanyaan lain di bagian ini yang sudah terjawab dan pindah ke
    badan dokumen: pembayaran sebagian tidak dilayani — bagian 3.5; kode
    pembayaran per batch terbit saat pendaftaran — bagian 3.4; nama anggota

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -302,12 +302,17 @@ benar baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
 
 ## 8. Rekomendasi
 
-> **Koreksi (Agustus 2026):** revisi sebelumnya salah mencatat "panitia
-> mencoret Kandidat A" — **panitia tidak pernah mencoretnya**. Yang benar:
-> panitia menyukai solusi Sheets (dipakai 7 tahun) dan meminta kandidat ini
-> diuji jujur terhadap tiga permintaan terbaru, karena bisa jadi Sheets mampu.
-> Hasil ujiannya di bagian 8.3 — ringkasnya: **ketiganya bisa**. Kandidat A
-> tetap pilihan yang hidup.
+> **KEPUTUSAN PANITIA (Agustus 2026): Kandidat B dieksekusi.** Setelah ujian
+> jujur Kandidat A di bagian 8.3 (ketiga permintaan terbaru terbukti bisa
+> dilakukan Sheets), panitia memilih B secara eksplisit, dengan satu syarat
+> yang dipegang sebagai kebutuhan keras: **UI/UX harus mudah — panitia bisa
+> diajari selama tampilannya mudah.** Google Sheets tidak dibuang: ia tetap
+> hidup sebagai jendela baca (bagian 8.1). Frontend di Cloudflare
+> (bagian 8.2). Rancangan detail menyusul di `rancangan-b.md`.
+
+> Catatan riwayat: revisi sebelumnya sempat salah mencatat "panitia mencoret
+> Kandidat A" — panitia tidak pernah mencoretnya; keputusan baru diambil
+> setelah ujian bagian 8.3 tersedia.
 
 1. **Rekomendasi utama: Kandidat B (Supabase + Cloudflare Pages).**
    Alasannya satu kalimat: **tiga kebutuhan yang paling berbahaya kalau salah


### PR DESCRIPTION
## What

Records the panitia's explicit decision: **execute candidate B** — Supabase free tier as the engine, static Indonesian SPA on Cloudflare, Google Sheets retained as a read window (§8.1), Cloudflare over Vercel (§8.2).

The stated condition is recorded as a hard requirement equal to correctness: **the UI/UX must be easy enough that panitia can be taught it** — every screen judged by "usable by a first-timer after one demonstration."

## Context

The decision lands *after* §8.3's honest test showed Sheets could satisfy all three newest requests. The choice was made on margin and depth of enforcement — not capability — and it was the panitia's own, made explicitly this time.

Detail design (data model, screens, config engine) follows in `rancangan-b.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)