### PR TITLE
refactor: rename the gerbang Worker to gateway

### DIFF
--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -1,5 +1,5 @@
 # ============================================================================
-# hrcd-rekap : deploy-gerbang.yml — set secret Worker + deploy, dari HP.
+# hrcd-rekap : deploy-gateway.yml — set secret Worker + deploy, dari HP.
 #
 # Dipicu manual (workflow_dispatch) — dipakai untuk deploy pertama dan untuk
 # redeploy/rotasi secret kapan pun, bukan otomatis tiap push (deploy rutin
@@ -21,7 +21,7 @@
 # nanti, tambahkan baris `wrangler secret put TURNSTILE_SECRET` di bawah.
 # ============================================================================
 
-name: Deploy gerbang Worker
+name: Deploy gateway Worker
 
 on:
   workflow_dispatch:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: workers/gerbang
+        working-directory: workers/gateway
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -21,7 +21,7 @@ penyelesaiannya dicatat di bagian 11.
 3. **Halaman live publik** — file statis (`live.html` + `live.json`) di
    Cloudflare Pages, di-regenerate berkala oleh GitHub Actions. Penonton
    **tidak pernah** menyentuh Supabase.
-4. **Satu Cloudflare Worker kecil** — gerbang form pendaftaran publik:
+4. **Satu Cloudflare Worker kecil** — gateway form pendaftaran publik:
    memverifikasi Turnstile (anti-spam gratis) + rate limit, baru meneruskan ke
    database. Satu-satunya jalur tulis dari luar.
 5. **Google Sheets** — jendela baca: tombol Export CSV di semua layar daftar,
@@ -80,7 +80,7 @@ penyelesaiannya dicatat di bagian 11.
 2. Dua fungsi helper `peran()` dan `pos_saya()` (membaca `akun_panitia` dari
    `auth.uid()`) dipakai seluruh policy; hanya akun `aktif=true` yang lolos.
 3. **Anon nyaris nol**: hanya `SELECT sekolah` (autocomplete form, tanpa PII).
-   Form publik menulis lewat gerbang Worker (bagian 8), penonton membaca file
+   Form publik menulis lewat gateway Worker (bagian 8), penonton membaca file
    statis (bagian 7) — **tidak ada jalur anon lain ke database**.
 4. **Rotasi tahunan**: akun membawa akhiran edisi. Tiap edisi: akun lama
    `aktif=false` (jejak riwayat utuh), ±10 akun baru dibuat pemilik lewat
@@ -288,7 +288,7 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
    regu: sudah lewat pos mana, **tanpa angka**), `penuh` (klasemen 4 golongan
    setelah closing). Admin memindah fase dari layar konfigurasi.
 
-## 8. Gerbang form publik
+## 8. Gateway form publik
 
 1. Form pendaftaran mengirim ke **satu Worker Cloudflare kecil** (±50 baris,
    satu-satunya kode "server" di seluruh sistem): verifikasi token
@@ -536,7 +536,7 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
 | Tahap | Isi | Bukti selesai |
 | --- | --- | --- |
 | 1. Fondasi | Struktur repo, migrasi SQL lengkap (tabel + RLS + fungsi + view), seed konfigurasi edisi 37, seed contoh | Tes SQL: nomor dada ganda tertolak, RLS pos menggigit, contoh konversi & penalti cocok dengan dokumen ini |
-| 2. Meja | Login, beranda meja, form pendaftaran + gerbang Worker, pembayaran, daftar ulang | Alur daftar → bayar → nomor dada jalan penuh di lingkungan uji |
+| 2. Meja | Login, beranda meja, form pendaftaran + gateway Worker, pembayaran, daftar ulang | Alur daftar → bayar → nomor dada jalan penuh di lingkungan uji |
 | 3. Hari-H | Garis start, input pos (manual + massal), closing, monitoring | Simulasi input 500 regu × 5 pos |
 | 4. Admin | Konfigurasi, klasemen, cetak, barak, riwayat | Panitia bisa mengubah aturan skor tanpa menyentuh kode |
 | 5. Publik | Live page + GitHub Actions + fase bertahap + keep-alive | Halaman live berjalan tanpa satu request pun ke Supabase |
@@ -550,7 +550,7 @@ Migrasi SQL Tahap 1 diserang tiga reviewer adversarial (keamanan, kesesuaian,
 kebenaran SQL); 39 temuan menghasilkan penyesuaian berikut — dokumen di atas
 dibaca dengan koreksi ini:
 
