### PR TITLE
fix: tabel Keberangkatan tetap tabel di HP, tidak ditumpuk

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -939,8 +939,8 @@ async function layarKeberangkatan() {
             : `<span class="badge badge-yellow">BELUM BERANGKAT</span>`}
         </div>
 
-        <div class="table-wrapper" style="margin-top:.6rem">
-          <table class="table data-table">
+        <div class="table-wrapper table-wrapper-tetap" style="margin-top:.6rem">
+          <table class="table data-table table-tetap">
             <thead>
               <tr>
                 <th class="text-center">Hadir</th><th>Nomor</th><th>Regu</th>

--- a/web/style.css
+++ b/web/style.css
@@ -706,10 +706,21 @@ input.small-input { text-align: center; }
   /* HANYA baris invoice yang dijadikan blok. Tanpa pembatas ini, aturannya
      ikut menyapu .detail-table yang bersarang di dalamnya dan mematahkan
      grid-nya — kotak angka turun ke bawah, bukan sejajar nama regu. */
-  .data-table, .data-table > tbody, .data-table > tbody > tr { display: block; }
-  .data-table > tbody > tr > td { display: block; }
-  .data-table > thead { display: none; }
+  .data-table:not(.table-tetap),
+  .data-table:not(.table-tetap) > tbody,
+  .data-table:not(.table-tetap) > tbody > tr { display: block; }
+  .data-table:not(.table-tetap) > tbody > tr > td { display: block; }
+  .data-table:not(.table-tetap) > thead { display: none; }
   .table-wrapper { overflow-x: visible; max-height: none; }
+
+  /* .table-tetap = tabel yang TETAP tabel di HP. Keberangkatan adalah
+     CEKLIS: nomor dada, nama regu, kontrak, centang — dibaca menyamping dan
+     disapu mata cepat sambil memberangkatkan kloter. Menumpuknya membuat
+     satu regu memakan lima baris dan justru menghilangkan kemampuan itu.
+     Di sini geser samping bukan cacat, melainkan bentuk yang benar. */
+  .table-wrapper-tetap { overflow-x: auto; }
+  .table-tetap { white-space: nowrap; }
+  .table-tetap th, .table-tetap td { padding: .45rem .5rem; }
 
   .data-table tbody tr[data-baris] {
     border: 1.5px solid var(--garis); border-radius: var(--radius);


### PR DESCRIPTION
## What

Tabel Keberangkatan dikecualikan dari aturan menumpuk-jadi-kartu (#72). Di HP ia tetap tabel yang digeser menyamping.

## Why

Keberangkatan bukan daftar untuk dibaca satu per satu — ia **ceklis**. Petugas garis start menyapu matanya dari atas ke bawah sambil mencocokkan nomor dada dengan regu di depannya, lalu mencentang.

Ditumpuk, satu regu memakan lima baris dan kemampuan menyapu itu hilang: kotak centang sendirian, nomor sendirian, nama sendirian, kontrak sendirian.

Di sini geser samping **bukan cacat melainkan bentuk yang benar** — satu-satunya tempat di aplikasi yang begitu, jadi penandanya dibuat eksplisit (`.table-tetap`), bukan aturan diam-diam.

## Notes

Penanda dipasang sebagai kelas di pembungkusnya, bukan lewat `:has()`, supaya tidak bergantung dukungan browser dan langsung terbaca maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)