### PR TITLE
chore: English names for workflows, scripts, and test harness

### DIFF
--- a/.github/workflows/apply-migration.yml
+++ b/.github/workflows/apply-migration.yml
@@ -1,0 +1,76 @@
+# ============================================================================
+# hrcd-rekap : apply-migration.yml — jalankan SATU berkas migrasi ke Supabase.
+#
+# SENGAJA manual (workflow_dispatch), TIDAK otomatis saat push/merge. Alasannya
+# tegas: ini satu-satunya jalur otomatis yang menyentuh database produksi, dan
+# migrasi yang keliru di sini merusak data yang tidak bisa dikembalikan lewat
+# git revert. Merge yang salah tidak boleh diam-diam mengubah produksi —
+# harus selalu ada manusia yang menekan tombolnya.
+#
+# CARA PAKAI (bisa dari HP):
+#   1. Repo -> tab Actions -> "Terapkan migrasi ke Supabase" -> Run workflow.
+#   2. Isi "berkas" dengan path lengkap, misalnya:
+#        supabase/migrations/0011_nomor_dada_manual.sql
+#   3. Run workflow, lalu buka log-nya untuk memastikan "MIGRASI BERHASIL".
+#
+# URUTAN YANG BENAR saat migrasi mengubah bentuk RPC (mis. 0011 mengganti
+# daftar_ulang_batch jadi dua argumen): terapkan migrasi DULU, lalu segera
+# merge PR kodenya. Di antara keduanya ada jeda singkat di mana layar yang
+# memanggil RPC lama akan gagal — lakukan berurutan cepat, jangan ditinggal.
+#
+# Butuh secret SUPABASE_DB_URL: connection string Postgres (Session pooler,
+# port 5432 — BUKAN Direct connection yang IPv6-only dan tak terjangkau
+# runner GitHub, bukan pula transaction pooler 6543 yang menolak sebagian DDL).
+# ============================================================================
+
+name: Apply migration to Supabase
+
+on:
+  workflow_dispatch:
+    inputs:
+      berkas:
+        description: >-
+          Path berkas migrasi, mis. supabase/migrations/0011_nomor_dada_manual.sql
+        required: true
+        type: string
+
+jobs:
+  terapkan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Periksa berkasnya ada
+        # Lewat env var, BUKAN interpolasi ${{ }} langsung ke shell — input
+        # workflow_dispatch adalah teks bebas (lihat catatan sama di
+        # provision-accounts.yml).
+        env:
+          BERKAS: ${{ inputs.berkas }}
+        run: |
+          if [ ! -f "$BERKAS" ]; then
+            echo "Berkas tidak ditemukan: $BERKAS"
+            echo "Migrasi yang tersedia:"
+            ls -1 supabase/migrations/
+            exit 1
+          fi
+          echo "Akan menerapkan: $BERKAS"
+          echo "--- isi berkas ---"
+          cat "$BERKAS"
+
+      - name: Terapkan ke Supabase
+        env:
+          BERKAS: ${{ inputs.berkas }}
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "$DB_URL" ]; then
+            echo "Secret SUPABASE_DB_URL belum diisi."
+            exit 1
+          fi
+          # --single-transaction: kalau ada satu statement yang gagal, SELURUH
+          # berkas di-rollback. Tidak ada bentuk "migrasi setengah jadi".
+          # ON_ERROR_STOP: psql berhenti di galat pertama, bukan lanjut diam-diam.
+          psql "$DB_URL" \
+            --single-transaction \
+            -v ON_ERROR_STOP=1 \
+            -f "$BERKAS"
+          echo "MIGRASI BERHASIL: $BERKAS"

--- a/.github/workflows/change-password.yml
+++ b/.github/workflows/change-password.yml
@@ -1,7 +1,7 @@
 # ============================================================================
-# hrcd-rekap : ganti-password.yml — ganti password SATU akun panitia dari HP.
+# hrcd-rekap : change-password.yml — ganti password SATU akun panitia dari HP.
 #
-# Dipicu manual (workflow_dispatch), pola sama dengan provision-akun.yml.
+# Dipicu manual (workflow_dispatch), pola sama dengan provision-accounts.yml.
 # Bedanya: ini untuk akun yang SUDAH ada, dan passwordnya SELALU digenerate
 # acak di server — tidak pernah diketik di kotak input, supaya tidak pernah
 # tertulis ke riwayat "Run workflow" GitHub (yang tersimpan permanen, beda
