### PR TITLE
feat: finish desk in two actions, and record the paper-laptop split

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -185,9 +185,19 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 8. **Ada 3 staging.** Verifikasi kehadiran regu dilakukan **di staging**, bukan
    di garis start: setelah masuk staging, peserta cukup menunggu sampai
    benar-benar diberangkatkan.
-9. **Panitia membawa kertas DAN laptop bersamaan.** Kertas dipakai untuk
-   membacakan dan mencentang; laptop untuk memverifikasi. Keduanya hidup
-   berdampingan — bukan salah satu menggantikan yang lain.
+9. **Panitia kertas dan panitia laptop duduk bersebelahan**, dan urutan
+   kerjanya searah:
+   1. Panitia **kertas** mencentang semua regu yang berangkat, menulis tangan
+      peserta yang tidak sesuai kloter awal, dan mencatat **jam keberangkatan
+      per kloter**.
+   2. Kertas itu diserahkan ke panitia **laptop** untuk **diverifikasi** dan
+      dimasukkan.
+
+   Artinya untuk keberangkatan, **kertas adalah pencatat utama dan laptop
+   memverifikasi** — kebalikan dari meja finish, di mana laptop yang mencatat
+   langsung (poin 10.2). Konsekuensinya: jam berangkat wajib bisa **diketik**
+   (menyalin dari kertas), bukan diambil dari tombol, dan layar keberangkatan
+   harus enak dipakai untuk **menyalin**, bukan hanya mencatat seketika.
 10. **Daftar kloter dicetak untuk dua pembaca:**
     - **Petugas staging** — ada kolom centang kehadiran dan tempat menulis jam
       berangkat sebenarnya.

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -393,6 +393,49 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
 4. **Garis start** (satu kloter per 3–5 menit): papan bergeser otomatis;
    konfirmasi kontrak tiga kloter di depan; tombol besar satu per kloter.
 
+### 10.5 Meja finish: dua aksi, ±3 detik
+
+Panitia menetapkan targetnya sendiri: *"cukup ketik nomor peserta, dan klik
+Sampai — itu hanya perlu 3 detik, jadi kalau ada 20 regu bersamaan pun tidak
+terlalu lama."*
+
+1. **Dua aksi, bukan tiga.** Tidak ada tombol "Cari": detail regu muncul
+   sendiri sambil operator mengetik (jeda 160 ms), lalu satu ketukan. Enter
+   sama dengan menekan tombol, sehingga seluruh loop bisa keyboard saja.
+2. **Echo-confirm tetap ada** — kartu identitas (nomor dada, nama regu,
+   sekolah, kloter, jam berangkat, target datang, dan selisih dari target)
+   sudah terpampang pada saat operator menekan.
+3. **Jam dikunci saat tombol ditekan, dari jam laptop panitia** — bukan cap
+   waktu server saat data sampai. Jaringan lambat tidak menggeser jam datang.
+4. **Yang jarang dipakai disembunyikan** di balik satu baris "Anggota kurang
+   dari 5, atau mencatat dari kertas?" — jumlah anggota (default 5) dan jam
+   susulan. Jalur cepat tetap dua aksi; jalur kertas tetap tersedia
+   (alur 12.3).
+5. **Keadaan yang menghalangi ditampilkan, bukan disimpan jadi galat**: kloter
+   belum berangkat, regu belum diceklis di staging, atau sudah pernah dicatat
+   datang (tombol berubah jadi "Perbaiki jam datang").
+6. **Bug yang ditemukan saat menguji alur ini, dan wajib tidak terulang:**
+   mengetik nomor baru lalu langsung menekan Enter sempat menyimpan regu
+   dari pencarian SEBELUMNYA — mencatat regu yang salah datang. Sekarang
+   hasil lookup lama dibuang seketika begitu angkanya berubah, dan tombol
+   memeriksa ulang bahwa nomor yang tersimpan sama dengan yang terlihat di
+   kotak isian.
+
+### 10.6 Keberangkatan vs kedatangan: siapa pencatat, siapa verifikator
+
+Panitia kertas dan panitia laptop duduk bersebelahan, tetapi perannya
+berkebalikan di dua meja:
+
+| | Pencatat utama | Peran laptop | Jam masuk lewat |
+| --- | --- | --- | --- |
+| **Keberangkatan (staging)** | Kertas — dicentang, sisipan ditulis tangan, jam kloter dicatat | **Verifikasi** kertas | **Diketik** (menyalin) |
+| **Kedatangan (finish)** | Laptop | Mencatat langsung | **Tombol** (jam saat ditekan) |
+
+Karena itu layar keberangkatan harus enak dipakai untuk **menyalin** dari
+kertas — jam wajib bisa diketik, dan urutan di layar mengikuti urutan di
+kertas. Sedangkan layar finish dioptimalkan untuk **kecepatan mencatat
+langsung**. Menyeragamkan keduanya akan merusak salah satunya.
+
 ### 10.4 Form publik: satu halaman, bukan wizard
 
 Keputusan panitia setelah mencoba versi wizard: **"Kenapa harus berkali-kali

