### PR TITLE
feat: nomor dada diketik petugas, bukan diterbitkan sistem

### DIFF
--- a/.github/workflows/tes-sql.yml
+++ b/.github/workflows/tes-sql.yml
@@ -1,0 +1,58 @@
+# ============================================================================
+# hrcd-rekap : tes-sql.yml — jalankan seluruh tes SQL di PostgreSQL sungguhan.
+#
+# Kenapa ada: sampai sekarang tes hanya bisa dijalankan kalau maintainer
+# kebetulan punya PostgreSQL lokal. Akibatnya migrasi bisa ter-merge tanpa
+# pernah sekali pun dieksekusi Postgres — persis risiko terbesar di repo ini,
+# karena yang paling gampang salah justru SQL-nya (fungsi, RLS, constraint),
+# bukan tampilannya.
+#
+# Runner GitHub sudah punya psql, dan Postgres-nya dijalankan sebagai service
+# container. Jadi setiap push dan setiap PR memverifikasi: seluruh migrasi
+# 0001..00NN jalan berurutan dari database kosong, seed masuk, dan semua
+# assert di tests/sql/ lolos.
+#
+# Port 55432 (bukan 5432) sengaja disamakan dengan tests/run.sh dan
+# tests/dev_db.sh supaya perintahnya persis sama di CI maupun di laptop.
+# ============================================================================
+
+name: Tes SQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tes:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: hrcd
+        ports:
+          - 55432:5432
+        # Job tidak boleh mulai sebelum Postgres benar-benar menerima koneksi.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tunjukkan versi psql & server
+        env:
+          PGPASSWORD: hrcd
+        run: |
+          psql --version
+          psql -h 127.0.0.1 -p 55432 -U postgres -d postgres -c "select version();"
+
+      - name: Jalankan seluruh tes
+        env:
+          PGPASSWORD: hrcd
+        run: bash tests/run.sh

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -118,10 +118,20 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    stok fisik yang sudah disiapkan sebelumnya. Karena nomor dada diambil dari
    stok saat itu juga dan meja daftar ulang lebih dari satu, satu nomor dada
    tidak boleh terpakai dua kali.
-5. **Pengambilan nomor dada dilakukan sekaligus per sekolah**, bukan satu regu
-   satu kali. Sekolah dengan 10 regu mengambil 10 nomor dada dalam satu
+5. **Nomor dadanya DIKETIK petugas, bukan diterbitkan sistem.** Yang ada di
+   tangan petugas adalah setumpuk kain apa adanya — ada yang hilang, sobek,
+   atau tertinggal di kardus lain — jadi sistem tidak boleh menebak nomor
+   mana yang tersedia secara fisik. Urutannya: petugas menyebut regu ini
+   nomornya ini, lalu sistem memastikan nomor itu ada di stok, belum
+   dipensiunkan, dan belum dipakai regu lain. Nomor yang sudah dipakai
+   ditolak dengan pesan, bukan diterima diam-diam.
+6. **Pengisian nomor dada dilakukan sekaligus per sekolah**, bukan satu regu
+   satu kali. Sekolah dengan 10 regu mengisi 10 nomor dada dalam satu
    transaksi di meja. Ini menjadi dasar pembagian kloter — lihat bagian 5.
-6. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
+7. **Kloternya tetap ditentukan sistem** (bagian 5.3). Yang manual hanya
+   nomor dadanya; penyebaran kloter justru tidak boleh diserahkan ke petugas
+   karena bertumpu pada keadaan seluruh sekolah, bukan satu meja saja.
+8. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
    petugas lapangan (bagian 8.4).
 
 ## 5. Kloter dan kontrak waktu
@@ -137,7 +147,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    regu satu sekolah yang berangkat bersamaan cenderung bercengkerama di
    sepanjang rute alih-alih berlomba.
 5. **Cara pembagiannya bertumpu pada pengambilan nomor dada per sekolah**