@@ -20,7 +20,7 @@
 #      pemilik akun lewat jalur pribadi (WA japri) — jangan di grup.
 #
 # Butuh secret SUPABASE_URL dan SUPABASE_SERVICE_KEY — SAMA PERSIS dengan
-# yang dipakai provision-akun.yml. Kalau itu sudah diisi (Settings -> Secrets
+# yang dipakai provision-accounts.yml. Kalau itu sudah diisi (Settings -> Secrets
 # and variables -> Actions), workflow ini tidak butuh setup tambahan.
 # ============================================================================
 
@@ -50,13 +50,13 @@ jobs:
 
       - name: Ganti password
         # Lewat env var, BUKAN diselipkan langsung ke shell (lihat catatan
-        # yang sama di provision-akun.yml — interpolasi ${{ }} langsung ke
+        # yang sama di provision-accounts.yml — interpolasi ${{ }} langsung ke
         # run: rawan shell injection dari input bebas).
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           USERNAME: ${{ inputs.username }}
-        run: python scripts/ganti_password.py "$USERNAME"
+        run: python scripts/change_password.py "$USERNAME"
 
       - name: Unggah hasil (berisi password — unduh sekali, lalu bagikan manual)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -13,8 +13,8 @@
 # Secrets and variables -> Actions -> New repository secret):
 #   CLOUDFLARE_API_TOKEN   dari Cloudflare > My Profile > API Tokens,
 #                          template "Edit Cloudflare Workers"
-#   SUPABASE_URL           (sudah ada, dipakai juga oleh provision-akun.yml)
-#   SUPABASE_SERVICE_KEY   (sudah ada, dipakai juga oleh provision-akun.yml)
+#   SUPABASE_URL           (sudah ada, dipakai juga oleh provision-accounts.yml)
+#   SUPABASE_SERVICE_KEY   (sudah ada, dipakai juga oleh provision-accounts.yml)
 #
 # TURNSTILE_SECRET sengaja TIDAK ditulis di sini — Turnstile dinonaktifkan
 # untuk edisi 37 (keputusan sadar, lihat worker.js). Kalau diaktifkan lagi

--- a/.github/workflows/provision-accounts.yml
+++ b/.github/workflows/provision-accounts.yml
@@ -1,5 +1,5 @@
 # ============================================================================
-# hrcd-rekap : provision-akun.yml — bikin akun panitia massal dari HP.
+# hrcd-rekap : provision-accounts.yml — bikin akun panitia massal dari HP.
 #
 # Dipicu manual (workflow_dispatch), bukan otomatis lewat push/merge — ini
 # alat admin sekali pakai per batch, bukan bagian dari deploy.
@@ -59,7 +59,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-        run: python scripts/provision_akun.py akun_masuk.csv hasil_provisioning.csv
+        run: python scripts/provision_accounts.py akun_masuk.csv hasil_provisioning.csv
 
       - name: Unggah hasil (berisi password — unduh sekali, lalu bagikan manual)
         if: always()

--- a/.github/workflows/sql-tests.yml
+++ b/.github/workflows/sql-tests.yml
@@ -1,5 +1,5 @@
 # ============================================================================
-# hrcd-rekap : tes-sql.yml — jalankan seluruh tes SQL di PostgreSQL sungguhan.
+# hrcd-rekap : sql-tests.yml — jalankan seluruh tes SQL di PostgreSQL sungguhan.
 #
 # Kenapa ada: sampai sekarang tes hanya bisa dijalankan kalau maintainer
 # kebetulan punya PostgreSQL lokal. Akibatnya migrasi bisa ter-merge tanpa
@@ -13,10 +13,10 @@
 # assert di tests/sql/ lolos.
 #
 # Port 55432 (bukan 5432) sengaja disamakan dengan tests/run.sh dan
-# tests/dev_db.sh supaya perintahnya persis sama di CI maupun di laptop.
+# tests/dev_database.sh supaya perintahnya persis sama di CI maupun di laptop.
 # ============================================================================
 
-name: Tes SQL
+name: SQL Tests
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,27 @@ Guidance for Claude Code when working in this repository.
 8. Rule 7 does not loosen rule 3. Domain terms stay Indonesian however technical
    they sound, because no familiar English equivalent exists: `regu` is not
    "squad", and `nomor dada` is not "bib number" to anyone at this event.
