### PR TITLE
fix: repair the unterminated confirm string breaking the whole app

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1290,12 +1290,12 @@ async function layarCetakKloter() {
 
     // Ditandai SETELAH dialog cetak ditutup — kalau operator membatalkan,
     // kloternya belum dianggap tercetak.
-    const lanjut = confirm("Kertasnya sudah keluar dengan benar?
-
-" +
-      "OK  = tandai kloter ini sudah dicetak (isinya dibekukan)
-" +
-      "Batal = belum, biarkan bisa dicetak lagi");
+    const lanjut = confirm([
+      "Kertasnya sudah keluar dengan benar?",
+      "",
+      "OK  = tandai kloter ini sudah dicetak (isinya dibekukan)",
+      "Batal = belum, biarkan bisa dicetak lagi",
+    ].join("\n"));
     if (!lanjut) return;
     try {
       const n = await tandaiKloterDicetak(null);


### PR DESCRIPTION
## What

The multi-line `confirm()` text in `cetak()` contained real newlines inside a string literal. Rewritten as an array joined on `\n`.

## Why

An unterminated string literal is a parse error, so `app.js` never loaded and **every** screen hung on `Memuat…` — Home included. Introduced in #95.

## Notes

This slipped through because `node --check <file>` was reporting exit 0 on a file with `import` statements rather than actually parsing it. The reliable form is `node --input-type=module --check < file`, which now reports all four modules parsing cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)