### PR TITLE
feat: day-of kloter moves, insertion warnings, two paper formats

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -182,6 +182,25 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    ditetapkan — lihat bagian 13.
 7. Konsekuensi bagi sistem: layar keberangkatan harus menampilkan **beberapa
    kloter sekaligus dalam status berbeda**, bukan satu kloter per layar.
+8. **Ada 3 staging.** Verifikasi kehadiran regu dilakukan **di staging**, bukan
+   di garis start: setelah masuk staging, peserta cukup menunggu sampai
+   benar-benar diberangkatkan.
+9. **Panitia membawa kertas DAN laptop bersamaan.** Kertas dipakai untuk
+   membacakan dan mencentang; laptop untuk memverifikasi. Keduanya hidup
+   berdampingan — bukan salah satu menggantikan yang lain.
+10. **Daftar kloter dicetak untuk dua pembaca:**
+    - **Petugas staging** — ada kolom centang kehadiran dan tempat menulis jam
+      berangkat sebenarnya.
+    - **Papan pengumuman utama dan barak** — dibaca peserta, memuat perkiraan
+      jam berangkat. Lembar ini juga menyediakan kotak bagi **pembina regu
+      untuk mencatat jam berangkat sebenarnya**, karena pembina biasa
+      mencatatnya sebagai bahan klarifikasi bila penilaian ketepatan waktu
+      dipersoalkan (target datang = jam berangkat + kontrak waktu).
+11. **Peserta yang terlambat masuk kloternya** diberangkatkan di **kloter
+    terakhir**. Bila keadaannya mendesak, panitia dapat memaksa nomor dada
+    tertentu masuk kloter mana pun — termasuk kloter yang kertasnya sudah
+    beredar. Regu yang disisipkan setelah cetak **wajib ditandai sistem**,
+    karena nomornya tidak ada di kertas yang dipegang petugas staging.
 
 ## 7. Rute dan pos
 
@@ -291,6 +310,14 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    Kloter yang berangkat 07.00 dengan kontrak 4 jam ditargetkan tiba 11.00.
 2. Jam berangkat berlaku **per kloter**; jam datang dicatat **per regu** di meja
    closing.