+9. **File names, directory names, and branch names are English** whenever the
+   thing they name is technical rather than domain. This is rule 4 applied to
+   the filesystem, and it was violated repeatedly before being written down:
+   `terapkan-migrasi.yml` should have been `apply-migration.yml`, `tes-sql.yml`
+   should have been `sql-tests.yml`, `ganti_password.py` should have been
+   `change_password.py`. A workflow, a script, a test harness, and a migration
+   are all technical concepts — the panitia never speak their names.
+10. **Use the term the industry already uses, not a literal translation.**
+    Migrations are *applied*, not "implemented"; tests *run*; servers *start*.
+    Translating word-for-word from Indonesian produces names that are English
+    but still unsearchable, which defeats the entire point of rule 5.
+11. Rule 9 stops where the domain begins. `0011_nomor_dada_manual.sql` and
+    `05_pindah_kloter.sql` keep their Indonesian parts, because `nomor dada`
+    and `kloter` are rule 3 terms — only the surrounding technical words
+    (`print`, `move`, `seed`, `test`) turn English.
+12. **A workflow's `name:` field is UI text, so rule 1 decides it — by
+    audience, not by file.** A workflow a panitia runs from the Actions tab on
+    their phone keeps an Indonesian name ("Ganti password akun panitia",
+    "Provision akun panitia"). A workflow only a developer ever reads gets an
+    English one ("SQL Tests", "Apply migration to Supabase"). The file name is
+    English either way — that is rule 9 and has no exceptions.
 
 ## 6. Who maintains this
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
 Untuk mencoba layarnya (butuh tiga terminal):
 
 ```bash
-bash tests/dev_db.sh          # siapkan database hrcd_dev
+bash tests/dev_database.sh          # siapkan database hrcd_dev
 python tests/dev_server.py    # tiruan Supabase di :8787
-python tests/layar_server.py  # layar panitia di :8788 (tanpa cache)
+python tests/static_server.py  # layar panitia di :8788 (tanpa cache)
 ```
 
 Runner membuat ulang database `hrcd_test` setiap kali — aman diulang. Tes
@@ -55,8 +55,8 @@ Uji konkurensi terpisah membuktikan beberapa meja daftar ulang yang menekan
 tombol serentak tidak pernah menghasilkan nomor dada ganda:
 
 ```bash
-bash tests/dev_db.sh            # siapkan database hrcd_dev
-python tests/uji_konkurensi.py  # 30 koneksi serentak memperebutkan 300 nomor
+bash tests/dev_database.sh            # siapkan database hrcd_dev
+python tests/concurrency_test.py  # 30 koneksi serentak memperebutkan 300 nomor
 ```
 
 ## Kontribusi

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -132,7 +132,7 @@ harus "simpan dulu ke database lalu query lagi supaya benar-benar cocok?"
    `pg_advisory_xact_lock`. Hanya satu meja berada di dalamnya pada satu saat;
    yang lain menunggu beberapa milidetik lalu membaca keadaan yang sudah pasti
    mutakhir. `SKIP LOCKED` tidak lagi diperlukan sama sekali.
-5. **Terukur, bukan diyakini** (`tests/uji_konkurensi.py`): 30 koneksi
+5. **Terukur, bukan diyakini** (`tests/concurrency_test.py`): 30 koneksi
    Postgres terpisah dilepas serentak lewat satu barrier, memperebutkan 300
    nomor dada. Hasil setelah perbaikan, lima putaran berturut-turut:
    **300/300 regu bernomor, nol error, nol duplikat, tidak ada kloter

--- a/scripts/change_password.py
+++ b/scripts/change_password.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python3
 # ============================================================================
-# hrcd-rekap : scripts/ganti_password.py — ganti password SATU akun panitia
+# hrcd-rekap : scripts/change_password.py — ganti password SATU akun panitia
 # yang SUDAH ada.
 #
-# Beda dari provision_akun.py: skrip itu MEMBUAT akun baru dan melewati akun
+# Beda dari provision_accounts.py: skrip itu MEMBUAT akun baru dan melewati akun
 # yang emailnya sudah terdaftar. Skrip ini untuk kebalikannya — akun yang
 # sudah ada, cari user_id-nya dari akun_panitia lewat username, lalu timpa
 # passwordnya lewat Supabase Admin API (service_role — melompati RLS).
 #
 # Password SELALU digenerate acak di sini (huruf/angka aman, sama seperti