-   (bagian 4.5). Sekolah yang mengambil 10 nomor dada langsung disebar ke 10
+   (bagian 4.6). Sekolah yang mengambil 10 nomor dada langsung disebar ke 10
    kloter berbeda; sekolah yang mengambil 5 nomor dada disebar ke 5 kloter
    berbeda. Dengan begitu satu sekolah tidak pernah menumpuk di satu kloter
    selama jumlah regunya tidak melebihi jumlah kloter.

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -98,7 +98,7 @@ Postgres — layar tidak pernah menulis "setengah jadi":
 | `submit_pendaftaran` | Buat sekolah (bila baru) + batch + N baris regu + kode pembayaran unik, sekali jalan; validasi ulang rincian golongan = total di server |
 | `verifikasi_pembayaran` | Cek nominal = jumlah regu × `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
 | `batalkan_verifikasi` | Jalan mundur yang sah untuk salah verifikasi (meja di hari yang sama, admin kapan pun) — dengan alasan, terekam riwayat |
-| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → **satu gerbang `pg_advisory_xact_lock`** → ambil N nomor terkecil yang tersedia → sebar ke N kloter berbeda dengan `lompatan_kloter`, hindari kloter yang sudah berisi sekolah itu, buka kloter 31–40 hanya bila 1–30 penuh → tulis semuanya sekaligus. Regu `batal` dilewati. Lihat 4.1 |
+| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → terima pasangan regu→nomor dada **yang diketik petugas** (`p_nomor` jsonb; wajib lengkap satu batch, nomor divalidasi ada di stok / belum pensiun / belum dipakai, baris stoknya dikunci) → **satu gerbang `pg_advisory_xact_lock`** → sebar ke N kloter berbeda dengan `lompatan_kloter`, hindari kloter yang sudah berisi sekolah itu, buka kloter 31–40 hanya bila 1–30 penuh → tulis semuanya sekaligus. Regu `batal` dilewati. Lihat 4.1 dan alur-lomba.md 4.5 |
 | `tukar_nomor_dada` | Nomor dada rusak/salah pasang: tukar dengan stok tersedia, terekam riwayat |
 | `konfirmasi_kontrak` | Validasi pilihan terhadap `kontrak_opsi` (bukan hardcode); boleh dikoreksi selama kloter belum berangkat |
 | `berangkatkan_kloter` | Jam berangkat **wajib dari argumen** (diketik) — fungsi tidak mengenal `now()`; menolak bila ada regu ter-ceklis berangkat yang belum punya kontrak (daftarnya ditampilkan layar) |
@@ -315,7 +315,7 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
 ### 10.1 Prinsip lintas layar (kontrak UX dengan panitia)
 
 1. **Satu layar, satu aksi utama** — satu tombol besar per layar
-   ("Ambil 10 Nomor Dada", "Berangkatkan Kloter 12", "Simpan 27 Baris").
+   ("Simpan 10 Nomor Dada", "Berangkatkan Kloter 12", "Simpan 27 Baris").
 2. **Nomor dada adalah jangkar universal** setelah daftar ulang (kode
    pembayaran sebelumnya); setiap layar dibuka dengan field kunci itu
    ter-autofocus.
@@ -372,7 +372,7 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
 | Beranda meja | meja | Pemilih fungsi + lencana angka dari data nyata (batch menunggu verifikasi, batch lunas belum bernomor, regu belum closing) |
 | Form pendaftaran | publik | Bagian 3 alur, **satu halaman** (bukan wizard — lihat 10.4): 5 bagian bernomor, autocomplete sekolah dari master (dimuat sekali, difilter di browser), blok per regu muncul mengikuti stepper, tombol Kirim menempel di bawah dengan total hidup; hasil akhir menampilkan kode pembayaran besar-besar |
 | Meja pembayaran | meja | Ketik kode → kartu batch → "Tandai Lunas" → panel sukses langsung menawarkan "Cetak Kwitansi" (satu alur, bukan dua); "Batalkan (salah)" memanggil `batalkan_verifikasi` |
-| Meja daftar ulang | meja | Ketik kode → kartu sekolah + daftar regu → satu tombol "Ambil N Nomor Dada" → hasil besar-besar per regu (nomor dada + kloter) untuk dibacakan; jalur "Tukar nomor" untuk stok rusak |
+| Meja daftar ulang | meja | Cari kode/sekolah → buka "Isi N Nomor Dada" → **ketik nomor dari kain fisik per regu** (nama regu + kategori + ketua terlihat, Enter = regu berikutnya) → satu tombol "Simpan N Nomor Dada" → kloter terisi otomatis dan dibacakan; jalur "Tukar nomor" untuk stok rusak |
 | Garis start | meja | Papan 4 kolom **turunan otomatis** dari kloter terakhir yang berangkat: N berangkat / N+1–N+2 siap / N+3 konfirmasi kontrak. Operator hanya punya dua aksi: ceklis regu + tombol besar "BERANGKATKAN" (jam diketik). Papan bergeser sendiri — operator tidak pernah memutuskan apa yang maju |
 | Input pos — manual | operator_pos | Loop ketik-Enter 5 detik; hanya komponen pos sendiri yang tampil |
 | Input pos — upload massal | operator_pos | Pipeline bagian 6 |

--- a/supabase/migrations/0011_nomor_dada_manual.sql
+++ b/supabase/migrations/0011_nomor_dada_manual.sql
@@ -1,0 +1,241 @@
+-- ============================================================================
+-- hrcd-rekap : 0011_nomor_dada_manual.sql
+--
+-- Nomor dada DIKETIK petugas, tidak lagi diambil otomatis dari stok.
+--
+-- Alasannya lapangan, bukan teknis: nomor dada adalah benda fisik di atas
+-- meja. Petugas mengambil setumpuk kain bernomor apa adanya — ada yang
+-- hilang, ada yang sobek, ada yang tertinggal di kardus lain — lalu
+-- menyandingkannya satu per satu dengan regu yang berdiri di depannya.
+-- Versi sebelumnya menerbitkan "N nomor terkecil yang tersedia" dari stok,
+-- sehingga layar mengarang nomor yang belum tentu ada di tangan petugas.
+-- Sekarang urutannya dibalik: petugas menyebut regu ini nomornya ini,
+-- database yang memastikan nomor itu sah dan belum terpakai.
+--
+-- Yang TIDAK berubah:
+--   * Pengisian tetap sekaligus satu batch (alur-lomba.md 4.6) — pembagian
+--     kloter bertumpu pada itu (alur-lomba.md 5.5), jadi seluruh regu satu
+--     sekolah harus masuk dalam satu transaksi.
+--   * Penempatan kloter tetap otomatis (alur-lomba.md 5.3) dan algoritmanya
+--     disalin apa adanya dari 0004.
+--   * Nomor ganda tetap mustahil — sekarang dijaga dua lapis: kunci baris
+--     stok di dalam RPC ini, dan UNIQUE di regu.nomor_dada sebagai jaring
+--     terakhir.
+-- ============================================================================
+
+-- Versi lama berargumen satu (p_kode) dan memilih nomor sendiri. Dibuang,
+-- bukan dibiarkan berdampingan: dua fungsi bernama sama dengan aturan berbeda
+-- adalah jebakan bagi maintainer berikutnya.
+drop function if exists daftar_ulang_batch(text);
+
+create or replace function daftar_ulang_batch(
+  p_kode  text,
+  -- [{"regu_id": "...", "nomor_dada": 12}, ...] — satu entri per regu yang
+  -- belum bernomor di batch ini, tidak boleh kurang dan tidak boleh lebih.
+  p_nomor jsonb
+)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_berhak     uuid[];
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];      -- kloter yang sudah berisi sekolah ini
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+  v_salah      text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where aktif;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Regu yang berhak: belum bernomor, tidak batal (rancangan-b.md, temuan 11).
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.batal and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Pasangan regu -> nomor dari meja. Urutan deterministik (nama regu) supaya
+  -- hasil yang dibacakan meja urut sama dengan kartu di layar.
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+         as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) as t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) as t(g) where not (t.g = any (v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+
+  if exists (select 1 from unnest(v_nomor) as t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct t.nomor) from unnest(v_nomor) as t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  -- Kunci baris stok yang diminta, urut nomor supaya dua meja yang meminta
+  -- himpunan bertumpang tindih tidak saling mengunci silang. Meja kedua
+  -- menunggu sebentar lalu ditolak pemeriksaan "sudah dipakai" di bawah,
+  -- dengan pesan yang bisa dibaca petugas — bukan galat unique mentah.
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any (v_nomor)
+  order by s.nomor
+  for update;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- Serialisasi bagian penempatan kloter (2-3 meja — advisory lock sederhana
+  -- lebih terbaca daripada retry unique-violation; lepas otomatis di akhir tx).
+  perform pg_advisory_xact_lock(hashtext('hrcd_kloter_assign'));
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  -- Sebar N regu: mulai dari kloter termuda yang layak, melompat
+  -- lompatan_kloter (alur 5.6); kloter 31.. dibuka hanya bila 1..30 tidak
+  -- menyediakan slot layak (alur 5.2). "Layak" = belum penuh + belum berisi
+  -- sekolah ini; bila tak terhindarkan, syarat sekolah dilonggarkan (alur 5.4
+  -- "sesedikit mungkin", bukan "tidak boleh").
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam 1..kloter_dasar.
+    if v_mulai is null then
+      v_langkah := 1;  -- pencarian pertama: kloter layak termuda
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and k.jam_berangkat is null
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama tapi abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: 1..kloter_dasar masih ada tempat tapi semuanya berisi
+    -- sekolah ini — sekolah sama boleh berkumpul DULU sebelum membuka
+    -- kloter cadangan (alur 5.2: 31-40 hanya bila 1-30 penuh; alur 5.4:
+    -- "sesedikit mungkin", bukan larangan mutlak). Pilih yang paling kosong.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan
+    -- (31..kloter_maks), hindari sekolah sama dulu lalu bebas.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),   -- false (bebas sekolah) dulu
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      -- Slot terkecil yang kosong, bukan count+1: lubang bekas koreksi admin
+      -- tidak boleh membuat slot palsu di atas 10 (temuan review).
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+grant execute on function daftar_ulang_batch(text, jsonb) to authenticated;

--- a/tests/dev_db.sh
+++ b/tests/dev_db.sh
@@ -29,6 +29,7 @@ run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/migrations/0008_cetak_kloter.sql
 run supabase/migrations/0009_sisip_kloter.sql
 run supabase/migrations/0010_lookup_finish.sql
+run supabase/migrations/0011_nomor_dada_manual.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -27,7 +27,7 @@ PORT = 8787
 RPC = {
     "verifikasi_pembayaran": ["p_kode", "p_nominal", "p_metode"],
     "batalkan_verifikasi":   ["p_kode", "p_alasan"],
-    "daftar_ulang_batch":    ["p_kode"],
+    "daftar_ulang_batch":    ["p_kode", "p_nomor"],
     "tukar_nomor_dada":      ["p_regu", "p_nomor_baru", "p_alasan"],
     "ubah_pendamping":       ["p_kode", "p_jumlah"],
     "konfirmasi_kontrak":    ["p_regu", "p_menit"],
@@ -223,7 +223,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     nilai.append(v)
                 # Postgres tidak meng-coerce integer->smallint saat memilih
                 # overload fungsi — cast eksplisit per jenis argumen.
-                CAST = {"p_baris": "::jsonb", "p_pos": "::smallint",
+                CAST = {"p_baris": "::jsonb", "p_nomor": "::jsonb", "p_pos": "::smallint",
                         "p_menit": "::smallint", "p_kloter": "::smallint",
                         "p_anggota_hadir": "::smallint", "p_jumlah": "::smallint",
                         "p_regu": "::uuid", "p_jam": "::timestamptz",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,6 +33,7 @@ run supabase/migrations/0007_kunci_daftar_ulang.sql
 run supabase/migrations/0008_cetak_kloter.sql
 run supabase/migrations/0009_sisip_kloter.sql
 run supabase/migrations/0010_lookup_finish.sql
+run supabase/migrations/0011_nomor_dada_manual.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql

--- a/tests/sql/01_seed_uji.sql
+++ b/tests/sql/01_seed_uji.sql
@@ -18,3 +18,32 @@ insert into akun_panitia (user_id, username, peran, pos, aktif) values
   ('00000000-0000-0000-0000-0000000000b1', 'meja1hrcd37',    'meja',         null, true),
   ('00000000-0000-0000-0000-0000000000b2', 'meja2hrcd37',    'meja',         null, true),
   ('00000000-0000-0000-0000-0000000000ff', 'lama_hrcd36',    'meja',         null, false);
+
+-- ---------------------------------------------------------------------------
+-- uji_dada — meniru petugas meja yang MENGETIK nomor dada (migrasi 0011).
+--
+-- Sejak nomor dada tidak lagi diterbitkan sistem, setiap pemanggilan
+-- daftar_ulang_batch harus membawa pasangan regu -> nomor. Di lapangan
+-- angkanya berasal dari kain fisik; di tes kita pilih nomor terkecil yang
+-- masih tersedia, supaya angka yang muncul di assertion tetap sama seperti
+-- sebelum manual — yang diuji adalah aturannya, bukan selera petugas.
+-- ---------------------------------------------------------------------------
+create function uji_dada(p_kode text) returns jsonb language sql as $$
+  with menunggu as (
+    select r.id, row_number() over (order by r.nama_regu, r.id) as urut
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    where d.kode_pembayaran = p_kode and not r.batal and r.nomor_dada is null
+  ),
+  tersedia as (
+    select s.nomor, row_number() over (order by s.nomor) as urut
+    from nomor_dada_stok s
+    where not exists (select 1 from regu x where x.nomor_dada = s.nomor)
+      and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+  )
+  select coalesce(jsonb_agg(jsonb_build_object(
+           'regu_id', m.id, 'nomor_dada', t.nomor) order by t.nomor), '[]'::jsonb)
+  from menunggu m
+  join tersedia t on t.urut = m.urut;
+$$;
+grant execute on function uji_dada(text) to authenticated, service_role;

--- a/tests/sql/03_alur.sql
+++ b/tests/sql/03_alur.sql
@@ -100,7 +100,7 @@ do $$
 begin
   -- daftar ulang sebelum lunas: tolak
   begin
-    perform daftar_ulang_batch(uji('A'));
+    perform daftar_ulang_batch(uji('A'), uji_dada(uji('A')));
     raise exception 'GAGAL: daftar ulang sebelum lunas diterima';
   exception when raise_exception then
     if sqlerrm like 'GAGAL:%' then raise; end if;
@@ -153,9 +153,9 @@ $$;
 do $$
 declare v_a uuid;
 begin
-  perform daftar_ulang_batch(uji('A'));
-  perform daftar_ulang_batch(uji('B'));
-  perform daftar_ulang_batch(uji('C'));
+  perform daftar_ulang_batch(uji('A'), uji_dada(uji('A')));
+  perform daftar_ulang_batch(uji('B'), uji_dada(uji('B')));
+  perform daftar_ulang_batch(uji('C'), uji_dada(uji('C')));
 
   select d.id into v_a from pendaftaran d where d.kode_pembayaran = uji('A');
 
@@ -175,7 +175,7 @@ begin
           where d.kode_pembayaran = uji('B')), 'sekolah B menumpuk';
   -- Daftar ulang dobel: tolak.
   begin
-    perform daftar_ulang_batch(uji('A'));
+    perform daftar_ulang_batch(uji('A'), uji_dada(uji('A')));
     raise exception 'GAGAL: daftar ulang dobel diterima';
   exception when raise_exception then
     if sqlerrm like 'GAGAL:%' then raise; end if;
@@ -200,7 +200,7 @@ begin
 
   -- Sekolah D menyusul: nomor berikutnya harus MELOMPATI 17 yang pensiun.
   perform verifikasi_pembayaran(uji('D'), 250000, 'tunai');
-  perform daftar_ulang_batch(uji('D'));
+  perform daftar_ulang_batch(uji('D'), uji_dada(uji('D')));
   assert (select r.nomor_dada from regu r
           join pendaftaran d on d.id = r.pendaftaran_id
           where d.kode_pembayaran = uji('D')) = 20,
@@ -215,7 +215,7 @@ set role authenticated;
 do $$
 begin
   begin
-    perform daftar_ulang_batch(uji('D'));
+    perform daftar_ulang_batch(uji('D'), uji_dada(uji('D')));
     raise exception 'GAGAL: daftar ulang tembus saat ditutup';
   exception when raise_exception then
     if sqlerrm like 'GAGAL:%' then raise; end if;

--- a/tests/sql/04_cetak_kloter.sql
+++ b/tests/sql/04_cetak_kloter.sql
@@ -121,7 +121,7 @@ begin
   set role authenticated;
   perform verifikasi_pembayaran(v_kode, v_biaya, 'tunai');
 
-  select * into v_hasil from daftar_ulang_batch(v_kode) limit 1;
+  select * into v_hasil from daftar_ulang_batch(v_kode, uji_dada(v_kode)) limit 1;
   assert v_hasil.nomor_dada is not null, 'pendaftar susulan tidak dapat nomor';
   assert (select dicetak_pada from kloter where nomor = v_hasil.kloter) is null,
     format('pendaftar susulan masuk kloter %s yang SUDAH dicetak', v_hasil.kloter);

--- a/tests/uji_konkurensi.py
+++ b/tests/uji_konkurensi.py
@@ -75,8 +75,46 @@ def siapkan():
     return kode
 
 
+def stok_tersedia(jumlah):
+    """Nomor dada yang masih boleh dipakai, urut kecil ke besar."""
+    baris = jalankan("""
+        select s.nomor from nomor_dada_stok s
+        where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+          and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+        order by s.nomor limit %s
+    """, (jumlah,), role="service_role")
+    return [r["nomor"] for r in baris]
+
+
+def pasangan(kode, nomor):
+    """Yang diketik petugas: regu ini nomornya ini (migrasi 0011)."""
+    regu = jalankan("""
+        select r.id::text as id from regu r
+        join pendaftaran d on d.id = r.pendaftaran_id
+        where d.kode_pembayaran = %s and not r.batal and r.nomor_dada is null
+        order by r.nama_regu, r.id
+    """, (kode,), role="service_role")
+    return json.dumps([{"regu_id": r["id"], "nomor_dada": n}
+                       for r, n in zip(regu, nomor)])
+
+
 def serbu(kode):
-    """Semua meja menekan tombol bersamaan lewat satu barrier."""
+    """Semua meja menekan tombol bersamaan lewat satu barrier.
+
+    Sejak nomor dada diketik manual, tiap meja memegang TUMPUKAN KAIN
+    SENDIRI — itu memang cara panitia membaginya sebelum antrean dibuka,
+    jadi dua meja tidak pernah menawarkan nomor yang sama. Yang diadu di
+    sini tetap sama seperti dulu: penempatan kloter dan penulisan serentak.
+    """
+    butuh = len(kode) * REGU_PER_SEKOLAH
+    stok = stok_tersedia(butuh)
+    if len(stok) < butuh:
+        raise SystemExit(f"stok nomor dada kurang: butuh {butuh}, ada {len(stok)}")
+    # Disiapkan SEBELUM barrier supaya yang diadu murni transaksinya, bukan
+    # waktu menyusun JSON di Python.
+    bawaan = {k: pasangan(k, stok[i * REGU_PER_SEKOLAH:(i + 1) * REGU_PER_SEKOLAH])
+              for i, k in enumerate(kode)}
+
     hasil, galat = [], []
     kunci = threading.Lock()
     barrier = threading.Barrier(len(kode))
@@ -86,8 +124,8 @@ def serbu(kode):
         barrier.wait()                      # <- serentak di sini
         try:
             baris = jalankan(
-                "select nomor_dada, kloter from daftar_ulang_batch(%s)",
-                (k,), uid=uid)
+                "select nomor_dada, kloter from daftar_ulang_batch(%s, %s::jsonb)",
+                (k, bawaan[k]), uid=uid)
             with kunci:
                 hasil.extend(baris)
         except Exception as e:               # noqa: BLE001 — semua galat dicatat
@@ -159,6 +197,59 @@ def periksa(hasil, galat):
     return lolos
 
 
+def uji_nomor_kembar():
+    """Risiko BARU yang dibawa nomor manual: dua meja mengetik nomor yang
+    sama untuk dua regu berbeda, pada detik yang sama. Tepat satu boleh
+    menang; yang kalah harus DITOLAK dengan pesan, bukan menimpa regu lain
+    atau lolos jadi nomor ganda."""
+    biaya = jalankan("select biaya_per_regu from edisi where aktif",
+                     role="service_role", fetch="one")["biaya_per_regu"]
+    kode = []
+    for i in range(2):
+        h = jalankan(
+            "select submit_pendaftaran(%s,%s,%s,%s,%s::jsonb,%s::smallint,%s::uuid) as h",
+            (f"UJI KONKUREN KEMBAR {i}", f"Jl. Kembar {i}", False, "081200000000",
+             json.dumps([{"nama_regu": f"Kembar {i}", "nama_ketua": "Ketua",
+                          "golongan": "penegak_pa"}]), 0, str(uuid.uuid4())),
+            role="service_role", fetch="one")["h"]
+        k = h["kode_pembayaran"]
+        jalankan("select verifikasi_pembayaran(%s,%s,%s)", (k, biaya, "tunai"),
+                 uid=MEJA[0], fetch="one")
+        kode.append(k)
+
+    rebutan = stok_tersedia(1)[0]        # satu nomor, dua meja
+    bawaan = {k: pasangan(k, [rebutan]) for k in kode}
+
+    sukses, ditolak = [], []
+    kunci = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def satu_meja(i, k):
+        barrier.wait()
+        try:
+            jalankan("select nomor_dada from daftar_ulang_batch(%s, %s::jsonb)",
+                     (k, bawaan[k]), uid=MEJA[i])
+            with kunci:
+                sukses.append(k)
+        except Exception as e:           # noqa: BLE001 — yang kalah memang error
+            with kunci:
+                ditolak.append(f"{type(e).__name__}: {e}")
+
+    utas = [threading.Thread(target=satu_meja, args=(i, k))
+            for i, k in enumerate(kode)]
+    for t in utas:
+        t.start()
+    for t in utas:
+        t.join()
+
+    ok = len(sukses) == 1 and len(ditolak) == 1
+    print(f"  {'OK  ' if ok else 'GAGAL'}  nomor {rebutan} diketik dua meja "
+          f"serentak: {len(sukses)} menang, {len(ditolak)} ditolak")
+    if not ok and ditolak:
+        print(f"         {ditolak[0][:140]}")
+    return ok
+
+
 if __name__ == "__main__":
     print(f"UJI KONKURENSI — {JUMLAH_SEKOLAH} meja menekan tombol serentak, "
           f"{JUMLAH_SEKOLAH * REGU_PER_SEKOLAH} nomor dada diperebutkan\n")
@@ -168,5 +259,7 @@ if __name__ == "__main__":
           f"{detik:.2f} detik untuk SEMUA meja selesai — "
           f"rata-rata {detik / len(kode) * 1000:.0f} ms per meja)\n")
     lolos = periksa(hasil, galat)
+    print("\nNOMOR KEMBAR — dua meja mengetik nomor yang sama:")
+    lolos = uji_nomor_kembar() and lolos
     print("\n" + ("SEMUA PEMERIKSAAN LULUS" if lolos else "ADA PEMERIKSAAN GAGAL"))
     sys.exit(0 if lolos else 1)

--- a/web/gaya.css
+++ b/web/gaya.css
@@ -568,6 +568,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   font-family: inherit;
 }
 .isian-kecil { width: 4.5rem; text-align: center; }
+/* Isian yang ditolak sebelum dikirim — memerah di tempatnya supaya petugas
+   tahu BARIS MANA yang salah, bukan cuma bahwa "ada yang salah". */
+.galat-isian { border-color: var(--bahaya); background: var(--bahaya-muda); }
 /* Kedip hijau sekejap = "tersimpan", supaya edit langsung di tabel tidak
    terasa seperti tidak terjadi apa-apa. */
 .pilih-kecil.tersimpan, .isian-kecil.tersimpan {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -259,8 +259,11 @@ export const verifikasiPembayaran = (kode, nominal, metode) =>
 export const batalkanVerifikasi = (kode, alasan) =>
   rpc("batalkan_verifikasi", { p_kode: kode, p_alasan: alasan });
 
-export const daftarUlang = (kode) =>
-  rpc("daftar_ulang_batch", { p_kode: kode });
+/** pasangan: [{ regu_id, nomor_dada }] — satu entri untuk SETIAP regu batch
+ *  yang belum bernomor. Nomornya diketik petugas dari kain fisik di meja,
+ *  bukan diterbitkan sistem (migrasi 0011). */
+export const daftarUlang = (kode, pasangan) =>
+  rpc("daftar_ulang_batch", { p_kode: kode, p_nomor: pasangan });
 
 export const tukarNomor = (reguId, nomorBaru, alasan) =>
   rpc("tukar_nomor_dada", { p_regu: reguId, p_nomor_baru: nomorBaru, p_alasan: alasan });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -659,6 +659,15 @@ async function layarDaftarUlang() {
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarDaftarUlang)); return; }
   if (location.hash !== layarIni) return;   // lihat catatan di layarPembayaran
 
+  // Batch yang daftar isian nomor dadanya sedang dibuka, dan nomor yang sudah
+  // sempat diketik (regu_id -> nomor). Keduanya hidup di luar gambar(): meja
+  // sering mengetik separuh lalu mengoreksi jumlah pendamping atau mencari
+  // sekolah lain, dan tabel digambar ulang setiap kali. Tanpa ini, angka yang
+  // sudah dibacakan dari kain fisik hilang diam-diam — persis kejadian yang
+  // paling mahal di meja daftar ulang.
+  const dibukaNomor = new Set();
+  const nilaiDada = new Map();
+
   LAYAR.replaceChildren(h(`
     <div class="kartu">
       ${alatTabel({
@@ -711,21 +720,27 @@ async function layarDaftarUlang() {
         .map(r => html`<span class="pil-nomor">${String(r.nomor_dada).padStart(3, "0")}
           <span class="pil-kloter">K${r.kloter_nomor}</span></span>`).join(" ");
 
+      const kode = esc(b.kode_pembayaran);
       const tombolTukar = nomorHtml
         ? `<button class="tombol tombol-kalem tombol-mini" type="button"
-                   data-tukar="${esc(b.kode_pembayaran)}">Tukar nomor rusak…</button>`
+                   data-tukar="${kode}">Tukar nomor rusak…</button>`
         : "";
+      // Nomor dada DIKETIK petugas, tidak diterbitkan sistem (migrasi 0011):
+      // kainnya benda fisik di meja, dan yang ada di tangan petugas belum
+      // tentu nomor terkecil yang tersedia. Jadi tombolnya membuka daftar
+      // regu untuk diisi satu per satu, bukan langsung menarik stok.
+      const terbuka = dibukaNomor.has(b.kode_pembayaran);
       const aksi = menunggu.length
         ? `<button class="tombol tombol-utama tombol-kecil" type="button"
-                   data-ambil="${esc(b.kode_pembayaran)}">
-             Ambil ${menunggu.length} Nomor
+                   data-isi="${kode}" aria-expanded="${terbuka}">
+             ${terbuka ? "▾" : "▸"} Isi ${menunggu.length} Nomor Dada
            </button>${nomorHtml ? `<div class="sub">${nomorHtml} ${tombolTukar}</div>` : ""}`
         : `<div class="pil-baris">${nomorHtml} ${tombolTukar}</div>`;
 
       // Template biasa (lihat catatan sama di layar Pembayaran).
       return `
-        <tr data-baris="${esc(b.kode_pembayaran)}">
-          <td class="mono">${esc(b.kode_pembayaran)}</td>
+        <tr data-baris="${kode}">
+          <td class="mono">${kode}</td>
           <td>
             <strong>${esc(b.sekolah?.nama || "—")}</strong>
             <div class="sub">${esc(aktif.map(r => r.nama_regu).join(", "))}</div>
@@ -733,10 +748,37 @@ async function layarDaftarUlang() {
           <td class="rata-tengah">${aktif.length}</td>
           <td class="rata-tengah">
             <input type="number" class="isian-kecil" min="0" max="30" inputmode="numeric"
-                   value="${esc(b.jumlah_pendamping)}" data-pendamping="${esc(b.kode_pembayaran)}">
+                   value="${esc(b.jumlah_pendamping)}" data-pendamping="${kode}">
           </td>
           <td>${aksi}</td>
-        </tr>`;
+        </tr>
+        ${!menunggu.length ? "" : `
+        <tr class="baris-detail" data-nomor-untuk="${kode}" ${terbuka ? "" : "hidden"}>
+          <td colspan="5">
+            <table class="tabel-detail">
+              <thead>
+                <tr><th>Regu</th><th>Kategori</th><th>Ketua</th><th>Nomor dada</th></tr>
+              </thead>
+              <tbody>
+                ${menunggu.map(r => `
+                  <tr>
+                    <td><strong>${esc(r.nama_regu)}</strong></td>
+                    <td>${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}</td>
+                    <td>${esc(r.nama_ketua)}</td>
+                    <td><input type="number" class="isian-kecil" inputmode="numeric" min="1"
+                               data-dada="${esc(r.id)}" data-untuk="${kode}"
+                               value="${esc(nilaiDada.get(r.id) ?? "")}"></td>
+                  </tr>`).join("")}
+              </tbody>
+            </table>
+            <div class="aksi-baris" style="margin-top:.6rem">
+              <button class="tombol tombol-utama tombol-kecil" type="button"
+                      data-simpan-dada="${kode}">Simpan ${menunggu.length} Nomor Dada</button>
+              <span class="sub">Ketik nomor dari kain yang ada di meja.
+                Enter = pindah ke regu berikutnya.</span>
+            </div>
+          </td>
+        </tr>`}`;
     }).join("")));
 
     // Jumlah pendamping boleh dikoreksi langsung di tabel — angkanya hanya
@@ -797,29 +839,94 @@ async function layarDaftarUlang() {
         } catch (err) { notif(err.message, true); }
       }));
 
