### PR TITLE
fix: kloter sheet — reword note, drop pembina box, keep last border

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1298,16 +1298,8 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
           <tbody>${baris}</tbody>
         </table>
         <p class="print-note">Bersiap di staging paling lambat 15 menit sebelum
-           perkiraan berangkat. Jam sebenarnya bisa bergeser — ikuti panggilan petugas.</p>
-        <!-- Pembina regu mencatat jam berangkat sebenarnya sebagai bahan
-             klarifikasi: penalti waktu dihitung dari jam ini + kontrak waktu. -->
-        <div class="supervisor-box">
-          <strong>Catatan pembina — isi saat kloter benar-benar berangkat:</strong>
-          <p class="isian-jam">Jam berangkat sebenarnya: <span class="garis-isi"></span></p>
-          <p class="print-note">Target kedatangan tiap regu = jam di atas + kontrak
-             waktu regu itu (3,5 / 4 / 4,5 jam). Simpan lembar ini bila perlu
-             mengklarifikasi penilaian ketepatan waktu.</p>
-        </div>
+           perkiraan berangkat.<br>
+           Jam sebenarnya bisa bergeser, ikuti panggilan petugas.</p>
       </section>`;
   }).join("");
   document.body.appendChild(h(`<div id="cetakan" class="printout">${halaman}</div>`));

--- a/web/style.css
+++ b/web/style.css
@@ -462,20 +462,6 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
   .print-note { font-size: 9pt; color: #333; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
-
-  /* Kotak untuk pembina mencatat jam berangkat sebenarnya — bahan klarifikasi
-     bila penilaian ketepatan waktu dipersoalkan. */
-  .supervisor-box {
-    margin-top: 8mm;
-    border: 1.5pt solid #000;
-    padding: 4mm;
-  }
-  .supervisor-box .isian-jam { font-size: 12pt; margin: 3mm 0; }
-  .garis-isi {
-    display: inline-block;
-    width: 45mm;
-    border-bottom: 1pt solid #000;
-  }
 }
 
 @page { margin: 12mm; }

--- a/web/style.css
+++ b/web/style.css
@@ -436,7 +436,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .print-page { break-after: page; page-break-after: always; }
   .print-page:last-child { break-after: auto; page-break-after: auto; }
 
-  .print-table { width: 100%; border-collapse: collapse; margin-top: .5rem; }
+  /* Lebar disisakan 1pt dari 100%. Dengan border-collapse, garis kanan tabel
+     selebar-penuh jatuh PERSIS di batas cetak, dan pembulatan browser
+     melemparkannya keluar halaman — kolom terakhir (Hadir) tercetak tanpa
+     garis penutup dan terlihat seperti terpotong. */
+  .print-table { width: calc(100% - 1pt); border-collapse: collapse; margin-top: .5rem; }
   .print-table th, .print-table td {
     border: 1px solid #000;
     padding: 5pt 6pt;


### PR DESCRIPTION
## What

On the printed kloter sheets:

- The pembina sheet's note becomes two lines: `...perkiraan berangkat.` / `Jam sebenarnya bisa bergeser, ikuti panggilan petugas.`
- The `Catatan pembina` box is removed, along with its CSS.
- `.print-table` is held 1pt short of full width so the last column keeps its right border.

## Why

The note joined two unrelated instructions with a dash; being at staging on time and following the marshal's call are separate things.

The box asked pembina to hand-write the real departure time as material for disputing a time score. The app now owns that number — it is typed at the desk, correctable there, and the previous value is kept in `history`. Keeping a paper field for it creates a second source of truth for the one figure that decides every penalty in the kloter.

At exactly 100% with collapsed borders, the table's right edge lands on the print boundary and rounding pushes it off the page, so the Hadir column printed with no closing line and read as cut off.

## Notes

The staging sheet's departure line is unchanged: a departed kloter prints its real time and drops the `Jam sebenarnya: ____` blank; one that has not departed keeps the original format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)