+   - **Jam berangkat diketik panitia** — dicatat di kertas oleh pencatat, lalu
+     dimasukkan.
+   - **Jam datang diisi tombol**: panitia mengetik nomor dada, detail regu
+     muncul untuk dipastikan, lalu menekan satu tombol "Sampai di Finish".
+     Targetnya ±3 detik per regu, sehingga 20 regu yang datang bersamaan pun
+     tidak menumpuk. Jam yang tersimpan adalah **jam saat tombol ditekan di
+     laptop panitia**, bukan cap waktu server saat data sampai — dan tetap
+     dapat diubah manual untuk pencatatan susulan dari kertas (bagian 12.3).
 3. Penalti dihitung dari selisih mutlak antara jam datang dan target:
 
    ```

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -171,6 +171,48 @@ Panitia: *"nanti kloter final akan diprint."* Itu mengubah sifat datanya.
    kloter ditandai tercetak, sekolah susulan masuk kloter yang belum pernah
    dicetak — bukan diselipkan.
 
+### 4.3 Pindah kloter hari-H, dan kenapa sisipan wajib berteriak
+
+Pembekuan di 4.2 mencegah perubahan **diam-diam**, bukan melarang keputusan
+sadar panitia. Hari-H butuh dua jalur (migrasi 0009, RPC `pindah_kloter`):
+
+1. **Telat biasa** — panggil tanpa menyebut kloter; regu mendarat di **kloter
+   terakhir** yang belum berangkat dan masih muat.
+2. **Urgent** — sebut kloter tujuannya; regu dipaksa masuk, **termasuk kloter
+   yang kertasnya sudah beredar**.
+
+Keduanya wajib beralasan dan terekam riwayat. Yang **tidak** boleh ditembus
+meski urgent: kloter yang sudah berangkat, dan kapasitas fisik 10 regu —
+kertas boleh dilanggar, kapasitas tidak.
+
+**Bagian yang tidak diminta tetapi paling penting: sisipan harus berteriak.**
+Petugas staging memegang kertas yang tidak memuat nomor itu. Kalau sistem diam,
+regu tersebut ada di database tapi **tidak akan pernah dipanggil**. Maka:
+
+- Regu yang mendarat di kloter tercetak ditandai `disisipkan_pada`.
+- RPC mengembalikan kalimat siap-baca: *"Nomor 042 TIDAK ADA di kertas kloter
+  3. Beri tahu petugas staging."*
+- Layar menampilkannya sebagai kartu merah **menetap** (bukan toast yang hilang
+  sendiri), dan menyediakan daftar seluruh sisipan aktif untuk dicetak atau
+  dibacakan.
+- Lembar staging menandai regu sisipan dengan ★ beserta keterangannya.
+
+### 4.4 Dua bentuk kertas, karena pembacanya dua
+
+Panitia membawa **kertas dan laptop bersamaan** — kertas untuk membacakan dan
+mencentang, laptop untuk memverifikasi. Daftar kloter karena itu dicetak dalam
+dua bentuk dari data yang sama:
+
+| Bentuk | Pembaca | Isi khasnya |
+| --- | --- | --- |
+| **Staging** | Petugas di 3 staging | Kolom centang kehadiran, tempat menulis jam berangkat sebenarnya, tanda ★ untuk sisipan |
+| **Umum** | Papan pengumuman utama & barak | Perkiraan jam berangkat dicetak besar; **kotak catatan pembina** untuk menulis jam berangkat sebenarnya |
+
+Kotak pembina itu bukan hiasan: pembina regu memang mencatat jam berangkat
+untuk klarifikasi, karena target kedatangan — dan karenanya penalti waktu —
+dihitung dari jam berangkat + kontrak waktu. Memberi mereka tempat menulis di
+lembar resmi membuat klarifikasi berpijak pada angka yang sama.
+
 ## 5. Mesin skor — hitung-saat-baca, tanpa tombol "hitung ulang"
 
 1. **Tidak ada angka turunan yang disimpan.** Semua skor dihitung saat dibaca

--- a/supabase/migrations/0009_sisip_kloter.sql
+++ b/supabase/migrations/0009_sisip_kloter.sql
@@ -1,0 +1,283 @@
+-- ============================================================================
+-- hrcd-rekap : 0009_sisip_kloter.sql
+--
+-- Panitia:
+--   "Kertas dibagikan ke setiap barak, beserta perkiraan berangkat, jadi
+--    tidak mungkin berubah. Namun di hari-H ada peserta yang terlambat masuk
+--    kloter — akan diberangkatkan ke kloter terakhir. Atau bisa jadi sangat
+--    urgent, harus diberangkatkan saat itu, jadi harus ada sistem di mana kita
+--    bisa memasukkan nomor dada tertentu ke kloter di luar yang sudah
+--    terdaftar."
+--
+-- Tiga hal yang ditambahkan:
+--
+-- 1. PERKIRAAN BERANGKAT di kertas. Regu di barak perlu tahu kapan harus siap;
+--    tanpa itu kertasnya hanya daftar nama. Dihitung dari jam mulai + interval
+--    x (nomor kloter - 1). Kalau kloter sudah berangkat, yang tampil adalah
+--    jam sebenarnya, bukan perkiraan.
+--
+-- 2. JALUR SAH untuk memindahkan regu. Pembekuan di 0008 dimaksudkan mencegah
+--    perubahan DIAM-DIAM, bukan melarang keputusan sadar panitia. Jadi
+--    pembekuan tetap, tetapi ada satu pintu resmi: pindah_kloter(), yang wajib
+--    beralasan dan terekam riwayat.
+--
+-- 3. PENANDA SISIPAN — bagian terpenting, dan tidak diminta secara eksplisit.
+--    Petugas staging memegang kertas yang TIDAK memuat regu sisipan itu.
+--    Kalau sistem diam saja, regu itu ada di database tapi tidak akan pernah
+--    dipanggil. Maka tiap regu yang disisipkan setelah kertas cetak diberi
+--    tanda, dan layar staging wajib menyorotnya: "nomor ini TIDAK ADA di
+--    kertas Anda."
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Jam mulai keberangkatan (untuk perkiraan di kertas)
+-- ---------------------------------------------------------------------------
+
+alter table edisi add column jam_mulai_berangkat time not null default '07:00';
+
+comment on column edisi.jam_mulai_berangkat is
+  'Perkiraan jam berangkat kloter 1. Dipakai menghitung perkiraan di kertas '
+  'yang dibagikan ke barak; jam sebenarnya tetap diketik panitia saat start.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Penanda sisipan pada regu
+-- ---------------------------------------------------------------------------
+
+alter table regu add column disisipkan_pada timestamptz;
+alter table regu add column alasan_sisip text;
+
+comment on column regu.disisipkan_pada is
+  'Diisi bila regu dipindahkan ke kloter SETELAH daftar kloter dicetak. '
+  'Artinya nomor dada ini TIDAK ADA di kertas yang dipegang petugas garis '
+  'start — layar wajib menyorotnya.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Trigger 0008 diberi pintu resmi.
+--    Perubahan kloter tetap ditolak, KECUALI dilakukan lewat pindah_kloter()
+--    yang menyalakan penanda transaksi hrcd.izin_pindah.
+-- ---------------------------------------------------------------------------
+
+create or replace function tolak_ubah_kloter_tercetak()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  -- Pintu resmi: pindah_kloter() menyalakan penanda ini di dalam transaksinya.
+  if coalesce(current_setting('hrcd.izin_pindah', true), '') = '1' then
+    return new;
+  end if;
+
+  if old.kloter_nomor is not null
+     and old.kloter_nomor is distinct from new.kloter_nomor
+     and exists (select 1 from kloter where nomor = old.kloter_nomor
+                 and dicetak_pada is not null) then
+    raise exception 'kloter % sudah dicetak — isinya tidak boleh berubah. Pakai menu "Pindah kloter" bila memang perlu.',
+      old.kloter_nomor;
+  end if;
+  if new.kloter_nomor is not null
+     and new.kloter_nomor is distinct from old.kloter_nomor
+     and exists (select 1 from kloter where nomor = new.kloter_nomor
+                 and dicetak_pada is not null) then
+    raise exception 'kloter % sudah dicetak — regu baru tidak boleh disisipkan ke sana. Pakai menu "Pindah kloter" bila memang perlu.',
+      new.kloter_nomor;
+  end if;
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. pindah_kloter — satu pintu untuk dua kebutuhan hari-H.
+--
+--    p_kloter NULL  -> "telat biasa": taruh di kloter TERAKHIR yang belum
+--                      berangkat dan masih muat (jalur yang panitia sebut).
+--    p_kloter diisi -> "urgent": paksa ke kloter itu, termasuk yang sudah
+--                      dicetak atau yang sebentar lagi berangkat.
+--
+--    Keduanya wajib beralasan dan tercatat. Regu yang mendarat di kloter
+--    tercetak otomatis diberi tanda sisipan.
+-- ---------------------------------------------------------------------------
+
+create or replace function pindah_kloter(
+  p_nomor_dada integer,
+  p_alasan     text,
+  p_kloter     smallint default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu    regu%rowtype;
+  v_cfg     edisi%rowtype;
+  v_tujuan  smallint;
+  v_isi     int;
+  v_tercetak boolean;
+  v_lama    smallint;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan pemindahan wajib diisi — tercatat di riwayat';
+  end if;
+
+  select * into v_cfg from edisi where aktif;
+
+  -- Serialisasi bersama daftar ulang: keduanya menyentuh isi kloter.
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  select * into v_regu from regu where nomor_dada = p_nomor_dada for update;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+  if v_regu.batal then
+    raise exception 'regu % berstatus batal', p_nomor_dada;
+  end if;
+  v_lama := v_regu.kloter_nomor;
+
+  if v_lama is not null
+     and exists (select 1 from kloter where nomor = v_lama and jam_berangkat is not null) then
+    raise exception 'regu % sudah diberangkatkan di kloter % — tidak bisa dipindah',
+      p_nomor_dada, v_lama;
+  end if;
+
+  if p_kloter is null then
+    -- TELAT BIASA: kloter terakhir yang belum berangkat dan masih muat.
+    select k.nomor into v_tujuan
+    from kloter k
+    where k.jam_berangkat is null
+      and k.nomor <= v_cfg.kloter_maks
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor desc
+    limit 1;
+    if v_tujuan is null then
+      raise exception 'tidak ada kloter tersisa yang belum berangkat dan masih muat';
+    end if;
+  else
+    -- URGENT: kloter yang disebut panitia, apa pun keadaannya.
+    v_tujuan := p_kloter;
+    if not exists (select 1 from kloter where nomor = v_tujuan) then
+      raise exception 'kloter % tidak ada', v_tujuan;
+    end if;
+    if exists (select 1 from kloter where nomor = v_tujuan and jam_berangkat is not null) then
+      raise exception 'kloter % sudah berangkat', v_tujuan;
+    end if;
+  end if;
+
+  if v_tujuan = v_lama then
+    raise exception 'regu % sudah ada di kloter %', p_nomor_dada, v_tujuan;
+  end if;
+
+  -- Kapasitas tetap dijaga: kertas boleh dilanggar, kapasitas fisik tidak.
+  select count(*) into v_isi from regu where kloter_nomor = v_tujuan;
+  if v_isi >= v_cfg.maks_regu_per_kloter then
+    raise exception 'kloter % sudah penuh (% regu)', v_tujuan, v_isi;
+  end if;
+
+  select dicetak_pada is not null into v_tercetak from kloter where nomor = v_tujuan;
+
+  -- Buka pintu untuk trigger 0008, hanya di dalam transaksi ini.
+  perform set_config('hrcd.izin_pindah', '1', true);
+
+  update regu set
+    kloter_nomor  = v_tujuan,
+    urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                     where not exists (select 1 from regu x
+                                       where x.kloter_nomor = v_tujuan
+                                         and x.urutan_kloter = s)),
+    -- Ditandai sisipan HANYA bila kertas tujuan sudah beredar.
+    disisipkan_pada = case when v_tercetak then now() else disisipkan_pada end,
+    alasan_sisip    = case when v_tercetak then p_alasan else alasan_sisip end
+  where id = v_regu.id;
+
+  perform set_config('hrcd.izin_pindah', '0', true);
+
+  insert into riwayat (tabel, baris_id, regu_id, aksi, nilai_baru, oleh)
+  values ('regu', v_regu.id::text, v_regu.id, 'UPDATE',
+          jsonb_build_object('pindah_kloter', jsonb_build_object(
+            'nomor_dada', p_nomor_dada, 'dari', v_lama, 'ke', v_tujuan,
+            'alasan', p_alasan, 'kloter_tujuan_sudah_dicetak', v_tercetak)),
+          auth.uid());
+
+  return jsonb_build_object(
+    'nomor_dada', p_nomor_dada,
+    'kloter_lama', v_lama,
+    'kloter_baru', v_tujuan,
+    'sisipan', v_tercetak,
+    'peringatan', case when v_tercetak
+      then format('Nomor %s TIDAK ADA di kertas kloter %s. Beri tahu petugas staging.',
+                  p_nomor_dada, v_tujuan)
+      end);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. View cetak diperbarui: perkiraan berangkat + penanda sisipan.
+-- ---------------------------------------------------------------------------
+
+drop view if exists v_daftar_kloter;
+
+create view v_daftar_kloter with (security_invoker = on) as
+select
+  r.kloter_nomor                        as kloter,
+  r.urutan_kloter                       as urutan,
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama                                as nama_sekolah,
+  r.golongan,
+  k.dicetak_pada,
+  k.jam_berangkat,
+  -- Perkiraan untuk kertas barak; kalau sudah berangkat, pakai jam nyata.
+  coalesce(
+    k.jam_berangkat,
+    (e.tanggal_lomba + e.jam_mulai_berangkat)::timestamptz
+      + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1))
+  )                                     as perkiraan_berangkat,
+  k.jam_berangkat is not null           as sudah_berangkat,
+  r.disisipkan_pada is not null         as sisipan,
+  r.alasan_sisip
+from regu r
+join kloter k       on k.nomor = r.kloter_nomor
+join pendaftaran d  on d.id = r.pendaftaran_id
+join sekolah s      on s.id = d.sekolah_id
+cross join edisi e
+where e.aktif
+  and not r.batal
+  and d.status = 'lunas'
+  and r.kloter_nomor is not null
+order by r.kloter_nomor, r.urutan_kloter;
+
+grant select on v_daftar_kloter to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 6. View sisipan: daftar pendek yang WAJIB dibacakan ke petugas garis start,
+--    karena nomor-nomor ini tidak ada di kertas mereka.
+-- ---------------------------------------------------------------------------
+
+create view v_sisipan_kloter with (security_invoker = on) as
+select
+  r.kloter_nomor    as kloter,
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama            as nama_sekolah,
+  r.golongan,
+  r.disisipkan_pada,
+  r.alasan_sisip,
+  k.jam_berangkat is not null as sudah_berangkat
+from regu r
+join kloter k      on k.nomor = r.kloter_nomor
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+where r.disisipkan_pada is not null
+  and not r.batal
+order by r.kloter_nomor, r.nomor_dada;
+
+grant select on v_sisipan_kloter to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 7. Hak eksekusi
+-- ---------------------------------------------------------------------------
+
+revoke execute on function pindah_kloter(integer, text, smallint) from public, anon;
+grant execute on function pindah_kloter(integer, text, smallint) to authenticated;

--- a/tests/dev_db.sh
+++ b/tests/dev_db.sh
@@ -27,6 +27,7 @@ run supabase/migrations/0005_views.sql
 run supabase/migrations/0006_idempotensi.sql
 run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/migrations/0008_cetak_kloter.sql
+run supabase/migrations/0009_sisip_kloter.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -38,6 +38,7 @@ RPC = {
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
     "susun_barak":           [],
     "tandai_kloter_dicetak": ["p_kloter"],
+    "pindah_kloter":         ["p_nomor_dada", "p_alasan", "p_kloter"],
     "batalkan_tanda_cetak":  ["p_kloter", "p_alasan"],
 }
 # RPC yang hasilnya tabel (bukan skalar/jsonb).
@@ -87,6 +88,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/edisi":
                 self._kirim(200, q(
                     "select * from v_edisi_publik", role="anon", fetch="one"))
+            elif u.path == "/sisipan":
+                self._kirim(200, q(
+                    "select * from v_sisipan_kloter", uid=p.get("uid")))
             elif u.path == "/kloter":
                 self._kirim(200, q(
                     "select * from v_daftar_kloter", uid=p.get("uid")))

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -31,10 +31,12 @@ run supabase/migrations/0005_views.sql
 run supabase/migrations/0006_idempotensi.sql
 run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/migrations/0008_cetak_kloter.sql
+run supabase/migrations/0009_sisip_kloter.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
 run tests/sql/03_alur.sql
 run tests/sql/04_cetak_kloter.sql
+run tests/sql/05_pindah_kloter.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/05_pindah_kloter.sql
+++ b/tests/sql/05_pindah_kloter.sql
@@ -1,0 +1,218 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/05_pindah_kloter.sql
+-- Dua kebutuhan hari-H: peserta telat masuk kloter terakhir, dan peserta
+-- urgent dipaksa masuk kloter tertentu meski kertasnya sudah beredar.
+-- Yang WAJIB dibuktikan: regu sisipan selalu tertandai, karena nomor itu
+-- tidak ada di kertas yang dipegang petugas garis start.
+-- ============================================================================
+
+\echo '== 05: pindah kloter =='
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+-- 5.1 Perkiraan berangkat muncul di kertas, dan berjarak sesuai interval.
+do $$
+declare
+  v_k1 timestamptz; v_k3 timestamptz; v_interval int;
+begin
+  select interval_berangkat_menit into v_interval from edisi where aktif;
+  select min(perkiraan_berangkat) into v_k1 from v_daftar_kloter where kloter = 1;
+  select min(perkiraan_berangkat) into v_k3 from v_daftar_kloter where kloter = 3;
+  assert v_k1 is not null, 'perkiraan berangkat kloter 1 kosong';
+  assert v_k3 is not null, 'perkiraan berangkat kloter 3 kosong';
+  assert extract(epoch from (v_k3 - v_k1)) / 60 = 2 * v_interval,
+    format('jarak kloter 1->3 = %s menit, harusnya %s',
+           extract(epoch from (v_k3 - v_k1)) / 60, 2 * v_interval);
+end;
+$$;
+
+-- 5.2 Alasan wajib — pemindahan tanpa alasan ditolak.
+do $$
+declare v_dada integer;
+begin
+  select nomor_dada into v_dada from regu where nomor_dada is not null limit 1;
+  begin
+    perform pindah_kloter(v_dada, '   ');
+    raise exception 'GAGAL: pindah kloter tanpa alasan diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+-- 5.3 TELAT BIASA (p_kloter null): mendarat di kloter TERAKHIR yang belum
+--     berangkat dan masih muat.
+do $$
+declare
+  v_dada    integer;
+  v_hasil   jsonb;
+  v_terakhir smallint;
+begin
+  -- Regu yang kloternya belum berangkat.
+  select r.nomor_dada into v_dada
+  from regu r join kloter k on k.nomor = r.kloter_nomor
+  where k.jam_berangkat is null and not r.batal
+  order by r.nomor_dada limit 1;
+
+  select max(k.nomor) into v_terakhir
+  from kloter k
+  where k.jam_berangkat is null
+    and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+        < (select maks_regu_per_kloter from edisi where aktif);
+
+  v_hasil := pindah_kloter(v_dada, 'terlambat masuk kloter');
+  assert (v_hasil ->> 'kloter_baru')::smallint = v_terakhir,
+    format('telat mendarat di kloter %s, harusnya %s',
+           v_hasil ->> 'kloter_baru', v_terakhir);
+end;
+$$;
+
+-- 5.4 URGENT: dipaksa ke kloter yang SUDAH DICETAK — berhasil, tapi WAJIB
+--     tertandai sisipan dan mengembalikan peringatan untuk dibacakan.
+do $$
+declare
+  v_dada     integer;
+  v_tercetak smallint;
+  v_hasil    jsonb;
+begin
+  select k.nomor into v_tercetak
+  from kloter k
+  where k.dicetak_pada is not null and k.jam_berangkat is null
+    and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+        < (select maks_regu_per_kloter from edisi where aktif)
+  limit 1;
+  assert v_tercetak is not null, 'tidak ada kloter tercetak yang masih muat untuk diuji';
+
+  select r.nomor_dada into v_dada
+  from regu r join kloter k on k.nomor = r.kloter_nomor
+  where k.jam_berangkat is null and r.kloter_nomor <> v_tercetak and not r.batal
+  order by r.nomor_dada desc limit 1;
+
+  v_hasil := pindah_kloter(v_dada, 'peserta urgent, harus berangkat sekarang', v_tercetak);
+
+  assert (v_hasil ->> 'kloter_baru')::smallint = v_tercetak, 'tidak mendarat di kloter tujuan';
+  assert (v_hasil ->> 'sisipan')::boolean, 'pemindahan ke kloter tercetak tidak ditandai sisipan';
+  assert v_hasil ->> 'peringatan' like '%TIDAK ADA di kertas%',
+    'peringatan untuk petugas garis start tidak dikembalikan';
+
+  -- Tanda sisipan harus tersimpan, bukan hanya di respons.
+  assert (select disisipkan_pada is not null from regu where nomor_dada = v_dada),
+    'tanda sisipan tidak tersimpan di regu';
+  assert exists (select 1 from v_sisipan_kloter where nomor_dada = v_dada),
+    'regu sisipan tidak muncul di v_sisipan_kloter';
+  assert (select sisipan from v_daftar_kloter where nomor_dada = v_dada),
+    'v_daftar_kloter tidak menandai regu sisipan';
+end;
+$$;
+
+-- Riwayat hanya terbaca admin (RLS) — jadi diperiksa dengan akun admin.
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+do $$
+begin
+  assert exists (select 1 from riwayat
+                 where nilai_baru -> 'pindah_kloter' ->> 'alasan'
+                       = 'peserta urgent, harus berangkat sekarang'),
+    'perpindahan tidak terekam riwayat';
+  assert exists (select 1 from riwayat
+                 where (nilai_baru -> 'pindah_kloter' ->> 'kloter_tujuan_sudah_dicetak')::boolean),
+    'riwayat tidak mencatat bahwa tujuannya kloter tercetak';
+end;
+$$;
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+
+-- 5.5 Pindah ke kloter yang BELUM dicetak tidak menandai sisipan —
+--     kertasnya memang belum beredar, jadi tidak ada yang perlu diperingatkan.
+do $$
+declare
+  v_dada   integer;
+  v_belum  smallint;
+  v_hasil  jsonb;
+begin
+  select k.nomor into v_belum
+  from kloter k
+  where k.dicetak_pada is null and k.jam_berangkat is null
+    and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+        < (select maks_regu_per_kloter from edisi where aktif)
+  limit 1;
+
+  select r.nomor_dada into v_dada
+  from regu r join kloter k on k.nomor = r.kloter_nomor
+  where k.jam_berangkat is null and r.disisipkan_pada is null
+    and r.kloter_nomor <> v_belum and not r.batal
+  order by r.nomor_dada limit 1;
+
+  if v_dada is not null and v_belum is not null then
+    v_hasil := pindah_kloter(v_dada, 'geser biasa', v_belum);
+    assert not (v_hasil ->> 'sisipan')::boolean,
+      'pindah ke kloter belum tercetak salah ditandai sisipan';
+    assert v_hasil ->> 'peringatan' is null, 'peringatan muncul padahal tidak perlu';
+  end if;
+end;
+$$;
+
+-- 5.6 Batas yang TIDAK boleh ditembus meski urgent:
+--     kloter yang sudah berangkat, dan kapasitas fisik.
+do $$
+declare
+  v_dada integer; v_kloter smallint; v_isi int; v_maks int;
+begin
+  -- Berangkatkan satu kloter untuk diuji.
+  select k.nomor into v_kloter from kloter k
+  where k.jam_berangkat is null
+    and exists (select 1 from regu r where r.kloter_nomor = k.nomor and not r.batal)
+  order by k.nomor limit 1;
+
+  -- Semua regu di kloter itu perlu kontrak sebelum boleh berangkat.
+  -- Lewat RPC, bukan UPDATE langsung: peran meja memang tidak berhak menulis
+  -- ke tabel regu (kebijakan sejak review tahap 1).
+  perform konfirmasi_kontrak(id, 240::smallint) from regu where kloter_nomor = v_kloter;
+  perform ceklis_berangkat(nomor_dada) from regu where kloter_nomor = v_kloter;
+  perform berangkatkan_kloter(v_kloter, now());
+
+  select r.nomor_dada into v_dada from regu r join kloter k on k.nomor = r.kloter_nomor
+  where k.jam_berangkat is null and not r.batal limit 1;
+
+  begin
+    perform pindah_kloter(v_dada, 'coba tembus', v_kloter);
+    raise exception 'GAGAL: regu bisa dipindah ke kloter yang sudah berangkat';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Regu yang SUDAH berangkat tidak bisa dipindah ke mana pun.
+  select r.nomor_dada into v_dada from regu r where r.kloter_nomor = v_kloter limit 1;
+  begin
+    perform pindah_kloter(v_dada, 'coba pindah yang sudah jalan');
+    raise exception 'GAGAL: regu yang sudah berangkat bisa dipindah';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+-- 5.7 Tulisan langsung ke tabel tetap ditolak — pintu resmi hanya
+--     pindah_kloter(), dan penandanya tidak bocor ke luar transaksi.
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+do $$
+declare v_regu uuid; v_tercetak smallint;
+begin
+  assert coalesce(current_setting('hrcd.izin_pindah', true), '') <> '1',
+    'penanda izin pindah bocor ke luar transaksi RPC';
+
+  select k.nomor into v_tercetak from kloter k
+  where k.dicetak_pada is not null and k.jam_berangkat is null limit 1;
+  select r.id into v_regu from regu r join kloter k on k.nomor = r.kloter_nomor
+  where k.jam_berangkat is null and r.kloter_nomor <> v_tercetak limit 1;
+
+  begin
+    update regu set kloter_nomor = v_tercetak where id = v_regu;
+    raise exception 'GAGAL: admin bisa menembus pembekuan lewat UPDATE langsung';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+reset role;
+\echo '== 05: OK =='

--- a/web/gaya.css
+++ b/web/gaya.css
@@ -425,6 +425,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .tabel-cetak .dada { font-size: 15pt; font-weight: 800; text-align: center; width: 15mm; }
   /* Kolom centang kehadiran diisi tangan di lapangan. */
   .tabel-cetak .kotak { width: 18mm; }
+
+  /* Lembar papan/barak: jam perkiraan harus terbaca dari jarak berdiri. */
+  .jam-besar { font-size: 18pt; font-weight: 800; margin: .3rem 0 .6rem; }
+
+  .catatan-cetak { font-size: 9pt; color: #333; margin-top: .5rem; }
+  .catatan-sisip { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
+
+  /* Kotak untuk pembina mencatat jam berangkat sebenarnya — bahan klarifikasi
+     bila penilaian ketepatan waktu dipersoalkan. */
+  .kotak-pembina {
+    margin-top: 8mm;
+    border: 1.5pt solid #000;
+    padding: 4mm;
+  }
+  .kotak-pembina .isian-jam { font-size: 12pt; margin: 3mm 0; }
+  .garis-isi {
+    display: inline-block;
+    width: 45mm;
+    border-bottom: 1pt solid #000;
+  }
 }
 
 @page { margin: 12mm; }

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -257,3 +257,13 @@ export async function daftarKloter() {
 
 export const tandaiKloterDicetak = (nomorKloter) =>
   rpc("tandai_kloter_dicetak", { p_kloter: nomorKloter || null });
+
+/** Pindah kloter hari-H. kloter null = "telat biasa" -> kloter terakhir yang
+ *  belum berangkat. kloter diisi = "urgent" -> paksa ke kloter itu. */
+export const pindahKloter = (nomorDada, alasan, kloter = null) =>
+  rpc("pindah_kloter", { p_nomor_dada: nomorDada, p_alasan: alasan, p_kloter: kloter });
+
+export async function daftarSisipan() {
+  if (K.mode === "dev") return baca("/sisipan");
+  return baca(null, "v_sisipan_kloter?select=*&order=kloter.asc,nomor_dada.asc");
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -12,7 +12,7 @@ import {
   sesi, masuk, keluar, GalatApi,
   lihatBatch, infoEdisi, ringkasanMeja,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor, ubahPendamping,
-  daftarKloter, tandaiKloterDicetak,
+  daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -133,7 +133,11 @@ async function layarBeranda() {
       </a>
       <a href="#/cetak-kloter">
         <div class="nama-fungsi">🖨️ Cetak Daftar Kloter</div>
-        <div class="ket">Kertas untuk garis start — setelah dicetak, isi kloter dibekukan</div>
+        <div class="ket">Kertas untuk papan pengumuman, barak, dan petugas staging</div>
+      </a>
+      <a href="#/pindah-kloter">
+        <div class="nama-fungsi">🔀 Pindah Kloter</div>
+        <div class="ket">Peserta telat atau urgent — pindahkan nomor dada ke kloter lain</div>
       </a>
     </div>
     <p class="keterangan" style="margin-top:1.2rem">Angka kuning = masih ada antrean.
@@ -508,7 +512,18 @@ async function layarCetakKloter() {
         <tr><td>Belum pernah dicetak</td><td class="angka">${belum.length}</td></tr>
         <tr><td>Total regu</td><td class="angka">${baris.length}</td></tr>
       </table>
-      <div class="pilihan-baris" style="margin-top:.9rem">
+      <div class="medan" style="margin-top:.9rem;margin-bottom:.5rem">
+        <label>Kertasnya untuk siapa?</label>
+        <div class="pilihan-baris">
+          <button class="pilihan" data-bentuk="staging" aria-pressed="true" type="button">
+            Petugas staging<br><span class="keterangan">ada kolom centang</span>
+          </button>
+          <button class="pilihan" data-bentuk="umum" aria-pressed="false" type="button">
+            Papan &amp; barak<br><span class="keterangan">untuk dibaca peserta</span>
+          </button>
+        </div>
+      </div>
+      <div class="pilihan-baris" style="margin-top:.6rem">
         <button class="tombol tombol-utama" id="cetak-belum" type="button"
                 ${belum.length ? "" : "disabled"}>
           🖨️ Cetak ${belum.length} kloter baru
@@ -520,6 +535,13 @@ async function layarCetakKloter() {
     </div>
     <div id="pratayang"></div>
   `));
