### PR TITLE
feat: akordeon — hanya satu sekolah terbuka saat mengisi nomor dada

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -697,7 +697,8 @@ async function layarDaftarUlang() {
       const terbuka = dibukaNomor.has(b.kode_pembayaran);
       const aksi = menunggu.length
         ? `<button class="button-detail" type="button"
-                   data-isi="${kode}" aria-expanded="${terbuka}">
+                   data-isi="${kode}" data-jumlah="${menunggu.length}"
+                   aria-expanded="${terbuka}">
              ${terbuka ? "▾" : "▸"} Isi ${menunggu.length} Nomor Dada
            </button>${nomorHtml ? `<div class="sub">${nomorHtml} ${tombolTukar}</div>` : ""}`
         : `<div class="pill-row">${nomorHtml} ${tombolTukar}</div>`;
@@ -784,6 +785,25 @@ async function layarDaftarUlang() {
         const kode = btn.dataset.isi;
         const barisNomor = tbody.querySelector(`[data-nomor-untuk="${CSS.escape(kode)}"]`);
         const buka = barisNomor.hidden;
+
+        // AKORDEON: hanya SATU sekolah terbuka pada satu waktu. Dua daftar
+        // isian terbuka bersamaan membuat petugas mudah mengetik nomor
+        // sekolah A ke baris sekolah B — kesalahan yang tidak menimbulkan
+        // galat apa pun dan baru ketahuan saat klasemen keluar. Angka yang
+        // sudah diketik TIDAK hilang: tersimpan di nilaiDada dan muncul lagi
+        // saat sekolahnya dibuka ulang.
+        if (buka) {
+          tbody.querySelectorAll("[data-nomor-untuk]").forEach(lain => {
+            if (lain !== barisNomor) lain.hidden = true;
+          });
+          tbody.querySelectorAll("[data-isi]").forEach(lainBtn => {
+            if (lainBtn === btn) return;
+            lainBtn.setAttribute("aria-expanded", "false");
+            lainBtn.textContent = `▸ Isi ${lainBtn.dataset.jumlah} Nomor Dada`;
+          });
+          dibukaNomor.clear();
+        }
+
         if (buka) dibukaNomor.add(kode); else dibukaNomor.delete(kode);
         barisNomor.hidden = !buka;
         btn.setAttribute("aria-expanded", String(buka));

--- a/web/style.css
+++ b/web/style.css
@@ -553,15 +553,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* Rincian regu di dalam satu baris invoice. */
 .detail-row > td { background: var(--kertas); padding: .5rem .75rem; }
-/* Lebar mengikuti isi, TAPI dengan lantai minimum: menempel penuh ke kiri
-   membuat kolomnya berdempetan dan angka rupiah kehilangan tempat berpijak.
-   min-width memberi ruang bernapas tanpa melemparkan kolom sejauh 100%. */
-.detail-table { width: auto; min-width: 62%; border-collapse: collapse; font-size: .85rem; }
+/* Lebar mengikuti ISI saja — tanpa min-width. Diberi lantai 62%, kolom
+   Biaya terlempar jauh dari Sekolah dan rata kanannya terlihat menggantung.
+   Sekarang kelima kolom menempel di kiri; yang tetap rata kanan hanya isi
+   kolom uangnya, di dalam kolomnya sendiri. */
+.detail-table { width: auto; border-collapse: collapse; font-size: .85rem; }
 .detail-table th, .detail-table td { padding-right: 1.6rem; }
-/* Kolom uang rata kanan dengan lebar tetap: satuan rupiah jadi sejajar
-   antar baris, dan mata bisa membandingkan angkanya tanpa membaca. */
+/* Angka rupiah tetap sejajar antar baris supaya bisa dibandingkan sekilas,
+   tapi kolomnya sendiri sesempit isinya. */
 .detail-table th:last-child, .detail-table td:last-child {
-  padding-right: .4rem; text-align: right; min-width: 7rem;
+  padding-right: .4rem; text-align: right; min-width: 6rem;
 }
 .detail-table th {
   text-align: left; padding: .25rem .4rem; font-size: .72rem;


### PR DESCRIPTION
## What

Membuka satu sekolah menutup yang lain.

## Why

Bukan kerapian — **keselamatan data**. Dua daftar isian terbuka bersamaan membuat petugas bisa mengetik nomor sekolah A ke baris sekolah B. Kesalahan itu **tidak menimbulkan galat apa pun**: tersimpan normal, lolos semua validasi, dan baru ketahuan saat klasemen keluar dengan regu dinilai memakai lembar orang lain.

Laporan pengguna juga menunjukkan akibat visualnya: tiga panel terbuka membuat header tabel saling tumpang tindih dan ada dua tombol "Simpan" di layar tanpa penanda jelas milik sekolah mana.

## Notes

Angka yang sudah diketik **tidak hilang** saat panelnya menutup — tersimpan di `nilaiDada` dan muncul lagi begitu sekolahnya dibuka ulang.

Diuji di harness dengan handler yang sama persis: klik A lalu B → tepat satu panel terbuka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)