### PR TITLE
fix: widen detail tables to fill the card

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -717,7 +717,7 @@ async function layarDaftarUlang() {
         ${!menunggu.length ? "" : `
         <tr class="detail-row" data-nomor-untuk="${kode}" ${terbuka ? "" : "hidden"}>
           <td colspan="4">
-            <table class="detail-table">
+            <table class="detail-table detail-table-dada">
               <thead>
                 <tr><th>Regu</th><th>Kategori</th><th>Ketua</th><th>Nomor dada</th></tr>
               </thead>

--- a/web/style.css
+++ b/web/style.css
@@ -562,15 +562,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .card-title { text-align: center; }
 
 .detail-table {
-  width: auto; border-collapse: collapse; font-size: .85rem;
-  /* DITENGAHKAN, bukan menempel tepi kiri. Lebar mengikuti isi membuatnya
-     terlalu rapat ke pinggir dan terlihat seperti terlepas dari barisnya;
-     ditengahkan ia duduk di bawah baris induknya dengan ruang seimbang. */
-  margin: 0 auto;
+  /* MELEBAR PENUH, bukan selebar isinya. Tabel yang menciut menumpuk semua
+     kolom di kiri dan menyisakan lahan kosong di kanan — terbaca seperti
+     potongan yang terlepas dari baris induknya. Selebar kartu, kolomnya
+     jatuh sejajar dengan kolom di atasnya dan rincian terbaca menyatu. */
+  width: 100%; border-collapse: collapse; font-size: .85rem;
 }
 .detail-table th, .detail-table td { padding-right: 1.6rem; }
-/* Angka rupiah tetap sejajar antar baris supaya bisa dibandingkan sekilas,
-   tapi kolomnya sendiri sesempit isinya. */
+/* Angka rupiah rata kanan sampai ujung, sejajar antar baris supaya bisa
+   dibandingkan sekilas. */
 .detail-table th:last-child, .detail-table td:last-child {
   padding-right: .4rem; text-align: right; min-width: 6rem;
 }
@@ -583,6 +583,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    sekilas, dan sekilas itulah satu-satunya cara panitia membacanya. Kalau
    sempit, tabelnya yang menggeser di dalam kartu (aturan 10.1.13). */
 .detail-table td:nth-child(2) { white-space: nowrap; }
+
+/* Varian daftar ulang: melebar penuh, dan kolom terakhir dipatok 28% supaya
+   kotak nomor dada jatuh TEPAT DI BAWAH tombol "Isi N Nomor Dada" di baris
+   induknya — pasangan tombol dan isian terbaca sebagai satu kolom, bukan dua
+   hal yang kebetulan bertumpuk. Angka 28% menyamai lebar kolom aksi tabel
+   induk; kalau kolom induk berubah, angka ini ikut disetel. */
+.detail-table-dada { width: 100%; margin: 0; }
+.detail-table-dada th:last-child, .detail-table-dada td:last-child {
+  width: 28%; text-align: left; min-width: 0; padding-right: .4rem;
+}
 
 @media (max-width: 560px) {
   /* Satu regu = satu blok dua baris, kotak angka di kanan sejajar namanya.


### PR DESCRIPTION
## What

`.detail-table` goes from `width: auto` to `width: 100%`. A new `.detail-table-dada` modifier pins the last column to 28% and left-aligns it, so the bib-number input lands under the `Isi N Nomor Dada` toggle in the parent row.

## Why

Auto width piled every column against the left edge and left a wide empty strip on the right, so the panel read as a loose fragment rather than as the breakdown of the row above it. Money stays right-aligned so amounts compare at a glance.

## Notes

The 28% mirrors the parent table's action column. If that column's width changes, this number needs to follow — noted in the CSS comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)