### PR TITLE
docs: make every document match the system that actually runs

### DIFF
--- a/.github/workflows/apply-migration.yml
+++ b/.github/workflows/apply-migration.yml
@@ -4,14 +4,26 @@
 # SENGAJA manual (workflow_dispatch), TIDAK otomatis saat push/merge. Alasannya
 # tegas: ini satu-satunya jalur otomatis yang menyentuh database produksi, dan
 # migrasi yang keliru di sini merusak data yang tidak bisa dikembalikan lewat
-# git revert. Merge yang salah tidak boleh diam-diam mengubah produksi —
-# harus selalu ada manusia yang menekan tombolnya.
+# git revert. Merge yang salah tidak boleh diam-diam mengubah produksi.
+#
+# Berkas ini dulu menambahkan "harus selalu ada manusia yang menekan
+# tombolnya". Itu TIDAK lagi berlaku sejak 14 Agustus 2026: pemilik repo
+# memilih agar migrasi dijalankan langsung oleh asisten setelah PR-nya merge,
+# karena perbaikan yang sudah merge tapi belum diterapkan berkali-kali terlihat
+# seperti "masih rusak" padahal kodenya sudah benar. Yang tetap dipertahankan
+# adalah sifat manual workflow-nya — ia tidak pernah ikut berjalan sendiri saat
+# push, jadi selalu ada satu perintah sadar yang memicunya, bukan efek samping
+# dari merge.
 #
 # CARA PAKAI (bisa dari HP):
-#   1. Repo -> tab Actions -> "Terapkan migrasi ke Supabase" -> Run workflow.
+#   1. Repo -> tab Actions -> "Apply migration to Supabase" -> Run workflow.
 #   2. Isi "berkas" dengan path lengkap, misalnya:
 #        supabase/migrations/0011_nomor_dada_manual.sql
 #   3. Run workflow, lalu buka log-nya untuk memastikan "MIGRASI BERHASIL".
+#
+# Dari baris perintah:
+#   gh workflow run "Apply migration to Supabase" --ref main \
+#     -f berkas=supabase/migrations/0020_nomor_dada_tiga_digit.sql
 #
 # URUTAN YANG BENAR saat migrasi mengubah bentuk RPC (mis. 0011 mengganti
 # daftar_ulang_batch jadi dua argumen): terapkan migrasi DULU, lalu segera

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md
 
-Guidance for Codex when working in this repository.
+Guidance for coding agents working in this repository. **Isinya sengaja identik dengan CLAUDE.md** — kalau salah satu diubah, yang lain WAJIB ikut diubah di commit yang sama.
+
+Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md sempat tertinggal 21 baris — seluruh butir bahasa 9-12 hilang, termasuk aturan penamaan berkas — dan tiga string di dalamnya rusak oleh find-and-replace buta atas nama agen, salah satunya jadi URL yang mengarah ke situs pihak ketiga yang tak berhubungan.
 
 ## 1. Branching
 
@@ -11,7 +13,7 @@ Guidance for Codex when working in this repository.
    git checkout -b <type>/<short-description>
    ```
 3. Name branches `<type>/<short-description>` in kebab-case — for example
-   `feat/rekap-export`, `fix/duplicate-rows`, `docs/Codex-md`.
+   `feat/rekap-export`, `fix/duplicate-rows`, `docs/claude-md`.
 4. Use the same `<type>` vocabulary as commits: `feat`, `fix`, `chore`, `docs`,
    `refactor`, `test`.
 
@@ -23,7 +25,7 @@ Guidance for Codex when working in this repository.
    it from the subject with a blank line.
 3. End every commit message with the co-author trailer:
    ```
-   Co-Authored-By: Codex Opus 5 <noreply@anthropic.com>
+   Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
    ```
 4. Keep a commit to one logical change. Do not bundle unrelated edits.
 
@@ -43,7 +45,7 @@ Guidance for Codex when working in this repository.
    **Notes** only when there is a caveat worth flagging.
 5. End the PR body with:
    ```