-1. **`submit_pendaftaran` hanya bisa dipanggil gerbang Worker** (service
+1. **`submit_pendaftaran` hanya bisa dipanggil gateway Worker** (service
    role) — akun login mana pun tidak bisa, supaya Turnstile tidak bisa
    dilompati. Grant fungsi kini per-fungsi, bukan massal: RPC baru tidak
    pernah terekspos otomatis.

--- a/supabase/migrations/0003_rls.sql
+++ b/supabase/migrations/0003_rls.sql
@@ -6,7 +6,7 @@
 --   admin        — semua tabel, semua operasi
 --   operator_pos — nilai_mentah hanya baris pos = pos_saya()
 --   meja         — semua layar meja; ganti fungsi = pindah layar (R14)
--- Anon nyaris nol: hanya SELECT sekolah. Form publik menulis lewat gerbang
+-- Anon nyaris nol: hanya SELECT sekolah. Form publik menulis lewat gateway
 -- Worker (service role); penonton membaca file statis — tidak ada jalur anon
 -- lain ke database.
 -- ============================================================================
@@ -42,7 +42,7 @@ alter table nomor_dada_pensiun enable row level security;
 
 grant usage on schema public to anon, authenticated, service_role;
 grant select, insert, update, delete on all tables in schema public to authenticated;
--- service_role (BYPASSRLS) dipakai gerbang Worker & GitHub Actions; di
+-- service_role (BYPASSRLS) dipakai gateway Worker & GitHub Actions; di
 -- Supabase asli grant ini datang dari default privileges — dieksplisitkan
 -- supaya lingkungan uji lokal berperilaku sama.
 grant select, insert, update, delete on all tables in schema public to service_role;

--- a/supabase/migrations/0004_rpcs.sql
+++ b/supabase/migrations/0004_rpcs.sql
@@ -10,7 +10,7 @@
 -- ============================================================================
 
 -- ---------------------------------------------------------------------------
--- 1. submit_pendaftaran — satu-satunya jalur tulis dari luar (via gerbang
+-- 1. submit_pendaftaran — satu-satunya jalur tulis dari luar (via gateway
 --    Worker). Buat sekolah bila baru + batch + N baris regu + kode pembayaran,
 --    sekali jalan.
 -- ---------------------------------------------------------------------------
@@ -884,11 +884,11 @@ $$;
 
 -- ---------------------------------------------------------------------------
 -- 12. Eksekusi: hanya authenticated (panitia). Anon TIDAK bisa memanggil apa
---     pun — submit_pendaftaran dipanggil gerbang Worker memakai service role.
+--     pun — submit_pendaftaran dipanggil gateway Worker memakai service role.
 -- ---------------------------------------------------------------------------
 
 -- Temuan review (blocker): grant massal "all functions to authenticated"
--- membuka submit_pendaftaran ke SEMUA akun login — melompati gerbang
+-- membuka submit_pendaftaran ke SEMUA akun login — melompati gateway
 -- Turnstile. Model baru: cabut semuanya, beri per fungsi secara eksplisit;
 -- fungsi baru TIDAK PERNAH terekspos otomatis.
 revoke execute on all functions in schema public from public, anon, authenticated;
@@ -915,7 +915,7 @@ grant execute on function catat_closing(integer, timestamptz, smallint, text) to
 grant execute on function susun_barak()                                     to authenticated;
 grant execute on function ubah_pendamping(text, smallint)                   to authenticated;
 
--- submit_pendaftaran HANYA untuk gerbang Worker (service role). Akun login
+-- submit_pendaftaran HANYA untuk gateway Worker (service role). Akun login
 -- yang mendaftarkan sekolah di meja offline tetap lewat form publik yang
 -- sama (link sama, alur 3.6) — bukan lewat RPC langsung.
 grant execute on function submit_pendaftaran(text, text, boolean, text, jsonb, smallint)

--- a/tests/sql/03_alur.sql
+++ b/tests/sql/03_alur.sql
@@ -12,7 +12,7 @@ create table uji_kode (label text primary key, hasil jsonb);
 grant all on uji_kode to authenticated, service_role;
 
 -- ---------------------------------------------------------------------------
--- 3.1 Pendaftaran (jalur gerbang Worker = service_role).
+-- 3.1 Pendaftaran (jalur gateway Worker = service_role).
 --     A: 12 regu penegak_pa, butuh barak. B: 5 regu penegak_pa, butuh barak.
 --     C: 2 regu penegak_pi (uji tie-break). D: 1 regu (uji pembatalan).
 -- ---------------------------------------------------------------------------
@@ -135,7 +135,7 @@ begin
           join pendaftaran d on d.id = b.pendaftaran_id
           where d.kode_pembayaran = uji('D')), 'pembayaran D masih ada';
 
-  -- Akun login TIDAK bisa memanggil submit_pendaftaran — hanya gerbang
+  -- Akun login TIDAK bisa memanggil submit_pendaftaran — hanya gateway
   -- Worker (temuan review, blocker).
   begin
     perform submit_pendaftaran('Selundup', 'X', false, '0812999',

--- a/web/config.js
+++ b/web/config.js
@@ -12,7 +12,7 @@ window.HRCD = {
   // --- produksi (mode: "supabase") ---
   // supabaseUrl: "https://xxxx.supabase.co",
   // anonKey:     "eyJ...",
-  // gerbangUrl:  "https://gerbang.hrcd.workers.dev",
+  // gatewayUrl:  "https://gateway.<subdomain>.workers.dev",
   // domainAkun:  "panitia.hrcd.local",   // username + '@' + domain ini = email auth
   // turnstileSiteKey: "0x4AAA...",
 };

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -192,7 +192,7 @@ export async function kirimPendaftaran(payload, tokenTurnstile) {
       body: JSON.stringify(payload),
     });
   }