--- a/supabase/migrations/0010_lookup_finish.sql
+++ b/supabase/migrations/0010_lookup_finish.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- hrcd-rekap : 0010_lookup_finish.sql
+--
+-- Panitia menyebut targetnya: "cukup ketik nomor peserta, dan klik Sampai —
+-- itu hanya perlu 3 detik, jadi kalau ada 20 regu bersamaan pun tidak lama."
+--
+-- Dua aksi, bukan tiga: TIDAK ADA tombol "Cari". Detail regu harus muncul
+-- sendiri sambil operator mengetik. Karena itu dibutuhkan satu view ringkas
+-- yang menjawab semua yang perlu dilihat operator dalam satu kali baca:
+-- siapa regunya, sudah berangkat atau belum, dan sudah tercatat datang atau
+-- belum (supaya pencatatan ganda langsung kelihatan, bukan jadi galat).
+-- ============================================================================
+
+create view v_regu_ringkas with (security_invoker = on) as
+select
+  r.id                                   as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  r.nama_ketua,
+  s.nama                                 as nama_sekolah,
+  r.golongan,
+  r.kloter_nomor                         as kloter,
+  r.kontrak_menit,
+  k.jam_berangkat,
+  k.jam_berangkat is not null            as sudah_berangkat,
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                                         as sudah_ceklis,
+  c.jam_datang,
+  c.anggota_hadir,
+  c.regu_id is not null                  as sudah_finish,
+  r.disisipkan_pada is not null          as sisipan,
+  -- Target kedatangan, supaya operator closing bisa melihat langsung apakah
+  -- regu ini datang jauh dari targetnya (tanpa menghitung di kepala).
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+    then k.jam_berangkat + make_interval(mins => r.kontrak_menit)
+  end                                    as target_datang
+from regu r
+join pendaftaran d      on d.id = r.pendaftaran_id
+join sekolah s          on s.id = d.sekolah_id
+left join kloter k      on k.nomor = r.kloter_nomor
+left join closing_regu c on c.regu_id = r.id
+where not r.batal
+  and d.status = 'lunas'
+  and r.nomor_dada is not null;
+
+grant select on v_regu_ringkas to authenticated;

--- a/tests/dev_db.sh
+++ b/tests/dev_db.sh
@@ -28,6 +28,7 @@ run supabase/migrations/0006_idempotensi.sql
 run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/migrations/0008_cetak_kloter.sql
 run supabase/migrations/0009_sisip_kloter.sql
+run supabase/migrations/0010_lookup_finish.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -88,6 +88,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/edisi":
                 self._kirim(200, q(
                     "select * from v_edisi_publik", role="anon", fetch="one"))