-    tbody.querySelectorAll("[data-ambil]").forEach(btn =>
+    // Buka daftar regu untuk diisi nomornya, lalu taruh kursor di regu pertama.
+    tbody.querySelectorAll("[data-isi]").forEach(btn =>
+      btn.addEventListener("click", () => {
+        const kode = btn.dataset.isi;
+        const barisNomor = tbody.querySelector(`[data-nomor-untuk="${CSS.escape(kode)}"]`);
+        const buka = barisNomor.hidden;
+        if (buka) dibukaNomor.add(kode); else dibukaNomor.delete(kode);
+        barisNomor.hidden = !buka;
+        btn.setAttribute("aria-expanded", String(buka));
+        const jumlah = barisNomor.querySelectorAll("[data-dada]").length;
+        btn.textContent = `${buka ? "▾" : "▸"} Isi ${jumlah} Nomor Dada`;
+        if (buka) barisNomor.querySelector("[data-dada]")?.focus();
+      }));
+
+    // Loop ketik-Enter (rancangan-b.md 10.1.4): Enter pindah ke regu
+    // berikutnya, dan di regu terakhir langsung menyimpan — satu sekolah
+    // selesai tanpa memegang mouse.
+    tbody.querySelectorAll("[data-dada]").forEach(inp => {
+      inp.addEventListener("input", () => nilaiDada.set(inp.dataset.dada, inp.value));
+      inp.addEventListener("keydown", e => {
+        if (e.key !== "Enter") return;
+        e.preventDefault();
+        const untuk = CSS.escape(inp.dataset.untuk);
+        const sekelompok = [...tbody.querySelectorAll(`[data-dada][data-untuk="${untuk}"]`)];
+        const berikut = sekelompok[sekelompok.indexOf(inp) + 1];
+        if (berikut) berikut.focus();
+        else tbody.querySelector(`[data-simpan-dada="${untuk}"]`)?.click();
+      });
+    });
+
+    tbody.querySelectorAll("[data-simpan-dada]").forEach(btn =>
       btn.addEventListener("click", async () => {
         if (btn.dataset.jalan === "1") return;
-        const kode = btn.dataset.ambil;
+        const kode = btn.dataset.simpanDada;
         const b = semua.find(x => x.kode_pembayaran === kode);
-        btn.dataset.jalan = "1"; btn.disabled = true; btn.textContent = "Mengambil…";
+        const isian = [...tbody.querySelectorAll(
+          `[data-dada][data-untuk="${CSS.escape(kode)}"]`)];
+
+        // Gagal itu nyaring dan LOKAL (rancangan-b.md 10.1.11): isian yang
+        // salah memerah di tempatnya, bukan cuma pesan umum di bawah layar.
+        isian.forEach(i => i.classList.remove("galat-isian"));
+        const pasangan = [];
+        const dipakai = new Set();
+        let keluhan = null;
+        for (const inp of isian) {
+          const angka = Number(inp.value.trim());
+          if (!inp.value.trim() || !Number.isInteger(angka) || angka <= 0) {
+            inp.classList.add("galat-isian");
+            keluhan = keluhan || "Setiap regu harus diberi nomor dada berupa angka.";
+            continue;
+          }
+          if (dipakai.has(angka)) {
+            inp.classList.add("galat-isian");
+            keluhan = keluhan || `Nomor ${angka} diketik untuk dua regu.`;
+            continue;
+          }
+          dipakai.add(angka);
+          pasangan.push({ regu_id: inp.dataset.dada, nomor_dada: angka });
+        }
+        if (keluhan) {
+          notif(keluhan, true);
+          isian.find(i => i.classList.contains("galat-isian"))?.focus();
+          return;
+        }
+
+        btn.dataset.jalan = "1"; btn.disabled = true; btn.textContent = "Menyimpan…";
         let hasil;
         try {
-          hasil = await daftarUlang(kode);
+          hasil = await daftarUlang(kode, pasangan);
         } catch (err) {
           notif(err.message, true);
           btn.dataset.jalan = ""; btn.disabled = false;
-          gambar(cari, saring);
+          btn.textContent = `Simpan ${isian.length} Nomor Dada`;
           return;
         }
-        // Tempelkan nomor yang baru terbit ke data lokal.
+        // Tempelkan nomor + kloter ke data lokal. Kloternya yang baru: itu
+        // satu-satunya bagian yang masih ditentukan sistem, jadi itu yang
+        // disebut di notifikasi.
         hasil.forEach(x => {
           const r = (b.regu || []).find(y => y.id === x.regu_id);
           if (r) { r.nomor_dada = x.nomor_dada; r.kloter_nomor = x.kloter; }
         });
-        catatTerakhir("daftar-ulang", kode,
-          hasil.map(x => String(x.nomor_dada).padStart(3, "0")).join(", "));
-        notif(`${b.sekolah?.nama || kode}: ${hasil.length} nomor dada terbit.`);
+        dibukaNomor.delete(kode);
+        pasangan.forEach(p => nilaiDada.delete(p.regu_id));
+        catatTerakhir("daftar-ulang", kode, hasil.map(x =>
+          `${x.nama_regu} ${String(x.nomor_dada).padStart(3, "0")}`).join(", "));
+        const kloter = [...new Set(hasil.map(x => x.kloter))].sort((x, y) => x - y).join(", ");
+        notif(`${b.sekolah?.nama || kode}: ${hasil.length} regu tersimpan — kloter ${kloter}.`);
         gambar(cari, saring);
       }));
   };


