### PR TITLE
fix: dropdown cara bayar terpotong, tombol jadi "Lunas", jarak dilonggarkan

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -391,7 +391,7 @@ async function layarPembayaran() {
                  <option value="transfer">Transfer</option>
                </select>
                <button class="button button-primary button-small" type="button"
-                       data-lunas="${esc(b.kode_pembayaran)}">Tandai Lunas</button>
+                       data-lunas="${esc(b.kode_pembayaran)}">Lunas</button>
              </div>`;
       // Satu baris = satu invoice, karena satu invoice memang dibayar
       // sekaligus. Rincian regunya (nama, kategori, asal sekolah) ada di
@@ -500,7 +500,7 @@ async function layarPembayaran() {
           r = await verifikasiPembayaran(kode, tagihan, metode);
         } catch (err) {
           notif(err.message, true);
-          btn.dataset.jalan = ""; btn.disabled = false; btn.textContent = "Tandai Lunas";
+          btn.dataset.jalan = ""; btn.disabled = false; btn.textContent = "Lunas";
           return;
         }
         // Sumber data lokal ikut diperbarui supaya saringan & baris lain

--- a/web/style.css
+++ b/web/style.css
@@ -603,7 +603,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kwitansi { display: block; font-size: .8rem; color: var(--tinta-lembut); }
 
 /* Kontrol di dalam sel: cukup besar untuk jari, cukup ringkas untuk tabel. */
-.action-row { display: flex; gap: .4rem; align-items: center; flex-wrap: wrap; }
+.action-row { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; }
 .select-small, .small-input {
   /* 1rem = 16px, BUKAN .9rem. Di bawah 16px iOS Safari memaksa zoom tiap
      kali isian disentuh — batas keras di kepala berkas ini, dan sempat
@@ -615,7 +615,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* input[type=number] (spesifisitas 0,1,1) mengalahkan .small-input (0,1,0),
    jadi width:100% dari aturan dasar yang menang dan kotaknya melebar penuh
    satu kolom. Disamakan spesifisitasnya supaya lebar ringkasnya berlaku. */
-input.small-input, select.select-small { width: 4.5rem; }
+/* Lebar ringkas HANYA untuk kotak ANGKA. Dropdown cara bayar harus selebar
+   isinya — dipaksa 4.5rem, "Transfer" terpotong jadi "Tuna". */
+input.small-input { width: 4.5rem; }
+select.select-small { width: auto; min-width: 6.5rem; }
 input.small-input { text-align: center; }
 /* Isian yang ditolak sebelum dikirim — memerah di tempatnya supaya petugas
    tahu BARIS MANA yang salah, bukan cuma bahwa "ada yang salah". */


### PR DESCRIPTION
## What

1. Dropdown cara bayar tidak terpotong lagi — "Transfer" muat penuh
2. "Tandai Lunas" → **"Lunas"**
3. Jarak dropdown ↔ tombol dilonggarkan

## Why

Poin 1 adalah **regresi saya sendiri di #73**. Saat memperbaiki lebar kotak angka, saya ikut menyertakan `select.select-small` ke aturan `width: 4.5rem` — padahal aslinya hanya `.small-input` yang punya lebar itu. Akibatnya "Transfer" tampil sebagai "Tuna".

Sekarang lebar ringkas hanya untuk kotak **angka**; dropdown selebar isinya.

Poin 2: kolomnya sudah berjudul "Status / Aksi" dan dropdown di sebelahnya sudah menyatakan caranya — kata "Tandai" hanya menambah panjang tanpa menambah arti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)