### PR TITLE
feat: add web/wrangler.toml for Workers static assets hosting

### DIFF
--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,0 +1,20 @@
+# ============================================================================
+# hrcd-rekap : web/wrangler.toml — Workers static assets untuk situs statis
+# (layar panitia + form pendaftaran publik).
+#
+# Cloudflare Pages berstatus "maintenance mode" (docs/desain-sistem.md 8.2) —
+# ini jalur yang aktif dikembangkan Cloudflare untuk kebutuhan yang sama:
+# terhubung Git, deploy otomatis tiap push ke main, tanpa build step.
+#
+# PENTING saat menyambungkan repo ini di dashboard Cloudflare:
+#   Root directory: web
+# Folder ini SENDIRI jadi akar proyek untuk koneksi Git tersebut — terpisah
+# total dari workers/gateway/wrangler.toml (Worker gateway punya deploy-nya
+# sendiri lewat GitHub Actions, tidak saling menyentuh dengan file ini).
+# ============================================================================
+
+name = "hrcd-rekap"
+compatibility_date = "2026-08-12"
+
+[assets]
+directory = "."


### PR DESCRIPTION
## What

`web/wrangler.toml` — a minimal `[assets]` config so `web/` can be
deployed as Workers static assets, Git-connected for deploy-on-push.

## Why

Cloudflare's onboarding flow defaults new Git-connected projects to a
Workers-style setup (`npx wrangler deploy`) rather than surfacing
classic Pages as a distinct choice — matching what
`docs/desain-sistem.md` §8.2 already flagged: Pages is in maintenance
mode, Workers static assets is the actively developed equivalent for
the same use case.

## Notes

Lives at `web/wrangler.toml`, not the repo root — pair with setting
**Root directory: `web`** on the Cloudflare project so this folder is
its own self-contained project, with no overlap with
`workers/gateway/wrangler.toml` (deployed independently via its own
GitHub Actions workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)