### PR TITLE
fix: header HP jadi satu baris — judul kiri, akun kanan

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -473,11 +473,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .giant-number { font-size: 1.9rem; }
   .isi { padding: .8rem .7rem 3rem; }
 
-  /* Kepala di HP: judul sebaris penuh, tombol turun ke bawahnya supaya
-     tidak berdesakan dan tetap cukup besar untuk jempol. */
-  .header { padding: .5rem .7rem; gap: .4rem; }
-  .header .title { flex: 1 0 100%; font-size: .95rem; }
-  .header .user-info { font-size: .78rem; flex: 1; }
+  /* Kepala di HP: SATU baris — judul kiri, identitas akun kanan. Dulu judul
+     dipaksa sebaris penuh (flex: 1 0 100%) supaya tidak berdesakan dengan
+     tiga tombol di sebelahnya; sejak tombol-tombol itu pindah ke menu bawah,
+     aturan itu hanya menyisakan celah kosong di bawah judul. */
+  .header { padding: .6rem .8rem; gap: .5rem; flex-wrap: nowrap; }
+  .header .title { flex: 0 1 auto; font-size: 1rem; white-space: nowrap; }
+  .header .user-info {
+    font-size: .78rem; text-align: right; line-height: 1.25;
+    min-width: 0;   /* boleh menyusut daripada mendorong judul keluar layar */
+  }
   .header .button-small { min-height: 36px; font-size: .8rem; padding: .25rem .6rem; }
 }
 


### PR DESCRIPTION
Judul dipaksa sebaris penuh (`flex: 1 0 100%`) supaya tidak berdesakan dengan tiga tombol di sebelahnya. Sejak tombol-tombol itu pindah ke menu bawah (#69), aturan itu hanya menyisakan celah kosong.

`user-info` diberi `min-width: 0` supaya menyusut lebih dulu daripada mendorong judul keluar layar pada nama akun panjang.

Diverifikasi di pratinjau 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)