### PR TITLE
feat: switch config.js to production, lock CORS to the real site

### DIFF
--- a/web/config.js
+++ b/web/config.js
@@ -6,13 +6,11 @@
    ========================================================================== */
 
 window.HRCD = {
-  mode: "dev",
-  devUrl: "http://127.0.0.1:8787",
-
-  // --- produksi (mode: "supabase") ---
-  // supabaseUrl: "https://xxxx.supabase.co",
-  // anonKey:     "eyJ...",
-  // gatewayUrl:  "https://gateway.<subdomain>.workers.dev",
-  // domainAkun:  "panitia.hrcd.local",   // username + '@' + domain ini = email auth
-  // turnstileSiteKey: "0x4AAA...",
+  mode: "supabase",
+  supabaseUrl: "https://pwszijhnftvqjkdldqrf.supabase.co",
+  anonKey: "sb_publishable_fVRvaYucCPJxOiphJWC_ZQ_8hgFKDsi",
+  gatewayUrl: "https://gateway.ciradyka.workers.dev",
+  domainAkun: "ciradyka.com",   // username + '@' + domain ini = email auth
+  // turnstileSiteKey sengaja tidak diisi — Turnstile dinonaktifkan untuk
+  // edisi 37 (keputusan sadar, lihat workers/gateway/worker.js).
 };

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -22,7 +22,7 @@ const BATAS_BYTE = 32_000;      // payload wajar: 30 regu ~ 6 KB
 // dari WiFi venue yang sama (satu IP) bisa memicu ini kalau terlalu ketat.
 // Angka ini cuma pagar terakhir untuk banjir skrip, bukan penghalang panitia.
 const BATAS_PER_MENIT = 30;     // pengiriman per IP per menit
-const ASAL_BOLEH = "*";         // ganti ke origin Pages saat produksi
+const ASAL_BOLEH = "https://hrcd-rekap.ciradyka.workers.dev";
 
 const CORS = {
   "Access-Control-Allow-Origin": ASAL_BOLEH,


### PR DESCRIPTION
## What

- `web/config.js`: `mode: "supabase"` with the real Supabase project
  URL, publishable key, deployed gateway Worker URL, and the
  `ciradyka.com` account domain — replacing the local-dev defaults.
- `workers/gateway/worker.js`: `ASAL_BOLEH` moves from `"*"` to
  `https://hrcd-rekap.ciradyka.workers.dev`, the real site origin.

## Why

Every screen (panitia and public registration) was still pointed at
`127.0.0.1:8787` — the local dev server on a laptop, unreachable to
anyone else. This is the config that makes the deployed infrastructure
actually load and function for a real visitor. CORS gets tightened at
the same time now that the real origin is known, rather than staying
wide open indefinitely.

## Notes

`turnstileSiteKey` intentionally omitted — matches the earlier decision
to keep Turnstile disabled for edisi 37.

Merging this needs the gateway Worker redeployed afterward (CORS
change doesn't take effect until then) — will trigger it right after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)