### PR TITLE
feat: production Worker setup and account provisioning tooling

### DIFF
--- a/.github/workflows/provision-akun.yml
+++ b/.github/workflows/provision-akun.yml
@@ -1,0 +1,70 @@
+# ============================================================================
+# hrcd-rekap : provision-akun.yml — bikin akun panitia massal dari HP.
+#
+# Dipicu manual (workflow_dispatch), bukan otomatis lewat push/merge — ini
+# alat admin sekali pakai per batch, bukan bagian dari deploy.
+#
+# CARA PAKAI DARI HP:
+#   1. Buka repo di app/browser GitHub -> tab Actions -> "Provision akun
+#      panitia" -> Run workflow.
+#   2. Tempel CSV di kotak "csv_akun": username,email,peran,pos (kosongkan
+#      pos untuk admin/meja). JANGAN sertakan password di sini — kotak ini
+#      terekam di log Actions, dan password digenerate otomatis di server.
+#   3. Run workflow. Tunggu selesai (~10-20 detik untuk puluhan baris).
+#   4. Buka run yang baru selesai -> bagian "Artifacts" di bawah -> unduh
+#      hasil-provisioning-<nomor>.zip. Isinya CSV berisi password yang
+#      di-generate untuk tiap akun -> bagikan ke pemiliknya masing-masing.
+#      Artifact terhapus otomatis setelah 3 hari.
+#
+# SEBELUM DIPAKAI PERTAMA KALI, tambahkan dua repository secret (Settings ->
+# Secrets and variables -> Actions -> New repository secret), diketik sendiri
+# di sana — tidak pernah lewat percakapan atau file di repo ini:
+#   SUPABASE_URL           https://xxxx.supabase.co
+#   SUPABASE_SERVICE_KEY   dari Supabase Settings > API Keys > Secret keys
+# ============================================================================
+
+name: Provision akun panitia
+
+on:
+  workflow_dispatch:
+    inputs:
+      csv_akun:
+        description: >-
+          CSV: username,email,peran,pos (header wajib). Contoh baris:
+          meja4hrcd37,meja4hrcd37@ciradyka.com,meja,
+        required: true
+        type: string
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: pip install requests
+
+      - name: Tulis CSV masukan dari input workflow
+        # Lewat env var, BUKAN diselipkan langsung ke skrip shell: input
+        # workflow_dispatch adalah teks bebas (nama/email bisa berisi tanda
+        # kutip dsb.) — interpolasi langsung ke `run:` rawan shell injection.
+        env:
+          CSV_AKUN: ${{ inputs.csv_akun }}
+        run: printf '%s\n' "$CSV_AKUN" > akun_masuk.csv
+
+      - name: Jalankan provisioning
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: python scripts/provision_akun.py akun_masuk.csv hasil_provisioning.csv
+
+      - name: Unggah hasil (berisi password — unduh sekali, lalu bagikan manual)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hasil-provisioning-${{ github.run_id }}
+          path: hasil_provisioning.csv
+          retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 vendor/
 dist/
 build/
+.wrangler/

