### PR TITLE
feat: link Pendaftaran langsung + validasi langsung di form publik

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -131,9 +131,9 @@ async function layarHome() {
   LAYAR.replaceChildren(h(`
     ${galat ? kartuGalat(`Jumlah antrean tidak bisa dibaca: ${galat}`) : ""}
     <div class="menu-fungsi">
-      <a href="#/pendaftaran-offline">
+      <a href="daftar.html" target="_blank" rel="noopener">
         <div class="nama-fungsi">📝 Pendaftaran</div>
-        <div class="ket">Buka form pendaftaran — link sama untuk online maupun diisikan langsung</div>
+        <div class="ket">Buka form pendaftaran — diisikan langsung, tab baru supaya meja ini tetap terbuka</div>
       </a>
       <a href="#/pembayaran">
         <div class="nama-fungsi">💳 Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
@@ -1669,22 +1669,6 @@ function kartuSisipan(sisipan) {
     </div>`;
 }
 
-/* ============================ PENDAFTARAN OFFLINE ======================== */
-
-function layarPendaftaranOffline() {
-  pasangKepala("Pendaftaran");
-  LAYAR.replaceChildren(h(`
-    <div class="kartu">
-      <h2>Link yang sama untuk online maupun langsung</h2>
-      <p class="keterangan" style="margin-top:.4rem">
-        Bukakan form ini di HP pendaftar, atau isikan bersama di laptop meja.
-        Setelah dapat kode pembayaran, arahkan ke meja pembayaran.</p>
-      <a class="tombol tombol-utama" href="daftar.html" target="_blank" rel="noopener"
-         style="text-decoration:none;margin-top:.8rem">Buka Form Pendaftaran</a>
-    </div>
-  `));
-}
-
 /* ---------------- layar "edisi belum termuat" ---------------- */
 
 function layarButuhEdisi(judul) {
@@ -1700,7 +1684,6 @@ const RUTE = {
   "#/home": layarHome,
   "#/pembayaran": layarPembayaran,
   "#/daftar-ulang": layarDaftarUlang,
-  "#/pendaftaran-offline": layarPendaftaranOffline,
   "#/cetak-kloter": layarCetakKloter,
   "#/keberangkatan": layarKeberangkatan,
   "#/pindah-kloter": layarPindahKloter,

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -29,6 +29,12 @@ const KUNCI_DRAF = "hrcd_draf";
 const KUNCI_HASIL = "hrcd_hasil";
 const MAKS_REGU = 30;
 
+// Format nomor Indonesia, HANYA 08xx (bukan +62 8xx — disederhanakan sengaja
+// supaya panitia tidak perlu mikir dua format): 08, lalu kode operator
+// (1-9, bukan 0), lalu 6-10 digit lagi. Dipakai untuk validasi live (saat
+// mengetik) maupun pemeriksaan akhir sebelum kirim — satu pola, satu tempat.
+const POLA_WA = /^08[1-9][0-9]{6,10}$/;
+
 const kosong = () => ({
   sekolah: null,                 // {id?, nama, alamat}
   butuh_barak: null,
@@ -134,8 +140,10 @@ function halaman() {
   gambarStepper();
   gambarRegu();
   document.getElementById("wa").value = jawab.kontak_wa;
+  cekWaLive();
   document.getElementById("wa").addEventListener("input", e => {
     jawab.kontak_wa = e.target.value; simpanDraf();
+    cekWaLive();
     if (sudahDiperiksa) periksa(false);
   });
 
@@ -339,24 +347,58 @@ function gambarRegu() {
         <div class="medan" style="margin:0">
           <label for="r-nama-${i}">Nama regu</label>
           <input type="text" id="r-nama-${i}" value="${r.nama_regu}" placeholder="contoh: Rajawali">
+          <div class="galat" id="r-nama-galat-${i}" hidden>Nama regu wajib diisi.</div>
         </div>
         <div class="medan" style="margin:0">
           <label for="r-ketua-${i}">Nama ketua</label>
           <input type="text" id="r-ketua-${i}" value="${r.nama_ketua}" placeholder="contoh: Andi Saputra">
+          <div class="galat" id="r-ketua-galat-${i}" hidden>Nama ketua wajib diisi.</div>
         </div>
       </div>
     </div>`).join("")));
 
+  // Warning SEKETIKA kalau nama regu/ketua kosong — tidak menunggu tombol
+  // Kirim ditekan dulu. Dua isian dicek bersama supaya kartu tidak salah
+  // dianggap lengkap hanya karena satu dari dua kotaknya sudah terisi.
+  const cekRegu = (i) => {
+    const inpNama = document.getElementById(`r-nama-${i}`);
+    const inpKetua = document.getElementById(`r-ketua-${i}`);
+    const namaKosong = !inpNama.value.trim();
+    const ketuaKosong = !inpKetua.value.trim();
+    inpNama.setAttribute("aria-invalid", String(namaKosong));
+    inpKetua.setAttribute("aria-invalid", String(ketuaKosong));
+    document.getElementById(`r-nama-galat-${i}`).hidden = !namaKosong;
+    document.getElementById(`r-ketua-galat-${i}`).hidden = !ketuaKosong;
+    document.getElementById(`regu-${i}`).classList.toggle("kartu-regu-galat", namaKosong || ketuaKosong);
+  };
+
   jawab.regu.forEach((r, i) => {
     document.getElementById(`r-nama-${i}`).addEventListener("input", e => {
       r.nama_regu = e.target.value.trim(); simpanDraf();
+      cekRegu(i);
       if (sudahDiperiksa) periksa(false);
     });
     document.getElementById(`r-ketua-${i}`).addEventListener("input", e => {
       r.nama_ketua = e.target.value.trim(); simpanDraf();
+      cekRegu(i);
       if (sudahDiperiksa) periksa(false);
     });
+    cekRegu(i);   // baris baru (kosong) langsung tertandai, tanpa perlu disentuh dulu
   });
+}
+
+/* ---------------- 5. kontak WA: validasi live ---------------- */
+
+/** Warning SEKETIKA sambil mengetik nomor WA — tidak menunggu tombol Kirim
+ *  ditekan dulu. Kotak yang masih kosong (belum mulai diketik) tidak
+ *  ditandai galat; begitu ada isi, formatnya dicek ulang di tiap ketukan. */
+function cekWaLive() {
+  const wa = document.getElementById("wa");
+  const digitWa = wa.value.replace(/\D/g, "");
+  const kosong = digitWa.length === 0;
+  const sah = POLA_WA.test(digitWa);
+  wa.setAttribute("aria-invalid", String(!kosong && !sah));
+  document.getElementById("g-wa").hidden = kosong || sah;
 }
 
 /* ---------------- pemeriksaan: SEMUA galat sekaligus ---------------- */
@@ -383,11 +425,8 @@ function periksa(gulir = true) {
     if (kurang) galat.push({ ke: `regu-${i}`, teks: `Regu ${i + 1} belum lengkap` });
   });
 
-  // Format nomor Indonesia, HANYA 08xx (bukan +62 8xx — disederhanakan
-  // sengaja supaya panitia tidak perlu mikir dua format): 08, lalu kode
-  // operator (1-9, bukan 0), lalu 6-10 digit lagi.
   const digitWa = jawab.kontak_wa.replace(/\D/g, "");
-  const waSah = /^08[1-9][0-9]{6,10}$/.test(digitWa);
+  const waSah = POLA_WA.test(digitWa);
   if (!waSah) galat.push({ ke: "bagian-kontak", teks: "Nomor WA belum sesuai format Indonesia" });
   tandai("g-wa", !waSah);
 


### PR DESCRIPTION
## What

1. **Link "Pendaftaran" langsung** — menu Home sebelumnya membuka layar perantara ("Link yang sama untuk online maupun langsung") berisi satu tombol lagi untuk membuka form sungguhan. Sekarang langsung ke `daftar.html` (tab baru), satu ketukan. Layar perantara dan rutenya (`#/pendaftaran-offline`) dihapus.
2. **Nama regu & nama ketua**: warning "wajib diisi" tampil seketika begitu kotaknya kosong — termasuk baris regu yang baru ditambah — bukan menunggu tombol Kirim ditekan.
3. **Nomor WA**: format divalidasi live di setiap ketukan, bukan cuma setelah percobaan Kirim pertama.

## Why

Ketiganya sama-sama soal jarak antara kesalahan dan tahu-nya kesalahan. Klik ganda untuk buka form itu langkah tak perlu; nama kosong atau WA salah format yang baru ketahuan di ringkasan galat (setelah Kirim ditekan) berarti pendaftar sudah menganggap selesai padahal belum.

## Notes

Pola regex WA (`POLA_WA`) diekstrak jadi satu konstanta dipakai bersama validasi live dan pemeriksaan akhir — sebelumnya regex yang sama ditulis dua kali di file yang sama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
