### PR TITLE
fix: tombol buka/tutup bisa diketuk ulang di HP + rapikan tombol simpan

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -720,8 +720,8 @@ async function layarDaftarUlang() {
             <div class="action-row" style="margin-top:.6rem">
               <button class="button button-primary button-small" type="button"
                       data-simpan-dada="${kode}">Simpan ${menunggu.length} Nomor Dada</button>
-              <span class="sub">Ketik nomor dari kain yang ada di meja.
-                Enter = pindah ke regu berikutnya.</span>
+              <span class="sub">Nomor dada yang diinput harus SAMA dengan
+                yang diberikan ke regunya. Enter = pindah ke regu berikutnya.</span>
             </div>
           </td>
         </tr>`}`;
@@ -774,7 +774,12 @@ async function layarDaftarUlang() {
         btn.setAttribute("aria-expanded", String(buka));
         const jumlah = barisNomor.querySelectorAll("[data-dada]").length;
         btn.textContent = `${buka ? "▾" : "▸"} Isi ${jumlah} Nomor Dada`;
-        if (buka) barisNomor.querySelector("[data-dada]")?.focus();
+        // Auto-focus HANYA di layar lebar. Di HP, focus() memunculkan
+        // keyboard dan menggeser halaman, sehingga ketukan berikutnya
+        // meleset dari tombol ini — terasa seperti tombolnya tidak bisa
+        // diklik ulang (laporan pengguna).
+        if (buka && window.matchMedia("(min-width: 561px)").matches)
+          barisNomor.querySelector("[data-dada]")?.focus();
       }));
 
     // Loop ketik-Enter (rancangan-b.md 10.1.4): Enter pindah ke regu

--- a/web/style.css
+++ b/web/style.css
@@ -586,6 +586,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .detail-table input.small-input {
     width: 100%; min-height: 52px; font-size: 1.25rem; font-weight: 700;
   }
+
+  /* Tombol simpan melebar penuh seperti tombol lain di HP — versi rata kiri
+     terlihat seperti tombol setengah jadi. Keterangannya turun ke bawahnya. */
+  .detail-row .action-row { flex-direction: column; align-items: stretch; }
+  .detail-row .action-row .button-small { width: 100%; }
+  .detail-row .action-row .sub { text-align: center; }
   .detail-table td:nth-child(3)::before { content: "· "; }
 }
 
@@ -721,6 +727,7 @@ input.small-input { text-align: center; }
   .data-table tbody tr[data-baris] > td[data-label="Kode Bayar"] { font-size: 1.05rem; font-weight: 700; }
   .data-table tbody tr[data-baris] > td:last-child { margin-top: .5rem; }
   .data-table tbody tr[data-baris] .button-small { width: 100%; }
+
 
   /* Baris rincian regu ikut jadi blok, bukan sel tabel. */
   .data-table tbody tr.detail-row { display: block; }


### PR DESCRIPTION
## What

1. **Tombol "Isi N Nomor Dada" tidak bisa diklik ulang di HP** — diperbaiki
2. **"Simpan N Nomor Dada"** melebar penuh di HP (sebelumnya rata kiri, terlihat setengah jadi)
3. **Teks bantuan** → "Nomor dada yang diinput harus SAMA dengan yang diberikan ke regunya"
4. Tombol buka/tutup tetap tombol besar

## Why

Poin 1 menarik: **logikanya tidak salah**. Diuji di laptop, dua klik kembali tertutup dengan benar. Penyebabnya khusus HP — setelah membuka, kode memanggil `.focus()` ke kotak pertama, keyboard muncul, halaman bergeser, dan ketukan kedua mendarat di tempat lain. Terasa persis seperti tombolnya mati.

Auto-focus sekarang hanya di layar ≥561px, tempat keyboard tidak menggeser apa pun dan loop ketik-Enter memang berguna.

Poin 3 mengubah pesan ke risiko yang sebenarnya: salah ketik nomor dada berarti regu dinilai dengan lembar orang lain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)