### PR TITLE
ci: jalankan tes SQL di GitHub Actions dengan Postgres sungguhan

### DIFF
--- a/.github/workflows/tes-sql.yml
+++ b/.github/workflows/tes-sql.yml
@@ -1,0 +1,58 @@
+# ============================================================================
+# hrcd-rekap : tes-sql.yml — jalankan seluruh tes SQL di PostgreSQL sungguhan.
+#
+# Kenapa ada: sampai sekarang tes hanya bisa dijalankan kalau maintainer
+# kebetulan punya PostgreSQL lokal. Akibatnya migrasi bisa ter-merge tanpa
+# pernah sekali pun dieksekusi Postgres — persis risiko terbesar di repo ini,
+# karena yang paling gampang salah justru SQL-nya (fungsi, RLS, constraint),
+# bukan tampilannya.
+#
+# Runner GitHub sudah punya psql, dan Postgres-nya dijalankan sebagai service
+# container. Jadi setiap push dan setiap PR memverifikasi: seluruh migrasi
+# 0001..00NN jalan berurutan dari database kosong, seed masuk, dan semua
+# assert di tests/sql/ lolos.
+#
+# Port 55432 (bukan 5432) sengaja disamakan dengan tests/run.sh dan
+# tests/dev_db.sh supaya perintahnya persis sama di CI maupun di laptop.
+# ============================================================================
+
+name: Tes SQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tes:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: hrcd
+        ports:
+          - 55432:5432
+        # Job tidak boleh mulai sebelum Postgres benar-benar menerima koneksi.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tunjukkan versi psql & server
+        env:
+          PGPASSWORD: hrcd
+        run: |
+          psql --version
+          psql -h 127.0.0.1 -p 55432 -U postgres -d postgres -c "select version();"
+
+      - name: Jalankan seluruh tes
+        env:
+          PGPASSWORD: hrcd
+        run: bash tests/run.sh


### PR DESCRIPTION
## What

Workflow baru: setiap push ke `main` dan setiap PR menjalankan `tests/run.sh` di PostgreSQL 16 sungguhan (service container), bukan hanya kalau maintainer kebetulan punya Postgres lokal.

## Why

Sampai sekarang migrasi bisa ter-merge tanpa pernah sekali pun dieksekusi Postgres — persis yang sedang terjadi pada `0011` di PR #48. Yang paling gampang salah di repo ini justru SQL-nya (fungsi, RLS, constraint), bukan tampilannya.

## Notes

Port 55432 sengaja disamakan dengan `tests/run.sh` dan `tests/dev_db.sh` supaya perintahnya identik di CI maupun di laptop.

Ini workflow pertama di repo dengan trigger otomatis (`push`/`pull_request`) — tiga yang lama semuanya `workflow_dispatch`. Perlu mendarat di `main` dulu supaya GitHub mendaftarkannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