+
+  let bentuk = "staging";
+  LAYAR.querySelectorAll("[data-bentuk]").forEach(b => b.addEventListener("click", () => {
+    bentuk = b.dataset.bentuk;
+    LAYAR.querySelectorAll("[data-bentuk]").forEach(x =>
+      x.setAttribute("aria-pressed", String(x === b)));
+  }));
 
   const gambarPratayang = (nomorKloter) => {
     const dipakai = nomorKloter
@@ -543,7 +565,7 @@ async function layarCetakKloter() {
             <table class="tabel">${baris}</table>
           </div>`;
       }).join("")));
-    siapkanCetakKloter(dipakai);
+    siapkanCetakKloter(dipakai, bentuk);
   };
 
   document.getElementById("cetak-belum").addEventListener("click", () => cetak(belum));
@@ -567,27 +589,224 @@ async function layarCetakKloter() {
   }
 }
 
-/** Blok cetak khusus daftar kloter — satu kloter per halaman kertas. */
-function siapkanCetakKloter(dipakai) {
+/** Blok cetak daftar kloter — satu kloter per halaman kertas.
+ *  Dua pembaca, dua bentuk (panitia menyebutkan keduanya):
+ *   - 'staging' : dipegang petugas staging, ada kolom centang kehadiran dan
+ *                 tempat menulis jam berangkat sebenarnya.
+ *   - 'umum'    : ditempel di papan pengumuman & dibagikan ke barak, dibaca
+ *                 peserta — perkiraan berangkat dibesarkan, kolom centang
+ *                 dihilangkan karena tidak ada gunanya bagi peserta.
+ */
+function siapkanCetakKloter(dipakai, bentuk = "staging") {
   document.getElementById("cetakan")?.remove();
+  const jam = (t) => t ? new Date(t).toLocaleTimeString("id-ID",
+    { hour: "2-digit", minute: "2-digit" }) : "—";
+
   const halaman = dipakai.map(([nomor, v]) => {
-    const baris = v.isi.map(r => html`
-      <tr><td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
-          <td>${r.nama_regu}</td>
-          <td>${r.nama_sekolah}</td>
-          <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>
-          <td class="kotak"></td></tr>`).join("");
-    return `
+    const contoh = v.isi[0] || {};
+    const perkiraan = jam(contoh.perkiraan_berangkat);
+    const nyata = contoh.sudah_berangkat;
+
+    const baris = v.isi.map(r => bentuk === "staging"
+      ? html`
+        <tr><td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
+            <td>${r.nama_regu}${r.sisipan ? " ★" : ""}</td>
+            <td>${r.nama_sekolah}</td>
+            <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>
+            <td class="kotak"></td></tr>`
+      : html`
+        <tr><td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
+            <td>${r.nama_regu}</td>
+            <td>${r.nama_sekolah}</td>
+            <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td></tr>`).join("");
+
+    const adaSisipan = v.isi.some(r => r.sisipan);
+
+    return bentuk === "staging" ? `
       <section class="halaman-cetak">
-        <h1>KLOTER ${esc(nomor)} — Hiking Rally Ciradyka ${esc(EDISI ? EDISI.nama : "")}</h1>
-        <p>Jam berangkat: ________  ·  Petugas: ________________</p>
+        <h1>KLOTER ${esc(nomor)} — ${esc(EDISI ? EDISI.nama : "")}</h1>
+        <p><strong>${nyata ? "Berangkat" : "Perkiraan berangkat"}: ${esc(perkiraan)}</strong>
+           ${nyata ? "" : " · Jam sebenarnya: ________"} · Petugas: ________________</p>
         <table class="tabel-cetak">
           <thead><tr><th>No Dada</th><th>Nama Regu</th><th>Sekolah</th><th>Golongan</th><th>Hadir</th></tr></thead>
           <tbody>${baris}</tbody>
         </table>
+        ${adaSisipan ? `<p class="catatan-sisip">★ = regu sisipan, ditambahkan setelah kertas ini dicetak.</p>` : ""}
+        <p class="catatan-cetak">Centang kolom Hadir saat regu masuk staging.
+           Kloter berangkat setelah semua tercentang atau diputuskan panitia.</p>
+      </section>` : `
+      <section class="halaman-cetak">
+        <h1>KLOTER ${esc(nomor)}</h1>
+        <p class="jam-besar">${nyata ? "Berangkat" : "Perkiraan berangkat"}: ${esc(perkiraan)}</p>
+        <table class="tabel-cetak">
+          <thead><tr><th>No Dada</th><th>Nama Regu</th><th>Sekolah</th><th>Golongan</th></tr></thead>
+          <tbody>${baris}</tbody>
+        </table>
+        <p class="catatan-cetak">Bersiap di staging paling lambat 15 menit sebelum
+           perkiraan berangkat. Jam sebenarnya bisa bergeser — ikuti panggilan petugas.</p>
+        <!-- Pembina regu mencatat jam berangkat sebenarnya sebagai bahan
+             klarifikasi: penalti waktu dihitung dari jam ini + kontrak waktu. -->
+        <div class="kotak-pembina">
+          <strong>Catatan pembina — isi saat kloter benar-benar berangkat:</strong>
+          <p class="isian-jam">Jam berangkat sebenarnya: <span class="garis-isi"></span></p>
+          <p class="catatan-cetak">Target kedatangan tiap regu = jam di atas + kontrak
+             waktu regu itu (3,5 / 4 / 4,5 jam). Simpan lembar ini bila perlu
+             mengklarifikasi penilaian ketepatan waktu.</p>
+        </div>
       </section>`;
   }).join("");
   document.body.appendChild(h(`<div id="cetakan" class="cetakan">${halaman}</div>`));
