### PR TITLE
refactor(db): tier 2 — kata umum di database jadi bahasa Inggris

### DIFF
--- a/supabase/migrations/0014_rename_common_columns.sql
+++ b/supabase/migrations/0014_rename_common_columns.sql
@@ -1,0 +1,1040 @@
+-- ============================================================================
+-- hrcd-rekap : 0014_rename_common_columns.sql
+--
+-- Lanjutan 0012: kata UMUM di database ikut Inggris. Ini kosakata biasa yang
+-- kebetulan dipakai sebagai nama kolom (nama, aktif, alasan, catatan), bukan
+-- istilah lomba. Kosakata DOMAIN tetap utuh (CLAUDE.md 5.3): regu, kloter,
+-- nomor_dada, golongan, sekolah, pembayaran, pendaftaran, wahana, pos, barak,
+-- kwitansi, daftar_ulang.
+--
+-- View, policy RLS, constraint, dan index ikut ter-update sendiri saat RENAME
+-- (pohon parse). Yang TIDAK ikut adalah body fungsi plpgsql — disimpan sebagai
+-- teks — jadi ketujuh belas fungsi di bawah dibuat ulang, disalin terprogram
+-- dari definisi TERBARU masing-masing (beberapa sudah ditulis ulang di 0011,
+-- 0012, dan 0013; menyalin dari 0004 akan memundurkannya).
+--
+-- Penggantian dilakukan sadar konteks: dilewati di dalam komentar dan di dalam
+-- literal string. Itu wajib — `alasan`, `batal`, dan `nama` juga muncul sebagai
+-- KUNCI JSON (jsonb_build_object('alasan', ...)) dan sebagai NILAI status
+-- ('batal'); mengubahnya akan merusak bentuk audit dan logika status tanpa ada
+-- yang gagal saat migrasi dijalankan.
+-- ============================================================================
+
+-- 1. Kolom -------------------------------------------------------------
+alter table edisi rename column nama to name;
+alter table edisi rename column aktif to is_active;
+alter table pos rename column nama to name;
+alter table wahana rename column nama to name;
+alter table wahana rename column jenis to type;
+alter table wahana rename column bentuk to form;
+alter table wahana rename column urutan to sort_order;
+alter table kontrak_opsi rename column urutan to sort_order;
+alter table sekolah rename column nama to name;
+alter table sekolah rename column alamat to address;
+alter table nomor_dada_pensiun rename column alasan to reason;
+alter table regu rename column batal to is_cancelled;
+alter table pembayaran rename column nominal to amount;
+alter table pembayaran rename column metode to method;
+alter table nilai_mentah rename column sumber to source;
+alter table closing_regu rename column catatan to note;
+alter table ruangan rename column nama to name;
+alter table ruangan rename column kapasitas to capacity;
+alter table penempatan_barak rename column ruangan_id to room_id;
+alter table akun_panitia rename column aktif to is_active;
+
+-- 2. Tabel ruangan -> room ---------------------------------------------
+alter table ruangan rename to room;
+
+-- 3. Fungsi yang body-nya menyebut kolom di atas -----------------------
+
+-- terbaru dari 0002_functions.sql
+create or replace function peran()
+returns text
+language sql stable security definer
+set search_path = public
+as $$
+  select peran from akun_panitia
+  where user_id = auth.uid() and is_active
+$$;
+
+-- terbaru dari 0002_functions.sql
+create or replace function pos_saya()
+returns smallint
+language sql stable security definer
+set search_path = public
+as $$
+  select pos from akun_panitia
+  where user_id = auth.uid() and is_active
+$$;
+
+-- terbaru dari 0002_functions.sql
+create or replace function edisi_aktif()
+returns smallint
+language sql stable
+set search_path = public
+as $$
+  select nomor from edisi where is_active
+$$;
+
+-- terbaru dari 0013_nama_kontak.sql
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+begin
+  -- Kiriman ulang dengan kunci yang sama: kembalikan hasil yang dulu.
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', v_ada.jumlah_regu * (select biaya_per_regu from edisi where is_active),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in
+       ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi') then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+  end loop;
+
+  insert into sekolah (name, address)
+  values (trim(p_nama_sekolah), trim(p_alamat_sekolah))
+  on conflict (name, address) do nothing;
+  select id into v_sekolah from sekolah
+  where name = trim(p_nama_sekolah) and address = trim(p_alamat_sekolah);
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim, nama_kontak)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''))
+  returning id into v_batch;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan'
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', v_n * (select biaya_per_regu from edisi where is_active));
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function verifikasi_pembayaran(
+  p_kode    text,
+  p_nominal integer,
+  p_metode  text
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch     pendaftaran%rowtype;
+  v_tagihan   integer;
+  v_kwitansi  text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'menunggu_pembayaran' then
+    raise exception 'batch berstatus %, bukan menunggu_pembayaran', v_batch.status;
+  end if;
+
+  -- Semua-atau-tidak: nominal harus pas seluruh batch (alur 3.5).
+  select v_batch.jumlah_regu * biaya_per_regu into v_tagihan from edisi where is_active;
+  if p_nominal <> v_tagihan then
+    raise exception 'nominal % tidak sama dengan tagihan % — pembayaran sebagian tidak dilayani; sarankan daftar batch lebih kecil',
+      p_nominal, v_tagihan;
+  end if;
+
+  v_kwitansi := 'KW-HRCD' || edisi_aktif() || '-' ||
+                lpad(nextval('kwitansi_seq')::text, 4, '0');
+
+  insert into pembayaran (pendaftaran_id, amount, method, nomor_kwitansi, verified_by)
+  values (v_batch.id, p_nominal, p_metode, v_kwitansi, auth.uid());
+
+  update pendaftaran set status = 'lunas' where id = v_batch.id;
+
+  return jsonb_build_object('nomor_kwitansi', v_kwitansi);
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function batalkan_verifikasi(
+  p_kode   text,
+  p_alasan text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_bayar pembayaran%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan pembatalan wajib diisi';
+  end if;
+
+  select b.* into v_bayar
+  from pembayaran b join pendaftaran d on d.id = b.pendaftaran_id
+  where d.kode_pembayaran = p_kode
+  for update;
+  if not found then
+    raise exception 'tidak ada pembayaran untuk kode %', p_kode;
+  end if;
+
+  -- Temuan review: membatalkan verifikasi SETELAH daftar ulang meninggalkan
+  -- regu yatim — bernomor dada & berkloter tapi "belum bayar", hilang dari
+  -- kwitansi dan tergusur dari barak. Tolak keras.
+  if exists (select 1 from regu r
+             where r.pendaftaran_id = v_bayar.pendaftaran_id
+               and r.nomor_dada is not null) then
+    raise exception 'batch sudah daftar ulang (nomor dada terbit) — pembatalan harus lewat admin dengan mengosongkan nomor dada dulu';
+  end if;
+
+  -- Hari yang sama dihitung dalam WIB, bukan zona server (temuan review).
+  if peran() = 'meja'
+     and (v_bayar.verified_at at time zone 'Asia/Jakarta')::date
+         <> (now() at time zone 'Asia/Jakarta')::date then
+    raise exception 'meja hanya boleh membatalkan verifikasi di hari yang sama — hubungi admin';
+  end if;
+
+  -- Alasan ikut terekam riwayat lewat trigger audit pada DELETE + catatan ini.
+  insert into history (table_name, row_id, action, new_value, changed_by)
+  values ('pembayaran', v_bayar.id::text, 'DELETE',
+          jsonb_build_object('alasan_pembatalan', p_alasan), auth.uid());
+
+  delete from pembayaran where id = v_bayar.id;
+  update pendaftaran set status = 'menunggu_pembayaran' where id = v_bayar.pendaftaran_id;
+end;
+$$;
+
+-- terbaru dari 0011_nomor_dada_manual.sql
+create or replace function daftar_ulang_batch(
+  p_kode  text,
+  -- [{"regu_id": "...", "nomor_dada": 12}, ...] — satu entri per regu yang
+  -- belum bernomor di batch ini, tidak boleh kurang dan tidak boleh lebih.
+  p_nomor jsonb
+)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_berhak     uuid[];
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];      -- kloter yang sudah berisi sekolah ini
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+  v_salah      text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Regu yang berhak: belum bernomor, tidak batal (rancangan-b.md, temuan 11).
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.is_cancelled and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Pasangan regu -> nomor dari meja. Urutan deterministik (nama regu) supaya
+  -- hasil yang dibacakan meja urut sama dengan kartu di layar.
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+         as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) as t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) as t(g) where not (t.g = any (v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+
+  if exists (select 1 from unnest(v_nomor) as t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct t.nomor) from unnest(v_nomor) as t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  -- Kunci baris stok yang diminta, urut nomor supaya dua meja yang meminta
+  -- himpunan bertumpang tindih tidak saling mengunci silang. Meja kedua
+  -- menunggu sebentar lalu ditolak pemeriksaan "sudah dipakai" di bawah,
+  -- dengan pesan yang bisa dibaca petugas — bukan galat unique mentah.
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any (v_nomor)
+  order by s.nomor
+  for update;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- Serialisasi bagian penempatan kloter (2-3 meja — advisory lock sederhana
+  -- lebih terbaca daripada retry unique-violation; lepas otomatis di akhir tx).
+  perform pg_advisory_xact_lock(hashtext('hrcd_kloter_assign'));
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  -- Sebar N regu: mulai dari kloter termuda yang layak, melompat
+  -- lompatan_kloter (alur 5.6); kloter 31.. dibuka hanya bila 1..30 tidak
+  -- menyediakan slot layak (alur 5.2). "Layak" = belum penuh + belum berisi
+  -- sekolah ini; bila tak terhindarkan, syarat sekolah dilonggarkan (alur 5.4
+  -- "sesedikit mungkin", bukan "tidak boleh").
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam 1..kloter_dasar.
+    if v_mulai is null then
+      v_langkah := 1;  -- pencarian pertama: kloter layak termuda
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and k.jam_berangkat is null
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama tapi abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: 1..kloter_dasar masih ada tempat tapi semuanya berisi
+    -- sekolah ini — sekolah sama boleh berkumpul DULU sebelum membuka
+    -- kloter cadangan (alur 5.2: 31-40 hanya bila 1-30 penuh; alur 5.4:
+    -- "sesedikit mungkin", bukan larangan mutlak). Pilih yang paling kosong.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan
+    -- (31..kloter_maks), hindari sekolah sama dulu lalu bebas.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and k.jam_berangkat is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),   -- false (bebas sekolah) dulu
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      -- Slot terkecil yang kosong, bukan count+1: lubang bekas koreksi admin
+      -- tidak boleh membuat slot palsu di atas 10 (temuan review).
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function tukar_nomor_dada(
+  p_regu       uuid,
+  p_nomor_baru integer,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu regu%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan tukar wajib diisi';
+  end if;
+
+  select * into v_regu from regu where id = p_regu for update;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_regu.is_cancelled then
+    raise exception 'regu berstatus batal';
+  end if;
+  if v_regu.nomor_dada is null then
+    raise exception 'regu belum punya nomor dada';
+  end if;
+  -- Setelah kloter berangkat, lembar kertas beredar memakai nomor lama —
+  -- penukaran hanya boleh oleh admin yang paham konsekuensinya.
+  if peran() <> 'admin' and exists (
+       select 1 from kloter where nomor = v_regu.kloter_nomor
+         and jam_berangkat is not null) then
+    raise exception 'kloter sudah berangkat — tukar nomor hanya lewat admin';
+  end if;
+  if not exists (select 1 from nomor_dada_stok where nomor = p_nomor_baru) then
+    raise exception 'nomor % tidak ada di stok', p_nomor_baru;
+  end if;
+  if exists (select 1 from regu where nomor_dada = p_nomor_baru)
+     or exists (select 1 from nomor_dada_pensiun where nomor = p_nomor_baru) then
+    raise exception 'nomor % sudah terpakai / pensiun', p_nomor_baru;
+  end if;
+
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('regu', p_regu::text, p_regu, 'UPDATE',
+          jsonb_build_object('alasan_tukar_nomor', p_alasan,
+                             'nomor_lama', v_regu.nomor_dada,
+                             'nomor_baru', p_nomor_baru), auth.uid());
+
+  -- Nomor lama PENSIUN — tidak pernah terbit ulang ke regu lain, supaya
+  -- lembar/foto lama yang masih menuliskannya tidak menilai regu yang salah.
+  insert into nomor_dada_pensiun (nomor, reason)
+  values (v_regu.nomor_dada, p_alasan);
+
+  update regu set nomor_dada = p_nomor_baru where id = p_regu;
+end;
+$$;
+
+-- terbaru dari 0004_rpcs.sql
+create or replace function berangkatkan_kloter(
+  p_kloter smallint,
+  p_jam    timestamptz
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_tanpa_kontrak text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jam is null then
+    raise exception 'jam berangkat wajib diketik';
+  end if;
+  if exists (select 1 from kloter where nomor = p_kloter and jam_berangkat is not null) then
+    raise exception 'kloter % sudah berangkat', p_kloter;
+  end if;
+  -- Papan pipeline diturunkan dari max(nomor berangkat) — satu ketukan salah
+  -- (memberangkatkan kloter kosong / melompati) merusak seluruh papan.
+  -- Guard: kloter harus berisi regu, dan tidak boleh melompati kloter berisi
+  -- regu yang belum berangkat (temuan review).
+  if not exists (select 1 from regu r where r.kloter_nomor = p_kloter and not r.is_cancelled) then
+    raise exception 'kloter % tidak berisi regu', p_kloter;
+  end if;
+  if exists (
+       select 1 from kloter k
+       where k.nomor < p_kloter and k.jam_berangkat is null
+         and exists (select 1 from regu r
+                     where r.kloter_nomor = k.nomor and not r.is_cancelled)) then
+    raise exception 'masih ada kloter sebelum % yang belum berangkat — urutan keberangkatan wajib berurut', p_kloter;
+  end if;
+
+  -- Regu yang diceklis berangkat wajib sudah berkontrak — mencegah penalti
+  -- waktu yang tak terhitung (NULL) di kemudian hari.
+  select string_agg(r.nomor_dada::text, ', ') into v_tanpa_kontrak
+  from regu r
+  join keberangkatan_regu k on k.regu_id = r.id
+  where r.kloter_nomor = p_kloter and r.kontrak_menit is null;
+  if v_tanpa_kontrak is not null then
+    raise exception 'regu nomor dada % belum konfirmasi kontrak waktu', v_tanpa_kontrak;
+  end if;
+
+  update kloter set jam_berangkat = p_jam where nomor = p_kloter;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function batalkan_keberangkatan(p_kloter smallint, p_alasan text)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if peran() <> 'admin' then
+    raise exception 'hanya admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan wajib diisi';
+  end if;
+  if p_kloter <> (select max(nomor) from kloter where jam_berangkat is not null) then
+    raise exception 'hanya kloter berangkat terakhir yang bisa dibatalkan';
+  end if;
+  insert into history (table_name, row_id, action, new_value, changed_by)
+  values ('kloter', p_kloter::text, 'UPDATE',
+          jsonb_build_object('alasan_batal_berangkat', p_alasan), auth.uid());
+  update kloter set jam_berangkat = null where nomor = p_kloter;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function simpan_nilai_massal(
+  p_baris  jsonb,  -- [{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40,"nilai_2":null}, ...]
+  p_sumber text default 'upload',
+  p_pos    smallint default null  -- wajib untuk admin; operator memakai pos-nya sendiri
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_r      jsonb;
+  v_regu   regu%rowtype;
+  v_wahana wahana%rowtype;
+  v_hasil  jsonb := '[]'::jsonb;
+  v_status text;
+  v_alasan text;
+  v_idx    int := 0;
+  v_pos    smallint;
+  v_kunci  text;
+  v_sudah  text[] := '{}';
+  v_n1     numeric;
+  v_n2     numeric;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+  if p_sumber not in ('manual', 'upload') then
+    raise exception 'sumber tidak dikenal: %', p_sumber;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_baris) loop
+    v_idx := v_idx + 1;
+    v_status := 'tersimpan'; v_alasan := null;
+
+    -- Seluruh pemrosesan baris terlindungi: format angka rusak di baris 7
+    -- tidak boleh menggagalkan 26 baris lain (temuan review).
+    begin
+      v_n1 := (v_r ->> 'nilai_1')::numeric;
+      v_n2 := nullif(v_r ->> 'nilai_2', '')::numeric;
+
+      -- Baris ganda dalam SATU paste = merah (bagian 6.3) — juga di server.
+      v_kunci := (v_r ->> 'nomor_dada') || '|' ||
+                 regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g');
+      if v_kunci = any (v_sudah) then
+        raise exception 'baris ganda dalam paste (nomor dada + komponen sama)';
+      end if;
+      v_sudah := v_sudah || v_kunci;
+
+      -- Regu: harus dikenal, bernomor, tidak batal.
+      select * into v_regu from regu
+      where nomor_dada = (v_r ->> 'nomor_dada')::integer and not is_cancelled;
+      if not found then
+        raise exception 'nomor dada tidak dikenal / regu batal';
+      end if;
+
+      -- Komponen: HANYA pos ini (kode boleh kembar antar pos — temuan
+      -- review); normalisasi dua arah supaya "Lari Zigzag" dari header foto
+      -- cocok dengan kode lari_zigzag.
+      select w.* into v_wahana from wahana w
+      where w.edisi = edisi_aktif()
+        and w.pos = v_pos
+        and regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g')
+            = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+      if not found then
+        raise exception 'kode komponen tidak dikenal di pos % — mungkin ini lembar pos lain?', v_pos;
+      end if;
+
+      -- Rentang wajar dari konfigurasi (merah di preview = tolak di server).
+      if v_n1 is null
+         or v_n1 not between v_wahana.rentang_mentah_min and v_wahana.rentang_mentah_maks then
+        raise exception 'nilai % di luar rentang wajar %-%',
+          coalesce(v_r ->> 'nilai_1', '(kosong)'),
+          v_wahana.rentang_mentah_min, v_wahana.rentang_mentah_maks;
+      end if;
+      -- nilai_2 (jumlah salah) ikut divalidasi (temuan review).
+      if v_n2 is not null
+         and v_n2 not between 0 and v_wahana.rentang_mentah_maks then
+        raise exception 'nilai_2 % di luar rentang 0-%', v_n2, v_wahana.rentang_mentah_maks;
+      end if;
+
+      insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+      values (v_regu.id, v_wahana.id, v_n1, v_n2, p_sumber, auth.uid())
+      on conflict (regu_id, wahana_id) do update set
+        nilai_1 = excluded.nilai_1,
+        nilai_2 = excluded.nilai_2,
+        source  = excluded.source,
+        created_by = excluded.created_by,
+        created_at = now()
+      -- Simpan ulang tanpa perubahan = tidak menulis apa pun: kepengarangan
+      -- tidak tergeser, riwayat tidak dibanjiri (temuan review).
+      where nilai_mentah.nilai_1 is distinct from excluded.nilai_1
+         or nilai_mentah.nilai_2 is distinct from excluded.nilai_2;
+
+    exception when others then
+      v_status := 'ditolak';
+      v_alasan := sqlerrm;
+    end;
+
+    v_hasil := v_hasil || jsonb_build_object(
+      'baris', v_idx,
+      'nomor_dada', v_r ->> 'nomor_dada',
+      'kode', v_r ->> 'kode',
+      'status', v_status,
+      'alasan', v_alasan);
+  end loop;
+
+  return v_hasil;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function catat_closing(
+  p_nomor_dada    integer,
+  p_jam_datang    timestamptz,
+  p_anggota_hadir smallint default 5,
+  p_catatan       text default null
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu regu%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jam_datang is null then
+    raise exception 'jam datang wajib diketik';
+  end if;
+
+  select * into v_regu from regu where nomor_dada = p_nomor_dada;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+  if v_regu.is_cancelled then
+    raise exception 'regu % berstatus batal', p_nomor_dada;
+  end if;
+  if not exists (select 1 from keberangkatan_regu where regu_id = v_regu.id) then
+    raise exception 'regu % belum tercatat berangkat', p_nomor_dada;
+  end if;
+
+  insert into closing_regu (regu_id, jam_datang, anggota_hadir, recorded_by, note)
+  values (v_regu.id, p_jam_datang, p_anggota_hadir, auth.uid(), p_catatan)
+  on conflict (regu_id) do update set
+    jam_datang    = excluded.jam_datang,
+    anggota_hadir = excluded.anggota_hadir,
+    recorded_by  = excluded.recorded_by,
+    recorded_at  = now(),
+    note       = excluded.note
+  -- Simpan ulang tanpa perubahan tidak menulis (kepengarangan & riwayat).
+  where closing_regu.jam_datang    is distinct from excluded.jam_datang
+     or closing_regu.anggota_hadir is distinct from excluded.anggota_hadir
+     or closing_regu.note       is distinct from excluded.note;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function ceklis_berangkat(p_nomor_dada integer)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  select id into v_id from regu where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal / batal', p_nomor_dada;
+  end if;
+  -- Ceklis MENYUSUL (kloter sudah berangkat) wajib berkontrak dulu — tanpa
+  -- ini regu lolos penalti waktu selamanya (temuan review, blocker).
+  if exists (
+       select 1 from regu r
+       join kloter k on k.nomor = r.kloter_nomor
+       where r.id = v_id and k.jam_berangkat is not null
+         and r.kontrak_menit is null) then
+    raise exception 'kloter sudah berangkat dan regu belum berkontrak — konfirmasi kontrak dulu (admin)';
+  end if;
+  insert into keberangkatan_regu (regu_id, recorded_by)
+  values (v_id, auth.uid())
+  on conflict (regu_id) do nothing;
+end;
+$$;
+
+-- terbaru dari 0004_rpcs.sql
+create or replace function susun_barak()
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_b   record;
+  v_r   record;
+  v_sisa integer;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+
+  delete from penempatan_barak;
+
+  -- Kebutuhan per batch: regu aktif x 5 + pendamping, terbesar dulu.
+  for v_b in
+    select d.id, (count(r.id) filter (where not r.is_cancelled)) * 5
+           + d.jumlah_pendamping as butuh
+    from pendaftaran d
+    join regu r on r.pendaftaran_id = d.id
+    where d.butuh_barak and d.status = 'lunas'
+    group by d.id, d.jumlah_pendamping
+    having (count(r.id) filter (where not r.is_cancelled)) > 0
+    order by butuh desc
+  loop
+    v_sisa := v_b.butuh;
+
+    -- Urutan prioritas per sisa (temuan review: "pas-dulu" yang lama justru
+    -- memecah sekolah yang sebenarnya muat satu ruangan):
+    --   1) ruangan KOSONG terkecil yang MUAT seluruh sisa  -> 1 sekolah 1 ruangan
+    --   2) ruangan KOSONG terbesar                          -> pecah seminimal mungkin
+    --   3) sisa ruangan BERPENGHUNI terkecil yang muat      -> gabung, terpaksa
+    --   4) sisa ruangan BERPENGHUNI terbesar                -> gabung + pecah
+    while v_sisa > 0 loop
+      select * into v_r from (
+        select ru.id,
+               ru.capacity - coalesce((select sum(p.jumlah_orang)
+                 from penempatan_barak p where p.room_id = ru.id), 0) as longgar,
+               not exists (select 1 from penempatan_barak p
+                           where p.room_id = ru.id) as kosong
+        from room ru
+      ) x
+      where x.longgar > 0
+      order by
+        case
+          when x.kosong and x.longgar >= v_sisa then 1
+          when x.kosong                          then 2
+          when x.longgar >= v_sisa               then 3
+          else 4
+        end,
+        case when x.longgar >= v_sisa then x.longgar end asc,   -- paling pas
+        x.longgar desc                                          -- paling lapang
+      limit 1;
+
+      if v_r.id is null then
+        raise exception 'kapasitas barak kurang % orang untuk batch % — tambah ruangan',
+          v_sisa, v_b.id;
+      end if;
+
+      insert into penempatan_barak (pendaftaran_id, room_id, jumlah_orang)
+      values (v_b.id, v_r.id, least(v_sisa, v_r.longgar));
+      v_sisa := v_sisa - least(v_sisa, v_r.longgar);
+      v_r := null;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- terbaru dari 0008_cetak_kloter.sql
+create or replace function tandai_kloter_dicetak(p_kloter smallint[] default null)
+returns integer
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_jumlah integer;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+
+  update kloter k
+  set dicetak_pada = now()
+  where k.dicetak_pada is null
+    and (p_kloter is null or k.nomor = any (p_kloter))
+    and exists (select 1 from regu r
+                join pendaftaran d on d.id = r.pendaftaran_id
+                where r.kloter_nomor = k.nomor and not r.is_cancelled
+                  and d.status = 'lunas');
+  get diagnostics v_jumlah = row_count;
+  return v_jumlah;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function batalkan_tanda_cetak(p_kloter smallint, p_alasan text)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if peran() <> 'admin' then
+    raise exception 'hanya admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan wajib diisi';
+  end if;
+  insert into history (table_name, row_id, action, new_value, changed_by)
+  values ('kloter', p_kloter::text, 'UPDATE',
+          jsonb_build_object('alasan_batal_tanda_cetak', p_alasan), auth.uid());
+  update kloter set dicetak_pada = null where nomor = p_kloter;
+end;
+$$;
+
+-- terbaru dari 0012_rename_audit_columns.sql
+create or replace function pindah_kloter(
+  p_nomor_dada integer,
+  p_alasan     text,
+  p_kloter     smallint default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu    regu%rowtype;
+  v_cfg     edisi%rowtype;
+  v_tujuan  smallint;
+  v_isi     int;
+  v_tercetak boolean;
+  v_lama    smallint;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan pemindahan wajib diisi — tercatat di riwayat';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+
+  -- Serialisasi bersama daftar ulang: keduanya menyentuh isi kloter.
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  select * into v_regu from regu where nomor_dada = p_nomor_dada for update;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+  if v_regu.is_cancelled then
+    raise exception 'regu % berstatus batal', p_nomor_dada;
+  end if;
+  v_lama := v_regu.kloter_nomor;
+
+  if v_lama is not null
+     and exists (select 1 from kloter where nomor = v_lama and jam_berangkat is not null) then
+    raise exception 'regu % sudah diberangkatkan di kloter % — tidak bisa dipindah',
+      p_nomor_dada, v_lama;
+  end if;
+
+  if p_kloter is null then
+    -- TELAT BIASA: kloter terakhir yang belum berangkat dan masih muat.
+    select k.nomor into v_tujuan
+    from kloter k
+    where k.jam_berangkat is null
+      and k.nomor <= v_cfg.kloter_maks
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor desc
+    limit 1;
+    if v_tujuan is null then
+      raise exception 'tidak ada kloter tersisa yang belum berangkat dan masih muat';
+    end if;
+  else
+    -- URGENT: kloter yang disebut panitia, apa pun keadaannya.
+    v_tujuan := p_kloter;
+    if not exists (select 1 from kloter where nomor = v_tujuan) then
+      raise exception 'kloter % tidak ada', v_tujuan;
+    end if;
+    if exists (select 1 from kloter where nomor = v_tujuan and jam_berangkat is not null) then
+      raise exception 'kloter % sudah berangkat', v_tujuan;
+    end if;
+  end if;
+
+  if v_tujuan = v_lama then
+    raise exception 'regu % sudah ada di kloter %', p_nomor_dada, v_tujuan;
+  end if;
+
+  -- Kapasitas tetap dijaga: kertas boleh dilanggar, kapasitas fisik tidak.
+  select count(*) into v_isi from regu where kloter_nomor = v_tujuan;
+  if v_isi >= v_cfg.maks_regu_per_kloter then
+    raise exception 'kloter % sudah penuh (% regu)', v_tujuan, v_isi;
+  end if;
+
+  select dicetak_pada is not null into v_tercetak from kloter where nomor = v_tujuan;
+
+  -- Buka pintu untuk trigger 0008, hanya di dalam transaksi ini.
+  perform set_config('hrcd.izin_pindah', '1', true);
+
+  update regu set
+    kloter_nomor  = v_tujuan,
+    urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                     where not exists (select 1 from regu x
+                                       where x.kloter_nomor = v_tujuan
+                                         and x.urutan_kloter = s)),
+    -- Ditandai sisipan HANYA bila kertas tujuan sudah beredar.
+    disisipkan_pada = case when v_tercetak then now() else disisipkan_pada end,
+    alasan_sisip    = case when v_tercetak then p_alasan else alasan_sisip end
+  where id = v_regu.id;
+
+  perform set_config('hrcd.izin_pindah', '0', true);
+
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('regu', v_regu.id::text, v_regu.id, 'UPDATE',
+          jsonb_build_object('pindah_kloter', jsonb_build_object(
+            'nomor_dada', p_nomor_dada, 'dari', v_lama, 'ke', v_tujuan,
+            'alasan', p_alasan, 'kloter_tujuan_sudah_dicetak', v_tercetak)),
+          auth.uid());
+
+  return jsonb_build_object(
+    'nomor_dada', p_nomor_dada,
+    'kloter_lama', v_lama,
+    'kloter_baru', v_tujuan,
+    'sisipan', v_tercetak,
+    'peringatan', case when v_tercetak
+      then format('Nomor %s TIDAK ADA di kertas kloter %s. Beri tahu petugas staging.',
+                  p_nomor_dada, v_tujuan)
+      end);
+end;
+$$;
+
+-- 4. Hak akses submit_pendaftaran ikut dipasang ulang: fungsi yang dibuat
+--    ulang lahir dengan EXECUTE ke PUBLIC (default PostgreSQL), yang berarti
+--    akun panitia mana pun bisa melewati gerbang Worker + Turnstile.
+revoke execute on function
+  submit_pendaftaran(text, text, boolean, text, jsonb, smallint, uuid, text)
+  from public, anon, authenticated;
+grant execute on function
+  submit_pendaftaran(text, text, boolean, text, jsonb, smallint, uuid, text)
+  to service_role;

