### PR TITLE
feat: show whether a time difference changes the penalty; phone-ready

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -324,6 +324,11 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
      dimasukkan.
    - **Jam datang diisi tombol**: panitia mengetik nomor dada, detail regu
      muncul untuk dipastikan, lalu menekan satu tombol "Sampai di Finish".
+     Di meja finish juga ada penulisan manual di kertas, **tetapi hanya untuk
+     verifikasi** — tombol laptop tetap pencatat utamanya. Selisih semenit dua
+     menit antara kertas dan tombol adalah hal wajar (menekan tombol bisa
+     terlambat sedikit) dan hampir tidak pernah mengubah penalti, karena
+     penalti dibulatkan per 10 menit.
      Targetnya ±3 detik per regu, sehingga 20 regu yang datang bersamaan pun
      tidak menumpuk. Jam yang tersimpan adalah **jam saat tombol ditekan di
      laptop panitia**, bukan cap waktu server saat data sampai — dan tetap

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -343,7 +343,14 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
     lagi"; tidak ada yang hilang diam-diam.
 12. Teks UI = kalimat yang memang diucapkan operator, dengan serapan familiar
     (upload, preview, password — bukan unggah/pratinjau/kata sandi).
-13. **Ukuran dibedakan menurut konteks, bukan seragam.** Versi pertama memakai
+13. **Semua layar — termasuk layar panitia — wajib jalan di HP.** Panitia
+    memakai HP, bukan hanya laptop. Diperiksa terukur pada lebar 390 px untuk
+    keenam layar panitia: tidak ada elemen yang meluber, halaman tidak pernah
+    menggeser ke samping, dan tidak ada sasaran sentuh di bawah 36 px. Tabel
+    lebar menggeser di dalam kartunya sendiri, bukan menyeret seluruh halaman;
+    di HP kepala memecah judul ke barisnya sendiri agar tombol tetap terjangkau
+    jempol.
+14. **Ukuran dibedakan menurut konteks, bukan seragam.** Versi pertama memakai
     ukuran "meja" (tubuh 18px, input 23px, sasaran sentuh 56px) untuk semua
     layar; hasilnya form pendaftaran menjadi 4,1 layar HP penuh — panitia
     mengeluh kebanyakan menggulir. Sekarang:
@@ -426,10 +433,24 @@ terlalu lama."*
 Panitia kertas dan panitia laptop duduk bersebelahan, tetapi perannya
 berkebalikan di dua meja:
 
-| | Pencatat utama | Peran laptop | Jam masuk lewat |
+| | Pencatat utama | Peran kertas | Jam masuk lewat |
 | --- | --- | --- | --- |
