### PR TITLE
feat: nama edisi tampil sebagai "HRCD XXXVII"

### DIFF
--- a/supabase/migrations/0016_nama_edisi_romawi.sql
+++ b/supabase/migrations/0016_nama_edisi_romawi.sql
@@ -1,0 +1,19 @@
+-- ============================================================================
+-- hrcd-rekap : 0016_nama_edisi_romawi.sql
+--
+-- Nama edisi yang DIBACA ORANG memakai angka Romawi: "HRCD XXXVII".
+-- Itu bentuk resmi yang dipakai panitia di poster, sertifikat, dan kwitansi.
+--
+-- Yang TIDAK ikut berubah, karena bukan teks tampilan melainkan pengenal
+-- yang harus pendek dan mudah diketik:
+--   * username akun    -> meja1hrcd37, pos1hrcd37, admin.ciradyka
+--   * nomor kwitansi   -> KW-HRCD37-0013 (dirakit dari edisi_aktif())
+--   * nama project     -> hrcd37 (Cloudflare, URL)
+--   * kolom edisi.nomor -> tetap 37, karena dipakai berhitung
+--
+-- Satu baris ini mengubah SEMUA tampilan sekaligus: header layar panitia,
+-- judul kwitansi, dan judul lembar cetak kloter — ketiganya membaca
+-- edisi.name, tidak ada yang menuliskannya sendiri di kode.
+-- ============================================================================
+
+update edisi set name = 'HRCD XXXVII' where nomor = 37;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -7,7 +7,7 @@
 insert into edisi (nomor, name, tahun, tanggal_lomba, biaya_per_regu,
                    maks_regu_per_kloter, kloter_dasar, kloter_maks,
                    lompatan_kloter, interval_berangkat_menit, is_active)
-values (37, 'HRCD 37', 2027, date '2027-02-21', 250000, 10, 30, 40, 2, 4, true);
+values (37, 'HRCD XXXVII', 2027, date '2027-02-21', 250000, 10, 30, 40, 2, 4, true);
 
 insert into pos (edisi, nomor, name, bobot) values
   (37, 1, 'Pos 1', 1.00),

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -38,6 +38,7 @@ run supabase/migrations/0012_rename_audit_columns.sql
 run supabase/migrations/0013_nama_kontak.sql
 run supabase/migrations/0014_rename_common_columns.sql
 run supabase/migrations/0015_v_kwitansi_column.sql
+run supabase/migrations/0016_nama_edisi_romawi.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql


### PR DESCRIPTION
## What

`edisi.name`: "HRCD 37" → **"HRCD XXXVII"**.

Berubah di **semua tampilan sekaligus**: header layar panitia, judul kwitansi, judul lembar cetak kloter.

## Why

Angka Romawi adalah bentuk resmi yang dipakai panitia di poster, sertifikat, dan kwitansi.

## Notes — yang sengaja TIDAK berubah

Pengenal yang harus pendek dan mudah diketik tetap `hrcd37`:

- username akun — `meja1hrcd37`, `pos1hrcd37`
- nomor kwitansi — `KW-HRCD37-0013` (dirakit dari `edisi_aktif()`)
- nama project & URL — `hrcd37`
- `edisi.nomor` — tetap `37`, dipakai berhitung

**Nol perubahan JavaScript.** Ketiga tempat yang menampilkannya membaca `edisi.name` dari database, tidak ada satu pun yang menuliskan namanya sendiri di kode — jadi satu `UPDATE` cukup. `seed.sql` ikut diperbarui supaya pemasangan baru langsung benar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)