### PR TITLE
fix: tabel rincian regu padat ke kiri, tidak meregang selebar kartu

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -553,7 +553,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* Rincian regu di dalam satu baris invoice. */
 .detail-row > td { background: var(--kertas); padding: .5rem .75rem; }
-.detail-table { width: 100%; border-collapse: collapse; font-size: .85rem; }
+/* Lebar mengikuti ISI, bukan meregang selebar kartu. Diregangkan, lima
+   kolom pendek terlempar berjauhan dan mata harus melompat jauh dari nama
+   regu ke biayanya — padahal keduanya dibaca bersama. */
+.detail-table { width: auto; border-collapse: collapse; font-size: .85rem; }
+.detail-table th, .detail-table td { padding-right: 2rem; }
+.detail-table th:last-child, .detail-table td:last-child { padding-right: .4rem; }
 .detail-table th {
   text-align: left; padding: .25rem .4rem; font-size: .72rem;
   text-transform: uppercase; letter-spacing: .04em; color: var(--tinta-lembut);


### PR DESCRIPTION
Lebar mengikuti isi (`width: auto`), bukan 100%.

Diregangkan, lima kolom pendek terlempar berjauhan dan mata harus melompat jauh dari nama regu ke biayanya — padahal keduanya dibaca bersama saat mencocokkan uang di meja.

Jarak antar kolom diatur lewat `padding-right`, jadi tetap lega tanpa ruang kosong menganga di kanan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)