### PR TITLE
feat: show accepted WA number formats, update stale error hint

### DIFF
--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -113,8 +113,8 @@ function halaman() {
       <p class="keterangan">Satu nomor untuk semua regu — panitia menghubungi lewat sini.</p>
       <div class="medan" style="margin-top:.7rem">
         <label for="wa" class="visually-hidden">Nomor WA</label>
-        <input type="tel" id="wa" inputmode="numeric" placeholder="contoh: 081234567890">
-        <div class="galat" id="g-wa" hidden>Isi nomor WA yang benar (minimal 9 angka).</div>
+        <input type="tel" id="wa" inputmode="numeric" placeholder="contoh: 0822xxxxxxx atau +62822xxxxxxx">
+        <div class="galat" id="g-wa" hidden>Isi nomor WA yang benar — diawali 08 atau +62 8.</div>
       </div>
     </section>
 


### PR DESCRIPTION
## What

- Placeholder on the Nomor WhatsApp field now shows both accepted
  prefix styles: `0822xxxxxxx atau +62822xxxxxxx`.
- The error hint under the field updated to describe the actual
  format requirement instead of the old length-only wording.

## Why

Confirmed both `08xx` and `+628xx` formats already pass the
validation added in #42 -- this makes that visible to whoever's
filling the form, and fixes a stale hint ("minimal 9 angka") left over
from before that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)