### PR TITLE
fix: compact sizing so the form fits a phone

### DIFF
--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -236,6 +236,19 @@ Postgres — layar tidak pernah menulis "setengah jadi":
     lagi"; tidak ada yang hilang diam-diam.
 12. Teks UI = kalimat yang memang diucapkan operator, dengan serapan familiar
     (upload, preview, password — bukan unggah/pratinjau/kata sandi).
+13. **Ukuran dibedakan menurut konteks, bukan seragam.** Versi pertama memakai
+    ukuran "meja" (tubuh 18px, input 23px, sasaran sentuh 56px) untuk semua
+    layar; hasilnya form pendaftaran menjadi 4,1 layar HP penuh — panitia
+    mengeluh kebanyakan menggulir. Sekarang:
+    - **Tubuh 16px, input 17px, sasaran sentuh 46px** — padat di HP, masih di
+      atas ambang sentuh 44px.
+    - **Angka yang dibacakan atau dicatat tetap besar**: nomor dada di hasil
+      daftar ulang justru dinaikkan (2,3rem), kode pembayaran 2,1rem.
+    - **Batas keras: font kotak isian minimal 16px.** Di bawah itu iOS Safari
+      memaksa zoom setiap kali isian disentuh — halaman melompat-lompat, persis
+      masalah yang ingin dihindari.
+    - Hasil terukur: form pendaftaran 5 regu turun dari 3.429px menjadi
+      2.242px pada lebar 390px (**−35%**, dari 4,1 layar jadi 2,7 layar).
 
 ### 10.2 Inventaris layar
 

--- a/web/daftar.html
+++ b/web/daftar.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pendaftaran — Hiking Rally Ciradyka</title>
-  <link rel="stylesheet" href="gaya.css">
+  <link rel="stylesheet" href="gaya.css?v=2">
 </head>
 <body>
   <header class="kepala">