-   🤖 Generated with [Codex](https://Codex.com/Codex)
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
    ```
 6. Only create or push a PR when the user has asked for it.
 
@@ -98,6 +100,27 @@ Guidance for Codex when working in this repository.
 8. Rule 7 does not loosen rule 3. Domain terms stay Indonesian however technical
    they sound, because no familiar English equivalent exists: `regu` is not
    "squad", and `nomor dada` is not "bib number" to anyone at this event.
+9. **File names, directory names, and branch names are English** whenever the
+   thing they name is technical rather than domain. This is rule 4 applied to
+   the filesystem, and it was violated repeatedly before being written down:
+   `terapkan-migrasi.yml` should have been `apply-migration.yml`, `tes-sql.yml`
+   should have been `sql-tests.yml`, `ganti_password.py` should have been
+   `change_password.py`. A workflow, a script, a test harness, and a migration
+   are all technical concepts — the panitia never speak their names.
+10. **Use the term the industry already uses, not a literal translation.**
+    Migrations are *applied*, not "implemented"; tests *run*; servers *start*.
+    Translating word-for-word from Indonesian produces names that are English
+    but still unsearchable, which defeats the entire point of rule 5.
+11. Rule 9 stops where the domain begins. `0011_nomor_dada_manual.sql` and
+    `05_pindah_kloter.sql` keep their Indonesian parts, because `nomor dada`
+    and `kloter` are rule 3 terms — only the surrounding technical words
+    (`print`, `move`, `seed`, `test`) turn English.
+12. **A workflow's `name:` field is UI text, so rule 1 decides it — by
+    audience, not by file.** A workflow a panitia runs from the Actions tab on
+    their phone keeps an Indonesian name ("Ganti password akun panitia",
+    "Provision akun panitia"). A workflow only a developer ever reads gets an
+    English one ("SQL Tests", "Apply migration to Supabase"). The file name is
+    English either way — that is rule 9 and has no exceptions.
 
 ## 6. Who maintains this
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,53 @@ Sistem rekapitulasi dan penilaian **Hiking Rally Ciradyka** — lomba gerak jala
 alam terbuka untuk SMP dan SMA yang diadakan Ambalan Ciung Wanara – Dyah
 Pitaloka, SMA Negeri 1 Ciamis.
 
-Arsitektur: **Supabase** (Postgres + Auth + RLS) sebagai mesin, SPA statis di
-**Cloudflare** sebagai tampilan, **Google Sheets** sebagai jendela baca —
-seluruhnya Rp 0. Alasan dan perbandingannya di `docs/desain-sistem.md`.
+Arsitektur yang berjalan: **Supabase** (Postgres + Auth + RLS) sebagai mesin,
+SPA statis di **Cloudflare Workers** sebagai tampilan, dan satu **Worker
+gateway** kecil untuk menerima form pendaftaran publik. Seluruhnya Rp 0.
+Gambaran lengkapnya di `docs/final-architecture.md`.
 
 ## Dokumen
 
-| Dokumen | Isi |
-| --- | --- |
-| `docs/alur-lomba.md` | Alur penyelenggaraan dan aturan penilaian (spesifikasi) |
-| `docs/desain-sistem.md` | Empat kandidat arsitektur gratis + keputusan |
-| `docs/rancangan-b.md` | Cetak biru implementasi (model data, layar, pipeline) |
+| Dokumen | Isi | Status |
+| --- | --- | --- |
+| `docs/final-architecture.md` | Sistem sebagaimana adanya sekarang | **Acuan utama** |
+| `docs/alur-lomba.md` | Alur penyelenggaraan dan aturan penilaian | Berlaku |
+| `docs/desain-sistem.md` | Perbandingan empat kandidat arsitektur + keputusan | Catatan keputusan |
+| `docs/rancangan-b.md` | Cetak biru implementasi yang dipakai membangun | Catatan keputusan |
+
+Dua dokumen terakhir merekam **keputusan pada saat itu**, bukan keadaan hari
+ini. Keduanya sengaja dipertahankan apa adanya karena 42 komentar di kode —
+tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.md
+11.9`, `bagian 4`, dan seterusnya). Kalau isinya berbeda dari sistem sekarang,
+`docs/final-architecture.md` yang benar.
 
 ## Struktur repo
 
 ```
 .
-├── docs/                     # spesifikasi & rancangan
+├── docs/                     # spesifikasi, catatan keputusan, arsitektur
+├── web/                      # SPA statis — layar panitia + form pendaftaran
+│   ├── index.html            # layar panitia (butuh login)
+│   ├── daftar.html           # form pendaftaran publik
+│   ├── js/                   # api.js, app.js, daftar.js, util.js
+│   ├── style.css             # seluruh gaya, termasuk aturan cetak
+│   ├── config.js             # URL Supabase + gateway (bukan rahasia)
+│   ├── _headers              # aturan cache Cloudflare
+│   └── wrangler.toml         # deploy Workers static assets
+├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0005
+│   ├── migrations/           # skema database, urut 0001..0020
+│   ├── checks/               # SQL pemeriksaan manual (row_counts, smoke, dst.)
 │   └── seed.sql              # konfigurasi edisi + baris wajib
+├── scripts/                  # provision_accounts.py, change_password.py
 ├── tests/
-│   ├── sql/                  # harness + tes constraint, alur, skor
-│   └── run.sh                # jalankan semuanya di database lokal
-└── README.md
+│   ├── sql/                  # harness + tes constraint, alur, skor, kloter
+│   ├── run.sh                # jalankan semuanya di database lokal
+│   ├── dev_server.py         # tiruan Supabase untuk mencoba layar
+│   └── static_server.py      # penyaji web/ tanpa cache
+├── .github/workflows/        # 5 workflow (lihat final-architecture.md)
+├── CLAUDE.md                 # konvensi kerja
+└── AGENTS.md                 # salinan identik CLAUDE.md
 ```
 
 ## Menjalankan tes
