### PR TITLE
fix: gate tukar_nomor_dada on printing, not departure

### DIFF
--- a/supabase/migrations/0019_tukar_nomor_patokan_cetak.sql
+++ b/supabase/migrations/0019_tukar_nomor_patokan_cetak.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- hrcd-rekap : 0019_tukar_nomor_patokan_cetak.sql
+--
+-- Membetulkan patokan tukar_nomor_dada: "kertas sudah beredar" ditentukan oleh
+-- dicetak_pada, bukan jam_berangkat.
+--
+-- MASALAHNYA ada di komentar fungsinya sendiri. Alasan yang ditulis adalah
+-- "lembar kertas beredar memakai nomor lama", tapi syarat yang dipakai
+-- jam_berangkat. Kertas mulai beredar saat DICETAK, dan mencetak selalu lebih
+-- dulu daripada berangkat — layar Cetak Kloter bahkan menyatakannya: setelah
+-- dicetak, isi kloter dibekukan.
+--
+-- Akibatnya ada satu jendela waktu — sudah dicetak, belum berangkat — di mana
+-- penjaganya tidak menggigit dan meja boleh mengganti nomor tanpa admin. Itu
+-- justru jendela ketika petugas staging sedang memegang kertas dan memanggil
+-- nama satu per satu:
+--
+--   di kertas : 001 — Melati
+--   kenyataan : Melati memakai 007; 001 pensiun, tidak dimiliki siapa pun
+--
+-- Petugas memanggil 001, tidak ada yang maju, dan regu yang memakai 007 tidak
+-- tercantum di kertas sama sekali. Tidak ada peringatan apa pun, karena
+-- mekanisme sisipan hanya dipasang di pindah_kloter.
+--
+-- Sekaligus menyeragamkan: pindah_kloter (0018) sudah memakai
+-- "dicetak_pada is not null or jam_berangkat is not null". Dua fungsi yang
+-- sama-sama mengubah isi kertas tidak boleh berbeda pendapat tentang kapan
+-- kertas itu beredar.
+--
+-- Admin tetap boleh menembusnya, seperti sebelumnya. Yang berubah hanya KAPAN
+-- pembatasan itu mulai berlaku — lebih awal, sesuai kenyataan di meja.
+-- ============================================================================
+
+create or replace function tukar_nomor_dada(
+  p_regu       uuid,
+  p_nomor_baru integer,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu regu%rowtype;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan tukar wajib diisi';
+  end if;
+
+  select * into v_regu from regu where id = p_regu for update;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_regu.is_cancelled then
+    raise exception 'regu berstatus batal';
+  end if;
+  if v_regu.nomor_dada is null then
+    raise exception 'regu belum punya nomor dada';
+  end if;
+  -- Begitu kertasnya DICETAK, lembar yang beredar memakai nomor lama —
+  -- penukaran hanya boleh oleh admin yang paham konsekuensinya. Keberangkatan
+  -- ikut dihitung karena kloter yang sudah jalan pasti kertasnya beredar,
+  -- walau tanda cetaknya sempat dibatalkan (batalkan_tanda_cetak tidak
+  -- memeriksa keberangkatan sama sekali).
+  if peran() <> 'admin' and exists (
+       select 1 from kloter where nomor = v_regu.kloter_nomor
+         and (dicetak_pada is not null or jam_berangkat is not null)) then
+    raise exception 'kertas kloter ini sudah beredar — tukar nomor hanya lewat admin';
+  end if;
+  if not exists (select 1 from nomor_dada_stok where nomor = p_nomor_baru) then
+    raise exception 'nomor % tidak ada di stok', p_nomor_baru;
+  end if;
+  if exists (select 1 from regu where nomor_dada = p_nomor_baru)
+     or exists (select 1 from nomor_dada_pensiun where nomor = p_nomor_baru) then
+    raise exception 'nomor % sudah terpakai / pensiun', p_nomor_baru;
+  end if;
+
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('regu', p_regu::text, p_regu, 'UPDATE',
+          jsonb_build_object('alasan_tukar_nomor', p_alasan,
+                             'nomor_lama', v_regu.nomor_dada,
+                             'nomor_baru', p_nomor_baru), auth.uid());
+
+  -- Nomor lama PENSIUN — tidak pernah terbit ulang ke regu lain, supaya
+  -- lembar/foto lama yang masih menuliskannya tidak menilai regu yang salah.
+  insert into nomor_dada_pensiun (nomor, reason)
+  values (v_regu.nomor_dada, p_alasan);
+
+  update regu set nomor_dada = p_nomor_baru where id = p_regu;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -41,6 +41,7 @@ run supabase/migrations/0015_v_kwitansi_column.sql
 run supabase/migrations/0016_nama_edisi_romawi.sql
 run supabase/migrations/0017_koreksi_jam_berangkat.sql
 run supabase/migrations/0018_pindah_setelah_berangkat.sql
+run supabase/migrations/0019_tukar_nomor_patokan_cetak.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql

--- a/tests/sql/04_cetak_kloter.sql
+++ b/tests/sql/04_cetak_kloter.sql
@@ -170,3 +170,59 @@ $$;
 
 reset role;
 \echo '== 04: OK =='
+
+-- ---------------------------------------------------------------------------
+-- 4.5 tukar_nomor_dada memakai patokan DICETAK, bukan berangkat (0019).
+--     Jendela "sudah dicetak, belum berangkat" adalah saat petugas staging
+--     memegang kertas dan memanggil nama — persis saat nomor di kertas tidak
+--     boleh berubah diam-diam.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+do $$
+declare
+  v_kloter smallint;
+  v_regu   uuid;
+  v_baru   integer;
+begin
+  -- Kloter yang sudah dicetak tapi BELUM berangkat.
+  select k.nomor into v_kloter
+  from kloter k
+  where k.dicetak_pada is not null and k.jam_berangkat is null
+  order by k.nomor limit 1;
+  if v_kloter is null then
+    raise notice '4.5 dilewati: tidak ada kloter tercetak yang belum berangkat';
+    return;
+  end if;
+
+  select r.id into v_regu from regu r
+  where r.kloter_nomor = v_kloter and r.nomor_dada is not null and not r.is_cancelled
+  limit 1;
+  assert v_regu is not null, 'kloter tercetak tanpa regu bernomor';
+
+  select s.nomor into v_baru from nomor_dada_stok s
+  where not exists (select 1 from regu r2 where r2.nomor_dada = s.nomor)
+    and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+  order by s.nomor limit 1;
+  assert v_baru is not null, 'stok nomor dada habis';
+
+  -- Meja DITOLAK: dulu diterima karena kloternya belum berangkat.
+  begin
+    perform tukar_nomor_dada(v_regu, v_baru, 'coba tukar padahal kertas sudah beredar');
+    raise exception 'GAGAL: meja menukar nomor di kloter yang kertasnya sudah dicetak';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Admin tetap boleh — pembatasannya soal siapa, bukan soal mustahil.
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  perform tukar_nomor_dada(v_regu, v_baru, 'nomor dada sobek, ganti kain');
+  assert (select nomor_dada from regu where id = v_regu) = v_baru,
+    'admin tidak bisa menukar nomor di kloter tercetak';
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+end;
+$$;
+
+reset role;
+\echo '== 4.5: OK =='


### PR DESCRIPTION
## What

Migration 0019 changes `tukar_nomor_dada`'s meja restriction from `jam_berangkat is not null` to `dicetak_pada is not null or jam_berangkat is not null`. Test case 4.5 covers it.

## Why

The guard's own comment gives the reason — *lembar kertas beredar memakai nomor lama* — while the condition it used was departure. Paper starts circulating when it is printed, and printing always comes first.

That left a window, printed but not departed, in which meja could change a number without an admin — the worst possible window, since the marshal is holding that sheet and calling names off it. The sheet says 001 is Melati; Melati now wears 007 and 001 has been retired to nobody, so the marshal calls 001 and no one steps forward, with no warning anywhere.

The condition now matches `pindah_kloter`'s after 0018. Two functions that both change what a printed sheet means must not disagree about when that sheet is out.

## Notes

Departure stays in the condition because a departed kloter's paper is certainly circulating even if its print mark was later cancelled — `batalkan_tanda_cetak` checks no such thing. Admin can still do it, exactly as before; what changes is when the restriction starts, not who it stops.

Applied to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)