### PR TITLE
fix: serialise daftar ulang so simultaneous desks never collide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ mencakup: nomor dada ganda tertolak, kapasitas kloter, RLS per pos, alur
 lengkap daftar → bayar → daftar ulang → berangkat → nilai → closing, dan
 kecocokan mesin skor dengan contoh angka di `docs/rancangan-b.md`.
 
+Uji konkurensi terpisah membuktikan beberapa meja daftar ulang yang menekan
+tombol serentak tidak pernah menghasilkan nomor dada ganda:
+
+```bash
+bash tests/dev_db.sh            # siapkan database hrcd_dev
+python tests/uji_konkurensi.py  # 30 koneksi serentak memperebutkan 300 nomor
+```
+
 ## Kontribusi
 
 Semua perubahan lewat branch + pull request — konvensi lengkap di `CLAUDE.md`.

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -98,13 +98,47 @@ Postgres — layar tidak pernah menulis "setengah jadi":
 | `submit_pendaftaran` | Buat sekolah (bila baru) + batch + N baris regu + kode pembayaran unik, sekali jalan; validasi ulang rincian golongan = total di server |
 | `verifikasi_pembayaran` | Cek nominal = jumlah regu × `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
 | `batalkan_verifikasi` | Jalan mundur yang sah untuk salah verifikasi (meja di hari yang sama, admin kapan pun) — dengan alasan, terekam riwayat |
-| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → ambil N nomor terkecil yang tersedia (`FOR UPDATE SKIP LOCKED`) → sebar ke N kloter berbeda dengan `lompatan_kloter`, hindari kloter yang sudah berisi sekolah itu, buka kloter 31–40 hanya bila 1–30 penuh → tulis semuanya sekaligus. Regu `batal` dilewati. 2–3 meja paralel aman |
+| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → **satu gerbang `pg_advisory_xact_lock`** → ambil N nomor terkecil yang tersedia → sebar ke N kloter berbeda dengan `lompatan_kloter`, hindari kloter yang sudah berisi sekolah itu, buka kloter 31–40 hanya bila 1–30 penuh → tulis semuanya sekaligus. Regu `batal` dilewati. Lihat 4.1 |
 | `tukar_nomor_dada` | Nomor dada rusak/salah pasang: tukar dengan stok tersedia, terekam riwayat |
 | `konfirmasi_kontrak` | Validasi pilihan terhadap `kontrak_opsi` (bukan hardcode); boleh dikoreksi selama kloter belum berangkat |
 | `berangkatkan_kloter` | Jam berangkat **wajib dari argumen** (diketik) — fungsi tidak mengenal `now()`; menolak bila ada regu ter-ceklis berangkat yang belum punya kontrak (daftarnya ditampilkan layar) |
 | `simpan_nilai_massal` | **Satu-satunya jalur tulis nilai** — upload massal dan input manual (batch isi 1) lewat pintu yang sama; `SECURITY INVOKER` sehingga RLS pos tetap menggigit; validasi ulang semua baris di server, hasil per baris dikembalikan (sukses/tolak + alasan) |
 | `catat_closing` | Upsert per regu — pemanggilan ulang = edit yang sah; `jam_datang` wajib dari argumen; `anggota_hadir` 0–5 |
 | `susun_barak` | Idempotent: hapus + hitung ulang + tulis. Urut sekolah terbesar; utamakan 1 sekolah 1 ruangan; sekolah besar boleh terpecah ke beberapa ruangan; sekolah kecil digabung hanya bila terpaksa; `jumlah_orang = regu aktif × 5 + pendamping` |
+
+### 4.1 Kenapa daftar ulang diserialisasi penuh
+
+Panitia bertanya: kalau dua laptop menekan tombol pada detik yang sama, apakah
+harus "simpan dulu ke database lalu query lagi supaya benar-benar cocok?"
+
+1. **Pola "cek dulu, baru tulis" justru tidak aman.** Antara membaca dan
+   menulis ada celah waktu: dua meja bisa sama-sama membaca "nomor 005 masih
+   kosong", lalu sama-sama menulisnya. Yang benar adalah membiarkan database
+   memutuskan **di dalam satu transaksi**, bukan browser bertanya lalu memberi
+   tahu.
+2. **Rancangan pertama masih bocor, dan uji membuktikannya.** Versi awal
+   memakai `FOR UPDATE SKIP LOCKED` pada `nomor_dada_stok`, padahal yang
+   menentukan sebuah nomor "sudah terpakai" adalah tabel lain
+   (`regu.nomor_dada`). Mengunci tabel A sambil memutuskan berdasarkan tabel B
+   adalah pola yang bocor. Pada uji 30 meja serentak: **1–3 meja gagal tiap
+   putaran**, 290 dari 300 regu yang berhasil.
+3. **Yang menahan datanya tetap constraint.** `UNIQUE (nomor_dada)` menolak
+   duplikatnya — tidak ada nomor ganda yang pernah lolos ke database. Yang
+   rusak hanyalah pengalaman operasional: satu sekolah gagal daftar ulang
+   dengan pesan error teknis. Ini contoh kenapa constraint database dipasang
+   sebagai jaring terakhir, bukan sebagai satu-satunya pengaman.
+4. **Perbaikannya menyederhanakan, bukan menambah kepintaran** (migrasi 0007):
+   seluruh bagian "pilih nomor + sebar kloter" dilewatkan **satu gerbang**
+   `pg_advisory_xact_lock`. Hanya satu meja berada di dalamnya pada satu saat;
+   yang lain menunggu beberapa milidetik lalu membaca keadaan yang sudah pasti
+   mutakhir. `SKIP LOCKED` tidak lagi diperlukan sama sekali.
+5. **Terukur, bukan diyakini** (`tests/uji_konkurensi.py`): 30 koneksi
+   Postgres terpisah dilepas serentak lewat satu barrier, memperebutkan 300
+   nomor dada. Hasil setelah perbaikan, lima putaran berturut-turut:
+   **300/300 regu bernomor, nol error, nol duplikat, tidak ada kloter
+   kelebihan, tidak ada sekolah menumpuk** — selesai seluruhnya dalam
+   **1,65 detik** (rata-rata 55 ms per meja). Serialisasi total tidak terasa
+   pada skala 2–3 meja yang sebenarnya.
 
 ## 5. Mesin skor — hitung-saat-baca, tanpa tombol "hitung ulang"
 

--- a/supabase/migrations/0007_kunci_daftar_ulang.sql
+++ b/supabase/migrations/0007_kunci_daftar_ulang.sql
@@ -1,0 +1,193 @@
+-- ============================================================================
+-- hrcd-rekap : 0007_kunci_daftar_ulang.sql
+--
+-- TEMUAN UJI KONKURENSI (tests/uji_konkurensi.py, skala 300 regu):
+-- versi 0004 memakai `FOR UPDATE SKIP LOCKED` pada nomor_dada_stok, tetapi
+-- yang menentukan sebuah nomor "sudah terpakai" bukan baris yang dikunci itu
+-- melainkan tabel LAIN (regu.nomor_dada). Mengunci tabel A sambil memutuskan
+-- berdasarkan tabel B adalah pola yang bocor: pada 30 meja serentak, dua
+-- transaksi bisa sama-sama menganggap nomor yang sama masih kosong.
+--
+-- Akibat nyatanya di hari-H: constraint UNIQUE menahan datanya (tidak ada
+-- nomor dada ganda yang lolos — itu bekerja persis seperti seharusnya), tetapi
+-- SATU SEKOLAH GAGAL daftar ulang dengan pesan error teknis, dan operator
+-- harus mengulang. Terukur: 290 dari 300 regu berhasil, 1-3 meja gagal per
+-- putaran.
+--
+-- PERBAIKAN: seluruh bagian "pilih nomor + sebar kloter" diserialisasi dengan
+-- satu advisory lock DI AWAL. Hanya satu meja berada di dalam bagian itu pada
+-- satu saat; meja lain menunggu beberapa milidetik lalu jalan dengan keadaan
+-- database yang sudah pasti mutakhir.
+--
+-- Kenapa serialisasi total dapat diterima di sini:
+--   * Operasinya hanya beberapa milidetik, dan pesertanya 2-3 meja — bukan
+--     ribuan transaksi per detik.
+--   * Uji 30 meja serentak (skenario jauh lebih ekstrem dari kenyataan)
+--     selesai tanpa antrean yang terasa.
+--   * Jauh lebih mudah dipahami penerus daripada penalaran SKIP LOCKED lintas
+--     tabel (CLAUDE.md bagian 6: kode yang jelas menang atas kode yang pintar).
+-- ============================================================================
+
+create or replace function daftar_ulang_batch(p_kode text)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where aktif;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- ===== GERBANG TUNGGAL =====
+  -- Semua keputusan nomor dada + kloter terjadi setelah baris ini, jadi tidak
+  -- ada dua meja yang pernah melihat keadaan stok yang sama. Lock dilepas
+  -- otomatis saat transaksi selesai (commit maupun rollback).
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  -- Regu yang berhak: belum bernomor, tidak batal. Dibaca SETELAH gerbang,
+  -- sehingga dua meja yang mengetik kode sama tidak sama-sama melihat "belum
+  -- bernomor" (meja kedua akan melihat daftar kosong dan ditolak di bawah).
+  select array_agg(r.id order by r.nama_regu, r.id) into v_regu
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.batal and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_regu, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Ambil N nomor terkecil yang tersedia. Tanpa SKIP LOCKED: gerbang di atas
+  -- sudah menjamin hanya satu meja yang membaca stok pada satu saat, sehingga
+  -- hasil baca ini pasti mutakhir.
+  select array_agg(nomor order by nomor) into v_nomor
+  from (
+    select s.nomor from nomor_dada_stok s
+    where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+      and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+    order by s.nomor
+    limit v_n
+  ) ambil;
+  if coalesce(array_length(v_nomor, 1), 0) < v_n then
+    raise exception 'stok nomor dada kurang: butuh %, tersedia %',
+      v_n, coalesce(array_length(v_nomor, 1), 0);
+  end if;
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    if v_mulai is null then
+      v_langkah := 1;
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam 1..kloter_dasar.
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and k.jam_berangkat is null
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama, abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: kloter dasar masih ada tempat tapi semuanya berisi sekolah
+    -- ini — berkumpul dulu sebelum membuka kloter cadangan (alur 5.2 & 5.4).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+revoke execute on function daftar_ulang_batch(text) from public, anon;
+grant execute on function daftar_ulang_batch(text) to authenticated;

--- a/tests/dev_db.sh
+++ b/tests/dev_db.sh
@@ -25,6 +25,7 @@ run supabase/migrations/0003_rls.sql
 run supabase/migrations/0004_rpcs.sql
 run supabase/migrations/0005_views.sql
 run supabase/migrations/0006_idempotensi.sql
+run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,6 +29,7 @@ run supabase/migrations/0003_rls.sql
 run supabase/migrations/0004_rpcs.sql
 run supabase/migrations/0005_views.sql
 run supabase/migrations/0006_idempotensi.sql
+run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql

--- a/tests/uji_konkurensi.py
+++ b/tests/uji_konkurensi.py
@@ -1,0 +1,172 @@
+# ============================================================================
+# hrcd-rekap : tests/uji_konkurensi.py
+# Membuktikan bahwa dua-tiga meja daftar ulang yang menekan tombol PADA DETIK
+# YANG SAMA tidak pernah menghasilkan nomor dada ganda atau kloter kelebihan.
+#
+# Ini bukan simulasi berurutan: tiap "meja" adalah koneksi Postgres sendiri di
+# thread sendiri, dan semuanya dilepas bersamaan lewat satu barrier — sedekat
+# mungkin dengan tiga jari menekan Enter serentak.
+#
+# Jalankan:
+#   python tests/uji_konkurensi.py
+# (butuh database hrcd_dev — siapkan dengan: bash tests/dev_db.sh)
+# ============================================================================
+
+import json
+import sys
+import threading
+import time
+import uuid
+
+import psycopg2
+import psycopg2.extras
+
+DSN = "host=127.0.0.1 port=55432 dbname=hrcd_dev user=postgres password=hrcd"
+MEJA = ("00000000-0000-0000-0000-0000000000b1",
+        "00000000-0000-0000-0000-0000000000b2",
+        "00000000-0000-0000-0000-00000000000a")   # 2 meja + admin
+JUMLAH_SEKOLAH = 30          # 12 sekolah berebut bersamaan
+REGU_PER_SEKOLAH = 10         # 48 regu, 48 nomor dada
+
+
+def jalankan(sql, args=(), uid=None, role="authenticated", fetch="all"):
+    with psycopg2.connect(DSN) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("set local app.uid = %s", (uid or "",))
+            cur.execute(f"set local role {role}")
+            cur.execute(sql, args or None)
+            if fetch == "all":
+                return cur.fetchall()
+            if fetch == "one":
+                return cur.fetchone()
+            return None
+
+
+def siapkan():
+    """Bersihkan sisa uji sebelumnya, lalu daftarkan + lunasi N sekolah."""
+    jalankan("""
+        delete from penempatan_barak;
+        delete from keberangkatan_regu;
+        delete from nilai_mentah;
+        delete from closing_regu;
+        delete from pembayaran;
+        delete from regu;
+        delete from pendaftaran;
+        delete from sekolah where nama like 'UJI KONKUREN%';
+        update kloter set jam_berangkat = null;
+    """, role="service_role", fetch=None)
+
+    kode = []
+    for i in range(JUMLAH_SEKOLAH):
+        regu = [{"nama_regu": f"Regu {i}-{j}", "nama_ketua": f"Ketua {i}-{j}",
+                 "golongan": "penegak_pa"} for j in range(REGU_PER_SEKOLAH)]
+        h = jalankan(
+            "select submit_pendaftaran(%s,%s,%s,%s,%s::jsonb,%s::smallint,%s::uuid) as h",
+            (f"UJI KONKUREN {i}", f"Jl. Uji {i}", False, "081200000000",
+             json.dumps(regu), 0, str(uuid.uuid4())),
+            role="service_role", fetch="one")["h"]
+        k = h["kode_pembayaran"]
+        biaya = jalankan("select biaya_per_regu from edisi where aktif",
+                         role="service_role", fetch="one")["biaya_per_regu"]
+        jalankan("select verifikasi_pembayaran(%s,%s,%s)",
+                 (k, REGU_PER_SEKOLAH * biaya, "tunai"),
+                 uid=MEJA[0], fetch="one")
+        kode.append(k)
+    return kode
+
+
+def serbu(kode):
+    """Semua meja menekan tombol bersamaan lewat satu barrier."""
+    hasil, galat = [], []
+    kunci = threading.Lock()
+    barrier = threading.Barrier(len(kode))
+
+    def satu_meja(i, k):
+        uid = MEJA[i % len(MEJA)]
+        barrier.wait()                      # <- serentak di sini
+        try:
+            baris = jalankan(
+                "select nomor_dada, kloter from daftar_ulang_batch(%s)",
+                (k,), uid=uid)
+            with kunci:
+                hasil.extend(baris)
+        except Exception as e:               # noqa: BLE001 — semua galat dicatat
+            with kunci:
+                galat.append(f"{k}: {type(e).__name__}: {e}")
+
+    utas = [threading.Thread(target=satu_meja, args=(i, k))
+            for i, k in enumerate(kode)]
+    mulai = time.perf_counter()
+    for t in utas:
+        t.start()
+    for t in utas:
+        t.join()
+    return hasil, galat, time.perf_counter() - mulai
+
+
+def periksa(hasil, galat):
+    lolos = True
+
+    def cek(nama, ok, catatan=""):
+        nonlocal lolos
+        print(f"  {'OK  ' if ok else 'GAGAL'}  {nama}{'  ' + catatan if catatan else ''}")
+        if not ok:
+            lolos = False
+
+    total = JUMLAH_SEKOLAH * REGU_PER_SEKOLAH
+    cek("tidak ada meja yang error", not galat, "; ".join(galat[:3]))
+    cek(f"semua {total} regu menerima nomor", len(hasil) == total,
+        f"dapat {len(hasil)}")
+
+    nomor = [r["nomor_dada"] for r in hasil]
+    cek("tidak ada nomor dada ganda", len(nomor) == len(set(nomor)),
+        f"{len(nomor) - len(set(nomor))} duplikat")
+
+    db = jalankan("""
+        select count(*) as regu_bernomor,
+               count(distinct nomor_dada) as nomor_unik
+        from regu where nomor_dada is not null
+    """, uid=MEJA[2], fetch="one")
+    cek("database sepakat: nomor unik",
+        db["regu_bernomor"] == db["nomor_unik"] == total,
+        f"{db['regu_bernomor']} baris / {db['nomor_unik']} unik")
+
+    penuh = jalankan("""
+        select k.nomor, count(r.id) as isi
+        from kloter k join regu r on r.kloter_nomor = k.nomor
+        group by k.nomor having count(r.id) > (select maks_regu_per_kloter from edisi where aktif)
+    """, uid=MEJA[2])
+    cek("tidak ada kloter melebihi kapasitas", not penuh, str(penuh[:3]))
+
+    urutan = jalankan("""
+        select kloter_nomor, urutan_kloter, count(*) as n
+        from regu where kloter_nomor is not null
+        group by 1,2 having count(*) > 1
+    """, uid=MEJA[2])
+    cek("tidak ada urutan kloter kembar", not urutan, str(urutan[:3]))
+
+    # Inti aturannya: satu sekolah tersebar, tidak menumpuk di satu kloter.
+    tumpuk = jalankan("""
+        select s.nama, r.kloter_nomor, count(*) as n
+        from regu r
+        join pendaftaran d on d.id = r.pendaftaran_id
+        join sekolah s on s.id = d.sekolah_id
+        where r.kloter_nomor is not null
+        group by 1,2 having count(*) > 1
+    """, uid=MEJA[2])
+    cek("tidak ada sekolah menumpuk di satu kloter", not tumpuk, str(tumpuk[:3]))
+
+    return lolos
+
+
+if __name__ == "__main__":
+    print(f"UJI KONKURENSI — {JUMLAH_SEKOLAH} meja menekan tombol serentak, "
+          f"{JUMLAH_SEKOLAH * REGU_PER_SEKOLAH} nomor dada diperebutkan\n")
+    kode = siapkan()
+    hasil, galat, detik = serbu(kode)
+    print(f"  ({len(hasil)} baris kembali, {len(galat)} error, "
+          f"{detik:.2f} detik untuk SEMUA meja selesai — "
+          f"rata-rata {detik / len(kode) * 1000:.0f} ms per meja)\n")
+    lolos = periksa(hasil, galat)
+    print("\n" + ("SEMUA PEMERIKSAAN LULUS" if lolos else "ADA PEMERIKSAAN GAGAL"))
+    sys.exit(0 if lolos else 1)


### PR DESCRIPTION
## The question that found a bug

The panitia asked: *"bisa jadi ada 2 laptop klik tombol di waktu yang sama — berarti harus masuk database dulu lalu query, supaya benar-benar match?"*

Writing a test to answer it **found a real bug**.

`tests/uji_konkurensi.py` runs each desk as its own Postgres connection in its own thread, released together through a barrier — as close as a script gets to several fingers hitting Enter at once.

| Scale | Result (before fix) |
|---|---|
| 12 desks | Passed |
| **30 desks / 300 bibs** | **Failed every run** — `UniqueViolation` on `regu_nomor_dada_key`; 290/300 numbered, 1–3 desks failed outright |

The `UNIQUE` constraint did its job — **no duplicate bib ever reached the data**. But a school would have been turned away at the desk with a technical error. That distinction is the point: the constraint is the last net, not the only guard.

## Cause

The old code took `FOR UPDATE SKIP LOCKED` on `nomor_dada_stok`, while what actually decides whether a number is taken lives in a **different table** (`regu.nomor_dada`). Locking table A while deciding from table B leaks.

## Fix — simpler, not cleverer

Migration 0007 passes the whole choose-number-and-spread-kloter section through **one `pg_advisory_xact_lock`**. Only one desk is inside at a time; the rest wait a few milliseconds then read state that is certainly current. `SKIP LOCKED` is no longer needed at all.

## Measured after the fix — five consecutive runs

```
(300 baris kembali, 0 error, 1.65 detik — rata-rata 55 ms per meja)
  OK  semua 300 regu menerima nomor
  OK  tidak ada nomor dada ganda            0 duplikat
  OK  database sepakat: nomor unik          300 baris / 300 unik
  OK  tidak ada kloter melebihi kapasitas
  OK  tidak ada urutan kloter kembar
  OK  tidak ada sekolah menumpuk di satu kloter
```

Full serialisation costs nothing at the 2–3 desks this will actually see.

## Notes

Blueprint §4.1 records the reasoning — including **why "check the database first, then write" is the unsafe instinct** it looks like a fix for: between the read and the write, two desks can both see the same number as free.

SQL suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)