### PR TITLE
fix: sisa rename di v_kwitansi + pemindai identifier lama

### DIFF
--- a/supabase/checks/stale_identifiers.sql
+++ b/supabase/checks/stale_identifiers.sql
@@ -1,15 +1,16 @@
--- Read-only. Cari SISA identifier lama di seluruh objek database live.
--- Body fungsi plpgsql disimpan sebagai TEKS: ia tidak ikut ter-rename, dan
--- kesalahannya baru muncul saat fungsinya dipanggil. Ini satu-satunya cara
--- membuktikan tidak ada yang terlewat.
-select p.proname as fungsi_bermasalah,
-       (select string_agg(distinct m[1], ', ')
-        from regexp_matches(pg_get_functiondef(p.oid),
-             '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id)\M',
-             'g') m) as identifier_lama
+-- Read-only. Cari SISA identifier lama di seluruh fungsi & view database live.
+-- Body fungsi plpgsql disimpan sebagai TEKS: ia tidak ikut ter-rename saat
+-- ALTER, dan kesalahannya baru muncul saat fungsinya DIPANGGIL di lapangan.
+-- Ini satu-satunya cara membuktikan tidak ada yang terlewat.
+select 'FUNGSI' as jenis, p.proname as nama_objek
 from pg_proc p
 join pg_namespace n on n.oid = p.pronamespace
 where n.nspname = 'public'
-  and pg_get_functiondef(p.oid) ~
-      '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id)\M'
-order by 1;
+  and pg_get_functiondef(p.oid) ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id|riwayat)\M'
+union all
+select 'VIEW', c.relname
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public' and c.relkind = 'v'
+  and pg_get_viewdef(c.oid) ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|kapasitas|ruangan_id)\M'
+order by 1, 2;

--- a/supabase/checks/stale_identifiers.sql
+++ b/supabase/checks/stale_identifiers.sql
@@ -6,6 +6,7 @@ select 'FUNGSI' as jenis, p.proname as nama_objek
 from pg_proc p
 join pg_namespace n on n.oid = p.pronamespace
 where n.nspname = 'public'
+  and p.prokind = 'f'   -- pg_get_functiondef() menolak agregat/window
   and pg_get_functiondef(p.oid) ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id|riwayat)\M'
 union all
 select 'VIEW', c.relname

--- a/supabase/checks/stale_identifiers.sql
+++ b/supabase/checks/stale_identifiers.sql
@@ -1,17 +1,17 @@
--- Read-only. Cari SISA identifier lama di seluruh fungsi & view database live.
--- Body fungsi plpgsql disimpan sebagai TEKS: ia tidak ikut ter-rename saat
--- ALTER, dan kesalahannya baru muncul saat fungsinya DIPANGGIL di lapangan.
--- Ini satu-satunya cara membuktikan tidak ada yang terlewat.
-select 'FUNGSI' as jenis, p.proname as nama_objek
+-- Read-only. Tunjukkan BARIS PERSIS yang memuat identifier lama, supaya
+-- komentar prosa Indonesia (tidak berbahaya) bisa dibedakan dari referensi
+-- kolom sungguhan (bug yang baru meledak saat fungsi dipanggil).
+select p.proname as objek, l.baris
 from pg_proc p
 join pg_namespace n on n.oid = p.pronamespace
-where n.nspname = 'public'
-  and p.prokind = 'f'   -- pg_get_functiondef() menolak agregat/window
-  and pg_get_functiondef(p.oid) ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id|riwayat)\M'
+cross join lateral unnest(string_to_array(pg_get_functiondef(p.oid), E'\n')) as l(baris)
+where n.nspname = 'public' and p.prokind = 'f'
+  and l.baris ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id|riwayat)\M'
 union all
-select 'VIEW', c.relname
+select c.relname, l.baris
 from pg_class c
 join pg_namespace n on n.oid = c.relnamespace
