### PR TITLE
fix: nomor kwitansi tidak lagi ditampilkan di tabel Pembayaran

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -384,9 +384,11 @@ async function layarPembayaran() {
       // tentang uang yang sama, dibaca bersama. Kolom aksi tinggal berisi
       // tombol saja, jadi tombolnya muat berderet ke samping.
       const metode = b.status === "lunas"
+        // Nomor kwitansi TIDAK ditampilkan di tabel: panjang, tidak pernah
+        // dicari lewat layar ini, dan sudah tercetak di kwitansinya sendiri
+        // — di situlah ia berguna saat menyusun berkas.
         ? html`<div>${b.pembayaran ? b.pembayaran.method : "—"}</div>
-               <span class="badge badge-green">LUNAS</span>
-               <span class="kwitansi">${b.pembayaran ? b.pembayaran.nomor_kwitansi : ""}</span>`
+               <span class="badge badge-green">LUNAS</span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`
           : `<select class="select-small" data-metode="${esc(b.kode_pembayaran)}">

--- a/web/style.css
+++ b/web/style.css
@@ -611,7 +611,6 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .data-table td[data-label="Metode"] { text-transform: capitalize; }
 .data-table td[data-label="Metode"] .badge { text-transform: none; }
 .table-empty { text-align: center; color: var(--tinta-lembut); padding: 1.4rem .5rem; }
-.kwitansi { display: block; font-size: .8rem; color: var(--tinta-lembut); }
 
 /* Kontrol di dalam sel: cukup besar untuk jari, cukup ringkas untuk tabel. */
 .action-row { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; }


### PR DESCRIPTION
Nomornya panjang, tidak pernah dicari lewat layar ini, dan sudah tercetak di kwitansinya sendiri.

Tetap ada di tempat yang membutuhkannya: notifikasi setelah menandai lunas, dialog tawaran cetak, dialog pembatalan verifikasi, dan kwitansi cetaknya.

Kelas `.kwitansi` ikut dihapus dari `style.css` karena jadi yatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)