### PR TITLE
fix: title the panitia app HRCD XXXVII

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>HRCD Rekap — Panitia</title>
+  <title>HRCD XXXVII</title>
   <link rel="stylesheet" href="style.css?v=3">
 </head>
 <body>


### PR DESCRIPTION
## What

`web/index.html` title goes from `HRCD Rekap — Panitia` to `HRCD XXXVII`.

## Why

The old title named the software rather than the event. On a phone the tab strip shows only the first few characters, and panitia switching tabs mid-shift are looking for the event.

## Notes

`daftar.html` keeps `Pendaftaran — Hiking Rally Ciradyka` — that page is for peserta, who need to know what they are signing up for rather than which edition it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)