### PR TITLE
fix: title each tab by screen, and read the renamed edisi column

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>HRCD XXXVII</title>
+  <title>Hiking Rally Ciradyka</title>
   <link rel="stylesheet" href="style.css?v=3">
 </head>
 <body>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -32,6 +32,16 @@ const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
 
 /** lebar = layar tabel (butuh ruang horizontal); sisanya tetap sempit supaya
  *  satu aksi utama gampang ditemukan di layar kecil. */
+/** Nama acara untuk judul tab: "Hiking Rally Ciradyka XXXVII".
+ *  Angka romawinya DIAMBIL dari nama edisi di database ("HRCD XXXVII"),
+ *  bukan ditulis di sini — tahun depan cukup mengubah satu baris di tabel
+ *  edisi, tidak ada yang perlu mencarinya di dalam JavaScript. Sebelum edisi
+ *  termuat (layar masuk), angkanya dilewati saja. */
+const namaAcara = () => {
+  const romawi = EDISI ? String(EDISI.name || "").replace(/^HRCD\s*/i, "").trim() : "";
+  return `Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
+};
+
 function pasangKepala(judul, lebar = false) {
   const s = sesi();
   document.getElementById("kepala").hidden = !s;
@@ -48,6 +58,7 @@ function pasangKepala(judul, lebar = false) {
       .setAttribute("aria-current", location.hash === "#/ganti-password" ? "page" : "false");
   }
   document.getElementById("judul-layar").textContent = judul;
+  document.title = `${judul} — ${namaAcara()}`;
   LAYAR.classList.toggle("wide", lebar);
   if (s) document.getElementById("siapa").textContent =
     `${s.username} · ${EDISI ? EDISI.name : ""}`;

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -599,7 +599,11 @@ async function mulai() {
     LAYAR.replaceChildren(kartuGagalMuat(e.message, mulai));
     return;
   }
-  document.getElementById("label-edisi").textContent = EDISI.nama;
+  // v_edisi_publik memberi kolom `name` sejak migrasi 0014 — `nama` sudah
+  // tidak ada, dan membacanya diam-diam menghasilkan undefined.
+  document.getElementById("label-edisi").textContent = EDISI.name;
+  const romawi = String(EDISI.name || "").replace(/^HRCD\s*/i, "").trim();
+  document.title = `Pendaftaran — Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
 
   let hasilLama = null, draf = null;
   try { hasilLama = JSON.parse(localStorage.getItem(KUNCI_HASIL) || "null"); } catch {}


### PR DESCRIPTION
## What

- Panitia tabs read `<screen> — Hiking Rally Ciradyka XXXVII`; the public form reads `Pendaftaran — Hiking Rally Ciradyka XXXVII`.
- The roman numeral is derived from the edisi row rather than hardcoded.
- `daftar.js` reads `EDISI.name` instead of `EDISI.nama`.

## Why

Panitia keep several desks open at once, and a tab strip where every entry reads the same thing has to be clicked through rather than scanned.

The second item is a live bug, not a cleanup. `v_edisi_publik` has exposed `name` since migration 0014, and reading a missing property fails silently in JavaScript — so the edition label on the public registration page has been rendering as `undefined`. Confirmed against production:

```
[{"nomor":37,"name":"HRCD XXXVII","biaya_per_regu":250000,"tanggal_lomba":"2027-02-21"}]
```

## Notes

The static `<title>` in each HTML file is the pre-JavaScript fallback and carries no numeral, since the edition is not known until the edisi row loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)