### PR TITLE
feat: header jadi ikon Home + Setelan, bukan tombol berlabel

### DIFF
--- a/web/gaya.css
+++ b/web/gaya.css
@@ -134,7 +134,18 @@ button { font: inherit; cursor: pointer; }
 }
 .tombol-kecil { min-height: 40px; font-size: .9rem; padding: .35rem .8rem; width: auto; }
 
-.tombol:focus-visible, input:focus-visible, .pilihan:focus-visible {
+/* Logo/tombol Home di pojok kiri header — ikon polos, bukan kotak tombol
+   biasa, supaya tidak bersaing dengan judul layar di sebelahnya. */
+.tombol-ikon {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 40px; min-height: 40px; font-size: 1.3rem; line-height: 1;
+  border: 0; background: transparent; border-radius: var(--radius);
+  cursor: pointer; padding: 0;
+}
+.tombol-ikon:hover { background: rgba(255,255,255,.15); }
+
+.tombol:focus-visible, input:focus-visible, .pilihan:focus-visible,
+.tombol-ikon:focus-visible {
   outline: 3px solid #1a73e8;
   outline-offset: 2px;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <span class="judul" id="judul-layar">HRCD Rekap</span>
     <span class="spacer"></span>
     <span class="siapa" id="siapa"></span>
-    <button class="tombol tombol-kecil tombol-kalem" id="ganti-password" type="button">Ganti Password</button>
+    <button class="tombol-ikon" id="ganti-password" type="button" aria-label="Ganti Password" title="Ganti Password">⚙️</button>
     <button class="tombol tombol-kecil tombol-kalem" id="btn-keluar" type="button">Keluar</button>
   </header>
 

--- a/web/index.html
+++ b/web/index.html
@@ -8,10 +8,10 @@
 </head>
 <body>
   <header class="kepala" id="kepala" hidden>
+    <button class="tombol-ikon" id="btn-home" type="button" aria-label="Home" title="Home">🏠</button>
     <span class="judul" id="judul-layar">HRCD Rekap</span>
     <span class="spacer"></span>
     <span class="siapa" id="siapa"></span>
-    <button class="tombol tombol-kecil tombol-kalem" id="ganti-fungsi" type="button">Ganti fungsi</button>
     <button class="tombol tombol-kecil tombol-kalem" id="ganti-password" type="button">Ganti Password</button>
     <button class="tombol tombol-kecil tombol-kalem" id="btn-keluar" type="button">Keluar</button>
   </header>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -92,7 +92,7 @@ function layarLogin(pesan) {
     try {
       await masuk(u.value.trim(), document.getElementById("p").value);
       EDISI = null;
-      location.hash = "#/beranda";
+      location.hash = "#/home";
       arahkan();
     } catch (e) {
       layarLogin(e instanceof ErrorApi ? e.message : "Username atau password salah.");
@@ -103,9 +103,9 @@ function layarLogin(pesan) {
     i.addEventListener("keydown", e => { if (e.key === "Enter") aksi(); }));
 }
 
-/* ============================ BERANDA MEJA =============================== */
+/* ============================ BERANDA MEJA (home) ========================= */
 
-async function layarBeranda() {
+async function layarHome() {
   pasangKepala("Beranda Meja");
   const peran = sesi().peran;
   LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
@@ -1697,7 +1697,7 @@ function layarButuhEdisi(judul) {
 /* ============================ RUTE ======================================= */
 
 const RUTE = {
-  "#/beranda": layarBeranda,
+  "#/home": layarHome,
   "#/pembayaran": layarPembayaran,
   "#/daftar-ulang": layarDaftarUlang,
   "#/pendaftaran-offline": layarPendaftaranOffline,
@@ -1714,14 +1714,14 @@ async function arahkan() {
     try { EDISI = await infoEdisi(); }
     catch (e) { layarButuhEdisi("HRCD Rekap"); return; }
   }
-  (RUTE[location.hash] || layarBeranda)();
+  (RUTE[location.hash] || layarHome)();
 }
 
 document.getElementById("btn-keluar").addEventListener("click", () => {
   keluar(); EDISI = null; location.hash = ""; arahkan();
 });
-document.getElementById("ganti-fungsi").addEventListener("click", () => {
-  if (location.hash === "#/beranda") arahkan(); else location.hash = "#/beranda";
+document.getElementById("btn-home").addEventListener("click", () => {
+  if (location.hash === "#/home") arahkan(); else location.hash = "#/home";
 });
 document.getElementById("ganti-password").addEventListener("click", () => {
   if (location.hash === "#/ganti-password") arahkan(); else location.hash = "#/ganti-password";


### PR DESCRIPTION
## What

- Tombol "Ganti fungsi" diganti ikon 🏠 di pojok kiri header (rute `#/beranda` → `#/home`, fungsi `layarBeranda` → `layarHome`, konsisten satu sama lain).
- Tombol "Ganti Password" diganti ikon ⚙️, posisi tetap di sebelah kanan.

Fungsinya tidak berubah, cuma bentuknya — dari tombol berlabel teks jadi ikon polos.

## Why

Header lebih ringkas di HP, dan "Home" sebagai konsep navigasi lebih jelas sebagai ikon logo daripada tombol teks "Ganti fungsi".

## Notes

Kelas CSS baru `.tombol-ikon` dipakai untuk keduanya — ikon polos 40×40px, tanpa border, cocok jadi target sentuh di HP (masih di atas ambang 36px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
