### PR TITLE
fix: remove placeholder example from Username field

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -64,7 +64,7 @@ function layarLogin(pesan) {
       <div class="medan" style="margin-top:1rem">
         <label for="u">Username</label>
         <input type="text" id="u" autocomplete="username" autocapitalize="none"
-               spellcheck="false" placeholder="contoh: meja1hrcd37">
+               spellcheck="false">
       </div>
       <div class="medan">
         <label for="p">Password</label>


### PR DESCRIPTION
## What

Removed the "contoh: meja1hrcd37" placeholder from the login screen's
Username field.

## Why

Requested directly -- not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)