--- a/supabase/migrations/0014_rename_common_columns.sql
+++ b/supabase/migrations/0014_rename_common_columns.sql
@@ -45,6 +45,13 @@ alter table akun_panitia rename column aktif to is_active;
 -- 2. Tabel ruangan -> room ---------------------------------------------
 alter table ruangan rename to room;
 
+-- View menyimpan nama kolom OUTPUT-nya sendiri; rename di tabel sumber tidak
+-- ikut mengubahnya. v_edisi_publik satu-satunya view yang mengekspos nama
+-- generik apa adanya (yang lain sudah beralias domain: nama_regu, nama_sekolah).
+alter view v_edisi_publik rename column nama to name;
+alter view v_barak rename column ruangan to room;
+alter view v_barak rename column kapasitas to capacity;
+
 -- 3. Fungsi yang body-nya menyebut kolom di atas -----------------------
 
 -- terbaru dari 0002_functions.sql

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,12 +4,12 @@
 -- wajib: status_acara, kloter 1-40, stok nomor dada 1-500.
 -- ============================================================================
 
-insert into edisi (nomor, nama, tahun, tanggal_lomba, biaya_per_regu,
+insert into edisi (nomor, name, tahun, tanggal_lomba, biaya_per_regu,
                    maks_regu_per_kloter, kloter_dasar, kloter_maks,
-                   lompatan_kloter, interval_berangkat_menit, aktif)
+                   lompatan_kloter, interval_berangkat_menit, is_active)
 values (37, 'HRCD 37', 2027, date '2027-02-21', 250000, 10, 30, 40, 2, 4, true);
 