+cross join lateral unnest(string_to_array(pg_get_viewdef(c.oid), E'\n')) as l(baris)
 where n.nspname = 'public' and c.relkind = 'v'
-  and pg_get_viewdef(c.oid) ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|kapasitas|ruangan_id)\M'
-order by 1, 2;
+  and l.baris ~ '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|kapasitas|ruangan_id)\M'
+order by 1;

--- a/supabase/checks/stale_identifiers.sql
+++ b/supabase/checks/stale_identifiers.sql
@@ -1,0 +1,15 @@
+-- Read-only. Cari SISA identifier lama di seluruh objek database live.
+-- Body fungsi plpgsql disimpan sebagai TEKS: ia tidak ikut ter-rename, dan
+-- kesalahannya baru muncul saat fungsinya dipanggil. Ini satu-satunya cara
+-- membuktikan tidak ada yang terlewat.
+select p.proname as fungsi_bermasalah,
+       (select string_agg(distinct m[1], ', ')
+        from regexp_matches(pg_get_functiondef(p.oid),
+             '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id)\M',
+             'g') m) as identifier_lama
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and pg_get_functiondef(p.oid) ~
+      '\m(dibuat_pada|dicatat_pada|dicatat_oleh|diinput_pada|diinput_oleh|diverifikasi_pada|diverifikasi_oleh|baris_id|nilai_lama|nilai_baru|catat_riwayat|kapasitas|ruangan_id)\M'
+order by 1;

--- a/supabase/migrations/0015_v_kwitansi_column.sql
+++ b/supabase/migrations/0015_v_kwitansi_column.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- hrcd-rekap : 0015_v_kwitansi_column.sql
+--
+-- Sisa terakhir dari rename 0012. View menyimpan nama kolom OUTPUT-nya
+-- sendiri; me-rename kolom di tabel sumber TIDAK ikut mengubahnya. Jadi
+-- v_kwitansi masih mengeluarkan "diverifikasi_pada" padahal tabelnya sudah
+-- "verified_at" — inkonsistensi yang menyesatkan siapa pun yang membaca view
+-- ini nanti.
+--
+-- Ditemukan lewat pemindaian pg_get_viewdef/pg_get_functiondef terhadap
+-- database live, bukan dari berkas migrasi — dan itu memang satu-satunya cara
+-- menemukannya, karena berkas migrasi tidak tahu bentuk akhir objek.
+--
+-- Tidak ada kode aplikasi yang membaca view ini, jadi ini kerapian, bukan
+-- perbaikan kerusakan.
+-- ============================================================================
+
+alter view v_kwitansi rename column diverifikasi_pada to verified_at;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -37,6 +37,7 @@ run supabase/migrations/0011_nomor_dada_manual.sql
 run supabase/migrations/0012_rename_audit_columns.sql
 run supabase/migrations/0013_nama_kontak.sql
 run supabase/migrations/0014_rename_common_columns.sql
+run supabase/migrations/0015_v_kwitansi_column.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql


### PR DESCRIPTION
## What

- `0015` — kolom output `v_kwitansi` ikut jadi `verified_at`.
- `supabase/checks/stale_identifiers.sql` — query read-only yang memindai **database live** (bukan berkas migrasi) untuk sisa identifier lama di fungsi dan view.

## Why

View menyimpan nama kolom output-nya sendiri; rename kolom di tabel sumber tidak ikut mengubahnya. `v_kwitansi` masih mengeluarkan `diverifikasi_pada` padahal tabelnya sudah `verified_at`.

Ditemukan lewat pemindaian live — dan itu memang satu-satunya cara, karena berkas migrasi tidak tahu bentuk akhir objek. Tujuh temuan lain dari pemindaian yang sama ternyata **komentar dan pesan galat berbahasa Indonesia**, yang memang benar Indonesia.

Tidak ada kode aplikasi yang membaca view ini — kerapian, bukan perbaikan kerusakan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)