### PR TITLE
feat: menu bawah untuk HP — Home, Setelan, Keluar

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -20,6 +20,22 @@
     <p>Memuat…</p>
   </main>
 
+  <!-- Menu bawah khusus HP. Panitia memakai sistem ini sambil berdiri di
+       meja; aksi utama harus di jangkauan jempol, bukan di pojok atas yang
+       menuntut memindahkan genggaman. Di layar lebar tetap tersembunyi
+       karena header sudah cukup. -->
+  <nav class="bottom-nav" id="bottom-nav" hidden aria-label="Menu utama">
+    <button class="bottom-nav-item" id="nav-home" type="button">
+      <span class="bottom-nav-icon">🏠</span><span>Home</span>
+    </button>
+    <button class="bottom-nav-item" id="nav-setting" type="button">
+      <span class="bottom-nav-icon">⚙️</span><span>Setelan</span>
+    </button>
+    <button class="bottom-nav-item" id="nav-keluar" type="button">
+      <span class="bottom-nav-icon">🚪</span><span>Keluar</span>
+    </button>
+  </nav>
+
   <script src="config.js"></script>
   <script type="module" src="js/app.js"></script>
 </body>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -34,6 +34,18 @@ const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
 function pasangKepala(judul, lebar = false) {
   const s = sesi();
   document.getElementById("kepala").hidden = !s;
+  // Menu bawah HP ikut aturan yang sama dengan header: hanya untuk yang
+  // sudah login. Penanda halaman aktif dipasang di sini juga supaya ikon
+  // Home menyala saat memang sedang di Home.
+  const nav = document.getElementById("bottom-nav");
+  if (nav) {
+    nav.hidden = !s;
+    const diHome = location.hash === "#/home" || location.hash === "";
+    document.getElementById("nav-home")
+      .setAttribute("aria-current", diHome ? "page" : "false");
+    document.getElementById("nav-setting")
+      .setAttribute("aria-current", location.hash === "#/ganti-password" ? "page" : "false");
+  }
   document.getElementById("judul-layar").textContent = judul;
   LAYAR.classList.toggle("wide", lebar);
   if (s) document.getElementById("siapa").textContent =
@@ -1657,14 +1669,23 @@ async function arahkan() {
   (RUTE[location.hash] || layarHome)();
 }
 
-document.getElementById("btn-keluar").addEventListener("click", () => {
-  keluar(); EDISI = null; location.hash = ""; arahkan();
-});
-document.getElementById("btn-home").addEventListener("click", () => {
+// Tiga aksi yang sama dipasang di DUA tempat: tombol header (layar lebar)
+// dan menu bawah (HP). Dideklarasikan lebih dulu supaya tidak ada listener
+// yang menunjuk const yang belum terisi.
+const keHome = () => {
   if (location.hash === "#/home") arahkan(); else location.hash = "#/home";
-});
-document.getElementById("ganti-password").addEventListener("click", () => {
-  if (location.hash === "#/ganti-password") arahkan(); else location.hash = "#/ganti-password";
-});
+};
+const keSetelan = () => {
+  if (location.hash === "#/ganti-password") arahkan();
+  else location.hash = "#/ganti-password";
+};
+const keluarSekarang = () => { keluar(); EDISI = null; location.hash = ""; arahkan(); };
+
+document.getElementById("btn-keluar").addEventListener("click", keluarSekarang);
+document.getElementById("btn-home").addEventListener("click", keHome);
+document.getElementById("nav-home").addEventListener("click", keHome);
+document.getElementById("nav-setting").addEventListener("click", keSetelan);
+document.getElementById("nav-keluar").addEventListener("click", keluarSekarang);
+document.getElementById("ganti-password").addEventListener("click", keSetelan);
 window.addEventListener("hashchange", arahkan);
 arahkan();

--- a/web/style.css
+++ b/web/style.css
@@ -607,3 +607,39 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-count { text-align: right; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
+
+/* ---------- menu bawah (HP) ---------- */
+
+/* Pola yang sudah dikenal panitia dari aplikasi belanja: tiga aksi tetap di
+   bawah, selalu terjangkau jempol tanpa menggulir ke atas. Di layar lebar
+   tidak muncul — header di atas sudah cukup dan tidak menghalangi apa pun. */
+.bottom-nav { display: none; }
+
+@media (max-width: 560px) {
+  .bottom-nav {
+    display: flex;
+    position: fixed; left: 0; right: 0; bottom: 0;
+    background: var(--kartu);
+    border-top: 1.5px solid var(--garis);
+    box-shadow: 0 -2px 10px rgba(0,0,0,.06);
+    padding-bottom: env(safe-area-inset-bottom);
+    z-index: 40;
+  }
+  .bottom-nav[hidden] { display: none; }
+  .bottom-nav-item {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center; gap: .15rem;
+    padding: .45rem .2rem; min-height: 56px;
+    border: 0; background: none; font-family: inherit;
+    color: var(--tinta-lembut); font-size: .72rem; font-weight: 600;
+    cursor: pointer;
+  }
+  .bottom-nav-icon { font-size: 1.3rem; line-height: 1; }
+  .bottom-nav-item[aria-current="page"] { color: var(--utama); }
+
+  /* Ruang supaya baris terakhir isi halaman tidak tertutup bar. */
+  .isi { padding-bottom: 6rem; }
+
+  /* Tombol header pindah ke bawah — sisakan judul dan identitas akun saja. */
+  .header .icon-button, .header .button-small { display: none; }
+}


### PR DESCRIPTION
## What

Menu bawah tetap (bottom navigation) di HP berisi **Home · Setelan · Keluar**, pola yang sudah dikenal panitia dari aplikasi belanja.

- Muncul hanya di lebar ≤560px dan hanya setelah login
- Ikon menyala saat halamannya aktif (`aria-current`)
- Tombol header disembunyikan di HP — judul dan identitas akun tetap terlihat
- Isi halaman diberi ruang bawah; bar menghormati safe-area iPhone

## Why

Panitia memakai sistem ini sambil berdiri di meja. Tombol di pojok kanan atas menuntut memindahkan genggaman; menu bawah selalu di jangkauan jempol.

## Notes

Ketiga aksi dideklarasikan sekali lalu dipasang di dua tempat, supaya header dan menu bawah tidak bisa berbeda perilaku diam-diam. Deklarasi ditaruh **sebelum** listener — versi pertama menaruhnya di bawah dan itu `ReferenceError` saat halaman dimuat.

Diverifikasi di pratinjau lokal pada lebar 390px sebelum deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)