@@ -41,23 +64,36 @@ PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
 Untuk mencoba layarnya (butuh tiga terminal):
 
 ```bash
-bash tests/dev_database.sh          # siapkan database hrcd_dev
-python tests/dev_server.py    # tiruan Supabase di :8787
+bash tests/dev_database.sh     # siapkan database hrcd_dev
+python tests/dev_server.py     # tiruan Supabase di :8787
 python tests/static_server.py  # layar panitia di :8788 (tanpa cache)
 ```
 
 Runner membuat ulang database `hrcd_test` setiap kali — aman diulang. Tes
 mencakup: nomor dada ganda tertolak, kapasitas kloter, RLS per pos, alur
-lengkap daftar → bayar → daftar ulang → berangkat → nilai → closing, dan
-kecocokan mesin skor dengan contoh angka di `docs/rancangan-b.md`.
+lengkap daftar → bayar → daftar ulang → berangkat → nilai → closing, pemindahan
+kloter, koreksi jam berangkat, dan kecocokan mesin skor dengan contoh angka di
+`docs/rancangan-b.md`.
 
 Uji konkurensi terpisah membuktikan beberapa meja daftar ulang yang menekan
 tombol serentak tidak pernah menghasilkan nomor dada ganda:
 
 ```bash
-bash tests/dev_database.sh            # siapkan database hrcd_dev
-python tests/concurrency_test.py  # 30 koneksi serentak memperebutkan 300 nomor
+bash tests/dev_database.sh        # siapkan database hrcd_dev
+python tests/concurrency_test.py  # 30 meja serentak, 300 nomor diperebutkan
 ```
+
+## Menerapkan migrasi ke produksi
+
+Merge TIDAK menerapkan migrasi. Jalankan workflow-nya sendiri:
+
+```bash
+gh workflow run "Apply migration to Supabase" --ref main \
+  -f berkas=supabase/migrations/0020_nomor_dada_tiga_digit.sql
+```
+
+Atau dari HP: **Actions → Apply migration to Supabase → Run workflow**. Pastikan
+log-nya mencetak `MIGRASI BERHASIL`.
 
 ## Kontribusi
 

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -78,14 +78,18 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
       penting karena banyak sekolah bernama sama di kota berbeda.
    3. **Butuh penginapan?** Jawaban ya memasukkan seluruh batch ke skema
       penempatan barak (bagian 11).