--- a/web/gaya.css
+++ b/web/gaya.css
@@ -1,11 +1,21 @@
 /* ============================================================================
    hrcd-rekap : gaya.css — sistem desain untuk orang awam
-   Aturan mainnya (rancangan-b.md 10.1 + syarat panitia):
-   - Huruf BESAR: tubuh 18px, input 22px, angka penting 40px+.
-   - Sasaran sentuh minimal 56px — dipakai sambil berdiri, di HP, terburu-buru.
-   - Satu aksi utama per layar: satu tombol besar berwarna, sisanya kalem.
-   - Status = warna + angka, terbaca dari seberang meja.
-   - Bahasa: kalimat yang memang diucapkan orang, tanpa istilah teknis.
+
+   Ukuran dikalibrasi ulang setelah panitia mencoba di HP: versi pertama
+   memakai ukuran "meja" (tubuh 18px, input 23px, sasaran sentuh 56px) untuk
+   SEMUA layar, sehingga form pendaftaran jadi 4 layar HP penuh — kebanyakan
+   menggulir. Sekarang dibedakan:
+
+   - Tubuh 16px, input 17px, sasaran sentuh 46px  -> nyaman & padat di HP.
+   - ANGKA yang dibacakan/dicatat tetap besar (nomor dada, kode pembayaran) —
+     itu memang harus terbaca dari seberang meja.
+
+   BATAS YANG TIDAK BOLEH DILANGGAR: font kotak isian minimal 16px. Di bawah
+   itu, iOS Safari memaksa zoom setiap kali isian disentuh, dan halaman jadi
+   melompat-lompat — persis masalah yang ingin dihindari.
+
+   Aturan lain (rancangan-b.md 10.1): satu aksi utama per layar; status =
+   warna + angka; bahasa = kalimat yang memang diucapkan orang.
    ========================================================================== */
 
 :root {
@@ -32,13 +42,13 @@
 /* [hidden] harus menang atas display:flex/grid kelas mana pun */
 [hidden] { display: none !important; }
 
-html { font-size: 18px; }
+html { font-size: 16px; }
 
 body {
   font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
   background: var(--kertas);
   color: var(--tinta);
-  line-height: 1.55;
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -47,20 +57,20 @@ body {
 .kepala {
   background: var(--utama);
   color: #fff;
-  padding: .7rem 1rem;
+  padding: .55rem .9rem;
   display: flex;
   align-items: center;
-  gap: .8rem;
+  gap: .7rem;
   flex-wrap: wrap;
 }
-.kepala .judul  { font-weight: 700; font-size: 1.05rem; }
+.kepala .judul  { font-weight: 700; font-size: 1rem; }
 .kepala .spacer { flex: 1; }
 .kepala .siapa  { font-size: .85rem; opacity: .9; }
 
 .isi {
   max-width: 760px;
   margin: 0 auto;
-  padding: 1.2rem 1rem 4rem;
+  padding: .9rem .8rem 3rem;
 }
 .isi.lebar { max-width: 1080px; }
 
@@ -71,19 +81,19 @@ body {
   border: 1.5px solid var(--garis);
   border-radius: var(--radius);
   box-shadow: var(--bayang);
-  padding: 1.2rem;
-  margin-bottom: 1rem;
+  padding: .9rem;
+  margin-bottom: .8rem;
 }
-.kartu h2 { font-size: 1.25rem; margin-bottom: .6rem; }
-.kartu .keterangan { color: var(--tinta-lembut); font-size: .95rem; }
+.kartu h2 { font-size: 1.1rem; margin-bottom: .45rem; }
+.kartu .keterangan { color: var(--tinta-lembut); font-size: .9rem; }
 
 /* Kartu identitas hasil lookup (echo-confirm) — HARUS terbaca dari jauh */
 .kartu-identitas {
   border: 2.5px solid var(--utama);
   background: var(--utama-muda);
 }
-.kartu-identitas .nama    { font-size: 1.7rem; font-weight: 800; }
-.kartu-identitas .detail  { font-size: 1.05rem; margin-top: .2rem; }
+.kartu-identitas .nama    { font-size: 1.35rem; font-weight: 800; line-height: 1.25; }
+.kartu-identitas .detail  { font-size: .95rem; margin-top: .15rem; }
 
 /* ---------- tombol ---------- */
 
@@ -94,9 +104,9 @@ button { font: inherit; cursor: pointer; }
   align-items: center;
   justify-content: center;
   gap: .5rem;
-  min-height: 56px;
-  padding: .7rem 1.4rem;
-  font-size: 1.15rem;
+  min-height: 46px;
+  padding: .55rem 1.1rem;
+  font-size: 1rem;
   font-weight: 700;
   border-radius: var(--radius);
   border: 2px solid transparent;
@@ -122,7 +132,7 @@ button { font: inherit; cursor: pointer; }
   color: var(--bahaya);
   border-color: var(--bahaya);
 }
-.tombol-kecil { min-height: 44px; font-size: .95rem; width: auto; }
+.tombol-kecil { min-height: 40px; font-size: .9rem; padding: .35rem .8rem; width: auto; }
 
 .tombol:focus-visible, input:focus-visible, .pilihan:focus-visible {
   outline: 3px solid #1a73e8;
@@ -131,51 +141,52 @@ button { font: inherit; cursor: pointer; }
 
 /* ---------- formulir ---------- */
 
-.medan { margin-bottom: 1.1rem; }
+.medan { margin-bottom: .8rem; }
 .medan label {
   display: block;
   font-weight: 700;
-  margin-bottom: .35rem;
+  font-size: .95rem;
+  margin-bottom: .25rem;
 }
 .medan .bantuan {
   font-weight: 400;
   color: var(--tinta-lembut);
-  font-size: .9rem;
-  margin-top: .25rem;
+  font-size: .85rem;
+  margin-top: .2rem;
 }
 
 input[type=text], input[type=number], input[type=password], input[type=time], input[type=tel] {
   width: 100%;
   font: inherit;
-  font-size: 1.3rem;
-  padding: .7rem .9rem;
-  min-height: 58px;
+  font-size: 1.0625rem;
+  padding: .55rem .75rem;
+  min-height: 46px;
   border: 2px solid var(--garis);
   border-radius: var(--radius);
   background: #fff;
 }
-input.besar { font-size: 1.8rem; letter-spacing: .06em; text-align: center; }
+input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min-height: 54px; }
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }
 
 .galat {
   color: var(--bahaya);
   font-weight: 600;
-  margin-top: .35rem;
-  font-size: .95rem;
+  margin-top: .25rem;
+  font-size: .9rem;
 }
 
 /* Pilihan besar (pengganti dropdown): kartu yang bisa diketuk */
-.pilihan-baris { display: grid; gap: .7rem; grid-template-columns: 1fr 1fr; }
+.pilihan-baris { display: grid; gap: .55rem; grid-template-columns: 1fr 1fr; }
 .pilihan {
   border: 2px solid var(--garis);
   border-radius: var(--radius);
   background: #fff;
-  padding: 1rem;
-  font-size: 1.15rem;
+  padding: .7rem;
+  font-size: 1rem;
   font-weight: 700;
   text-align: center;
-  min-height: 64px;
+  min-height: 50px;
 }
 .pilihan[aria-pressed="true"] {
   border-color: var(--utama);
@@ -183,15 +194,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 
 /* Stepper +/- untuk angka kecil (rincian golongan) */
-.stepper { display: flex; align-items: center; gap: .6rem; }
+.stepper { display: flex; align-items: center; gap: .5rem; }
 .stepper button {
-  width: 56px; height: 56px;
-  font-size: 1.6rem; font-weight: 800;
+  width: 46px; height: 46px;
+  font-size: 1.4rem; font-weight: 800;
   border-radius: 50%;
   border: 2px solid var(--garis);
   background: #fff;
 }
-.stepper .angka { font-size: 1.6rem; font-weight: 800; min-width: 2.2rem; text-align: center; }
+.stepper .angka { font-size: 1.35rem; font-weight: 800; min-width: 2rem; text-align: center; }
 
 /* ---------- lencana status: warna + angka ---------- */
 
@@ -199,10 +210,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   display: inline-flex;
   align-items: center;
   gap: .4rem;
-  padding: .25rem .7rem;
+  padding: .2rem .6rem;
   border-radius: 999px;
   font-weight: 700;
-  font-size: .95rem;
+  font-size: .85rem;
 }
 .lencana-hijau  { background: var(--hijau-muda);  color: var(--hijau); }
 .lencana-kuning { background: var(--kuning-muda); color: var(--kuning); }
@@ -212,9 +223,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* ---------- angka besar (kode pembayaran, nomor dada) ---------- */
 
 .angka-raksasa {
-  font-size: 2.6rem;
+  font-size: 2.1rem;
   font-weight: 800;
-  letter-spacing: .05em;
+  letter-spacing: .04em;
   text-align: center;
   font-variant-numeric: tabular-nums;
   word-break: break-all;
@@ -222,7 +233,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* ---------- tabel sederhana ---------- */
 
-.tabel { width: 100%; border-collapse: collapse; font-size: 1.05rem; }
+.tabel { width: 100%; border-collapse: collapse; font-size: .95rem; }
 .tabel th {
   text-align: left;
   color: var(--tinta-lembut);
@@ -232,44 +243,44 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   padding: .4rem .6rem;
   border-bottom: 2px solid var(--garis);
 }
-.tabel td { padding: .65rem .6rem; border-bottom: 1px solid var(--garis); }
-.tabel .angka { font-weight: 800; font-size: 1.3rem; font-variant-numeric: tabular-nums; }
+.tabel td { padding: .45rem .5rem; border-bottom: 1px solid var(--garis); }
+.tabel .angka { font-weight: 800; font-size: 1.15rem; font-variant-numeric: tabular-nums; }
 
 /* ---------- form satu halaman (publik) ---------- */
 
 /* Nomor bagian: penanda urutan tanpa memaksa halaman terpisah. */
 .nomor-bagian {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 30px; height: 30px; margin-right: .5rem;
+  width: 26px; height: 26px; margin-right: .45rem;
   border-radius: 50%;
   background: var(--utama); color: #fff;
-  font-size: .95rem; font-weight: 800;
+  font-size: .85rem; font-weight: 800;
 }
 
 .baris-stepper {
   display: flex; align-items: center; justify-content: space-between;
-  gap: 1rem; padding: .7rem 0;
+  gap: .8rem; padding: .5rem 0;
   border-bottom: 1px solid var(--garis);
 }
 .baris-stepper:last-child { border-bottom: 0; }
 
 .kotak-total {
-  margin-top: .9rem; padding: .8rem 1rem;
+  margin-top: .7rem; padding: .6rem .8rem;
   background: var(--utama-muda);
   border: 2px solid var(--utama);
   border-radius: var(--radius);
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .kartu-regu {
   border: 1.5px solid var(--garis);
   border-radius: var(--radius);
-  padding: .9rem;
-  margin-bottom: .8rem;
+  padding: .65rem .7rem;
+  margin-bottom: .55rem;
 }
 .kartu-regu-galat { border-color: var(--bahaya); background: var(--bahaya-muda); }
 
-.dua-kolom { display: grid; gap: .8rem; grid-template-columns: 1fr 1fr; margin-top: .6rem; }
+.dua-kolom { display: grid; gap: .6rem; grid-template-columns: 1fr 1fr; margin-top: .45rem; }
 @media (max-width: 640px) { .dua-kolom { grid-template-columns: 1fr; } }
 
 /* Ringkasan galat: satu tempat, tiap barisnya bisa diketuk untuk melompat. */
@@ -286,8 +297,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    boleh hilang di ujung gulungan. */
 .kirim-bar {
   position: sticky; bottom: 0;
-  margin: 1rem -1rem 0;
-  padding: .7rem 1rem calc(.7rem + env(safe-area-inset-bottom));
+  margin: .8rem -.8rem 0;
+  padding: .55rem .8rem calc(.55rem + env(safe-area-inset-bottom));
   background: rgba(247, 246, 243, .96);
   border-top: 1.5px solid var(--garis);
   backdrop-filter: blur(6px);
@@ -316,14 +327,14 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .saran button {
   display: block; width: 100%;
   text-align: left;
-  padding: .8rem 1rem;
+  padding: .6rem .8rem;
   border: 0; background: none;
-  font-size: 1.1rem;
+  font-size: 1rem;
   border-bottom: 1px solid var(--garis);
-  min-height: 56px;
+  min-height: 48px;
 }
 .saran button:hover { background: var(--utama-muda); }
-.saran .alamat { display: block; color: var(--tinta-lembut); font-size: .9rem; }
+.saran .alamat { display: block; color: var(--tinta-lembut); font-size: .85rem; }
 
 /* ---------- notifikasi ---------- */
 
@@ -352,11 +363,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   background: var(--kartu);
   border: 2px solid var(--garis);
   border-radius: var(--radius);
-  padding: 1.3rem;
+  padding: 1rem;
   box-shadow: var(--bayang);
 }
 .menu-fungsi a:hover { border-color: var(--utama); }
-.menu-fungsi .nama-fungsi { font-size: 1.3rem; font-weight: 800; display: flex; justify-content: space-between; align-items: center; }
+.menu-fungsi .nama-fungsi { font-size: 1.15rem; font-weight: 800; display: flex; justify-content: space-between; align-items: center; }
 .menu-fungsi .ket { color: var(--tinta-lembut); margin-top: .3rem; }
 
 /* ---------- dialog (pengganti prompt) ---------- */
@@ -402,9 +413,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* ---------- responsif ---------- */
 
 @media (max-width: 560px) {
-  html { font-size: 17px; }
   .pilihan-baris { grid-template-columns: 1fr; }
-  .angka-raksasa { font-size: 2rem; }
+  .angka-raksasa { font-size: 1.9rem; }
+  .isi { padding: .8rem .7rem 3rem; }
 }
 
 /* ---------- aksesibilitas ---------- */

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>HRCD Rekap — Panitia</title>
-  <link rel="stylesheet" href="gaya.css">
+  <link rel="stylesheet" href="gaya.css?v=2">
 </head>
 <body>
   <header class="kepala" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -417,8 +417,10 @@ function layarDaftarUlang() {
           <table class="tabel" style="background:#fff;border-radius:8px;margin-top:.6rem">
             ${hasil.map(r => html`
               <tr>
-                <td class="angka" style="font-size:2rem">${String(r.nomor_dada).padStart(3, "0")}</td>
-                <td><strong style="font-size:1.2rem">${r.nama_regu}</strong><br>
+                <!-- Nomor dada DIBACAKAN sambil menyerahkan nomor fisik —
+                     ini satu-satunya angka yang sengaja tidak ikut diperkecil. -->
+                <td class="angka" style="font-size:2.3rem;line-height:1.1">${String(r.nomor_dada).padStart(3, "0")}</td>
+                <td><strong style="font-size:1.1rem">${r.nama_regu}</strong><br>
                     <span class="keterangan">${GOLONGAN_LABEL[r.golongan] || r.golongan}</span></td>
                 <td><span class="lencana lencana-abu">Kloter ${r.kloter}</span></td>
               </tr>`).join("")}


### PR DESCRIPTION
## Why

The panitia tried it on a phone: type too large, too much scrolling. Correct — the first pass calibrated for a **desk operator standing in a hurry**, then applied those same sizes to every screen, including a long registration form read **sitting down on a phone**.

## Measured, not guessed

Same scenario both times — 390px viewport, five regu filled in:

| | Before | After |
|---|---|---|
| Page height | 3429px | **2242px** (−35%) |
| Phone screens of scrolling | 4.1 | **2.7** |
| Body / input font | 18px / 23px | 16px / 17px |
| Touch targets | 56px | 46px (still above the 44px guideline) |

## Sizes now differ by context

Numbers that get **read aloud or copied** stay large. The nomor dada on the daftar ulang result is actually *bigger* than before (2.3rem) — an operator reads it across a crowded desk while handing over the physical bib. All four bibs now fit one screen with no scrolling at all.

## One hard floor

**Input font stays ≥16px.** Below that, iOS Safari force-zooms on every field tap and the page jumps around — exactly the problem this change removes. Documented in the stylesheet header so nobody "optimizes" it away later.

## Also

Stylesheet links carry a version query: the browser served a cached stylesheet during testing and would do the same to panitia after a mid-event fix.

Blueprint §10.1.13 records the rule and the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)