+}
+
+/* ============================ PINDAH KLOTER (HARI-H) ===================== */
+
+async function layarPindahKloter() {
+  pasangKepala("Pindah Kloter");
+  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+
+  let sisipan = [];
+  try { sisipan = await daftarSisipan(); } catch { /* daftar boleh telat */ }
+
+  LAYAR.replaceChildren(h(`
+    ${sisipan.length ? kartuSisipan(sisipan) : ""}
+    <div class="kartu">
+      <div class="medan" style="margin-bottom:0">
+        <label for="dada">Nomor dada yang mau dipindah</label>
+        <input type="text" id="dada" class="besar" inputmode="numeric"
+               autocomplete="off" placeholder="001">
+      </div>
+      <button class="tombol tombol-utama" id="cari" type="button" style="margin-top:.8rem">
+        Cari
+      </button>
+    </div>
+    <div id="hasil"></div>
+  `));
+  const inp = document.getElementById("dada");
+  inp.focus();
+
+  const cari = async () => {
+    const dada = Number(inp.value.trim());
+    const kotak = document.getElementById("hasil");
+    if (!dada) { inp.focus(); return; }
+    kotak.replaceChildren(h(`<p>Mencari nomor ${esc(dada)}…</p>`));
+    let semua;
+    try { semua = await daftarKloter(); }
+    catch (e) { kotak.replaceChildren(h(kartuGalat(e.message))); return; }
+
+    const r = semua.find(x => x.nomor_dada === dada);
+    if (!r) {
+      kotak.replaceChildren(h(kartuGalat(
+        `Nomor dada ${dada} belum punya kloter — mungkin belum daftar ulang.`)));
+      inp.select();
+      return;
+    }
+    if (r.sudah_berangkat) {
+      kotak.replaceChildren(h(kartuBatchRingkas(r) +
+        kartuGalat(`Kloter ${r.kloter} sudah berangkat — regu ini tidak bisa dipindah lagi.`)));
+      return;
+    }
+
+    // Kloter tujuan yang masih mungkin, dikelompokkan supaya operator paham
+    // konsekuensinya sebelum memilih.
+    const isiPerKloter = new Map();
+    for (const x of semua) isiPerKloter.set(x.kloter, (isiPerKloter.get(x.kloter) || 0) + 1);
+    const belumBerangkat = [...new Set(semua.filter(x => !x.sudah_berangkat).map(x => x.kloter))];
+    const terakhir = Math.max(...belumBerangkat);
+
+    kotak.replaceChildren(h(`
+      ${kartuBatchRingkas(r)}
+      <div class="kartu" style="border-color:var(--utama)">
+        <h2>Mau dipindah ke mana?</h2>
+        <button class="tombol tombol-utama" id="ke-terakhir" type="button" style="margin-top:.6rem">
+          Kloter terakhir (${terakhir}) — telat biasa
+        </button>
+        <p class="keterangan" style="margin-top:.5rem">Pilihan biasa untuk peserta
+           yang terlambat masuk kloternya.</p>
+        <hr style="margin:1rem 0;border:0;border-top:1px solid var(--garis)">
+        <div class="medan" style="margin-bottom:.5rem">
+          <label for="tujuan">Atau paksa ke kloter tertentu (urgent)</label>
+          <input type="number" id="tujuan" inputmode="numeric" min="1" max="40"
+                 placeholder="nomor kloter">
+          <div class="bantuan">Bisa ke kloter yang kertasnya sudah beredar —
+             sistem akan memberi peringatan untuk dibacakan ke petugas staging.</div>
+        </div>
+        <button class="tombol tombol-kalem" id="ke-tujuan" type="button">
+          Pindahkan ke kloter itu
+        </button>
+      </div>
+    `));
+
+    const jalankan = async (kloterTujuan) => {
+      const jawab = await dialog({
+        judul: kloterTujuan ? `Pindahkan ke kloter ${kloterTujuan}?` : "Pindahkan ke kloter terakhir?",
+        kartuHtml: kartuBatchRingkas(r),
+        medan: [{ label: "Alasan pemindahan",
+                  contoh: kloterTujuan ? "peserta urgent" : "terlambat masuk kloter",
+                  bantuan: "Wajib diisi — tercatat di riwayat." }],
+        labelAksi: "Pindahkan",
+      });
+      if (!jawab) return;
+      try {
+        const hasil = await pindahKloter(dada, jawab[0], kloterTujuan);
+        layarPindahKloter();
+        // Peringatan sisipan TIDAK boleh berupa toast yang hilang sendiri:
+        // petugas staging memegang kertas yang tidak memuat nomor ini.
+        setTimeout(() => {
+          if (hasil.peringatan) {
+            LAYAR.prepend(h(html`
+              <div class="kartu" style="border:3px solid var(--bahaya);background:var(--bahaya-muda)">
+                <h2 style="color:var(--bahaya)">⚠️ Bacakan ke petugas staging</h2>
+                <p style="font-size:1.1rem;margin-top:.4rem">${hasil.peringatan}</p>
+              </div>`));
+          } else {
+            notif(`Nomor ${dada} pindah dari kloter ${hasil.kloter_lama} ke ${hasil.kloter_baru}.`);
+          }
+        }, 100);
+      } catch (err) { notif(err.message, true); }
+    };
+
+    document.getElementById("ke-terakhir").addEventListener("click", () => jalankan(null));
+    document.getElementById("ke-tujuan").addEventListener("click", () => {
+      const t = Number(document.getElementById("tujuan").value);
+      if (!t) { notif("Isi nomor kloter tujuannya dulu.", true); return; }
+      jalankan(t);
+    });
+  };
+  document.getElementById("cari").addEventListener("click", cari);
+  inp.addEventListener("keydown", e => { if (e.key === "Enter") cari(); });
+}
+
+function kartuBatchRingkas(r) {
+  return html`
+    <div class="kartu kartu-identitas">
+      <div class="nama">${String(r.nomor_dada).padStart(3, "0")} · ${r.nama_regu}</div>
+      <div class="detail">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</div>
+      <div class="detail">Sekarang di <strong>Kloter ${r.kloter}</strong>${
+        r.sisipan ? " (sisipan)" : ""}</div>
+    </div>`;
+}
+
+/** Daftar sisipan: nomor-nomor yang TIDAK ADA di kertas petugas staging.
+ *  Ditaruh paling atas dan diberi bingkai merah — ini satu-satunya cara
+ *  petugas tahu ada regu tambahan di kloternya. */
+function kartuSisipan(sisipan) {
+  const aktif = sisipan.filter(s => !s.sudah_berangkat);
+  if (!aktif.length) return "";
+  const baris = aktif.map(s => html`
+    <tr><td class="angka">${String(s.nomor_dada).padStart(3, "0")}</td>
+        <td><strong>${s.nama_regu}</strong><br>
+            <span class="keterangan">${s.nama_sekolah}</span></td>
+        <td><span class="lencana lencana-merah">Kloter ${s.kloter}</span></td>
+        <td class="keterangan">${s.alasan_sisip}</td></tr>`).join("");
+  return `
+    <div class="kartu" style="border:3px solid var(--bahaya);background:var(--bahaya-muda)">
+      <h2 style="color:var(--bahaya)">⚠️ ${aktif.length} regu TIDAK ADA di kertas</h2>
+      <p class="keterangan">Nomor-nomor ini disisipkan setelah daftar kloter dicetak.
+         Bacakan ke petugas staging kloter terkait, atau tulis tangan di kertasnya.</p>
+      <table class="tabel" style="background:#fff;border-radius:8px;margin-top:.6rem">${baris}</table>
+      <button class="tombol tombol-kalem" onclick="window.print()" type="button"
+              style="margin-top:.6rem">🖨️ Cetak daftar sisipan</button>
+    </div>`;
 }
 
 /* ============================ PENDAFTARAN OFFLINE ======================== */
