### PR TITLE
feat: let panitia correct a recorded departure time

### DIFF
--- a/supabase/migrations/0017_koreksi_jam_berangkat.sql
+++ b/supabase/migrations/0017_koreksi_jam_berangkat.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- hrcd-rekap : 0017_koreksi_jam_berangkat.sql
+--
+-- Membetulkan jam berangkat kloter yang sudah terlanjur tercatat.
+--
+-- KENAPA PERLU FUNGSI BARU. Yang ada sekarang tidak menutup kasus ini:
+--
+--   berangkatkan_kloter   menolak kloter yang jam_berangkat-nya sudah terisi
+--                         ('kloter % sudah berangkat'), jadi tidak bisa dipakai
+--                         untuk membetulkan.
+--   batalkan_keberangkatan hanya admin, dan hanya untuk kloter berangkat
+--                         TERAKHIR. Salah ketik jam justru biasanya baru
+--                         ketahuan setelah kloter berikutnya jalan — persis
+--                         saat fungsi itu sudah tidak bisa dipakai lagi.
+--
+-- KENAPA INI PENTING. jam_berangkat bukan sekadar catatan. Penalti waktu
+-- dihitung di v_nilai_regu sebagai selisih jam_datang terhadap
+-- (jam_berangkat + kontrak_menit). Satu digit salah ketik menggeser penalti
+-- SELURUH regu di kloter itu, tanpa galat apa pun, dan baru ketahuan saat
+-- klasemen keluar. Karena angkanya dihitung di view dan tidak disimpan,
+-- membetulkan jam_berangkat langsung membetulkan seluruh penilaian kloter —
+-- tidak ada yang perlu dihitung ulang.
+--
+-- SIAPA YANG BOLEH. meja/admin, sama dengan berangkatkan_kloter. Membatasinya
+-- ke admin saja terdengar lebih aman tapi tidak: meja sudah memegang wewenang
+-- MENETAPKAN jam itu di awal, jadi mengunci KOREKSI-nya lebih ketat daripada
+-- penetapannya hanya berarti pencatat harus mencari admin di tengah lomba —
+-- dan koreksi yang harus menunggu adalah koreksi yang tidak pernah terjadi.
+-- Sebagai gantinya alasan wajib diisi dan tercatat di history bersama jam
+-- lamanya, jadi perubahannya selalu bisa ditelusuri.
+-- ============================================================================
+
+create or replace function koreksi_jam_berangkat(
+  p_kloter smallint,
+  p_jam    timestamptz,
+  p_alasan text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_lama    timestamptz;
+  v_tetangga smallint;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jam is null then
+    raise exception 'jam berangkat wajib diketik';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan koreksi wajib diisi';
+  end if;
+
+  select jam_berangkat into v_lama from kloter where nomor = p_kloter;
+  if not found then
+    raise exception 'kloter % tidak ada', p_kloter;
+  end if;
+  if v_lama is null then
+    raise exception 'kloter % belum berangkat — pakai tombol Berangkatkan, bukan koreksi', p_kloter;
+  end if;
+  -- Tidak berubah: jangan tulis baris audit palsu yang nanti membingungkan
+  -- orang yang menelusuri riwayat.
+  if p_jam = v_lama then
+    return;
+  end if;
+
+  -- Kloter berangkat berurutan, jadi jamnya ikut menaik. Koreksi yang
+  -- melanggar urutan itu hampir selalu salah ketik yang KEDUA (mau membetulkan
+  -- 07.40, malah terketik 08.40). Ditolak di sini, karena kalau lolos ia
+  -- menghasilkan penalti negatif yang tampak wajar di layar.
+  select k.nomor into v_tetangga
+  from kloter k
+  where k.nomor < p_kloter and k.jam_berangkat is not null and k.jam_berangkat > p_jam
+  order by k.nomor desc limit 1;
+  if v_tetangga is not null then
+    raise exception 'jam koreksi lebih awal daripada kloter % yang berangkat sebelumnya', v_tetangga;
+  end if;
+
+  select k.nomor into v_tetangga
+  from kloter k
+  where k.nomor > p_kloter and k.jam_berangkat is not null and k.jam_berangkat < p_jam
+  order by k.nomor asc limit 1;
+  if v_tetangga is not null then
+    raise exception 'jam koreksi lebih lambat daripada kloter % yang berangkat sesudahnya', v_tetangga;
+  end if;
+
+  insert into history (table_name, row_id, action, old_value, new_value, changed_by)
+  values ('kloter', p_kloter::text, 'UPDATE',
+          jsonb_build_object('jam_berangkat', v_lama),
+          jsonb_build_object('jam_berangkat', p_jam, 'alasan_koreksi', p_alasan),
+          auth.uid());
+
+  update kloter set jam_berangkat = p_jam where nomor = p_kloter;
+end;
+$$;

--- a/supabase/migrations/0017_koreksi_jam_berangkat.sql
+++ b/supabase/migrations/0017_koreksi_jam_berangkat.sql
@@ -28,6 +28,10 @@
 -- dan koreksi yang harus menunggu adalah koreksi yang tidak pernah terjadi.
 -- Sebagai gantinya alasan wajib diisi dan tercatat di history bersama jam
 -- lamanya, jadi perubahannya selalu bisa ditelusuri.
+--
+-- KENAPA URUTAN JAM TIDAK DIPERIKSA. Lihat catatan di dalam badan fungsi:
+-- memeriksanya membuat dua kloter yang jamnya sama-sama salah saling
+-- mengunci, sehingga tidak satu pun bisa dibetulkan.
 -- ============================================================================
 
 create or replace function koreksi_jam_berangkat(
@@ -39,8 +43,7 @@ language plpgsql security definer
 set search_path = public
 as $$
 declare
-  v_lama    timestamptz;
-  v_tetangga smallint;
+  v_lama timestamptz;
 begin
   if peran() not in ('admin', 'meja') then
     raise exception 'hanya meja/admin';
@@ -65,26 +68,14 @@ begin
     return;
   end if;
 
-  -- Kloter berangkat berurutan, jadi jamnya ikut menaik. Koreksi yang
-  -- melanggar urutan itu hampir selalu salah ketik yang KEDUA (mau membetulkan
-  -- 07.40, malah terketik 08.40). Ditolak di sini, karena kalau lolos ia
-  -- menghasilkan penalti negatif yang tampak wajar di layar.
-  select k.nomor into v_tetangga
-  from kloter k
-  where k.nomor < p_kloter and k.jam_berangkat is not null and k.jam_berangkat > p_jam
-  order by k.nomor desc limit 1;
-  if v_tetangga is not null then
-    raise exception 'jam koreksi lebih awal daripada kloter % yang berangkat sebelumnya', v_tetangga;
-  end if;
-
-  select k.nomor into v_tetangga
-  from kloter k
-  where k.nomor > p_kloter and k.jam_berangkat is not null and k.jam_berangkat < p_jam
-  order by k.nomor asc limit 1;
-  if v_tetangga is not null then
-    raise exception 'jam koreksi lebih lambat daripada kloter % yang berangkat sesudahnya', v_tetangga;
-  end if;
-
+  -- SENGAJA TIDAK ADA PEMERIKSAAN URUTAN JAM di sini, walau menggoda.
+  -- berangkatkan_kloter hanya menjaga urutan NOMOR kloter, bukan urutan jam
+  -- yang diketik, jadi data yang jamnya sudah kacau memang mungkin ada. Kalau
+  -- fungsi ini menolak jam yang melanggar urutan, kloter 1 tidak bisa
+  -- dibetulkan karena jam kloter 2 salah, dan kloter 2 tidak bisa dibetulkan
+  -- karena jam kloter 1 salah — panitia terkunci persis di keadaan yang
+  -- membuat mereka membuka layar ini. Urutan ditampilkan di dialog koreksi
+  -- supaya pencatat melihatnya sendiri; menampilkan menolong, menolak tidak.
   insert into history (table_name, row_id, action, old_value, new_value, changed_by)
   values ('kloter', p_kloter::text, 'UPDATE',
           jsonb_build_object('jam_berangkat', v_lama),

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -39,11 +39,13 @@ run supabase/migrations/0013_nama_kontak.sql
 run supabase/migrations/0014_rename_common_columns.sql
 run supabase/migrations/0015_v_kwitansi_column.sql
 run supabase/migrations/0016_nama_edisi_romawi.sql
+run supabase/migrations/0017_koreksi_jam_berangkat.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
 run tests/sql/03_alur.sql
 run tests/sql/04_cetak_kloter.sql
 run tests/sql/05_pindah_kloter.sql
+run tests/sql/06_koreksi_jam_berangkat.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/06_koreksi_jam_berangkat.sql
+++ b/tests/sql/06_koreksi_jam_berangkat.sql
@@ -2,9 +2,9 @@
 -- hrcd-rekap : tests/sql/06_koreksi_jam_berangkat.sql
 -- Membetulkan jam berangkat yang salah ketik (migrasi 0017).
 --
--- Yang WAJIB dibuktikan: jam lamanya tercatat di history, dan koreksi yang
--- merusak urutan keberangkatan ditolak. Keduanya tidak kelihatan di layar —
--- jam berangkat yang salah tidak menimbulkan galat apa pun, ia hanya muncul
+-- Yang WAJIB dibuktikan: jam lamanya tercatat di history, dan koreksi TIDAK
+-- terkunci oleh jam kloter tetangga. Keduanya tidak kelihatan di layar — jam
+-- berangkat yang salah tidak menimbulkan galat apa pun, ia hanya muncul
 -- sebagai penalti yang keliru saat klasemen keluar.
 -- ============================================================================
 
@@ -76,14 +76,15 @@ begin
 end;
 $$;
 
--- 6.4 Urutan keberangkatan dijaga. Kloter berangkat berurutan, jadi jamnya
---     ikut menaik; koreksi yang melanggar itu hampir selalu salah ketik yang
---     KEDUA, dan kalau lolos ia menghasilkan penalti negatif yang tampak
---     wajar di layar.
+-- 6.4 Koreksi TIDAK boleh terkunci oleh jam kloter tetangga.
+--     berangkatkan_kloter hanya menjaga urutan NOMOR kloter, bukan urutan jam
+--     yang diketik, jadi data yang jamnya kacau memang bisa ada. Kalau fungsi
+--     ini menolak jam yang melanggar urutan, dua kloter yang sama-sama salah
+--     akan saling mengunci dan tidak satu pun bisa dibetulkan — tepat di
+--     keadaan yang membuat panitia membuka layar ini.
 do $$
 declare
-  v_awal   smallint; v_akhir smallint;
-  v_jam_akhir timestamptz;
+  v_awal smallint; v_akhir smallint; v_jam_akhir timestamptz;
 begin
   select min(nomor), max(nomor) into v_awal, v_akhir
   from kloter where jam_berangkat is not null;
@@ -93,23 +94,12 @@ begin
   end if;
   select jam_berangkat into v_jam_akhir from kloter where nomor = v_akhir;
 
-  -- Kloter pertama digeser ke SETELAH kloter terakhir: harus ditolak.
-  begin
-    perform koreksi_jam_berangkat(v_awal, v_jam_akhir + interval '5 minutes',
-                                  'sengaja melanggar urutan');
-    raise exception 'GAGAL: koreksi yang melanggar urutan diterima';
-  exception when raise_exception then
-    if sqlerrm like 'GAGAL:%' then raise; end if;
-  end;
-
-  -- Arah sebaliknya: kloter terakhir digeser ke SEBELUM kloter pertama.
-  begin
-    perform koreksi_jam_berangkat(v_akhir, timestamptz '2027-02-21 06:00+07',
-                                  'sengaja melanggar urutan');
-    raise exception 'GAGAL: koreksi mundur yang melanggar urutan diterima';
-  exception when raise_exception then
-    if sqlerrm like 'GAGAL:%' then raise; end if;
-  end;
+  -- Kloter pertama digeser ke SETELAH kloter terakhir: harus tetap diterima.
+  perform koreksi_jam_berangkat(v_awal, v_jam_akhir + interval '5 minutes',
+                                'jam kloter tetangga yang salah, ini dibetulkan belakangan');
+  assert (select jam_berangkat from kloter where nomor = v_awal)
+         = v_jam_akhir + interval '5 minutes',
+    'koreksi terkunci oleh jam kloter tetangga';
 end;
 $$;
 

--- a/tests/sql/06_koreksi_jam_berangkat.sql
+++ b/tests/sql/06_koreksi_jam_berangkat.sql
@@ -1,0 +1,135 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/06_koreksi_jam_berangkat.sql
+-- Membetulkan jam berangkat yang salah ketik (migrasi 0017).
+--
+-- Yang WAJIB dibuktikan: jam lamanya tercatat di history, dan koreksi yang
+-- merusak urutan keberangkatan ditolak. Keduanya tidak kelihatan di layar —
+-- jam berangkat yang salah tidak menimbulkan galat apa pun, ia hanya muncul
+-- sebagai penalti yang keliru saat klasemen keluar.
+-- ============================================================================
+
+\echo '== 06: koreksi jam berangkat =='
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+-- 6.1 Alasan wajib — koreksi tanpa alasan ditolak.
+do $$
+declare v_kloter smallint;
+begin
+  select nomor into v_kloter from kloter
+  where jam_berangkat is not null order by nomor limit 1;
+  assert v_kloter is not null, 'tidak ada kloter berangkat untuk diuji';
+  begin
+    perform koreksi_jam_berangkat(v_kloter, timestamptz '2027-02-21 07:05+07', '   ');
+    raise exception 'GAGAL: koreksi tanpa alasan diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+-- 6.2 Kloter yang BELUM berangkat ditolak — itu urusan berangkatkan_kloter,
+--     dan mencampurnya berarti kloter bisa "berangkat" lewat pintu yang tidak
+--     memeriksa kontrak waktu maupun urutan.
+do $$
+declare v_kloter smallint;
+begin
+  select nomor into v_kloter from kloter
+  where jam_berangkat is null order by nomor limit 1;
+  assert v_kloter is not null, 'tidak ada kloter belum berangkat untuk diuji';
+  begin
+    perform koreksi_jam_berangkat(v_kloter, timestamptz '2027-02-21 07:05+07', 'salah ketik');
+    raise exception 'GAGAL: koreksi kloter belum berangkat diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+-- 6.3 Koreksi yang sah: jam berubah, DAN jam lamanya tersimpan di history.
+--     Bagian kedua yang penting — tanpa jejak jam lama, tidak ada cara
+--     memastikan penalti sebuah kloter dihitung dari angka yang benar.
+do $$
+declare
+  v_kloter smallint;
+  v_lama   timestamptz;
+  v_baru   timestamptz;
+  v_catat  jsonb;
+begin
+  select nomor, jam_berangkat into v_kloter, v_lama
+  from kloter where jam_berangkat is not null order by nomor limit 1;
+  v_baru := v_lama - interval '3 minutes';
+
+  perform koreksi_jam_berangkat(v_kloter, v_baru, 'salah ketik di meja');
+
+  assert (select jam_berangkat from kloter where nomor = v_kloter) = v_baru,
+    'jam berangkat tidak berubah setelah koreksi';
+
+  select old_value into v_catat from history
+  where table_name = 'kloter' and row_id = v_kloter::text
+  order by changed_at desc limit 1;
+  assert v_catat is not null, 'koreksi tidak tercatat di history';
+  assert (v_catat->>'jam_berangkat')::timestamptz = v_lama,
+    format('history menyimpan jam lama %s, harusnya %s',
+           v_catat->>'jam_berangkat', v_lama);
+end;
+$$;
+
+-- 6.4 Urutan keberangkatan dijaga. Kloter berangkat berurutan, jadi jamnya
+--     ikut menaik; koreksi yang melanggar itu hampir selalu salah ketik yang
+--     KEDUA, dan kalau lolos ia menghasilkan penalti negatif yang tampak
+--     wajar di layar.
+do $$
+declare
+  v_awal   smallint; v_akhir smallint;
+  v_jam_akhir timestamptz;
+begin
+  select min(nomor), max(nomor) into v_awal, v_akhir
+  from kloter where jam_berangkat is not null;
+  if v_awal = v_akhir then
+    raise notice '6.4 dilewati: hanya satu kloter yang berangkat';
+    return;
+  end if;
+  select jam_berangkat into v_jam_akhir from kloter where nomor = v_akhir;
+
+  -- Kloter pertama digeser ke SETELAH kloter terakhir: harus ditolak.
+  begin
+    perform koreksi_jam_berangkat(v_awal, v_jam_akhir + interval '5 minutes',
+                                  'sengaja melanggar urutan');
+    raise exception 'GAGAL: koreksi yang melanggar urutan diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Arah sebaliknya: kloter terakhir digeser ke SEBELUM kloter pertama.
+  begin
+    perform koreksi_jam_berangkat(v_akhir, timestamptz '2027-02-21 06:00+07',
+                                  'sengaja melanggar urutan');
+    raise exception 'GAGAL: koreksi mundur yang melanggar urutan diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+-- 6.5 Operator pos tidak boleh — jam berangkat menentukan penalti seluruh
+--     kloter, dan pos hanya berurusan dengan nilai wahana.
+do $$
+declare v_kloter smallint;
+begin
+  select nomor into v_kloter from kloter
+  where jam_berangkat is not null order by nomor limit 1;
+  perform set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+  begin
+    perform koreksi_jam_berangkat(v_kloter, timestamptz '2027-02-21 07:05+07', 'coba-coba');
+    raise exception 'GAGAL: operator pos bisa mengoreksi jam berangkat';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+end;
+$$;
+
+reset role;
+\echo '   06 lulus'

--- a/tests/sql/06_koreksi_jam_berangkat.sql
+++ b/tests/sql/06_koreksi_jam_berangkat.sql
@@ -66,9 +66,14 @@ begin
   assert (select jam_berangkat from kloter where nomor = v_kloter) = v_baru,
     'jam berangkat tidak berubah setelah koreksi';
 
+  -- history hanya boleh dibaca admin (policy sel_riwayat di 0003_rls.sql),
+  -- jadi identitasnya ditukar dulu — sebagai meja, select-nya kosong dan
+  -- assert di bawah akan gagal dengan alasan yang menyesatkan.
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
   select old_value into v_catat from history
   where table_name = 'kloter' and row_id = v_kloter::text
   order by changed_at desc limit 1;
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
   assert v_catat is not null, 'koreksi tidak tercatat di history';
   assert (v_catat->>'jam_berangkat')::timestamptz = v_lama,
     format('history menyimpan jam lama %s, harusnya %s',

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -380,3 +380,9 @@ export const batalCeklisBerangkat = (nomorDada) =>
 /** Jam WAJIB diketik panitia pencatat — tidak pernah now() (alur 12.4). */
 export const berangkatkanKloter = (kloter, jam) =>
   rpc("berangkatkan_kloter", { p_kloter: kloter, p_jam: jam });
+
+/** Membetulkan jam kloter yang SUDAH berangkat. Alasan wajib: jam berangkat
+ *  menentukan penalti seluruh regu di kloter itu, jadi setiap perubahannya
+ *  tercatat di history bersama jam lamanya. */
+export const koreksiJamBerangkat = (kloter, jam, alasan) =>
+  rpc("koreksi_jam_berangkat", { p_kloter: kloter, p_jam: jam, p_alasan: alasan });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -16,6 +16,7 @@ import {
   cariRegu, catatFinish, infoPenalti,
   papanKeberangkatan, reguKloter, kontrakOpsi,
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
+  koreksiJamBerangkat,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -970,7 +971,10 @@ async function layarKeberangkatan() {
         <div class="kloter-header">
           <h2>Kloter ${kloterAktif}</h2>
           ${sudahBerangkat
-            ? html`<span class="badge badge-green">BERANGKAT ${jamPendek(info.jam_berangkat)}</span>`
+            ? html`<span class="badge badge-green">BERANGKAT ${jamPendek(info.jam_berangkat)}</span>
+                   <button class="icon-button icon-button-inline" id="koreksi-jam" type="button"
+                           title="Betulkan jam berangkat"
+                           aria-label="Betulkan jam berangkat Kloter ${kloterAktif}">&#9998;</button>`
             : `<span class="badge badge-yellow">BELUM BERANGKAT</span>`}
         </div>
 
@@ -1056,6 +1060,37 @@ async function layarKeberangkatan() {
         }
         sel.disabled = false;
       }));
+
+    // Membetulkan jam yang sudah tercatat. Jam berangkat menentukan penalti
+    // SELURUH regu di kloter ini, dan salah ketik tidak menimbulkan galat apa
+    // pun — ia hanya muncul sebagai nilai yang salah saat klasemen keluar.
+    // Karena itu koreksinya minta alasan dan tercatat di history.
+    const tombolKoreksi = document.getElementById("koreksi-jam");
+    if (tombolKoreksi) tombolKoreksi.addEventListener("click", async () => {
+      const jawab = await dialog({
+        judul: `Betulkan jam berangkat Kloter ${kloterAktif}`,
+        kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
+          <div class="nama">Sekarang tercatat ${jamPendek(info.jam_berangkat)}</div>
+          <div class="detail">Mengubah jam ini menghitung ulang penalti waktu
+            seluruh regu di Kloter ${kloterAktif}.</div>
+        </div>`,
+        medan: [
+          { label: "Jam berangkat yang benar", tipe: "time",
+            nilai: jamHHMM(info.jam_berangkat) },
+          { label: "Alasan koreksi", contoh: "salah ketik, seharusnya 07.40" },
+        ],
+        labelAksi: "Simpan Koreksi",
+      });
+      if (!jawab) return;
+      const [hhmm, alasan] = jawab;
+      try {
+        await koreksiJamBerangkat(kloterAktif, jamHariIni(hhmm).toISOString(), alasan);
+      } catch (err) { notif(err.message, true); return; }
+      notif(`Jam berangkat Kloter ${kloterAktif} dibetulkan jadi ${hhmm}.`);
+      papan = await papanKeberangkatan();
+      gambarPita();
+      gambarKloter();
+    });
 
     const tombol = document.getElementById("aksi-berangkat");
     if (tombol) tombol.addEventListener("click", async () => {
@@ -1500,6 +1535,15 @@ function layarFinish() {
 const jamPendek = (t) => t
   ? new Date(t).toLocaleTimeString("id-ID", { hour: "2-digit", minute: "2-digit" })
   : "—";
+
+/** Kebalikan jamPendek: timestamp -> "07:04" untuk mengisi <input type="time">.
+ *  Dipisah dari jamPendek karena jamPendek memakai locale id-ID yang memberi
+ *  "07.04" — titik, bukan titik dua — dan input time menolaknya diam-diam. */
+const jamHHMM = (t) => {
+  if (!t) return "";
+  const d = new Date(t);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+};
 
 /** "14:35" -> Date hari ini pada jam itu (untuk pencatatan susulan). */
 function jamHariIni(hhmm) {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1067,12 +1067,24 @@ async function layarKeberangkatan() {
     // Karena itu koreksinya minta alasan dan tercatat di history.
     const tombolKoreksi = document.getElementById("koreksi-jam");
     if (tombolKoreksi) tombolKoreksi.addEventListener("click", async () => {
+      // Jam kloter tetangga ditampilkan, BUKAN dipaksakan. Fungsi database
+      // sengaja tidak menolak jam yang melanggar urutan (kalau menolak, dua
+      // kloter yang jamnya sama-sama salah saling mengunci). Yang menangkap
+      // salah ketik di sini adalah mata pencatat, jadi angka pembandingnya
+      // ditaruh di depan mata.
+      const sebelum = papan.filter(k => k.nomor < kloterAktif && k.jam_berangkat).pop();
+      const sesudah = papan.find(k => k.nomor > kloterAktif && k.jam_berangkat);
+      const tetangga = [
+        sebelum && `Kloter ${sebelum.nomor} berangkat ${jamPendek(sebelum.jam_berangkat)}`,
+        sesudah && `Kloter ${sesudah.nomor} berangkat ${jamPendek(sesudah.jam_berangkat)}`,
+      ].filter(Boolean).join(" · ");
+
       const jawab = await dialog({
         judul: `Betulkan jam berangkat Kloter ${kloterAktif}`,
         kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
           <div class="nama">Sekarang tercatat ${jamPendek(info.jam_berangkat)}</div>
           <div class="detail">Mengubah jam ini menghitung ulang penalti waktu
-            seluruh regu di Kloter ${kloterAktif}.</div>
+            seluruh regu di Kloter ${kloterAktif}.${tetangga ? ` ${tetangga}.` : ""}</div>
         </div>`,
         medan: [
           { label: "Jam berangkat yang benar", tipe: "time",

--- a/web/style.css
+++ b/web/style.css
@@ -143,6 +143,10 @@ button { font: inherit; cursor: pointer; }
   cursor: pointer; padding: 0;
 }
 .icon-button:hover { background: rgba(255,255,255,.15); }
+/* Varian di atas kartu terang: hover putih tidak terlihat di sana, dan
+   ukurannya diturunkan supaya tidak bersaing dengan badge di sebelahnya. */
+.icon-button-inline { min-width: 32px; min-height: 32px; font-size: 1rem; color: var(--tinta-lembut); }
+.icon-button-inline:hover { background: var(--garis); color: var(--tinta); }
 
 .button:focus-visible, input:focus-visible, .option:focus-visible,
 .icon-button:focus-visible {


### PR DESCRIPTION
## What

Migration 0017 adds `koreksi_jam_berangkat(p_kloter, p_jam, p_alasan)`, and the Keberangkatan screen gets an edit button beside the BERANGKAT badge. The dialog shows the currently recorded time, the neighbouring kloter's departure times, and asks for a reason.

## Why

Neither existing RPC covers this. `berangkatkan_kloter` refuses a kloter that has already departed; `batalkan_keberangkatan` is admin-only and limited to the most recently departed kloter — exactly the wrong shape, because a mistyped time is usually noticed only after the next kloter has already gone.

It matters because `jam_berangkat` is not a note. Penalties are computed in `v_nilai_regu` as `jam_datang` against `(jam_berangkat + kontrak_menit)`, so one wrong digit shifts the penalty for every regu in that kloter, raises no error anywhere, and surfaces only when the standings come out. Since the figure is derived in a view rather than stored, correcting the time corrects the whole kloter's scoring — nothing needs recomputing.

`meja` may do it, same as `berangkatkan_kloter`: the desk already holds the authority to set that time, so locking the correction down harder than the original entry only means the recorder has to hunt for an admin mid-event. A reason is required instead, and the old time is written to `history`.

## Notes

The first version also refused a correction that put a kloter out of order relative to its neighbours. CI showed why that is wrong: `berangkatkan_kloter` only enforces the order of kloter *numbers*, never the order of the times typed into it, so two kloter with tangled times would each block the other's correction and neither could be fixed. The ordering is shown in the dialog instead — informing the recorder without being able to trap them.

Migration 0017 is already applied to production, and the PostgREST schema cache has been reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)