### PR TITLE
fix: keep panitia logged in across tab/app close on phones

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -10,14 +10,19 @@
 const K = window.HRCD || { mode: "dev", devUrl: "http://127.0.0.1:8787" };
 const BATAS_MS = 20000;   // internet lambat tidak boleh menggantung selamanya
 
-/* ---------- sesi ---------- */
+/* ---------- sesi ----------
+   localStorage, BUKAN sessionStorage: di HP, menutup tab/app (bahkan cuma
+   berpindah app sebentar) sering dianggap browser sebagai "sesi berakhir"
+   dan sessionStorage langsung kosong — panitia harus login ulang tiap kali
+   membuka lagi. localStorage bertahan sampai betul-betul ditekan Keluar,
+   dan token di dalamnya tetap kedaluwarsa sendiri via pastikanSesiSegar(). */
 
 export function sesi() {
-  const s = sessionStorage.getItem("hrcd_sesi");
+  const s = localStorage.getItem("hrcd_sesi");
   return s ? JSON.parse(s) : null;
 }
-function simpanSesi(s) { sessionStorage.setItem("hrcd_sesi", JSON.stringify(s)); }
-export function keluar() { sessionStorage.removeItem("hrcd_sesi"); }
+function simpanSesi(s) { localStorage.setItem("hrcd_sesi", JSON.stringify(s)); }
+export function keluar() { localStorage.removeItem("hrcd_sesi"); }
 
 /* ---------- kesalahan yang ramah ---------- */
 


### PR DESCRIPTION
## What

`sesi()`/`simpanSesi()`/`keluar()` in `web/js/api.js` moved from
`sessionStorage` to `localStorage`.

## Why

Reported symptom: logging in on a phone, closing the tab/app, and
being logged out immediately on reopen. Root cause: `sessionStorage`
is cleared far more aggressively on mobile browsers than desktop --
closing a tab, or sometimes just switching apps briefly, counts as
"session ended." `localStorage` persists until an explicit Keluar; the
existing refresh-token logic (`pastikanSesiSegar()`) already handles
actual token expiry underneath, unaffected by this change.

`daftar.js`'s separate `sessionStorage` usage (the "just submitted"
flag on the public form) is untouched -- different purpose, correctly
scoped as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)