### PR TITLE
fix: validate WhatsApp number against Indonesian mobile format

### DIFF
--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -383,8 +383,13 @@ function periksa(gulir = true) {
     if (kurang) galat.push({ ke: `regu-${i}`, teks: `Regu ${i + 1} belum lengkap` });
   });
 
-  const waSah = jawab.kontak_wa.replace(/\D/g, "").length >= 9;
-  if (!waSah) galat.push({ ke: "bagian-kontak", teks: "Nomor WA belum benar" });
+  // Format nomor Indonesia: diawali 0 atau 62, lalu 8, lalu kode operator
+  // (1-9, bukan 0), lalu 6-10 digit lagi — mencakup 08xx maupun +62 8xx.
+  // Sekadar "panjang >= 9" lolos untuk angka acak yang bukan nomor sama
+  // sekali (temuan review).
+  const digitWa = jawab.kontak_wa.replace(/\D/g, "");
+  const waSah = /^(62|0)8[1-9][0-9]{6,10}$/.test(digitWa);
+  if (!waSah) galat.push({ ke: "bagian-kontak", teks: "Nomor WA belum sesuai format Indonesia" });
   tandai("g-wa", !waSah);
 
   // Ringkasan galat: satu tempat, bisa diketuk untuk lompat ke isiannya.


### PR DESCRIPTION
## What

WA number validation on the registration form now checks the actual
Indonesian mobile shape (`0` or `62` prefix, then `8`, then a non-zero
operator digit, then 6-10 more digits) instead of just "9+ digits."

## Why

The old check passed any random digit string of sufficient length --
not necessarily a phone number, let alone one WhatsApp could reach.
Landline-shaped numbers are now correctly rejected too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)