### PR TITLE
fix: make the Hadir checkbox respond immediately

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1069,22 +1069,33 @@ async function layarKeberangkatan() {
       </div>
     `));
 
-    kotak.querySelectorAll("[data-ceklis]").forEach(cb =>
-      cb.addEventListener("change", async () => {
+    kotak.querySelectorAll("[data-ceklis]").forEach(cb => {
+      // Klik beruntun diantrekan, TIDAK diblokir: petugas yang salah centang
+      // langsung membatalkannya, dan kotak yang menolak klik kedua membuat
+      // koreksi itu mustahil. Antrean menjaga urutannya tetap benar.
+      let antre = Promise.resolve();
+      cb.addEventListener("change", () => {
         const dada = Number(cb.dataset.ceklis);
-        cb.disabled = true;
-        try {
-          if (cb.checked) await ceklisBerangkat(dada);
-          else await batalCeklisBerangkat(dada);
-          // Papan ikut berubah (hitungan sudah_ceklis) — muat ulang ringkas.
-          papan = await papanKeberangkatan();
-          gambarPita();
-        } catch (err) {
-          notif(err.message, true);
-          cb.checked = !cb.checked;
-        }
-        cb.disabled = false;
-      }));
+        const mau = cb.checked;
+        cb.classList.add("saving");
+        antre = antre.then(async () => {
+          try {
+            if (mau) await ceklisBerangkat(dada);
+            else await batalCeklisBerangkat(dada);
+            // Redup dilepas begitu tulisannya masuk. Papan menyusul di bawah:
+            // menunggunya membuat centang terasa lambat sedetik padahal
+            // datanya sudah tersimpan.
+            cb.classList.remove("saving");
+            papan = await papanKeberangkatan();
+            gambarPita();
+          } catch (err) {
+            notif(err.message, true);
+            cb.checked = !mau;
+            cb.classList.remove("saving");
+          }
+        });
+      });
+    });
 
     kotak.querySelectorAll("[data-kontrak]").forEach(sel =>
       sel.addEventListener("change", async () => {

--- a/web/style.css
+++ b/web/style.css
@@ -727,7 +727,12 @@ input.small-input { text-align: center; }
   font-weight: 800; font-variant-numeric: tabular-nums;
 }
 .pill-number .kloter-pill { font-weight: 600; font-size: .75rem; opacity: .8; }
-.checkbox { width: 26px; height: 26px; accent-color: var(--utama); }
+.checkbox { width: 26px; height: 26px; accent-color: var(--utama); cursor: pointer; }
+/* Sedang disimpan: DIREDUPKAN, bukan di-disable. Kotak yang di-disable
+   berubah abu-abu dan kehilangan kursor pointer, jadi selama sedetik itu
+   petugas mengira klik-nya tidak masuk dan mengklik lagi. Diredupkan, ia
+   tetap terlihat hidup dan centangnya tetap terbaca. */
+.checkbox.saving { opacity: .55; }
 
 /* ---------- keberangkatan ---------- */
 


### PR DESCRIPTION
## What

The Hadir checkbox is dimmed while saving rather than disabled, the dim clears as soon as the write lands instead of after the board refresh, and rapid clicks queue instead of being dropped.

## Why

`disabled` removes the pointer cursor and the accent colour, so for the second it was set the box looked broken rather than busy — and the petugas clicked again. The second network call (`papanKeberangkatan`) was what made that second long, and the checkbox does not depend on its result.

Queueing rather than blocking matters because the common correction is ticking the wrong regu and immediately unticking it. A box that refuses the second click makes that impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)