### PR TITLE
refactor: rename the site to hrcd37, update gateway CORS to match

### DIFF
--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -11,9 +11,16 @@
 # Folder ini SENDIRI jadi akar proyek untuk koneksi Git tersebut — terpisah
 # total dari workers/gateway/wrangler.toml (Worker gateway punya deploy-nya
 # sendiri lewat GitHub Actions, tidak saling menyentuh dengan file ini).
+#
+# `name` SENGAJA memuat nomor edisi (beda dari gateway Worker atau project
+# Supabase, yang sengaja TIDAK memuat nomor edisi supaya bisa dipakai lintas
+# tahun). Keputusan sadar: situs ini bukan cuma "rekap", jadi nama generik
+# terasa kurang jelas — tiap edisi ganti nama + URL (hrcd37 -> hrcd38 -> ...).
+# Cloudflare tidak mendukung rename in-place: ganti nama di sini, deploy,
+# baru hapus project lama (`wrangler delete --name <nama-lama>`).
 # ============================================================================
 
-name = "hrcd-rekap"
+name = "hrcd37"
 compatibility_date = "2026-08-12"
 
 [assets]

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -22,7 +22,7 @@ const BATAS_BYTE = 32_000;      // payload wajar: 30 regu ~ 6 KB
 // dari WiFi venue yang sama (satu IP) bisa memicu ini kalau terlalu ketat.
 // Angka ini cuma pagar terakhir untuk banjir skrip, bukan penghalang panitia.
 const BATAS_PER_MENIT = 30;     // pengiriman per IP per menit
-const ASAL_BOLEH = "https://hrcd-rekap.ciradyka.workers.dev";
+const ASAL_BOLEH = "https://hrcd37.ciradyka.workers.dev";
 
 const CORS = {
   "Access-Control-Allow-Origin": ASAL_BOLEH,


### PR DESCRIPTION
## What

- `web/wrangler.toml`: project name `hrcd-rekap` -> `hrcd37`
- `workers/gateway/worker.js`: `ASAL_BOLEH` -> `https://hrcd37.ciradyka.workers.dev`

## Why

Deliberate reversal of the earlier "keep infra names edition-agnostic"
default. The site covers registration and payment, not just recap, so
a generic name read as unclear. Accepted tradeoff: this gets renamed
and re-migrated every edition (hrcd38 next year), unlike the Supabase
project and the gateway Worker, which stay edition-agnostic on purpose.

## Notes

Cloudflare doesn't rename Workers in place. Once `hrcd37` is confirmed
live under the Git connection, the old `hrcd-rekap` project needs
`wrangler delete --name hrcd-rekap` — doing that right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)