### PR TITLE
docs: add the detail design blueprint for architecture B

### DIFF
--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -1,0 +1,337 @@
+# Rancangan Detail hrcd-rekap — Arsitektur B
+
+Cetak biru implementasi untuk keputusan di `desain-sistem.md` bagian 8:
+**Supabase (Postgres + Auth + RLS + Realtime) + SPA statis di Cloudflare +
+Google Sheets sebagai jendela baca.** Syarat keras panitia berlaku di seluruh
+dokumen: **setiap layar harus bisa dipakai panitia baru setelah satu kali
+diperagakan.**
+
+Rancangan ini disusun oleh tiga perancang paralel (model data, layar, mesin
+konfigurasi) lalu diserang dua verifikator (cakupan spesifikasi, keterajaran);
+38 temuan dan 11 celah mereka sudah dilebur ke dalam dokumen ini — keputusan
+penyelesaiannya dicatat di bagian 11.
+
+## 1. Gambaran arsitektur
+
+1. **Supabase free tier** — satu-satunya backend. Postgres memegang seluruh
+   data dan konfigurasi; Auth memegang akun panitia; RLS menegakkan batas
+   akses; Realtime menghidupkan layar pemantau. Tidak ada server custom.
+2. **SPA statis di Cloudflare Pages** — HTML + JS polos berbahasa Indonesia,
+   tanpa framework berat, deploy = `git push`. Satu link untuk semua panitia.
+3. **Halaman live publik** — file statis (`live.html` + `live.json`) di
+   Cloudflare Pages, di-regenerate berkala oleh GitHub Actions. Penonton
+   **tidak pernah** menyentuh Supabase.
+4. **Satu Cloudflare Worker kecil** — gerbang form pendaftaran publik:
+   memverifikasi Turnstile (anti-spam gratis) + rate limit, baru meneruskan ke
+   database. Satu-satunya jalur tulis dari luar.
+5. **Google Sheets** — jendela baca: tombol Export CSV di semua layar daftar,
+   arsip tahunan berupa spreadsheet.
+6. Seluruh komponen Rp 0 tanpa kartu kredit: Supabase Free, Cloudflare
+   Pages/Workers Free, GitHub Free (Actions cron), Turnstile Free.
+
+## 2. Model data
+
+### 2.1 Tabel operasional
+
+| Tabel | Isi | Penjaga kebenaran |
+| --- | --- | --- |
+| `sekolah` | Master sekolah (nama + alamat), tumbuh tiap tahun; sumber autocomplete | `UNIQUE (nama, alamat)` |
+| `pendaftaran` | Satu baris per batch (per pengisian form): kode pembayaran, butuh barak, jumlah pendamping, kontak WA, status | `UNIQUE (kode_pembayaran)`; status `menunggu_pembayaran → lunas / batal` — tanpa bentuk "lunas sebagian" |
+| `regu` | Satu baris per regu: nama, ketua, golongan, nomor dada, kloter, kontrak, batal | `UNIQUE (nomor_dada)` — nomor ganda **mustahil**, bukan dihindari; `UNIQUE (kloter_nomor, urutan_kloter)` + `CHECK (urutan 1–10)` — kapasitas kloter ditegakkan database; nomor dada & kloter lahir bersama (`CHECK` berpasangan) |
+| `nomor_dada_stok` | Stok fisik nomor yang disiapkan admin (mis. 1–500) | Nomor tersedia = belum ada di `regu.nomor_dada`; satu sumber kebenaran, tanpa flag yang bisa basi |
+| `pembayaran` | Satu pembayaran penuh per batch + nomor kwitansi | `UNIQUE (pendaftaran_id)` — verifikasi ganda dari dua meja tertolak |
+| `kloter` | 40 baris (30 dasar + 31–40 cadangan): jam berangkat **diketik** | `CHECK`: status berangkat wajib punya jam; **tidak ada `DEFAULT now()`** |
+| `keberangkatan_regu` | Ceklis berangkat per regu; keberadaan baris = berangkat | `PK (regu_id)` — ceklis ganda mustahil |
+| `nilai_mentah` | Data mentah per regu per komponen: `nilai_1`, `nilai_2` (khusus benar−salah), sumber `manual/upload` | `UNIQUE (regu_id, wahana_id)`; RLS pos |
+| `closing_regu` | Checkout: `jam_datang` **diketik & bisa di-edit**, `anggota_hadir` (0–5) | `PK (regu_id)`; upsert = mekanisme edit yang sah |
+| `ruangan` | Daftar ruang kelas barak + kapasitas orang | — |
+| `penempatan_barak` | Hasil alokasi; satu sekolah **boleh** terpecah ke >1 ruangan bila terpaksa | `UNIQUE (pendaftaran_id, ruangan_id)` |
+| `akun_panitia` | Peta `auth.uid` → peran (`admin/meja/operator_pos`) + nomor pos + aktif | Rotasi tahunan tanpa menyentuh policy |
+| `riwayat` | Audit otomatis via trigger: siapa, kapan, tabel, nilai lama → baru, + `regu_id` agar bisa dicari per regu | Append-only; tidak bisa dimatikan dari klien |
+| `status_acara` | **Satu baris** saklar hari-H: `daftar_ulang_ditutup`, `fase_live` (`pra/progres/penuh`), `konfigurasi_terkunci` | Trigger menolak edit konfigurasi saat terkunci (kecuali admin) |
+
+### 2.2 Tabel konfigurasi (diedit admin tiap edisi)
+
+| Tabel | Isi | Contoh edisi 37 |
+| --- | --- | --- |
+| `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | `biaya_per_regu=250000, maks_regu_per_kloter=10, kloter_dasar=30, kloter_maks=40, lompatan_kloter=2, interval_berangkat_menit=4` |
+| `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
+| `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis`): bentuk konversi + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
+| `kontrak_opsi` | Pilihan kontrak waktu | `('3,5 jam',210), ('4 jam',240), ('4,5 jam',270)` |
+| `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=10, penalti_per_blok=10, penalti_tanpa_checkout=100, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
+
+1. `wahana.kode` dibatasi `CHECK` huruf-kecil/angka/underscore — kode ini
+   dipakai sebagai **header kolom lembar cetak sekaligus header import**,
+   sehingga kertas, foto, hasil AI, dan paste selalu memakai kosakata yang
+   sama persis.
+2. Konfigurasi berkunci `edisi`; data operasional hanya milik edisi aktif dan
+   diarsip lalu dikosongkan tiap tahun (bagian 9.3).
+
+## 3. Aturan akses
+
+1. **Tiga peran, satu link:**
+
+   | Peran | Contoh akun | Boleh |
+   | --- | --- | --- |
+   | `admin` | `admin.ciradyka` | Semua tabel, semua layar, konfigurasi |
+   | `operator_pos` | `pos1hrcd37` … `pos5hrcd37` | `nilai_mentah` **hanya** baris `pos = pos_saya()` — ditegakkan RLS, devtools tidak menolong |
+   | `meja` | `meja1hrcd37` … | Semua layar meja (pendaftaran, pembayaran, daftar ulang, garis start, closing) — satu peran untuk semua fungsi meja, jadi **ganti fungsi = pindah layar**, tanpa admin (R14) |
+
+2. Dua fungsi helper `peran()` dan `pos_saya()` (membaca `akun_panitia` dari
+   `auth.uid()`) dipakai seluruh policy; hanya akun `aktif=true` yang lolos.
+3. **Anon nyaris nol**: hanya `SELECT sekolah` (autocomplete form, tanpa PII).
+   Form publik menulis lewat gerbang Worker (bagian 8), penonton membaca file
+   statis (bagian 7) — **tidak ada jalur anon lain ke database**.
+4. **Rotasi tahunan**: akun membawa akhiran edisi. Tiap edisi: akun lama
+   `aktif=false` (jejak riwayat utuh), ±10 akun baru dibuat pemilik lewat
+   dashboard Supabase (±10 menit, bagian dari ritual Januari — dari SPA statis
+   memang mustahil membuat akun, dan itu disengaja). Login memakai username;
+   layar login menambahkan akhiran domain email tetap secara otomatis.
+
+## 4. Transaksi inti (RPC)
+
+Semua operasi rawan tabrakan atau multi-baris berjalan sebagai satu transaksi
+Postgres — layar tidak pernah menulis "setengah jadi":
+
+| RPC | Menjamin |
+| --- | --- |
+| `submit_pendaftaran` | Buat sekolah (bila baru) + batch + N baris regu + kode pembayaran unik, sekali jalan; validasi ulang rincian golongan = total di server |
+| `verifikasi_pembayaran` | Cek nominal = jumlah regu × `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
+| `batalkan_verifikasi` | Jalan mundur yang sah untuk salah verifikasi (meja di hari yang sama, admin kapan pun) — dengan alasan, terekam riwayat |
+| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → ambil N nomor terkecil yang tersedia (`FOR UPDATE SKIP LOCKED`) → sebar ke N kloter berbeda dengan `lompatan_kloter`, hindari kloter yang sudah berisi sekolah itu, buka kloter 31–40 hanya bila 1–30 penuh → tulis semuanya sekaligus. Regu `batal` dilewati. 2–3 meja paralel aman |
+| `tukar_nomor_dada` | Nomor dada rusak/salah pasang: tukar dengan stok tersedia, terekam riwayat |
+| `konfirmasi_kontrak` | Validasi pilihan terhadap `kontrak_opsi` (bukan hardcode); boleh dikoreksi selama kloter belum berangkat |
+| `berangkatkan_kloter` | Jam berangkat **wajib dari argumen** (diketik) — fungsi tidak mengenal `now()`; menolak bila ada regu ter-ceklis berangkat yang belum punya kontrak (daftarnya ditampilkan layar) |
+| `simpan_nilai_massal` | **Satu-satunya jalur tulis nilai** — upload massal dan input manual (batch isi 1) lewat pintu yang sama; `SECURITY INVOKER` sehingga RLS pos tetap menggigit; validasi ulang semua baris di server, hasil per baris dikembalikan (sukses/tolak + alasan) |
+| `catat_closing` | Upsert per regu — pemanggilan ulang = edit yang sah; `jam_datang` wajib dari argumen; `anggota_hadir` 0–5 |
+| `susun_barak` | Idempotent: hapus + hitung ulang + tulis. Urut sekolah terbesar; utamakan 1 sekolah 1 ruangan; sekolah besar boleh terpecah ke beberapa ruangan; sekolah kecil digabung hanya bila terpaksa; `jumlah_orang = regu aktif × 5 + pendamping` |
+
+## 5. Mesin skor — hitung-saat-baca, tanpa tombol "hitung ulang"
+
+1. **Tidak ada angka turunan yang disimpan.** Semua skor dihitung saat dibaca
+   oleh rantai SQL view pendek — tidak ada job rekap, tidak ada cache basi,
+   dan edit konfigurasi langsung berlaku pada muat ulang layar berikutnya.
+2. Rantainya:
+   1. `hitung_poin(bentuk, …)` — satu fungsi `IMMUTABLE` berisi satu `CASE`
+      untuk kelima bentuk: `kecil_baik`/`besar_baik` = interpolasi linear
+      `raw_terbaik→poin_maks` … `raw_terburuk→0` (di-clamp), `biner`,
+      `benar_per_total`, `benar_kurang_salah` (clamp ke ≥0).
+   2. `v_poin_wahana` — nilai mentah → poin per komponen.
+   3. `v_poin_pos` — Σ poin per pos × bobot; pos terlewat menyumbang 0 via
+      `LEFT JOIN`, tanpa pengurangan tambahan (aturan 10.8).
+   4. `v_penalti_waktu` — `target = jam_berangkat kloter + kontrak`;
+      `selisih_menit` bertanda, presisi menit;
+      `penalti = floor(|selisih|/blok_menit) × penalti_per_blok` — simetris;
+      toleransi 0–9 menit **lahir dari floor**, bukan aturan tersendiri.
+   5. `v_total_skor` — Σ pos − penalti waktu − `penalti_tanpa_checkout` (bila
+      tidak ada baris closing; penalti waktu saat itu 0 karena tak
+      terhitung) − `(5 − anggota_hadir) × penalti_per_anggota_hilang`.
+   6. `v_klasemen` — `rank() OVER (PARTITION BY golongan ORDER BY total DESC,
+      |selisih_menit| ASC)` — empat klasemen, tie-break ketepatan waktu sudah
+      tertanam. Regu `batal` dan yang tidak pernah berangkat tidak ikut
+      diperingkat.
+3. View pendukung: `v_monitoring_input` (matriks regu × pos),
+   `v_keberangkatan` (papan garis start), `v_lembar_nilai` (cetak, urut nomor
+   dada), `v_kwitansi`, `v_barak`, `v_progres_publik` (baris aman-publik tanpa
+   angka).
+
+## 6. Pipeline import nilai (jalur tersibuk hari-H)
+
+1. **Tahap tempel**: textarea besar menerima paste langsung dari Excel/Sheets
+   (TSV) + pemilih file .csv. File .xlsx sengaja **tidak** di-parse — operator
+   membuka dan menyalin dari Excel; menghapus satu dependensi parser dan tetap
+   menutup alur foto → AI → Excel → copy → paste.
+2. **Tahap parse**: deteksi delimiter otomatis; kolom 1 wajib nomor dada;
+   header lain dicocokkan (abaikan kapital/spasi) ke `wahana.kode` **pos ini
+   saja** — header tak dikenal menandai seluruh kolom: *"kolom tidak dikenal —
+   mungkin ini lembar pos lain?"* (penangkap salah-pos). `v/x/✓` → 1/0 untuk
+   bentuk biner.
+3. **Tahap validasi & preview** — kesalahan harus **terlihat**, bukan sekadar
+   terdaftar:
+   - **Setiap baris menampilkan identitas hasil lookup**: nomor dada → nama
+     regu + sekolah + golongan. Nomor yang salah baca tapi kebetulan valid
+     akan terlihat janggal oleh mata operator — inilah pagar utama terhadap
+     salah transkripsi AI.
+   - Warna tegas tiga arti: **merah = tidak akan di-commit** (nomor tak
+     dikenal, baris ganda, di luar rentang wajar dari konfigurasi), **kuning =
+     butuh persetujuan eksplisit** (menimpa nilai lama, ditampilkan
+     `lama → baru`; regu belum tercatat berangkat), **hijau = siap**.
+   - Sel kosong dilewati diam-diam — lembar setengah terisi adalah hal normal,
+     bukan error.
+4. **Tahap commit**: satu tombol `Simpan N baris hijau (+M kuning yang
+   disetujui)` → `simpan_nilai_massal` memvalidasi ulang semuanya di server
+   (preview di browser bukan otoritas), menulis dengan audit, mengembalikan
+   hasil per baris.
+5. Input manual = formulir satu regu dengan pola yang sama (ketik nomor dada →
+   kartu identitas muncul → isi angka → Enter) lewat RPC yang sama.
+
+## 7. Halaman live publik — statis, bertahap, nol beban
+
+1. `live.html` + `live.json` di Cloudflare Pages; halaman memuat ulang
+   `live.json` tiap 60 detik dan menampilkan cap "Diperbarui 10:35". Ratusan
+   HP penonton hanya menyentuh hosting statis — bandwidth gratis tak terbatas,
+   **nol request ke Supabase**.
+2. Regenerasi: workflow GitHub Actions (`publish-live.yml`) — cron 5 menit
+   (dinyalakan hanya minggu lomba) + tombol manual. Tiga langkah yang bisa
+   dibaca pelajar: baca view publik memakai **service role key dari GitHub
+   Secrets** (bukan anon — anon tidak bisa baca apa pun) → tulis `live.json` →
+   deploy ke Pages. ±144 run di hari-H ≪ kuota gratis 2.000 menit/bulan.
+3. **Bertahap sebagai data, bukan kode**: `status_acara.fase_live` menentukan
+   isi view publik — `pra` (jumlah pendaftar per golongan), `progres` (per
+   regu: sudah lewat pos mana, **tanpa angka**), `penuh` (klasemen 4 golongan
+   setelah closing). Admin memindah fase dari layar konfigurasi.
+
+## 8. Gerbang form publik
+
+1. Form pendaftaran mengirim ke **satu Worker Cloudflare kecil** (±50 baris,
+   satu-satunya kode "server" di seluruh sistem): verifikasi token
+   **Turnstile** (CAPTCHA gratis tanpa kartu) + rate limit per IP + batas
+   ukuran payload → baru memanggil `submit_pendaftaran`.
+2. Kunci-kunci rahasia (Turnstile secret, service role) hidup di Worker/GitHub
+   Secrets — **tidak pernah** di SPA.
+
+## 9. Jendela Sheets & arsip
+
+1. **Export CSV di semua layar daftar**, posisi tombol sama di header setiap
+   layar; serialisasi di browser, UTF-8 ber-BOM agar Excel membukanya bersih;
+   nama file berpola `hrcd37-klasemen-penegak-pa.csv`. Sengaja tanpa Sheets
+   API/OAuth — download adalah jalur satu-demo tanpa kredensial.
+2. Masuknya data memang sudah berbentuk Excel (pipeline paste); keluarnya
+   selalu tersedia sebagai CSV — bolak-balik tanpa konsep baru.
+3. **Arsip tahunan**: setelah acara, admin meng-export semua view utama ke
+   CSV → Google Sheets "HRCD 37 — Arsip", plus dump SQL ke Drive; lalu data
+   operasional dikosongkan untuk edisi berikutnya. Arsip terbaca selamanya
+   tanpa sistem berjalan.
+
+## 10. Layar
+
+### 10.1 Prinsip lintas layar (kontrak UX dengan panitia)
+
+1. **Satu layar, satu aksi utama** — satu tombol besar per layar
+   ("Ambil 10 Nomor Dada", "Berangkatkan Kloter 12", "Simpan 27 Baris").
+2. **Nomor dada adalah jangkar universal** setelah daftar ulang (kode
+   pembayaran sebelumnya); setiap layar dibuka dengan field kunci itu
+   ter-autofocus.
+3. **Echo-confirm sebelum simpan**: mengetik kunci apa pun langsung
+   menampilkan kartu besar *milik siapa* (nama regu, sekolah, golongan,
+   kloter); tombol simpan mati sampai lookup berhasil.
+4. **Ketik lebih cepat daripada dropdown**: angka & jam diketik; Enter =
+   simpan + fokus kembali ke field kunci — loop input manual ±5 detik/entri
+   tanpa mouse.
+5. **Jam selalu diketik, tidak pernah otomatis**: field jam datang / jam
+   berangkat **kosong** secara default dengan chip "Jam sekarang" satu ketuk
+   di sampingnya — cepat saat mencatat langsung, aman saat menyalin susulan
+   dari kertas. Tidak ada `now()` tersembunyi di mana pun.
+6. **Setiap simpanan terlihat & bisa di-edit di tempat**: daftar "baris
+   terakhir" di kaki setiap layar input; ketuk untuk koreksi; audit merekam
+   semuanya.
+7. **Massal tidak pernah melewati mata manusia** (bagian 6).
+8. **Status = warna + angka**, bukan kalimat — terbaca dari seberang meja.
+9. **Kerangka sama di semua layar**: header (saya siapa + ganti fungsi +
+   Export CSV), tengah (satu form/papan), kaki (baris terakhir) — belajar satu
+   layar = belajar semuanya.
+10. **Maksimal satu dialog konfirmasi**, hanya untuk aksi yang benar-benar
+    tak terulangi (berangkatkan kloter, commit massal, pindah fase live).
+11. **Gagal itu nyaring dan lokal**: baris gagal memerah + tombol "Coba
+    lagi"; tidak ada yang hilang diam-diam.
+12. Teks UI = kalimat yang memang diucapkan operator, dengan serapan familiar
+    (upload, preview, password — bukan unggah/pratinjau/kata sandi).
+
+### 10.2 Inventaris layar
+
+| Layar | Peran | Inti |
+| --- | --- | --- |
+| Login | semua | Username + password; akhiran email ditambah otomatis |
+| Beranda meja | meja | Pemilih fungsi + lencana angka dari data nyata (batch menunggu verifikasi, batch lunas belum bernomor, regu belum closing) |
+| Form pendaftaran | publik | Bagian 3 alur; autocomplete sekolah dari master (dimuat sekali, difilter di browser), blok per regu dinamis, validasi jumlah golongan; hasil akhir menampilkan kode pembayaran besar-besar |
+| Meja pembayaran | meja | Ketik kode → kartu batch → "Tandai Lunas" → panel sukses langsung menawarkan "Cetak Kwitansi" (satu alur, bukan dua); "Batalkan (salah)" memanggil `batalkan_verifikasi` |
+| Meja daftar ulang | meja | Ketik kode → kartu sekolah + daftar regu → satu tombol "Ambil N Nomor Dada" → hasil besar-besar per regu (nomor dada + kloter) untuk dibacakan; jalur "Tukar nomor" untuk stok rusak |
+| Garis start | meja | Papan 4 kolom **turunan otomatis** dari kloter terakhir yang berangkat: N berangkat / N+1–N+2 siap / N+3 konfirmasi kontrak. Operator hanya punya dua aksi: ceklis regu + tombol besar "BERANGKATKAN" (jam diketik). Papan bergeser sendiri — operator tidak pernah memutuskan apa yang maju |
+| Input pos — manual | operator_pos | Loop ketik-Enter 5 detik; hanya komponen pos sendiri yang tampil |
+| Input pos — upload massal | operator_pos | Pipeline bagian 6 |
+| Meja closing | meja | Ketik nomor dada → kartu regu → jam datang (kosong + chip "Jam sekarang") + anggota hadir (default 5) → Enter; dirancang setara arus 10 regu / 5 menit; catatan kertas tetap jadi cadangan resmi di meja |
+| Monitoring | semua panitia | Matriks regu × pos live (Realtime); kolom closing ikut live |
+| Klasemen (admin) | admin | Empat tab golongan; **tanpa tombol hitung ulang** — selalu segar karena hitung-saat-baca; Export CSV |
+| Konfigurasi (admin) | admin | Tab per tabel konfigurasi; editor baris dengan bahasa manusia + kolom "contoh hasil" live (ubah `raw_terbaik` → contoh konversi ikut berubah); saklar `fase_live`, `daftar_ulang_ditutup`, `konfigurasi_terkunci` |
+| Cetak | admin/meja | Lembar nilai per pos (aktif setelah `daftar_ulang_ditutup`; urut nomor dada; header kolom = `wahana.kode` dari konfigurasi) + kwitansi; print CSS browser |
+| Barak | meja/admin | Panel kebutuhan (+pendamping) vs kapasitas; tombol "Susun Ulang"; hasil bisa dikoreksi manual sebelum ditempel |
+| Riwayat | admin | Cari per nomor dada / tabel / akun; baca-saja |
+| Live publik | tanpa login | Bagian 7 |
+
+### 10.3 Empat alur tersibuk (target waktu per transaksi)
+
+1. **Daftar ulang batch** (target ≤ 40 detik/sekolah/meja): sebut kode → kartu
+   tampil → konfirmasi lisan nama regu + sekolah → satu tombol → bacakan hasil
+   → serahkan nomor dada fisik.
+2. **Import massal pos** (berjalan sepanjang lomba): foto masuk WA → AI →
+   Excel → copy → paste → mata menyapu kolom identitas → commit. Operator
+   kedua di pos memvalidasi sambil operator pertama menerima foto berikutnya.
+3. **Serbuan closing**: baris depan mencatat di kertas (nomor dada + jam +
+   jumlah orang), baris belakang mengetik dari kertas — layar dirancang untuk
+   penyalinan cepat, bukan hanya pencatatan langsung; jam diketik membuat
+   penyalinan susulan tetap akurat.
+4. **Garis start** (satu kloter per 3–5 menit): papan bergeser otomatis;
+   konfirmasi kontrak tiga kloter di depan; tombol besar satu per kloter.
+
+## 11. Keputusan yang menyelesaikan temuan verifikasi
+
+1. **Satu kosakata**: nama tabel konfigurasi mengikuti rancangan mesin
+   (`edisi`, `pos`, `wahana`, `kontrak_opsi`, `konfig_penalti`); dua rancangan
+   pendahulu yang saling beda istilah dilebur ke sini.
+2. **Satu pipeline publikasi**: GitHub Actions + service role dari Secrets;
+   anon tetap buta. (Sebelumnya ada dua rancangan yang saling bertentangan.)
+3. **Satu jalur tulis nilai**: manual dan massal sama-sama lewat
+   `simpan_nilai_massal`; preview di browser, otoritas di server.
+4. **Jam tidak pernah di-prefill**: temuan verifikator — prefill jam-sekarang
+   justru salah tepat ketika meja menumpuk (pengetikan susulan). Diganti field
+   kosong + chip "Jam sekarang".
+5. **Papan garis start turunan**, bukan status yang digeser manual: satu-satunya
+   penulisan adalah jam berangkat; posisi pipeline dihitung dari kloter
+   terakhir yang berangkat — menghapus RPC penggeser status dan kebingungan
+   "kolom ini untuk apa".
+6. **Kontrak wajib sebelum berangkat**: `berangkatkan_kloter` menolak bila ada
+   regu ter-ceklis tanpa kontrak — mencegah penalti waktu yang tak terhitung.
+7. **Nilai diterima sejak regu bernomor dada** (bukan wajib berangkat dulu);
+   belum-berangkat = kuning, bukan tolak — pos 1 sering menerima kloter yang
+   ceklis berangkatnya menyusul.
+8. **Barak boleh pecah ruangan** + kolom pendamping ditambah ke `pendaftaran`.
+9. **Undo pembayaran resmi** (`batalkan_verifikasi`) menggantikan janji tombol
+   undo tanpa jalur data.
+10. **`status_acara`** menampung saklar yang sebelumnya tidak punya rumah:
+    tutup daftar ulang (pemicu cetak lembar nilai), fase live, kunci
+    konfigurasi (ditegakkan trigger, bukan janji klien).
+11. **Riwayat bisa dicari per regu** (kolom `regu_id` diisi trigger).
+12. **Klasemen tidak memuat regu batal / tak berangkat** — mencegah −100 hantu
+    bagi regu yang memang tidak ikut.
+13. **Urutan lembar cetak dikanonkan**: nomor dada menaik, di view dan layar.
+14. **Akun dibuat pemilik setahun sekali lewat dashboard** — dari SPA memang
+    mustahil, dan 10 menit/tahun bukan alasan menambah server.
+
+## 12. Batas yang diterima secara sadar
+
+1. **Bentuk formula total** (Σ pos − penalti) adalah kode (satu view);
+   angka-angkanya konfigurasi. Bentuk yang benar-benar baru = pemilik
+   mengedit satu view SQL. Batas yang sama berlaku di semua kandidat.
+2. **Maks 10 regu/kloter** ditegakkan `CHECK` — mengubahnya = satu migrasi
+   kecil, bukan edit konfigurasi. Dipilih karena penegakan database lebih
+   berharga daripada kelenturan angka yang 7 tahun tidak pernah berubah.
+3. **.xlsx tidak di-parse** — paste dari Excel menutup kebutuhan yang sama
+   tanpa dependensi parser.
+4. **Pembayaran sebagian tidak punya bentuk data** — sesuai keputusan panitia;
+   layar pembayaran menampilkan teks arahan "daftarkan batch lebih kecil".
+5. **Supabase pause**: keep-alive = cron GitHub Actions mingguan yang menyentuh
+   tabel heartbeat + ritual cek Januari; jendela pemulihan 1 tahun menjadikan
+   kelalaian dapat dipulihkan, bukan fatal.
+
+## 13. Urutan implementasi
+
+| Tahap | Isi | Bukti selesai |
+| --- | --- | --- |
+| 1. Fondasi | Struktur repo, migrasi SQL lengkap (tabel + RLS + fungsi + view), seed konfigurasi edisi 37, seed contoh | Tes SQL: nomor dada ganda tertolak, RLS pos menggigit, contoh konversi & penalti cocok dengan dokumen ini |
+| 2. Meja | Login, beranda meja, form pendaftaran + gerbang Worker, pembayaran, daftar ulang | Alur daftar → bayar → nomor dada jalan penuh di lingkungan uji |
+| 3. Hari-H | Garis start, input pos (manual + massal), closing, monitoring | Simulasi input 500 regu × 5 pos |
+| 4. Admin | Konfigurasi, klasemen, cetak, barak, riwayat | Panitia bisa mengubah aturan skor tanpa menyentuh kode |
+| 5. Publik | Live page + GitHub Actions + fase bertahap + keep-alive | Halaman live berjalan tanpa satu request pun ke Supabase |
+| 6. Gladi | Seed 300 regu sintetis, drill semua meja, ukur waktu per transaksi terhadap target 10.3 | Angka gladi terlampir di repo |
+
+Setiap tahap masuk lewat PR sendiri mengikuti konvensi CLAUDE.md.