-  return kirim(`${K.gerbangUrl}/daftar`, {
+  return kirim(`${K.gatewayUrl}/daftar`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ ...payload, turnstile: tokenTurnstile }),

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -1,5 +1,5 @@
 /* ============================================================================
-   hrcd-rekap : workers/gerbang/worker.js — gerbang form pendaftaran publik.
+   hrcd-rekap : workers/gateway/worker.js — gateway form pendaftaran publik.
    Satu-satunya kode "server" di seluruh sistem (rancangan-b.md bagian 8):
    verifikasi Turnstile (opsional) + rate limit per IP + batas ukuran ->
    panggil RPC submit_pendaftaran memakai service role. Kunci rahasia hidup

--- a/workers/gateway/wrangler.toml
+++ b/workers/gateway/wrangler.toml
@@ -1,7 +1,7 @@
 # ============================================================================
-# hrcd-rekap : workers/gerbang/wrangler.toml — konfigurasi deploy Worker.
+# hrcd-rekap : workers/gateway/wrangler.toml — konfigurasi deploy Worker.
 #
-# Worker ini satu-satunya kode "server" di seluruh sistem: gerbang form
+# Worker ini satu-satunya kode "server" di seluruh sistem: gateway form
 # pendaftaran publik (Turnstile + rate limit) di POST /daftar.
 #
 # Sebelum `wrangler deploy` yang pertama:
@@ -14,7 +14,7 @@
 # SUPABASE_SERVICE_KEY hidup HANYA di sini, tidak pernah di web/config.js.
 # ============================================================================
 
-name = "gerbang"
+name = "gateway"
 main = "worker.js"
 compatibility_date = "2026-08-12"
 


### PR DESCRIPTION
## What

Renamed the Worker from "gerbang" to "gateway" everywhere it's
referenced: `workers/gerbang/` -> `workers/gateway/`, the Worker's
`name` in `wrangler.toml`, `deploy-gerbang.yml` ->
`deploy-gateway.yml`, `api.js`'s `K.gerbangUrl` -> `K.gatewayUrl`, and
every doc/comment describing this specific component — including
comment-only wording in already-applied migrations (0003, 0004) and
`tests/sql/03_alur.sql`, since it's pure text with no schema impact.

Left untouched: five places where "gerbang" is the ordinary Indonesian
word for "chokepoint," describing the unrelated
`pg_advisory_xact_lock` serialization point in `daftar_ulang_batch`
(migrations 0007/0008, `rancangan-b.md` 4.1/4.4).

## Why

"Gerbang" names a software-architecture role (the API gateway
pattern), not domain vocabulary the panitia would use talking about
the lomba — unlike `regu`/`nomor_dada`/`kloter`. Per `CLAUDE.md`'s own
rule, technical terms stay in English so maintainers can search
Cloudflare/gateway-pattern docs directly; this was misclassified as a
domain term originally.

## Notes

The Worker briefly existed on Cloudflare under the old name from an
earlier partial deploy attempt (uploaded, never routed — a separate
issue unblocked by prior PRs). Deleted directly via `wrangler delete`
before opening this PR, so there's nothing orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)