-insert into pos (edisi, nomor, nama, bobot) values
+insert into pos (edisi, nomor, name, bobot) values
   (37, 1, 'Pos 1', 1.00),
   (37, 2, 'Pos 2', 1.00),
   (37, 3, 'Pos 3', 1.00),
@@ -18,9 +18,9 @@ insert into pos (edisi, nomor, nama, bobot) values
 
 -- Satu contoh per bentuk konversi — angka persis dari rancangan-b.md supaya
 -- tes bisa mencocokkan hasil hitung dengan dokumen.
-insert into wahana (edisi, pos, kode, nama, jenis, bentuk, poin_maks,
+insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
                     raw_terbaik, raw_terburuk, poin_benar, poin_salah,
-                    total_soal, rentang_mentah_min, rentang_mentah_maks, urutan)
+                    total_soal, rentang_mentah_min, rentang_mentah_maks, sort_order)
 values
   -- raw 40 detik => 100 * (90-40)/(90-20) = 71.43
   (37, 1, 'lari_zigzag',  'Lari Zig-zag',        'wahana', 'kecil_baik', 100,
@@ -38,7 +38,7 @@ values
   (37, 5, 'sandi_morse',   'Sandi Morse',        'soal',   'benar_kurang_salah', 100,
    null, null, 10, -5, null, 0, 20, 1);
 
-insert into kontrak_opsi (edisi, label, menit, urutan) values
+insert into kontrak_opsi (edisi, label, menit, sort_order) values
   (37, '3,5 jam', 210, 1),
   (37, '4 jam',   240, 2),
   (37, '4,5 jam', 270, 3);

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -83,7 +83,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         try:
             if u.path == "/sekolah":
                 self._kirim(200, q(
-                    "select id, nama, alamat from sekolah order by nama",
+                    "select id, name, address from sekolah order by name",
                     role="anon"))
             elif u.path == "/edisi":
                 self._kirim(200, q(
@@ -117,16 +117,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
                            d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
                            d.created_at,
-                           jsonb_build_object('nama', s.nama, 'alamat', s.alamat) as sekolah,
+                           jsonb_build_object('name', s.name, 'address', s.address) as sekolah,
                            (select jsonb_agg(jsonb_build_object(
                               'id', r.id, 'nama_regu', r.nama_regu,
                               'nama_ketua', r.nama_ketua, 'golongan', r.golongan,
                               'nomor_dada', r.nomor_dada, 'kloter_nomor', r.kloter_nomor,
-                              'batal', r.batal)
+                              'is_cancelled', r.is_cancelled)
                               order by r.nama_regu)
                             from regu r where r.pendaftaran_id = d.id) as regu,
                            (select jsonb_build_object(
-                              'nominal', b.nominal, 'metode', b.metode,
+                              'amount', b.amount, 'method', b.method,
                               'nomor_kwitansi', b.nomor_kwitansi,
                               'verified_at', b.verified_at)
                             from pembayaran b where b.pendaftaran_id = d.id) as pembayaran
@@ -144,22 +144,22 @@ class Handler(http.server.BaseHTTPRequestHandler):
                       (select count(distinct d.id) from pendaftaran d
                        join regu r on r.pendaftaran_id = d.id
                        where d.status = 'lunas' and r.nomor_dada is null
-                         and not r.batal)::int as lunas_belum_nomor
+                         and not r.is_cancelled)::int as lunas_belum_nomor
                     """, uid=p.get("uid"), fetch="one"))
             elif u.path == "/batch":
                 b = q("""
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
                            d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
-                           jsonb_build_object('nama', s.nama, 'alamat', s.alamat) as sekolah,
+                           jsonb_build_object('name', s.name, 'address', s.address) as sekolah,
                            (select jsonb_agg(jsonb_build_object(
                               'id', r.id, 'nama_regu', r.nama_regu,
                               'nama_ketua', r.nama_ketua, 'golongan', r.golongan,
                               'nomor_dada', r.nomor_dada, 'kloter_nomor', r.kloter_nomor,
-                              'batal', r.batal)
+                              'is_cancelled', r.is_cancelled)
                               order by r.nama_regu)
                             from regu r where r.pendaftaran_id = d.id) as regu,
                            (select jsonb_build_object(
-                              'nominal', b.nominal, 'metode', b.metode,
+                              'amount', b.amount, 'method', b.method,
                               'nomor_kwitansi', b.nomor_kwitansi,
                               'verified_at', b.verified_at)
                             from pembayaran b where b.pendaftaran_id = d.id) as pembayaran