@@ -623,6 +842,7 @@ const RUTE = {
   "#/daftar-ulang": layarDaftarUlang,
   "#/pendaftaran-offline": layarPendaftaranOffline,
   "#/cetak-kloter": layarCetakKloter,
+  "#/pindah-kloter": layarPindahKloter,
 };
 
 async function arahkan() {


### PR DESCRIPTION
## What the panitia described

Sheets go to the noticeboard and every barak with an estimated departure time. There are **three staging areas** where attendance is verified — not at the start line itself. Staff carry **paper and a laptop together**: paper to read and tick, laptop to verify. And a regu that misses its kloter goes with the **last one** — or, when urgent, is **forced into a specific kloter** even though that sheet is already posted.

## The collision, resolved

That last case collides with the freeze from #22 — correctly. The freeze exists to stop **silent drift**, not to overrule a deliberate decision. Migration 0009 gives it **one official door**.

`pindah_kloter()` handles both cases: omit the kloter for *"late, send with the last one"*; name it to force an urgent move. Both demand a reason and land in riwayat.

| Urgency **can** override | Urgency **cannot** override |
|---|---|
| A printed, posted sheet | A kloter that already departed |
| The planned kloter assignment | The physical cap of ten regu |

## The part nobody asked for — and it matters most

Staging staff hold a sheet that **does not list the moved regu**. If the system stays quiet, that regu exists in the database and **is never called**. So:

- Regu landing in a printed kloter are flagged `disisipkan_pada`
- The RPC returns a ready-to-read sentence: *"Nomor 042 TIDAK ADA di kertas kloter 3. Beri tahu petugas staging."*
- The screen shows it as a **red card that stays put**, not a toast that vanishes, plus a printable list of all active insertions
- The staging sheet marks them with ★

Verified in the app: forcing bib 001 into printed kloter 3 returned the warning, set the flag, and surfaced it in the insertion list.

## Two paper formats, because there are two readers

| Format | Reader | What's different |
|---|---|---|
| **Staging** | Officers at the 3 staging areas | Tick column, blank for real departure time, ★ on insertions |
| **Umum** | Noticeboard & barak | Estimate printed large; **a box for the pembina** to write the actual departure time |

That box isn't decoration: pembina record departure times for clarification, because a regu's arrival target — and therefore its time penalty — is *departure + kontrak waktu*. Giving them a place to write it on the official sheet means any clarification starts from the same number.

Estimated departure comes from the new `edisi.jam_mulai_berangkat` plus the per-kloter interval, and gives way to the real time once a kloter has left.

Blueprint §4.3–4.4 record the reasoning; `alur-lomba.md` gains the staging, paper and pembina facts. Full SQL suite green (now 5 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)