### PR TITLE
feat: reorder beranda menu, English labels/naming

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -26,8 +26,8 @@ export function keluar() { localStorage.removeItem("hrcd_sesi"); }
 
 /* ---------- kesalahan yang ramah ---------- */
 
-export class GalatApi extends Error {
-  constructor(pesan) { super(pesan); this.name = "GalatApi"; }
+export class ErrorApi extends Error {
+  constructor(pesan) { super(pesan); this.name = "ErrorApi"; }
 }
 
 /** Terjemahkan pesan mentah (server / jaringan / enum RPC) jadi kalimat yang
@@ -70,7 +70,7 @@ async function kirim(url, opsi = {}) {
   try {
     r = await fetch(url, { ...opsi, signal: ac.signal });
   } catch (e) {
-    throw new GalatApi(pesanRamah(e.name === "AbortError" ? "timeout" : e.message));
+    throw new ErrorApi(pesanRamah(e.name === "AbortError" ? "timeout" : e.message));
   } finally {
     clearTimeout(jam);
   }
@@ -81,7 +81,7 @@ async function kirim(url, opsi = {}) {
     const pesan = (data && (data.message || data.error_description || data.error
                   || data.msg || data.hint))
       || (typeof data === "string" ? data : null) || `HTTP ${r.status}`;
-    throw new GalatApi(pesanRamah(String(pesan)));
+    throw new ErrorApi(pesanRamah(String(pesan)));
   }
   return data;
 }
@@ -159,7 +159,7 @@ export async function masuk(username, password) {
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,aktif`,
       { headers: { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` } });
     if (!akun.length || !akun[0].aktif)
-      throw new GalatApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
+      throw new ErrorApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
     s = {
       uid: j.user.id, token: j.access_token, refresh: j.refresh_token,
       kedaluwarsa: Date.now() + (j.expires_in || 3600) * 1000,
@@ -185,7 +185,7 @@ export async function infoEdisi() {
   const d = await kirim(`${K.supabaseUrl}/rest/v1/v_edisi_publik?select=*`, {
     headers: { apikey: K.anonKey, Authorization: `Bearer ${K.anonKey}` },
   });
-  if (!d.length) throw new GalatApi("Belum ada edisi lomba yang dibuka.");
+  if (!d.length) throw new ErrorApi("Belum ada edisi lomba yang dibuka.");
   return d[0];
 }
 
@@ -218,7 +218,7 @@ export async function lihatBatch(kode) {
     `pembayaran(nominal,metode,nomor_kwitansi,diverifikasi_pada)` +
     `&regu.order=nama_regu.asc`);
   if (!d.length)
-    throw new GalatApi(`Kode ${kode} tidak ditemukan. Periksa lagi hurufnya.`);
+    throw new ErrorApi(`Kode ${kode} tidak ditemukan. Periksa lagi hurufnya.`);
   return d[0];
 }
 

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -37,7 +37,7 @@ export function pesanRamah(m) {
   if (!m) return "Terjadi kesalahan. Coba lagi.";
   const t = String(m);
   if (/invalid[_ ]grant|invalid login credentials|bad_credentials/i.test(t))
-    return "Nama akun atau password salah. Periksa lagi, lalu coba masuk.";
+    return "Username atau password salah. Periksa lagi, lalu coba masuk.";
   if (/failed to fetch|networkerror|load failed|aborted|timeout/i.test(t))
     return "Internet lambat atau putus. Coba lagi — isianmu tidak hilang.";
   if (/jwt|token .*expired|pgrst301/i.test(t))

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9,7 +9,7 @@
    ========================================================================== */
 
 import {
-  sesi, masuk, keluar, GalatApi,
+  sesi, masuk, keluar, ErrorApi,
   lihatBatch, infoEdisi, ringkasanMeja,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor, ubahPendamping,
   daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
@@ -84,7 +84,7 @@ function layarLogin(pesan) {
       location.hash = "#/beranda";
       arahkan();
     } catch (e) {
-      layarLogin(e instanceof GalatApi ? e.message : "Username atau password salah.");
+      layarLogin(e instanceof ErrorApi ? e.message : "Username atau password salah.");
     }
   };
   document.getElementById("masuk").addEventListener("click", aksi);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -62,7 +62,7 @@ function layarLogin(pesan) {
       <p class="keterangan">Pakai akun yang dibagikan koordinatormu.</p>
       ${pesan ? `<div class="galat" style="margin-top:.5rem">${esc(pesan)}</div>` : ""}
       <div class="medan" style="margin-top:1rem">
-        <label for="u">Nama akun</label>
+        <label for="u">Username</label>
         <input type="text" id="u" autocomplete="username" autocapitalize="none"
                spellcheck="false" placeholder="contoh: meja1hrcd37">
       </div>
@@ -84,7 +84,7 @@ function layarLogin(pesan) {
       location.hash = "#/beranda";
       arahkan();
     } catch (e) {
-      layarLogin(e instanceof GalatApi ? e.message : "Nama akun atau password salah.");
+      layarLogin(e instanceof GalatApi ? e.message : "Username atau password salah.");
     }
   };
   document.getElementById("masuk").addEventListener("click", aksi);
@@ -120,6 +120,10 @@ async function layarBeranda() {
   LAYAR.replaceChildren(h(`
     ${galat ? kartuGalat(`Jumlah antrean tidak bisa dibaca: ${galat}`) : ""}
     <div class="menu-fungsi">
+      <a href="#/pendaftaran-offline">
+        <div class="nama-fungsi">📝 Pendaftaran</div>
+        <div class="ket">Buka form pendaftaran — link sama untuk online maupun diisikan langsung</div>
+      </a>
       <a href="#/pembayaran">
         <div class="nama-fungsi">💳 Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
         <div class="ket">Periksa transfer/tunai, tandai lunas, cetak kwitansi</div>
@@ -127,10 +131,6 @@ async function layarBeranda() {
       <a href="#/daftar-ulang">
         <div class="nama-fungsi">🎽 Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
         <div class="ket">Berikan nomor dada untuk sekolah yang sudah lunas</div>
-      </a>
-      <a href="#/pendaftaran-offline">
-        <div class="nama-fungsi">📝 Pendaftaran Offline</div>
-        <div class="ket">Bukakan form pendaftaran untuk sekolah yang datang langsung</div>
       </a>
       <a href="#/cetak-kloter">
         <div class="nama-fungsi">🖨️ Cetak Daftar Kloter</div>
@@ -1078,10 +1078,10 @@ function kartuSisipan(sisipan) {
 /* ============================ PENDAFTARAN OFFLINE ======================== */
 
 function layarPendaftaranOffline() {
-  pasangKepala("Pendaftaran Offline");
+  pasangKepala("Pendaftaran");
   LAYAR.replaceChildren(h(`
     <div class="kartu">
-      <h2>Pendaftaran offline = form yang sama</h2>
+      <h2>Link yang sama untuk online maupun langsung</h2>
       <p class="keterangan" style="margin-top:.4rem">
         Bukakan form ini di HP pendaftar, atau isikan bersama di laptop meja.
         Setelah dapat kode pembayaran, arahkan ke meja pembayaran.</p>

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -15,7 +15,7 @@
      tidak ada "perbaiki satu, ketemu satu lagi".
    ========================================================================== */
 
-import { daftarSekolah, kirimPendaftaran, infoEdisi, GalatApi } from "./api.js";
+import { daftarSekolah, kirimPendaftaran, infoEdisi, ErrorApi } from "./api.js";
 import { esc, h, html, rupiah, notif, kartuGagalMuat } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
@@ -459,7 +459,7 @@ async function kirim(e) {
     document.getElementById("ringkas-galat").replaceChildren(h(html`
       <div class="kartu" style="border-color:var(--bahaya);background:var(--bahaya-muda)">
         <strong>Belum terkirim.</strong>
-        ${err instanceof GalatApi ? err.message : "Coba lagi ya."}
+        ${err instanceof ErrorApi ? err.message : "Coba lagi ya."}
         <div class="keterangan" style="margin-top:.3rem">Isianmu tersimpan — tekan
           "Kirim Pendaftaran" sekali lagi.</div>
       </div>`));


### PR DESCRIPTION
## What

- Beranda menu reordered to match the actual workflow: Pendaftaran,
  Pembayaran, Daftar Ulang first.
- "Pendaftaran Offline" renamed to "Pendaftaran" (menu card, screen
  title, and heading) -- it opens the exact same public link, so
  calling it out as a separate "offline" thing overstated a
  difference that isn't there.
- Login field label "Nama akun" -> "Username", consistently in the
  label, inline error, and network-error fallback.
- `GalatApi` -> `ErrorApi` throughout `api.js`/`app.js`/`daftar.js`.

## Why

Language convention (established this session): technical/generic
terms stay English even in an otherwise Indonesian codebase, only
actual HRCD domain vocabulary stays Indonesian. Username, Error, and
"the offline form is just the same link" are all instances of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)