### PR TITLE
fix: query PostgREST yang terlewat saat rename tier-2

### DIFF
--- a/supabase/checks/spa_columns.sql
+++ b/supabase/checks/spa_columns.sql
@@ -1,0 +1,8 @@
+-- Kolom nyata dari view/tabel yang dipakai SPA, untuk dicocokkan dengan
+-- string query PostgREST di api.js.
+select table_name, string_agg(column_name, ', ' order by ordinal_position) as kolom
+from information_schema.columns
+where table_schema='public'
+  and table_name in ('v_daftar_kloter','v_regu_ringkas','v_keberangkatan',
+                     'v_sisipan_kloter','kontrak_opsi','konfig_penalti','regu')
+group by table_name order by table_name;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -252,7 +252,7 @@ export async function ringkasanMeja() {
   // masih punya regu tanpa nomor dada" (temuan review: query lama salah).
   const [menunggu, tanpaNomor] = await Promise.all([
     baca(null, "pendaftaran?status=eq.menunggu_pembayaran&select=id"),
-    baca(null, "regu?nomor_dada=is.null&batal=is.false" +
+    baca(null, "regu?nomor_dada=is.null&is_cancelled=is.false" +
                "&select=pendaftaran_id,pendaftaran!inner(status)" +
                "&pendaftaran.status=eq.lunas"),
   ]);
@@ -363,7 +363,7 @@ export async function reguKloter(kloter) {
  *  berbeda, lihat alur-lomba.md bagian 9). */
 export async function kontrakOpsi() {
   if (K.mode === "dev") return baca("/kontrak");
-  return baca(null, "kontrak_opsi?select=label,menit&order=urutan.asc");
+  return baca(null, "kontrak_opsi?select=label,menit&order=sort_order.asc");
 }
 
 export const konfirmasiKontrak = (reguId, menit) =>


### PR DESCRIPTION
## What

- `regu?...&batal=is.false` → `is_cancelled=is.false`
- `kontrak_opsi?...&order=urutan.asc` → `order=sort_order.asc`

## Why

Layar **Home gagal memuat jumlah antrean di produksi**:

```
Jumlah antrean tidak bisa dibaca: column regu.batal does not exist
```

Ditemukan dari screenshot HP pengguna — bukan CI, bukan pemeriksaan aset.

## Notes

`v_daftar_kloter.urutan` sengaja **tidak** diubah: itu alias dari `urutan_kloter`, istilah domain yang memang tetap Indonesia.

Ditambahkan `supabase/checks/spa_columns.sql` untuk mencocokkan seluruh query PostgREST terhadap kolom nyata di database — sisanya sudah dicek dan cocok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)