+            elif u.path == "/regu":
+                self._kirim(200, q(
+                    "select * from v_regu_ringkas where nomor_dada = %s",
+                    (p.get("dada") or 0,), uid=p.get("uid")))
             elif u.path == "/sisipan":
                 self._kirim(200, q(
                     "select * from v_sisipan_kloter", uid=p.get("uid")))

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,6 +32,7 @@ run supabase/migrations/0006_idempotensi.sql
 run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/migrations/0008_cetak_kloter.sql
 run supabase/migrations/0009_sisip_kloter.sql
+run supabase/migrations/0010_lookup_finish.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -263,6 +263,23 @@ export const tandaiKloterDicetak = (nomorKloter) =>
 export const pindahKloter = (nomorDada, alasan, kloter = null) =>
   rpc("pindah_kloter", { p_nomor_dada: nomorDada, p_alasan: alasan, p_kloter: kloter });
 
+/** Lookup cepat satu regu untuk layar finish — dipanggil sambil mengetik,
+ *  jadi harus ringan dan tidak pernah melempar untuk "tidak ketemu". */
+export async function cariRegu(nomorDada) {
+  const d = K.mode === "dev"
+    ? await baca(`/regu?dada=${encodeURIComponent(nomorDada)}`)
+    : await baca(null, `v_regu_ringkas?nomor_dada=eq.${encodeURIComponent(nomorDada)}&select=*`);
+  return d.length ? d[0] : null;
+}
+
+export const catatFinish = (nomorDada, jamDatang, anggotaHadir, catatan) =>
+  rpc("catat_closing", {
+    p_nomor_dada: nomorDada,
+    p_jam_datang: jamDatang,
+    p_anggota_hadir: anggotaHadir,
+    p_catatan: catatan || null,
+  });
+
 export async function daftarSisipan() {
   if (K.mode === "dev") return baca("/sisipan");
   return baca(null, "v_sisipan_kloter?select=*&order=kloter.asc,nomor_dada.asc");

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -13,6 +13,7 @@ import {
   lihatBatch, infoEdisi, ringkasanMeja,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor, ubahPendamping,
   daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
+  cariRegu, catatFinish,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -22,7 +23,7 @@ const GOLONGAN_LABEL = {
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
 };
 let EDISI = null;
-const terakhir = { pembayaran: [], "daftar-ulang": [] };
+const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
 
 /* ---------------- kerangka ---------------- */
 
@@ -134,6 +135,10 @@ async function layarBeranda() {
       <a href="#/cetak-kloter">
         <div class="nama-fungsi">🖨️ Cetak Daftar Kloter</div>
         <div class="ket">Kertas untuk papan pengumuman, barak, dan petugas staging</div>
+      </a>
+      <a href="#/finish">
+        <div class="nama-fungsi">🏁 Meja Finish</div>
+        <div class="ket">Ketik nomor dada, tekan Sampai — catat kedatangan regu</div>
       </a>
       <a href="#/pindah-kloter">
         <div class="nama-fungsi">🔀 Pindah Kloter</div>
@@ -658,6 +663,207 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
   document.body.appendChild(h(`<div id="cetakan" class="cetakan">${halaman}</div>`));
 }
 
+/* ============================ MEJA FINISH ================================ */
+
+/** Target panitia: DUA aksi, ±3 detik per regu — "ketik nomor, klik Sampai".
+ *  Karena itu TIDAK ADA tombol Cari: detail regu muncul sendiri sambil
+ *  mengetik, dan Enter sama dengan menekan tombol. Echo-confirm tetap ada
+ *  karena kartu identitas sudah terpampang saat operator menekan.
+ *
+ *  Jam yang tersimpan adalah jam saat TOMBOL DITEKAN di laptop panitia —
+ *  bukan cap waktu server saat data sampai (alur 10.2). Untuk pencatatan
+ *  susulan dari kertas, jamnya bisa diubah.
+ */
+function layarFinish() {
+  pasangKepala("Meja Finish");
+  LAYAR.replaceChildren(h(`
+    <div class="kartu" style="border-color:var(--utama)">
+      <div class="medan" style="margin-bottom:0">
+        <label for="dada">Ketik nomor dada</label>
+        <input type="text" id="dada" class="besar" inputmode="numeric"
+               autocomplete="off" placeholder="001">
+      </div>
+      <div id="kartu-regu" style="margin-top:.7rem"></div>
+      <button class="tombol tombol-utama" id="sampai" type="button" disabled
+              style="margin-top:.7rem;min-height:60px;font-size:1.2rem">
+        ✅ SAMPAI DI FINISH
+      </button>
+      <div id="opsi-lanjut" style="margin-top:.6rem"></div>
+    </div>
+    <div id="riwayat-finish"></div>
+  `));
+
+  const inp = document.getElementById("dada");
+  const kotak = document.getElementById("kartu-regu");
+  const tombol = document.getElementById("sampai");
+  const opsi = document.getElementById("opsi-lanjut");
+  let regu = null;
+  let anggotaHadir = 5;
+  let jamManual = null;      // diisi hanya untuk pencatatan susulan
+  let jeda = null;
+
+  inp.focus();
+  gambarRiwayat();
+
+  const bersihkan = () => {
+    regu = null; anggotaHadir = 5; jamManual = null;
+    kotak.replaceChildren(); opsi.replaceChildren();
+    tombol.disabled = true;
+  };
+
+  // Lookup otomatis sambil mengetik — jeda pendek supaya tidak memanggil
+  // server di tiap ketukan, tapi tetap terasa seketika.
+  inp.addEventListener("input", () => {
+    clearTimeout(jeda);
+    const dada = Number(inp.value.trim());
+    // PENTING: begitu angkanya berubah, hasil lookup lama tidak boleh dipakai
+    // lagi. Tanpa ini, operator yang mengetik nomor baru lalu langsung menekan
+    // Enter akan menyimpan regu SEBELUMNYA — mencatat regu yang salah datang.
+    // (Ditemukan saat menguji alur ketik-Enter.)
+    if (!regu || regu.nomor_dada !== dada) {
+      regu = null;
+      tombol.disabled = true;
+    }
+    if (!dada) { bersihkan(); return; }
+    jeda = setTimeout(() => cariDanTampilkan(dada), 160);
+  });
+
+  inp.addEventListener("keydown", e => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    if (!tombol.disabled) tombol.click();
+  });
+
+  async function cariDanTampilkan(dada) {
+    let r;
+    try { r = await cariRegu(dada); }
+    catch (e) { kotak.replaceChildren(h(kartuGalat(e.message))); return; }
+    if (Number(inp.value.trim()) !== dada) return;   // operator sudah mengetik lagi
+
+    if (!r) {
+      regu = null; tombol.disabled = true; opsi.replaceChildren();
+      kotak.replaceChildren(h(kartuGalat(`Nomor ${esc(dada)} tidak dikenal.`)));
+      return;
+    }
+    regu = r;
+
+    // Keadaan yang menghalangi, ditampilkan jelas alih-alih jadi galat nanti.
+    let halangan = null;
+    if (!r.sudah_berangkat) halangan = `Kloter ${r.kloter} belum tercatat berangkat.`;
+    else if (!r.sudah_ceklis) halangan = "Regu ini belum diceklis berangkat di staging.";
+
+    kotak.replaceChildren(h(`
+      ${kartuReguFinish(r)}
+      ${r.sudah_finish ? `<div class="kartu" style="border-color:var(--kuning);background:var(--kuning-muda);margin-top:.5rem">
+          <strong>Sudah tercatat datang ${esc(jamPendek(r.jam_datang))}.</strong>
+          <div class="keterangan">Menekan tombol akan MENGGANTI jam itu.</div>
+        </div>` : ""}
+      ${halangan ? kartuGalat(halangan) : ""}
+    `));
+
+    tombol.disabled = !!halangan;
+    tombol.textContent = r.sudah_finish ? "✏️ PERBAIKI JAM DATANG" : "✅ SAMPAI DI FINISH";
+
+    // Dua hal yang jarang dipakai disembunyikan supaya jalur cepat tetap dua
+    // aksi: jumlah anggota (default 5) dan jam susulan dari kertas.
+    opsi.replaceChildren(h(`
+      <details>
+        <summary style="cursor:pointer;min-height:40px;font-size:.9rem;color:var(--tinta-lembut)">
+          Anggota kurang dari 5, atau mencatat dari kertas?
+        </summary>
+        <div class="medan" style="margin-top:.6rem">
+          <label for="hadir">Jumlah anggota yang hadir</label>
+          <input type="number" id="hadir" min="0" max="5" inputmode="numeric" value="5">
+          <div class="bantuan">Tiap anggota yang tidak lengkap dikurangi 20 poin.</div>
+        </div>
+        <div class="medan">
+          <label for="jam">Jam datang (jam:menit) — kosongkan bila mencatat sekarang</label>
+          <input type="time" id="jam">
+          <div class="bantuan">Isi hanya bila menyalin dari catatan kertas.</div>
+        </div>
+      </details>`));
+    document.getElementById("hadir").addEventListener("input", e => {
+      anggotaHadir = Math.max(0, Math.min(5, Number(e.target.value) || 0));
+    });
+    document.getElementById("jam").addEventListener("input", e => {
+      jamManual = e.target.value || null;
+    });
+  }
+
+  tombol.addEventListener("click", async () => {
+    if (!regu || tombol.dataset.jalan === "1") return;
+    // Jaring kedua: yang disimpan HARUS regu yang nomornya sedang terlihat di
+    // kotak isian, bukan sisa lookup sebelumnya.
+    if (regu.nomor_dada !== Number(inp.value.trim())) {
+      notif("Nomor berubah — tunggu detailnya muncul dulu.", true);
+      return;
+    }
+    tombol.dataset.jalan = "1"; tombol.disabled = true;
+
+    // Jam dikunci DI SINI — saat tombol ditekan, dari jam laptop panitia.
+    const jam = jamManual ? jamHariIni(jamManual) : new Date();
+    const dada = regu.nomor_dada;
+    const nama = regu.nama_regu;
+    try {
+      await catatFinish(dada, jam.toISOString(), anggotaHadir, null);
+    } catch (err) {
+      notif(err.message, true);
+      tombol.dataset.jalan = ""; tombol.disabled = false;
+      return;
+    }
+    catatTerakhir("finish", String(dada).padStart(3, "0"),
+      `${nama} — ${jamPendek(jam)}${anggotaHadir < 5 ? ` · ${anggotaHadir} anggota` : ""}`);
+    tombol.dataset.jalan = "";
+    inp.value = ""; bersihkan(); inp.focus();
+    gambarRiwayat();
+    notif(`${String(dada).padStart(3, "0")} tercatat ${jamPendek(jam)}.`);
+  });
+
+  function gambarRiwayat() {
+    const daftar = terakhir.finish || [];
+    document.getElementById("riwayat-finish").replaceChildren(h(
+      daftar.length ? `
+        <div class="kartu">
+          <h2 style="font-size:1rem;color:var(--tinta-lembut)">
+            Baru saja tercatat (${daftar.length})</h2>
+          <table class="tabel">${daftar.slice(0, 12).map(b => html`
+            <tr><td class="angka">${b.apa}</td><td>${b.detail}</td></tr>`).join("")}
+          </table>
+        </div>` : `<p class="keterangan" style="text-align:center;margin-top:1rem">
+            Ketik nomor dada regu yang baru sampai.</p>`));
+  }
+}
+
+const jamPendek = (t) => t
+  ? new Date(t).toLocaleTimeString("id-ID", { hour: "2-digit", minute: "2-digit" })
+  : "—";
+
+/** "14:35" -> Date hari ini pada jam itu (untuk pencatatan susulan). */
+function jamHariIni(hhmm) {
+  const [j, m] = hhmm.split(":").map(Number);
+  const d = new Date();
+  d.setHours(j, m, 0, 0);
+  return d;
+}
+
+function kartuReguFinish(r) {
+  const selisih = r.target_datang
+    ? Math.round((Date.now() - new Date(r.target_datang).getTime()) / 60000)
+    : null;
+  const tandaWaktu = selisih === null ? ""
+    : `<span class="lencana ${Math.abs(selisih) < 10 ? "lencana-hijau" : "lencana-kuning"}">
+         ${selisih > 0 ? `+${selisih}` : selisih} menit dari target</span>`;
+  return `
+    <div class="kartu kartu-identitas" style="margin:0">
+      ${html`<div class="nama">${String(r.nomor_dada).padStart(3, "0")} · ${r.nama_regu}</div>
+      <div class="detail">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</div>
+      <div class="detail">Kloter ${r.kloter} · berangkat ${jamPendek(r.jam_berangkat)}${
+        r.target_datang ? ` · target ${jamPendek(r.target_datang)}` : ""}</div>`}
+      <div style="margin-top:.4rem">${tandaWaktu}
+        ${r.sisipan ? `<span class="lencana lencana-merah">sisipan</span>` : ""}</div>
+    </div>`;
+}
+
 /* ============================ PINDAH KLOTER (HARI-H) ===================== */
 
 async function layarPindahKloter() {
@@ -843,6 +1049,7 @@ const RUTE = {
   "#/pendaftaran-offline": layarPendaftaranOffline,
   "#/cetak-kloter": layarCetakKloter,
   "#/pindah-kloter": layarPindahKloter,
+  "#/finish": layarFinish,
 };
 
 async function arahkan() {


### PR DESCRIPTION
## The target, set by the panitia

*"Cukup ketik nomor peserta, dan klik Sampai — itu hanya perlu 3 detik, jadi kalau ada 20 regu bersamaan pun tidak terlalu lama."*

**Two actions means no separate Cari button.** Details appear as the operator types (160 ms debounce); Enter equals the button, so the whole loop is keyboard-only. Echo-confirm survives because the identity card — bib, regu, school, kloter, departure, target, and **minutes off target** — is already on screen when they press.

The stored time is **the moment the button is pressed on the panitia's laptop**, not a server timestamp when the request lands, so a slow network cannot shift an arrival time. Rarely-used things hide behind one line ("Anggota kurang dari 5, atau mencatat dari kertas?"): member count (default 5) and a typed time for copying from paper. Fast path stays two actions; paper path stays available.

Migration 0010 adds `v_regu_ringkas` so one read answers everything the operator must see — including whether this regu was **already** recorded, surfaced as *"sudah tercatat, tombol akan mengganti jam"* rather than failing later as an error.

## Testing the flow found a dangerous bug

Typing a new bib and pressing Enter immediately saved the **previous** lookup — recording the wrong regu as arrived. At a finish desk that is exactly the failure that must not exist.

```
ketik 5 → tunggu → ketik 1 → Enter   ⇒  yang tersimpan: 005  ❌
```

Fixed in two places, both verified:
- The stale result is discarded **the instant the number changes** (button disables immediately)
- The button re-checks that what it saves matches what is visible in the field

After the fix: changing the number disables the button at once, Enter saves nothing, and the normal flow (type → details → Enter) saves the right regu, clears the field, and returns focus — ready for the next bib.

## Also recorded: the two desks are opposites

| | Primary record | Laptop's role | Time enters via |
|---|---|---|---|
| **Staging (departure)** | Paper — ticked, insertions hand-written, kloter time noted | **Verifies** the paper | **Typed** (copying) |
| **Finish (arrival)** | Laptop | Records directly | **Button** (moment pressed) |

Making the two screens uniform would break one of them. Blueprint §10.5–10.6; `alur-lomba.md` gains the paper-laptop pairing and the button-versus-typed distinction.

Full SQL suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)