### PR TITLE
feat: layar ganti password akun sendiri untuk panitia

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,7 @@
     <span class="spacer"></span>
     <span class="siapa" id="siapa"></span>
     <button class="tombol tombol-kecil tombol-kalem" id="ganti-fungsi" type="button">Ganti fungsi</button>
+    <button class="tombol tombol-kecil tombol-kalem" id="ganti-password" type="button">Ganti Password</button>
     <button class="tombol tombol-kecil tombol-kalem" id="btn-keluar" type="button">Keluar</button>
   </header>
 

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -56,6 +56,10 @@ export function pesanRamah(m) {
     return "Daftar ulang sudah ditutup panitia. Hubungi admin.";
   if (/permission denied|insufficient/i.test(t))
     return "Akun ini tidak berhak melakukan itu. Pakai akun yang sesuai.";
+  if (/password.*(should be different|new password should be different)/i.test(t))
+    return "Password baru harus beda dari password lama.";
+  if (/password.*(at least|too short|should contain|characters)/i.test(t))
+    return "Password baru terlalu pendek atau terlalu sederhana. Coba yang lain.";
   if (/cannot read propert|undefined is not|null is not/i.test(t))
     return "Layar gagal memuat data acara. Muat ulang halaman, lalu coba lagi.";
   return t.replace(/^.*?(ERROR|error):\s*/, "");
@@ -168,6 +172,26 @@ export async function masuk(username, password) {
   }
   simpanSesi(s);
   return s;
+}
+
+/** Panitia mengganti PASSWORD AKUN SENDIRI — bukan admin mengganti punya
+ *  orang lain (itu jalurnya scripts/ganti_password.py + service_role, dari
+ *  luar aplikasi). Ini murni self-service: pakai token sesi yang sedang
+ *  login, lewat endpoint bawaan GoTrue yang memang mengizinkan pengguna
+ *  mengubah datanya sendiri — tidak perlu service_role sama sekali. */
+export async function gantiPasswordSendiri(passwordBaru) {
+  if (K.mode === "dev") {
+    // Dev server tidak menyimpan password sungguhan (README: "password
+    // bebas di dev") — tidak ada yang perlu ditimpa, cukup berhasil supaya
+    // alur layarnya bisa dicoba.
+    return { ok: true };
+  }
+  await pastikanSesiSegar();
+  return kirim(`${K.supabaseUrl}/auth/v1/user`, {
+    method: "PUT",
+    headers: kepalaSupabase(),
+    body: JSON.stringify({ password: passwordBaru }),
+  });
 }
 
 /* ============================ FORM PUBLIK ================================ */

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9,7 +9,7 @@
    ========================================================================== */
 
 import {
-  sesi, masuk, keluar, ErrorApi,
+  sesi, masuk, keluar, gantiPasswordSendiri, ErrorApi,
   infoEdisi, ringkasanMeja, daftarPendaftaran,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor, ubahPendamping,
   daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
@@ -163,6 +163,66 @@ async function layarBeranda() {
     <p class="keterangan" style="margin-top:1.2rem">Angka kuning = masih ada antrean.
        Meja boleh berganti fungsi kapan saja — cukup pilih dari sini.</p>
   `));
+}
+
+/* ============================ GANTI PASSWORD ============================= */
+
+// "ABCD" adalah kode konfirmasi TETAP, bukan rahasia dan bukan pemeriksaan
+// identitas — identitas sudah dibuktikan lewat sesi login yang sedang aktif.
+// Tujuannya cuma satu: HP sering dipegang orang lain sebentar (dipinjam,
+// disodorkan ke teman), dan ganti password bukan aksi yang boleh ketriggered
+// oleh ketukan tidak sengaja. Mengetik "ABCD" adalah jeda sadar sebelum aksi
+// itu benar-benar terjadi.
+const KODE_KONFIRMASI_PASSWORD = "ABCD";
+
+function layarGantiPassword() {
+  pasangKepala("Ganti Password");
+  LAYAR.replaceChildren(h(`
+    <div class="kartu" style="max-width:480px;margin:0 auto">
+      <h2>Ganti Password Akun Sendiri</h2>
+      <p class="keterangan">Berlaku untuk akun yang sedang login sekarang:
+         <strong>${esc(sesi().username)}</strong>.</p>
+      <div class="medan">
+        <label for="gp-baru">Password baru</label>
+        <input type="password" id="gp-baru" autocomplete="new-password">
+      </div>
+      <div class="medan">
+        <label for="gp-kode">Ketik <strong>${KODE_KONFIRMASI_PASSWORD}</strong> untuk konfirmasi</label>
+        <input type="text" id="gp-kode" autocomplete="off">
+      </div>
+      <div class="galat" id="gp-galat" hidden></div>
+      <button class="tombol tombol-utama" id="gp-simpan" type="button">Simpan Password Baru</button>
+    </div>
+  `));
+
+  const baru = document.getElementById("gp-baru");
+  const kode = document.getElementById("gp-kode");
+  const galat = document.getElementById("gp-galat");
+  const btn = document.getElementById("gp-simpan");
+
+  btn.addEventListener("click", async () => {
+    galat.hidden = true;
+    if (!baru.value || baru.value.length < 6) {
+      galat.textContent = "Password baru minimal 6 karakter.";
+      galat.hidden = false; baru.focus(); return;
+    }
+    if (kode.value.trim() !== KODE_KONFIRMASI_PASSWORD) {
+      galat.textContent = `Ketik persis "${KODE_KONFIRMASI_PASSWORD}" di kotak konfirmasi untuk lanjut.`;
+      galat.hidden = false; kode.focus(); return;
+    }
+    if (btn.dataset.jalan === "1") return;
+    btn.dataset.jalan = "1"; btn.disabled = true; btn.textContent = "Menyimpan…";
+    try {
+      await gantiPasswordSendiri(baru.value);
+      notif("Password berhasil diganti. Dipakai mulai login berikutnya.");
+      baru.value = ""; kode.value = "";
+    } catch (err) {
+      galat.textContent = err.message; galat.hidden = false;
+    } finally {
+      btn.dataset.jalan = ""; btn.disabled = false; btn.textContent = "Simpan Password Baru";
+    }
+  });
+  baru.focus();
 }
 
 /* ============================ ALAT TABEL ================================= */
@@ -1643,6 +1703,7 @@ const RUTE = {
   "#/keberangkatan": layarKeberangkatan,
   "#/pindah-kloter": layarPindahKloter,
   "#/finish": layarFinish,
+  "#/ganti-password": layarGantiPassword,
 };
 
 async function arahkan() {
@@ -1659,6 +1720,9 @@ document.getElementById("btn-keluar").addEventListener("click", () => {
 });
 document.getElementById("ganti-fungsi").addEventListener("click", () => {
   if (location.hash === "#/beranda") arahkan(); else location.hash = "#/beranda";
+});
+document.getElementById("ganti-password").addEventListener("click", () => {
+  if (location.hash === "#/ganti-password") arahkan(); else location.hash = "#/ganti-password";
 });
 window.addEventListener("hashchange", arahkan);
 arahkan();


### PR DESCRIPTION
## What

Layar baru "Ganti Password" — tombol di header, di samping "Ganti fungsi", tersedia untuk semua peran (admin/meja/operator_pos).

- Isi password baru + ketik kode konfirmasi tetap **`ABCD`** → simpan.
- Dikirim lewat endpoint self-service bawaan GoTrue (`PUT /auth/v1/user`, pakai token sesi sendiri) — tidak menyentuh `service_role`, tidak menyentuh admin API.
- Di mode dev, langsung berhasil tanpa panggilan jaringan (dev server tidak menyimpan password sungguhan).

## Why

Sebelumnya ganti password — termasuk untuk akun sendiri — hanya bisa lewat admin (dashboard Supabase / workflow #49). Wajar untuk ganti password **akun lain**, tapi berlebihan untuk akun sendiri.

## Notes

**Soal kode "`ABCD`"** — ini kode tetap (hardcoded), bukan rahasia, dan bukan pemeriksaan identitas. Identitas sudah dibuktikan lewat sesi login yang sedang aktif; tujuan kode ini murni jeda sadar sebelum aksi benar-benar berjalan, karena HP panitia sering berpindah tangan sebentar di lapangan. Ini keputusan eksplisit dari pemilik proyek, dikonfirmasi dua kali dalam percakapan yang menghasilkan PR ini.

Dua terjemahan pesan galat baru ditambahkan ke `pesanRamah()` untuk error password dari GoTrue (terlalu pendek / sama dengan yang lama), supaya tidak ada teks Inggris mentah lolos ke layar.

Sama seperti PR sebelumnya: belum sempat dicoba di browser sungguhan (mesin ini tidak punya Postgres untuk stack dev). `node --check` lolos untuk kedua file JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
