### PR TITLE
fix: Simpan pindah ke kanan, tombol buka diturunkan bobotnya

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -696,7 +696,7 @@ async function layarDaftarUlang() {
       // regu untuk diisi satu per satu, bukan langsung menarik stok.
       const terbuka = dibukaNomor.has(b.kode_pembayaran);
       const aksi = menunggu.length
-        ? `<button class="button button-primary button-small" type="button"
+        ? `<button class="button-detail" type="button"
                    data-isi="${kode}" aria-expanded="${terbuka}">
              ${terbuka ? "▾" : "▸"} Isi ${menunggu.length} Nomor Dada
            </button>${nomorHtml ? `<div class="sub">${nomorHtml} ${tombolTukar}</div>` : ""}`
@@ -732,11 +732,11 @@ async function layarDaftarUlang() {
                   </tr>`).join("")}
               </tbody>
             </table>
-            <div class="action-row" style="margin-top:.6rem">
-              <button class="button button-primary button-small" type="button"
-                      data-simpan-dada="${kode}">Simpan ${menunggu.length} Nomor Dada</button>
+            <div class="action-row action-row-simpan" style="margin-top:.6rem">
               <span class="sub">Nomor dada yang diinput harus SAMA dengan
                 yang diberikan ke regunya. Enter = pindah ke regu berikutnya.</span>
+              <button class="button button-primary button-small" type="button"
+                      data-simpan-dada="${kode}">Simpan ${menunggu.length} Nomor Dada</button>
             </div>
           </td>
         </tr>`}`;

--- a/web/style.css
+++ b/web/style.css
@@ -617,6 +617,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Cetak Kwitansi + Batalkan berderet ke samping, tidak menumpuk — dua aksi
    sejajar yang sama-sama milik satu baris lunas. */
 .action-row-rapat { flex-wrap: nowrap; gap: .4rem; }
+/* Keterangan di kiri, tombol Simpan didorong ke KANAN — sejajar kolom
+   nomor dada, tempat mata dan kursor berada setelah mengetik angka
+   terakhir. Tombol di kiri memaksa perjalanan balik melintasi tabel. */
+.action-row-simpan { justify-content: space-between; }
+.action-row-simpan .sub { flex: 1; min-width: 12rem; }
 .select-small, .small-input {
   /* 1rem = 16px, BUKAN .9rem. Di bawah 16px iOS Safari memaksa zoom tiap
      kali isian disentuh — batas keras di kepala berkas ini, dan sempat


### PR DESCRIPTION
## What

1. **"Simpan N Nomor Dada" pindah ke kanan**, sejajar kolom Nomor Dada
2. **"Isi N Nomor Dada" jadi teks halus** seperti "▸ N regu" di Pembayaran

## Why

Setelah mengetik angka terakhir, mata dan kursor ada di sisi kanan tabel — tombol di kiri memaksa perjalanan balik melintasi seluruh baris.

Tombol buka yang hijau pekat bersaing perhatian dengan Simpan, padahal ia cuma membuka daftar. Sekarang hanya ada **satu elemen mencolok per layar**, sesuai `rancangan-b.md` 10.1.1 ("satu aksi utama per layar").

## Notes

Urutan DOM ikut dibalik (keterangan dulu, tombol belakangan) supaya posisinya benar tanpa trik CSS — dan di HP urutannya jadi masuk akal juga: instruksi dulu, baru tombolnya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)