### PR TITLE
feat: database foundation — schema, RLS, RPCs, views, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,57 @@
 # HRCD Rekap
 
-> Status: scaffolding. The project's scope and stack are not yet decided.
+Sistem rekapitulasi dan penilaian **Hiking Rally Ciradyka** — lomba gerak jalan
+alam terbuka untuk SMP dan SMA yang diadakan Ambalan Ciung Wanara – Dyah
+Pitaloka, SMA Negeri 1 Ciamis.
 
-## Getting started
+Arsitektur: **Supabase** (Postgres + Auth + RLS) sebagai mesin, SPA statis di
+**Cloudflare** sebagai tampilan, **Google Sheets** sebagai jendela baca —
+seluruhnya Rp 0. Alasan dan perbandingannya di `docs/desain-sistem.md`.
 
-Not applicable yet — no application code has been added.
+## Dokumen
 
-## Repository layout
+| Dokumen | Isi |
+| --- | --- |
+| `docs/alur-lomba.md` | Alur penyelenggaraan dan aturan penilaian (spesifikasi) |
+| `docs/desain-sistem.md` | Empat kandidat arsitektur gratis + keputusan |
+| `docs/rancangan-b.md` | Cetak biru implementasi (model data, layar, pipeline) |
+
+## Struktur repo
 
 ```
 .
-├── .gitignore
+├── docs/                     # spesifikasi & rancangan
+├── supabase/
+│   ├── migrations/           # skema database, urut 0001..0005
+│   └── seed.sql              # konfigurasi edisi + baris wajib
+├── tests/
+│   ├── sql/                  # harness + tes constraint, alur, skor
+│   └── run.sh                # jalankan semuanya di database lokal
 └── README.md
 ```
 
-## Contributing
+## Menjalankan tes
 
-Work happens on branches off `main` and lands via pull request.
+Butuh PostgreSQL 16 (lokal atau portable, tanpa Supabase):
 
 ```bash
-git checkout -b <type>/<short-description>
-# ...make changes...
-git commit -m "<type>: <what changed>"
+PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
+```
+
+Runner membuat ulang database `hrcd_test` setiap kali — aman diulang. Tes
+mencakup: nomor dada ganda tertolak, kapasitas kloter, RLS per pos, alur
+lengkap daftar → bayar → daftar ulang → berangkat → nilai → closing, dan
+kecocokan mesin skor dengan contoh angka di `docs/rancangan-b.md`.
+
+## Kontribusi
+
+Semua perubahan lewat branch + pull request — konvensi lengkap di `CLAUDE.md`.
+
+```bash
+git checkout -b <type>/<deskripsi-singkat>
+# ...ubah...
 git push -u origin HEAD
 gh pr create --fill
 ```
 
-### Merging
-
-PRs are merged with a **merge commit** (`--no-ff`), never squashed or rebased, so
-every PR stays a distinct merge point in `main`'s history. The merge commit
-subject is the PR title followed by the PR number:
-
-```bash
-gh pr merge <number> --merge --subject "<PR title> (#<number>)" --delete-branch
-```
-
-Omitting `--subject` lets GitHub write `Merge pull request #N from <branch>`
-instead, which buries the title — so always pass it.
+PR di-merge dengan merge commit (`--no-ff`) bersubjek `Judul (#nomor)`.

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -335,3 +335,52 @@ Postgres — layar tidak pernah menulis "setengah jadi":
 | 6. Gladi | Seed 300 regu sintetis, drill semua meja, ukur waktu per transaksi terhadap target 10.3 | Angka gladi terlampir di repo |
 
 Setiap tahap masuk lewat PR sendiri mengikuti konvensi CLAUDE.md.
+
+## 14. Penyesuaian dari review implementasi Tahap 1
+
+Migrasi SQL Tahap 1 diserang tiga reviewer adversarial (keamanan, kesesuaian,
+kebenaran SQL); 39 temuan menghasilkan penyesuaian berikut — dokumen di atas
+dibaca dengan koreksi ini:
+
+1. **`submit_pendaftaran` hanya bisa dipanggil gerbang Worker** (service
+   role) — akun login mana pun tidak bisa, supaya Turnstile tidak bisa
+   dilompati. Grant fungsi kini per-fungsi, bukan massal: RPC baru tidak
+   pernah terekspos otomatis.
+2. **Semua tulisan non-admin lewat RPC, titik.** Tulisan langsung ke
+   `nilai_mentah`, `closing_regu`, `keberangkatan_regu`, `penempatan_barak`
+   ditutup — mencegah pemalsuan kolom pencatat dan pelompatan validasi.
+   `simpan_nilai_massal` menjadi `SECURITY DEFINER` dengan cek pos eksplisit
+   (pilihan kedua di bagian 4); admin wajib menyebut pos.
+3. **Nomor dada bekas tukar PENSIUN permanen** (tabel `nomor_dada_pensiun`) —
+   foto lembar lama yang masih menuliskan nomor itu tidak akan pernah menilai
+   regu lain. Penukaran setelah kloter berangkat hanya oleh admin.
+4. **Pembatalan verifikasi ditolak setelah daftar ulang** — tidak ada lagi
+   regu yatim bernomor-dada-tapi-belum-bayar. "Hari yang sama" dihitung WIB.
+5. **Ceklis menyusul wajib berkontrak dulu** (koreksi kontrak setelah
+   berangkat = admin) — regu yang ceklisnya terlambat tidak lagi lolos
+   penalti waktu. Keberangkatan wajib berurut (tidak bisa melompati kloter
+   berisi regu), dan ada `batalkan_keberangkatan` untuk ketukan salah
+   (admin, hanya kloter terakhir).
+6. **Klasemen mensyaratkan kloter benar-benar berangkat** dan batch berstatus
+   lunas; semua view nilai/cetak/publik menyaring status batch; matriks
+   monitoring untuk operator pos hanya menampilkan kolom pos-nya (tampilan
+   sempit lebih baik daripada tampilan palsu).
+7. **Penalti di-floor pada menit mentah** — selisih 9 menit 30 detik adalah
+   penalti 0, bukan dibulatkan dulu ke 10. Knob `nilai_pos_terlewat` kini
+   benar-benar terpasang di rumus total. `benar_kurang_salah` di-clamp ke
+   [0, poin_maks].
+8. **Kunci konfigurasi menahan admin juga** — membuka kunci adalah langkah
+   sadar tersendiri di `status_acara` (perlindungan dua langkah, revisi atas
+   kalimat "kecuali admin" di bagian 2.1).
+9. **Barak muat-dulu**: cari ruangan kosong terkecil yang memuat seluruh
+   rombongan sebelum memecah; menggabung tetap jalan terakhir. Jumlah
+   pendamping bisa diisi dari form dan dikoreksi meja (`ubah_pendamping`).
+10. **Kloter cadangan 31–40 benar-benar terakhir**: sekolah yang sama boleh
+    berkumpul di 1–30 dulu sebelum kloter cadangan dibuka.
+11. **Audit menempel juga di** `akun_panitia` (peta otorisasi), `sekolah`,
+    `ruangan`, `nomor_dada_pensiun`; simpan-ulang tanpa perubahan tidak
+    menulis apa pun sehingga riwayat tidak banjir dan kepengarangan tidak
+    tergeser.
+
+Setiap butir di atas dikawal tes di `tests/sql/` — 02 untuk constraint,
+03 untuk alur, akses, dan matematika skor.

