### PR TITLE
fix: align bib-number column under the toggle that opens it

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -645,7 +645,7 @@ async function layarDaftarUlang() {
         jumlah: semua.length,
       })}
       <div class="table-wrapper">
-        <table class="table data-table">
+        <table class="table data-table table-daftar-ulang">
           <thead>
             <tr>
               <th>Kode Bayar</th><th>Sekolah</th><th class="text-center">Regu</th>
@@ -716,7 +716,7 @@ async function layarDaftarUlang() {
         </tr>
         ${!menunggu.length ? "" : `
         <tr class="detail-row" data-nomor-untuk="${kode}" ${terbuka ? "" : "hidden"}>
-          <td colspan="4">
+          <td colspan="4" class="detail-cell-flush">
             <table class="detail-table detail-table-dada">
               <thead>
                 <tr><th>Regu</th><th>Kategori</th><th>Ketua</th><th>Nomor dada</th></tr>

--- a/web/style.css
+++ b/web/style.css
@@ -584,15 +584,36 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    sempit, tabelnya yang menggeser di dalam kartu (aturan 10.1.13). */
 .detail-table td:nth-child(2) { white-space: nowrap; }
 
-/* Varian daftar ulang: melebar penuh, dan kolom terakhir dipatok 28% supaya
-   kotak nomor dada jatuh TEPAT DI BAWAH tombol "Isi N Nomor Dada" di baris
-   induknya — pasangan tombol dan isian terbaca sebagai satu kolom, bukan dua
-   hal yang kebetulan bertumpuk. Angka 28% menyamai lebar kolom aksi tabel
-   induk; kalau kolom induk berubah, angka ini ikut disetel. */
+/* SEJAJAR DENGAN TABEL INDUKNYA.
+   Kotak nomor dada harus jatuh tepat di bawah tombol "Isi N Nomor Dada" yang
+   membukanya — kalau meleset, tombol dan isiannya terbaca sebagai dua hal
+   yang kebetulan bertumpuk, dan petugas harus menelusuri baris dengan jari
+   untuk memastikan ia mengetik di sekolah yang benar.
+
+   Caranya: kedua tabel dipatok `table-layout: fixed` dengan lebar kolom yang
+   PERSIS SAMA, dan sel pembungkusnya dibuat rata tanpa padding kiri-kanan
+   supaya tabel rincian selebar tabel induk, bukan menjorok ke dalam. Empat
+   angka di bawah ini berpasangan; kalau satu diubah, pasangannya ikut. */
+.table-daftar-ulang, .detail-table-dada { table-layout: fixed; }
+.table-daftar-ulang th:nth-child(1), .table-daftar-ulang td:nth-child(1),
+.detail-table-dada  th:nth-child(1), .detail-table-dada  td:nth-child(1) { width: 18%; }
+.table-daftar-ulang th:nth-child(2), .table-daftar-ulang td:nth-child(2),
+.detail-table-dada  th:nth-child(2), .detail-table-dada  td:nth-child(2) { width: 44%; }
+.table-daftar-ulang th:nth-child(3), .table-daftar-ulang td:nth-child(3),
+.detail-table-dada  th:nth-child(3), .detail-table-dada  td:nth-child(3) { width: 10%; }
+.table-daftar-ulang th:nth-child(4), .table-daftar-ulang td:nth-child(4),
+.detail-table-dada  th:nth-child(4), .detail-table-dada  td:nth-child(4) { width: 28%; }
+
 .detail-table-dada { width: 100%; margin: 0; }
+/* Padding sel disamakan dengan tabel induk (.table td), kalau tidak isinya
+   bergeser beberapa piksel dan kesejajarannya hilang lagi. */
+.detail-table-dada th, .detail-table-dada td { padding-left: .5rem; padding-right: .5rem; }
 .detail-table-dada th:last-child, .detail-table-dada td:last-child {
-  width: 28%; text-align: left; min-width: 0; padding-right: .4rem;
+  text-align: left; min-width: 0;
 }
+/* Sel pembungkus rincian dibuat rata kiri-kanan supaya tabel di dalamnya
+   selebar tabel induk. Padding atas-bawah tetap, itu yang memisahkan blok. */
+.detail-cell-flush { padding-left: 0 !important; padding-right: 0 !important; }
 
 @media (max-width: 560px) {
   /* Satu regu = satu blok dua baris, kotak angka di kanan sejajar namanya.


### PR DESCRIPTION
## What

The daftar ulang table and its detail table are pinned to `table-layout: fixed` on identical column widths (18/44/10/28), and the wrapping `<td>` drops its horizontal padding so the detail table spans the parent's full width instead of sitting inset.

## Why

The bib-number input landed wherever the text above it happened to end, never under the `Isi N Nomor Dada` button that opened it. That leaves the petugas tracing the row by eye to confirm they are typing under the right school — and typing a number under the wrong school raises no error at all, it just scores a regu against someone else's sheet.

## Notes

The four percentages are a matched pair across both tables. Changing one without the other breaks the alignment again; the CSS comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)