--- a/scripts/provision_akun.py
+++ b/scripts/provision_akun.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# ============================================================================
+# hrcd-rekap : scripts/provision_akun.py — bikin akun panitia massal.
+#
+# Dua langkah per baris CSV masukan:
+#   1. Buat user di Supabase Auth (auto-confirm, lewat Admin API).
+#   2. Tautkan ke akun_panitia (username, peran, pos) lewat REST — service_role
+#      melompati RLS, jadi tidak perlu login sebagai admin dulu.
+#
+# Password: kalau kolom "password" di CSV masukan kosong, digenerate acak
+# (huruf/angka, tanpa 0/O/1/l/I supaya tidak salah baca saat diketik ulang
+# di meja pendaftaran). Password yang dipakai — apa pun asalnya — SELALU
+# ditulis ke CSV hasil, supaya bisa dibagikan ke pemiliknya.
+#
+# Aman diulang: baris yang emailnya sudah terdaftar dilewati (dilaporkan,
+# bukan error fatal) — sisa baris tetap lanjut.
+#
+# PAKAI (di terminal SENDIRI — kunci ini tidak boleh masuk ke mana pun lain,
+# lihat README di .github/workflows/provision-akun.yml untuk versi HP):
+#   $env:SUPABASE_URL = "https://xxxx.supabase.co"
+#   $env:SUPABASE_SERVICE_KEY = "sb_secret_..."
+#   python scripts/provision_akun.py akun_masuk.csv hasil_provisioning.csv
+#
+# Format CSV masukan (header wajib persis ini; kolom password boleh kosong):
+#   username,email,peran,pos,password
+#   admin.ciradyka,admin.ciradyka@ciradyka.com,admin,,
+#   pos1hrcd37,pos1hrcd37@ciradyka.com,operator_pos,1,
+# ============================================================================
+import csv
+import os
+import secrets
+import sys
+
+import requests
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "").rstrip("/")
+SERVICE_KEY = os.environ.get("SUPABASE_SERVICE_KEY", "")
+
+# Tanpa karakter yang gampang tertukar saat diketik ulang di lapangan.
+ABJAD_AMAN = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+
+def buat_password():
+    return "".join(secrets.choice(ABJAD_AMAN) for _ in range(10))
+
+
+def headers():
+    return {
+        "apikey": SERVICE_KEY,
+        "Authorization": f"Bearer {SERVICE_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+def buat_user_auth(email, password):
+    r = requests.post(
+        f"{SUPABASE_URL}/auth/v1/admin/users",
+        headers=headers(),
+        json={"email": email, "password": password, "email_confirm": True},
+        timeout=20,
+    )
+    if r.status_code in (200, 201):
+        data = r.json()
+        return data.get("id") or data.get("user", {}).get("id"), None
+    if r.status_code == 422 and "already been registered" in r.text.lower():
+        return None, "sudah_ada"
+    return None, f"HTTP {r.status_code}: {r.text[:200]}"
+
+
+def tautkan_akun_panitia(user_id, username, peran, pos):
+    body = {
+        "user_id": user_id,
+        "username": username,
+        "peran": peran,
+        "pos": int(pos) if pos else None,
+        "aktif": True,
+    }
+    r = requests.post(
+        f"{SUPABASE_URL}/rest/v1/akun_panitia",
+        headers={**headers(), "Prefer": "return=minimal"},
+        json=body,
+        timeout=20,
+    )
+    if r.status_code in (200, 201, 204):
+        return None
+    return f"HTTP {r.status_code}: {r.text[:200]}"
+
+
+def main():
+    if not SUPABASE_URL or not SERVICE_KEY:
+        print("Set dulu SUPABASE_URL dan SUPABASE_SERVICE_KEY di environment "
+              "kamu sebelum menjalankan skrip ini.")
+        sys.exit(1)
+    if len(sys.argv) < 2:
+        print("Pakai: python provision_akun.py <masukan.csv> [hasil.csv]")
+        sys.exit(1)
+
+    berkas_hasil = sys.argv[2] if len(sys.argv) > 2 else None
+    baris_hasil = []
+    dibuat = dilewati = gagal = 0
+
+    with open(sys.argv[1], newline="", encoding="utf-8") as f:
+        for baris in csv.DictReader(f):
+            username = baris["username"].strip()
+            email = baris["email"].strip()
+            peran = baris["peran"].strip()
+            pos = baris["pos"].strip()
+            password = (baris.get("password") or "").strip() or buat_password()
+
+            user_id, err = buat_user_auth(email, password)
+            if err == "sudah_ada":
+                print(f"~ {username:20s} sudah ada di Auth, dilewati (tautkan manual bila belum di akun_panitia)")
+                baris_hasil.append([username, email, peran, pos, "", "sudah_ada"])
+                dilewati += 1
+                continue
+            if err:
+                print(f"x {username:20s} GAGAL buat user: {err}")
+                baris_hasil.append([username, email, peran, pos, "", f"gagal: {err}"])
+                gagal += 1
+                continue
+
+            err = tautkan_akun_panitia(user_id, username, peran, pos)
+            if err:
+                print(f"x {username:20s} user Auth dibuat TAPI gagal tautkan akun_panitia: {err}")
+                baris_hasil.append([username, email, peran, pos, password, f"auth ok, tautkan gagal: {err}"])
+                gagal += 1
+                continue
+
+            print(f"v {username:20s} dibuat + tertaut ({peran}"
+                  + (f" pos {pos}" if pos else "") + ")")
+            baris_hasil.append([username, email, peran, pos, password, "dibuat"])
+            dibuat += 1
+
+    if berkas_hasil:
+        with open(berkas_hasil, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["username", "email", "peran", "pos", "password", "status"])
+            w.writerows(baris_hasil)
+        print(f"\nhasil (termasuk password) ditulis ke {berkas_hasil}")
+
+    print(f"selesai: {dibuat} dibuat, {dilewati} dilewati (sudah ada), {gagal} gagal")
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/gerbang/worker.js
+++ b/workers/gerbang/worker.js
@@ -95,4 +95,23 @@ export default {
       return jawab(400, { message: isi.message || "Pendaftaran ditolak. Periksa isian." });
     return jawab(200, isi);
   },
+
+  // ------------------------------------------------------------------- cron
+  // Project Supabase gratis dijeda setelah ±7 hari menganggur. Sistem ini
+  // dipasang jauh sebelum lomba dan nyaris tidak disentuh sampai Januari,
+  // jadi tanpa ini project sudah tertidur saat panitia membukanya.
+  //
+  // Satu bacaan sepele sudah cukup dihitung sebagai aktivitas. Kalau gagal,
+  // biarkan gagal: jadwal berikutnya datang sendiri dan tidak ada yang
+  // menunggu jawabannya. Jadwalnya di wrangler.toml.
+  async scheduled(event, env, ctx) {
+    ctx.waitUntil(
+      fetch(`${env.SUPABASE_URL}/rest/v1/edisi?select=nomor&limit=1`, {
+        headers: {
+          apikey: env.SUPABASE_SERVICE_KEY,
+          Authorization: `Bearer ${env.SUPABASE_SERVICE_KEY}`,
+        },
+      }).catch(() => {}),
+    );
+  },
 };

