### PR TITLE
docs: tighten the wording on the public registration form

### DIFF
--- a/web/daftar.html
+++ b/web/daftar.html
@@ -8,7 +8,9 @@
 </head>
 <body>
   <header class="header">
-    <span class="title">Pendaftaran Hiking Rally Ciradyka</span>
+    <!-- Angka romawi edisinya ditambahkan daftar.js dari data, bukan ditulis
+         di sini — supaya tahun depan tidak ada yang lupa menggantinya. -->
+    <span class="title" id="judul-daftar">Pendaftaran Hiking Rally Ciradyka</span>
     <span class="spacer"></span>
     <span class="user-info" id="label-edisi"></span>
   </header>

--- a/web/js/daftar.js
+++ b/web/js/daftar.js
@@ -116,7 +116,7 @@ function halaman() {
 
     <!-- 5. Kontak -->
     <section class="card" id="bagian-kontak">
-      <h2><span class="section-number">5</span> Contact person</h2>
+      <h2><span class="section-number">5</span> Contact Person</h2>
       <p class="description">Satu orang untuk semua regu — panitia menghubungi lewat sini.</p>
       <div class="field" style="margin-top:.7rem">
         <label for="nama-kontak">Nama</label>
@@ -186,10 +186,13 @@ function gambarSekolah() {
 
   kotak.replaceChildren(h(`
     <div class="field" style="margin-bottom:.4rem">
-      <label for="cari">Ketik nama sekolahmu</label>
-      <input type="text" id="cari" autocomplete="off" placeholder="contoh: SMPN 1 Ciamis">
-      <div class="hint">Kalau muncul di daftar, tinggal pilih. Kalau tidak ada,
-         isi alamatnya sendiri.</div>
+      <!-- Tanpa <label> yang terlihat: placeholder-nya sudah memberi contoh
+           konkret, dan judul bagian di atasnya sudah menyebut "Sekolah".
+           aria-label tetap dipasang supaya pembaca layar tidak kehilangan
+           nama isian ini. -->
+      <input type="text" id="cari" autocomplete="off" aria-label="Nama sekolah"
+             placeholder="contoh: SMPN 1 Ciamis">
+      <div class="hint">Jika sekolah tidak muncul, silakan daftarkan + isi alamat</div>
       <div class="suggestions" id="saran" hidden></div>
     </div>
     <div id="manual"></div>
@@ -241,13 +244,12 @@ function gambarSekolah() {
     document.getElementById("manual").replaceChildren(h(`
       <div class="card" style="margin:.6rem 0 0;border-color:var(--utama)">
         <p style="font-weight:700">Sekolahmu belum ada di daftar?</p>
-        <p class="description">Isi alamatnya, lalu tekan Pakai sekolah ini.</p>
         <div class="field" style="margin-top:.6rem">
           <label for="m-alamat">Alamat sekolah (jalan + kota)</label>
           <input type="text" id="m-alamat"
                  placeholder="contoh: Jl. Raya Banjar No. 2, Kota Banjar">
         </div>
-        <button class="button button-primary" id="pakai" type="button">Pakai sekolah ini</button>
+        <button class="button button-primary" id="pakai" type="button">Simpan</button>
       </div>`));
     document.getElementById("pakai").addEventListener("click", () => {
       const nama = cari.value.trim();
@@ -603,6 +605,11 @@ async function mulai() {
   // tidak ada, dan membacanya diam-diam menghasilkan undefined.
   document.getElementById("label-edisi").textContent = EDISI.name;
   const romawi = String(EDISI.name || "").replace(/^HRCD\s*/i, "").trim();
+  // Judul di layar DAN judul tab memakai angka romawi yang sama. Sekolah
+  // sering membuka form ini setahun sekali; tanpa nomor edisi, halaman lama
+  // yang masih terbuka di tab lain tidak bisa dibedakan dari yang baru.
+  const judul = `Pendaftaran Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
+  document.getElementById("judul-daftar").textContent = judul;
   document.title = `Pendaftaran — Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
 
   let hasilLama = null, draf = null;


### PR DESCRIPTION
## What

Wording changes on `/daftar`, as requested after reading the live form:

| sebelum | sesudah |
|---|---|
| Pendaftaran Hiking Rally Ciradyka | Pendaftaran Hiking Rally Ciradyka **XXXVII** |
| Ketik nama sekolahmu | *(dihapus)* |
| Kalau muncul di daftar, tinggal pilih. Kalau tidak ada, isi alamatnya sendiri. | Jika sekolah tidak muncul, silakan daftarkan + isi alamat |
| Isi alamatnya, lalu tekan Pakai sekolah ini. | *(dihapus)* |
| Pakai sekolah ini | Simpan |
| Contact person | Contact Person |

## Why

The form is filled in once a year by people who have never seen it before, so every line that does not carry new information is a line that slows them down. Each removed sentence was already said by the field label, the placeholder, or the button underneath it.

The edition numeral is read from `EDISI.name`, which the page already fetches, rather than typed into the HTML — the same `romawi` value that already builds the tab title. Hardcoding it would mean someone has to remember to bump it next year.

## Notes

Dropping the visible `<label>` on the school search box would have left the input unnamed for screen readers, so it carries an `aria-label` instead.

The heading now reads "Contact Person". The two validation messages that mention the term mid-sentence ("Nama contact person wajib diisi") are left lowercase, since capitalising inside an Indonesian sentence reads wrong. Say the word if you want those changed too.

The header still shows the edition badge on the right, so on that row the numeral now appears twice — "Pendaftaran Hiking Rally Ciradyka XXXVII … HRCD XXXVII". Left alone because removing the badge was not asked for, but it is worth a look on a narrow phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)