--- a/supabase/migrations/0001_schema.sql
+++ b/supabase/migrations/0001_schema.sql
@@ -1,0 +1,271 @@
+-- ============================================================================
+-- hrcd-rekap : 0001_schema.sql
+-- Tabel operasional + konfigurasi. Acuan: docs/rancangan-b.md bagian 2.
+--
+-- Prinsip: kebenaran data ditegakkan constraint database, bukan kehati-hatian
+-- kode. UNIQUE (nomor_dada) membuat nomor ganda mustahil; UNIQUE
+-- (kloter_nomor, urutan_kloter) menegakkan kapasitas kloter.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Tabel konfigurasi (diedit admin tiap edisi — rancangan-b.md 2.2)
+-- ---------------------------------------------------------------------------
+
+create table edisi (
+  nomor                     smallint primary key,
+  nama                      text not null,
+  tahun                     smallint not null,
+  tanggal_lomba             date not null,
+  biaya_per_regu            integer not null check (biaya_per_regu >= 0),
+  maks_regu_per_kloter      smallint not null default 10 check (maks_regu_per_kloter between 1 and 10),
+  kloter_dasar              smallint not null default 30,
+  kloter_maks               smallint not null default 40,
+  lompatan_kloter           smallint not null default 2 check (lompatan_kloter >= 1),
+  interval_berangkat_menit  smallint not null default 4,
+  aktif                     boolean not null default false,
+  check (kloter_dasar <= kloter_maks)
+);
+
+-- Tepat satu edisi aktif.
+create unique index edisi_satu_aktif on edisi ((true)) where aktif;
+
+create table pos (
+  edisi   smallint not null references edisi (nomor),
+  nomor   smallint not null check (nomor between 1 and 5),
+  nama    text not null,
+  bobot   numeric(6,2) not null default 1.00 check (bobot > 0),
+  primary key (edisi, nomor)
+);
+
+create table wahana (
+  id                 uuid primary key default gen_random_uuid(),
+  edisi              smallint not null,
+  pos                smallint not null,
+  -- kode = header kolom lembar cetak SEKALIGUS header import massal.
+  -- Format ketat supaya kertas, foto, hasil AI, dan paste memakai kosakata
+  -- yang sama persis (rancangan-b.md 2.2.1).
+  kode               text not null check (kode ~ '^[a-z0-9_]+$'),
+  nama               text not null,
+  jenis              text not null check (jenis in ('wahana', 'soal')),
+  bentuk             text not null check (bentuk in
+                       ('kecil_baik', 'besar_baik', 'biner',
+                        'benar_per_total', 'benar_kurang_salah')),
+  poin_maks          numeric(8,2) not null check (poin_maks > 0),
+  raw_terbaik        numeric(10,2),          -- kecil_baik / besar_baik
+  raw_terburuk       numeric(10,2),          -- kecil_baik / besar_baik
+  poin_benar         numeric(8,2),           -- biner / benar_kurang_salah
+  poin_salah         numeric(8,2),           -- biner / benar_kurang_salah (negatif utk pengurang)
+  total_soal         numeric(6,0),           -- benar_per_total
+  rentang_mentah_min numeric(10,2) not null, -- batas validasi import
+  rentang_mentah_maks numeric(10,2) not null,
+  urutan             smallint not null default 1,
+  unique (edisi, pos, kode),
+  foreign key (edisi, pos) references pos (edisi, nomor),
+  check (rentang_mentah_min <= rentang_mentah_maks),
+  -- Parameter wajib sesuai bentuk — konfigurasi salah tertolak sejak insert.
+  check (bentuk not in ('kecil_baik', 'besar_baik')
+         or (raw_terbaik is not null and raw_terburuk is not null
+             and raw_terbaik <> raw_terburuk)),
+  check (bentuk <> 'biner'
+         or (poin_benar is not null and poin_salah is not null)),
+  check (bentuk <> 'benar_per_total'
+         or (total_soal is not null and total_soal > 0)),
+  check (bentuk <> 'benar_kurang_salah'
+         or (poin_benar is not null and poin_salah is not null))
+);
+
+create table kontrak_opsi (
+  edisi   smallint not null references edisi (nomor),
+  label   text not null,
+  menit   smallint not null check (menit > 0),
+  urutan  smallint not null default 1,
+  primary key (edisi, menit)
+);
+
+create table konfig_penalti (
+  edisi                       smallint primary key references edisi (nomor),
+  blok_menit                  smallint not null default 10 check (blok_menit > 0),
+  penalti_per_blok            numeric(6,2) not null default 10,
+  penalti_tanpa_checkout      numeric(6,2) not null default 100,
+  penalti_per_anggota_hilang  numeric(6,2) not null default 20,
+  nilai_pos_terlewat          numeric(6,2) not null default 0
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Saklar hari-H — satu baris (rancangan-b.md 2.1 status_acara)
+-- ---------------------------------------------------------------------------
+
+create table status_acara (
+  id                    boolean primary key default true check (id),
+  daftar_ulang_ditutup  boolean not null default false,
+  fase_live             text not null default 'pra'
+                        check (fase_live in ('pra', 'progres', 'penuh')),
+  konfigurasi_terkunci  boolean not null default false
+);
+
+-- ---------------------------------------------------------------------------
+-- 3. Tabel operasional
+-- ---------------------------------------------------------------------------
+
+create table sekolah (
+  id           uuid primary key default gen_random_uuid(),
+  nama         text not null check (length(trim(nama)) > 0),
+  alamat       text not null,
+  dibuat_pada  timestamptz not null default now(),
+  -- Sekolah bernama sama boleh ada selama alamatnya beda (alur 3.2.2).
+  unique (nama, alamat)
+);
+
+create table pendaftaran (
+  id                uuid primary key default gen_random_uuid(),
+  sekolah_id        uuid not null references sekolah (id),
+  -- Terbit saat submit; ID yang disebut sekolah saat bayar & daftar ulang.
+  kode_pembayaran   text not null unique,
+  butuh_barak       boolean not null default false,
+  jumlah_pendamping smallint not null default 0 check (jumlah_pendamping >= 0),
+  jumlah_regu       smallint not null check (jumlah_regu between 1 and 100),
+  kontak_wa         text not null,   -- PII: tertutup untuk anon
+  -- Semua-atau-tidak: tidak ada bentuk "lunas sebagian" (alur 3.5).
+  status            text not null default 'menunggu_pembayaran'
+                    check (status in ('menunggu_pembayaran', 'lunas', 'batal')),
+  dibuat_pada       timestamptz not null default now()
+);
+
+create table nomor_dada_stok (
+  -- Stok fisik yang disiapkan admin. Nomor "tersedia" = belum ada di
+  -- regu.nomor_dada dan belum pensiun — satu sumber kebenaran per fakta.
+  nomor integer primary key check (nomor > 0)
+);
+
+create table nomor_dada_pensiun (
+  -- Nomor yang pernah dilepas regu (rusak/tukar) TIDAK kembali ke antrean:
+  -- lembar kertas lama di lapangan masih menuliskan nomor itu, dan bila
+  -- terbit ulang di regu lain, foto susulan akan menilai regu yang salah
+  -- (temuan review). Pensiun permanen untuk edisi berjalan.
+  nomor integer primary key references nomor_dada_stok (nomor),
+  alasan text not null,
+  pada   timestamptz not null default now()
+);
+
+create table kloter (
+  nomor         smallint primary key check (nomor between 1 and 40),
+  -- DIKETIK panitia pencatat — TIDAK PERNAH default now() (alur 12.4).
+  -- Posisi pipeline garis start DITURUNKAN dari kolom ini (v_keberangkatan),
+  -- tidak ada kolom status yang digeser manual (rancangan-b.md 11.5).
+  jam_berangkat timestamptz
+);
+
+create table regu (
+  id             uuid primary key default gen_random_uuid(),
+  pendaftaran_id uuid not null references pendaftaran (id),
+  nama_regu      text not null check (length(trim(nama_regu)) > 0),
+  -- Empat anggota lain sengaja tidak dicatat (alur 3.2.6);
+  -- kelengkapan dicek fisik di closing (anggota_hadir).
+  nama_ketua     text not null,
+  golongan       text not null check (golongan in
+                   ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')),
+  -- UNIQUE: nomor dada ganda MUSTAHIL, dari berapa pun meja paralel.
+  nomor_dada     integer unique references nomor_dada_stok (nomor),
+  kloter_nomor   smallint references kloter (nomor),
+  urutan_kloter  smallint check (urutan_kloter between 1 and 10),
+  kontrak_menit  smallint,   -- divalidasi RPC terhadap kontrak_opsi
+  batal          boolean not null default false,
+  -- Kapasitas maks 10 regu/kloter ditegakkan database, bukan kode.
+  unique (kloter_nomor, urutan_kloter),
+  -- Nomor dada dan kloter lahir bersama di daftar_ulang_batch.
+  check ((nomor_dada is null) = (kloter_nomor is null)),
+  check ((kloter_nomor is null) = (urutan_kloter is null))
+);
+
+create index regu_pendaftaran_idx on regu (pendaftaran_id);
+create index regu_kloter_idx on regu (kloter_nomor);
+
+create table pembayaran (
+  id               uuid primary key default gen_random_uuid(),
+  -- UNIQUE = satu batch satu pembayaran penuh; verifikasi ganda dari dua
+  -- meja tertolak database.
+  pendaftaran_id   uuid not null unique references pendaftaran (id),
+  nominal          integer not null check (nominal > 0),
+  metode           text not null check (metode in ('tunai', 'transfer')),
+  nomor_kwitansi   text not null unique,
+  diverifikasi_oleh uuid not null references auth.users (id),
+  diverifikasi_pada timestamptz not null default now()
+);
+
+create table keberangkatan_regu (
+  -- Keberadaan baris = regu berangkat; PK membuat ceklis ganda mustahil.
+  regu_id      uuid primary key references regu (id),
+  dicatat_oleh uuid not null references auth.users (id),
+  -- Jejak administratif saja — jam yang DINILAI ada di kloter.jam_berangkat.
+  dicatat_pada timestamptz not null default now()
+);
+
+create table nilai_mentah (
+  id          bigint generated always as identity primary key,
+  regu_id     uuid not null references regu (id),
+  wahana_id   uuid not null references wahana (id),
+  nilai_1     numeric(10,2) not null,
+  nilai_2     numeric(10,2),   -- hanya benar_kurang_salah (jumlah salah)
+  sumber      text not null check (sumber in ('manual', 'upload')),
+  diinput_oleh uuid not null references auth.users (id),
+  diinput_pada timestamptz not null default now(),
+  -- Satu nilai per regu per komponen; input ulang = update (menimpa,
+  -- kuning di preview, terekam riwayat).
+  unique (regu_id, wahana_id)
+);
+
+create index nilai_mentah_wahana_idx on nilai_mentah (wahana_id);
+
+create table closing_regu (
+  regu_id       uuid primary key references regu (id),
+  -- DIKETIK dan bisa di-edit (upsert ulang) — bukan cap waktu server
+  -- (alur 12.3–12.4). Jalur kertas menyusul adalah kejadian normal.
+  jam_datang    timestamptz not null,
+  anggota_hadir smallint not null default 5 check (anggota_hadir between 0 and 5),
+  dicatat_oleh  uuid not null references auth.users (id),
+  dicatat_pada  timestamptz not null default now(),
+  catatan       text
+);
+
+create table ruangan (
+  id        uuid primary key default gen_random_uuid(),
+  nama      text not null unique,
+  kapasitas integer not null check (kapasitas > 0)
+);
+
+create table penempatan_barak (
+  id             uuid primary key default gen_random_uuid(),
+  pendaftaran_id uuid not null references pendaftaran (id),
+  ruangan_id     uuid not null references ruangan (id),
+  jumlah_orang   integer not null check (jumlah_orang > 0),
+  -- Satu sekolah BOLEH terpecah ke beberapa ruangan (rancangan-b.md 11.8);
+  -- yang unik hanyalah pasangannya.
+  unique (pendaftaran_id, ruangan_id)
+);
+
+create table akun_panitia (
+  user_id  uuid primary key references auth.users (id),
+  username text not null unique,   -- pola per edisi: pos1hrcd37, meja1hrcd37
+  peran    text not null check (peran in ('admin', 'meja', 'operator_pos')),
+  pos      smallint check (pos between 1 and 5),
+  aktif    boolean not null default true,
+  -- operator_pos wajib punya pos; peran lain wajib tidak.
+  check ((peran = 'operator_pos') = (pos is not null))
+);
+
+create table riwayat (
+  id         bigint generated always as identity primary key,
+  tabel      text not null,
+  baris_id   text not null,
+  -- Diisi trigger bila baris menyangkut satu regu — pencarian riwayat per
+  -- nomor dada jadi satu query (rancangan-b.md 11.11).
+  regu_id    uuid,
+  aksi       text not null check (aksi in ('INSERT', 'UPDATE', 'DELETE')),
+  nilai_lama jsonb,
+  nilai_baru jsonb,
+  oleh       uuid,
+  pada       timestamptz not null default now()
+);
+
+create index riwayat_regu_idx on riwayat (regu_id);
+create index riwayat_tabel_idx on riwayat (tabel, pada);

--- a/supabase/migrations/0002_functions.sql
+++ b/supabase/migrations/0002_functions.sql
@@ -1,0 +1,175 @@
+-- ============================================================================
+-- hrcd-rekap : 0002_functions.sql
+-- Fungsi helper, mesin konversi poin, dan trigger.
+-- Acuan: docs/rancangan-b.md bagian 3 (akses) dan 5 (mesin skor).
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Helper akses — dipakai seluruh policy RLS
+-- ---------------------------------------------------------------------------
+
+-- Peran akun yang sedang login; null bila tidak punya akun aktif.
+create or replace function peran()
+returns text
+language sql stable security definer
+set search_path = public
+as $$
+  select peran from akun_panitia
+  where user_id = auth.uid() and aktif
+$$;
+
+-- Nomor pos milik operator_pos yang sedang login; null untuk peran lain.
+create or replace function pos_saya()
+returns smallint
+language sql stable security definer
+set search_path = public
+as $$
+  select pos from akun_panitia
+  where user_id = auth.uid() and aktif
+$$;
+
+-- Edisi yang sedang aktif (tepat satu — index edisi_satu_aktif).
+create or replace function edisi_aktif()
+returns smallint
+language sql stable
+set search_path = public
+as $$
+  select nomor from edisi where aktif
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Mesin konversi — satu fungsi IMMUTABLE untuk lima bentuk
+--    (rancangan-b.md 5.2.1). Semua skor dihitung saat dibaca; tidak ada
+--    angka turunan yang disimpan.
+-- ---------------------------------------------------------------------------
+
+create or replace function hitung_poin(
+  p_bentuk       text,
+  p_nilai_1      numeric,
+  p_nilai_2      numeric,
+  p_poin_maks    numeric,
+  p_raw_terbaik  numeric,
+  p_raw_terburuk numeric,
+  p_poin_benar   numeric,
+  p_poin_salah   numeric,
+  p_total_soal   numeric
+) returns numeric
+language sql immutable
+as $$
+  select round(case p_bentuk
+    -- Interpolasi linear raw_terburuk→0 .. raw_terbaik→poin_maks, di-clamp.
+    -- Satu rumus untuk dua arah: kecil_baik punya terbaik < terburuk,
+    -- besar_baik sebaliknya — pembaginya ikut bertanda.
+    when 'kecil_baik' then
+      least(greatest(
+        p_poin_maks * (p_nilai_1 - p_raw_terburuk) / (p_raw_terbaik - p_raw_terburuk),
+        0), p_poin_maks)
+    when 'besar_baik' then
+      least(greatest(
+        p_poin_maks * (p_nilai_1 - p_raw_terburuk) / (p_raw_terbaik - p_raw_terburuk),
+        0), p_poin_maks)
+    -- Biner: kena/benar (nilai_1 > 0) atau tidak.
+    when 'biner' then
+      case when p_nilai_1 > 0 then p_poin_benar else p_poin_salah end
+    -- Proporsi jawaban benar.
+    when 'benar_per_total' then
+      least(greatest(p_poin_maks * p_nilai_1 / p_total_soal, 0), p_poin_maks)
+    -- Benar menambah, salah mengurangi (poin_salah disimpan negatif);
+    -- di-clamp supaya tidak minus.
+    when 'benar_kurang_salah' then
+      least(greatest(
+        p_poin_benar * p_nilai_1 + p_poin_salah * coalesce(p_nilai_2, 0),
+        0), p_poin_maks)
+  end, 2)
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Audit — trigger generik ke tabel riwayat (rancangan-b.md 2.1).
+--    SECURITY DEFINER supaya bisa menulis riwayat dari konteks peran mana pun;
+--    riwayat sendiri tidak menerima INSERT langsung dari klien.
+-- ---------------------------------------------------------------------------
+
+create or replace function catat_riwayat()
+returns trigger
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_lama  jsonb;
+  v_baru  jsonb;
+  v_baris text;
+  v_regu  uuid;
+begin
+  if tg_op <> 'INSERT' then v_lama := to_jsonb(old); end if;
+  if tg_op <> 'DELETE' then v_baru := to_jsonb(new); end if;
+
+  -- Kunci baris sebagai teks (PK tabel bersangkutan).
+  v_baris := coalesce(
+    v_baru ->> 'id', v_lama ->> 'id',
+    v_baru ->> 'regu_id', v_lama ->> 'regu_id',
+    v_baru ->> 'nomor', v_lama ->> 'nomor',
+    '?');
+
+  -- regu_id supaya riwayat bisa dicari per regu (rancangan-b.md 11.11).
+  v_regu := coalesce(
+    (v_baru ->> 'regu_id')::uuid, (v_lama ->> 'regu_id')::uuid,
+    case when tg_table_name = 'regu'
+      then coalesce((v_baru ->> 'id')::uuid, (v_lama ->> 'id')::uuid) end);
+
+  insert into riwayat (tabel, baris_id, regu_id, aksi, nilai_lama, nilai_baru, oleh)
+  values (tg_table_name, v_baris, v_regu, tg_op, v_lama, v_baru, auth.uid());
+
+  return coalesce(new, old);
+end;
+$$;
+
+-- Audit menempel di semua tabel yang menyangkut nilai atau keputusan.
+create trigger audit_regu               after insert or update or delete on regu               for each row execute function catat_riwayat();
+create trigger audit_pendaftaran        after insert or update or delete on pendaftaran        for each row execute function catat_riwayat();
+create trigger audit_pembayaran         after insert or update or delete on pembayaran         for each row execute function catat_riwayat();
+create trigger audit_nilai_mentah       after insert or update or delete on nilai_mentah       for each row execute function catat_riwayat();
+create trigger audit_closing_regu       after insert or update or delete on closing_regu       for each row execute function catat_riwayat();
+create trigger audit_keberangkatan      after insert or update or delete on keberangkatan_regu for each row execute function catat_riwayat();
+create trigger audit_kloter             after update on kloter                                 for each row execute function catat_riwayat();
+create trigger audit_penempatan_barak   after insert or update or delete on penempatan_barak   for each row execute function catat_riwayat();
+create trigger audit_status_acara       after update on status_acara                           for each row execute function catat_riwayat();
+create trigger audit_edisi              after insert or update or delete on edisi              for each row execute function catat_riwayat();
+create trigger audit_pos                after insert or update or delete on pos                for each row execute function catat_riwayat();
+create trigger audit_wahana             after insert or update or delete on wahana             for each row execute function catat_riwayat();
+create trigger audit_kontrak_opsi       after insert or update or delete on kontrak_opsi       for each row execute function catat_riwayat();
+create trigger audit_konfig_penalti     after insert or update or delete on konfig_penalti     for each row execute function catat_riwayat();
+-- Temuan review: akun_panitia adalah peta otorisasi seluruh sistem — tabel
+-- paling wajib beraudit; sekolah tampil ke publik (autocomplete); ruangan &
+-- stok menentukan kapasitas fisik.
+create trigger audit_akun_panitia       after insert or update or delete on akun_panitia       for each row execute function catat_riwayat();
+create trigger audit_sekolah            after insert or update or delete on sekolah            for each row execute function catat_riwayat();
+create trigger audit_ruangan            after insert or update or delete on ruangan            for each row execute function catat_riwayat();
+create trigger audit_nomor_dada_pensiun after insert or delete on nomor_dada_pensiun          for each row execute function catat_riwayat();
+
+-- ---------------------------------------------------------------------------
+-- 4. Kunci konfigurasi hari-H (rancangan-b.md 2.1 status_acara).
+--    Saat terkunci, SEMUA tulisan ke tabel konfigurasi tertolak — termasuk
+--    admin. Perlindungan dua langkah yang disengaja: admin harus membuka
+--    kunci dulu di status_acara, baru bisa mengedit. Mencegah edit refleks
+--    di tengah lomba.
+-- ---------------------------------------------------------------------------
+
+create or replace function tolak_saat_terkunci()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if (select konfigurasi_terkunci from status_acara) then
+    raise exception 'konfigurasi sedang terkunci (hari-H) — buka kunci di layar Konfigurasi dulu'
+      using errcode = 'P0001';
+  end if;
+  return coalesce(new, old);
+end;
+$$;
+
+create trigger kunci_edisi          before insert or update or delete on edisi          for each row execute function tolak_saat_terkunci();
+create trigger kunci_pos            before insert or update or delete on pos            for each row execute function tolak_saat_terkunci();
+create trigger kunci_wahana         before insert or update or delete on wahana         for each row execute function tolak_saat_terkunci();
+create trigger kunci_kontrak_opsi   before insert or update or delete on kontrak_opsi   for each row execute function tolak_saat_terkunci();
+create trigger kunci_konfig_penalti before insert or update or delete on konfig_penalti for each row execute function tolak_saat_terkunci();

--- a/supabase/migrations/0003_rls.sql
+++ b/supabase/migrations/0003_rls.sql
@@ -1,0 +1,155 @@
+-- ============================================================================
+-- hrcd-rekap : 0003_rls.sql
+-- Row-Level Security + grants. Acuan: docs/rancangan-b.md bagian 3.
+--
+-- Tiga peran di balik satu link:
+--   admin        — semua tabel, semua operasi
+--   operator_pos — nilai_mentah hanya baris pos = pos_saya()
+--   meja         — semua layar meja; ganti fungsi = pindah layar (R14)
+-- Anon nyaris nol: hanya SELECT sekolah. Form publik menulis lewat gerbang
+-- Worker (service role); penonton membaca file statis — tidak ada jalur anon
+-- lain ke database.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Aktifkan RLS di semua tabel
+-- ---------------------------------------------------------------------------
+
+alter table edisi              enable row level security;
+alter table pos                enable row level security;
+alter table wahana             enable row level security;
+alter table kontrak_opsi       enable row level security;
+alter table konfig_penalti     enable row level security;
+alter table status_acara       enable row level security;
+alter table sekolah            enable row level security;
+alter table pendaftaran        enable row level security;
+alter table nomor_dada_stok    enable row level security;
+alter table kloter             enable row level security;
+alter table regu               enable row level security;
+alter table pembayaran         enable row level security;
+alter table keberangkatan_regu enable row level security;
+alter table nilai_mentah       enable row level security;
+alter table closing_regu       enable row level security;
+alter table ruangan            enable row level security;
+alter table penempatan_barak   enable row level security;
+alter table akun_panitia       enable row level security;
+alter table riwayat            enable row level security;
+alter table nomor_dada_pensiun enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- 2. Grants dasar. Policy yang membatasi baris; grant membuka pintu kelasnya.
+-- ---------------------------------------------------------------------------
+
+grant usage on schema public to anon, authenticated, service_role;
+grant select, insert, update, delete on all tables in schema public to authenticated;
+-- service_role (BYPASSRLS) dipakai gerbang Worker & GitHub Actions; di
+-- Supabase asli grant ini datang dari default privileges — dieksplisitkan
+-- supaya lingkungan uji lokal berperilaku sama.
+grant select, insert, update, delete on all tables in schema public to service_role;
+-- Supabase asli MEMBERI grant ke anon lewat default privileges — cabut
+-- eksplisit supaya anon benar-benar hanya memegang sekolah (temuan review).
+revoke all on all tables in schema public from anon;
+grant select on sekolah to anon;
+
+-- ---------------------------------------------------------------------------
+-- 3. Policy per tabel
+-- ---------------------------------------------------------------------------
+
+-- Konfigurasi: semua panitia membaca (layar input pos butuh wahana + rentang);
+-- hanya admin menulis (dan trigger kunci hari-H tetap menghadang siapa pun).
+create policy sel_edisi          on edisi          for select using (peran() is not null);
+create policy adm_edisi          on edisi          for all    using (peran() = 'admin');
+create policy sel_pos            on pos            for select using (peran() is not null);
+create policy adm_pos            on pos            for all    using (peran() = 'admin');
+create policy sel_wahana         on wahana         for select using (peran() is not null);
+create policy adm_wahana         on wahana         for all    using (peran() = 'admin');
+create policy sel_kontrak_opsi   on kontrak_opsi   for select using (peran() is not null);
+create policy adm_kontrak_opsi   on kontrak_opsi   for all    using (peran() = 'admin');
+create policy sel_konfig_penalti on konfig_penalti for select using (peran() is not null);
+create policy adm_konfig_penalti on konfig_penalti for all    using (peran() = 'admin');
+
+-- Saklar hari-H: semua panitia membaca; admin menulis.
+create policy sel_status_acara on status_acara for select using (peran() is not null);
+create policy adm_status_acara on status_acara for update using (peran() = 'admin');
+
+-- Sekolah: anon + panitia membaca (autocomplete, tanpa PII); tulis via RPC
+-- submit_pendaftaran (SECURITY DEFINER) atau admin.
+create policy sel_sekolah_anon on sekolah for select using (true);
+create policy adm_sekolah      on sekolah for all    using (peran() = 'admin');
+
+-- Pendaftaran: kontak_wa adalah PII — hanya meja + admin; operator_pos tidak.
+-- Tulis hanya lewat RPC (DEFINER) atau admin langsung.
+create policy sel_pendaftaran on pendaftaran for select using (peran() in ('admin', 'meja'));
+create policy adm_pendaftaran on pendaftaran for all    using (peran() = 'admin');
+
+-- Stok nomor dada: panitia membaca; admin yang seeding.
+create policy sel_stok on nomor_dada_stok for select using (peran() is not null);
+create policy adm_stok on nomor_dada_stok for all    using (peran() = 'admin');
+create policy sel_pensiun on nomor_dada_pensiun for select using (peran() is not null);
+create policy adm_pensiun on nomor_dada_pensiun for all    using (peran() = 'admin');
+
+-- Kloter: panitia membaca (papan garis start); tulis via RPC atau admin.
+create policy sel_kloter on kloter for select using (peran() is not null);
+create policy adm_kloter on kloter for all    using (peran() = 'admin');
+
+-- Regu: semua panitia membaca — operator pos butuh identitas regu untuk
+-- kartu echo-confirm. Tulis via RPC atau admin.
+create policy sel_regu on regu for select using (peran() is not null);
+create policy adm_regu on regu for all    using (peran() = 'admin');
+
+-- Pembayaran: meja + admin; tulis via RPC.
+create policy sel_pembayaran on pembayaran for select using (peran() in ('admin', 'meja'));
+create policy adm_pembayaran on pembayaran for all    using (peran() = 'admin');
+
+-- Ceklis keberangkatan: panitia membaca. TULIS HANYA VIA RPC (temuan review:
+-- tulisan langsung memalsukan dicatat_oleh dan melompati guard RPC) — policy
+-- tulis langsung tersisa untuk admin.
+create policy sel_keberangkatan on keberangkatan_regu for select using (peran() is not null);
+create policy adm_keberangkatan on keberangkatan_regu for all using (peran() = 'admin');
+
+-- Nilai mentah — kebijakan inti R6. TULIS HANYA VIA simpan_nilai_massal
+-- (SECURITY DEFINER dengan cek pos eksplisit); tulisan langsung memalsukan
+-- diinput_oleh dan melompati validasi rentang, jadi policy tulis langsung
+-- hanya admin. Operator tetap MEMBACA baris pos-nya sendiri saja.
+create policy sel_nilai on nilai_mentah for select using (
+  peran() in ('admin', 'meja')
+  or (peran() = 'operator_pos' and exists (
+        select 1 from wahana w
+        where w.id = wahana_id and w.pos = pos_saya()))
+);
+create policy adm_nilai on nilai_mentah for all using (peran() = 'admin');
+
+-- Closing: panitia membaca. TULIS HANYA VIA catat_closing (alasan sama).
+create policy sel_closing on closing_regu for select using (peran() is not null);
+create policy adm_closing on closing_regu for all using (peran() = 'admin');
+
+-- Barak: panitia membaca; penyusunan via RPC susun_barak; koreksi manual
+-- langsung hanya admin.
+create policy sel_ruangan on ruangan for select using (peran() is not null);
+create policy adm_ruangan on ruangan for all    using (peran() = 'admin');
+create policy sel_barak   on penempatan_barak for select using (peran() is not null);
+create policy adm_barak   on penempatan_barak for all    using (peran() = 'admin');
+
+-- Akun: tiap orang melihat barisnya sendiri; admin semuanya.
+create policy sel_akun_sendiri on akun_panitia for select using (user_id = auth.uid());
+create policy adm_akun         on akun_panitia for all    using (peran() = 'admin');
+
+-- Riwayat: hanya admin membaca; INSERT hanya lewat trigger (DEFINER) —
+-- tidak ada policy insert untuk klien.
+create policy sel_riwayat on riwayat for select using (peran() = 'admin');
+
+-- ---------------------------------------------------------------------------
+-- 4. Realtime (layar pemantau & papan). Publication dibuat Supabase;
+--    di lingkungan uji lokal dibuat bila belum ada.
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  if not exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    create publication supabase_realtime;
+  end if;
+end;
+$$;
+
+alter publication supabase_realtime add table
+  nilai_mentah, kloter, keberangkatan_regu, closing_regu, regu, pendaftaran;

--- a/supabase/migrations/0004_rpcs.sql
+++ b/supabase/migrations/0004_rpcs.sql
@@ -1,0 +1,922 @@
+-- ============================================================================
+-- hrcd-rekap : 0004_rpcs.sql
+-- Sepuluh transaksi inti. Acuan: docs/rancangan-b.md bagian 4.
+--
+-- Semua operasi rawan tabrakan / multi-baris berjalan sebagai SATU transaksi
+-- Postgres — layar tidak pernah menulis "setengah jadi". Fungsi bertanda
+-- SECURITY DEFINER memeriksa peran() sendiri di baris pertama.
+-- Jam yang dinilai (jam_berangkat, jam_datang) SELALU datang dari argumen
+-- yang diketik panitia — tidak ada now() untuk waktu lomba di file ini.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. submit_pendaftaran — satu-satunya jalur tulis dari luar (via gerbang
+--    Worker). Buat sekolah bila baru + batch + N baris regu + kode pembayaran,
+--    sekali jalan.
+-- ---------------------------------------------------------------------------
+
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,  -- [{"nama_regu": "...", "nama_ketua": "...", "golongan": "penegak_pa"}, ...]
+  p_jumlah_pendamping smallint default 0
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+begin
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+
+  -- Validasi tiap regu SEBELUM menulis apa pun (validasi form diulang server).
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    -- coalesce: kunci yang hilang / null JSON tidak boleh lolos lewat
+    -- jebakan NULL pada NOT IN (temuan review).
+    if coalesce(v_r ->> 'golongan', '') not in
+       ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi') then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+  end loop;
+
+  -- Sekolah: pakai yang sudah ada (nama+alamat sama), atau buat baru.
+  insert into sekolah (nama, alamat)
+  values (trim(p_nama_sekolah), trim(p_alamat_sekolah))
+  on conflict (nama, alamat) do nothing;
+  select id into v_sekolah from sekolah
+  where nama = trim(p_nama_sekolah) and alamat = trim(p_alamat_sekolah);
+
+  -- Kode pembayaran unik: HRCD<edisi>-<6 hex>; ulang bila tabrakan (jarang).
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa))
+  returning id into v_batch;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan'
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', v_n * (select biaya_per_regu from edisi where aktif));
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. verifikasi_pembayaran — meja pembayaran menandai lunas; seluruh regu
+--    batch valid bersama (alur 3.4).
+-- ---------------------------------------------------------------------------
+
+create sequence if not exists kwitansi_seq;
+
+create or replace function verifikasi_pembayaran(
+  p_kode    text,
+  p_nominal integer,
+  p_metode  text
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch     pendaftaran%rowtype;
+  v_tagihan   integer;
+  v_kwitansi  text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'menunggu_pembayaran' then
+    raise exception 'batch berstatus %, bukan menunggu_pembayaran', v_batch.status;
+  end if;
+
+  -- Semua-atau-tidak: nominal harus pas seluruh batch (alur 3.5).
+  select v_batch.jumlah_regu * biaya_per_regu into v_tagihan from edisi where aktif;
+  if p_nominal <> v_tagihan then
+    raise exception 'nominal % tidak sama dengan tagihan % — pembayaran sebagian tidak dilayani; sarankan daftar batch lebih kecil',
+      p_nominal, v_tagihan;
+  end if;
+
+  v_kwitansi := 'KW-HRCD' || edisi_aktif() || '-' ||
+                lpad(nextval('kwitansi_seq')::text, 4, '0');
+
+  insert into pembayaran (pendaftaran_id, nominal, metode, nomor_kwitansi, diverifikasi_oleh)
+  values (v_batch.id, p_nominal, p_metode, v_kwitansi, auth.uid());
+
+  update pendaftaran set status = 'lunas' where id = v_batch.id;
+
+  return jsonb_build_object('nomor_kwitansi', v_kwitansi);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. batalkan_verifikasi — jalan mundur yang sah untuk salah verifikasi
+--    (rancangan-b.md 11.9). Meja: hari yang sama; admin: kapan pun.
+-- ---------------------------------------------------------------------------
+
+create or replace function batalkan_verifikasi(
+  p_kode   text,
+  p_alasan text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_bayar pembayaran%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan pembatalan wajib diisi';
+  end if;
+
+  select b.* into v_bayar
+  from pembayaran b join pendaftaran d on d.id = b.pendaftaran_id
+  where d.kode_pembayaran = p_kode
+  for update;
+  if not found then
+    raise exception 'tidak ada pembayaran untuk kode %', p_kode;
+  end if;
+
+  -- Temuan review: membatalkan verifikasi SETELAH daftar ulang meninggalkan
+  -- regu yatim — bernomor dada & berkloter tapi "belum bayar", hilang dari
+  -- kwitansi dan tergusur dari barak. Tolak keras.
+  if exists (select 1 from regu r
+             where r.pendaftaran_id = v_bayar.pendaftaran_id
+               and r.nomor_dada is not null) then
+    raise exception 'batch sudah daftar ulang (nomor dada terbit) — pembatalan harus lewat admin dengan mengosongkan nomor dada dulu';
+  end if;
+
+  -- Hari yang sama dihitung dalam WIB, bukan zona server (temuan review).
+  if peran() = 'meja'
+     and (v_bayar.diverifikasi_pada at time zone 'Asia/Jakarta')::date
+         <> (now() at time zone 'Asia/Jakarta')::date then
+    raise exception 'meja hanya boleh membatalkan verifikasi di hari yang sama — hubungi admin';
+  end if;
+
+  -- Alasan ikut terekam riwayat lewat trigger audit pada DELETE + catatan ini.
+  insert into riwayat (tabel, baris_id, aksi, nilai_baru, oleh)
+  values ('pembayaran', v_bayar.id::text, 'DELETE',
+          jsonb_build_object('alasan_pembatalan', p_alasan), auth.uid());
+
+  delete from pembayaran where id = v_bayar.id;
+  update pendaftaran set status = 'menunggu_pembayaran' where id = v_bayar.pendaftaran_id;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. daftar_ulang_batch — TRANSAKSI TERPENTING (rancangan-b.md bagian 4).
+--    Seluruh regu satu batch menerima nomor dada sekaligus + kloter
+--    ter-assign, dari 2-3 meja paralel, tanpa nomor ganda.
+-- ---------------------------------------------------------------------------
+
+create or replace function daftar_ulang_batch(p_kode text)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];      -- kloter yang sudah berisi sekolah ini
+  v_pilihan    int[] := '{}';
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where aktif;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Regu yang berhak: belum bernomor, tidak batal (rancangan-b.md, temuan 11).
+  -- Urutan deterministik (nama) supaya pasangan regu<->nomor bisa dibacakan
+  -- meja dengan urutan yang sama dengan kartu di layar.
+  select array_agg(r.id order by r.nama_regu, r.id) into v_regu
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.batal and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_regu, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Ambil N nomor terkecil yang tersedia. FOR UPDATE SKIP LOCKED: dua meja
+  -- yang menarik stok bersamaan tidak pernah memegang nomor yang sama.
+  -- Nomor pensiun (bekas tukar) tidak pernah terbit ulang.
+  select array_agg(nomor order by nomor) into v_nomor
+  from (
+    select s.nomor from nomor_dada_stok s
+    where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+      and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+    order by s.nomor
+    limit v_n
+    for update skip locked
+  ) ambil;
+  if coalesce(array_length(v_nomor, 1), 0) < v_n then
+    raise exception 'stok nomor dada kurang: butuh %, tersedia %',
+      v_n, coalesce(array_length(v_nomor, 1), 0);
+  end if;
+
+  -- Serialisasi bagian penempatan kloter (2-3 meja — advisory lock sederhana
+  -- lebih terbaca daripada retry unique-violation; lepas otomatis di akhir tx).
+  perform pg_advisory_xact_lock(hashtext('hrcd_kloter_assign'));
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  -- Sebar N regu: mulai dari kloter termuda yang layak, melompat
+  -- lompatan_kloter (alur 5.6); kloter 31.. dibuka hanya bila 1..30 tidak
+  -- menyediakan slot layak (alur 5.2). "Layak" = belum penuh + belum berisi
+  -- sekolah ini; bila tak terhindarkan, syarat sekolah dilonggarkan (alur 5.4
+  -- "sesedikit mungkin", bukan "tidak boleh").
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam 1..kloter_dasar.
+    if v_mulai is null then
+      v_langkah := 1;  -- pencarian pertama: kloter layak termuda
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and k.jam_berangkat is null
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama tapi abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: 1..kloter_dasar masih ada tempat tapi semuanya berisi
+    -- sekolah ini — sekolah sama boleh berkumpul DULU sebelum membuka
+    -- kloter cadangan (alur 5.2: 31-40 hanya bila 1-30 penuh; alur 5.4:
+    -- "sesedikit mungkin", bukan larangan mutlak). Pilih yang paling kosong.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan
+    -- (31..kloter_maks), hindari sekolah sama dulu lalu bebas.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),   -- false (bebas sekolah) dulu
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      -- Slot terkecil yang kosong, bukan count+1: lubang bekas koreksi admin
+      -- tidak boleh membuat slot palsu di atas 10 (temuan review).
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    if v_mulai is null then v_mulai := v_kandidat; else v_mulai := v_kandidat; end if;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. tukar_nomor_dada — nomor rusak / salah pasang (rancangan-b.md bagian 4).
+-- ---------------------------------------------------------------------------
+
+create or replace function tukar_nomor_dada(
+  p_regu       uuid,
+  p_nomor_baru integer,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu regu%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan tukar wajib diisi';
+  end if;
+
+  select * into v_regu from regu where id = p_regu for update;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_regu.batal then
+    raise exception 'regu berstatus batal';
+  end if;
+  if v_regu.nomor_dada is null then
+    raise exception 'regu belum punya nomor dada';
+  end if;
+  -- Setelah kloter berangkat, lembar kertas beredar memakai nomor lama —
+  -- penukaran hanya boleh oleh admin yang paham konsekuensinya.
+  if peran() <> 'admin' and exists (
+       select 1 from kloter where nomor = v_regu.kloter_nomor
+         and jam_berangkat is not null) then
+    raise exception 'kloter sudah berangkat — tukar nomor hanya lewat admin';
+  end if;
+  if not exists (select 1 from nomor_dada_stok where nomor = p_nomor_baru) then
+    raise exception 'nomor % tidak ada di stok', p_nomor_baru;
+  end if;
+  if exists (select 1 from regu where nomor_dada = p_nomor_baru)
+     or exists (select 1 from nomor_dada_pensiun where nomor = p_nomor_baru) then
+    raise exception 'nomor % sudah terpakai / pensiun', p_nomor_baru;
+  end if;
+
+  insert into riwayat (tabel, baris_id, regu_id, aksi, nilai_baru, oleh)
+  values ('regu', p_regu::text, p_regu, 'UPDATE',
+          jsonb_build_object('alasan_tukar_nomor', p_alasan,
+                             'nomor_lama', v_regu.nomor_dada,
+                             'nomor_baru', p_nomor_baru), auth.uid());
+
+  -- Nomor lama PENSIUN — tidak pernah terbit ulang ke regu lain, supaya
+  -- lembar/foto lama yang masih menuliskannya tidak menilai regu yang salah.
+  insert into nomor_dada_pensiun (nomor, alasan)
+  values (v_regu.nomor_dada, p_alasan);
+
+  update regu set nomor_dada = p_nomor_baru where id = p_regu;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. konfirmasi_kontrak — garis start, tiga kloter sebelum berangkat
+--    (alur 6.3). Pilihan divalidasi terhadap kontrak_opsi, bukan hardcode.
+-- ---------------------------------------------------------------------------
+
+create or replace function konfirmasi_kontrak(
+  p_regu  uuid,
+  p_menit smallint
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_kloter smallint;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if not exists (select 1 from kontrak_opsi
+                 where edisi = edisi_aktif() and menit = p_menit) then
+    raise exception 'kontrak % menit bukan pilihan edisi ini', p_menit;
+  end if;
+
+  select kloter_nomor into v_kloter from regu where id = p_regu;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_kloter is null then
+    raise exception 'regu belum daftar ulang (belum punya kloter)';
+  end if;
+  -- Setelah kloter berangkat, kontrak menentukan penalti yang sudah berjalan
+  -- — perbaikan susulan (ceklis menyusul) hanya lewat admin.
+  if peran() <> 'admin'
+     and exists (select 1 from kloter where nomor = v_kloter and jam_berangkat is not null) then
+    raise exception 'kloter % sudah berangkat — koreksi kontrak hanya lewat admin', v_kloter;
+  end if;
+
+  update regu set kontrak_menit = p_menit where id = p_regu;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 7. berangkatkan_kloter — jam WAJIB dari argumen (diketik pencatat);
+--    menolak bila ada regu ter-ceklis yang belum berkontrak
+--    (rancangan-b.md 11.6).
+-- ---------------------------------------------------------------------------
+
+create or replace function berangkatkan_kloter(
+  p_kloter smallint,
+  p_jam    timestamptz
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_tanpa_kontrak text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jam is null then
+    raise exception 'jam berangkat wajib diketik';
+  end if;
+  if exists (select 1 from kloter where nomor = p_kloter and jam_berangkat is not null) then
+    raise exception 'kloter % sudah berangkat', p_kloter;
+  end if;
+  -- Papan pipeline diturunkan dari max(nomor berangkat) — satu ketukan salah
+  -- (memberangkatkan kloter kosong / melompati) merusak seluruh papan.
+  -- Guard: kloter harus berisi regu, dan tidak boleh melompati kloter berisi
+  -- regu yang belum berangkat (temuan review).
+  if not exists (select 1 from regu r where r.kloter_nomor = p_kloter and not r.batal) then
+    raise exception 'kloter % tidak berisi regu', p_kloter;
+  end if;
+  if exists (
+       select 1 from kloter k
+       where k.nomor < p_kloter and k.jam_berangkat is null
+         and exists (select 1 from regu r
+                     where r.kloter_nomor = k.nomor and not r.batal)) then
+    raise exception 'masih ada kloter sebelum % yang belum berangkat — urutan keberangkatan wajib berurut', p_kloter;
+  end if;
+
+  -- Regu yang diceklis berangkat wajib sudah berkontrak — mencegah penalti
+  -- waktu yang tak terhitung (NULL) di kemudian hari.
+  select string_agg(r.nomor_dada::text, ', ') into v_tanpa_kontrak
+  from regu r
+  join keberangkatan_regu k on k.regu_id = r.id
+  where r.kloter_nomor = p_kloter and r.kontrak_menit is null;
+  if v_tanpa_kontrak is not null then
+    raise exception 'regu nomor dada % belum konfirmasi kontrak waktu', v_tanpa_kontrak;
+  end if;
+
+  update kloter set jam_berangkat = p_jam where nomor = p_kloter;
+end;
+$$;
+
+-- Jalan mundur untuk ketukan salah: hanya admin, dan hanya kloter berangkat
+-- terakhir (papan turunan langsung pulih).
+create or replace function batalkan_keberangkatan(p_kloter smallint, p_alasan text)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if peran() <> 'admin' then
+    raise exception 'hanya admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan wajib diisi';
+  end if;
+  if p_kloter <> (select max(nomor) from kloter where jam_berangkat is not null) then
+    raise exception 'hanya kloter berangkat terakhir yang bisa dibatalkan';
+  end if;
+  insert into riwayat (tabel, baris_id, aksi, nilai_baru, oleh)
+  values ('kloter', p_kloter::text, 'UPDATE',
+          jsonb_build_object('alasan_batal_berangkat', p_alasan), auth.uid());
+  update kloter set jam_berangkat = null where nomor = p_kloter;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8. simpan_nilai_massal — SATU-SATUNYA jalur tulis nilai: upload massal DAN
+--    input manual (batch isi 1). SECURITY DEFINER dengan cek pos EKSPLISIT
+--    (pilihan kedua rancangan-b.md bagian 4) — dipilih setelah review karena
+--    tabel nilai_mentah kini tertutup untuk tulisan langsung non-admin,
+--    sehingga fungsi ini benar-benar satu-satunya pintu. Validasi ulang semua
+--    baris di server; preview browser bukan otoritas (rancangan-b.md bag. 6).
+-- ---------------------------------------------------------------------------
+
+create or replace function simpan_nilai_massal(
+  p_baris  jsonb,  -- [{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40,"nilai_2":null}, ...]
+  p_sumber text default 'upload',
+  p_pos    smallint default null  -- wajib untuk admin; operator memakai pos-nya sendiri
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_r      jsonb;
+  v_regu   regu%rowtype;
+  v_wahana wahana%rowtype;
+  v_hasil  jsonb := '[]'::jsonb;
+  v_status text;
+  v_alasan text;
+  v_idx    int := 0;
+  v_pos    smallint;
+  v_kunci  text;
+  v_sudah  text[] := '{}';
+  v_n1     numeric;
+  v_n2     numeric;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+  if p_sumber not in ('manual', 'upload') then
+    raise exception 'sumber tidak dikenal: %', p_sumber;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_baris) loop
+    v_idx := v_idx + 1;
+    v_status := 'tersimpan'; v_alasan := null;
+
+    -- Seluruh pemrosesan baris terlindungi: format angka rusak di baris 7
+    -- tidak boleh menggagalkan 26 baris lain (temuan review).
+    begin
+      v_n1 := (v_r ->> 'nilai_1')::numeric;
+      v_n2 := nullif(v_r ->> 'nilai_2', '')::numeric;
+
+      -- Baris ganda dalam SATU paste = merah (bagian 6.3) — juga di server.
+      v_kunci := (v_r ->> 'nomor_dada') || '|' ||
+                 regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g');
+      if v_kunci = any (v_sudah) then
+        raise exception 'baris ganda dalam paste (nomor dada + komponen sama)';
+      end if;
+      v_sudah := v_sudah || v_kunci;
+
+      -- Regu: harus dikenal, bernomor, tidak batal.
+      select * into v_regu from regu
+      where nomor_dada = (v_r ->> 'nomor_dada')::integer and not batal;
+      if not found then
+        raise exception 'nomor dada tidak dikenal / regu batal';
+      end if;
+
+      -- Komponen: HANYA pos ini (kode boleh kembar antar pos — temuan
+      -- review); normalisasi dua arah supaya "Lari Zigzag" dari header foto
+      -- cocok dengan kode lari_zigzag.
+      select w.* into v_wahana from wahana w
+      where w.edisi = edisi_aktif()
+        and w.pos = v_pos
+        and regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g')
+            = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+      if not found then
+        raise exception 'kode komponen tidak dikenal di pos % — mungkin ini lembar pos lain?', v_pos;
+      end if;
+
+      -- Rentang wajar dari konfigurasi (merah di preview = tolak di server).
+      if v_n1 is null
+         or v_n1 not between v_wahana.rentang_mentah_min and v_wahana.rentang_mentah_maks then
+        raise exception 'nilai % di luar rentang wajar %-%',
+          coalesce(v_r ->> 'nilai_1', '(kosong)'),
+          v_wahana.rentang_mentah_min, v_wahana.rentang_mentah_maks;
+      end if;
+      -- nilai_2 (jumlah salah) ikut divalidasi (temuan review).
+      if v_n2 is not null
+         and v_n2 not between 0 and v_wahana.rentang_mentah_maks then
+        raise exception 'nilai_2 % di luar rentang 0-%', v_n2, v_wahana.rentang_mentah_maks;
+      end if;
+
+      insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, sumber, diinput_oleh)
+      values (v_regu.id, v_wahana.id, v_n1, v_n2, p_sumber, auth.uid())
+      on conflict (regu_id, wahana_id) do update set
+        nilai_1 = excluded.nilai_1,
+        nilai_2 = excluded.nilai_2,
+        sumber  = excluded.sumber,
+        diinput_oleh = excluded.diinput_oleh,
+        diinput_pada = now()
+      -- Simpan ulang tanpa perubahan = tidak menulis apa pun: kepengarangan
+      -- tidak tergeser, riwayat tidak dibanjiri (temuan review).
+      where nilai_mentah.nilai_1 is distinct from excluded.nilai_1
+         or nilai_mentah.nilai_2 is distinct from excluded.nilai_2;
+
+    exception when others then
+      v_status := 'ditolak';
+      v_alasan := sqlerrm;
+    end;
+
+    v_hasil := v_hasil || jsonb_build_object(
+      'baris', v_idx,
+      'nomor_dada', v_r ->> 'nomor_dada',
+      'kode', v_r ->> 'kode',
+      'status', v_status,
+      'alasan', v_alasan);
+  end loop;
+
+  return v_hasil;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 9. catat_closing — upsert per regu; pemanggilan ulang = edit yang sah.
+--    Jam datang WAJIB dari argumen (alur 12.3-12.4).
+-- ---------------------------------------------------------------------------
+
+create or replace function catat_closing(
+  p_nomor_dada    integer,
+  p_jam_datang    timestamptz,
+  p_anggota_hadir smallint default 5,
+  p_catatan       text default null
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu regu%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jam_datang is null then
+    raise exception 'jam datang wajib diketik';
+  end if;
+
+  select * into v_regu from regu where nomor_dada = p_nomor_dada;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+  if v_regu.batal then
+    raise exception 'regu % berstatus batal', p_nomor_dada;
+  end if;
+  if not exists (select 1 from keberangkatan_regu where regu_id = v_regu.id) then
+    raise exception 'regu % belum tercatat berangkat', p_nomor_dada;
+  end if;
+
+  insert into closing_regu (regu_id, jam_datang, anggota_hadir, dicatat_oleh, catatan)
+  values (v_regu.id, p_jam_datang, p_anggota_hadir, auth.uid(), p_catatan)
+  on conflict (regu_id) do update set
+    jam_datang    = excluded.jam_datang,
+    anggota_hadir = excluded.anggota_hadir,
+    dicatat_oleh  = excluded.dicatat_oleh,
+    dicatat_pada  = now(),
+    catatan       = excluded.catatan
+  -- Simpan ulang tanpa perubahan tidak menulis (kepengarangan & riwayat).
+  where closing_regu.jam_datang    is distinct from excluded.jam_datang
+     or closing_regu.anggota_hadir is distinct from excluded.anggota_hadir
+     or closing_regu.catatan       is distinct from excluded.catatan;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 10. ceklis_berangkat — ceklis per regu di garis start (alur 6.5);
+--     pasangannya batal_ceklis untuk koreksi.
+-- ---------------------------------------------------------------------------
+
+create or replace function ceklis_berangkat(p_nomor_dada integer)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  select id into v_id from regu where nomor_dada = p_nomor_dada and not batal;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal / batal', p_nomor_dada;
+  end if;
+  -- Ceklis MENYUSUL (kloter sudah berangkat) wajib berkontrak dulu — tanpa
+  -- ini regu lolos penalti waktu selamanya (temuan review, blocker).
+  if exists (
+       select 1 from regu r
+       join kloter k on k.nomor = r.kloter_nomor
+       where r.id = v_id and k.jam_berangkat is not null
+         and r.kontrak_menit is null) then
+    raise exception 'kloter sudah berangkat dan regu belum berkontrak — konfirmasi kontrak dulu (admin)';
+  end if;
+  insert into keberangkatan_regu (regu_id, dicatat_oleh)
+  values (v_id, auth.uid())
+  on conflict (regu_id) do nothing;
+end;
+$$;
+
+create or replace function batal_ceklis_berangkat(p_nomor_dada integer)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  select id into v_id from regu where nomor_dada = p_nomor_dada;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+  delete from keberangkatan_regu where regu_id = v_id;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 11. susun_barak — idempotent: hapus + hitung ulang + tulis
+--     (rancangan-b.md bagian 4). Urut sekolah terbesar; utamakan satu sekolah
+--     satu ruangan; sekolah besar boleh pecah; gabung hanya bila terpaksa.
+-- ---------------------------------------------------------------------------
+
+create or replace function susun_barak()
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_b   record;
+  v_r   record;
+  v_sisa integer;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+
+  delete from penempatan_barak;
+
+  -- Kebutuhan per batch: regu aktif x 5 + pendamping, terbesar dulu.
+  for v_b in
+    select d.id, (count(r.id) filter (where not r.batal)) * 5
+           + d.jumlah_pendamping as butuh
+    from pendaftaran d
+    join regu r on r.pendaftaran_id = d.id
+    where d.butuh_barak and d.status = 'lunas'
+    group by d.id, d.jumlah_pendamping
+    having (count(r.id) filter (where not r.batal)) > 0
+    order by butuh desc
+  loop
+    v_sisa := v_b.butuh;
+
+    -- Urutan prioritas per sisa (temuan review: "pas-dulu" yang lama justru
+    -- memecah sekolah yang sebenarnya muat satu ruangan):
+    --   1) ruangan KOSONG terkecil yang MUAT seluruh sisa  -> 1 sekolah 1 ruangan
+    --   2) ruangan KOSONG terbesar                          -> pecah seminimal mungkin
+    --   3) sisa ruangan BERPENGHUNI terkecil yang muat      -> gabung, terpaksa
+    --   4) sisa ruangan BERPENGHUNI terbesar                -> gabung + pecah
+    while v_sisa > 0 loop
+      select * into v_r from (
+        select ru.id,
+               ru.kapasitas - coalesce((select sum(p.jumlah_orang)
+                 from penempatan_barak p where p.ruangan_id = ru.id), 0) as longgar,
+               not exists (select 1 from penempatan_barak p
+                           where p.ruangan_id = ru.id) as kosong
+        from ruangan ru
+      ) x
+      where x.longgar > 0
+      order by
+        case
+          when x.kosong and x.longgar >= v_sisa then 1
+          when x.kosong                          then 2
+          when x.longgar >= v_sisa               then 3
+          else 4
+        end,
+        case when x.longgar >= v_sisa then x.longgar end asc,   -- paling pas
+        x.longgar desc                                          -- paling lapang
+      limit 1;
+
+      if v_r.id is null then
+        raise exception 'kapasitas barak kurang % orang untuk batch % — tambah ruangan',
+          v_sisa, v_b.id;
+      end if;
+
+      insert into penempatan_barak (pendaftaran_id, ruangan_id, jumlah_orang)
+      values (v_b.id, v_r.id, least(v_sisa, v_r.longgar));
+      v_sisa := v_sisa - least(v_sisa, v_r.longgar);
+      v_r := null;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 11b. ubah_pendamping — meja melengkapi jumlah pendamping saat daftar ulang
+--      (form publik boleh mengisinya, meja boleh mengoreksi).
+-- ---------------------------------------------------------------------------
+
+create or replace function ubah_pendamping(p_kode text, p_jumlah smallint)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jumlah is null or p_jumlah < 0 then
+    raise exception 'jumlah pendamping tidak sah';
+  end if;
+  update pendaftaran set jumlah_pendamping = p_jumlah
+  where kode_pembayaran = p_kode;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 12. Eksekusi: hanya authenticated (panitia). Anon TIDAK bisa memanggil apa
+--     pun — submit_pendaftaran dipanggil gerbang Worker memakai service role.
+-- ---------------------------------------------------------------------------
+
+-- Temuan review (blocker): grant massal "all functions to authenticated"
+-- membuka submit_pendaftaran ke SEMUA akun login — melompati gerbang
+-- Turnstile. Model baru: cabut semuanya, beri per fungsi secara eksplisit;
+-- fungsi baru TIDAK PERNAH terekspos otomatis.
+revoke execute on all functions in schema public from public, anon, authenticated;
+
+-- Helper yang dievaluasi policy RLS / view oleh peran pemanggil.
+grant execute on function peran() to authenticated;
+grant execute on function pos_saya() to authenticated;
+grant execute on function edisi_aktif() to authenticated, service_role;
+grant execute on function hitung_poin(text, numeric, numeric, numeric,
+  numeric, numeric, numeric, numeric, numeric) to authenticated, service_role;
+
+-- RPC panitia (peran dicek lagi DI DALAM fungsi masing-masing).
+grant execute on function verifikasi_pembayaran(text, integer, text)        to authenticated;
+grant execute on function batalkan_verifikasi(text, text)                   to authenticated;
+grant execute on function daftar_ulang_batch(text)                          to authenticated;
+grant execute on function tukar_nomor_dada(uuid, integer, text)             to authenticated;
+grant execute on function konfirmasi_kontrak(uuid, smallint)                to authenticated;
+grant execute on function berangkatkan_kloter(smallint, timestamptz)        to authenticated;
+grant execute on function batalkan_keberangkatan(smallint, text)            to authenticated;
+grant execute on function ceklis_berangkat(integer)                         to authenticated;
+grant execute on function batal_ceklis_berangkat(integer)                   to authenticated;
+grant execute on function simpan_nilai_massal(jsonb, text, smallint)        to authenticated;
+grant execute on function catat_closing(integer, timestamptz, smallint, text) to authenticated;
+grant execute on function susun_barak()                                     to authenticated;
+grant execute on function ubah_pendamping(text, smallint)                   to authenticated;
+
+-- submit_pendaftaran HANYA untuk gerbang Worker (service role). Akun login
+-- yang mendaftarkan sekolah di meja offline tetap lewat form publik yang
+-- sama (link sama, alur 3.6) — bukan lewat RPC langsung.
+grant execute on function submit_pendaftaran(text, text, boolean, text, jsonb, smallint)
+  to service_role;

