### PR TITLE
chore: add the desk-state and flow-test check scripts

### DIFF
--- a/supabase/checks/desk_state.sql
+++ b/supabase/checks/desk_state.sql
@@ -1,0 +1,9 @@
+-- Bahan uji: apa yang tersedia di layar panitia saat ini?
+select 'menunggu bayar' as keadaan, count(*) from pendaftaran where status = 'menunggu_pembayaran'
+union all select 'lunas, ada regu belum bernomor',
+  count(distinct d.id) from pendaftaran d join regu r on r.pendaftaran_id = d.id
+  where d.status = 'lunas' and r.nomor_dada is null and not r.is_cancelled
+union all select 'stok nomor dada tersedia',
+  count(*) from nomor_dada_stok s
+  where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+    and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);

--- a/supabase/checks/flow_test.sql
+++ b/supabase/checks/flow_test.sql
@@ -1,0 +1,46 @@
+-- Uji alur nyata terhadap fungsi-fungsi yang ditulis ulang saat rename.
+-- Memakai batch UJI MEJA PEMBAYARAN yang sengaja dibuat untuk ini.
+--
+-- request.jwt.claims di-set manual supaya auth.uid() terisi — di produksi
+-- nilainya datang dari JWT, di sini dari akses DB langsung. Ini menjalankan
+-- BODY fungsi sungguhan; tanpa uid yang sah, fungsinya berhenti di baris
+-- pertama ("hanya meja/admin") dan justru tidak menguji apa-apa.
+do $$
+declare
+  v_admin uuid;
+  v_kode  text := 'HRCD37-D16821';
+  v_hasil jsonb;
+  v_pas   jsonb;
+  v_n     int;
+begin
+  select user_id into v_admin from akun_panitia where peran = 'admin' and is_active limit 1;
+  perform set_config('request.jwt.claims', json_build_object('sub', v_admin)::text, true);
+
+  -- 1. verifikasi_pembayaran (ditulis ulang di 0012 & 0014)
+  v_hasil := verifikasi_pembayaran(v_kode, 500000, 'tunai');
+  raise notice 'LULUS verifikasi_pembayaran -> kwitansi %', v_hasil ->> 'nomor_kwitansi';
+
+  -- 2. daftar_ulang_batch dengan nomor dada MANUAL (0011, ditulis ulang 0014)
+  select jsonb_agg(jsonb_build_object('regu_id', r.id, 'nomor_dada', 900 + row_number() over (order by r.nama_regu)))
+    into v_pas
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_kode and r.nomor_dada is null and not r.is_cancelled;
+
+  select count(*) into v_n from daftar_ulang_batch(v_kode, v_pas);
+  raise notice 'LULUS daftar_ulang_batch -> % regu dapat nomor dada manual', v_n;
+
+  -- 3. Buktikan hasilnya benar-benar tertulis
+  for v_hasil in
+    select jsonb_build_object('regu', r.nama_regu, 'dada', r.nomor_dada, 'kloter', r.kloter_nomor)
+    from regu r join pendaftaran d on d.id = r.pendaftaran_id
+    where d.kode_pembayaran = v_kode order by r.nomor_dada
+  loop
+    raise notice '   %', v_hasil;
+  end loop;
+
+  -- 4. Audit trigger (record_history, ditulis ulang 0012) ikut menulis?
+  select count(*) into v_n from history
+  where table_name in ('regu','pembayaran') and changed_at > now() - interval '2 minutes';
+  raise notice 'LULUS record_history -> % baris audit baru', v_n;
+end;
+$$;

--- a/supabase/checks/flow_test.sql
+++ b/supabase/checks/flow_test.sql
@@ -21,14 +21,22 @@ begin
   raise notice 'LULUS verifikasi_pembayaran -> kwitansi %', v_hasil ->> 'nomor_kwitansi';
 
   -- 2. daftar_ulang_batch dengan nomor dada MANUAL (0011, ditulis ulang 0014)
-  -- Subquery: window function tidak boleh bersarang di dalam agregat.
-  select jsonb_agg(jsonb_build_object('regu_id', x.id, 'nomor_dada', 900 + x.urut))
+  -- Nomor diambil dari STOK yang benar-benar tersedia. Percobaan sebelumnya
+  -- memakai 901/902 dan ditolak 0011 dengan "di luar stok" — penjagaannya
+  -- bekerja, jadi di sini kita beri nomor yang sah.
+  select jsonb_agg(jsonb_build_object('regu_id', x.id, 'nomor_dada', y.nomor))
     into v_pas
   from (
     select r.id, row_number() over (order by r.nama_regu) as urut
     from regu r join pendaftaran d on d.id = r.pendaftaran_id
     where d.kode_pembayaran = v_kode and r.nomor_dada is null and not r.is_cancelled
-  ) x;
+  ) x
+  join (
+    select s.nomor, row_number() over (order by s.nomor) as urut
+    from nomor_dada_stok s
+    where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+      and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
+  ) y on y.urut = x.urut;
 
   select count(*) into v_n from daftar_ulang_batch(v_kode, v_pas);
   raise notice 'LULUS daftar_ulang_batch -> % regu dapat nomor dada manual', v_n;

