### PR TITLE
feat: contact person punya nama, bukan cuma nomor WhatsApp

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr merge:*)"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+Guidance for Codex when working in this repository.
+
+## 1. Branching
+
+1. Never commit directly to `main`. All work lands through a pull request.
+2. Branch off the latest `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b <type>/<short-description>
+   ```
+3. Name branches `<type>/<short-description>` in kebab-case — for example
+   `feat/rekap-export`, `fix/duplicate-rows`, `docs/Codex-md`.
+4. Use the same `<type>` vocabulary as commits: `feat`, `fix`, `chore`, `docs`,
+   `refactor`, `test`.
+
+## 2. Commits
+
+1. Write the subject as `<type>: <what changed>`, imperative mood, no trailing
+   period, ideally under 72 characters.
+2. Add a body when the change needs a *why*. Wrap it at 72 columns and separate
+   it from the subject with a blank line.
+3. End every commit message with the co-author trailer:
+   ```
+   Co-Authored-By: Codex Opus 5 <noreply@anthropic.com>
+   ```
+4. Keep a commit to one logical change. Do not bundle unrelated edits.
+
+## 3. Creating the pull request
+
+1. Push the branch and set upstream:
+   ```bash
+   git push -u origin HEAD
+   ```
+2. Open the PR against `main` with `gh`:
+   ```bash
+   gh pr create --base main --head <branch> --title "<type>: <what changed>" --body "..."
+   ```
+3. The PR title is what ends up in `main`'s history — see section 4.2 — so make
+   it read well on its own.
+4. Structure the body with a **What** section and a **Why** section. Add
+   **Notes** only when there is a caveat worth flagging.
+5. End the PR body with:
+   ```
+   🤖 Generated with [Codex](https://Codex.com/Codex)
+   ```
+6. Only create or push a PR when the user has asked for it.
+
+## 4. Merging to `main`
+
+1. Always merge with a **merge commit** (`--merge`, i.e. `--no-ff`). Never
+   `--squash`, never `--rebase` — every PR must stay a distinct merge point with
+   two parents in `main`'s history.
+2. The merge commit subject must be the PR title followed by the PR number:
+   `<PR title> (#<number>)`.
+3. The one command that satisfies both rules:
+   ```bash
+   gh pr merge <number> --merge --subject "<PR title> (#<number>)" --delete-branch
+   ```
+4. Never omit `--subject`. Without it GitHub writes
+   `Merge pull request #N from <branch>`, which buries the title.
+5. `--delete-branch` removes the remote branch and switches back to `main`. Run
+   `git remote prune origin` afterwards to clear the stale local ref.
+6. Verify the result — the merge commit must report two parents:
+   ```bash
+   git log --graph --oneline -5
+   git rev-list --parents -n1 HEAD   # expect: <merge> <parent1> <parent2>
+   ```
+7. Merging is a user decision. Do not merge unless the user asked for it.
+
+## 5. Language
+
+1. Split language by **audience**, not by file.
+2. **Indonesian** — UI text, everything under `docs/`, and all domain vocabulary
+   wherever it appears, including code identifiers, database tables, and column
+   names.
+3. **Never translate domain terms.** `regu`, `nomor dada`, `kloter`,
+   `kontrak waktu`, `pos`, `wahana`, `daftar ulang`, `barak`, `golongan`. The
+   panitia say these words, so the code says them too. Writing `chestNumber`
+   for `nomor_dada` creates a lookup tax on every conversation and eventually
+   becomes a bug.
+4. **English** — technical vocabulary (`repository`, `service`, `migration`,
+   `controller`, `cache`), commit messages, PR titles and bodies, and this file.
+5. **Do not translate technical terms into Indonesian.** `pengendali` for
+   controller or `penyimpanan` for repository sounds friendlier but cuts
+   maintainers off from every tutorial, library doc, and error message they will
+   need to search.
+6. Mixing both inside one identifier is expected and correct:
+   `KloterRepository`, `hitungPenalti()`, `nomor_dada`.
+7. **Prefer the word people actually say, even when it is an English loanword.**
+   Write `online`, `offline`, `link`, `upload`, `download`, `preview`,
+   `password`, `timestamp`, `edit`. Do not use the formal coinages `daring`,
+   `luring`, `tautan`, `unggah`, `unduh`, `pratinjau`, `kata sandi`,
+   `cap waktu`, `sunting` — they are correct Indonesian but the panitia stumble
+   over them, and a document that has to be decoded on first read does not get
+   read.
+8. Rule 7 does not loosen rule 3. Domain terms stay Indonesian however technical
+   they sound, because no familiar English equivalent exists: `regu` is not
+   "squad", and `nomor dada` is not "bib number" to anyone at this event.
+
+## 6. Who maintains this
+
+1. Maintainers are the next ambalan members — SMA students learning as they go —
+   with the current owner assisting.
+2. Therefore: prefer obvious code over clever code. A pattern that needs
+   explaining before it can be used is the wrong pattern here.
+3. Document generously. Assume the reader has no prior context and did not
+   attend any of the discussions.
+4. Keep the number of concepts small. Fewer layers a student must hold in their
+   head at once beats a more elegant structure they cannot navigate.
+
+## 7. Repository facts
+
+1. Remote: `https://github.com/ciradyka/hrcd-rekap` (private).
+2. Default branch: `main`. It has **no** branch protection, and squash and
+   rebase merges are still enabled on the repo — section 4 is a convention, not
+   something GitHub enforces. Follow it deliberately.
+3. Git identity is configured **repo-locally**, not globally:
+   `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
+4. PR #1 predates this convention and was squash-merged. It is the one commit on
+   `main` without a merge point; leave it as is.

--- a/supabase/migrations/0013_nama_kontak.sql
+++ b/supabase/migrations/0013_nama_kontak.sql
@@ -19,6 +19,13 @@
 
 alter table pendaftaran add column nama_kontak text;
 
+-- Parameter ber-default membuat OVERLOAD, bukan mengganti: tanda tangan lama
+-- tetap hidup dan panggilan 5 argumen jadi ambigu ("is not unique"). Versi
+-- lama harus dibuang eksplisit. 0006 pun dulu menambah p_kunci_kirim lewat
+-- create or replace, jadi tanda tangan 0004 masih tertinggal juga.
+drop function if exists submit_pendaftaran(text, text, boolean, text, jsonb, smallint);
+drop function if exists submit_pendaftaran(text, text, boolean, text, jsonb, smallint, uuid);
+
 create or replace function submit_pendaftaran(
   p_nama_sekolah   text,
   p_alamat_sekolah text,

--- a/supabase/migrations/0013_nama_kontak.sql
+++ b/supabase/migrations/0013_nama_kontak.sql
@@ -113,6 +113,12 @@ begin
 end;
 $$;
 
+-- Fungsi baru lahir dengan EXECUTE ke PUBLIC (default PostgreSQL). Tanpa
+-- revoke ini, akun panitia mana pun bisa memanggil submit_pendaftaran
+-- langsung dan melewati gerbang Worker + Turnstile.
+revoke execute on function
+  submit_pendaftaran(text, text, boolean, text, jsonb, smallint, uuid, text)
+  from public, anon, authenticated;
 grant execute on function
   submit_pendaftaran(text, text, boolean, text, jsonb, smallint, uuid, text)
   to service_role;

--- a/supabase/migrations/0013_nama_kontak.sql
+++ b/supabase/migrations/0013_nama_kontak.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- hrcd-rekap : 0013_nama_kontak.sql
+--
+-- Contact person sekarang punya NAMA, bukan cuma nomor WA. Panitia menelepon
+-- balik saat pembayaran tidak jelas, dan "menghubungi 08123..." tanpa tahu
+-- siapa yang akan mengangkat membuat percakapan canggung tiap kali.
+--
+-- Kolom sengaja NULLABLE: sembilan pendaftaran yang sudah masuk tidak punya
+-- nilai ini, dan memaksanya NOT NULL berarti mengarang nama orang.
+--
+-- DISALIN DARI 0006, BUKAN 0004: 0006 sudah mendefinisikan ulang fungsi ini
+-- dengan p_kunci_kirim (idempotensi — mencegah sinyal putus melahirkan dua
+-- pendaftaran). Menyalin dari 0004 akan diam-diam MENGHAPUS fitur itu.
+--
+-- Parameter baru ditaruh DI URUTAN TERAKHIR dan ber-default null, jadi
+-- gateway Worker versi lama yang belum mengirimkannya tetap jalan — tidak
+-- ada jendela rusak saat deploy.
+-- ============================================================================
+
+alter table pendaftaran add column nama_kontak text;
+
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+begin
+  -- Kiriman ulang dengan kunci yang sama: kembalikan hasil yang dulu.
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', v_ada.jumlah_regu * (select biaya_per_regu from edisi where aktif),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in
+       ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi') then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+  end loop;
+
+  insert into sekolah (nama, alamat)
+  values (trim(p_nama_sekolah), trim(p_alamat_sekolah))
+  on conflict (nama, alamat) do nothing;
+  select id into v_sekolah from sekolah
+  where nama = trim(p_nama_sekolah) and alamat = trim(p_alamat_sekolah);
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim, nama_kontak)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''))
+  returning id into v_batch;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan'
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', v_n * (select biaya_per_regu from edisi where aktif));
+end;
+$$;
+
+grant execute on function
+  submit_pendaftaran(text, text, boolean, text, jsonb, smallint, uuid, text)
+  to service_role;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -115,7 +115,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/daftar-pendaftaran":
                 self._kirim(200, q("""
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
-                           d.jumlah_pendamping, d.butuh_barak, d.kontak_wa,
+                           d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
                            d.created_at,
                            jsonb_build_object('nama', s.nama, 'alamat', s.alamat) as sekolah,
                            (select jsonb_agg(jsonb_build_object(
@@ -149,7 +149,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/batch":
                 b = q("""
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
-                           d.jumlah_pendamping, d.butuh_barak, d.kontak_wa,
+                           d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
                            jsonb_build_object('nama', s.nama, 'alamat', s.alamat) as sekolah,
                            (select jsonb_agg(jsonb_build_object(
                               'id', r.id, 'nama_regu', r.nama_regu,
@@ -198,12 +198,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 b = self._badan()
                 hasil = q(
                     "select submit_pendaftaran(%s, %s, %s, %s, %s::jsonb, "
-                    "%s::smallint, %s::uuid) as h",
+                    "%s::smallint, %s::uuid, %s) as h",
                     (b.get("nama_sekolah"), b.get("alamat_sekolah"),
                      bool(b.get("butuh_barak")), b.get("kontak_wa"),
                      json.dumps(b.get("regu") or []),
                      int(b.get("jumlah_pendamping") or 0),
-                     b.get("kunci_kirim")),
+                     b.get("kunci_kirim"), b.get("nama_kontak")),
                     role="service_role", fetch="one")
                 self._kirim(200, hasil["h"])
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -35,6 +35,7 @@ run supabase/migrations/0009_sisip_kloter.sql
 run supabase/migrations/0010_lookup_finish.sql
 run supabase/migrations/0011_nomor_dada_manual.sql
 run supabase/migrations/0012_rename_audit_columns.sql
+run supabase/migrations/0013_nama_kontak.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -42,6 +42,7 @@ const kosong = () => ({
   rincian: { penggalang_pa: 0, penggalang_pi: 0, penegak_pa: 0, penegak_pi: 0 },
   regu: [],                      // [{golongan, nama_regu, nama_ketua}]
   kontak_wa: "",
+  nama_kontak: "",
   kunci_kirim: (crypto.randomUUID ? crypto.randomUUID()
                 : String(Date.now()) + Math.random().toString(16).slice(2)),
 });
@@ -115,10 +116,16 @@ function halaman() {
 
     <!-- 5. Kontak -->
     <section class="card" id="bagian-kontak">
-      <h2><span class="section-number">5</span> Nomor WhatsApp yang bisa dihubungi</h2>
-      <p class="description">Satu nomor untuk semua regu — panitia menghubungi lewat sini.</p>
+      <h2><span class="section-number">5</span> Contact person</h2>
+      <p class="description">Satu orang untuk semua regu — panitia menghubungi lewat sini.</p>
       <div class="field" style="margin-top:.7rem">
-        <label for="wa" class="visually-hidden">Nomor WA</label>
+        <label for="nama-kontak">Nama</label>
+        <input type="text" id="nama-kontak" autocomplete="name"
+               placeholder="contoh: Bu Rina">
+        <div class="error" id="g-nama-kontak" hidden>Nama contact person wajib diisi.</div>
+      </div>
+      <div class="field">
+        <label for="wa">Nomor WhatsApp</label>
         <input type="tel" id="wa" inputmode="numeric" placeholder="contoh: 08123456789">
         <div class="error" id="g-wa" hidden>Isi nomor WA yang benar — diawali 08, bukan +62.</div>
       </div>
@@ -139,6 +146,12 @@ function halaman() {
   gambarBarak();
   gambarStepper();
   gambarRegu();
+  document.getElementById("nama-kontak").value = jawab.nama_kontak;
+  document.getElementById("nama-kontak").addEventListener("input", e => {
+    jawab.nama_kontak = e.target.value; simpanDraf();
+    document.getElementById("g-nama-kontak").hidden = !!e.target.value.trim();
+    if (sudahDiperiksa) periksa(false);
+  });
   document.getElementById("wa").value = jawab.kontak_wa;
   cekWaLive();
   document.getElementById("wa").addEventListener("input", e => {
@@ -425,6 +438,11 @@ function periksa(gulir = true) {
     if (kurang) galat.push({ ke: `regu-${i}`, teks: `Regu ${i + 1} belum lengkap` });
   });
 
+  const namaKontakKosong = !jawab.nama_kontak.trim();
+  if (namaKontakKosong)
+    galat.push({ ke: "bagian-kontak", teks: "Nama contact person belum diisi" });
+  tandai("g-nama-kontak", namaKontakKosong);
+
   const digitWa = jawab.kontak_wa.replace(/\D/g, "");
   const waSah = POLA_WA.test(digitWa);
   if (!waSah) galat.push({ ke: "bagian-kontak", teks: "Nomor WA belum sesuai format Indonesia" });
@@ -487,6 +505,7 @@ async function kirim(e) {
       butuh_barak: jawab.butuh_barak,
       jumlah_pendamping: jawab.jumlah_pendamping,
       kontak_wa: jawab.kontak_wa,
+      nama_kontak: jawab.nama_kontak,
       regu: jawab.regu,
       kunci_kirim: jawab.kunci_kirim,     // sama saat mencoba lagi
     }, tokenTurnstile);

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -93,6 +93,7 @@ export default {
         p_alamat_sekolah: b.alamat_sekolah,
         p_butuh_barak: !!b.butuh_barak,
         p_kontak_wa: b.kontak_wa,
+        p_nama_kontak: b.nama_kontak || null,
         p_regu: b.regu,
         p_jumlah_pendamping: b.jumlah_pendamping || 0,
         // Kunci idempotensi: kiriman ulang setelah sinyal putus tidak


### PR DESCRIPTION
## What

Bagian 5 form pendaftaran jadi dua isian: **Nama** + **Nomor WhatsApp**. Migrasi `0013` menambah kolom `pendaftaran.nama_kontak`.

## Why

Panitia menelepon balik saat pembayaran tidak jelas. "Menghubungi 08123..." tanpa tahu siapa yang akan mengangkat membuat percakapan canggung tiap kali.

## Notes

Tiga jebakan yang ditangkap CI sebelum menyentuh live:

1. **Disalin dari `0006`, bukan `0004`** — `0006` sudah mendefinisikan ulang `submit_pendaftaran` dengan `p_kunci_kirim` (idempotensi). Menyalin dari `0004` akan diam-diam menghapus fitur itu.
2. **Overload, bukan pengganti** — parameter ber-default bikin tanda tangan lama tetap hidup, panggilan 5 argumen jadi ambigu (`is not unique`). Versi lama harus di-`drop` eksplisit.
3. **`EXECUTE` default ke `PUBLIC`** — fungsi baru lahir bisa dipanggil siapa saja, melewati gerbang Worker + Turnstile. Tes RLS menangkapnya; `revoke` ditambahkan.

Kolom `NULLABLE` — sembilan pendaftaran yang sudah masuk tidak punya nilai ini. Parameter baru di urutan terakhir ber-default `null`, jadi Worker versi lama tetap jalan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
