### PR TITLE
fix: judul kolom rata tengah, status pindah ke Metode, tombol berderet

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -380,26 +380,31 @@ async function layarPembayaran() {
       // dropdown; untuk yang sudah, ia catatan cara pembayarannya benar-
       // benar diterima — pertanyaan yang sering ditanya saat menyusun
       // laporan keuangan, dan dulu tidak terlihat di mana pun.
+      // Kolom Metode memuat cara bayar SEKALIGUS statusnya: dua fakta
+      // tentang uang yang sama, dibaca bersama. Kolom aksi tinggal berisi
+      // tombol saja, jadi tombolnya muat berderet ke samping.
       const metode = b.status === "lunas"
-        ? html`${b.pembayaran ? b.pembayaran.method : "—"}`
+        ? html`<div>${b.pembayaran ? b.pembayaran.method : "—"}</div>
+               <span class="badge badge-green">LUNAS</span>
+               <span class="kwitansi">${b.pembayaran ? b.pembayaran.nomor_kwitansi : ""}</span>`
         : b.status === "batal"
-          ? "—"
+          ? `<span class="badge badge-red">BATAL</span>`
           : `<select class="select-small" data-metode="${esc(b.kode_pembayaran)}">
                <option value="tunai" selected>Tunai</option>
                <option value="transfer">Transfer</option>
              </select>`;
 
       const aksi = b.status === "lunas"
-        ? html`<span class="badge badge-green">LUNAS</span>
-               <span class="kwitansi">${b.pembayaran ? b.pembayaran.nomor_kwitansi : ""}</span>
-               <button class="button button-primary button-mini" type="button"
-                       data-cetak="${b.kode_pembayaran}">Cetak Kwitansi</button>
-               <button class="button button-secondary button-mini" type="button"
-                       data-batal-bayar="${b.kode_pembayaran}">Batalkan</button>`
+        ? html`<div class="action-row action-row-rapat">
+                 <button class="button button-primary button-mini" type="button"
+                         data-cetak="${b.kode_pembayaran}">Cetak Kwitansi</button>
+                 <button class="button button-secondary button-mini" type="button"
+                         data-batal-bayar="${b.kode_pembayaran}">Batalkan</button>
+               </div>`
         : b.status === "batal"
-          ? `<span class="badge badge-red">BATAL</span>`
+          ? ""
           : `<button class="button button-primary button-small" type="button"
-                     data-lunas="${esc(b.kode_pembayaran)}">Lunas</button>`;
+                     data-lunas="${esc(b.kode_pembayaran)}">Tandai Lunas</button>`;
       // Satu baris = satu invoice, karena satu invoice memang dibayar
       // sekaligus. Rincian regunya (nama, kategori, asal sekolah) ada di
       // baris detail yang dibuka lewat tombol "N regu" — itu yang dibacakan
@@ -508,7 +513,7 @@ async function layarPembayaran() {
           r = await verifikasiPembayaran(kode, tagihan, metode);
         } catch (err) {
           notif(err.message, true);
-          btn.dataset.jalan = ""; btn.disabled = false; btn.textContent = "Lunas";
+          btn.dataset.jalan = ""; btn.disabled = false; btn.textContent = "Tandai Lunas";
           return;
         }
         // Sumber data lokal ikut diperbarui supaya saringan & baris lain

--- a/web/style.css
+++ b/web/style.css
@@ -597,13 +597,27 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 .data-table .sub { color: var(--tinta-lembut); font-size: .82rem; margin-top: .15rem; }
 .data-table .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+/* .table th sudah menetapkan text-align: left dengan spesifisitas (0,1,1),
+   jadi .text-center (0,1,0) kalah dan JUDUL kolom tetap rata kiri meski
+   sudah diberi kelasnya. Disamakan spesifisitasnya di sini. */
 .text-center { text-align: center; }
 .text-right  { text-align: right; }
+.table th.text-center, .table td.text-center { text-align: center; }
+.table th.text-right,  .table td.text-right  { text-align: right; }
+
+/* Cara bayar disimpan huruf kecil di database ('tunai'/'transfer') karena
+   itu nilai CHECK constraint-nya. Yang dibaca panitia tetap huruf kapital
+   di depan. */
+.data-table td[data-label="Metode"] { text-transform: capitalize; }
+.data-table td[data-label="Metode"] .badge { text-transform: none; }
 .table-empty { text-align: center; color: var(--tinta-lembut); padding: 1.4rem .5rem; }
 .kwitansi { display: block; font-size: .8rem; color: var(--tinta-lembut); }
 
 /* Kontrol di dalam sel: cukup besar untuk jari, cukup ringkas untuk tabel. */
 .action-row { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; }
+/* Cetak Kwitansi + Batalkan berderet ke samping, tidak menumpuk — dua aksi
+   sejajar yang sama-sama milik satu baris lunas. */
+.action-row-rapat { flex-wrap: nowrap; gap: .4rem; }
 .select-small, .small-input {
   /* 1rem = 16px, BUKAN .9rem. Di bawah 16px iOS Safari memaksa zoom tiap
      kali isian disentuh — batas keras di kepala berkas ini, dan sempat


### PR DESCRIPTION
## What

1. Judul kolom Regu/Tagihan/Metode benar-benar rata tengah
2. "tunai" → "Tunai"
3. Status **LUNAS** + nomor kwitansi pindah ke kolom Metode
4. Cetak Kwitansi + Batalkan berderet ke samping
5. Tombol kembali "Tandai Lunas"

## Why

Poin 1 adalah **bug spesifisitas yang ketiga kalinya hari ini**: `.table th` (0,1,1) mengalahkan `.text-center` (0,1,0), jadi kelasnya terpasang tapi tidak berefek.

Poin 2: `tunai` memang nilai yang disimpan database — itu isi CHECK constraint-nya. Yang diubah hanya tampilannya lewat `text-transform`, nilai di database tetap.

Poin 3 membuat poin 4 mungkin: kolom aksi yang tadinya memuat lencana + nomor kwitansi + dua tombol sekarang cukup dua tombol, jadi muat sebaris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)