-# provision_akun.py) — tidak pernah diterima sebagai argumen mentah, supaya
+# provision_accounts.py) — tidak pernah diterima sebagai argumen mentah, supaya
 # tidak pernah tertulis ke log Actions atau riwayat "Run workflow" GitHub.
 # Hasilnya ditulis ke berkas terpisah dan diunggah sebagai artifact berumur
-# pendek oleh ganti-password.yml — bukan dicetak ke log biasa.
+# pendek oleh change-password.yml — bukan dicetak ke log biasa.
 #
 # PAKAI (di terminal SENDIRI — kunci ini tidak boleh masuk ke mana pun lain,
-# lihat README di .github/workflows/ganti-password.yml untuk versi HP):
+# lihat README di .github/workflows/change-password.yml untuk versi HP):
 #   $env:SUPABASE_URL = "https://xxxx.supabase.co"
 #   $env:SUPABASE_SERVICE_KEY = "sb_secret_..."
-#   python scripts/ganti_password.py admin.ciradyka
+#   python scripts/change_password.py admin.ciradyka
 # ============================================================================
 import os
 import secrets
@@ -28,14 +28,14 @@ import requests
 
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "").rstrip("/")
 SERVICE_KEY = os.environ.get("SUPABASE_SERVICE_KEY", "")
-BERKAS_HASIL = os.environ.get("BERKAS_HASIL", "hasil_ganti_password.txt")
+RESULT_FILE = os.environ.get("RESULT_FILE", "hasil_ganti_password.txt")
 
 # Tanpa karakter yang gampang tertukar saat diketik ulang di lapangan.
-ABJAD_AMAN = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789"
+SAFE_ALPHABET = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789"
 
 
-def buat_password():
-    return "".join(secrets.choice(ABJAD_AMAN) for _ in range(10))
+def generate_password():
+    return "".join(secrets.choice(SAFE_ALPHABET) for _ in range(10))
 
 
 def headers():
@@ -46,7 +46,7 @@ def headers():
     }
 
 
-def cari_user_id(username):
+def find_user_id(username):
     r = requests.get(
         f"{SUPABASE_URL}/rest/v1/akun_panitia",
         params={"username": f"eq.{username}", "select": "user_id,peran,aktif"},
@@ -62,14 +62,14 @@ def main():
         print("Set dulu SUPABASE_URL dan SUPABASE_SERVICE_KEY di environment kamu.")
         sys.exit(1)
     if len(sys.argv) < 2:
-        print("Pakai: python ganti_password.py <username>")
+        print("Pakai: python change_password.py <username>")
         sys.exit(1)
 
     # Terima juga kalau yang diketik email lengkap (kebiasaan dari layar
     # login) — bagian sebelum @ saja yang dicari di akun_panitia.
     username = sys.argv[1].strip().split("@")[0]
 
-    akun = cari_user_id(username)
+    akun = find_user_id(username)
     if not akun:
         print(f"x Username '{username}' tidak ditemukan di akun_panitia.")
         sys.exit(1)
@@ -77,7 +77,7 @@ def main():
         print(f"! '{username}' berstatus TIDAK AKTIF (edisi lama) — password tetap diganti, "
               "tapi akun ini tidak akan bisa dipakai login sampai diaktifkan lagi.")
 
-    password = buat_password()
+    password = generate_password()
     # Directive GitHub Actions: sembunyikan nilai ini dari SEMUA baris log
     # berikutnya di run ini, sekalipun ada langkah lain yang tanpa sengaja
     # ikut mencetaknya.
@@ -91,7 +91,7 @@ def main():
         print(f"x GAGAL ganti password: HTTP {r.status_code}: {r.text[:300]}")
         sys.exit(1)
 
-    with open(BERKAS_HASIL, "w", encoding="utf-8") as f:
+    with open(RESULT_FILE, "w", encoding="utf-8") as f:
         f.write(f"username: {username}\n")
         f.write(f"peran: {akun['peran']}\n")
         f.write(f"password baru: {password}\n")

--- a/scripts/provision_accounts.py
+++ b/scripts/provision_accounts.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ============================================================================
-# hrcd-rekap : scripts/provision_akun.py — bikin akun panitia massal.
+# hrcd-rekap : scripts/provision_accounts.py — bikin akun panitia massal.
 #
 # Dua langkah per baris CSV masukan:
 #   1. Buat user di Supabase Auth (auto-confirm, lewat Admin API).
@@ -16,10 +16,10 @@
 # bukan error fatal) — sisa baris tetap lanjut.
 #
 # PAKAI (di terminal SENDIRI — kunci ini tidak boleh masuk ke mana pun lain,
-# lihat README di .github/workflows/provision-akun.yml untuk versi HP):
+# lihat README di .github/workflows/provision-accounts.yml untuk versi HP):
 #   $env:SUPABASE_URL = "https://xxxx.supabase.co"
 #   $env:SUPABASE_SERVICE_KEY = "sb_secret_..."
-#   python scripts/provision_akun.py akun_masuk.csv hasil_provisioning.csv
+#   python scripts/provision_accounts.py akun_masuk.csv hasil_provisioning.csv
 #
 # Format CSV masukan (header wajib persis ini; kolom password boleh kosong):
 #   username,email,peran,pos,password
@@ -37,11 +37,11 @@ SUPABASE_URL = os.environ.get("SUPABASE_URL", "").rstrip("/")
 SERVICE_KEY = os.environ.get("SUPABASE_SERVICE_KEY", "")
 
 # Tanpa karakter yang gampang tertukar saat diketik ulang di lapangan.
-ABJAD_AMAN = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789"
+SAFE_ALPHABET = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789"
 
 
-def buat_password():
-    return "".join(secrets.choice(ABJAD_AMAN) for _ in range(10))
+def generate_password():
+    return "".join(secrets.choice(SAFE_ALPHABET) for _ in range(10))
 
 
 def headers():
@@ -52,7 +52,7 @@ def headers():
     }
 
 
