### PR TITLE
fix: remove the auto-save intro text on the registration form

### DIFF
--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -70,9 +70,6 @@ function halaman() {
   LAYAR.replaceChildren(h(`
     <div class="kartu" style="border-color:var(--utama)">
       <h2>Pendaftaran Regu</h2>
-      <p class="keterangan">Isi semuanya di halaman ini, lalu tekan Kirim di bawah.
-         Isianmu tersimpan otomatis — kalau HP mati atau halaman tertutup,
-         buka lagi dan lanjutkan.</p>
     </div>
 
     <!-- 1. Sekolah -->


### PR DESCRIPTION
## What

Removed the "Isi semuanya di halaman ini, lalu tekan Kirim di bawah.
Isianmu tersimpan otomatis..." paragraph from the top of `daftar.html`.
Page title card kept.

## Why

Requested directly -- not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)