--- a/workers/gerbang/wrangler.toml
+++ b/workers/gerbang/wrangler.toml
@@ -22,7 +22,7 @@ compatibility_date = "2026-08-13"
 # Tanpa ini rate limit per IP tidak punya tempat menyimpan hitungan.
 [[kv_namespaces]]
 binding = "RATE"
-id = "GANTI_DENGAN_ID_DARI_wrangler_kv_namespace_create"
+id = "c344415a45044d7e9716f41715ab3d9a"
 
 # Tiap 3 hari, 03.00 UTC (10.00 WIB) — menahan project Supabase tetap bangun.
 # Supabase menjeda setelah ±7 hari menganggur; 3 hari memberi dua kesempatan

--- a/workers/gerbang/wrangler.toml
+++ b/workers/gerbang/wrangler.toml
@@ -23,3 +23,9 @@ compatibility_date = "2026-08-13"
 [[kv_namespaces]]
 binding = "RATE"
 id = "GANTI_DENGAN_ID_DARI_wrangler_kv_namespace_create"
+
+# Tiap 3 hari, 03.00 UTC (10.00 WIB) — menahan project Supabase tetap bangun.
+# Supabase menjeda setelah ±7 hari menganggur; 3 hari memberi dua kesempatan
+# meleset sebelum benar-benar tertidur.
+[triggers]
+crons = ["0 3 */3 * *"]

--- a/workers/gerbang/wrangler.toml
+++ b/workers/gerbang/wrangler.toml
@@ -1,0 +1,25 @@
+# ============================================================================
+# hrcd-rekap : workers/gerbang/wrangler.toml — konfigurasi deploy Worker.
+#
+# Worker ini satu-satunya kode "server" di seluruh sistem: gerbang form
+# pendaftaran publik (Turnstile + rate limit) di POST /daftar.
+#
+# Sebelum `wrangler deploy` yang pertama:
+#
+#   wrangler kv namespace create RATE     # salin id-nya ke bawah
+#   wrangler secret put SUPABASE_URL
+#   wrangler secret put SUPABASE_SERVICE_KEY
+#   wrangler secret put TURNSTILE_SECRET
+#
+# SUPABASE_SERVICE_KEY hidup HANYA di sini, tidak pernah di web/config.js.
+# ============================================================================
+
+name = "gerbang"
+main = "worker.js"
+compatibility_date = "2026-08-13"
+
+# Isi id-nya dengan keluaran `wrangler kv namespace create RATE`.
+# Tanpa ini rate limit per IP tidak punya tempat menyimpan hitungan.
+[[kv_namespaces]]
+binding = "RATE"
+id = "GANTI_DENGAN_ID_DARI_wrangler_kv_namespace_create"


### PR DESCRIPTION
## What

- `workers/gerbang/wrangler.toml` for the gerbang Worker, with the `RATE`
  KV namespace wired to the live namespace created for this deploy.
- A cron trigger (`0 3 */3 * *`) that pings Supabase every 3 days.
- `scripts/provision_akun.py` — creates Supabase Auth users and links them
  into `akun_panitia` from a CSV in one pass; safe to re-run, skips
  accounts that already exist instead of failing the whole batch.
- `.github/workflows/provision-akun.yml` — the same script, triggerable
  via `workflow_dispatch` from a phone (GitHub mobile app or mobile
  browser). `SUPABASE_URL`/`SUPABASE_SERVICE_KEY` come from repository
  secrets and never leave the runner. Generated passwords come back only
  as a short-lived (3-day) downloadable artifact, not as workflow input —
  that input is visible in Actions run history to anyone with repo
  access, fine for usernames/emails, not for 100 plaintext passwords.

## Why

- The Worker had no `wrangler.toml` at all, so it couldn't be deployed —
  no entry point, no Worker name, no KV binding for the rate limiter it
  already reads from in `worker.js`.
- Supabase's free tier pauses a project after ~7 days idle. The system is
  set up months before the lomba and barely touched until January —
  without the cron it would be asleep exactly when panitia first open it.
- Onboarding 5-8 IT volunteers per pos across 5 pos, plus meja staff, is
  25-40+ accounts — clicking through Supabase's "Add user" dialog that
  many times doesn't scale, and needs to be runnable away from a laptop.

## Notes

This PR does not deploy anything live. Cloudflare's Git integration for
Pages/Workers isn't connected yet, and the Worker hasn't had its first
`wrangler deploy`. Merging puts the config and tooling in place; two
steps remain before the site is actually reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)