### PR TITLE
fix: kolom uang rata kanan, tabel rincian diberi lantai lebar

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -335,7 +335,7 @@ async function layarPembayaran() {
           <thead>
             <tr>
               <th>Kode Bayar</th><th>Sekolah</th><th class="text-center">Regu</th>
-              <th class="text-center">Tagihan</th><th class="text-center">Metode</th><th></th>
+              <th class="text-right">Tagihan</th><th class="text-center">Metode</th><th></th>
             </tr>
           </thead>
           <tbody id="isi-tabel"></tbody>
@@ -429,7 +429,7 @@ async function layarPembayaran() {
               : `<div class="sub">semua regu batal</div>`}
           </td>
           <td class="text-center" data-label="Regu">${aktif.length}</td>
-          <td class="text-center" data-label="Tagihan">${esc(rupiah(tagihan))}</td>
+          <td class="text-right" data-label="Tagihan">${esc(rupiah(tagihan))}</td>
           <td class="text-center" data-label="Metode">${metode}</td>
           <td data-label="">${aksi}</td>
         </tr>

--- a/web/style.css
+++ b/web/style.css
@@ -553,12 +553,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* Rincian regu di dalam satu baris invoice. */
 .detail-row > td { background: var(--kertas); padding: .5rem .75rem; }
-/* Lebar mengikuti ISI, bukan meregang selebar kartu. Diregangkan, lima
-   kolom pendek terlempar berjauhan dan mata harus melompat jauh dari nama
-   regu ke biayanya — padahal keduanya dibaca bersama. */
-.detail-table { width: auto; border-collapse: collapse; font-size: .85rem; }
-.detail-table th, .detail-table td { padding-right: 2rem; }
-.detail-table th:last-child, .detail-table td:last-child { padding-right: .4rem; }
+/* Lebar mengikuti isi, TAPI dengan lantai minimum: menempel penuh ke kiri
+   membuat kolomnya berdempetan dan angka rupiah kehilangan tempat berpijak.
+   min-width memberi ruang bernapas tanpa melemparkan kolom sejauh 100%. */
+.detail-table { width: auto; min-width: 62%; border-collapse: collapse; font-size: .85rem; }
+.detail-table th, .detail-table td { padding-right: 1.6rem; }
+/* Kolom uang rata kanan dengan lebar tetap: satuan rupiah jadi sejajar
+   antar baris, dan mata bisa membandingkan angkanya tanpa membaca. */
+.detail-table th:last-child, .detail-table td:last-child {
+  padding-right: .4rem; text-align: right; min-width: 7rem;
+}
 .detail-table th {
   text-align: left; padding: .25rem .4rem; font-size: .72rem;
   text-transform: uppercase; letter-spacing: .04em; color: var(--tinta-lembut);


### PR DESCRIPTION
Menempel penuh ke kiri (#83) ternyata terlalu jauh — kolomnya berdempetan. Sekarang lebarnya tetap mengikuti isi tapi dengan `min-width: 62%`.

Kolom **Tagihan** dan **Biaya** kembali rata kanan dengan lebar minimum tetap: angka uang dibandingkan antar baris, dan rata kanan membuat satuan rupiahnya sejajar — "Rp 250.000" dan "Rp 1.250.000" langsung terlihat bedanya tanpa membaca angkanya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)