### PR DESCRIPTION
## What

`docs/rancangan-b.md` — the implementation blueprint for the locked architecture, in 13 numbered sections:

1. Architecture overview — Supabase + static SPA + one tiny Worker + GitHub Actions, all Rp 0
2. Data model — 14 operational + 5 config tables; `UNIQUE(nomor_dada)` and `UNIQUE(kloter, urutan)` make the two worst corruptions physically impossible
3. Access — 3 roles behind one link (`admin` / `operator_pos` scoped by RLS / one fluid `meja` role satisfying R14), yearly account rotation
4. Ten transactional RPCs — `daftar_ulang_batch` with `FOR UPDATE SKIP LOCKED` at the core
5. Scoring — compute-on-read view chain; no recompute button exists because nothing can go stale
6. Bulk import — echo-confirm preview (each row shows WHO the nomor dada resolves to), red/yellow/green semantics, server revalidation
7. Public live page — static, staged via `fase_live`, regenerated by GitHub Actions with the service key in Secrets; spectators never touch Supabase
8. Form gateway — one ~50-line Turnstile Worker, the only outside write path
9. Sheets window & yearly archive
10. Sixteen screens under twelve UX principles + the four busiest flows with time targets
11. Fourteen decisions resolving the verifiers' findings
12. Consciously accepted bounds
13. Six implementation phases, each landing as its own PR

## How it was produced

Three parallel designers (schema, screens, config machinery) + two adversarial verifiers (spec coverage, teachability) — 38 findings and 11 gaps folded in. The three most consequential fixes: time fields are never prefilled with the current clock (wrong exactly when desks back up), the start-line board derives its pipeline positions rather than being advanced manually, and manual + bulk score entry share one server-validated write path.

## Notes

This is the blueprint code will be written against. The panitia's hard condition (one-demonstration teachability) is encoded as §10.1's twelve principles, not left as a wish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)