### PR TITLE
refactor: rename ASAL_BOLEH to ALLOWED_ORIGIN

### DIFF
--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -22,10 +22,10 @@ const BATAS_BYTE = 32_000;      // payload wajar: 30 regu ~ 6 KB
 // dari WiFi venue yang sama (satu IP) bisa memicu ini kalau terlalu ketat.
 // Angka ini cuma pagar terakhir untuk banjir skrip, bukan penghalang panitia.
 const BATAS_PER_MENIT = 30;     // pengiriman per IP per menit
-const ASAL_BOLEH = "https://hrcd37.ciradyka.workers.dev";
+const ALLOWED_ORIGIN = "https://hrcd37.ciradyka.workers.dev";
 
 const CORS = {
-  "Access-Control-Allow-Origin": ASAL_BOLEH,
+  "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
 };


### PR DESCRIPTION
## What

`ASAL_BOLEH` -> `ALLOWED_ORIGIN` in `workers/gateway/worker.js`.

## Why

Language convention: technical/generic terms stay English even in an
otherwise Indonesian codebase (Server, Origin), only actual HRCD domain
vocabulary stays Indonesian (Regu, Rekap, Juara). This constant names
a CORS concept, not something panitia would say discussing the lomba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)