--- a/supabase/migrations/0005_views.sql
+++ b/supabase/migrations/0005_views.sql
@@ -1,0 +1,297 @@
+-- ============================================================================
+-- hrcd-rekap : 0005_views.sql
+-- Rantai view hitung-saat-baca. Acuan: docs/rancangan-b.md bagian 5.
+--
+-- Tidak ada angka turunan yang disimpan: tidak ada job rekap, tidak ada cache
+-- basi, tidak ada tombol "hitung ulang". Edit konfigurasi langsung berlaku
+-- pada muat ulang layar berikutnya.
+--
+-- security_invoker = on: view tunduk pada RLS pemanggil — kecuali
+-- v_progres_publik dan v_klasemen_publik yang dibaca service role
+-- (GitHub Actions) dan memang tidak berisi PII.
+-- ============================================================================
+
+-- 1. Poin per komponen: nilai mentah -> poin (mesin konversi).
+create view v_poin_wahana with (security_invoker = on) as
+select
+  n.regu_id,
+  w.pos,
+  w.id   as wahana_id,
+  w.kode,
+  n.nilai_1,
+  n.nilai_2,
+  hitung_poin(w.bentuk, n.nilai_1, n.nilai_2, w.poin_maks,
+              w.raw_terbaik, w.raw_terburuk,
+              w.poin_benar, w.poin_salah, w.total_soal) as poin
+from nilai_mentah n
+join wahana w on w.id = n.wahana_id
+where w.edisi = edisi_aktif();
+
+-- 2. Poin per pos: jumlah komponen x bobot pos. Pos terlewat menyumbang 0
+--    lewat LEFT JOIN di v_total_skor — tanpa pengurangan tambahan (alur 10.8).
+create view v_poin_pos with (security_invoker = on) as
+select
+  pw.regu_id,
+  pw.pos,
+  round(sum(pw.poin) * p.bobot, 2) as poin_pos
+from v_poin_wahana pw
+join pos p on p.edisi = edisi_aktif() and p.nomor = pw.pos
+group by pw.regu_id, pw.pos, p.bobot;
+
+-- 3. Penalti waktu: target = jam berangkat kloter + kontrak; selisih presisi
+--    menit (tie-break); penalti = floor(|selisih| / blok) * per_blok —
+--    simetris; toleransi 0-9 menit LAHIR DARI floor, bukan aturan tersendiri.
+create view v_penalti_waktu with (security_invoker = on) as
+select
+  r.id as regu_id,
+  k.jam_berangkat,
+  r.kontrak_menit,
+  c.jam_datang,
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+            and c.jam_datang is not null
+    then round(extract(epoch from (
+           c.jam_datang - (k.jam_berangkat + make_interval(mins => r.kontrak_menit))
+         )) / 60)::int
+  end as selisih_menit,   -- bertanda: negatif = kecepatan, positif = telat
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+            and c.jam_datang is not null
+    -- floor pada menit MENTAH, bukan hasil pembulatan: 9m30s adalah selisih
+    -- 9,5 menit = penalti 0; membulatkan dulu ke 10 lalu mem-floor akan
+    -- menghukum regu yang sebenarnya masih di dalam blok (temuan review).
+    then floor((abs(extract(epoch from (
+           c.jam_datang - (k.jam_berangkat + make_interval(mins => r.kontrak_menit))
+         ))) / 60.0) / kp.blok_menit) * kp.penalti_per_blok
+    else 0
+  end as penalti_waktu
+from regu r
+left join kloter k        on k.nomor = r.kloter_nomor
+left join closing_regu c  on c.regu_id = r.id
+cross join konfig_penalti kp
+where kp.edisi = edisi_aktif();
+
+-- 4. Total skor per regu: seluruh pos - seluruh pengurangan (alur 9.3, 10).
+--    -100 tanpa checkout dihitung DI SINI (tidak ada baris closing => kena;
+--    penalti waktu saat itu 0 karena tak terhitung). -20 per anggota hilang.
+create view v_total_skor with (security_invoker = on) as
+select
+  r.id            as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama          as nama_sekolah,
+  r.golongan,
+  -- Pos terlewat menyumbang nilai_pos_terlewat per pos (knob konfigurasi;
+  -- default 0 — temuan review: sebelumnya knob ini mati).
+  coalesce(pp.total_pos, 0)
+    + (( (select count(*) from pos p where p.edisi = edisi_aktif())
+         - coalesce(pp.jumlah_pos, 0) ) * kp.nilai_pos_terlewat)
+                                                  as total_pos,
+  pw.penalti_waktu,
+  case when c.regu_id is null then kp.penalti_tanpa_checkout else 0 end
+                                                  as penalti_checkout,
+  case when c.regu_id is not null
+    then (5 - c.anggota_hadir) * kp.penalti_per_anggota_hilang else 0 end
+                                                  as penalti_anggota,
+  coalesce(pp.total_pos, 0)
+    + (( (select count(*) from pos p where p.edisi = edisi_aktif())
+         - coalesce(pp.jumlah_pos, 0) ) * kp.nilai_pos_terlewat)
+    - pw.penalti_waktu
+    - case when c.regu_id is null then kp.penalti_tanpa_checkout else 0 end
+    - case when c.regu_id is not null
+        then (5 - c.anggota_hadir) * kp.penalti_per_anggota_hilang else 0 end
+                                                  as total,
+  pw.selisih_menit
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join (select regu_id, sum(poin_pos) as total_pos, count(*) as jumlah_pos
+           from v_poin_pos group by regu_id) pp on pp.regu_id = r.id
+join v_penalti_waktu pw  on pw.regu_id = r.id
+left join closing_regu c on c.regu_id = r.id
+cross join konfig_penalti kp
+where kp.edisi = edisi_aktif()
+  and not r.batal
+  -- Batch yang mundur dari 'lunas' ikut keluar dari seluruh penilaian
+  -- (temuan review).
+  and d.status = 'lunas';
+
+-- 5. Klasemen: empat golongan terpisah; tie-break ketepatan waktu presisi
+--    menit sudah tertanam di ORDER BY. Regu batal / tak pernah berangkat
+--    tidak ikut diperingkat (rancangan-b.md 11.12).
+create view v_klasemen with (security_invoker = on) as
+select
+  rank() over (partition by t.golongan
+               order by t.total desc, abs(coalesce(t.selisih_menit, 100000)) asc)
+    as peringkat,
+  t.*
+from v_total_skor t
+where exists (select 1 from keberangkatan_regu kb where kb.regu_id = t.regu_id)
+  -- Ceklis saja belum cukup — jam yang dinilai milik kloter; regu yang
+  -- kloternya belum pernah berangkat tidak diperingkat (temuan review).
+  and exists (select 1 from regu r join kloter k on k.nomor = r.kloter_nomor
+              where r.id = t.regu_id and k.jam_berangkat is not null);
+
+-- 6. Monitoring input: matriks regu x pos — pos mana sudah menyetor untuk
+--    regu mana (alur 8.7).
+create view v_monitoring_input with (security_invoker = on) as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  r.golongan,
+  r.kloter_nomor,
+  p.nomor as pos,
+  exists (select 1 from nilai_mentah n
+          join wahana w on w.id = n.wahana_id
+          where n.regu_id = r.id and w.pos = p.nomor) as sudah_input,
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.pos = p.nomor) as jumlah_komponen_terisi,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.batal
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  -- Operator pos hanya melihat kolom pos-nya: RLS nilai_mentah membuat
+  -- kolom pos lain SELALU tampak kosong — tampilan palsu lebih buruk
+  -- daripada tampilan sempit (temuan review).
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya());
+
+-- 7. Papan garis start: posisi pipeline DITURUNKAN dari kloter terakhir yang
+--    berangkat (rancangan-b.md 11.5) — tidak ada status yang digeser manual.
+--    N terakhir berangkat => N+1..N+2 siap, N+3 konfirmasi kontrak.
+create view v_keberangkatan with (security_invoker = on) as
+with terakhir as (
+  select coalesce(max(nomor), 0) as n
+  from kloter where jam_berangkat is not null
+)
+select
+  k.nomor,
+  k.jam_berangkat,
+  case
+    when k.jam_berangkat is not null            then 'berangkat'
+    when k.nomor <= t.n + 2                     then 'siap'
+    when k.nomor =  t.n + 3                     then 'konfirmasi_kontrak'
+    else 'menunggu'
+  end as posisi,
+  (select count(*) from regu r
+   where r.kloter_nomor = k.nomor and not r.batal) as jumlah_regu,
+  (select count(*) from regu r
+   join keberangkatan_regu kb on kb.regu_id = r.id
+   where r.kloter_nomor = k.nomor)               as sudah_ceklis,
+  (select count(*) from regu r
+   where r.kloter_nomor = k.nomor and not r.batal
+     and r.kontrak_menit is not null)            as sudah_kontrak
+from kloter k
+cross join terakhir t
+where exists (select 1 from regu r where r.kloter_nomor = k.nomor)
+   or k.jam_berangkat is not null;
+
+-- 8. Lembar nilai cetak per pos: identitas terisi, kolom nilai kosong untuk
+--    petugas; urut nomor dada — urutan kanonik (rancangan-b.md 11.13).
+--    Header kolom diambil layar cetak dari wahana.kode pos bersangkutan.
+create view v_lembar_nilai with (security_invoker = on) as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama as nama_sekolah,
+  r.golongan
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+where not r.batal and r.nomor_dada is not null and d.status = 'lunas'
+order by r.nomor_dada;
+
+-- 9. Kwitansi cetak per batch.
+create view v_kwitansi with (security_invoker = on) as
+select
+  b.nomor_kwitansi,
+  d.kode_pembayaran,
+  s.nama   as nama_sekolah,
+  s.alamat as alamat_sekolah,
+  d.jumlah_regu,
+  b.nominal,
+  b.metode,
+  b.diverifikasi_pada,
+  (select jsonb_agg(jsonb_build_object(
+            'nama_regu', r.nama_regu, 'golongan', r.golongan)
+          order by r.nama_regu)
+   from regu r where r.pendaftaran_id = d.id) as daftar_regu
+from pembayaran b
+join pendaftaran d on d.id = b.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id;
+
+-- 10. Okupansi barak.
+create view v_barak with (security_invoker = on) as
+select
+  ru.nama       as ruangan,
+  ru.kapasitas,
+  coalesce(sum(p.jumlah_orang), 0)                as terisi,
+  ru.kapasitas - coalesce(sum(p.jumlah_orang), 0) as sisa,
+  coalesce(jsonb_agg(jsonb_build_object(
+             'sekolah', s.nama, 'orang', p.jumlah_orang))
+           filter (where p.id is not null), '[]') as penghuni
+from ruangan ru
+left join penempatan_barak p on p.ruangan_id = ru.id
+left join pendaftaran d      on d.id = p.pendaftaran_id
+left join sekolah s          on s.id = d.sekolah_id
+group by ru.id, ru.nama, ru.kapasitas;
+
+-- 11. View publik — dibaca HANYA oleh service role (GitHub Actions), tanpa
+--     PII, isinya mengikuti fase_live (rancangan-b.md bagian 7).
+--     fase 'pra':     baris kosong (halaman menampilkan hitungan pendaftar
+--                     dari v_publik_ringkas).
+--     fase 'progres': per regu tanpa angka — hanya pos mana yang sudah lewat.
+--     fase 'penuh':   klasemen lengkap.
+create view v_progres_publik as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama as nama_sekolah,
+  r.golongan,
+  (select jsonb_object_agg(p.nomor::text,
+            exists (select 1 from nilai_mentah n
+                    join wahana w on w.id = n.wahana_id
+                    where n.regu_id = r.id and w.pos = p.nomor))
+   from pos p where p.edisi = edisi_aktif())     as pos_terlewati,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+where not r.batal
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+  and (select fase_live from status_acara) in ('progres', 'penuh');
+
+create view v_klasemen_publik as
+select peringkat, nomor_dada, nama_regu, nama_sekolah, golongan,
+       total_pos, penalti_waktu, penalti_checkout, penalti_anggota, total
+from v_klasemen
+where (select fase_live from status_acara) = 'penuh';
+
+create view v_publik_ringkas as
+select
+  (select fase_live from status_acara) as fase_live,
+  (select count(*) from regu r
+   join pendaftaran d on d.id = r.pendaftaran_id
+   where d.status = 'lunas' and not r.batal) as jumlah_regu_lunas,
+  (select jsonb_object_agg(golongan, jumlah) from (
+     select golongan, count(*) as jumlah
+     from regu r join pendaftaran d on d.id = r.pendaftaran_id
+     where d.status = 'lunas' and not r.batal
+     group by golongan) g) as per_golongan;
+
+-- View panitia: grant eksplisit (dibuat setelah grant massal di 0003).
+-- service_role ikut karena rantai view publik melewatinya.
+grant select on v_poin_wahana, v_poin_pos, v_penalti_waktu, v_total_skor,
+  v_klasemen, v_monitoring_input, v_keberangkatan, v_lembar_nilai,
+  v_kwitansi, v_barak to authenticated, service_role;
+
+-- View publik tidak untuk klien anon/authenticated — hanya service role
+-- (GitHub Actions memakai service key).
+revoke all on v_progres_publik, v_klasemen_publik, v_publik_ringkas
+  from anon, authenticated;
+grant select on v_progres_publik, v_klasemen_publik, v_publik_ringkas
+  to service_role;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- hrcd-rekap : seed.sql
+-- Konfigurasi edisi 37 (contoh angka dari docs/rancangan-b.md 2.2) + baris
+-- wajib: status_acara, kloter 1-40, stok nomor dada 1-500.
+-- ============================================================================
+
+insert into edisi (nomor, nama, tahun, tanggal_lomba, biaya_per_regu,
+                   maks_regu_per_kloter, kloter_dasar, kloter_maks,
+                   lompatan_kloter, interval_berangkat_menit, aktif)
+values (37, 'HRCD 37', 2027, date '2027-02-21', 250000, 10, 30, 40, 2, 4, true);
+
+insert into pos (edisi, nomor, nama, bobot) values
+  (37, 1, 'Pos 1', 1.00),
+  (37, 2, 'Pos 2', 1.00),
+  (37, 3, 'Pos 3', 1.00),
+  (37, 4, 'Pos 4', 1.00),
+  (37, 5, 'Pos 5', 1.00);
+
+-- Satu contoh per bentuk konversi — angka persis dari rancangan-b.md supaya
+-- tes bisa mencocokkan hasil hitung dengan dokumen.
+insert into wahana (edisi, pos, kode, nama, jenis, bentuk, poin_maks,
+                    raw_terbaik, raw_terburuk, poin_benar, poin_salah,
+                    total_soal, rentang_mentah_min, rentang_mentah_maks, urutan)
+values
+  -- raw 40 detik => 100 * (90-40)/(90-20) = 71.43
+  (37, 1, 'lari_zigzag',  'Lari Zig-zag',        'wahana', 'kecil_baik', 100,
+   20, 90, null, null, null, 5, 300, 1),
+  -- raw 3 kena dari maks 5 => 100 * (3-0)/(5-0) = 60
+  (37, 2, 'lempar_sasaran', 'Lempar Sasaran',    'wahana', 'besar_baik', 100,
+   5, 0, null, null, null, 0, 5, 1),
+  -- centang => 50, tidak => 0
+  (37, 3, 'impk',          'IMPK',               'soal',   'biner', 50,
+   null, null, 50, 0, null, 0, 1, 1),
+  -- 7 benar dari 10 => 100 * 7/10 = 70
+  (37, 4, 'soal_umum',     'Soal Pengetahuan',   'soal',   'benar_per_total', 100,
+   null, null, null, null, 10, 0, 10, 1),
+  -- benar +10, salah -5 (poin_salah negatif), clamp [0, 100]
+  (37, 5, 'sandi_morse',   'Sandi Morse',        'soal',   'benar_kurang_salah', 100,
+   null, null, 10, -5, null, 0, 20, 1);
+
+insert into kontrak_opsi (edisi, label, menit, urutan) values
+  (37, '3,5 jam', 210, 1),
+  (37, '4 jam',   240, 2),
+  (37, '4,5 jam', 270, 3);
+
+insert into konfig_penalti (edisi, blok_menit, penalti_per_blok,
+                            penalti_tanpa_checkout, penalti_per_anggota_hilang,
+                            nilai_pos_terlewat)
+values (37, 10, 10, 100, 20, 0);
+
+-- Saklar hari-H: satu baris.
+insert into status_acara (id) values (true);
+
+-- 40 kloter (30 dasar + 31-40 cadangan).
+insert into kloter (nomor) select generate_series(1, 40);
+
+-- Stok nomor dada fisik 1-500.
+insert into nomor_dada_stok (nomor) select generate_series(1, 500);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ============================================================================
+# hrcd-rekap : tests/run.sh
+# Jalankan seluruh migrasi + seed + tes di database lokal sekali pakai.
+#
+# Pakai:
+#   PSQL=/path/ke/psql PGHOST=127.0.0.1 PGPORT=55432 PGUSER=postgres \
+#   PGPASSWORD=... bash tests/run.sh
+#
+# Database hrcd_test di-drop dan dibuat ulang setiap kali — aman diulang.
+# ============================================================================
+set -euo pipefail
+
+PSQL="${PSQL:-psql}"
+export PGHOST="${PGHOST:-127.0.0.1}" PGPORT="${PGPORT:-55432}" PGUSER="${PGUSER:-postgres}"
+DB=hrcd_test
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+"$PSQL" -d postgres -v ON_ERROR_STOP=1 -q \
+  -c "drop database if exists $DB;" \
+  -c "create database $DB;"
+
+run() { echo "-- $1"; "$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q -f "$ROOT/$1"; }
+
+run tests/sql/00_harness.sql
+run supabase/migrations/0001_schema.sql
+run supabase/migrations/0002_functions.sql
+run supabase/migrations/0003_rls.sql
+run supabase/migrations/0004_rpcs.sql
+run supabase/migrations/0005_views.sql
+run supabase/seed.sql
+run tests/sql/01_seed_uji.sql
+run tests/sql/02_constraints.sql
+run tests/sql/03_alur.sql
+
+echo "SEMUA TES LULUS"

--- a/tests/sql/00_harness.sql
+++ b/tests/sql/00_harness.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/00_harness.sql
+-- Tiruan lingkungan Supabase untuk PostgreSQL polos, supaya migrasi bisa
+-- diuji lokal tanpa Docker: schema auth + auth.uid() + peran anon /
+-- authenticated / service_role.
+--
+-- auth.uid() Supabase membaca klaim JWT; tiruan ini membaca setting sesi
+-- app.uid — tes berpindah identitas dengan:
+--   set local app.uid = '<uuid>';  set local role authenticated;
+-- ============================================================================
+
+create schema if not exists auth;
+
+create table if not exists auth.users (
+  id uuid primary key,
+  email text unique
+);
+
+create or replace function auth.uid()
+returns uuid
+language sql stable
+as $$
+  select nullif(current_setting('app.uid', true), '')::uuid
+$$;
+
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then
+    create role anon nologin;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then
+    create role service_role nologin bypassrls;
+  end if;
+end;
+$$;
+
+grant usage on schema auth to anon, authenticated, service_role;
+grant select on auth.users to authenticated, service_role;
+grant anon, authenticated, service_role to current_user;

--- a/tests/sql/01_seed_uji.sql
+++ b/tests/sql/01_seed_uji.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/01_seed_uji.sql
+-- Akun uji + data contoh yang dipakai seluruh berkas tes.
+-- ============================================================================
+
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-00000000000a', 'admin.ciradyka@uji.local'),
+  ('00000000-0000-0000-0000-000000000001', 'pos1hrcd37@uji.local'),
+  ('00000000-0000-0000-0000-000000000002', 'pos2hrcd37@uji.local'),
+  ('00000000-0000-0000-0000-0000000000b1', 'meja1hrcd37@uji.local'),
+  ('00000000-0000-0000-0000-0000000000b2', 'meja2hrcd37@uji.local'),
+  ('00000000-0000-0000-0000-0000000000ff', 'nonaktif@uji.local');
+
+insert into akun_panitia (user_id, username, peran, pos, aktif) values
+  ('00000000-0000-0000-0000-00000000000a', 'admin.ciradyka', 'admin',        null, true),
+  ('00000000-0000-0000-0000-000000000001', 'pos1hrcd37',     'operator_pos', 1,    true),
+  ('00000000-0000-0000-0000-000000000002', 'pos2hrcd37',     'operator_pos', 2,    true),
+  ('00000000-0000-0000-0000-0000000000b1', 'meja1hrcd37',    'meja',         null, true),
+  ('00000000-0000-0000-0000-0000000000b2', 'meja2hrcd37',    'meja',         null, true),
+  ('00000000-0000-0000-0000-0000000000ff', 'lama_hrcd36',    'meja',         null, false);

--- a/tests/sql/02_constraints.sql
+++ b/tests/sql/02_constraints.sql
@@ -1,0 +1,136 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/02_constraints.sql
+-- Bukti tahap 1 (rancangan-b.md 13): constraint menegakkan kebenaran data.
+-- Setiap blok gagal = RAISE EXCEPTION = psql keluar dengan error
+-- (ON_ERROR_STOP di runner).
+-- ============================================================================
+
+\echo '== 02: constraint =='
+
+-- 2.1 Nomor dada ganda MUSTAHIL.
+do $$
+declare
+  v_batch uuid; v_r1 uuid; v_r2 uuid;
+begin
+  insert into sekolah (nama, alamat) values ('SMP Uji Constraint', 'Jl. Uji 1')
+  returning id into strict v_batch;  -- dipakai ulang sbg penampung sementara
+  insert into pendaftaran (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa)
+  values (v_batch, 'UJI-DUP', 2, '0812xxxx') returning id into strict v_batch;
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, nomor_dada, kloter_nomor, urutan_kloter)
+  values (v_batch, 'Uji A', 'Ketua A', 'penegak_pa', 401, 39, 1) returning id into v_r1;
+
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, nomor_dada, kloter_nomor, urutan_kloter)
+    values (v_batch, 'Uji B', 'Ketua B', 'penegak_pa', 401, 39, 2);
+    raise exception 'GAGAL: nomor dada ganda diterima';
+  exception when unique_violation then
+    null;  -- yang diharapkan
+  end;
+end;
+$$;
+
+-- 2.2 Kapasitas kloter: urutan ke-11 tertolak CHECK; urutan kembar tertolak
+--     UNIQUE (kloter, urutan).
+do $$
+declare v_batch uuid;
+begin
+  select p.id into v_batch from pendaftaran p where kode_pembayaran = 'UJI-DUP';
+
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, nomor_dada, kloter_nomor, urutan_kloter)
+    values (v_batch, 'Uji C', 'Ketua C', 'penegak_pa', 402, 39, 11);
+    raise exception 'GAGAL: urutan kloter 11 diterima';
+  exception when check_violation then null;
+  end;
+
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, nomor_dada, kloter_nomor, urutan_kloter)
+    values (v_batch, 'Uji D', 'Ketua D', 'penegak_pa', 403, 39, 1);
+    raise exception 'GAGAL: urutan kloter kembar diterima';
+  exception when unique_violation then null;
+  end;
+end;
+$$;
+
+-- 2.3 Nomor dada dan kloter lahir bersama.
+do $$
+declare v_batch uuid;
+begin
+  select p.id into v_batch from pendaftaran p where kode_pembayaran = 'UJI-DUP';
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, nomor_dada)
+    values (v_batch, 'Uji E', 'Ketua E', 'penegak_pa', 404);
+    raise exception 'GAGAL: nomor dada tanpa kloter diterima';
+  exception when check_violation then null;
+  end;
+end;
+$$;
+
+-- 2.4 Konfigurasi salah bentuk tertolak sejak insert.
+do $$
+begin
+  begin
+    insert into wahana (edisi, pos, kode, nama, jenis, bentuk, poin_maks,
+                        rentang_mentah_min, rentang_mentah_maks)
+    values (37, 1, 'salah_param', 'Tanpa Raw', 'wahana', 'kecil_baik', 100, 0, 10);
+    raise exception 'GAGAL: kecil_baik tanpa raw_terbaik/terburuk diterima';
+  exception when check_violation then null;
+  end;
+
+  begin
+    insert into wahana (edisi, pos, kode, nama, jenis, bentuk, poin_maks,
+                        poin_benar, poin_salah, rentang_mentah_min, rentang_mentah_maks)
+    values (37, 1, 'Kode Spasi!', 'Kode Jelek', 'wahana', 'biner', 10, 10, 0, 0, 1);
+    raise exception 'GAGAL: kode berspasi diterima';
+  exception when check_violation then null;
+  end;
+end;
+$$;
+
+-- 2.5 Tepat satu edisi aktif.
+do $$
+begin
+  begin
+    insert into edisi (nomor, nama, tahun, tanggal_lomba, biaya_per_regu, aktif)
+    values (38, 'HRCD 38', 2028, date '2028-02-20', 275000, true);
+    raise exception 'GAGAL: dua edisi aktif diterima';
+  exception when unique_violation then null;
+  end;
+end;
+$$;
+
+-- 2.6 Kunci konfigurasi hari-H menolak SEMUA tulisan ke tabel konfigurasi —
+--     termasuk superuser konteks tes — sampai dibuka lagi.
+do $$
+begin
+  update status_acara set konfigurasi_terkunci = true;
+  begin
+    update wahana set poin_maks = 999 where kode = 'lari_zigzag';
+    raise exception 'GAGAL: edit konfigurasi tembus saat terkunci';
+  exception when raise_exception then null;
+  end;
+  update status_acara set konfigurasi_terkunci = false;
+  -- setelah dibuka, edit jalan lagi
+  update wahana set poin_maks = poin_maks where kode = 'lari_zigzag';
+end;
+$$;
+
+-- 2.7 akun_panitia: operator_pos wajib punya pos, peran lain wajib tidak.
+do $$
+begin
+  begin
+    insert into auth.users (id) values ('00000000-0000-0000-0000-0000000000e1');
+    insert into akun_panitia (user_id, username, peran, pos)
+    values ('00000000-0000-0000-0000-0000000000e1', 'ops_tanpa_pos', 'operator_pos', null);
+    raise exception 'GAGAL: operator_pos tanpa pos diterima';
+  exception when check_violation then null;
+  end;
+end;
+$$;
+
+-- Bersihkan artefak tes constraint.
+delete from regu where nama_regu like 'Uji %';
+delete from pendaftaran where kode_pembayaran = 'UJI-DUP';
+delete from sekolah where nama = 'SMP Uji Constraint';
+
+\echo '== 02: OK =='