--- a/supabase/checks/flow_test.sql
+++ b/supabase/checks/flow_test.sql
@@ -1,3 +1,21 @@
+-- ============================================================================
+-- PERINGATAN: BERKAS INI MENGUBAH DATA.
+--
+-- Berbeda dari berkas lain di supabase/checks/ yang hanya membaca, skrip ini
+-- MENJALANKAN transaksi sungguhan: ia menandai sebuah pembayaran LUNAS,
+-- menerbitkan kwitansi, dan memakai nomor dada dari stok. Efeknya tidak bisa
+-- dibatalkan dengan menutup jendela.
+--
+-- Kode batch di bawah (v_kode) DITULIS MATI dan menunjuk batch uji yang
+-- sengaja dibuat untuk ini. Menjalankannya apa adanya terhadap database yang
+-- berisi pendaftaran sungguhan akan melunasi tagihan sekolah yang tidak
+-- membayar, dan menghabiskan nomor dada dari stok fisik yang belum dibagikan.
+--
+-- Jalankan HANYA di database lokal/uji, dan hanya setelah memastikan v_kode
+-- memang batch uji. Namanya "flow_test" — bacalah sebagai tes, bukan sebagai
+-- pemeriksaan.
+-- ============================================================================
+
 -- Uji alur nyata terhadap fungsi-fungsi yang ditulis ulang saat rename.
 -- Memakai batch UJI MEJA PEMBAYARAN yang sengaja dibuat untuk ini.
 --

--- a/supabase/checks/flow_test.sql
+++ b/supabase/checks/flow_test.sql
@@ -21,10 +21,14 @@ begin
   raise notice 'LULUS verifikasi_pembayaran -> kwitansi %', v_hasil ->> 'nomor_kwitansi';
 
   -- 2. daftar_ulang_batch dengan nomor dada MANUAL (0011, ditulis ulang 0014)
-  select jsonb_agg(jsonb_build_object('regu_id', r.id, 'nomor_dada', 900 + row_number() over (order by r.nama_regu)))
+  -- Subquery: window function tidak boleh bersarang di dalam agregat.
+  select jsonb_agg(jsonb_build_object('regu_id', x.id, 'nomor_dada', 900 + x.urut))
     into v_pas
-  from regu r join pendaftaran d on d.id = r.pendaftaran_id
-  where d.kode_pembayaran = v_kode and r.nomor_dada is null and not r.is_cancelled;
+  from (
+    select r.id, row_number() over (order by r.nama_regu) as urut
+    from regu r join pendaftaran d on d.id = r.pendaftaran_id
+    where d.kode_pembayaran = v_kode and r.nomor_dada is null and not r.is_cancelled
+  ) x;
 
   select count(*) into v_n from daftar_ulang_batch(v_kode, v_pas);
   raise notice 'LULUS daftar_ulang_batch -> % regu dapat nomor dada manual', v_n;


### PR DESCRIPTION
## What

Brings two manual check scripts in `supabase/checks/` onto `main`. They were sitting on a branch with no PR since 13 August.

- `desk_state.sql` — read-only. Counts what the panitia screens should be showing: batches awaiting payment, paid batches with regu still unnumbered, and nomor dada still free in stock.
- `flow_test.sql` — exercises `verifikasi_pembayaran`, `daftar_ulang_batch` and the `record_history` trigger against a real batch, to check the functions that were rewritten during the `0012`/`0014` renames.

One commit added on top: a warning header on `flow_test.sql`.

## Why

The two `fix:` commits on the branch are real findings worth keeping — a window function cannot nest inside an aggregate, and the test has to draw nomor dada from stock that actually exists (an earlier attempt used 901/902 and was correctly rejected by the `0011` guard).

The header exists because everything else in `supabase/checks/` only reads, so the directory reads as safe to poke at. `flow_test.sql` runs real transactions: it marks a payment paid, issues a kwitansi, and consumes nomor dada from stock. Its batch code is hardcoded, so running it as-is against a database holding real registrations would settle a bill for a school that never paid and burn numbers off the physical stock. The name says none of that.

## Notes

Nothing runs `supabase/checks/` automatically — no workflow and not `tests/run.sh` — so these only execute when a person runs them.

`flow_test.sql` targets batch `HRCD37-D16821`, which exists only as test data. That is part of the test data due to be cleared before the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)