@@ -184,7 +184,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 b = self._badan()
                 akun = q(
                     "select user_id::text as uid, username, peran, pos "
-                    "from akun_panitia where username = %s and aktif",
+                    "from akun_panitia where username = %s and is_active",
                     (b.get("username", ""),), role="service_role", fetch="one")
                 # Dev server: password apa pun diterima — auth sungguhan milik
                 # Supabase; yang diuji di sini adalah alur & RLS.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -36,6 +36,7 @@ run supabase/migrations/0010_lookup_finish.sql
 run supabase/migrations/0011_nomor_dada_manual.sql
 run supabase/migrations/0012_rename_audit_columns.sql
 run supabase/migrations/0013_nama_kontak.sql
+run supabase/migrations/0014_rename_common_columns.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql

--- a/tests/sql/01_seed_uji.sql
+++ b/tests/sql/01_seed_uji.sql
@@ -11,7 +11,7 @@ insert into auth.users (id, email) values
   ('00000000-0000-0000-0000-0000000000b2', 'meja2hrcd37@uji.local'),
   ('00000000-0000-0000-0000-0000000000ff', 'nonaktif@uji.local');
 
-insert into akun_panitia (user_id, username, peran, pos, aktif) values
+insert into akun_panitia (user_id, username, peran, pos, is_active) values
   ('00000000-0000-0000-0000-00000000000a', 'admin.ciradyka', 'admin',        null, true),
   ('00000000-0000-0000-0000-000000000001', 'pos1hrcd37',     'operator_pos', 1,    true),
   ('00000000-0000-0000-0000-000000000002', 'pos2hrcd37',     'operator_pos', 2,    true),