### PR DESCRIPTION
## What

Nomor dada tidak lagi diterbitkan sistem. Petugas meja yang mengetiknya, satu
per satu, dari kain yang benar-benar ada di tangannya.

- **Migrasi 0011** mengganti `daftar_ulang_batch(text)` dengan
  `daftar_ulang_batch(text, jsonb)`. Argumen barunya berisi pasangan
  `regu_id → nomor_dada`. Versi lama dibuang, tidak dibiarkan berdampingan.
- **Validasi pindah ke database**: nomor harus ada di `nomor_dada_stok`, belum
  dipensiunkan, belum dipakai regu lain, tidak kembar di dalam satu
  permintaan, dan lengkap untuk seluruh regu batch. Baris stok yang diminta
  dikunci lebih dulu, jadi dua meja yang mengetik nomor sama pada detik yang
  sama ditolak dengan pesan yang bisa dibaca petugas — bukan galat `unique`
  mentah, dan bukan nomor ganda.
- **Layar daftar ulang**: tombol "Ambil N Nomor" diganti daftar isian per regu.
  Nama regu, kategori, dan ketua terlihat saat mengetik, Enter pindah ke regu
  berikutnya, isian terakhir langsung menyimpan. Isian yang ditolak memerah di
  barisnya sendiri, dan nomor yang sudah diketik tidak hilang saat tabel
  digambar ulang.
