### PR TITLE
fix: keep desk table columns from collapsing on narrow screens

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -405,16 +405,22 @@ async function layarPembayaran() {
              </select>`;
 
       const aksi = b.status === "lunas"
-        ? html`<div class="action-row action-row-rapat">
+        // <span class="teks-lebar"> = kata yang DIBUANG di layar sempit, jadi
+        // tombolnya menyusut sendiri: "Cetak Kwitansi" -> "Kwitansi",
+        // "Tandai Lunas" -> "Lunas". Tanpa ini, di jendela sempit tombolnya
+        // melebar sampai menutupi dropdown cara bayar di sebelahnya.
+        ? `<div class="action-row action-row-rapat">
                  <button class="button button-primary button-mini" type="button"
-                         data-cetak="${b.kode_pembayaran}">Cetak Kwitansi</button>
+                         data-cetak="${esc(b.kode_pembayaran)}"><span
+                         class="teks-lebar">Cetak </span>Kwitansi</button>
                  <button class="button button-secondary button-mini" type="button"
-                         data-batal-bayar="${b.kode_pembayaran}">Batalkan</button>
+                         data-batal-bayar="${esc(b.kode_pembayaran)}">Batalkan</button>
                </div>`
         : b.status === "batal"
           ? ""
           : `<button class="button button-primary button-small" type="button"
-                     data-lunas="${esc(b.kode_pembayaran)}">Tandai Lunas</button>`;
+                     data-lunas="${esc(b.kode_pembayaran)}"><span
+                     class="teks-lebar">Tandai </span>Lunas</button>`;
       // Satu baris = satu invoice, karena satu invoice memang dibayar
       // sekaligus. Rincian regunya (nama, kategori, asal sekolah) ada di
       // baris detail yang dibuka lewat tombol "N regu" — itu yang dibacakan

--- a/web/style.css
+++ b/web/style.css
@@ -587,70 +587,153 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    Caranya: kedua tabel dipatok `table-layout: fixed` dengan lebar kolom yang
    PERSIS SAMA, dan sel pembungkusnya dibuat rata tanpa padding kiri-kanan
    supaya tabel rincian selebar tabel induk, bukan menjorok ke dalam. Empat
-   angka di bawah ini berpasangan; kalau satu diubah, pasangannya ikut. */
-.table-daftar-ulang, .detail-table-dada { table-layout: fixed; }
-.table-daftar-ulang th:nth-child(1), .table-daftar-ulang td:nth-child(1),
-.detail-table-dada  th:nth-child(1), .detail-table-dada  td:nth-child(1) { width: 18%; }
-.table-daftar-ulang th:nth-child(2), .table-daftar-ulang td:nth-child(2),
-.detail-table-dada  th:nth-child(2), .detail-table-dada  td:nth-child(2) { width: 44%; }
-.table-daftar-ulang th:nth-child(3), .table-daftar-ulang td:nth-child(3),
-.detail-table-dada  th:nth-child(3), .detail-table-dada  td:nth-child(3) { width: 10%; }
-.table-daftar-ulang th:nth-child(4), .table-daftar-ulang td:nth-child(4),
-.detail-table-dada  th:nth-child(4), .detail-table-dada  td:nth-child(4) { width: 28%; }
+   angka di bawah ini berpasangan; kalau satu diubah, pasangannya ikut.
+
+   HANYA DI LAYAR LEBAR. Di HP tabelnya berhenti jadi tabel — tiap sel
+   dijadikan blok (lihat "Di HP, tabel BERHENTI jadi tabel" di bawah), dan
+   `width: 18%` pada sebuah BLOK bukan lagi lebar kolom melainkan 18% lebar
+   kartu. Itulah yang membuat "Regu: 2" tercetak jadi "Reg / u: 2" dan kode
+   pembayaran terpenggal dua baris. Jadi seluruh patokan lebar di bawah ini
+   dikurung di min-width: 561px dan tidak pernah menyentuh layar HP. */
+@media (min-width: 561px) {
+  .table-daftar-ulang, .detail-table-dada { table-layout: fixed; }
+  /* LANTAI LEBAR. Dengan table-layout: fixed, kolom yang menyempit tidak
+     membuat isinya membungkus — isinya MELUAP menimpa kolom sebelahnya.
+     Di bawah lebar ini tabelnya menggeser di dalam kartu (.table-wrapper
+     sudah overflow-x: auto), dan tidak ada lagi yang saling tertutup. */
+  .table-daftar-ulang { min-width: 860px; }
+  /* Keempat kolom rincian dipatok PERSIS ke kolom induknya. Ini yang membuat
+     Regu (induk) dan Ketua (rincian) jatuh di satu pita, lalu tombol "Isi N
+     Nomor Dada", kotak nomor dadanya, dan tombol Simpan di pita berikutnya.
+     Kalau salah satu angka diubah, pasangannya ikut. */
+  .table-daftar-ulang th:nth-child(1), .table-daftar-ulang td:nth-child(1),
+  .detail-table-dada  th:nth-child(1), .detail-table-dada  td:nth-child(1) { width: 16%; }
+  .table-daftar-ulang th:nth-child(2), .table-daftar-ulang td:nth-child(2),
+  .detail-table-dada  th:nth-child(2), .detail-table-dada  td:nth-child(2) { width: 40%; }
+  /* 16%, bukan 10%: pita ini dipakai bersama angka Regu yang cuma satu digit
+     DAN nama ketua yang bisa tiga kata. Yang menentukan lebarnya nama. */
+  .table-daftar-ulang th:nth-child(3), .table-daftar-ulang td:nth-child(3),
+  .detail-table-dada  th:nth-child(3), .detail-table-dada  td:nth-child(3) { width: 16%; }
+  .table-daftar-ulang th:nth-child(4), .table-daftar-ulang td:nth-child(4),
+  .detail-table-dada  th:nth-child(4), .detail-table-dada  td:nth-child(4) { width: 28%; }
+
+  /* Isi kolom terakhir DITENGAHKAN, bukan rata kiri atau rata kanan. Tombol
+     "Isi N Nomor Dada", deretan nomor yang sudah terbit, kotak isian di
+     rinciannya, dan tombol "Simpan N Nomor Dada" jadi berbagi satu garis
+     tengah — mata turun lurus dari tombol pembuka ke kotak isian ke tombol
+     simpan, tidak melompat ke kiri lalu ke kanan. */
+  .table-daftar-ulang td:nth-child(4) { text-align: center; }
+  .table-daftar-ulang td:nth-child(4) .pill-row { justify-content: center; }
+  /* Kotak angka melebar sedikit — sasaran klik lebih besar, dan titik
+     tengahnya jatuh persis segaris dengan tombol Simpan di bawahnya. */
+  .detail-table-dada input.small-input { width: 100%; max-width: 8rem; }
+}
 
 .detail-table-dada { width: 100%; margin: 0; }
 /* Padding sel disamakan dengan tabel induk (.table td), kalau tidak isinya
    bergeser beberapa piksel dan kesejajarannya hilang lagi. */
 .detail-table-dada th, .detail-table-dada td { padding-left: .5rem; padding-right: .5rem; }
-.detail-table-dada th:last-child, .detail-table-dada td:last-child {
-  text-align: left; min-width: 0;
-}
+.detail-table-dada th:last-child, .detail-table-dada td:last-child { min-width: 0; }
 /* Sel pembungkus rincian dibuat rata kiri-kanan supaya tabel di dalamnya
    selebar tabel induk. Padding atas-bawah tetap, itu yang memisahkan blok. */
 .detail-cell-flush { padding-left: 0 !important; padding-right: 0 !important; }
 
 /* Meja Pembayaran, cara yang sama. Bedanya tabel induk punya ENAM kolom dan
-   rinciannya LIMA, jadi rincian sengaja berhenti di ujung kolom Metode —
-   kolom terakhir induk berisi tombol aksi, dan menaruh angka di bawahnya
-   membuat rincian tampak menerus ke wilayah tombol.
+   rinciannya LIMA. Rincian dulu sengaja berhenti di 71% supaya angka rupiah
+   tidak jatuh di bawah tombol aksi — tapi yang tersisa justru lahan kosong
+   selebar seperempat tabel di sebelah kanan, dan itu yang lebih mengganggu.
+   Sekarang rincian SELEBAR PENUH dan kolom Biaya berhenti mentok di kanan.
 
-   Lebar rincian = jumlah lima kolom pertama induk (71%), lalu tiap kolomnya
-   dihitung sebagai bagian dari 71% itu supaya jatuh persis sekolom:
-   Regu di bawah Kode Bayar, Kategori di bawah Sekolah, Ketua di bawah Regu,
-   Sekolah di bawah Tagihan, Biaya di bawah Metode. */
-.table-bayar, .detail-table-bayar { table-layout: fixed; }
-.table-bayar th:nth-child(1), .table-bayar td:nth-child(1) { width: 15%; }
-.table-bayar th:nth-child(2), .table-bayar td:nth-child(2) { width: 22%; }
-.table-bayar th:nth-child(3), .table-bayar td:nth-child(3) { width:  8%; }
-.table-bayar th:nth-child(4), .table-bayar td:nth-child(4) { width: 13%; }
-.table-bayar th:nth-child(5), .table-bayar td:nth-child(5) { width: 13%; }
-.table-bayar th:nth-child(6), .table-bayar td:nth-child(6) { width: 29%; }
+   Tiap kolom rincian tetap jatuh persis di bawah kolom induknya:
+   Regu di bawah Kode Bayar, Kategori di bawah Sekolah, Ketua di bawah
+   Regu+Tagihan, Sekolah di bawah Metode, Biaya di bawah kolom aksi.
+   (Ketua memakan dua kolom induk karena nama ketua yang panjang dulu
+   bersinggungan dengan kolom sebelahnya sampai terbaca "NurhalizaSD 3
+   Ciamis". Kalau salah satu angka diubah, pasangannya ikut.)
 
-.detail-table-bayar { width: 71%; margin: 0; }
+   Sama seperti tabel daftar ulang: HANYA di layar lebar. Di HP angka-angka
+   ini justru yang merusak tampilannya. */
+@media (min-width: 561px) {
+  .table-bayar, .detail-table-bayar { table-layout: fixed; }
+  /* Lantai lebar — lihat alasan lengkapnya di tabel daftar ulang. Di sinilah
+     akibatnya paling terasa: kolom Metode menyempit sampai dropdown cara
+     bayar tertimpa tombol "Tandai Lunas" di sebelahnya, jadi petugas tidak
+     bisa lagi memilih Transfer.
+
+     780px = jumlah kebutuhan minimum tiap kolom saat tombolnya sudah memakai
+     label pendek ("Lunas", "Kwitansi" — lihat .teks-lebar di bawah): kode
+     pembayaran 140, sekolah 187, regu 47, tagihan 94, dropdown metode 117,
+     tombol 195. Kalau salah satu kolom dilebarkan, angka ini ikut naik. */
+  .table-bayar { min-width: 780px; }
+  .table-bayar th:nth-child(1), .table-bayar td:nth-child(1) { width: 18%; }
+  .table-bayar th:nth-child(2), .table-bayar td:nth-child(2) { width: 24%; }
+  .table-bayar th:nth-child(3), .table-bayar td:nth-child(3) { width:  6%; }
+  .table-bayar th:nth-child(4), .table-bayar td:nth-child(4) { width: 12%; }
+  .table-bayar th:nth-child(5), .table-bayar td:nth-child(5) { width: 15%; }
+  .table-bayar th:nth-child(6), .table-bayar td:nth-child(6) { width: 25%; }
+
+  /* Tombol aksi DITENGAHKAN di kolomnya, dan kolom Biaya di rincian memakai
+     lebar yang sama (25%). Akibatnya angka rupiah tiap regu jatuh tepat di
+     bawah tombol "Tandai Lunas" — itu jumlah yang sedang dihitung petugas
+     saat jarinya sudah di atas tombol itu. */
+  .table-bayar td:nth-child(6) { text-align: center; }
+  .table-bayar td:nth-child(6) .action-row { justify-content: center; }
+
+  .detail-table-bayar { width: 100%; }
+  .detail-table-bayar th:nth-child(1), .detail-table-bayar td:nth-child(1) { width: 18%; }
+  .detail-table-bayar th:nth-child(2), .detail-table-bayar td:nth-child(2) { width: 24%; }
+  .detail-table-bayar th:nth-child(3), .detail-table-bayar td:nth-child(3) { width: 18%; }
+  .detail-table-bayar th:nth-child(4), .detail-table-bayar td:nth-child(4) { width: 15%; }
+  .detail-table-bayar th:nth-child(5), .detail-table-bayar td:nth-child(5) { width: 25%; }
+}
+
+.detail-table-bayar { margin: 0; }
 .detail-table-bayar th, .detail-table-bayar td { padding-left: .5rem; padding-right: .5rem; }
-.detail-table-bayar th:nth-child(1), .detail-table-bayar td:nth-child(1) { width: 21.1%; }
-.detail-table-bayar th:nth-child(2), .detail-table-bayar td:nth-child(2) { width: 31.0%; }
-.detail-table-bayar th:nth-child(3), .detail-table-bayar td:nth-child(3) { width: 11.3%; }
-.detail-table-bayar th:nth-child(4), .detail-table-bayar td:nth-child(4) { width: 18.3%; }
-.detail-table-bayar th:nth-child(5), .detail-table-bayar td:nth-child(5) { width: 18.3%; }
 
 @media (max-width: 560px) {
-  /* Satu regu = satu blok dua baris, kotak angka di kanan sejajar namanya.
-     Judul kolom disembunyikan karena pasangannya sudah jelas dari bentuk. */
+  /* Satu regu = satu blok dua baris, isi kolom terakhir di kanan sejajar
+     namanya. Judul kolom disembunyikan karena pasangannya sudah jelas dari
+     bentuknya. Selebar kartu — patokan persen di atas sudah tidak berlaku
+     di sini, dan tanpa ini rincian pembayaran tetap menciut ke 71%. */
   .detail-table, .detail-table tbody, .detail-table tr, .detail-table td { display: block; }
   .detail-table thead { display: none; }
+  .detail-table { width: 100%; }
   .detail-table tr {
     display: grid;
-    grid-template-columns: auto 1fr 5.5rem;
-    grid-template-areas: "nama nama input" "kat ketua input";
-    align-items: center; gap: .1rem .5rem;
+    /* Jarak antar kolom .9rem, bukan .5rem: golongan dan nama ketua duduk
+       bersebelahan di baris kedua, dan dengan celah sempit "Penggalang PI"
+       menempel ke namanya sampai terbaca seperti satu kalimat. */
+    align-items: center; gap: .1rem .9rem;
     padding: .55rem 0; border-top: 1px solid var(--garis);
   }
   .detail-table td { border: 0; padding: 0; }
   .detail-table td:nth-child(1) { grid-area: nama; }
   .detail-table td:nth-child(2) { grid-area: kat;   font-size: .78rem; color: var(--tinta-lembut); }
   .detail-table td:nth-child(3) { grid-area: ketua; font-size: .78rem; color: var(--tinta-lembut); }
-  .detail-table td:nth-child(4) { grid-area: input; }
+
+  /* Daftar ulang: kolom keempat adalah KOTAK ISIAN nomor dada. */
+  .detail-table-dada tr {
+    grid-template-columns: auto 1fr 5.5rem;
+    grid-template-areas: "nama nama input" "kat ketua input";
+  }
+  .detail-table-dada td:nth-child(4) { grid-area: input; }
+
+  /* Pembayaran: kolom keempat BUKAN isian melainkan nama sekolah, dan kolom
+     kelima angka rupiahnya. Dua tabel ini dulu memakai satu aturan yang sama,
+     jadi "Sekolah" jatuh di petak kotak isian selebar 5,5rem dan nama ketua
+     terjepit sampai tercetak satu huruf per baris.
+
+     Kolom Sekolah dihilangkan di HP: isinya mengulang nama sekolah yang sudah
+     tertulis di kartu invoice tepat di atasnya, dan lebar yang dimakannya
+     justru yang dibutuhkan nama regu dan nama ketua. */
+  .detail-table-bayar tr {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: "nama nama biaya" "kat ketua biaya";
+  }
+  .detail-table-bayar td:nth-child(4) { display: none; }
+  .detail-table-bayar td:nth-child(5) {
+    grid-area: biaya; text-align: right; font-weight: 700; min-width: 0;
+  }
   /* Sasaran sentuh jempol: lebih lebar dan lebih tinggi daripada di laptop,
      angkanya besar supaya terbaca sambil berdiri. */
   .detail-table input.small-input {
@@ -662,7 +745,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .detail-row .action-row { flex-direction: column; align-items: stretch; }
   .detail-row .action-row .button-small { width: 100%; }
   .detail-row .action-row .sub { text-align: center; }
-  .detail-table td:nth-child(3)::before { content: "· "; }
+  /* Titik pemisah diberi ruang di kanannya juga, supaya nama ketua benar-
+     benar berdiri sendiri dan tidak menempel ke titiknya. */
+  .detail-table td:nth-child(3)::before { content: "·"; padding-right: .4rem; }
 }
 
 .data-table .sub { color: var(--tinta-lembut); font-size: .82rem; margin-top: .15rem; }
@@ -674,6 +759,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .text-right  { text-align: right; }
 .table th.text-center, .table td.text-center { text-align: center; }
 .table th.text-right,  .table td.text-right  { text-align: right; }
+
+/* SELURUH kolom rincian DITENGAHKAN — judul kolom maupun isinya, di kedua
+   tabel rincian. Rincian adalah panel yang dibuka sebentar untuk dibacakan
+   ke sekolah, bukan daftar yang disapu mata dari atas ke bawah, jadi tiap
+   kolom berdiri sendiri di tengah petaknya.
+
+   HARUS DI SINI, tepat di bawah dua baris di atasnya. Tabel rincian bersarang
+   DI DALAM tabel induk, jadi `.table td.text-right` ikut mengenai sel Biaya
+   di rincian — spesifisitasnya sama (0,2,1) dengan aturan ini, dan yang
+   menang adalah yang ditulis belakangan. Dipindah ke atas, kolom Biaya
+   kembali rata kanan sendirian sementara empat kolom lain di tengah.
+
+   Hanya di layar lebar — di HP kolom sudah tidak ada, tiap regu jadi satu
+   blok dua baris dan perataannya diatur grid di bagian bawah berkas ini. */
+@media (min-width: 561px) {
+  .detail-table th, .detail-table td,
+  .detail-table th:last-child, .detail-table td:last-child,
+  .detail-table th.text-right, .detail-table td.text-right { text-align: center; }
+}
 
 /* Cara bayar disimpan huruf kecil di database ('tunai'/'transfer') karena
    itu nilai CHECK constraint-nya. Yang dibaca panitia tetap huruf kapital
@@ -692,6 +796,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    terakhir. Tombol di kiri memaksa perjalanan balik melintasi tabel. */
 .action-row-simpan { justify-content: space-between; }
 .action-row-simpan .sub { flex: 1; min-width: 12rem; }
+/* Tombol Simpan selebar kolom Nomor Dada (28%) supaya titik tengahnya jatuh
+   segaris dengan kotak-kotak isian di atasnya — satu pita lurus dari tombol
+   "Isi N Nomor Dada", turun ke kotak isian, turun ke tombol Simpan. Dulu
+   tombol ini menempel ke tepi kanan kartu, jauh di kanan kotak isiannya. */
+@media (min-width: 561px) {
+  .action-row-simpan .button-small { flex: 0 0 28%; }
+}
 .select-small, .small-input {
   /* 1rem = 16px, BUKAN .9rem. Di bawah 16px iOS Safari memaksa zoom tiap
      kali isian disentuh — batas keras di kepala berkas ini, dan sempat
@@ -718,6 +829,20 @@ input.small-input { text-align: center; }
 }
 .button-mini {
   min-height: 34px; padding: .2rem .55rem; font-size: .8rem; width: auto;
+}
+
+/* Kata pertama label tombol, dibuang di jendela sempit: "Tandai Lunas" jadi
+   "Lunas", "Cetak Kwitansi" jadi "Kwitansi". Kata keduanya sudah cukup
+   membedakan aksinya, dan tombol yang menyusut memberi ruang untuk dropdown
+   cara bayar di sebelahnya — di jendela ~560-700px tombol panjang menimpa
+   dropdown itu sampai "Tunai"/"Transfer" tidak bisa lagi dipilih.
+
+   Rentangnya sengaja dibatasi dua sisi. Di bawah 561px tabelnya sudah bukan
+   tabel lagi melainkan kartu bertumpuk, tombolnya melebar penuh sendirian di
+   satu baris, dan di sana label lengkap justru yang benar — "Lunas" sendirian
+   di tombol selebar layar terbaca seperti label status, bukan perintah. */
+@media (min-width: 561px) and (max-width: 900px) {
+  .teks-lebar { display: none; }
 }
 .pill-row { display: flex; gap: .3rem; flex-wrap: wrap; align-items: center; }
 .pill-number {
@@ -835,10 +960,32 @@ input.small-input { text-align: center; }
   .data-table tbody tr[data-baris] > td:last-child { margin-top: .5rem; }
   .data-table tbody tr[data-baris] .button-small { width: 100%; }
 
+  /* "Regu: 2" di meja pembayaran mengulang tombol "▸ 2 regu" dua baris di
+     atasnya. Di layar lebar keduanya kolom terpisah dan tidak bertabrakan;
+     ditumpuk di HP, angkanya terbaca dua kali. Meja daftar ulang TIDAK ikut
+     disembunyikan — tombolnya di sana menghitung regu yang BELUM dapat nomor,
+     bukan seluruh regu, jadi angkanya memang beda. */
+  .table-bayar tbody tr[data-baris] > td[data-label="Regu"] { display: none; }
 
-  /* Baris rincian regu ikut jadi blok, bukan sel tabel. */
-  .data-table tbody tr.detail-row { display: block; }
+  /* Baris rincian regu ikut jadi blok, bukan sel tabel. Ia dibuat menempel
+     ke kartu invoice di atasnya — bertumpuk, rincian yang mengambang bebas
+     terbaca seperti kartu invoice lain, bukan seperti isi kartu barusan. */
+  .data-table tbody tr.detail-row {
+    display: block;
+    margin: -.7rem 0 .7rem;
+    padding: .1rem .75rem .5rem;
+    background: var(--kertas);
+    border: 1.5px solid var(--garis);
+    border-top: 0;
+    border-radius: 0 0 var(--radius) var(--radius);
+  }
   .data-table tbody tr.detail-row > td { display: block; padding: 0; border: 0; }
+  /* Sudut bawah kartu invoice diratakan selama rinciannya terbuka, supaya
+     sambungannya tidak menyisakan takik. Browser tanpa :has() melewatkan
+     aturan ini dan hanya kehilangan kerapian itu. */
+  .data-table tbody tr[data-baris]:has(+ tr.detail-row:not([hidden])) {
+    border-bottom-left-radius: 0; border-bottom-right-radius: 0;
+  }
 
   /* Tombol header pindah ke bawah — sisakan judul dan identitas akun saja. */
   .header .icon-button, .header .button-small { display: none; }


### PR DESCRIPTION
## What

Fixes the layout of **Meja Pembayaran** and **Meja Daftar Ulang** on phones and narrow windows, and rebalances their columns on laptops.

- Every fixed column-width rule is now scoped to `@media (min-width: 561px)`, so it never reaches the stacked-card layout.
- `.detail-table-bayar` gets its own mobile grid instead of inheriting the four-column daftar ulang one. Its redundant Sekolah column is hidden on phones.
- The expanded rincian now attaches to the invoice card above it instead of floating below as a loose grey band.
- Columns rebalanced into aligned bands: Regu sits above Ketua; the "Isi N Nomor Dada" button, the nomor dada boxes and the Simpan button share one centre line; Biaya falls under Tandai Lunas.
- All rincian columns are centred.
- Both tables get a `min-width` floor, and between 561px and 900px the action buttons drop their first word ("Tandai Lunas" → "Lunas", "Cetak Kwitansi" → "Kwitansi").

## Why

Both tables pin their columns with percentages so the rincian lines up with the row above. Those rules had no media query. At ≤560px the stylesheet turns every cell into a block, and a percentage width on a block is a fraction of the *card*, not a column width — so `Regu: 2` rendered as `Reg / u: 2`, the payment code split across two lines, and the primary button shrank to 29% of the screen.

The rincian grid was written for the four-column daftar ulang table; the five-column payment table inherited it, so "Sekolah" landed in the 5.5rem input slot and the ketua name was squeezed to one letter per line.

The `min-width` floor addresses a different failure of `table-layout: fixed`: a narrowing column does not wrap its contents, it overflows them onto its neighbour. That is how the cara bayar dropdown ended up underneath the Tandai Lunas button, leaving no way to select Transfer.

## Notes

Verified against the real stylesheet at 360 / 390 / 564 / 720 / 820 / 1080 / 1280px using a harness built from the exact markup `app.js` emits.

Between 561px and 780px the payment table now scrolls sideways inside its card rather than overlapping. Nothing is hidden, but the action button sits off-screen until scrolled. The cleaner fix is to raise the card-stacking breakpoint from 560px to ~900px so tablets get the card layout — deliberately left out of this PR and queued for the follow-up mobile pass.

`html\`\`` escapes each interpolation, so the two payment buttons switched to a plain template literal (needed for the `<span>`) carry explicit `esc()` calls; escaping is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)