### PR TITLE
fix: Worker compatibility_date rejected as in-the-future by Cloudflare

### DIFF
--- a/workers/gerbang/wrangler.toml
+++ b/workers/gerbang/wrangler.toml
@@ -16,7 +16,7 @@
 
 name = "gerbang"
 main = "worker.js"
-compatibility_date = "2026-08-13"
+compatibility_date = "2026-08-12"
 
 # Isi id-nya dengan keluaran `wrangler kv namespace create RATE`.
 # Tanpa ini rate limit per IP tidak punya tempat menyimpan hitungan.


### PR DESCRIPTION
## What

`compatibility_date` in `workers/gerbang/wrangler.toml` moved from
2026-08-13 to 2026-08-12.

## Why

The first deploy attempt failed outright:

    Can't set compatibility date in the future: 2026-08-13 [code: 10021]

2026-08-13 was picked from local context at authoring time; Cloudflare
validates against its own UTC clock, which was still on 2026-08-12 at
deploy time (confirmed from the failing request's own log timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)