### PR TITLE
fix: tombol tutup notifikasi tampil sebagai HTML mentah + label Kedatangan

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -52,6 +52,8 @@ export function pesanRamah(m) {
     return "Semua regu sekolah ini sudah menerima nomor dada.";
   if (/nominal .* tidak sama dengan tagihan/i.test(t))
     return "Jumlah tagihan berubah (biaya per regu diperbarui admin). Muat ulang halaman, lalu ulangi.";
+  if (/sudah daftar ulang \(nomor dada terbit\)/i.test(t))
+    return "Sekolah ini sudah menerima nomor dada, jadi pembayarannya tidak bisa dibatalkan — regunya akan jadi yatim: bernomor dada tapi tercatat belum bayar. Kosongkan dulu nomor dadanya lewat admin.";
   if (/daftar ulang sudah ditutup/i.test(t))
     return "Daftar ulang sudah ditutup panitia. Hubungi admin.";
   if (/permission denied|insufficient/i.test(t))

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -164,7 +164,7 @@ async function layarHome() {
         <div class="description">Ceklis regu yang hadir, pilih kontrak waktu, catat jam berangkat</div>
       </a>
       <a href="#/finish">
-        <div class="function-name">🏁 Meja Finish</div>
+        <div class="function-name">🏁 Kedatangan</div>
         <div class="description">Ketik nomor dada, tekan Sampai — catat kedatangan regu</div>
       </a>
       <a href="#/pindah-kloter">
@@ -1258,7 +1258,7 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
  *  susulan dari kertas, jamnya bisa diubah.
  */
 function layarFinish() {
-  pasangKepala("Meja Finish");
+  pasangKepala("Kedatangan");
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
       <div class="field" style="margin-bottom:0">

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -39,8 +39,13 @@ export const jamSekarang = () =>
  *  sedang melihat papan ketik saat pesan muncul (temuan review). */
 export function notif(pesan, galat = false) {
   document.querySelectorAll(".notification").forEach(n => n.remove());
-  const n = h(html`<div class="notification ${galat ? "error" : ""}" role="alert">
-      <span>${pesan}</span>
+  // Template BIASA, bukan tag html`` — tombol tutupnya HTML yang memang
+  // harus DIRENDER. Tag html`` meng-escape SEMUA yang disisipkan (itu
+  // gunanya, mencegah XSS dari nama sekolah), jadi tombolnya ikut jadi
+  // korban dan tampil apa adanya sebagai teks di layar panitia.
+  // Pesannya tetap lewat esc() — itu satu-satunya bagian dari luar.
+  const n = h(`<div class="notification ${galat ? "error" : ""}" role="alert">
+      <span>${esc(pesan)}</span>
       ${galat ? '<button class="notification-close" type="button" aria-label="tutup">✕</button>' : ""}
     </div>`);
   document.body.appendChild(n);


### PR DESCRIPTION
## What

1. **Tombol tutup notifikasi galat** tampil sebagai HTML mentah di layar
2. Galat pembatalan setelah daftar ulang diterjemahkan ke bahasa manusia
3. "Meja Finish" → **"Kedatangan"**

## Why

Poin 1 adalah **bug lama yang baru terlihat**. `notif()` dibangun dengan tag `html```, yang meng-escape semua nilai yang disisipkan — itu memang gunanya, mencegah XSS dari nama sekolah yang diketik orang luar. Tapi tombol tutupnya ikut jadi korban:

```
<button class="notification-close" type="button" aria-label="tutup">✕</button>
```

muncul apa adanya sebagai teks, menempel di sebelah pesan galat.

Sekarang strukturnya memakai template biasa dan **hanya pesannya** yang lewat `esc()` — satu-satunya bagian yang berasal dari luar, jadi perlindungan XSS-nya tetap utuh.

Poin 2: pesan lama hanya menolak. Yang baru menjelaskan akibatnya — regunya akan jadi yatim, bernomor dada tapi tercatat belum bayar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)