-| **Keberangkatan (staging)** | Kertas — dicentang, sisipan ditulis tangan, jam kloter dicatat | **Verifikasi** kertas | **Diketik** (menyalin) |
-| **Kedatangan (finish)** | Laptop | Mencatat langsung | **Tombol** (jam saat ditekan) |
+| **Keberangkatan (staging)** | **Kertas** — dicentang, sisipan ditulis tangan, jam kloter dicatat | Sumber; laptop menyalin | **Diketik** |
+| **Kedatangan (finish)** | **Laptop** — tombol | Cek silang saja | **Tombol** (jam saat ditekan) |
+
+Di finish ada penulisan manual juga, **tetapi hanya untuk verifikasi** —
+tombol laptop tetap pencatat utamanya. Karena itu kolom jam dan jumlah anggota
+sengaja **tidak** disejajarkan dengan tombol: keduanya dipakai saat
+memperbaiki hasil cek silang, bukan pada tiap regu. Menaikkannya ke jalur
+utama akan merusak target dua-aksi.
+
+**Selisih semenit dua menit antara kertas dan tombol itu wajar** — menekan
+tombol bisa terlambat sedikit. Yang perlu diketahui panitia bukan "beda berapa
+menit", melainkan **apakah bedanya mengubah penalti**; karena penalti
+dibulatkan per 10 menit, biasanya tidak. Layar finish menjawab itu langsung:
+mengisi kolom jam memunculkan lencana **hijau** ("1 menit lebih awal — penalti
+tetap −10") atau **kuning** ("15 menit lebih awal — penalti berubah −10 → 0").
+Hanya yang kuning yang perlu diperdebatkan.
 
 Karena itu layar keberangkatan harus enak dipakai untuk **menyalin** dari
 kertas — jam wajib bisa diketik, dan urutan di layar mengikuti urutan di

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -88,6 +88,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/edisi":
                 self._kirim(200, q(
                     "select * from v_edisi_publik", role="anon", fetch="one"))
+            elif u.path == "/penalti":
+                self._kirim(200, q(
+                    "select * from konfig_penalti where edisi = edisi_aktif()",
+                    uid=p.get("uid"), fetch="one"))
             elif u.path == "/regu":
                 self._kirim(200, q(
                     "select * from v_regu_ringkas where nomor_dada = %s",

--- a/web/gaya.css
+++ b/web/gaya.css
@@ -455,6 +455,27 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .pilihan-baris { grid-template-columns: 1fr; }
   .angka-raksasa { font-size: 1.9rem; }
   .isi { padding: .8rem .7rem 3rem; }
+
+  /* Kepala di HP: judul sebaris penuh, tombol turun ke bawahnya supaya
+     tidak berdesakan dan tetap cukup besar untuk jempol. */
+  .kepala { padding: .5rem .7rem; gap: .4rem; }
+  .kepala .judul { flex: 1 0 100%; font-size: .95rem; }
+  .kepala .siapa { font-size: .78rem; flex: 1; }
+  .kepala .tombol-kecil { min-height: 36px; font-size: .8rem; padding: .25rem .6rem; }
+}
+
+/* Tabel lebar (daftar regu, kloter, riwayat) tidak boleh memaksa SELURUH
+   halaman menggeser ke samping di HP — cukup tabelnya sendiri yang menggeser.
+   Panitia memakai sistem ini di HP juga, bukan hanya laptop. */
+.kartu { overflow-x: auto; }
+.tabel { min-width: 0; }
+
+@media (max-width: 560px) {
+  .tabel { font-size: .88rem; }
+  .tabel td { padding: .4rem .3rem; }
+  .tabel .angka { font-size: 1.05rem; }
+  /* Nama sekolah boleh membungkus, jangan memaksa tabel melebar. */
+  .tabel td:nth-child(2), .tabel td:nth-child(3) { word-break: break-word; }
 }
 
 /* ---------- aksesibilitas ---------- */

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -272,6 +272,15 @@ export async function cariRegu(nomorDada) {
   return d.length ? d[0] : null;
 }
 
+/** Angka penalti edisi aktif — dipakai layar finish untuk menunjukkan apakah
+ *  selisih jam kertas vs laptop benar-benar mengubah penalti. */
+export async function infoPenalti() {
+  const d = K.mode === "dev"
+    ? await baca("/penalti")
+    : await baca(null, "konfig_penalti?select=*");
+  return Array.isArray(d) ? d[0] : d;
+}
+
 export const catatFinish = (nomorDada, jamDatang, anggotaHadir, catatan) =>
   rpc("catat_closing", {
     p_nomor_dada: nomorDada,

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -13,7 +13,7 @@ import {
   lihatBatch, infoEdisi, ringkasanMeja,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor, ubahPendamping,
   daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
-  cariRegu, catatFinish,
+  cariRegu, catatFinish, infoPenalti,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -688,7 +688,31 @@ function layarFinish() {
               style="margin-top:.7rem;min-height:60px;font-size:1.2rem">
         ✅ SAMPAI DI FINISH
       </button>
-      <div id="opsi-lanjut" style="margin-top:.6rem"></div>
+      <!-- TOMBOL adalah pencatat utama di meja ini; kertas panitia hanya untuk
+           cek silang. Jadi jam & anggota sengaja TIDAK sejajar dengan tombol —
+           keduanya dipakai saat memperbaiki hasil verifikasi, bukan tiap regu. -->
+      <details style="margin-top:.6rem">
+        <summary style="cursor:pointer;min-height:40px;font-size:.9rem;color:var(--tinta-lembut)">
+          Perbaiki jam atau jumlah anggota
+        </summary>
+        <div class="dua-kolom" style="margin-top:.5rem">
+          <div class="medan" style="margin:0">
+            <label for="jam">Jam datang</label>
+            <input type="time" id="jam" step="60">
+            <div class="bantuan">Kosong = jam saat tombol ditekan.</div>
+          </div>
+          <div class="medan" style="margin:0">
+            <label for="hadir">Anggota hadir</label>
+            <input type="number" id="hadir" min="0" max="5" inputmode="numeric" value="5">
+            <div class="bantuan">Tiap orang kurang: −20 poin.</div>
+          </div>
+        </div>
+        <div id="dampak-jam" style="margin-top:.5rem"></div>
+        <p class="bantuan">Beda semenit dua menit antara catatan kertas dan tombol
+           itu wajar — penalti dibulatkan per 10 menit, jadi biasanya tidak
+           mengubah apa pun. Yang perlu diperhatikan hanya kalau kotak di atas
+           berwarna kuning.</p>
+      </details>
     </div>
     <div id="riwayat-finish"></div>
   `));
@@ -696,19 +720,67 @@ function layarFinish() {
   const inp = document.getElementById("dada");
   const kotak = document.getElementById("kartu-regu");
   const tombol = document.getElementById("sampai");
-  const opsi = document.getElementById("opsi-lanjut");
+  const inpJam = document.getElementById("jam");
+  const inpHadir = document.getElementById("hadir");
   let regu = null;
-  let anggotaHadir = 5;
-  let jamManual = null;      // diisi hanya untuk pencatatan susulan
   let jeda = null;
 
   inp.focus();
   gambarRiwayat();
 
+  [inpJam, inpHadir].forEach(el => el.addEventListener("keydown", e => {
+    if (e.key === "Enter" && !tombol.disabled) { e.preventDefault(); tombol.click(); }
+  }));
+
+  // Angka penalti dipakai untuk menjawab pertanyaan yang sebenarnya saat
+  // membandingkan catatan kertas dengan jam tombol: bukan "beda berapa menit",
+  // melainkan "apakah bedanya MENGUBAH penalti". Karena penalti dibulatkan per
+  // 10 menit, selisih semenit dua menit hampir selalu tidak berpengaruh.
+  let PENALTI = null;
+  infoPenalti().then(p => { PENALTI = p; }).catch(() => {});
+
+  const hitungPenalti = (jam, target) => {
+    if (!PENALTI || !target) return null;
+    const selisih = Math.abs(new Date(jam) - new Date(target)) / 60000;
+    return Math.floor(selisih / PENALTI.blok_menit) * Number(PENALTI.penalti_per_blok);
+  };
+
+  const perbaruiDampak = () => {
+    const el = document.getElementById("dampak-jam");
+    if (!el) return;
+    if (!regu || !regu.target_datang || !PENALTI) { el.replaceChildren(); return; }
+    // Pembandingnya beda menurut keadaan: regu yang BELUM tercatat dibandingkan
+    // dengan jam tombol sekarang; yang SUDAH tercatat dibandingkan dengan jam
+    // yang tersimpan — itulah angka yang sedang diverifikasi terhadap kertas.
+    const dasar = regu.sudah_finish && regu.jam_datang
+      ? new Date(regu.jam_datang) : new Date();
+    const jamIsi = inpJam.value ? jamHariIni(inpJam.value) : dasar;
+    const pDasar = hitungPenalti(dasar, regu.target_datang);
+    const pIsi = hitungPenalti(jamIsi, regu.target_datang);
+    const tulis = (n) => n === 0 ? "0" : `−${n}`;
+
+    if (!inpJam.value) {
+      el.innerHTML = html`<span class="lencana lencana-abu">Penalti waktu: ${tulis(pDasar)}</span>`;
+      return;
+    }
+    const beda = Math.round((jamIsi - dasar) / 60000);
+    if (beda === 0) {
+      el.innerHTML = html`<span class="lencana lencana-hijau">Sama dengan catatan — penalti ${tulis(pIsi)}</span>`;
+      return;
+    }
+    const arah = beda > 0 ? `${beda} menit lebih lambat` : `${-beda} menit lebih awal`;
+    el.innerHTML = pIsi === pDasar
+      ? html`<span class="lencana lencana-hijau">${arah} — penalti tetap ${tulis(pIsi)}</span>`
+      : html`<span class="lencana lencana-kuning">${arah} — penalti berubah ${tulis(pDasar)} → ${tulis(pIsi)}</span>`;
+  };
+  inpJam.addEventListener("input", perbaruiDampak);
+
   const bersihkan = () => {
-    regu = null; anggotaHadir = 5; jamManual = null;
-    kotak.replaceChildren(); opsi.replaceChildren();
+    regu = null;
+    kotak.replaceChildren();
     tombol.disabled = true;
+    // Jam & anggota TIDAK dikosongkan di sini: saat menyalin sederet catatan
+    // kertas, operator sering mengetik jam lalu baru memperbaiki nomornya.
   };
 
   // Lookup otomatis sambil mengetik — jeda pendek supaya tidak memanggil
@@ -741,7 +813,7 @@ function layarFinish() {
     if (Number(inp.value.trim()) !== dada) return;   // operator sudah mengetik lagi
 
     if (!r) {
-      regu = null; tombol.disabled = true; opsi.replaceChildren();
+      regu = null; tombol.disabled = true;
       kotak.replaceChildren(h(kartuGalat(`Nomor ${esc(dada)} tidak dikenal.`)));
       return;
     }
@@ -766,28 +838,13 @@ function layarFinish() {
 
     // Dua hal yang jarang dipakai disembunyikan supaya jalur cepat tetap dua
     // aksi: jumlah anggota (default 5) dan jam susulan dari kertas.
-    opsi.replaceChildren(h(`
-      <details>
-        <summary style="cursor:pointer;min-height:40px;font-size:.9rem;color:var(--tinta-lembut)">
-          Anggota kurang dari 5, atau mencatat dari kertas?
-        </summary>
-        <div class="medan" style="margin-top:.6rem">
-          <label for="hadir">Jumlah anggota yang hadir</label>
-          <input type="number" id="hadir" min="0" max="5" inputmode="numeric" value="5">
-          <div class="bantuan">Tiap anggota yang tidak lengkap dikurangi 20 poin.</div>
-        </div>
-        <div class="medan">
-          <label for="jam">Jam datang (jam:menit) — kosongkan bila mencatat sekarang</label>
-          <input type="time" id="jam">
-          <div class="bantuan">Isi hanya bila menyalin dari catatan kertas.</div>
-        </div>
-      </details>`));
-    document.getElementById("hadir").addEventListener("input", e => {
-      anggotaHadir = Math.max(0, Math.min(5, Number(e.target.value) || 0));
-    });
-    document.getElementById("jam").addEventListener("input", e => {
-      jamManual = e.target.value || null;
-    });
+    // Regu yang sudah tercatat: tampilkan jam lamanya di kolom perbaikan,
+    // supaya verifikasi terhadap kertas tinggal membandingkan lalu mengubah.
+    if (r.sudah_finish && r.jam_datang) {
+      inpJam.value = new Date(r.jam_datang).toTimeString().slice(0, 5);
+      inpHadir.value = r.anggota_hadir ?? 5;
+    }
+    perbaruiDampak();
   }
 
   tombol.addEventListener("click", async () => {
@@ -801,20 +858,23 @@ function layarFinish() {
     tombol.dataset.jalan = "1"; tombol.disabled = true;
 
     // Jam dikunci DI SINI — saat tombol ditekan, dari jam laptop panitia.
-    const jam = jamManual ? jamHariIni(jamManual) : new Date();
+    // Kolom jam hanya dipakai bila memang diisi (koreksi hasil verifikasi).
+    const jam = inpJam.value ? jamHariIni(inpJam.value) : new Date();
+    const hadir = Math.max(0, Math.min(5, Number(inpHadir.value) || 0));
     const dada = regu.nomor_dada;
     const nama = regu.nama_regu;
     try {
-      await catatFinish(dada, jam.toISOString(), anggotaHadir, null);
+      await catatFinish(dada, jam.toISOString(), hadir, null);
     } catch (err) {
       notif(err.message, true);
       tombol.dataset.jalan = ""; tombol.disabled = false;
       return;
     }
     catatTerakhir("finish", String(dada).padStart(3, "0"),
-      `${nama} — ${jamPendek(jam)}${anggotaHadir < 5 ? ` · ${anggotaHadir} anggota` : ""}`);
+      `${nama} — ${jamPendek(jam)}${hadir < 5 ? ` · ${hadir} anggota` : ""}`);
     tombol.dataset.jalan = "";
-    inp.value = ""; bersihkan(); inp.focus();
+    inp.value = ""; inpJam.value = ""; inpHadir.value = "5";
+    bersihkan(); inp.focus();
     gambarRiwayat();
     notif(`${String(dada).padStart(3, "0")} tercatat ${jamPendek(jam)}.`);
   });


### PR DESCRIPTION
## Three clarifications, one of which corrected a wrong turn of mine

**1. Finish has manual writing too — but only to cross-check.** The laptop button stays the primary record. I had briefly promoted the time and member fields to sit beside the button, which would have slowed the two-action target for *every* regu. They are back behind one line, used when correcting after a cross-check rather than on each arrival.

| | Primary record | Paper's role | Time enters via |
|---|---|---|---|
| **Staging** | **Paper** | Source; laptop copies it | Typed |
| **Finish** | **Laptop** — button | Cross-check only | Button |

**2. A minute or two apart is normal**, since pressing can lag. So the useful question isn't *"how many minutes apart"* but **"does the difference change the penalty"** — and since penalties round to ten-minute blocks, usually it doesn't.

The finish screen now answers that directly:

```
1 menit lebih awal  — penalti tetap −10        (hijau)
15 menit lebih awal — penalti berubah −10 → 0  (kuning)
```

Only yellow needs discussion. For a regu already recorded, the comparison runs against its **stored** time — that's the number being verified. Verified live at both 1-minute and 15-minute differences.

**3. Everything must work on a phone**, including the panitia screens, not just the public form. Measured at **390px across all six panitia screens**:

| Check | Result |
|---|---|
| Elements overflowing | none |
| Page scrolls sideways | never |
| Touch targets under 36px | none |

Wide tables now scroll inside their own card instead of dragging the whole page, and on phones the header puts the title on its own line so buttons stay thumb-reachable.

Blueprint §10.1.13 and §10.6 record both rules; `alur-lomba.md` notes that finish paper is verification only. Full SQL suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)