### PR TITLE
fix: print nomor dada three digits wide in the departure error

### DIFF
--- a/supabase/migrations/0020_nomor_dada_tiga_digit.sql
+++ b/supabase/migrations/0020_nomor_dada_tiga_digit.sql
@@ -1,0 +1,82 @@
+-- ============================================================================
+-- hrcd-rekap : 0020_nomor_dada_tiga_digit.sql
+--
+-- Nomor dada di pesan galat dicetak TIGA DIGIT, sama seperti di seluruh layar.
+--
+-- Kain nomor dada yang dipegang regu tertulis "076", dan setiap layar yang
+-- menampilkannya memakai bentuk itu (padStart(3, "0") di web/js/app.js —
+-- daftar kloter, lembar barak, kwitansi, semuanya). Hanya pesan galat dari
+-- database yang mencetak angka mentahnya: "regu nomor dada 76 belum
+-- konfirmasi kontrak waktu".
+--
+-- Kelihatannya sepele, tapi bedanya nyata di lapangan. Petugas keberangkatan
+-- membaca pesan itu lalu MENCARI kain fisiknya di antara puluhan regu, dan
+-- yang tertulis di kain adalah 076. Dua bentuk untuk benda yang sama membuat
+-- ia ragu sejenak setiap kali — persis di saat kloter sudah menunggu di garis
+-- start.
+--
+-- Sekalian daftarnya diurutkan. string_agg tanpa ORDER BY mengikuti urutan
+-- baris yang kebetulan dikembalikan Postgres, jadi pesan yang sama bisa
+-- menyebut "076, 012" sekali dan "012, 076" di lain waktu. Petugas menyapu
+-- daftar itu dengan mata; urutan yang berubah-ubah membuatnya menghitung
+-- ulang dari awal.
+--
+-- Fungsi lain masih mencetak nomor dada mentah di pesannya (mis.
+-- 'nomor dada % tidak dikenal' di catat_closing dan pindah_kloter). Itu
+-- masalah yang sama dan layak dibereskan, tapi sengaja TIDAK diborong ke
+-- migrasi ini: tiap perbaikan menuntut seluruh badan fungsinya disalin ulang,
+-- dan menyalin lima fungsi sekaligus menukar satu cacat tampilan dengan
+-- risiko salah ketik yang jauh lebih mahal.
+-- ============================================================================
+
+-- terbaru dari 0014_rename_common_columns.sql
+create or replace function berangkatkan_kloter(
+  p_kloter smallint,
+  p_jam    timestamptz
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_tanpa_kontrak text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if p_jam is null then
+    raise exception 'jam berangkat wajib diketik';
+  end if;
+  if exists (select 1 from kloter where nomor = p_kloter and jam_berangkat is not null) then
+    raise exception 'kloter % sudah berangkat', p_kloter;
+  end if;
+  -- Papan pipeline diturunkan dari max(nomor berangkat) — satu ketukan salah
+  -- (memberangkatkan kloter kosong / melompati) merusak seluruh papan.
+  -- Guard: kloter harus berisi regu, dan tidak boleh melompati kloter berisi
+  -- regu yang belum berangkat (temuan review).
+  if not exists (select 1 from regu r where r.kloter_nomor = p_kloter and not r.is_cancelled) then
+    raise exception 'kloter % tidak berisi regu', p_kloter;
+  end if;
+  if exists (
+       select 1 from kloter k
+       where k.nomor < p_kloter and k.jam_berangkat is null
+         and exists (select 1 from regu r
+                     where r.kloter_nomor = k.nomor and not r.is_cancelled)) then
+    raise exception 'masih ada kloter sebelum % yang belum berangkat — urutan keberangkatan wajib berurut', p_kloter;
+  end if;
+
+  -- Regu yang diceklis berangkat wajib sudah berkontrak — mencegah penalti
+  -- waktu yang tak terhitung (NULL) di kemudian hari.
+  -- lpad(...) = bentuk yang tertulis di kain nomor dadanya; lihat kepala
+  -- berkas ini. ORDER BY supaya daftarnya tidak berubah urutan tiap kali.
+  select string_agg(lpad(r.nomor_dada::text, 3, '0'), ', ' order by r.nomor_dada)
+    into v_tanpa_kontrak
+  from regu r
+  join keberangkatan_regu k on k.regu_id = r.id
+  where r.kloter_nomor = p_kloter and r.kontrak_menit is null;
+  if v_tanpa_kontrak is not null then
+    raise exception 'regu nomor dada % belum konfirmasi kontrak waktu', v_tanpa_kontrak;
+  end if;
+
+  update kloter set jam_berangkat = p_jam where nomor = p_kloter;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -42,6 +42,7 @@ run supabase/migrations/0016_nama_edisi_romawi.sql
 run supabase/migrations/0017_koreksi_jam_berangkat.sql
 run supabase/migrations/0018_pindah_setelah_berangkat.sql
 run supabase/migrations/0019_tukar_nomor_patokan_cetak.sql
+run supabase/migrations/0020_nomor_dada_tiga_digit.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql


### PR DESCRIPTION
## What

Migration `0020_nomor_dada_tiga_digit.sql` — the departure error now reads

> regu nomor dada **076** belum konfirmasi kontrak waktu

instead of `76`. The list is also sorted.

## Why

The cloth a regu wears reads `076`, and every screen that shows a nomor dada uses that form (`padStart(3, "0")` throughout `app.js` — kloter lists, barak sheets, kwitansi). Only the database error messages print the raw integer.

It sounds cosmetic, but the petugas reads that message and then goes looking for the physical cloth among dozens of regu. Two forms for the same object is a pause every time, at exactly the moment the kloter is already waiting at the start line.

`string_agg` without `ORDER BY` follows whatever row order Postgres happens to return, so the same message could read "076, 012" once and "012, 076" the next time. It is read by sweeping the eye down it.

## Notes

⚠️ **Merging this does not apply it.** The migration workflow is deliberately manual — see the header of `apply-migration.yml`: this is the only automated path that touches the production database, so a human always presses the button. After merging:

> Actions → **Apply migration to Supabase** → Run workflow → `supabase/migrations/0020_nomor_dada_tiga_digit.sql`

The function is otherwise byte-identical to its definition in `0014`, so it is safe to apply at any time — there is no code change waiting on it and nothing breaks if it is applied late.

Other functions still print raw nomor dada (`nomor dada % tidak dikenal` in `catat_closing` and `pindah_kloter`, among others). Same defect, deliberately not bundled: each fix requires copying its whole function body forward, and copying five at once trades a cosmetic flaw for a far more expensive transcription mistake. Happy to do them as a follow-up.

`tests/run.sh` picks the new migration up, so the SQL suite runs against it on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)