### PR TITLE
fix: form kosong setelah Daftarkan Regu Lain tidak lagi langsung memerah

### DIFF
--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -580,6 +580,10 @@ function sukses(hasil) {
     try { localStorage.removeItem(KUNCI_HASIL); } catch {}
     sessionStorage.removeItem("hrcd_selesai");
     jawab = kosong();
+    // Tanpa ini, form yang baru saja dikosongkan langsung memerah semua:
+    // sudahDiperiksa masih true dari pendaftaran sebelumnya, jadi periksa()
+    // menandai isian yang memang belum sempat disentuh siapa pun.
+    sudahDiperiksa = false;
     halaman();
     window.scrollTo(0, 0);
   });


### PR DESCRIPTION
`sudahDiperiksa` tetap `true` dari pendaftaran sebelumnya, jadi `periksa()` menandai galat pada isian yang belum sempat disentuh siapa pun.

Ditemukan saat mencoba tombolnya di browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)