### PR TITLE
fix: widen payment detail table up to the Metode column

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -331,7 +331,7 @@ async function layarPembayaran() {
         jumlah: semua.length,
       })}
       <div class="table-wrapper">
-        <table class="table data-table">
+        <table class="table data-table table-bayar">
           <thead>
             <tr>
               <th>Kode Bayar</th><th>Sekolah</th><th class="text-center">Regu</th>
@@ -435,8 +435,8 @@ async function layarPembayaran() {
         </tr>
         ${!aktif.length ? "" : `
         <tr class="detail-row" data-detail-untuk="${kode}" ${terbuka ? "" : "hidden"}>
-          <td colspan="6">
-            <table class="detail-table">
+          <td colspan="6" class="detail-cell-flush">
+            <table class="detail-table detail-table-bayar">
               <thead>
                 <tr><th>Regu</th><th>Kategori</th><th>Ketua</th><th>Sekolah</th>
                     <th class="text-right">Biaya</th></tr>

--- a/web/style.css
+++ b/web/style.css
@@ -615,6 +615,31 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    selebar tabel induk. Padding atas-bawah tetap, itu yang memisahkan blok. */
 .detail-cell-flush { padding-left: 0 !important; padding-right: 0 !important; }
 
+/* Meja Pembayaran, cara yang sama. Bedanya tabel induk punya ENAM kolom dan
+   rinciannya LIMA, jadi rincian sengaja berhenti di ujung kolom Metode —
+   kolom terakhir induk berisi tombol aksi, dan menaruh angka di bawahnya
+   membuat rincian tampak menerus ke wilayah tombol.
+
+   Lebar rincian = jumlah lima kolom pertama induk (71%), lalu tiap kolomnya
+   dihitung sebagai bagian dari 71% itu supaya jatuh persis sekolom:
+   Regu di bawah Kode Bayar, Kategori di bawah Sekolah, Ketua di bawah Regu,
+   Sekolah di bawah Tagihan, Biaya di bawah Metode. */
+.table-bayar, .detail-table-bayar { table-layout: fixed; }
+.table-bayar th:nth-child(1), .table-bayar td:nth-child(1) { width: 15%; }
+.table-bayar th:nth-child(2), .table-bayar td:nth-child(2) { width: 22%; }
+.table-bayar th:nth-child(3), .table-bayar td:nth-child(3) { width:  8%; }
+.table-bayar th:nth-child(4), .table-bayar td:nth-child(4) { width: 13%; }
+.table-bayar th:nth-child(5), .table-bayar td:nth-child(5) { width: 13%; }
+.table-bayar th:nth-child(6), .table-bayar td:nth-child(6) { width: 29%; }
+
+.detail-table-bayar { width: 71%; margin: 0; }
+.detail-table-bayar th, .detail-table-bayar td { padding-left: .5rem; padding-right: .5rem; }
+.detail-table-bayar th:nth-child(1), .detail-table-bayar td:nth-child(1) { width: 21.1%; }
+.detail-table-bayar th:nth-child(2), .detail-table-bayar td:nth-child(2) { width: 31.0%; }
+.detail-table-bayar th:nth-child(3), .detail-table-bayar td:nth-child(3) { width: 11.3%; }
+.detail-table-bayar th:nth-child(4), .detail-table-bayar td:nth-child(4) { width: 18.3%; }
+.detail-table-bayar th:nth-child(5), .detail-table-bayar td:nth-child(5) { width: 18.3%; }
+
 @media (max-width: 560px) {
   /* Satu regu = satu blok dua baris, kotak angka di kanan sejajar namanya.
      Judul kolom disembunyikan karena pasangannya sudah jelas dari bentuk. */


### PR DESCRIPTION
## What

The Meja Pembayaran table and its breakdown are pinned to `table-layout: fixed`. The breakdown is 71% wide — the sum of the parent's first five columns — with each of its own columns sized as a share of that, so every column lands under its counterpart and the table stops at the right edge of Metode.

## Why

The breakdown sat cramped in the middle of the row. It now spreads across the row like the daftar ulang one, but stops before the action column: the parent's last column holds Cetak Kwitansi / Batalkan, and running figures under buttons makes the breakdown read as if it continues into them.

## Notes

The percentages in the two blocks are a matched set — the detail widths are shares of 71%, not of the card. Changing a parent column means recomputing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)