--- a/tests/sql/03_alur.sql
+++ b/tests/sql/03_alur.sql
@@ -1,0 +1,576 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/03_alur.sql
+-- Alur lengkap lewat RPC + RLS + kecocokan mesin skor dengan contoh di
+-- docs/rancangan-b.md. Identitas berpindah lewat app.uid + set role.
+-- Hasil submit disimpan di tabel bantu uji_kode (psql tidak menginterpolasi
+-- variabel di dalam dollar-quote).
+-- ============================================================================
+
+\echo '== 03: alur lengkap =='
+
+create table uji_kode (label text primary key, hasil jsonb);
+grant all on uji_kode to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3.1 Pendaftaran (jalur gerbang Worker = service_role).
+--     A: 12 regu penegak_pa, butuh barak. B: 5 regu penegak_pa, butuh barak.
+--     C: 2 regu penegak_pi (uji tie-break). D: 1 regu (uji pembatalan).
+-- ---------------------------------------------------------------------------
+
+set role service_role;
+
+insert into uji_kode values ('A', submit_pendaftaran(
+  'SMAN 1 Ciamis', 'Jl. Gunung Galuh 37', true, '081200000001',
+  (select jsonb_agg(jsonb_build_object(
+     'nama_regu', format('Regu A%s', lpad(i::text, 2, '0')),
+     'nama_ketua', format('Ketua A%s', i),
+     'golongan', 'penegak_pa'))
+   from generate_series(1, 12) i)));
+
+insert into uji_kode values ('B', submit_pendaftaran(
+  'SMAN 2 Banjar', 'Jl. Raya Banjar 2', true, '081200000002',
+  (select jsonb_agg(jsonb_build_object(
+     'nama_regu', format('Regu B%s', lpad(i::text, 2, '0')),
+     'nama_ketua', format('Ketua B%s', i),
+     'golongan', 'penegak_pa'))
+   from generate_series(1, 5) i)));
+
+insert into uji_kode values ('C', submit_pendaftaran(
+  'SMAN 3 Tasikmalaya', 'Jl. Siliwangi 3', false, '081200000003',
+  '[{"nama_regu":"Cendrawasih 1","nama_ketua":"Ketua C1","golongan":"penegak_pi"},
+    {"nama_regu":"Cendrawasih 2","nama_ketua":"Ketua C2","golongan":"penegak_pi"}]'));
+
+insert into uji_kode values ('D', submit_pendaftaran(
+  'SMP Uji Batal', 'Jl. Batal 1', false, '081200000004',
+  '[{"nama_regu":"Regu D01","nama_ketua":"Ketua D1","golongan":"penggalang_pa"}]'));
+
+do $$
+declare v jsonb;
+begin
+  select hasil into strict v from uji_kode where label = 'A';
+  assert v ->> 'jumlah_regu' = '12', 'jumlah regu A salah';
+  assert (v ->> 'total_tagihan')::int = 12 * 250000, 'tagihan A salah';
+  assert v ->> 'kode_pembayaran' like 'HRCD37-%', 'format kode salah';
+
+  -- Validasi server menolak golongan liar (walau form sudah memvalidasi).
+  begin
+    perform submit_pendaftaran('X', 'X', false, '0812000000xx',
+      '[{"nama_regu":"X","nama_ketua":"X","golongan":"dewasa"}]');
+    raise exception 'GAGAL: golongan liar diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+reset role;
+
+-- Fungsi bantu pengambil kode — dipakai semua blok berikutnya.
+create function uji(p text) returns text language sql as
+  $$ select hasil ->> 'kode_pembayaran' from uji_kode where label = p $$;
+grant execute on function uji(text) to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3.2 Pembayaran (meja). Nominal kurang = tolak (semua-atau-tidak).
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+do $$
+begin
+  -- daftar ulang sebelum lunas: tolak
+  begin
+    perform daftar_ulang_batch(uji('A'));
+    raise exception 'GAGAL: daftar ulang sebelum lunas diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  -- bayar sebagian: tolak
+  begin
+    perform verifikasi_pembayaran(uji('A'), 250000 * 3, 'transfer');
+    raise exception 'GAGAL: pembayaran sebagian diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  -- bayar penuh: jalan, kwitansi terbit
+  assert (verifikasi_pembayaran(uji('A'), 250000 * 12, 'transfer')) ->> 'nomor_kwitansi'
+         like 'KW-HRCD37-%', 'kwitansi tidak terbit';
+  -- verifikasi dobel: tolak
+  begin
+    perform verifikasi_pembayaran(uji('A'), 250000 * 12, 'transfer');
+    raise exception 'GAGAL: verifikasi dobel diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  perform verifikasi_pembayaran(uji('B'), 250000 * 5, 'tunai');
+  perform verifikasi_pembayaran(uji('C'), 250000 * 2, 'transfer');
+  perform verifikasi_pembayaran(uji('D'), 250000 * 1, 'tunai');
+
+  -- Batalkan verifikasi D (salah pencet) — status kembali menunggu.
+  perform batalkan_verifikasi(uji('D'), 'salah klik saat uji');
+  assert (select status from pendaftaran where kode_pembayaran = uji('D'))
+         = 'menunggu_pembayaran', 'status D tidak kembali';
+  assert not exists (select 1 from pembayaran b
+          join pendaftaran d on d.id = b.pendaftaran_id
+          where d.kode_pembayaran = uji('D')), 'pembayaran D masih ada';
+
+  -- Akun login TIDAK bisa memanggil submit_pendaftaran — hanya gerbang
+  -- Worker (temuan review, blocker).
+  begin
+    perform submit_pendaftaran('Selundup', 'X', false, '0812999',
+      '[{"nama_regu":"S","nama_ketua":"S","golongan":"penegak_pa"}]');
+    raise exception 'GAGAL: submit_pendaftaran terbuka untuk akun login';
+  exception when insufficient_privilege then null;
+  end;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3.3 Daftar ulang batch: nomor dada + kloter sekaligus.
+-- ---------------------------------------------------------------------------
+
+do $$
+declare v_a uuid;
+begin
+  perform daftar_ulang_batch(uji('A'));
+  perform daftar_ulang_batch(uji('B'));
+  perform daftar_ulang_batch(uji('C'));
+
+  select d.id into v_a from pendaftaran d where d.kode_pembayaran = uji('A');
+
+  -- A: 12 nomor pertama, kloter semua berbeda & ganjil (lompatan 2), <= 30.
+  assert (select array_agg(nomor_dada order by nomor_dada)
+          from regu where pendaftaran_id = v_a)
+         = array[1,2,3,4,5,6,7,8,9,10,11,12], 'dada A bukan 1..12';
+  assert (select count(distinct kloter_nomor) from regu where pendaftaran_id = v_a) = 12,
+         'sekolah A menumpuk di satu kloter';
+  assert (select bool_and(kloter_nomor % 2 = 1) from regu where pendaftaran_id = v_a),
+         'lompatan 2 tidak dihormati untuk A';
+  assert (select max(kloter_nomor) from regu where pendaftaran_id = v_a) <= 30,
+         'A menyentuh kloter cadangan padahal 1-30 belum penuh';
+  -- B: tak ada dua regu B sekloter.
+  assert (select count(distinct r.kloter_nomor) = count(*)
+          from regu r join pendaftaran d on d.id = r.pendaftaran_id
+          where d.kode_pembayaran = uji('B')), 'sekolah B menumpuk';
+  -- Daftar ulang dobel: tolak.
+  begin
+    perform daftar_ulang_batch(uji('A'));
+    raise exception 'GAGAL: daftar ulang dobel diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Batalkan verifikasi SETELAH daftar ulang: tolak keras (temuan review —
+  -- mencegah regu yatim bernomor-dada-tapi-belum-bayar).
+  begin
+    perform batalkan_verifikasi(uji('C'), 'coba-coba');
+    raise exception 'GAGAL: batalkan verifikasi setelah daftar ulang diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Tukar nomor dada (nomor rusak): 17 -> 250. Nomor 17 PENSIUN dan tidak
+  -- pernah terbit ulang (temuan review: foto lama masih menulis 17).
+  perform tukar_nomor_dada((select id from regu where nomor_dada = 17), 250,
+                           'nomor sobek saat uji');
+  assert exists (select 1 from regu where nomor_dada = 250), 'tukar nomor gagal';
+  assert exists (select 1 from nomor_dada_pensiun where nomor = 17),
+         'nomor lama tidak pensiun';
+
+  -- Sekolah D menyusul: nomor berikutnya harus MELOMPATI 17 yang pensiun.
+  perform verifikasi_pembayaran(uji('D'), 250000, 'tunai');
+  perform daftar_ulang_batch(uji('D'));
+  assert (select r.nomor_dada from regu r
+          join pendaftaran d on d.id = r.pendaftaran_id
+          where d.kode_pembayaran = uji('D')) = 20,
+         'nomor pensiun 17 terbit ulang (atau urutan stok salah)';
+end;
+$$;
+
+-- Saklar tutup daftar ulang menghentikan meja.
+reset role;
+update status_acara set daftar_ulang_ditutup = true;
+set role authenticated;
+do $$
+begin
+  begin
+    perform daftar_ulang_batch(uji('D'));
+    raise exception 'GAGAL: daftar ulang tembus saat ditutup';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+reset role;
+update status_acara set daftar_ulang_ditutup = false;
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3.4 Garis start. Kloter 1 = dada 1 (A), 13 (B), 18 (C1); kloter 3 = dada
+--     2, 14, 19 (C2). Kontrak wajib sebelum berangkat; jam DIKETIK.
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  perform ceklis_berangkat(1);
+  perform ceklis_berangkat(13);
+  perform ceklis_berangkat(18);
+
+  -- Belum ada kontrak -> berangkat ditolak.
+  begin
+    perform berangkatkan_kloter(1::smallint, timestamptz '2027-02-21 07:00+07');
+    raise exception 'GAGAL: berangkat tanpa kontrak diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  -- Kontrak di luar pilihan edisi -> tolak.
+  begin
+    perform konfirmasi_kontrak((select id from regu where nomor_dada = 1), 300::smallint);
+    raise exception 'GAGAL: kontrak liar diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  perform konfirmasi_kontrak((select id from regu where nomor_dada = 1),  240::smallint);
+  perform konfirmasi_kontrak((select id from regu where nomor_dada = 13), 240::smallint);
+  perform konfirmasi_kontrak((select id from regu where nomor_dada = 18), 240::smallint);
+  perform berangkatkan_kloter(1::smallint, timestamptz '2027-02-21 07:00+07');
+
+  -- Kloter 3: hanya C2 (dada 19) — jalur no-show untuk A02/B02.
+  perform ceklis_berangkat(19);
+  perform konfirmasi_kontrak((select id from regu where nomor_dada = 19), 240::smallint);
+  perform berangkatkan_kloter(3::smallint, timestamptz '2027-02-21 07:08+07');
+
+  -- Papan turunan: setelah kloter 3 berangkat -> 5 siap, 7 menunggu.
+  assert (select posisi from v_keberangkatan where nomor = 5) = 'siap',
+         'kloter 5 seharusnya siap';
+  assert (select posisi from v_keberangkatan where nomor = 7) = 'menunggu',
+         'kloter 7 seharusnya menunggu';
+
+  -- Berangkat dobel & jam kosong: tolak.
+  begin
+    perform berangkatkan_kloter(1::smallint, timestamptz '2027-02-21 07:30+07');
+    raise exception 'GAGAL: berangkat dobel diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  begin
+    perform berangkatkan_kloter(5::smallint, null);
+    raise exception 'GAGAL: jam kosong diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  -- Melompati kloter berisi regu yang belum berangkat: tolak (temuan review
+  -- — satu ketukan salah merusak papan turunan).
+  begin
+    perform berangkatkan_kloter(7::smallint, timestamptz '2027-02-21 07:20+07');
+    raise exception 'GAGAL: lompat kloter diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Ceklis MENYUSUL (kloter 3 sudah berangkat): dada 14 belum berkontrak —
+  -- ceklis ditolak sampai kontrak diisi admin (temuan review, blocker:
+  -- tanpa ini regu lolos penalti waktu selamanya).
+  begin
+    perform ceklis_berangkat(14);
+    raise exception 'GAGAL: ceklis menyusul tanpa kontrak diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  begin
+    perform konfirmasi_kontrak((select id from regu where nomor_dada = 14), 240::smallint);
+    raise exception 'GAGAL: meja mengubah kontrak setelah kloter berangkat';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+-- Koreksi susulan oleh admin: kontrak dulu, baru ceklis jalan.
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+select konfirmasi_kontrak((select id from regu where nomor_dada = 14), 240::smallint);
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+select ceklis_berangkat(14);
+
+-- ---------------------------------------------------------------------------
+-- 3.5 Input nilai. RLS pos harus menggigit.
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+
+do $$
+declare v jsonb; v_riwayat int;
+begin
+  -- pos1: satu paste berisi baris sah + semua jenis baris bermasalah.
+  v := simpan_nilai_massal('[
+    {"nomor_dada": 1,    "kode": "lari_zigzag",    "nilai_1": 40},
+    {"nomor_dada": 18,   "kode": "lari_zigzag",    "nilai_1": 40},
+    {"nomor_dada": 19,   "kode": "lari_zigzag",    "nilai_1": 40},
+    {"nomor_dada": 9999, "kode": "lari_zigzag",    "nilai_1": 40},
+    {"nomor_dada": 1,    "kode": "lari_zigzag",    "nilai_1": 400},
+    {"nomor_dada": 1,    "kode": "lempar_sasaran", "nilai_1": 3},
+    {"nomor_dada": 18,   "kode": "Lari Zigzag",    "nilai_1": 40},
+    {"nomor_dada": 20,   "kode": "lari_zigzag",    "nilai_1": "abc"}
+  ]'::jsonb, 'upload');
+  assert v -> 0 ->> 'status' = 'tersimpan', 'baris sah 1: ' || coalesce(v -> 0 ->> 'alasan', '?');
+  assert v -> 1 ->> 'status' = 'tersimpan', 'baris sah 2 gagal';
+  assert v -> 2 ->> 'status' = 'tersimpan', 'baris sah 3 gagal';
+  assert v -> 3 ->> 'status' = 'ditolak'
+     and v -> 3 ->> 'alasan' like '%tidak dikenal%', 'dada liar lolos';
+  -- catatan: baris 5 (dada 1, 400) tertangkap sebagai baris ganda lebih dulu
+  -- (dada 1 + lari_zigzag sudah muncul di baris 1) — tetap ditolak.
+  assert v -> 4 ->> 'status' = 'ditolak', 'baris ganda/di luar rentang lolos';
+  assert v -> 5 ->> 'status' = 'ditolak'
+     and v -> 5 ->> 'alasan' like '%pos%', 'komponen pos lain lolos di pos 1';
+  -- "Lari Zigzag" ternormalisasi = lari_zigzag -> ganda terhadap baris 2.
+  assert v -> 6 ->> 'status' = 'ditolak'
+     and v -> 6 ->> 'alasan' like '%ganda%', 'normalisasi header tidak jalan';
+  -- Format angka rusak menolak BARISNYA SAJA, bukan seluruh paste.
+  assert v -> 7 ->> 'status' = 'ditolak', 'format rusak lolos';
+
+  -- Tembak tabel langsung: kini tertutup untuk SEMUA non-admin.
+  begin
+    insert into nilai_mentah (regu_id, wahana_id, nilai_1, sumber, diinput_oleh)
+    values ((select id from regu where nomor_dada = 1),
+            (select id from wahana where kode = 'lari_zigzag'),
+            3, 'manual', auth.uid());
+    raise exception 'GAGAL: tulisan langsung ke nilai_mentah tembus';
+  exception when insufficient_privilege then null;
+  end;
+
+  -- pos1 hanya melihat nilai pos-nya sendiri.
+  assert not exists (
+    select 1 from nilai_mentah n join wahana w on w.id = n.wahana_id
+    where w.pos <> 1), 'pos1 melihat nilai pos lain';
+
+  -- Timpa nilai (kuning yang disetujui): 40 -> 45 -> 40; lalu simpan ulang
+  -- nilai yang sama TIDAK menulis apa pun (riwayat tidak banjir).
+  perform simpan_nilai_massal('[{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":45}]'::jsonb, 'manual');
+  perform simpan_nilai_massal('[{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40}]'::jsonb, 'manual');
+  select count(*) into v_riwayat from riwayat where tabel = 'nilai_mentah';
+  perform simpan_nilai_massal('[{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40}]'::jsonb, 'manual');
+  assert (select count(*) from riwayat where tabel = 'nilai_mentah') = v_riwayat,
+         'simpan ulang tanpa perubahan membanjiri riwayat';
+end;
+$$;
+
+-- pos2 mengisi lempar; admin mengisi pos 3-5 dengan p_pos eksplisit.
+select set_config('app.uid', '00000000-0000-0000-0000-000000000002', false);
+select simpan_nilai_massal('[{"nomor_dada":1,"kode":"lempar_sasaran","nilai_1":3}]'::jsonb, 'upload');
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+select simpan_nilai_massal('[{"nomor_dada":1,"kode":"impk","nilai_1":1}]'::jsonb,      'upload', 3::smallint);
+select simpan_nilai_massal('[{"nomor_dada":1,"kode":"soal_umum","nilai_1":7}]'::jsonb, 'upload', 4::smallint);
+select simpan_nilai_massal('[{"nomor_dada":1,"kode":"sandi_morse","nilai_1":8,"nilai_2":3}]'::jsonb, 'upload', 5::smallint);
+
+do $$
+declare v jsonb;
+begin
+  -- Admin tanpa p_pos: tolak.
+  begin
+    perform simpan_nilai_massal('[{"nomor_dada":1,"kode":"impk","nilai_1":1}]'::jsonb, 'upload');
+    raise exception 'GAGAL: admin tanpa p_pos diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  -- nilai_2 di luar rentang: tolak (temuan review).
+  v := simpan_nilai_massal('[{"nomor_dada":1,"kode":"sandi_morse","nilai_1":8,"nilai_2":99}]'::jsonb,
+                           'upload', 5::smallint);
+  assert v -> 0 ->> 'status' = 'ditolak'
+     and v -> 0 ->> 'alasan' like '%nilai_2%', 'nilai_2 liar lolos';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3.6 Closing: jam DIKETIK, upsert = edit sah; wajib sudah berangkat.
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b2', false);
+
+do $$
+begin
+  begin
+    perform catat_closing(2, timestamptz '2027-02-21 11:00+07', 5::smallint, null);
+    raise exception 'GAGAL: closing regu belum berangkat diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Tulisan langsung ke closing (memalsukan pencatat / melompati guard):
+  -- tertutup untuk meja — hanya lewat catat_closing.
+  begin
+    insert into closing_regu (regu_id, jam_datang, dicatat_oleh)
+    values ((select id from regu where nomor_dada = 13),
+            timestamptz '2027-02-21 11:00+07', auth.uid());
+    raise exception 'GAGAL: tulisan langsung ke closing tembus';
+  exception when insufficient_privilege then null;
+  end;
+
+  -- A1: salah ketik 11:08, dikoreksi 11:18 (upsert); 4 anggota hadir.
+  perform catat_closing(1, timestamptz '2027-02-21 11:08+07', 4::smallint, null);
+  perform catat_closing(1, timestamptz '2027-02-21 11:18+07', 4::smallint, 'koreksi salah ketik');
+  -- C1: 11:11 (selisih 11). C2: target 11:08, datang 11:26 (selisih 18).
+  -- B1 (dada 13): TIDAK checkout.
+  perform catat_closing(18, timestamptz '2027-02-21 11:11+07', 5::smallint, null);
+  perform catat_closing(19, timestamptz '2027-02-21 11:26+07', 5::smallint, null);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3.7 Mesin skor: angka harus PERSIS contoh dokumen (rancangan-b.md).
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+
+do $$
+declare t record;
+begin
+  -- A1: 71.43 + 60 + 50 + 70 + 65 = 316.43; -10 (18 mnt); -20 (hadir 4).
+  select * into strict t from v_total_skor where nomor_dada = 1;
+  assert t.total_pos = 316.43,   'total pos A1 = ' || t.total_pos || ', harusnya 316.43';
+  assert t.selisih_menit = 18,   'selisih A1 = ' || t.selisih_menit || ', harusnya 18';
+  assert t.penalti_waktu = 10,   'penalti waktu A1 = ' || t.penalti_waktu;
+  assert t.penalti_checkout = 0, 'A1 kena -100 padahal checkout';
+  assert t.penalti_anggota = 20, 'penalti anggota A1 = ' || t.penalti_anggota;
+  assert t.total = 286.43,       'total A1 = ' || t.total || ', harusnya 286.43';
+
+  -- B1: tanpa checkout -> -100; penalti waktu 0 (tak terhitung).
+  select * into strict t from v_total_skor where nomor_dada = 13;
+  assert t.penalti_checkout = 100, 'B1 tidak kena -100';
+  assert t.penalti_waktu = 0,      'B1 kena penalti waktu padahal tak terhitung';
+  assert t.total = -100,           'total B1 = ' || t.total || ', harusnya -100';
+
+  -- Klasemen 4 golongan + tie-break presisi menit.
+  assert (select peringkat from v_klasemen where nomor_dada = 1)  = 1, 'A1 bukan rank 1';
+  assert (select peringkat from v_klasemen where nomor_dada = 13) = 2, 'B1 bukan rank 2';
+  assert (select total from v_klasemen where nomor_dada = 18)
+       = (select total from v_klasemen where nomor_dada = 19), 'C1/C2 harusnya seri';
+  assert (select peringkat from v_klasemen where nomor_dada = 18) = 1,
+         'tie-break gagal: C1 (|11|) harus di atas C2 (|18|)';
+  -- Regu tak pernah berangkat tidak diperingkat — tanpa -100 hantu.
+  assert not exists (select 1 from v_klasemen where nomor_dada = 2),
+         'regu tak berangkat ikut klasemen';
+
+  -- Riwayat merekam koreksi nilai & closing.
+  assert (select count(*) from riwayat
+          where tabel = 'nilai_mentah' and aksi = 'UPDATE') >= 2,
+         'riwayat timpa nilai tidak terekam';
+  assert (select count(*) from riwayat
+          where tabel = 'closing_regu' and aksi = 'UPDATE') >= 1,
+         'riwayat koreksi closing tidak terekam';
+
+  -- Monitoring.
+  assert (select sudah_input from v_monitoring_input where nomor_dada = 1 and pos = 1),
+         'monitoring: pos 1 dada 1 harusnya sudah';
+  assert not (select sudah_input from v_monitoring_input where nomor_dada = 13 and pos = 1),
+         'monitoring: pos 1 dada 13 harusnya belum';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3.8 Barak: A butuh 60 (12x5); B butuh 27 (5x5 + 2 pendamping).
+--     Ruangan 60 + 40: pas-dulu -> A = R40 penuh + sisa 20 di R60;
+--     B menggabung di sisa R60 (terpaksa).
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  perform ubah_pendamping(uji('B'), 2::smallint);
+  insert into ruangan (nama, kapasitas) values ('Kelas X-A', 50), ('Kelas X-B', 40);
+  perform susun_barak();
+
+  assert (select sum(jumlah_orang) from penempatan_barak) = 87,
+         'total penempatan barak bukan 87';
+  assert not exists (select 1 from v_barak where terisi > kapasitas),
+         'ada ruangan kelebihan muatan';
+  -- A (60 orang): tidak ada ruangan tunggal yang muat -> pecah 50 + 10.
+  assert (select count(*) from penempatan_barak p
+          join pendaftaran d on d.id = p.pendaftaran_id
+          where d.kode_pembayaran = uji('A')) = 2,
+         'sekolah besar tidak terpecah dua ruangan';
+  -- B (27 orang): tidak ada ruangan kosong tersisa -> gabung terpaksa di
+  -- sisa Kelas X-B, TANPA terpecah (algoritma muat-dulu, temuan review).
+  assert (select count(*) from penempatan_barak p
+          join pendaftaran d on d.id = p.pendaftaran_id
+          where d.kode_pembayaran = uji('B')) = 1,
+         'sekolah kecil ikut terpecah padahal muat satu ruangan';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3.9 Batas akses: akun nonaktif buta; anon hanya sekolah; view publik
+--     mengikuti fase.
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000ff', false);
+do $$
+begin
+  assert (select count(*) from regu) = 0, 'akun nonaktif masih melihat regu';
+  assert (select count(*) from nilai_mentah) = 0, 'akun nonaktif masih melihat nilai';
+end;
+$$;
+
+select set_config('app.uid', '', false);
+reset role;
+set role anon;
+do $$
+begin
+  assert (select count(*) from sekolah) > 0, 'anon tidak bisa autocomplete sekolah';
+  begin
+    perform count(*) from pendaftaran;
+    raise exception 'GAGAL: anon membaca pendaftaran';
+  exception when insufficient_privilege then null;
+  end;
+  begin
+    perform count(*) from regu;
+    raise exception 'GAGAL: anon membaca regu';
+  exception when insufficient_privilege then null;
+  end;
+end;
+$$;
+reset role;
+
+-- Fase live bertahap (dibaca service role, seperti GitHub Actions nanti).
+set role service_role;
+do $$
+begin
+  assert (select count(*) from v_progres_publik) = 0, 'progres bocor di fase pra';
+  assert (select count(*) from v_klasemen_publik) = 0, 'klasemen bocor di fase pra';
+end;
+$$;
+reset role;
+update status_acara set fase_live = 'progres';
+set role service_role;
+do $$
+begin
+  -- 5 regu ter-ceklis berangkat: dada 1, 13, 18, 19, dan 14 (menyusul).
+  assert (select count(*) from v_progres_publik) = 5,
+         'fase progres: harusnya 5 regu yang berangkat';
+  assert (select count(*) from v_klasemen_publik) = 0, 'klasemen bocor di fase progres';
+end;
+$$;
+reset role;
+update status_acara set fase_live = 'penuh';
+set role service_role;
+do $$
+begin
+  assert (select count(*) from v_klasemen_publik) = 5, 'fase penuh: harusnya 5 baris klasemen';
+end;
+$$;
+reset role;
+
+-- Lembar nilai memuat semua regu lunas bernomor: 12 + 5 + 2 + 1 = 20.
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+do $$
+begin
+  assert (select count(*) from v_lembar_nilai) = 20,
+         'v_lembar_nilai bukan 20 baris';
+end;
+$$;
+reset role;
+
+\echo '== 03: OK =='