@@ -33,7 +33,7 @@ create function uji_dada(p_kode text) returns jsonb language sql as $$
     select r.id, row_number() over (order by r.nama_regu, r.id) as urut
     from regu r
     join pendaftaran d on d.id = r.pendaftaran_id
-    where d.kode_pembayaran = p_kode and not r.batal and r.nomor_dada is null
+    where d.kode_pembayaran = p_kode and not r.is_cancelled and r.nomor_dada is null
   ),
   tersedia as (
     select s.nomor, row_number() over (order by s.nomor) as urut

--- a/tests/sql/02_constraints.sql
+++ b/tests/sql/02_constraints.sql
@@ -12,7 +12,7 @@ do $$
 declare
   v_batch uuid; v_r1 uuid; v_r2 uuid;
 begin
-  insert into sekolah (nama, alamat) values ('SMP Uji Constraint', 'Jl. Uji 1')
+  insert into sekolah (name, address) values ('SMP Uji Constraint', 'Jl. Uji 1')
   returning id into strict v_batch;  -- dipakai ulang sbg penampung sementara
   insert into pendaftaran (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa)
   values (v_batch, 'UJI-DUP', 2, '0812xxxx') returning id into strict v_batch;
@@ -70,7 +70,7 @@ $$;
 do $$
 begin
   begin
-    insert into wahana (edisi, pos, kode, nama, jenis, bentuk, poin_maks,
+    insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
                         rentang_mentah_min, rentang_mentah_maks)
     values (37, 1, 'salah_param', 'Tanpa Raw', 'wahana', 'kecil_baik', 100, 0, 10);
     raise exception 'GAGAL: kecil_baik tanpa raw_terbaik/terburuk diterima';
@@ -78,7 +78,7 @@ begin
   end;
 
   begin
-    insert into wahana (edisi, pos, kode, nama, jenis, bentuk, poin_maks,
+    insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
                         poin_benar, poin_salah, rentang_mentah_min, rentang_mentah_maks)
     values (37, 1, 'Kode Spasi!', 'Kode Jelek', 'wahana', 'biner', 10, 10, 0, 0, 1);
     raise exception 'GAGAL: kode berspasi diterima';
@@ -91,7 +91,7 @@ $$;
 do $$
 begin
   begin
-    insert into edisi (nomor, nama, tahun, tanggal_lomba, biaya_per_regu, aktif)
+    insert into edisi (nomor, name, tahun, tanggal_lomba, biaya_per_regu, is_active)
     values (38, 'HRCD 38', 2028, date '2028-02-20', 275000, true);
     raise exception 'GAGAL: dua edisi aktif diterima';
   exception when unique_violation then null;
@@ -131,6 +131,6 @@ $$;
 -- Bersihkan artefak tes constraint.
 delete from regu where nama_regu like 'Uji %';
 delete from pendaftaran where kode_pembayaran = 'UJI-DUP';
-delete from sekolah where nama = 'SMP Uji Constraint';
+delete from sekolah where name = 'SMP Uji Constraint';
 
 \echo '== 02: OK =='

--- a/tests/sql/03_alur.sql
+++ b/tests/sql/03_alur.sql
@@ -352,7 +352,7 @@ begin
 
   -- Tembak tabel langsung: kini tertutup untuk SEMUA non-admin.
   begin
-    insert into nilai_mentah (regu_id, wahana_id, nilai_1, sumber, created_by)
+    insert into nilai_mentah (regu_id, wahana_id, nilai_1, source, created_by)
     values ((select id from regu where nomor_dada = 1),
             (select id from wahana where kode = 'lari_zigzag'),
             3, 'manual', auth.uid());
@@ -498,12 +498,12 @@ $$;
 do $$
 begin
   perform ubah_pendamping(uji('B'), 2::smallint);
-  insert into ruangan (nama, kapasitas) values ('Kelas X-A', 50), ('Kelas X-B', 40);
+  insert into room (name, capacity) values ('Kelas X-A', 50), ('Kelas X-B', 40);
   perform susun_barak();
 
   assert (select sum(jumlah_orang) from penempatan_barak) = 87,
          'total penempatan barak bukan 87';
-  assert not exists (select 1 from v_barak where terisi > kapasitas),
+  assert not exists (select 1 from v_barak where terisi > capacity),
          'ada ruangan kelebihan muatan';
   -- A (60 orang): tidak ada ruangan tunggal yang muat -> pecah 50 + 10.
   assert (select count(*) from penempatan_barak p

--- a/tests/sql/04_cetak_kloter.sql
+++ b/tests/sql/04_cetak_kloter.sql
@@ -15,7 +15,7 @@ declare v_ditandai int; v_berisi int;
 begin
   select count(distinct r.kloter_nomor) into v_berisi
   from regu r join pendaftaran d on d.id = r.pendaftaran_id
-  where r.kloter_nomor is not null and not r.batal and d.status = 'lunas';
+  where r.kloter_nomor is not null and not r.is_cancelled and d.status = 'lunas';
 
   v_ditandai := tandai_kloter_dicetak();
   assert v_ditandai = v_berisi,
@@ -56,7 +56,7 @@ declare
   v_n        int;
 begin
   select nomor into v_tercetak from kloter where dicetak_pada is not null limit 1;
-  select id into v_regu from regu where kloter_nomor is null and not batal limit 1;
+  select id into v_regu from regu where kloter_nomor is null and not is_cancelled limit 1;
   assert v_tercetak is not null, 'tidak ada kloter tercetak untuk diuji';
   assert v_regu is not null, 'tidak ada regu tanpa kloter untuk diuji';
 
@@ -77,7 +77,7 @@ declare
   v_regu     uuid;
 begin
   select nomor into v_tercetak from kloter where dicetak_pada is not null limit 1;
-  select id into v_regu from regu where kloter_nomor is null and not batal limit 1;
+  select id into v_regu from regu where kloter_nomor is null and not is_cancelled limit 1;
 
   -- Menyisipkan regu baru ke kloter tercetak.
   begin
@@ -109,7 +109,7 @@ declare
   v_biaya integer;
 begin
   reset role;
-  select biaya_per_regu into v_biaya from edisi where aktif;
+  select biaya_per_regu into v_biaya from edisi where is_active;
   set role service_role;
   v_kode := (submit_pendaftaran('SMP Susulan Cetak', 'Jl. Susulan 1', false,
     '081277778888',

--- a/tests/sql/05_pindah_kloter.sql
+++ b/tests/sql/05_pindah_kloter.sql
@@ -16,7 +16,7 @@ do $$
 declare
   v_k1 timestamptz; v_k3 timestamptz; v_interval int;
 begin
-  select interval_berangkat_menit into v_interval from edisi where aktif;
+  select interval_berangkat_menit into v_interval from edisi where is_active;
   select min(perkiraan_berangkat) into v_k1 from v_daftar_kloter where kloter = 1;
   select min(perkiraan_berangkat) into v_k3 from v_daftar_kloter where kloter = 3;
   assert v_k1 is not null, 'perkiraan berangkat kloter 1 kosong';
@@ -52,14 +52,14 @@ begin
   -- Regu yang kloternya belum berangkat.
   select r.nomor_dada into v_dada
   from regu r join kloter k on k.nomor = r.kloter_nomor
-  where k.jam_berangkat is null and not r.batal
+  where k.jam_berangkat is null and not r.is_cancelled
   order by r.nomor_dada limit 1;
 
   select max(k.nomor) into v_terakhir
   from kloter k
   where k.jam_berangkat is null
     and (select count(*) from regu r where r.kloter_nomor = k.nomor)
-        < (select maks_regu_per_kloter from edisi where aktif);
+        < (select maks_regu_per_kloter from edisi where is_active);
 
   v_hasil := pindah_kloter(v_dada, 'terlambat masuk kloter');
   assert (v_hasil ->> 'kloter_baru')::smallint = v_terakhir,
@@ -80,13 +80,13 @@ begin
   from kloter k
   where k.dicetak_pada is not null and k.jam_berangkat is null
     and (select count(*) from regu r where r.kloter_nomor = k.nomor)
-        < (select maks_regu_per_kloter from edisi where aktif)
+        < (select maks_regu_per_kloter from edisi where is_active)
   limit 1;
   assert v_tercetak is not null, 'tidak ada kloter tercetak yang masih muat untuk diuji';
 
   select r.nomor_dada into v_dada
   from regu r join kloter k on k.nomor = r.kloter_nomor
-  where k.jam_berangkat is null and r.kloter_nomor <> v_tercetak and not r.batal
+  where k.jam_berangkat is null and r.kloter_nomor <> v_tercetak and not r.is_cancelled
   order by r.nomor_dada desc limit 1;
 
   v_hasil := pindah_kloter(v_dada, 'peserta urgent, harus berangkat sekarang', v_tercetak);
@@ -133,13 +133,13 @@ begin
   from kloter k
   where k.dicetak_pada is null and k.jam_berangkat is null
     and (select count(*) from regu r where r.kloter_nomor = k.nomor)
-        < (select maks_regu_per_kloter from edisi where aktif)
+        < (select maks_regu_per_kloter from edisi where is_active)
   limit 1;
 
   select r.nomor_dada into v_dada
   from regu r join kloter k on k.nomor = r.kloter_nomor
   where k.jam_berangkat is null and r.disisipkan_pada is null
-    and r.kloter_nomor <> v_belum and not r.batal
+    and r.kloter_nomor <> v_belum and not r.is_cancelled
   order by r.nomor_dada limit 1;
 
   if v_dada is not null and v_belum is not null then
@@ -160,7 +160,7 @@ begin
   -- Berangkatkan satu kloter untuk diuji.
   select k.nomor into v_kloter from kloter k
   where k.jam_berangkat is null
-    and exists (select 1 from regu r where r.kloter_nomor = k.nomor and not r.batal)
+    and exists (select 1 from regu r where r.kloter_nomor = k.nomor and not r.is_cancelled)
   order by k.nomor limit 1;
 
   -- Semua regu di kloter itu perlu kontrak sebelum boleh berangkat.
@@ -171,7 +171,7 @@ begin
   perform berangkatkan_kloter(v_kloter, now());
 
   select r.nomor_dada into v_dada from regu r join kloter k on k.nomor = r.kloter_nomor
-  where k.jam_berangkat is null and not r.batal limit 1;
+  where k.jam_berangkat is null and not r.is_cancelled limit 1;
 
   begin
     perform pindah_kloter(v_dada, 'coba tembus', v_kloter);

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -160,9 +160,9 @@ export async function masuk(username, password) {
       body: JSON.stringify({ email, password }),
     });
     const akun = await kirim(
-      `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,aktif`,
+      `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,
       { headers: { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` } });
-    if (!akun.length || !akun[0].aktif)
+    if (!akun.length || !akun[0].is_active)
       throw new ErrorApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
     s = {
       uid: j.user.id, token: j.access_token, refresh: j.refresh_token,
@@ -199,7 +199,7 @@ export async function gantiPasswordSendiri(passwordBaru) {
 export async function daftarSekolah() {
   // Dimuat SEKALI saat halaman dibuka, difilter di browser.
   if (K.mode === "dev") return baca("/sekolah");
-  return kirim(`${K.supabaseUrl}/rest/v1/sekolah?select=id,nama,alamat&order=nama`, {
+  return kirim(`${K.supabaseUrl}/rest/v1/sekolah?select=id,name,address&order=name`, {
     headers: { apikey: K.anonKey, Authorization: `Bearer ${K.anonKey}` },
   });
 }
@@ -237,9 +237,9 @@ export async function lihatBatch(kode) {
   const d = await baca(null,
     `pendaftaran?kode_pembayaran=eq.${encodeURIComponent(kode)}` +
     `&select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping,butuh_barak,kontak_wa,` +
-    `sekolah(nama,alamat),` +
-    `regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,batal),` +
-    `pembayaran(nominal,metode,nomor_kwitansi,verified_at)` +
+    `sekolah(name,address),` +
+    `regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled),` +
+    `pembayaran(amount,method,nomor_kwitansi,verified_at)` +
     `&regu.order=nama_regu.asc`);
   if (!d.length)
     throw new ErrorApi(`Kode ${kode} tidak ditemukan. Periksa lagi hurufnya.`);
@@ -271,9 +271,9 @@ export async function daftarPendaftaran() {
   return baca(null,
     "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping," +
     "butuh_barak,kontak_wa,created_at," +
-    "sekolah(nama,alamat)," +
-    "regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,batal)," +
-    "pembayaran(nominal,metode,nomor_kwitansi,verified_at)" +
+    "sekolah(name,address)," +
+    "regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled)," +
+    "pembayaran(amount,method,nomor_kwitansi,verified_at)" +
     "&regu.order=nama_regu.asc&order=created_at.asc");
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -37,7 +37,7 @@ function pasangKepala(judul, lebar = false) {
   document.getElementById("judul-layar").textContent = judul;
   LAYAR.classList.toggle("wide", lebar);
   if (s) document.getElementById("siapa").textContent =
-    `${s.username} · ${EDISI ? EDISI.nama : ""}`;
+    `${s.username} · ${EDISI ? EDISI.name : ""}`;
 }
 
 /** Jam sekarang dalam bentuk HH:MM untuk <input type="time">. */
@@ -283,10 +283,10 @@ function pasangAlatTabel(gambar) {
  *  bukan kodenya. */
 const cocokCari = (b, cari) => !cari
   || b.kode_pembayaran.toLowerCase().includes(cari)
-  || (b.sekolah?.nama || "").toLowerCase().includes(cari)
+  || (b.sekolah?.name || "").toLowerCase().includes(cari)
   || (b.regu || []).some(r => (r.nama_regu || "").toLowerCase().includes(cari));
 
-const reguAktif = (b) => (b.regu || []).filter(r => !r.batal);
+const reguAktif = (b) => (b.regu || []).filter(r => !r.is_cancelled);
 
 /* ============================ MEJA PEMBAYARAN ============================ */
 
@@ -386,7 +386,7 @@ async function layarPembayaran() {
       // baris detail yang dibuka lewat tombol "N regu" — itu yang dibacakan
       // saat sekolah menyerahkan uang, dan itu juga yang dicetak di kwitansi.
       const kode = esc(b.kode_pembayaran);
-      const sekolah = esc(b.sekolah?.nama || "—");
+      const sekolah = esc(b.sekolah?.name || "—");
       const terbuka = dibuka.has(b.kode_pembayaran);
 
       // Template biasa, BUKAN tag html`` — aksi sudah berupa HTML jadi tidak
@@ -456,7 +456,7 @@ async function layarPembayaran() {
         const jawab = await dialog({
           judul: "Batalkan verifikasi pembayaran",
           kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
-            <div class="nama">${b.sekolah?.nama || kode}</div>
+            <div class="nama">${b.sekolah?.name || kode}</div>
             <div class="detail">${kode} · kwitansi ${b.pembayaran?.nomor_kwitansi || "—"}</div>
           </div>`,
           medan: [{ label: "Alasan pembatalan", contoh: "salah klik" }],
@@ -494,7 +494,7 @@ async function layarPembayaran() {
         // Sumber data lokal ikut diperbarui supaya saringan & baris lain
         // tetap konsisten tanpa memuat ulang seluruh tabel.
         tandaiLunasLokal(b, tagihan, metode, r.nomor_kwitansi);
-        notif(`${b.sekolah?.nama || kode} LUNAS — kwitansi ${r.nomor_kwitansi}`);
+        notif(`${b.sekolah?.name || kode} LUNAS — kwitansi ${r.nomor_kwitansi}`);
         gambarUlang();
 
         // Panel sukses langsung menawarkan cetak (rancangan-b.md 10.2) —
@@ -504,7 +504,7 @@ async function layarPembayaran() {
           judul: "Lunas — cetak kwitansi?",
           kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
             <div class="nama">${r.nomor_kwitansi}</div>
-            <div class="detail">${b.sekolah?.nama || kode} · ${kode} ·
+            <div class="detail">${b.sekolah?.name || kode} · ${kode} ·
               ${aktif.length} regu · ${rupiah(tagihan)}</div>
           </div>`,
           labelAksi: "Cetak Kwitansi",
@@ -525,7 +525,7 @@ function tandaiLunasLokal(b, nominal, metode, nomorKwitansi) {
     verified_at: new Date().toISOString(),
   };
   catatTerakhir("pembayaran", b.kode_pembayaran,
-    `${b.sekolah?.nama || ""} — lunas, ${nomorKwitansi}`);
+    `${b.sekolah?.name || ""} — lunas, ${nomorKwitansi}`);
 }
 
 /** Kwitansi siap cetak — satu invoice satu lembar, dengan rincian regu yang
@@ -542,7 +542,7 @@ function cetakKwitansi(daftar) {
   const halaman = daftar.map(b => {
     const aktif = reguAktif(b);
     const bayar = b.pembayaran || {};
-    const total = bayar.nominal ?? aktif.length * EDISI.biaya_per_regu;
+    const total = bayar.amount ?? aktif.length * EDISI.biaya_per_regu;
     const baris = aktif.map((r, i) => html`
       <tr><td>${String(i + 1)}</td>
           <td>${r.nama_regu}</td>
@@ -552,11 +552,11 @@ function cetakKwitansi(daftar) {
 
     return `
       <section class="print-page">
-        <h1>KWITANSI — ${esc(EDISI ? EDISI.nama : "")}</h1>
+        <h1>KWITANSI — ${esc(EDISI ? EDISI.name : "")}</h1>
         <p class="receipt-number">${esc(bayar.nomor_kwitansi || "—")}</p>
-        <p><strong>Diterima dari:</strong> ${esc(b.sekolah?.nama || "—")}</p>
+        <p><strong>Diterima dari:</strong> ${esc(b.sekolah?.name || "—")}</p>
         <p><strong>Kode pembayaran:</strong> ${esc(b.kode_pembayaran)}
-           · <strong>Cara bayar:</strong> ${esc(bayar.metode || "—")}
+           · <strong>Cara bayar:</strong> ${esc(bayar.method || "—")}
            · <strong>Tanggal:</strong> ${esc(tanggal(bayar.verified_at))}</p>
         <p><strong>Untuk pembayaran:</strong> pendaftaran ${aktif.length} regu
            @ ${esc(rupiah(EDISI.biaya_per_regu))}</p>
@@ -680,7 +680,7 @@ async function layarDaftarUlang() {
         <tr data-baris="${kode}">
           <td class="mono">${kode}</td>
           <td>
-            <strong>${esc(b.sekolah?.nama || "—")}</strong>
+            <strong>${esc(b.sekolah?.name || "—")}</strong>
             <div class="sub">${esc(aktif.map(r => r.nama_regu).join(", "))}</div>
           </td>
           <td class="text-center">${aktif.length}</td>
@@ -838,7 +838,7 @@ async function layarDaftarUlang() {
         catatTerakhir("daftar-ulang", kode, hasil.map(x =>
           `${x.nama_regu} ${String(x.nomor_dada).padStart(3, "0")}`).join(", "));
         const kloter = [...new Set(hasil.map(x => x.kloter))].sort((x, y) => x - y).join(", ");
-        notif(`${b.sekolah?.nama || kode}: ${hasil.length} regu tersimpan — kloter ${kloter}.`);
+        notif(`${b.sekolah?.name || kode}: ${hasil.length} regu tersimpan — kloter ${kloter}.`);
         gambar(cari, saring);
       }));
   };
@@ -1180,7 +1180,7 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
 
     return bentuk === "staging" ? `
       <section class="print-page">
-        <h1>KLOTER ${esc(nomor)} — ${esc(EDISI ? EDISI.nama : "")}</h1>
+        <h1>KLOTER ${esc(nomor)} — ${esc(EDISI ? EDISI.name : "")}</h1>
         <p><strong>${nyata ? "Berangkat" : "Perkiraan berangkat"}: ${esc(perkiraan)}</strong>
            ${nyata ? "" : " · Jam sebenarnya: ________"} · Petugas: ________________</p>
         <table class="print-table">

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -202,12 +202,12 @@ function gambarSekolah() {
   cari.addEventListener("input", () => {
     const q = normal(cari.value.trim());
     if (q.length < 2) { saran.hidden = true; return; }
-    const cocok = SEKOLAH.filter(s => normal(s.nama).includes(q)).slice(0, 6);
+    const cocok = SEKOLAH.filter(s => normal(s.name).includes(q)).slice(0, 6);
     saran.hidden = cocok.length === 0;
     saran.replaceChildren(...cocok.map(s => {
       const b = document.createElement("button");
       b.type = "button";
-      b.innerHTML = html`<strong>${s.nama}</strong><span class="alamat">${s.alamat}</span>`;
+      b.innerHTML = html`<strong>${s.name}</strong><span class="alamat">${s.address}</span>`;
       b.addEventListener("click", () => pilih(s));
       return b;
     }));
@@ -216,7 +216,7 @@ function gambarSekolah() {
   cari.addEventListener("blur", () => setTimeout(() => { saran.hidden = true; }, 200));
 
   function pilih(s) {
-    jawab.sekolah = { id: s.id, nama: s.nama, alamat: s.alamat };
+    jawab.sekolah = { id: s.id, nama: s.name, alamat: s.address };
     simpanDraf(); gambarSekolah();
     if (sudahDiperiksa) periksa(false);
   }
@@ -226,7 +226,7 @@ function gambarSekolah() {
   function gambarManual() {
     const teks = cari.value.trim();
     if (teks.length < 3) { document.getElementById("manual").replaceChildren(); return; }
-    if (SEKOLAH.some(s => normal(s.nama) === normal(teks))) {
+    if (SEKOLAH.some(s => normal(s.name) === normal(teks))) {
       document.getElementById("manual").replaceChildren(); return;
     }
     if (document.getElementById("m-alamat")) return;    // sudah tergambar


### PR DESCRIPTION
Lanjutan #59. `aktif`→`is_active`, `nama`→`name`, `alamat`→`address`, `batal`→`is_cancelled`, `metode`→`method`, `nominal`→`amount`, `ruangan`→`room`, dll.

Domain tetap: regu, kloter, nomor_dada, golongan, sekolah, pembayaran, wahana, barak, kwitansi.

17 fungsi dibuat ulang dari definisi **terbaru** masing-masing. Penggantian **sadar konteks** — dilewati di komentar dan literal string, karena `'alasan'`/`'batal'` juga kunci JSON audit dan nilai status.

CI menangkap satu hal: view menyimpan nama kolom outputnya sendiri, jadi `v_barak` dan `v_edisi_publik` perlu `alter view ... rename column` terpisah.

Migrasi **sudah diterapkan ke Supabase**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)