### PR TITLE
fix: revert to hrcd-rekap - the hrcd37 rename never took effect

### DIFF
--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -12,15 +12,21 @@
 # total dari workers/gateway/wrangler.toml (Worker gateway punya deploy-nya
 # sendiri lewat GitHub Actions, tidak saling menyentuh dengan file ini).
 #
-# `name` SENGAJA memuat nomor edisi (beda dari gateway Worker atau project
-# Supabase, yang sengaja TIDAK memuat nomor edisi supaya bisa dipakai lintas
-# tahun). Keputusan sadar: situs ini bukan cuma "rekap", jadi nama generik
-# terasa kurang jelas — tiap edisi ganti nama + URL (hrcd37 -> hrcd38 -> ...).
-# Cloudflare tidak mendukung rename in-place: ganti nama di sini, deploy,
-# baru hapus project lama (`wrangler delete --name <nama-lama>`).
+# RENCANA (belum berhasil): pindah ke "hrcd37" sengaja memuat nomor edisi
+# (beda dari gateway Worker/project Supabase yang sengaja tidak) — situs ini
+# bukan cuma "rekap", jadi nama generik terasa kurang jelas; tiap edisi ganti
+# nama + URL (hrcd37 -> hrcd38 -> ...).
+#
+# TAPI: mengubah `name` di sini TIDAK mengubah nama project yang tersambung
+# Git — Cloudflare mengikat identitas project ke koneksinya, bukan ke file
+# ini (dicoba 2026-08-12, project tetap ter-deploy sebagai "hrcd-rekap").
+# Rename sungguhan harus lewat dashboard (Settings -> cari opsi rename) atau
+# hapus+sambung ulang project dengan nama baru. `name` di bawah dikembalikan
+# ke "hrcd-rekap" supaya cocok dengan yang SUNGGUHAN live — jangan diubah
+# sendirian tanpa juga menyamakan ALLOWED_ORIGIN di workers/gateway/worker.js.
 # ============================================================================
 
-name = "hrcd37"
+name = "hrcd-rekap"
 compatibility_date = "2026-08-12"
 
 [assets]

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -22,7 +22,7 @@ const BATAS_BYTE = 32_000;      // payload wajar: 30 regu ~ 6 KB
 // dari WiFi venue yang sama (satu IP) bisa memicu ini kalau terlalu ketat.
 // Angka ini cuma pagar terakhir untuk banjir skrip, bukan penghalang panitia.
 const BATAS_PER_MENIT = 30;     // pengiriman per IP per menit
-const ALLOWED_ORIGIN = "https://hrcd37.ciradyka.workers.dev";
+const ALLOWED_ORIGIN = "https://hrcd-rekap.ciradyka.workers.dev";
 
 const CORS = {
   "Access-Control-Allow-Origin": ALLOWED_ORIGIN,


### PR DESCRIPTION
## What

`web/wrangler.toml` and `workers/gateway/worker.js`'s `ALLOWED_ORIGIN`
both reverted from `hrcd37` back to `hrcd-rekap`.

## Why

Verified directly: `hrcd-rekap.ciradyka.workers.dev` serves the site
(HTTP 307), `hrcd37.ciradyka.workers.dev` is 404. The rename only
changed the config file's `name` field, which Cloudflare's
Git-integration doesn't use to rename an already-connected project.
Left mismatched, the gateway would have rejected CORS requests from
the site that's actually live.

## Notes

The `hrcd37` rename itself is unresolved -- needs a dashboard action
(Settings -> rename, if it exists) or delete+reconnect under the new
name. Left a note in `wrangler.toml` explaining this so a future
attempt doesn't repeat the same half-effective change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)