-   4. **Mendaftarkan berapa regu?**
-   5. **Rincian golongan** yang jumlahnya harus sama dengan total — misal 5
-      regu = 3 Penegak PA + 1 Penegak PI + 1 Penggalang PA. Form memvalidasi
-      penjumlahannya.
-   6. **Untuk setiap regu:** nama regu dan nama ketua. **Nama empat anggota
+   4. **Mendaftarkan berapa regu?** — tidak pernah diketik. Pendaftar menaikkan
+      dan menurunkan jumlah **per golongan** lewat tombol + / −, dan totalnya
+      diturunkan dari situ ("Total: N regu"). Karena totalnya hasil hitungan,
+      tidak ada penjumlahan yang bisa meleset dan tidak ada yang perlu
+      divalidasi. Yang diperiksa hanya batas bawah ("Tambahkan minimal satu
+      regu") dan batas atas per pengiriman.
+   5. **Untuk setiap regu:** nama regu dan nama ketua. **Nama empat anggota
       lain tidak diminta** — untuk sekarang sistem tidak mencatatnya;
       kelengkapan 5 orang dicek fisik di akhir lomba (bagian 10.9).
-   7. **Satu kontak person WA** untuk keseluruhan batch.
+   6. **Satu Contact Person** untuk keseluruhan batch: nama (wajib) dan nomor
+      WhatsApp. Namanya disimpan sebagai `pendaftaran.nama_kontak` dan itulah
+      yang dipanggil panitia saat menghubungi sekolah.
 3. Setelah dikirim, sistem **memecah batch menjadi satu baris per regu** —
    5 regu menjadi 5 baris — yang tetap terikat pada satu tagihan bersama.
 4. Begitu form dikirim, terbit **kode pembayaran yang terikat pada regu-regu
@@ -319,9 +323,12 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    | `pos2hrcd37` | Hanya input nilai Pos 2 |
    | `admin.ciradyka` | Semua bagian sistem |
 
-   Akun hanya diberikan kepada admin tiap pos dan tim IT. Operator sebuah pos
-   tidak dapat menyentuh nilai pos lain — ditegakkan oleh sistem, bukan sekadar
-   disembunyikan dari layar.
+   Ada tiga peran: `admin`, `meja` (petugas pembayaran / daftar ulang /
+   keberangkatan), dan `operator_pos`. Akun hanya diberikan kepada admin tiap
+   pos, petugas meja, dan tim IT. Operator sebuah pos tidak dapat menyentuh
+   nilai pos lain, dan akun pos ditolak masuk ke layar meja dengan pesan "Akun
+   pos, bukan akun meja" — ditegakkan oleh sistem, bukan sekadar disembunyikan
+   dari layar.
 9. Pola nama akun mengikuti edisi (`hrcd37` = edisi ke-37), sehingga akun dan
    password dapat diganti bersih setiap tahun tanpa membongkar sistem.
 9. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap
@@ -479,11 +486,13 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
      yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
      Dokumen ini mengasumsikan per orang.
-5. **Teknologi yang dipakai: SUDAH DIPUTUSKAN.** Panitia memilih Kandidat B —
-   Supabase + frontend statis di Cloudflare, dengan Google Sheets tetap
-   sebagai jendela baca — dengan syarat keras UI/UX harus mudah diajarkan.
-   Perbandingan lengkap dan alasan di `desain-sistem.md` bagian 8; rancangan
-   detail di `rancangan-b.md`.
+5. **Teknologi yang dipakai: SUDAH DIPUTUSKAN dan sudah berjalan.** Panitia
+   memilih Kandidat B — Supabase + frontend statis di Cloudflare — dengan
+   syarat keras UI/UX harus mudah diajarkan. Google Sheets sempat direncanakan
+   sebagai jendela baca tetapi **tidak pernah dipakai**; tidak ada di kode.
+   Perbandingan dan alasannya di `desain-sistem.md` bagian 8, cetak birunya di
+   `rancangan-b.md` — keduanya catatan keputusan. Untuk keadaan sistem
+   sekarang, baca `final-architecture.md`.
    *(Pertanyaan-pertanyaan lain di bagian ini yang sudah terjawab dan pindah ke
    badan dokumen: pembayaran sebagian tidak dilayani — bagian 3.5; kode
    pembayaran per batch terbit saat pendaftaran — bagian 3.4; nama anggota

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -1,9 +1,20 @@
 # Desain Sistem hrcd-rekap — Kandidat Arsitektur Gratis
 
+> **CATATAN KEPUTUSAN — bukan keadaan sekarang.**
+> Dokumen ini ditulis SEBELUM sistemnya dibangun, untuk memilih arsitektur.
+> Kandidat B dipilih (bagian 8) dan sudah lama berjalan di produksi.
+>
+> Isinya sengaja **tidak** diperbarui: nilainya justru pada rekaman apa yang
+> diketahui dan dipertimbangkan saat keputusan diambil. Maka kalimat di bagian
+> 4 seperti "Cloudflare Pages", "tanpa server custom", `FOR UPDATE SKIP LOCKED`,
+> atau tabel `riwayat` menggambarkan RENCANA saat itu — beberapa di antaranya
+> memang berubah saat dibangun.
+>
+> **Untuk keadaan sistem sekarang, baca `final-architecture.md`.**
+
 Dokumen ini menawarkan **empat kandidat arsitektur** untuk mengimplementasikan
 seluruh alur di `alur-lomba.md` dengan **biaya Rp 0** — hosting, database,
-subdomain, SSL, semuanya. Belum ada kode yang ditulis atau dieksekusi; ini murni
-rancangan untuk dipilih.
+subdomain, SSL, semuanya.
 
 Setiap kandidat dirancang lengkap terhadap 14 kebutuhan (bagian 1), lalu **diuji
 secara adversarial**: klaim biayanya diverifikasi terhadap ketentuan free tier
@@ -408,11 +419,19 @@ tahun kebiasaan panitia, dan keputusan sepenuhnya milik panitia.
 
 ## 9. Keputusan yang menunggu panitia
 
-1. Pilih kandidat (bagian 8).
+> Ditulis saat keputusan belum diambil. Yang sudah selesai ditandai di bawah;
+> sisanya masih relevan.
+
+1. ~~Pilih kandidat (bagian 8).~~ **Selesai: B.** Sudah berjalan di produksi —
+   Supabase, situs statis Cloudflare Workers, Worker gateway, 20 migrasi.
 2. Siapa yang memegang akun-akun gratis (Google/Supabase/Cloudflare/GitHub) —
    disarankan akun organisasi ambalan, bukan akun pribadi pengurus, dengan
    minimal dua orang tahu password-nya.
 3. Untuk kandidat B: siapa yang menjalankan ritual cek Januari (buka dashboard,
    verifikasi project aktif, uji satu alur input).
-4. Bentuk pagar anti-spam form pendaftaran (pertanyaan sederhana / rate limit).
+4. ~~Bentuk pagar anti-spam form pendaftaran (pertanyaan sederhana / rate
+   limit).~~ **Selesai:** rate limit 30 pengiriman per IP per menit (KV
+   namespace `RATE`) + batas payload 32.000 byte di Worker gateway. Turnstile
+   ada di kode tapi sengaja dinonaktifkan untuk edisi 37 — pendaftaran lewat
+   Google Form di tahun-tahun sebelumnya tidak pernah disalahgunakan.
 5. Jadwal latihan hari-H (drill failover) — relevan untuk kandidat mana pun.

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -1,0 +1,262 @@
+# Sistem sebagaimana adanya
+
+**Acuan utama.** Dokumen ini menggambarkan apa yang benar-benar berjalan hari
+ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
+dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
+sebelum sistemnya dibangun.
+
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0020`.
+
+---
+
+## 1. Bentuk sistem
+
+Tiga bagian, dan hanya satu di antaranya kode yang kita tulis dan jalankan
+sendiri di server:
+
+| Bagian | Isi | Di mana |
+| --- | --- | --- |
+| Database | Postgres + Auth + RLS + seluruh logika | Supabase |
+| Tampilan | SPA statis, tanpa build step | Cloudflare Workers static assets |
+| Gateway | Penerima form pendaftaran publik | Cloudflare Worker |
+
+**Tidak ada server aplikasi.** Layar panitia berbicara langsung ke Supabase
+lewat PostgREST memakai anon key; yang menjaga data bukan lapisan tengah,
+melainkan RLS dan RPC di database. Satu-satunya kode server adalah gateway,
+dan ia hanya menangani satu hal: form pendaftaran publik, yang harus bisa
+dikirim tanpa login.
+
+Yang **tidak** dipakai, meski disebut di dokumen lama: Google Sheets, Cloudflare
+Pages, halaman `live.json`/`live.html`. Tidak ada satu pun di kode.
+
+### Alamat produksi
+
+| Apa | Alamat |
+| --- | --- |
+| Layar panitia + form daftar | `https://hrcd37.ciradyka.workers.dev` |
+| Gateway pendaftaran | `https://gateway.ciradyka.workers.dev` |
+| Supabase | `https://pwszijhnftvqjkdldqrf.supabase.co` |
+
+Nama project situs memuat nomor edisi (`hrcd37`) dan berganti tiap tahun.
+Gateway dan project Supabase sengaja TIDAK memuat nomor edisi supaya bisa
+dipakai lintas tahun. Kalau `name` di `web/wrangler.toml` diubah, `ALLOWED_ORIGIN`
+di `workers/gateway/worker.js` wajib ikut diubah.
+
+---
+
+## 2. Database
+
+20 migrasi, `0001` sampai `0020`, dijalankan berurutan tanpa lubang penomoran.
+`supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
+perubahan yang dilakukan lewat dashboard.
+
+**Migrasi tidak pernah disunting setelah diterapkan.** Perubahan atas fungsi
+yang sudah ada ditulis sebagai migrasi baru berisi `create or replace function`
+lengkap. Itu sebabnya definisi terbaru sebuah RPC sering berada di berkas
+bernomor besar, bukan di `0004_rpcs.sql`.
+
+### Tabel
+
+Operasional: `pendaftaran`, `regu`, `sekolah`, `pembayaran`, `kloter`,
+`keberangkatan_regu`, `nilai_mentah`, `closing_regu`, `penempatan_barak`,
+`nomor_dada_stok`, `nomor_dada_pensiun`.
+
+Konfigurasi per edisi: `edisi`, `pos`, `wahana`, `kontrak_opsi`,
+`konfig_penalti`, `ruangan`, `status_acara`.
+
+Akun & jejak: `akun_panitia`, `history`.
+
+> Tabel jejak audit bernama **`history`** dengan kolom `table_name`, `row_id`,
+> `action`, `old_value`, `new_value`, `changed_by`, `changed_at`. Dokumen lama
+> menyebutnya `riwayat` — itu nama sebelum migrasi `0012`.
+
+### Cara skor dihitung
+
+Skor **tidak pernah disimpan**. Seluruhnya diturunkan saat dibaca lewat rantai
+view: `v_poin_pos`, `v_poin_wahana`, `v_penalti_waktu` → `v_total_skor` →
+`v_klasemen`. Mengubah aturan penilaian berarti mengubah baris konfigurasi,
+bukan menghitung ulang data.
+
+Konsekuensinya: memperbaiki satu nilai yang salah ketik langsung memperbaiki
+klasemen, tanpa proses hitung ulang apa pun.
+
+### Kunci daftar ulang
+
+Pemberian nomor dada dan penyebaran kloter diserialisasi dengan satu
+**advisory lock** di awal transaksi (`pg_advisory_xact_lock`), bukan
+`FOR UPDATE SKIP LOCKED`. Pola lama itu dibuang di migrasi `0007` karena bocor:
+ia mengunci `nomor_dada_stok` sambil memutuskan kloter, sehingga dua meja bisa
+sampai pada kloter yang sama.
+
+Nomor dada **diketik petugas**, tidak diterbitkan sistem (migrasi `0011`) —
+kainnya benda fisik di meja, dan yang ada di tangan petugas belum tentu nomor
+terkecil yang tersedia.
+
+---
+
+## 3. Layar panitia
+
+SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
+
+| Rute | Layar | Kerjanya |
+| --- | --- | --- |
+| `#/home` | Beranda | menu + dua lencana angka: menunggu pembayaran, lunas belum bernomor |
+| `#/pembayaran` | Meja Pembayaran | tabel semua invoice, tandai lunas, cetak kwitansi |
+| `#/daftar-ulang` | Meja Daftar Ulang | isi nomor dada per regu, tukar nomor rusak |
+| `#/cetak-kloter` | Cetak Daftar Kloter | lembar per kloter untuk petugas start |
+| `#/keberangkatan` | Keberangkatan | ceklis hadir, kontrak waktu, pindah kloter, berangkatkan |
+| `#/finish` | Kedatangan | catat jam datang + anggota hadir |
+| `#/ganti-password` | Ganti Password | — |
+
+Peran akun: `admin`, `meja`, `operator_pos`. Seluruh RPC meja menuntut
+`peran() in ('admin','meja')`; akun `operator_pos` ditolak di Home dengan pesan
+"Akun pos, bukan akun meja".
+
+### Bentuk tabel meja menurut lebar layar
+
+Meja Pembayaran dan Meja Daftar Ulang berganti bentuk di dua ambang. Angkanya
+ditentukan isi tabel, bukan ukuran jempol:
+
+| Lebar | Bentuk |
+| --- | --- |
+| ≤ 560px | tiap baris jadi kartu bertumpuk; tidak ada geser samping |
+| 561–940px | tetap tabel, lebar kolom mengikuti isi, label tombol dipendekkan ("Lunas", "Kwitansi") |
+| ≥ 941px | tabel dengan lebar kolom dipatok persen, supaya rincian sejajar kolom induknya |
+
+Ambang 940px berasal dari `min-width` tabelnya (820px) ditambah padding dan
+scrollbar. **Kalau kolom ditambah, `min-width` naik — dan ambang ini harus ikut
+naik**, kalau tidak tabelnya menggeser ke samping dan kolom paling kanan (kolom
+tombol) hilang dari layar tanpa petunjuk apa pun.
+
+Meja Daftar Ulang berkolom tiga: Kode Bayar, Sekolah, tombol "Isi N Nomor Dada".
+Jumlah regu tidak punya kolom sendiri — angkanya sudah tercetak di dalam tombol.
+
+---
+
+## 4. Form pendaftaran publik
+
+`web/daftar.html` + `web/js/daftar.js`, tanpa login. Kiriman tidak langsung ke
+Supabase melainkan ke gateway, yang memanggil `submit_pendaftaran` memakai
+service role.
+
+Pagar yang benar-benar aktif di gateway:
+
+- **Batas ukuran** 32.000 byte (30 regu ≈ 6 KB).
+- **Rate limit** 30 pengiriman per IP per menit, disimpan di KV namespace `RATE`.
+- **Turnstile opsional** — dilompati kalau `TURNSTILE_SECRET` tidak diisi.
+  Untuk edisi 37 sengaja dinonaktifkan; riwayat pendaftaran lewat Google Form
+  sebelumnya tidak pernah disalahgunakan.
+
+Service key hidup sebagai `wrangler secret` di Worker, tidak pernah di SPA.
+`web/config.js` hanya memuat anon key, yang memang publik.
+
+---
+
+## 5. Deploy
+
+| Yang di-deploy | Cara | Pemicu |
+| --- | --- | --- |
+| Situs statis (`web/`) | Cloudflare Workers, tersambung Git | otomatis tiap push ke `main` |
+| Gateway Worker | GitHub Actions `deploy-gateway.yml` | manual |
+| Migrasi database | GitHub Actions `apply-migration.yml` | manual, satu berkas per jalan |
+
+**Merge ke `main` = deploy situs.** Tidak ada build step; berkas di `web/`
+disajikan apa adanya, dengan `web/wrangler.toml` menyetel root proyek ke folder
+itu.
+
+**Merge TIDAK menerapkan migrasi.** Migrasi dijalankan terpisah:
+
+```bash
+gh workflow run "Apply migration to Supabase" --ref main \
+  -f berkas=supabase/migrations/0020_nomor_dada_tiga_digit.sql
+```
+
+Berkasnya dijalankan `--single-transaction` dengan `ON_ERROR_STOP=1`: kalau satu
+statement gagal, seluruh berkas di-rollback. Tidak ada bentuk "migrasi setengah
+jadi". Pastikan log-nya mencetak `MIGRASI BERHASIL`.
+
+Kalau sebuah migrasi mengubah bentuk RPC yang dipanggil layar, terapkan migrasi
+**dulu**, lalu segera merge PR kodenya — di antara keduanya ada jeda singkat
+saat layar memanggil RPC lama dan gagal.
+
+### Cache
+
+`web/_headers` menyetel `Cache-Control: no-cache` untuk semua aset: browser
+boleh menyimpan, tapi wajib bertanya dulu. Asetnya kecil (<100 KB seluruhnya),
+jadi biayanya hampir nol — dan tanpa itu, perbaikan mendadak pagi hari-H tidak
+akan sampai ke panitia.
+
+### Workflow lain
+
+| Workflow | Nama di Actions | Untuk siapa |
+| --- | --- | --- |
+| `sql-tests.yml` | SQL Tests | otomatis tiap PR dan push ke `main` |
+| `provision-accounts.yml` | Provision akun panitia | panitia, dari HP |
+| `change-password.yml` | Ganti password akun panitia | panitia, dari HP |
+
+Nama workflow mengikuti pembacanya: yang dijalankan panitia berbahasa Indonesia,
+yang hanya dibaca developer berbahasa Inggris. Nama berkasnya selalu Inggris
+(CLAUDE.md aturan 9 dan 12).
+
+---
+
+## 6. Menjalankan secara lokal
+
+Tanpa akun Supabase sama sekali. `tests/dev_server.py` menirukan PostgREST +
+GoTrue di atas Postgres lokal, termasuk RLS: tiap request dijalankan dalam
+transaksi dengan `SET LOCAL app.uid` dan `SET LOCAL ROLE`, sehingga policy yang
+sama dengan produksi ikut menggigit.
+
+```bash
+bash tests/dev_database.sh     # siapkan database hrcd_dev
+python tests/dev_server.py     # tiruan Supabase di :8787
+python tests/static_server.py  # layar panitia di :8788, tanpa cache
+```
+
+Ganti `mode` di `web/config.js` jadi `"dev"` untuk menunjuk ke sana.
+
+---
+
+## 7. Yang paling mudah salah
+
+Dikumpulkan dari kesalahan yang benar-benar terjadi, bukan daftar teoretis.
+
+1. **Merge bukan berarti diterapkan.** Perbaikan pesan galat dari database
+   pernah terlihat "masih rusak" berjam-jam padahal kodenya sudah di `main` —
+   migrasinya belum dijalankan.
+2. **`table-layout: fixed` tidak membungkus, ia meluap.** Kolom yang menyempit
+   menimpa kolom sebelahnya. Di Meja Pembayaran itu membuat dropdown cara bayar
+   tertimbun tombol "Tandai Lunas" sampai Transfer tidak bisa dipilih.
+3. **Persentase lebar kolom bocor ke tampilan kartu HP.** Saat sel jadi
+   `display: block`, `width: 18%` bukan lagi lebar kolom melainkan 18% lebar
+   kartu. Semua patokan persen wajib dikurung di `@media (min-width: 941px)`.
+4. **Nomor anak CSS yang basi tidak menimbulkan galat.** Setelah kolom Regu
+   dihapus, `td:nth-child(4)` sekadar tidak mengenai apa-apa — dan tombolnya
+   meleset 74px dari kotak isian di bawahnya tanpa pesan apa pun.
+5. **`grid-area: … / -1` tidak bisa diandalkan** di aturan kartu ini; ia pernah
+   menaruh nama sekolah kembali di kolom 1–2 sehingga bertumpuk dengan kode
+   pembayaran. Pakai nomor garis eksplisit.
+6. **Komentar CSS yang menutup dua kali** (`*/ … */`) menelan deklarasi
+   sesudahnya tanpa galat apa pun. Layout tampak jalan lewat kolom implisit.
+7. **`AGENTS.md` wajib identik dengan `CLAUDE.md`.** Ia pernah menyimpang 21
+   baris dan tiga stringnya rusak oleh find-and-replace atas nama agen.
+
+---
+
+## 8. Yang belum dibereskan
+
+Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
+
+- **`docs/arsitektur-hrcd.svg` dan `.png`** masih menggambarkan Google Sheets
+  sebagai bagian arsitektur, dan angkanya sudah bergeser: tertulis "18 view
+  berlapis" (sekarang 17) dan "24 RPC bertransaksi" (sekarang 26 fungsi, 14 di
+  antaranya dipanggil layar). Diagramnya tidak dirujuk dari dokumen mana pun,
+  jadi dibiarkan sampai ada yang menggambar ulang.
+- **Beberapa RPC masih mencetak nomor dada mentah** di pesan galatnya
+  (`nomor dada % tidak dikenal` di `catat_closing` dan `pindah_kloter`, antara
+  lain), padahal di layar selalu tiga digit. Migrasi `0020` baru membetulkan
+  `berangkatkan_kloter`; sisanya menunggu karena tiap perbaikan menuntut
+  seluruh badan fungsinya disalin ulang.
+- **Halaman live publik belum ada.** `live.html` + `live.json` di
+  `rancangan-b.md` bagian 7 tidak pernah dibangun, dan tidak ada workflow yang
+  menghasilkannya.

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -1,5 +1,31 @@
 # Rancangan Detail hrcd-rekap — Arsitektur B
 
+> **CATATAN KEPUTUSAN — bukan keadaan sekarang.**
+> Ini cetak biru yang dipakai membangun sistem, ditulis sebelum kodenya ada.
+> Ia **sengaja dipertahankan apa adanya**: 42 komentar di kode — tersebar di
+> migrasi, tes, SPA, dan Worker — menunjuk ke nomor bagian dokumen ini
+> (`rancangan-b.md 11.9`, `bagian 4`, `2.2.1`, dan seterusnya). Menulis ulang
+> isinya akan memutus seluruh penunjuk itu, termasuk yang tertanam di migrasi
+> yang sudah diterapkan dan tidak boleh disunting.
+>
+> Beberapa hal berubah saat dibangun, jadi jangan baca dokumen ini sebagai
+> gambaran layar hari ini. Yang sudah diketahui berbeda:
+>
+> - **Google Sheets tidak pernah dipakai.** Tidak ada di kode mana pun.
+> - **`live.html` / `live.json` tidak pernah dibangun** (bagian 7).
+> - **Chip "Jam sekarang" tidak ada.** Jam berangkat justru diisi otomatis;
+>   jam datang dikosongkan dengan keterangan "Kosong = jam saat tombol ditekan."
+> - **Meja Pembayaran bukan alur ketik-kode → kartu**, melainkan tabel berisi
+>   semua invoice dengan kotak cari dan saringan.
+> - **Keberangkatan bukan papan 4 kolom**, melainkan satu pita chip berisi
+>   semua kloter + satu tabel 5 kolom untuk kloter terpilih.
+> - **Beranda hanya punya dua lencana angka**, bukan tiga.
+> - **Export CSV belum ada** (dijadwalkan Tahap 4 di bagian 13).
+> - Aturan tampilan di bagian 10.1 sudah banyak berubah — ambang responsif,
+>   perilaku kepala di HP, dan ukuran sasaran sentuh.
+>
+> **Untuk keadaan sistem sekarang, baca `final-architecture.md`.**
+
 Cetak biru implementasi untuk keputusan di `desain-sistem.md` bagian 8:
 **Supabase (Postgres + Auth + RLS + Realtime) + SPA statis di Cloudflare +
 Google Sheets sebagai jendela baca.** Syarat keras panitia berlaku di seluruh

--- a/web/_headers
+++ b/web/_headers
@@ -22,7 +22,10 @@
   Cache-Control: no-cache
   Content-Type: text/css; charset=utf-8
 
-# live.json diperbarui GitHub Actions tiap beberapa menit; halaman publik
-# memuat ulang sendiri, jadi cukup singkat saja.
-/live.json
-  Cache-Control: max-age=30
+# Aturan untuk /live.json sengaja BELUM ada di sini. Halaman live publik
+# (live.html + live.json) baru rencana — lihat docs/rancangan-b.md bagian 7 —
+# dan berkasnya tidak pernah dibuat. Aturan cache-nya sempat ditulis lebih dulu
+# beserta komentar yang menyatakan "diperbarui GitHub Actions tiap beberapa
+# menit", padahal workflow itu tidak ada; aturan untuk berkas yang tidak ada
+# hanya menyesatkan pembaca berikutnya. Tambahkan kembali saat halamannya
+# benar-benar dibangun.


### PR DESCRIPTION
## What

An audit of all six markdown files against the code found **21 confirmed stale claims** and **9 reported ones that were false**. Nothing was deleted.

- **`docs/final-architecture.md`** (new) — the reference for how the system actually works.
- **`desain-sistem.md`, `rancangan-b.md`** — contents kept, banner added marking them decision records with the known differences listed.
- **`README.md`** — repo tree and migration range corrected.
- **`docs/alur-lomba.md`** — three corrections.
- **`AGENTS.md`** — now byte-identical to `CLAUDE.md` apart from its heading.
- **`web/_headers`** — cache rule for a file that was never built, removed.
- **`apply-migration.yml`** — comment no longer contradicts how migrations are actually run.

## Why

The false findings mattered as much as the real ones. Most sat inside sections describing a candidate architecture under comparison, so "correcting" them would have rewritten the record of *why* the architecture was chosen. That is what shaped the approach.

`desain-sistem.md` and `rancangan-b.md` are kept whole because **42 comments across migrations, tests, the SPA and the Worker point at their section numbers** (`rancangan-b.md 11.9`, `bagian 4`, `2.2.1`). Some of those comments live inside migrations that have already been applied and must not be edited. Rewriting either document would leave all 42 dangling.

What was actually wrong:

- README claimed the repo held only `docs/`, `supabase/` and `tests/` — omitting `web/`, `workers/`, `scripts/` and `.github/` — and gave the migration range as `0001..0005` against 20 migrations.
- **Google Sheets** is named as part of the architecture in several places. It appears nowhere in the code and never did.
- `alur-lomba.md`: the form derives its regu total from steppers rather than validating a typed sum; section 5 is "Contact Person" with a required name; there are three account roles, not pos admins alone.
- `AGENTS.md` was 21 lines behind `CLAUDE.md` — the whole of language rules 9–12 — and three strings had been mangled by a blind find-and-replace of the agent name, one into a URL pointing at an unrelated third-party site.
- `web/_headers` cached `/live.json`, which was never built, with a comment claiming a workflow refreshed it every few minutes. No such workflow exists.

**`CLAUDE.md` needed no changes.** Both findings against it were refuted — one by showing that `terapkan-migrasi.yml`, which it cites as a past naming mistake, really did exist in a commit that is now dangling and so invisible to `git log --all`.

## Notes

Known-stale and deliberately left, recorded in section 8 of the new document so nobody assumes it was checked: `docs/arsitektur-hrcd.svg`/`.png` still shows Google Sheets and its counts have drifted (18 views → 17, 24 RPC → 26). It is referenced from no document, so it waits for someone to redraw it.

Documentation only — no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)