### PR TITLE
fix: let error notifications fade out instead of staying forever

### DIFF
--- a/web/js/util.js
+++ b/web/js/util.js
@@ -35,8 +35,23 @@ export const rupiah = n => "Rp " + Number(n || 0).toLocaleString("id-ID");
 export const jamSekarang = () =>
   new Date().toLocaleTimeString("id-ID", { hour: "2-digit", minute: "2-digit" });
 
-/** Notifikasi bawah layar. Galat TIDAK hilang sendiri — orang awam sering
- *  sedang melihat papan ketik saat pesan muncul (temuan review). */
+/** Notifikasi bawah layar.
+ *
+ *  Keduanya hilang sendiri, tapi galat diberi waktu DUA KALI LIPAT: 8 detik
+ *  lawan 4. Sebelumnya galat tidak hilang sama sekali — orang awam sering
+ *  sedang menatap papan ketik saat pesan muncul (temuan review), dan pesan
+ *  yang keburu pergi sama saja dengan tidak pernah ada. Tapi pesan yang
+ *  menetap selamanya punya harganya sendiri: ia menumpuk di bawah layar
+ *  sepanjang hari dan menutupi tombol di sana, sampai panitia belajar
+ *  mengabaikannya. Delapan detik cukup untuk mengangkat kepala dan membaca,
+ *  dan tombol tutupnya tetap ada untuk yang ingin membuangnya lebih cepat.
+ *
+ *  Redupnya dilakukan lewat kelas .pudar, bukan animasi JavaScript, supaya
+ *  aturan prefers-reduced-motion di gaya ikut berlaku: pengguna yang memilih
+ *  "kurangi gerak" mendapat hilang seketika, bukan pudar. */
+const DETIK_NOTIF      = 4000;
+const DETIK_NOTIF_GALAT = 8000;
+
 export function notif(pesan, galat = false) {
   document.querySelectorAll(".notification").forEach(n => n.remove());
   // Template BIASA, bukan tag html`` — tombol tutupnya HTML yang memang
@@ -57,7 +72,15 @@ export function notif(pesan, galat = false) {
   document.body.appendChild(n);
   const el = document.body.lastElementChild;
   if (galat) el.querySelector(".notification-close").addEventListener("click", () => el.remove());
-  else setTimeout(() => el.remove(), 4000);
+
+  // Dipudarkan dulu, baru dibuang setelah transisinya selesai (.35s di gaya).
+  // Kalau sudah ditutup manual, el sudah lepas dari halaman dan kedua baris
+  // ini tidak melakukan apa-apa — remove() pada simpul yang sudah lepas aman.
+  const jeda = galat ? DETIK_NOTIF_GALAT : DETIK_NOTIF;
+  setTimeout(() => {
+    el.classList.add("pudar");
+    setTimeout(() => el.remove(), 400);
+  }, jeda);
 }
 
 /** Dialog sederhana pengganti prompt(): punya judul, kartu identitas,

--- a/web/style.css
+++ b/web/style.css
@@ -374,6 +374,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   max-width: 92vw;
 }
 .notification.error { background: var(--bahaya); }
+/* Memudar sebelum dibuang (lihat notif() di util.js). Transisinya dipatok di
+   sini, bukan di JavaScript, supaya aturan prefers-reduced-motion di bawah
+   berkas ini ikut mematikannya — di sana `transition: none` membuat pesannya
+   hilang seketika, tanpa gerakan. */
+.notification { transition: opacity .35s ease; }
+.notification.pudar { opacity: 0; }
 
 /* ---------- menu beranda meja ---------- */
 


### PR DESCRIPTION
## What

Error notifications now fade out and disappear after **8 seconds**, against the 4 a normal notification gets. The close button stays for anyone who wants it gone sooner.

## Why

Errors used to sit at the bottom of the screen until dismissed by hand. That was a deliberate call from an earlier review — the petugas is often looking at the keyboard when a message appears, and one that leaves too early is the same as one that never came.

But a message that never leaves has its own cost: it stacks at the bottom of the screen all day, covers the buttons that live down there, and teaches the panitia to ignore it. Eight seconds is long enough to look up and read.

## Notes

The fade is a class toggled from JavaScript with the transition declared in the stylesheet, not an animation driven from JavaScript. That keeps the existing `prefers-reduced-motion` rule in force — people who ask for less motion get an instant disappearance rather than a fade.

`remove()` on an already-detached node is a no-op, so dismissing by hand before the timer fires is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)