-def buat_user_auth(email, password):
+def create_auth_user(email, password):
     r = requests.post(
         f"{SUPABASE_URL}/auth/v1/admin/users",
         headers=headers(),
@@ -67,7 +67,7 @@ def buat_user_auth(email, password):
     return None, f"HTTP {r.status_code}: {r.text[:200]}"
 
 
-def tautkan_akun_panitia(user_id, username, peran, pos):
+def link_akun_panitia(user_id, username, peran, pos):
     body = {
         "user_id": user_id,
         "username": username,
@@ -92,7 +92,7 @@ def main():
               "kamu sebelum menjalankan skrip ini.")
         sys.exit(1)
     if len(sys.argv) < 2:
-        print("Pakai: python provision_akun.py <masukan.csv> [hasil.csv]")
+        print("Pakai: python provision_accounts.py <masukan.csv> [hasil.csv]")
         sys.exit(1)
 
     berkas_hasil = sys.argv[2] if len(sys.argv) > 2 else None
@@ -105,9 +105,9 @@ def main():
             email = baris["email"].strip()
             peran = baris["peran"].strip()
             pos = baris["pos"].strip()
-            password = (baris.get("password") or "").strip() or buat_password()
+            password = (baris.get("password") or "").strip() or generate_password()
 
-            user_id, err = buat_user_auth(email, password)
+            user_id, err = create_auth_user(email, password)
             if err == "sudah_ada":
                 print(f"~ {username:20s} sudah ada di Auth, dilewati (tautkan manual bila belum di akun_panitia)")
                 baris_hasil.append([username, email, peran, pos, "", "sudah_ada"])
@@ -119,7 +119,7 @@ def main():
                 gagal += 1
                 continue
 
-            err = tautkan_akun_panitia(user_id, username, peran, pos)
+            err = link_akun_panitia(user_id, username, peran, pos)
             if err:
                 print(f"x {username:20s} user Auth dibuat TAPI gagal tautkan akun_panitia: {err}")
                 baris_hasil.append([username, email, peran, pos, password, f"auth ok, tautkan gagal: {err}"])

--- a/tests/concurrency_test.py
+++ b/tests/concurrency_test.py
@@ -1,5 +1,5 @@
 # ============================================================================
-# hrcd-rekap : tests/uji_konkurensi.py
+# hrcd-rekap : tests/concurrency_test.py
 # Membuktikan bahwa dua-tiga meja daftar ulang yang menekan tombol PADA DETIK
 # YANG SAMA tidak pernah menghasilkan nomor dada ganda atau kloter kelebihan.
 #
@@ -8,8 +8,8 @@
 # mungkin dengan tiga jari menekan Enter serentak.
 #
 # Jalankan:
-#   python tests/uji_konkurensi.py
-# (butuh database hrcd_dev — siapkan dengan: bash tests/dev_db.sh)
+#   python tests/concurrency_test.py
+# (butuh database hrcd_dev — siapkan dengan: bash tests/dev_database.sh)
 # ============================================================================
 
 import json

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # ============================================================================
-# hrcd-rekap : tests/dev_db.sh — siapkan database hrcd_dev untuk dev server.
+# hrcd-rekap : tests/dev_database.sh — siapkan database hrcd_dev untuk dev server.
 # Sama seperti run.sh tapi TANPA data tes 02/03 — database bersih berisi
 # konfigurasi edisi + akun uji, siap dipakai layar.
-#   PSQL=/path/ke/psql PGPASSWORD=... bash tests/dev_db.sh
+#   PSQL=/path/ke/psql PGPASSWORD=... bash tests/dev_database.sh
 # ============================================================================
 set -euo pipefail
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -10,7 +10,7 @@
 #
 # Jalankan:
 #   python tests/dev_server.py            # port 8787, db hrcd_dev @ 55432
-# Siapkan db-nya sekali dengan: bash tests/dev_db.sh
+# Siapkan db-nya sekali dengan: bash tests/dev_database.sh
 # ============================================================================
 
 import json

--- a/tests/static_server.py
+++ b/tests/static_server.py
@@ -1,5 +1,5 @@
 # ============================================================================
-# hrcd-rekap : tests/layar_server.py — server statis untuk web/ saat mengembang.
+# hrcd-rekap : tests/static_server.py — server statis untuk web/ saat mengembang.
 #
 # Bukan sekadar `python -m http.server`: server itu mengizinkan browser
 # menyimpan cache, dan selama pengujian kami sempat melihat style.css serta
@@ -10,7 +10,7 @@
 # (Untuk produksi, aturan setaranya ada di web/_headers — Cloudflare Pages.)
 #
 # Jalankan:
-#   python tests/layar_server.py          # http://127.0.0.1:8788
+#   python tests/static_server.py          # http://127.0.0.1:8788
 # ============================================================================
 
 import functools


### PR DESCRIPTION
## What

Nama berkas infrastruktur diganti ke Inggris, plus workflow baru `apply-migration.yml`.

| Sebelum | Sesudah |
|---|---|
| `terapkan-migrasi.yml` | `apply-migration.yml` *(baru di PR ini)* |
| `tes-sql.yml` | `sql-tests.yml` |
| `provision-akun.yml` | `provision-accounts.yml` |
| `ganti-password.yml` | `change-password.yml` |
| `provision_akun.py` | `provision_accounts.py` |
| `ganti_password.py` | `change_password.py` |
| `dev_db.sh` | `dev_database.sh` |
| `layar_server.py` | `static_server.py` |
| `uji_konkurensi.py` | `concurrency_test.py` |

Identifier internal ikut: `BERKAS_HASIL`→`RESULT_FILE`, `ABJAD_AMAN`→`SAFE_ALPHABET`, `buat_password`→`generate_password`, `buat_user_auth`→`create_auth_user`, `cari_user_id`→`find_user_id`.

## Why

CLAUDE.md rule 4/5 sudah lama bilang kosakata teknis tetap Inggris — tapi tidak pernah diterapkan ke nama berkas, jadi repo mengumpulkan `terapkan-migrasi.yml` dan kawan-kawan. Workflow, script, test harness, dan migration semuanya konsep teknis; panitia tidak pernah menyebut namanya.

## Notes

**CLAUDE.md bagian 5 bertambah aturan 9–12** supaya ini tidak terulang:

- **9** — nama berkas/direktori/branch ikut rule 4
- **10** — pakai istilah yang dipakai industri, bukan terjemahan harfiah (migrasi *di-apply*, bukan "di-implement")
- **11** — bagian domain tetap bertahan: `0011_nomor_dada_manual.sql` dan `05_pindah_kloter.sql` tidak berubah, hanya kata teknis di sekitarnya
- **12** — `name:` workflow ditentukan audiensnya: yang dijalankan panitia dari HP tetap Indonesia ("Ganti password akun panitia"), yang cuma dibaca developer jadi Inggris ("SQL Tests", "Apply migration to Supabase")

`link_akun_panitia` sengaja tetap separuh Indonesia karena `akun_panitia` itu nama tabel (rule 3).

**Belum disentuh:** identifier internal di `web/js/*.js` (`judul`, `galat`, `pesan`, `id="kepala"`) dan nama berkas `tests/sql/*.sql` — yang terakhir ditahan supaya tidak bentrok dengan PR #48 yang sedang menunggu merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
