### PR TITLE
fix: sekolah isian manual terkirim tanpa nama

### DIFF
--- a/supabase/checks/reload_schema_cache.sql
+++ b/supabase/checks/reload_schema_cache.sql
@@ -1,0 +1,5 @@
+-- PostgREST menyimpan cache skema. Fungsi dengan tanda tangan BARU (mis.
+-- submit_pendaftaran + p_nama_kontak dari 0013) tidak terlihat sampai cache
+-- itu dimuat ulang — gejalanya "Could not find the function ... in the schema
+-- cache" padahal fungsinya jelas ada di database.
+notify pgrst, 'reload schema';

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -215,8 +215,16 @@ function gambarSekolah() {
   });
   cari.addEventListener("blur", () => setTimeout(() => { saran.hidden = true; }, 200));
 
+  // s DATANG DARI DUA ARAH: hasil autocomplete (baris database — kolomnya
+  // sudah name/address sejak migrasi 0014) dan isian manual di bawah. Terima
+  // keduanya, karena memaksa satu bentuk saja pernah membuat sekolah manual
+  // terkirim tanpa nama sama sekali dan RPC-nya tidak ketemu.
   function pilih(s) {
-    jawab.sekolah = { id: s.id, nama: s.name, alamat: s.address };
+    jawab.sekolah = {
+      id: s.id,
+      nama: s.name ?? s.nama,
+      alamat: s.address ?? s.alamat,
+    };
     simpanDraf(); gambarSekolah();
     if (sudahDiperiksa) periksa(false);
   }


### PR DESCRIPTION
## What

`pilih()` di form pendaftaran sekarang menerima kedua bentuk kunci (`name`/`address` dari database, `nama`/`alamat` dari isian manual).

## Why

Rename tier-2 (#62) mengubah `pilih()` membaca `s.name`/`s.address` — benar untuk hasil autocomplete, tapi jalur **isi manual** masih memanggil `pilih({ nama, alamat })`. Keduanya jadi `undefined`, hilang dari payload JSON, dan RPC-nya tidak cocok:

```
Could not find the function public.submit_pendaftaran(p_butuh_barak,
p_jumlah_pendamping, p_kontak_wa, p_kunci_kirim, p_nama_kontak, p_regu)
```

Ditemukan dengan **mencoba form sungguhan di browser**. CI SQL tidak mungkin menangkapnya — murni sisi JavaScript.

## Notes

Ditambahkan `supabase/checks/reload_schema_cache.sql` — PostgREST menyimpan cache skema, jadi tanda tangan fungsi baru bisa tidak terlihat sampai `notify pgrst, 'reload schema'` dijalankan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)