### PR TITLE
fix: center detail panel and page title, capitalize error messages

### DIFF
--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -75,7 +75,7 @@ const labelGolongan = k => GOLONGAN.find(g => g.kode === k).label;
 
 function halaman() {
   LAYAR.replaceChildren(h(`
-    <div class="card" style="border-color:var(--utama)">
+    <div class="card card-title" style="border-color:var(--utama)">
       <h2>Pendaftaran Regu</h2>
     </div>
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -44,8 +44,14 @@ export function notif(pesan, galat = false) {
   // gunanya, mencegah XSS dari nama sekolah), jadi tombolnya ikut jadi
   // korban dan tampil apa adanya sebagai teks di layar panitia.
   // Pesannya tetap lewat esc() — itu satu-satunya bagian dari luar.
+  // Pesan galat dari database lahir huruf kecil — itu konvensi SQL
+  // (`raise exception 'regu ... belum konfirmasi kontrak waktu'`). Di layar
+  // panitia ia terbaca seperti potongan log, bukan kalimat. Huruf pertama
+  // dibesarkan DI SINI, satu tempat, supaya pesan dari mana pun ikut rapi
+  // tanpa perlu menyentuh belasan `raise exception` di migrasi.
+  const kalimat = String(pesan).charAt(0).toUpperCase() + String(pesan).slice(1);
   const n = h(`<div class="notification ${galat ? "error" : ""}" role="alert">
-      <span>${esc(pesan)}</span>
+      <span>${esc(kalimat)}</span>
       ${galat ? '<button class="notification-close" type="button" aria-label="tutup">✕</button>' : ""}
     </div>`);
   document.body.appendChild(n);

--- a/web/style.css
+++ b/web/style.css
@@ -552,12 +552,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .button-detail:hover { text-decoration: underline; }
 
 /* Rincian regu di dalam satu baris invoice. */
-.detail-row > td { background: var(--kertas); padding: .5rem .75rem; }
+.detail-row > td { background: var(--kertas); padding: .7rem 1.2rem; }
 /* Lebar mengikuti ISI saja — tanpa min-width. Diberi lantai 62%, kolom
    Biaya terlempar jauh dari Sekolah dan rata kanannya terlihat menggantung.
    Sekarang kelima kolom menempel di kiri; yang tetap rata kanan hanya isi
    kolom uangnya, di dalam kolomnya sendiri. */
-.detail-table { width: auto; border-collapse: collapse; font-size: .85rem; }
+/* Kartu judul halaman: satu baris teks sendirian di dalam kartu terbaca
+   seperti label yang tertinggal kalau rata kiri. Ditengahkan ia jadi judul. */
+.card-title { text-align: center; }
+
+.detail-table {
+  width: auto; border-collapse: collapse; font-size: .85rem;
+  /* DITENGAHKAN, bukan menempel tepi kiri. Lebar mengikuti isi membuatnya
+     terlalu rapat ke pinggir dan terlihat seperti terlepas dari barisnya;
+     ditengahkan ia duduk di bawah baris induknya dengan ruang seimbang. */
+  margin: 0 auto;
+}
 .detail-table th, .detail-table td { padding-right: 1.6rem; }
 /* Angka rupiah tetap sejajar antar baris supaya bisa dibandingkan sekilas,
    tapi kolomnya sendiri sesempit isinya. */


### PR DESCRIPTION
## What

- Detail panel (bib numbers, payment breakdown) is centered instead of pinned to the left edge, with a little more padding.
- `Pendaftaran Regu` title card is centered.
- `notif()` capitalizes the first letter of every message.

## Why

All three were reported from the desks. The last one matters most: database errors are written in lower case because that is SQL convention, but panitia read them as log output rather than as a sentence addressed to them. Capitalizing in `notif()` fixes every message at once — including ones raised by migrations nobody has revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)