### PR TITLE
chore: query verifikasi + pembersihan data uji browser

### DIFF
--- a/supabase/checks/cleanup_smoke.sql
+++ b/supabase/checks/cleanup_smoke.sql
@@ -1,0 +1,9 @@
+-- Buang data sisa uji browser. Urutannya mengikuti foreign key, dan hanya
+-- menyentuh baris yang namanya jelas-jelas penanda uji — tidak ada DELETE
+-- tanpa WHERE di sini.
+delete from regu where pendaftaran_id in (
+  select d.id from pendaftaran d join sekolah s on s.id = d.sekolah_id
+  where s.name like 'SMOKE TEST BROWSER%');
+delete from pendaftaran where sekolah_id in (
+  select id from sekolah where name like 'SMOKE TEST BROWSER%');
+delete from sekolah where name like 'SMOKE TEST BROWSER%';

--- a/supabase/checks/row_counts.sql
+++ b/supabase/checks/row_counts.sql
@@ -17,4 +17,5 @@ union all select 'sekolah BER-name', count(name) from sekolah
 union all select 'regu AKTIF (is_cancelled=false)', count(*) from regu where not is_cancelled
 union all select 'room', count(*) from room
 union all select 'edisi is_active', count(*) from edisi where is_active
+union all select 'SMOKE: pendaftaran BER-nama_kontak', count(nama_kontak) from pendaftaran
 order by 1;

--- a/supabase/checks/smoke_result.sql
+++ b/supabase/checks/smoke_result.sql
@@ -1,0 +1,10 @@
+-- Read-only: buktikan pendaftaran dari uji browser benar-benar mendarat utuh,
+-- termasuk kolom nama_kontak yang baru dan kolom hasil rename tier-2.
+select d.kode_pembayaran, s.name as sekolah, s.address as alamat,
+       d.nama_kontak, d.kontak_wa, d.jumlah_regu, d.created_at,
+       (select string_agg(r.nama_regu || ' / ' || r.nama_ketua, ', ')
+        from regu r where r.pendaftaran_id = d.id) as regu
+from pendaftaran d
+join sekolah s on s.id = d.sekolah_id
+where s.name like 'SMOKE TEST BROWSER%'
+order by d.created_at;


### PR DESCRIPTION
Query read-only untuk membuktikan pendaftaran uji mendarat utuh, plus pembersihannya. Keduanya menyaring `name like 'SMOKE TEST BROWSER%'` — tidak ada DELETE tanpa WHERE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)