- **Uji konkurensi** menyesuaikan premis (tiap meja memegang tumpukan nomornya
  sendiri, seperti di lapangan) dan bertambah satu uji untuk risiko yang
  memang lahir dari input manual: dua meja mengetik nomor yang sama, tepat
  satu boleh menang.

## Why

Stok fisik tidak pernah serapi tabel. Kain nomor hilang, sobek, tertinggal di
kardus lain, atau sudah dibagikan duluan. Sistem yang menerbitkan "nomor
terkecil yang tersedia" memaksa petugas mencari kain nomor 7 yang mungkin
tidak ada, lalu menambalnya lewat jalur "tukar nomor" — koreksi untuk masalah
yang seharusnya tidak pernah terjadi.

Yang tidak berubah: **penempatan kloter tetap otomatis** (`alur-lomba.md` 5.3),
algoritmanya disalin apa adanya dari `0004`. Kloter memang tidak boleh
diserahkan ke petugas karena bertumpu pada keadaan seluruh sekolah, bukan satu
meja. Pengisian juga tetap sekaligus satu batch (`alur-lomba.md` 4.6), karena
penyebaran kloter bertumpu pada itu.

## Notes

**Urutan merge**: PR ini menumpuk di atas #47 (memakai pola baris-detail yang
lahir di sana). Merge #47 dulu, baru PR ini — setelah #47 masuk, diff PR ini
akan menyusut jadi perubahan nomor dada saja.

**Belum dijalankan**: mesin tempat perubahan ini dibuat tidak punya PostgreSQL,
jadi `tests/run.sh` dan `tests/uji_konkurensi.py` belum sempat dijalankan
sekali pun. Yang sudah diperiksa hanya `node --check`, `python -m py_compile`,
dan `bash -n`. **Tolong jalankan `bash tests/run.sh` sebelum merge** — migrasi
0011 dan helper `uji_dada` di `01_seed_uji.sql` belum pernah dieksekusi
PostgreSQL, dan di situlah letak risiko terbesar PR ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
