### PR TITLE
feat: print the kloter list and freeze what has been printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Butuh PostgreSQL 16 (lokal atau portable, tanpa Supabase):
 PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
 ```
 
+Untuk mencoba layarnya (butuh tiga terminal):
+
+```bash
+bash tests/dev_db.sh          # siapkan database hrcd_dev
+python tests/dev_server.py    # tiruan Supabase di :8787
+python tests/layar_server.py  # layar panitia di :8788 (tanpa cache)
+```
+
 Runner membuat ulang database `hrcd_test` setiap kali — aman diulang. Tes
 mencakup: nomor dada ganda tertolak, kapasitas kloter, RLS per pos, alur
 lengkap daftar → bayar → daftar ulang → berangkat → nilai → closing, dan

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -140,6 +140,37 @@ harus "simpan dulu ke database lalu query lagi supaya benar-benar cocok?"
    **1,65 detik** (rata-rata 55 ms per meja). Serialisasi total tidak terasa
    pada skala 2–3 meja yang sebenarnya.
 
+### 4.2 Kloter yang sudah dicetak dibekukan
+
+Panitia: *"nanti kloter final akan diprint."* Itu mengubah sifat datanya.
+
+1. **Begitu dicetak, kertas menjadi kebenaran di lapangan.** Petugas garis start
+   memanggil regu dari kertas, bukan dari layar. Maka setiap perubahan isi
+   kloter setelah cetak membuat kertas berbohong tanpa ada yang menyadari.
+2. **Kejadian nyatanya bukan hipotetis**: sekolah datang terlambat, daftar
+   ulang setelah cetakan dibagikan, dan regunya diselipkan ke kloter yang sudah
+   tercetak. Di garis start, kloter itu memanggil 10 nama padahal kertas hanya
+   memuat 9 — atau regu itu tidak pernah dipanggil sama sekali.
+3. **Perlindungannya berlapis** (migrasi 0008):
+   - Kolom `kloter.dicetak_pada` menandai kloter yang kertasnya sudah keluar.
+   - `daftar_ulang_batch` hanya memilih kloter dengan `dicetak_pada is null`,
+     sehingga pendaftar susulan otomatis jatuh ke kloter cadangan (31–40) dan
+     dicetakkan **lembar tambahan** — bukan ditolak.
+   - Trigger `jaga_kloter_tercetak` menolak perubahan `kloter_nomor` yang masuk
+     ke atau keluar dari kloter tercetak, dari jalur mana pun — termasuk
+     koreksi admin lewat SQL yang lupa aturan ini.
+   - `batalkan_tanda_cetak` (admin, wajib beralasan, terekam riwayat) untuk
+     kertas macet / cetak ulang.
+4. **Penandaan terjadi SETELAH dialog cetak ditutup**, dan operator ditanya
+   "kertasnya sudah keluar dengan benar?" — kalau cetakan batal, kloternya
+   belum dianggap final.
+5. **Bentuk kertasnya**: satu kloter per lembar (`break-after: page`), kolom
+   No Dada besar, plus kolom kosong "Hadir" untuk dicentang tangan, dan tempat
+   menulis jam berangkat + nama petugas.
+6. Diuji di `tests/sql/04_cetak_kloter.sql` dan lewat aplikasi: setelah 5
+   kloter ditandai tercetak, sekolah susulan masuk kloter yang belum pernah
+   dicetak — bukan diselipkan.
+
 ## 5. Mesin skor — hitung-saat-baca, tanpa tombol "hitung ulang"
 
 1. **Tidak ada angka turunan yang disimpan.** Semua skor dihitung saat dibaca

--- a/supabase/migrations/0008_cetak_kloter.sql
+++ b/supabase/migrations/0008_cetak_kloter.sql
@@ -1,0 +1,304 @@
+-- ============================================================================
+-- hrcd-rekap : 0008_cetak_kloter.sql
+--
+-- Panitia: "nanti kloter final akan diprint."
+--
+-- Begitu daftar kloter dicetak dan dibagikan, KERTAS menjadi kebenaran di
+-- lapangan — panitia garis start memanggil regu dari kertas, bukan dari layar.
+-- Karena itu setiap perubahan kloter SETELAH cetak membuat kertas berbohong
+-- tanpa ada yang menyadarinya.
+--
+-- Kejadian nyatanya: sekolah datang terlambat, daftar ulang setelah cetakan
+-- dibagikan, dan regunya diselipkan ke kloter yang sudah tercetak. Di garis
+-- start, kloter itu memanggil 10 nama padahal kertas hanya memuat 9 — atau
+-- lebih buruk, regu itu tidak pernah dipanggil sama sekali.
+--
+-- PERLINDUNGAN: kloter yang sudah dicetak DIBEKUKAN. Pendaftar susulan hanya
+-- boleh masuk kloter yang belum pernah tercetak (cadangan 31-40), lalu
+-- dicetakkan lembar tambahan untuk kloter itu saja.
+-- ============================================================================
+
+-- Penanda per kloter: kapan daftar isinya dicetak. NULL = belum pernah.
+alter table kloter add column dicetak_pada timestamptz;
+
+comment on column kloter.dicetak_pada is
+  'Waktu daftar isi kloter ini dicetak. Setelah terisi, isi kloter dibekukan '
+  'karena kertas sudah beredar di garis start.';
+
+-- ---------------------------------------------------------------------------
+-- 1. View cetak: satu baris per regu, urut kloter lalu nomor dada.
+--    Kolomnya persis yang dibutuhkan panitia garis start untuk memanggil.
+-- ---------------------------------------------------------------------------
+
+create view v_daftar_kloter with (security_invoker = on) as
+select
+  r.kloter_nomor                        as kloter,
+  r.urutan_kloter                       as urutan,
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama                                as nama_sekolah,
+  r.golongan,
+  k.dicetak_pada,
+  k.jam_berangkat
+from regu r
+join kloter k       on k.nomor = r.kloter_nomor
+join pendaftaran d  on d.id = r.pendaftaran_id
+join sekolah s      on s.id = d.sekolah_id
+where not r.batal
+  and d.status = 'lunas'
+  and r.kloter_nomor is not null
+order by r.kloter_nomor, r.urutan_kloter;
+
+grant select on v_daftar_kloter to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. Tandai kloter sebagai sudah dicetak.
+--    Dipanggil layar cetak SETELAH pengguna menekan cetak — jadi penandaan
+--    hanya terjadi kalau kertasnya memang benar-benar keluar.
+-- ---------------------------------------------------------------------------
+
+create or replace function tandai_kloter_dicetak(p_kloter smallint[] default null)
+returns integer
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_jumlah integer;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+
+  update kloter k
+  set dicetak_pada = now()
+  where k.dicetak_pada is null
+    and (p_kloter is null or k.nomor = any (p_kloter))
+    and exists (select 1 from regu r
+                join pendaftaran d on d.id = r.pendaftaran_id
+                where r.kloter_nomor = k.nomor and not r.batal
+                  and d.status = 'lunas');
+  get diagnostics v_jumlah = row_count;
+  return v_jumlah;
+end;
+$$;
+
+-- Jalan mundur bila cetakan gagal/kertas macet — hanya admin, dengan alasan.
+create or replace function batalkan_tanda_cetak(p_kloter smallint, p_alasan text)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if peran() <> 'admin' then
+    raise exception 'hanya admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan wajib diisi';
+  end if;
+  insert into riwayat (tabel, baris_id, aksi, nilai_baru, oleh)
+  values ('kloter', p_kloter::text, 'UPDATE',
+          jsonb_build_object('alasan_batal_tanda_cetak', p_alasan), auth.uid());
+  update kloter set dicetak_pada = null where nomor = p_kloter;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. daftar_ulang_batch: hormati kloter yang sudah dicetak.
+--    Satu-satunya perubahan dari 0007 adalah syarat `dicetak_pada is null`
+--    pada keempat putaran pemilihan kloter.
+-- ---------------------------------------------------------------------------
+
+create or replace function daftar_ulang_batch(p_kode text)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where aktif;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Gerbang tunggal (0007): tidak ada dua meja yang melihat stok yang sama.
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  select array_agg(r.id order by r.nama_regu, r.id) into v_regu
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.batal and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_regu, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  select array_agg(nomor order by nomor) into v_nomor
+  from (
+    select s.nomor from nomor_dada_stok s
+    where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+      and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+    order by s.nomor
+    limit v_n
+  ) ambil;
+  if coalesce(array_length(v_nomor, 1), 0) < v_n then
+    raise exception 'stok nomor dada kurang: butuh %, tersedia %',
+      v_n, coalesce(array_length(v_nomor, 1), 0);
+  end if;
+
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+    if v_mulai is null then v_langkah := 1; else v_langkah := v_cfg.lompatan_kloter; end if;
+
+    -- Putaran 1: lompatan + hindari sekolah sama, kloter dasar, BELUM DICETAK.
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and k.jam_berangkat is null
+      and k.dicetak_pada is null
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: abaikan lompatan, masih hindari sekolah sama.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and k.dicetak_pada is null
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: berkumpul di kloter dasar sebelum membuka cadangan.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and k.dicetak_pada is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter cadangan (31..maks) — jalur normal bagi pendaftar
+    -- susulan setelah daftar kloter dicetak.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and k.jam_berangkat is null
+        and k.dicetak_pada is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'tidak ada kloter yang masih bisa diisi — semua penuh, sudah berangkat, atau daftarnya sudah dicetak. Tambah kloter cadangan lewat admin.';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Jaring terakhir: trigger menolak perubahan kloter pada regu yang
+--    kloternya SUDAH dicetak. Melindungi dari jalur mana pun — termasuk
+--    koreksi admin lewat SQL langsung yang lupa aturan ini.
+-- ---------------------------------------------------------------------------
+
+create or replace function tolak_ubah_kloter_tercetak()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  -- Pindah KELUAR dari kloter yang sudah dicetak.
+  if old.kloter_nomor is not null
+     and old.kloter_nomor is distinct from new.kloter_nomor
+     and exists (select 1 from kloter where nomor = old.kloter_nomor
+                 and dicetak_pada is not null) then
+    raise exception 'kloter % sudah dicetak — isinya tidak boleh berubah. Batalkan tanda cetak lewat admin bila memang perlu cetak ulang.',
+      old.kloter_nomor;
+  end if;
+  -- Masuk KE DALAM kloter yang sudah dicetak.
+  if new.kloter_nomor is not null
+     and new.kloter_nomor is distinct from old.kloter_nomor
+     and exists (select 1 from kloter where nomor = new.kloter_nomor
+                 and dicetak_pada is not null) then
+    raise exception 'kloter % sudah dicetak — regu baru tidak boleh disisipkan ke sana.',
+      new.kloter_nomor;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger jaga_kloter_tercetak
+  before update of kloter_nomor on regu
+  for each row execute function tolak_ubah_kloter_tercetak();
+
+-- ---------------------------------------------------------------------------
+-- 5. Hak eksekusi (model per-fungsi dari 0004).
+-- ---------------------------------------------------------------------------
+
+revoke execute on function tandai_kloter_dicetak(smallint[]) from public, anon;
+revoke execute on function batalkan_tanda_cetak(smallint, text) from public, anon;
+grant execute on function tandai_kloter_dicetak(smallint[]) to authenticated;
+grant execute on function batalkan_tanda_cetak(smallint, text) to authenticated;

--- a/tests/dev_db.sh
+++ b/tests/dev_db.sh
@@ -26,6 +26,7 @@ run supabase/migrations/0004_rpcs.sql
 run supabase/migrations/0005_views.sql
 run supabase/migrations/0006_idempotensi.sql
 run supabase/migrations/0007_kunci_daftar_ulang.sql
+run supabase/migrations/0008_cetak_kloter.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -37,6 +37,8 @@ RPC = {
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
     "susun_barak":           [],
+    "tandai_kloter_dicetak": ["p_kloter"],
+    "batalkan_tanda_cetak":  ["p_kloter", "p_alasan"],
 }
 # RPC yang hasilnya tabel (bukan skalar/jsonb).
 RPC_TABEL = {"daftar_ulang_batch"}
@@ -85,6 +87,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/edisi":
                 self._kirim(200, q(
                     "select * from v_edisi_publik", role="anon", fetch="one"))
+            elif u.path == "/kloter":
+                self._kirim(200, q(
+                    "select * from v_daftar_kloter", uid=p.get("uid")))
             elif u.path == "/ringkasan":
                 self._kirim(200, q("""
                     select
@@ -177,6 +182,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         "p_anggota_hadir": "::smallint", "p_jumlah": "::smallint",
                         "p_regu": "::uuid", "p_jam": "::timestamptz",
                         "p_jam_datang": "::timestamptz"}
+                if nama == "tandai_kloter_dicetak":
+                    CAST = {**CAST, "p_kloter": "::smallint[]"}
                 tanda = ", ".join("%s" + CAST.get(k, "") for k in urutan)
                 if nama in RPC_TABEL:
                     sql = f"select coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) as h from {nama}({tanda}) t"

--- a/tests/layar_server.py
+++ b/tests/layar_server.py
@@ -1,0 +1,38 @@
+# ============================================================================
+# hrcd-rekap : tests/layar_server.py — server statis untuk web/ saat mengembang.
+#
+# Bukan sekadar `python -m http.server`: server itu mengizinkan browser
+# menyimpan cache, dan selama pengujian kami sempat melihat gaya.css serta
+# app.js versi LAMA disajikan sehingga perbaikan tidak terlihat sama sekali.
+# Di sini semua respons dikirim dengan no-store, jadi apa yang tampil di layar
+# selalu isi file yang barusan disimpan.
+#
+# (Untuk produksi, aturan setaranya ada di web/_headers — Cloudflare Pages.)
+#
+# Jalankan:
+#   python tests/layar_server.py          # http://127.0.0.1:8788
+# ============================================================================
+
+import functools
+import http.server
+import os
+
+PORT = 8788
+AKAR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "web")
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+    def log_message(self, fmt, *args):
+        pass   # senyap: log yang berguna datang dari dev_server.py
+
+
+if __name__ == "__main__":
+    handler = functools.partial(Handler, directory=os.path.normpath(AKAR))
+    print(f"layar hrcd-rekap -> http://127.0.0.1:{PORT}  (tanpa cache)")
+    http.server.ThreadingHTTPServer(("127.0.0.1", PORT), handler).serve_forever()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,9 +30,11 @@ run supabase/migrations/0004_rpcs.sql
 run supabase/migrations/0005_views.sql
 run supabase/migrations/0006_idempotensi.sql
 run supabase/migrations/0007_kunci_daftar_ulang.sql
+run supabase/migrations/0008_cetak_kloter.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
 run tests/sql/03_alur.sql
+run tests/sql/04_cetak_kloter.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/04_cetak_kloter.sql
+++ b/tests/sql/04_cetak_kloter.sql
@@ -1,0 +1,172 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/04_cetak_kloter.sql
+-- Kloter yang sudah dicetak harus BEKU: kertas sudah beredar di garis start,
+-- jadi isinya tidak boleh berubah lewat jalur mana pun.
+-- ============================================================================
+
+\echo '== 04: cetak kloter =='
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+-- 4.1 Cetak menandai hanya kloter yang benar-benar berisi regu lunas.
+do $$
+declare v_ditandai int; v_berisi int;
+begin
+  select count(distinct r.kloter_nomor) into v_berisi
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where r.kloter_nomor is not null and not r.batal and d.status = 'lunas';
+
+  v_ditandai := tandai_kloter_dicetak();
+  assert v_ditandai = v_berisi,
+    format('yang ditandai %s, kloter berisi %s', v_ditandai, v_berisi);
+
+  -- Kloter kosong tidak boleh ikut tertandai.
+  assert not exists (
+    select 1 from kloter k
+    where k.dicetak_pada is not null
+      and not exists (select 1 from regu r where r.kloter_nomor = k.nomor)),
+    'kloter kosong ikut ditandai tercetak';
+
+  -- Menandai ulang tidak menambah apa-apa (idempotent).
+  assert tandai_kloter_dicetak() = 0, 'penandaan kedua menandai ulang';
+end;
+$$;
+
+-- 4.2 View cetak memuat kolom yang dibutuhkan garis start, urut kloter.
+do $$
+declare v record;
+begin
+  select * into v from v_daftar_kloter limit 1;
+  assert v.kloter is not null and v.nomor_dada is not null
+     and v.nama_regu is not null and v.nama_sekolah is not null,
+    'v_daftar_kloter kekurangan kolom';
+  assert (select bool_and(dicetak_pada is not null) from v_daftar_kloter),
+    'v_daftar_kloter tidak menampilkan status cetak';
+end;
+$$;
+
+-- 4.3 INTI, dua lapis.
+--     Lapis 1 (RLS): peran meja tidak boleh menulis langsung ke tabel regu —
+--     UPDATE-nya tersaring, nol baris berubah, tanpa error.
+do $$
+declare
+  v_tercetak smallint;
+  v_regu     uuid;
+  v_n        int;
+begin
+  select nomor into v_tercetak from kloter where dicetak_pada is not null limit 1;
+  select id into v_regu from regu where kloter_nomor is null and not batal limit 1;
+  assert v_tercetak is not null, 'tidak ada kloter tercetak untuk diuji';
+  assert v_regu is not null, 'tidak ada regu tanpa kloter untuk diuji';
+
+  update regu set kloter_nomor = v_tercetak, urutan_kloter = 9, nomor_dada = 499
+  where id = v_regu;
+  get diagnostics v_n = row_count;
+  assert v_n = 0, 'RLS: peran meja bisa menulis langsung ke tabel regu';
+end;
+$$;
+
+--     Lapis 2 (trigger): ADMIN yang berhak menulis langsung pun ditolak —
+--     inilah jaring terakhirnya, karena koreksi admin lewat SQL adalah jalur
+--     yang paling mungkin melupakan aturan "kertas sudah beredar".
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+do $$
+declare
+  v_tercetak smallint;
+  v_regu     uuid;
+begin
+  select nomor into v_tercetak from kloter where dicetak_pada is not null limit 1;
+  select id into v_regu from regu where kloter_nomor is null and not batal limit 1;
+
+  -- Menyisipkan regu baru ke kloter tercetak.
+  begin
+    update regu set kloter_nomor = v_tercetak, urutan_kloter = 9, nomor_dada = 499
+    where id = v_regu;
+    raise exception 'GAGAL: admin bisa menyisipkan regu ke kloter tercetak';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Memindahkan regu KELUAR dari kloter tercetak.
+  select id into v_regu from regu where kloter_nomor = v_tercetak limit 1;
+  begin
+    update regu set kloter_nomor = 40 where id = v_regu;
+    raise exception 'GAGAL: admin bisa memindah regu keluar dari kloter tercetak';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+
+-- 4.4 Pendaftar SUSULAN setelah cetak tetap dilayani — masuk kloter yang
+--     belum pernah tercetak (cadangan), bukan diselipkan ke yang sudah.
+do $$
+declare
+  v_kode  text;
+  v_hasil record;
+  v_biaya integer;
+begin
+  reset role;
+  select biaya_per_regu into v_biaya from edisi where aktif;
+  set role service_role;
+  v_kode := (submit_pendaftaran('SMP Susulan Cetak', 'Jl. Susulan 1', false,
+    '081277778888',
+    '[{"nama_regu":"Terlambat","nama_ketua":"Tono","golongan":"penegak_pa"}]',
+    0::smallint, gen_random_uuid())) ->> 'kode_pembayaran';
+  reset role;
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+  set role authenticated;
+  perform verifikasi_pembayaran(v_kode, v_biaya, 'tunai');
+
+  select * into v_hasil from daftar_ulang_batch(v_kode) limit 1;
+  assert v_hasil.nomor_dada is not null, 'pendaftar susulan tidak dapat nomor';
+  assert (select dicetak_pada from kloter where nomor = v_hasil.kloter) is null,
+    format('pendaftar susulan masuk kloter %s yang SUDAH dicetak', v_hasil.kloter);
+end;
+$$;
+
+-- 4.5 Cetak lembar tambahan hanya menandai kloter baru itu.
+do $$
+declare v_baru int;
+begin
+  v_baru := tandai_kloter_dicetak();
+  assert v_baru = 1, format('lembar tambahan menandai %s kloter, harusnya 1', v_baru);
+end;
+$$;
+
+-- 4.6 Batalkan tanda cetak: hanya admin, wajib beralasan, dan setelah itu
+--     kloter bisa diisi lagi (untuk cetak ulang).
+do $$
+declare v_tercetak smallint;
+begin
+  select nomor into v_tercetak from kloter where dicetak_pada is not null limit 1;
+  begin
+    perform batalkan_tanda_cetak(v_tercetak, 'kertas macet');
+    raise exception 'GAGAL: meja bisa membatalkan tanda cetak';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  begin
+    perform batalkan_tanda_cetak(v_tercetak, '');
+    raise exception 'GAGAL: tanda cetak dibatalkan tanpa alasan';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  perform batalkan_tanda_cetak(v_tercetak, 'kertas macet, cetak ulang');
+  assert (select dicetak_pada from kloter where nomor = v_tercetak) is null,
+    'tanda cetak tidak terhapus';
+  assert exists (select 1 from riwayat
+                 where tabel = 'kloter'
+                   and nilai_baru ? 'alasan_batal_tanda_cetak'),
+    'pembatalan tanda cetak tidak terekam riwayat';
+end;
+$$;
+
+reset role;
+\echo '== 04: OK =='

--- a/web/_headers
+++ b/web/_headers
@@ -1,0 +1,28 @@
+# ============================================================================
+# hrcd-rekap : _headers — aturan cache untuk Cloudflare Pages.
+#
+# Kenapa ini penting: saat pengujian, browser menyajikan gaya.css dan app.js
+# versi LAMA dari cache sehingga perbaikan tidak terlihat sama sekali. Kalau
+# itu terjadi pada panitia di hari-H — misal ada perbaikan mendadak jam 07.00 —
+# mereka akan memakai versi lama tanpa tahu, dan tidak ada yang menyadarinya.
+#
+# Aset di sini kecil (<100 KB seluruhnya), jadi memaksa browser bertanya dulu
+# ke server tiap kali hampir tidak berbiaya. no-cache berarti "boleh disimpan,
+# tapi WAJIB divalidasi ulang" — jauh lebih murah daripada no-store.
+# ============================================================================
+
+/*
+  Cache-Control: no-cache
+
+/*.js
+  Cache-Control: no-cache
+  Content-Type: text/javascript; charset=utf-8
+
+/*.css
+  Cache-Control: no-cache
+  Content-Type: text/css; charset=utf-8
+
+# live.json diperbarui GitHub Actions tiap beberapa menit; halaman publik
+# memuat ulang sendiri, jadi cukup singkat saja.
+/live.json
+  Cache-Control: max-age=30

--- a/web/gaya.css
+++ b/web/gaya.css
@@ -405,10 +405,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     font-size: 12pt;
     color: #000;
   }
-  .cetakan h1 { font-size: 16pt; margin-bottom: 1rem; }
+  .cetakan h1 { font-size: 16pt; margin-bottom: .6rem; }
   .cetakan p { margin: .45rem 0; }
   body { background: #fff; }
+
+  /* Daftar kloter: satu kloter per lembar, supaya tiap petugas garis start
+     memegang kertasnya sendiri. */
+  .halaman-cetak { break-after: page; page-break-after: always; }
+  .halaman-cetak:last-child { break-after: auto; page-break-after: auto; }
+
+  .tabel-cetak { width: 100%; border-collapse: collapse; margin-top: .5rem; }
+  .tabel-cetak th, .tabel-cetak td {
+    border: 1px solid #000;
+    padding: 5pt 6pt;
+    text-align: left;
+    font-size: 11pt;
+  }
+  .tabel-cetak th { background: #eee; font-size: 9pt; text-transform: uppercase; }
+  .tabel-cetak .dada { font-size: 15pt; font-weight: 800; text-align: center; width: 15mm; }
+  /* Kolom centang kehadiran diisi tangan di lapangan. */
+  .tabel-cetak .kotak { width: 18mm; }
 }
+
+@page { margin: 12mm; }
 
 /* ---------- responsif ---------- */
 

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -247,3 +247,13 @@ export const tukarNomor = (reguId, nomorBaru, alasan) =>
 
 export const ubahPendamping = (kode, jumlah) =>
   rpc("ubah_pendamping", { p_kode: kode, p_jumlah: jumlah });
+
+/* ============================ CETAK KLOTER ============================== */
+
+export async function daftarKloter() {
+  if (K.mode === "dev") return baca("/kloter");
+  return baca(null, "v_daftar_kloter?select=*&order=kloter.asc,urutan.asc");
+}
+
+export const tandaiKloterDicetak = (nomorKloter) =>
+  rpc("tandai_kloter_dicetak", { p_kloter: nomorKloter || null });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -12,6 +12,7 @@ import {
   sesi, masuk, keluar, GalatApi,
   lihatBatch, infoEdisi, ringkasanMeja,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor, ubahPendamping,
+  daftarKloter, tandaiKloterDicetak,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -129,6 +130,10 @@ async function layarBeranda() {
       <a href="#/pendaftaran-offline">
         <div class="nama-fungsi">📝 Pendaftaran Offline</div>
         <div class="ket">Bukakan form pendaftaran untuk sekolah yang datang langsung</div>
+      </a>
+      <a href="#/cetak-kloter">
+        <div class="nama-fungsi">🖨️ Cetak Daftar Kloter</div>
+        <div class="ket">Kertas untuk garis start — setelah dicetak, isi kloter dibekukan</div>
       </a>
     </div>
     <p class="keterangan" style="margin-top:1.2rem">Angka kuning = masih ada antrean.
@@ -465,6 +470,126 @@ function layarDaftarUlang() {
   });
 }
 
+/* ============================ CETAK DAFTAR KLOTER ======================== */
+
+async function layarCetakKloter() {
+  pasangKepala("Cetak Daftar Kloter");
+  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+
+  let baris;
+  try { baris = await daftarKloter(); }
+  catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarCetakKloter)); return; }
+
+  if (!baris.length) {
+    LAYAR.replaceChildren(h(`<div class="kartu">
+      <h2>Belum ada regu berkloter</h2>
+      <p class="keterangan">Daftar kloter bisa dicetak setelah ada sekolah yang daftar ulang.</p>
+    </div>`));
+    return;
+  }
+
+  // Kelompokkan per kloter; pisahkan yang belum pernah dicetak.
+  const perKloter = new Map();
+  for (const b of baris) {
+    if (!perKloter.has(b.kloter)) perKloter.set(b.kloter, { dicetak: b.dicetak_pada, isi: [] });
+    perKloter.get(b.kloter).isi.push(b);
+  }
+  const belum = [...perKloter.entries()].filter(([, v]) => !v.dicetak).map(([k]) => k);
+
+  LAYAR.replaceChildren(h(`
+    <div class="kartu" style="border-color:var(--utama)">
+      <h2>Daftar kloter untuk garis start</h2>
+      <p class="keterangan">Setelah dicetak, isi kloter <strong>dibekukan</strong> —
+         kertas ini yang dipakai memanggil regu, jadi sistem tidak boleh
+         mengubahnya diam-diam. Sekolah yang daftar ulang setelah ini masuk
+         kloter cadangan dan dicetak sebagai lembar tambahan.</p>
+      <table class="tabel" style="margin-top:.6rem">
+        <tr><td>Kloter berisi regu</td><td class="angka">${perKloter.size}</td></tr>
+        <tr><td>Belum pernah dicetak</td><td class="angka">${belum.length}</td></tr>
+        <tr><td>Total regu</td><td class="angka">${baris.length}</td></tr>
+      </table>
+      <div class="pilihan-baris" style="margin-top:.9rem">
+        <button class="tombol tombol-utama" id="cetak-belum" type="button"
+                ${belum.length ? "" : "disabled"}>
+          🖨️ Cetak ${belum.length} kloter baru
+        </button>
+        <button class="tombol tombol-kalem" id="cetak-semua" type="button">
+          Cetak ulang semua
+        </button>
+      </div>
+    </div>
+    <div id="pratayang"></div>
+  `));
+
+  const gambarPratayang = (nomorKloter) => {
+    const dipakai = nomorKloter
+      ? [...perKloter.entries()].filter(([k]) => nomorKloter.includes(k))
+      : [...perKloter.entries()];
+    // CATATAN: baris tabel dirakit dengan html`` (nilai di-escape), lalu
+    // digabung memakai template BIASA. Menyisipkan HTML jadi ke dalam html``
+    // akan meng-escape-nya dua kali dan tabelnya tampil sebagai teks mentah.
+    document.getElementById("pratayang").replaceChildren(h(
+      dipakai.map(([nomor, v]) => {
+        const baris = v.isi.map(r => html`
+          <tr><td class="angka">${String(r.nomor_dada).padStart(3, "0")}</td>
+              <td><strong>${r.nama_regu}</strong></td>
+              <td>${r.nama_sekolah}</td>
+              <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td></tr>`).join("");
+        return `
+          <div class="kartu">
+            <h2>Kloter ${esc(nomor)}
+              <span class="lencana ${v.dicetak ? "lencana-abu" : "lencana-kuning"}">
+                ${v.dicetak ? "sudah dicetak" : "baru"}</span></h2>
+            <table class="tabel">${baris}</table>
+          </div>`;
+      }).join("")));
+    siapkanCetakKloter(dipakai);
+  };
+
+  document.getElementById("cetak-belum").addEventListener("click", () => cetak(belum));
+  document.getElementById("cetak-semua").addEventListener("click", () => cetak(null));
+  gambarPratayang(null);
+
+  async function cetak(nomorKloter) {
+    gambarPratayang(nomorKloter);
+    window.print();
+    // Ditandai SETELAH dialog cetak ditutup — kalau operator membatalkan,
+    // kloternya belum dianggap tercetak.
+    const lanjut = confirm("Kertasnya sudah keluar dengan benar?\n\n" +
+      "OK  = tandai kloter ini sudah dicetak (isinya dibekukan)\n" +
+      "Batal = belum, biarkan bisa dicetak lagi");
+    if (!lanjut) return;
+    try {
+      const n = await tandaiKloterDicetak(nomorKloter);
+      notif(`${n} kloter ditandai sudah dicetak dan dibekukan.`);
+      layarCetakKloter();
+    } catch (err) { notif(err.message, true); }
+  }
+}
+
+/** Blok cetak khusus daftar kloter — satu kloter per halaman kertas. */
+function siapkanCetakKloter(dipakai) {
+  document.getElementById("cetakan")?.remove();
+  const halaman = dipakai.map(([nomor, v]) => {
+    const baris = v.isi.map(r => html`
+      <tr><td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
+          <td>${r.nama_regu}</td>
+          <td>${r.nama_sekolah}</td>
+          <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>
+          <td class="kotak"></td></tr>`).join("");
+    return `
+      <section class="halaman-cetak">
+        <h1>KLOTER ${esc(nomor)} — Hiking Rally Ciradyka ${esc(EDISI ? EDISI.nama : "")}</h1>
+        <p>Jam berangkat: ________  ·  Petugas: ________________</p>
+        <table class="tabel-cetak">
+          <thead><tr><th>No Dada</th><th>Nama Regu</th><th>Sekolah</th><th>Golongan</th><th>Hadir</th></tr></thead>
+          <tbody>${baris}</tbody>
+        </table>
+      </section>`;
+  }).join("");
+  document.body.appendChild(h(`<div id="cetakan" class="cetakan">${halaman}</div>`));
+}
+
 /* ============================ PENDAFTARAN OFFLINE ======================== */
 
 function layarPendaftaranOffline() {
@@ -497,6 +622,7 @@ const RUTE = {
   "#/pembayaran": layarPembayaran,
   "#/daftar-ulang": layarDaftarUlang,
   "#/pendaftaran-offline": layarPendaftaranOffline,
+  "#/cetak-kloter": layarCetakKloter,
 };
 
 async function arahkan() {


### PR DESCRIPTION
## Why

*"Nanti kloter final akan diprint."* That changes what the data **is**: once the sheets are handed out, **the paper is the truth at the start line** — staff call regu from paper, not from a screen. Any change to kloter contents after printing makes the paper lie with nobody noticing.

Not hypothetical: a school arrives late, does daftar ulang after the sheets are out, and its regu are slotted into an already-printed kloter. At the start line that kloter calls ten names while the paper lists nine — or the regu is never called at all.

## Defence in layers (migration 0008)

| Layer | What it does |
|---|---|
| `kloter.dicetak_pada` | Marks kloter whose sheet has been printed |
| `daftar_ulang_batch` | Only picks **never-printed** kloter, so late arrivals fall into reserve kloter 31–40 and get an **extra sheet** — not turned away |
| Trigger `jaga_kloter_tercetak` | Refuses any `kloter_nomor` change into or out of a printed kloter, **from any path** — including admin SQL that forgets the rule |
| `batalkan_tanda_cetak` | Admin only, reason required, recorded in riwayat — for a jammed printer |

The screen marks kloter as printed **only after the print dialog closes** and the operator confirms the paper actually came out. Paper layout: one kloter per sheet, large bib column, blank "Hadir" column to tick by hand, space for departure time and officer name.

## Verified end to end in the app

Five kloter marked printed → a late school's daftar ulang landed in an **unprinted** kloter rather than being slotted into a frozen one. Also covered by `tests/sql/04_cetak_kloter.sql`, which tests both layers separately: RLS stops a `meja` writing directly (0 rows, no error), and the trigger stops an **admin** who can.

## Two fixes found while testing this — both real beyond it

1. **Browsers served stale `app.js`**, the same way they served stale CSS earlier. A mid-event fix would silently never reach the panitia. `web/_headers` sets `no-cache` for Cloudflare Pages; `tests/layar_server.py` replaces `python -m http.server` with a no-store equivalent.
2. **Double-escaping**: nesting already-built HTML inside the escaping ``html`` `` tag made the kloter tables render as visible markup. Rows are now built with ``html`` `` and joined with a plain template, with a comment explaining why so it doesn't regress.

Blueprint §4.2 records the reasoning. Full SQL suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)