### PR DESCRIPTION
## What

Phase 1 of `rancangan-b.md` §13 — the complete Postgres layer, **proven against a real PostgreSQL 16 instance**, not just written.

| File | Contents |
|---|---|
| `0001_schema.sql` | 19 tables; `UNIQUE(nomor_dada)` + `UNIQUE(kloter, urutan)` + paired CHECKs make the two worst corruptions physically impossible; config-shape CHECKs reject bad wahana rows at insert |
| `0002_functions.sql` | `peran()`/`pos_saya()`, the five-shape `hitung_poin`, generic audit trigger on 18 tables, config-lock trigger |
| `0003_rls.sql` | Three roles behind one link; anon holds **only** `sekolah`; all non-admin writes closed off (RPC-only) |
| `0004_rpcs.sql` | 15 transactional RPCs — `daftar_ulang_batch` (FOR UPDATE SKIP LOCKED + stride spread), `simpan_nilai_massal` (per-row protected, dup/format/range/pos validation), `catat_closing` (typed time, upsert-as-edit), start-line pipeline, barak allocator |
| `0005_views.sql` | Compute-on-read chain: raw → poin → pos → penalti (floored on raw minutes) → total → 4 klasemen with minute-precision tie-break; staged public views |
| `tests/` | Harness that fakes Supabase on plain Postgres + suites that assert the scoring arithmetic to the blueprint's exact numbers (316.43 / 286.43 / −100 / tie-break 11 vs 18) |

## How it was verified

1. Full suite run on portable PostgreSQL 16.4 — constraints, complete flow (register → pay → daftar ulang → depart → score → close → klasemen), RLS bite from three principals, anon/inactive lockout, staged live phases. **All green.**
2. Then three adversarial reviewers (security / conformance / SQL correctness) attacked the passing code: **39 findings, all blockers & majors fixed, each fix carrying a test.** Highlights: `submit_pendaftaran` is service-role-only (Turnstile can't be bypassed by any logged-in account), per-function grants, retired bib numbers never reissue, late-ceklis regu can no longer escape the time penalty, departures are ordered with an admin undo, penalties floor on raw minutes (9m30s = 0), barak fits before it splits.
3. Suite re-run after fixes: **all green again.** Deltas recorded as `rancangan-b.md` §14.

## Notes

README rewritten in Indonesian with the doc map and test instructions. Next phase: meja screens (login, form + Worker gateway, pembayaran, daftar ulang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)