### PR TITLE
feat: add the Input Pos screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │   └── wrangler.toml         # deploy Workers static assets
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0020
+│   ├── migrations/           # skema database, urut 0001..0024
 │   ├── checks/               # SQL pemeriksaan manual (row_counts, smoke, dst.)
 │   └── seed.sql              # konfigurasi edisi + baris wajib
 ├── scripts/                  # provision_accounts.py, change_password.py
@@ -75,6 +75,11 @@ lengkap daftar → bayar → daftar ulang → berangkat → nilai → closing, p
 kloter, koreksi jam berangkat, dan kecocokan mesin skor dengan contoh angka di
 `docs/rancangan-b.md`.
 
+`tests/sql/08_lembar_pos.sql` mengujinya dari arah lain: angka yang dipakai
+adalah baris **nyata** dari lembar penilaian HRCD XXXVI, lengkap dengan Nilai
+Pos yang tercetak di sana. Kalau mesin skor menghasilkan angka lain, yang salah
+kodenya — bukan lembarnya.
+
 Uji konkurensi terpisah membuktikan beberapa meja daftar ulang yang menekan
 tombol serentak tidak pernah menghasilkan nomor dada ganda:
 
@@ -89,7 +94,7 @@ Merge TIDAK menerapkan migrasi. Jalankan workflow-nya sendiri:
 
 ```bash
 gh workflow run "Apply migration to Supabase" --ref main \
-  -f berkas=supabase/migrations/0020_nomor_dada_tiga_digit.sql
+  -f berkas=supabase/migrations/0021_pos_bayangan.sql
 ```
 
 Atau dari HP: **Actions → Apply migration to Supabase → Run workflow**. Pastikan

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -230,8 +230,25 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
 1. Terdapat **5 pos utama** di sepanjang rute, masing-masing dengan soal dan
    wahana yang berbeda.
-2. Selain itu ada **pos bayangan**. Pos bayangan umumnya tidak memiliki wahana
-   dan **tidak dinilai**, sehingga tidak dimodelkan oleh sistem sama sekali.
+2. Selain itu ada **pos bayangan** — pos yang tidak diberitahukan lebih dulu ke
+   peserta. Pos bayangan **tetap dinilai**, hanya saja yang dinilai bukan
+   wahana melainkan hal yang melekat pada regunya sepanjang perjalanan:
+   kostum, kekompakan, kesopanan.
+
+   > Sampai 14 Agustus 2026 dokumen ini menulis pos bayangan "tidak dinilai,
+   > sehingga tidak dimodelkan sistem sama sekali", dan skema database
+   > mengunci nomor pos ke 1–5 atas dasar kalimat itu. Lembar penilaian yang
+   > benar-benar dipakai panitia membuktikan sebaliknya — "Pos Bayangan 1
+   > Kostum" punya kolom Kreativitas, Kekompakan, dan Kesopanan, punya Nilai
+   > Pos, bahkan punya kolom RANK. Dokumennya yang salah; dibetulkan bersama
+   > migrasi `0021`.
+
+   Pos bayangan dinilai **dengan mesin yang sama persis** seperti pos utama.
+   Ia bukan cabang tersendiri di kode: sebuah baris di tabel `pos` bertanda
+   `bayangan`, dengan komponen penilaiannya sendiri, dan bobotnya diatur
+   seperti pos mana pun. Yang membedakan hanya kata di judul layar dan di
+   kertas. Nomor posnya melanjutkan pos utama — pos bayangan pertama bernomor
+   6.
 3. Di setiap pos utama ada dua hal yang dinilai, dan **keduanya berasal dari
    tempat yang berbeda**:
    - **Wahana** — tantangan fisik seperti merangkak, berlari, atau memanjat,

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0020`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0024`.
 
 ---
 
@@ -46,7 +46,7 @@ di `workers/gateway/worker.js` wajib ikut diubah.
 
 ## 2. Database
 
-20 migrasi, `0001` sampai `0020`, dijalankan berurutan tanpa lubang penomoran.
+24 migrasi, `0001` sampai `0024`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -80,6 +80,17 @@ bukan menghitung ulang data.
 Konsekuensinya: memperbaiki satu nilai yang salah ketik langsung memperbaiki
 klasemen, tanpa proses hitung ulang apa pun.
 
+Apa yang dinilai di tiap pos juga konfigurasi: satu baris `wahana` per kolom
+penilaian, dengan **enam bentuk konversi** — `kecil_baik`, `besar_baik`,
+`biner`, `benar_per_total`, `benar_kurang_salah`, dan `bertingkat` (tangga
+poin per pita, dipakai kolom waktu yang menilai "masuk pita 1 menit", bukan
+tiap detik). Layar Input Pos membangun kolomnya dari baris-baris itu, jadi
+mengubah penilaian tahun depan tidak menyentuh kode sama sekali.
+
+**Pos bayangan ikut dinilai** (migrasi `0021`). Ia pos biasa dengan penanda
+`pos.bayangan`, bernomor melanjutkan pos utama — bukan cabang tersendiri di
+mesin skor.
+
 ### Kunci daftar ulang
 
 Pemberian nomor dada dan penyebaran kloter diserialisasi dengan satu
@@ -106,11 +117,50 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/cetak-kloter` | Cetak Daftar Kloter | lembar per kloter untuk petugas start |
 | `#/keberangkatan` | Keberangkatan | ceklis hadir, kontrak waktu, pindah kloter, berangkatkan |
 | `#/finish` | Kedatangan | catat jam datang + anggota hadir |
+| `#/pos` | Input Nilai Pos | lembar penilaian satu pos, satu baris per regu |
 | `#/ganti-password` | Ganti Password | — |
 
 Peran akun: `admin`, `meja`, `operator_pos`. Seluruh RPC meja menuntut
-`peran() in ('admin','meja')`; akun `operator_pos` ditolak di Home dengan pesan
-"Akun pos, bukan akun meja".
+`peran() in ('admin','meja')`; akun `operator_pos` ditolak di layar meja dengan
+pesan "Akun pos, bukan akun meja", dan sebaliknya akun `meja` ditolak di
+`#/pos`. Home menampilkan menu yang berbeda per peran — akun pos hanya melihat
+layar posnya sendiri.
+
+### Layar Input Pos
+
+Bentuknya sengaja meniru lembar Google Sheets yang dipakai panitia selama ini:
+Nomor Dada · Nama Regu · Organisasi · Golongan, lalu satu kolom per hal yang
+dinilai, lalu Nilai Pos. Petugas yang menyalin dari foto lembar tidak perlu
+belajar bentuk baru.
+
+| Yang menentukan | Dari mana |
+| --- | --- |
+| Nama & urutan kolom | `wahana.name`, `wahana.sort_order` |
+| Bentuk kotaknya | `wahana.form` — centang untuk `biner`, dua kotak untuk `benar_kurang_salah` |
+| Kotak Menit : Detik | `wahana.satuan = 'detik'` — tersimpan sebagai satu angka detik |
+| Rentang yang boleh diketik | `wahana.rentang_mentah_min/maks` |
+| Angka Nilai Pos | `v_lembar_pos`, dibaca ulang tiap kali satu baris tersimpan |
+
+Tiga hal yang menentukan layar ini benar atau tidak:
+
+1. **Tidak ada tombol Simpan.** Baris tersimpan sendiri saat petugas
+   meninggalkannya, dan diberi ✓ hijau. Tombol yang bisa lupa ditekan adalah
+   nilai yang hilang.
+2. **Simpanan yang menumpuk diantre, bukan ditolak.** Satu baris punya banyak
+   kotak dan tiap kotak memicu simpanannya sendiri; menolak yang datang saat
+   sibuk sempat membuat baris diberi ✓ padahal empat nilai terakhir tidak
+   pernah terkirim.
+3. **Layar tidak pernah menghitung skor.** Nilai Pos selalu angka dari
+   database. Menghitungnya di browser akan melahirkan mesin skor kedua yang
+   suatu hari berbeda pendapat dengan `v_poin_pos`.
+
+`v_lembar_pos` adalah **satu-satunya view yang bukan `security_invoker`**.
+Alasannya ada di kepala migrasi `0023`: jalan menuju nama sekolah melewati
+tabel `pendaftaran`, yang tertutup untuk operator pos karena memuat nomor
+WhatsApp. Kalau view-nya tunduk RLS, operator mendapat lembar kosong — dan
+lembar kosong terbaca sebagai "belum ada peserta", bukan sebagai galat hak
+akses. Pagarnya dipasang di dalam view: `peran() is not null`, dan operator
+hanya posnya sendiri.
 
 ### Bentuk tabel meja menurut lebar layar
 
@@ -168,7 +218,7 @@ itu.
 
 ```bash
 gh workflow run "Apply migration to Supabase" --ref main \
-  -f berkas=supabase/migrations/0020_nomor_dada_tiga_digit.sql
+  -f berkas=supabase/migrations/0021_pos_bayangan.sql
 ```
 
 Berkasnya dijalankan `--single-transaction` dengan `ON_ERROR_STOP=1`: kalau satu
@@ -260,3 +310,18 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
 - **Halaman live publik belum ada.** `live.html` + `live.json` di
   `rancangan-b.md` bagian 7 tidak pernah dibangun, dan tidak ada workflow yang
   menghasilkannya.
+- **Upload massal nilai belum ada.** `rancangan-b.md` bagian 6 menjelaskan
+  jalur tempel-dari-Excel lengkap dengan layar preview. Yang sudah dibangun
+  baru input tabelnya (`#/pos`) — yang sebenarnya sudah menutup sebagian besar
+  kebutuhannya, karena satu layar memuat seluruh lembar sekaligus. RPC-nya
+  (`simpan_nilai_massal`) memang sudah menerima banyak baris sekaligus, jadi
+  yang kurang hanya pengurai tempelan dan preview-nya.
+- **Nama Pos 5 masih "Pos 5".** Lembar penilaiannya tidak ada di antara yang
+  diserahkan panitia, jadi migrasi `0024` sengaja tidak menebak nama maupun
+  komponennya. Pos 5 akan tampil di layar Input Pos sebagai pos tanpa kolom
+  penilaian sampai diisi.
+- **Dua sel di lembar XXXVI tidak cocok dengan rumusnya sendiri** (Pos 3 regu
+  016 tertulis 380, rumus memberi 355; Pos 4 regu 009 tertulis 100, rumus
+  memberi 80). 75 dari 77 baris yang bisa dibaca cocok tanpa sisa, jadi
+  keduanya kemungkinan ketikan tangan di atas formula. Konfigurasi mengikuti
+  rumusnya.

--- a/supabase/migrations/0021_pos_bayangan.sql
+++ b/supabase/migrations/0021_pos_bayangan.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- hrcd-rekap : 0021_pos_bayangan.sql
+--
+-- Pos bayangan IKUT DINILAI.
+--
+-- `docs/alur-lomba.md` 7.2 menulis pos bayangan "tidak dinilai, sehingga tidak
+-- dimodelkan sistem sama sekali", dan skema mengunci nomor pos ke 1-5 atas
+-- dasar kalimat itu. Lembar penilaian yang benar-benar dipakai panitia
+-- menunjukkan sebaliknya: "Pos Bayangan 1 Kostum" punya kolom Kreativitas,
+-- Kekompakan, dan Kesopanan, punya Nilai Pos, bahkan punya kolom RANK. Yang
+-- salah adalah dokumennya, bukan lembarnya — dan dokumennya sudah dibetulkan
+-- bersama migrasi ini.
+--
+-- Yang berubah karena itu:
+--   1. Nomor pos tidak lagi dibatasi 1-5. Batas barunya 1-20 — cukup longgar
+--      untuk pos bayangan sebanyak apa pun yang masuk akal, tapi tetap sebuah
+--      batas, supaya salah ketik (pos 300) tertahan database.
+--   2. `pos.bayangan` menandai mana yang pos bayangan. Penilaiannya sama persis
+--      dengan pos utama — penanda ini untuk MANUSIA (judul layar, kertas,
+--      pengurutan), bukan cabang logika di mesin skor.
+--   3. `akun_panitia.pos` ikut dilonggarkan, kalau tidak akun operator untuk
+--      pos bayangan tidak bisa dibuat sama sekali.
+--
+-- Tidak ada perubahan pada mesin skor. Pos bayangan adalah pos biasa yang
+-- kebetulan dinilai lebih ringan; bobot relatifnya diatur lewat `pos.bobot`,
+-- bukan lewat kode.
+-- ============================================================================
+
+-- 1. Nomor pos -------------------------------------------------------------
+alter table pos drop constraint if exists pos_nomor_check;
+alter table pos add constraint pos_nomor_check check (nomor between 1 and 20);
+
+alter table akun_panitia drop constraint if exists akun_panitia_pos_check;
+alter table akun_panitia add constraint akun_panitia_pos_check
+  check (pos between 1 and 20);
+
+-- Nama constraint bawaan PostgreSQL (`<tabel>_<kolom>_check`) tidak dijamin
+-- apa pun — kalau di database ini namanya ternyata lain, DROP IF EXISTS di
+-- atas tidak melakukan apa-apa dan batas 1-5 yang lama diam-diam tetap
+-- berlaku. Migrasinya akan tampak berhasil, lalu insert pos 6 di 0024 gagal
+-- dengan pesan yang menunjuk ke tempat yang salah. Jadi diperiksa di sini,
+-- selagi penyebabnya masih terlihat.
+do $$
+begin
+  if exists (
+    select 1 from pg_constraint
+    where conrelid in ('pos'::regclass, 'akun_panitia'::regclass)
+      and contype = 'c'
+      and pg_get_constraintdef(oid) like '%<= 5)%') then
+    raise exception 'batas lama pos 1-5 masih terpasang dengan nama constraint yang berbeda — cari namanya lewat \d pos lalu drop manual';
+  end if;
+end;
+$$;
+
+-- 2. Penanda pos bayangan --------------------------------------------------
+alter table pos add column bayangan boolean not null default false;
+
+comment on column pos.bayangan is
+  'Pos bayangan (kostum, yel-yel, dsb). Dinilai persis seperti pos utama; '
+  'penanda ini hanya untuk judul layar dan kertas.';

--- a/supabase/migrations/0022_bentuk_bertingkat.sql
+++ b/supabase/migrations/0022_bentuk_bertingkat.sql
@@ -1,0 +1,153 @@
+-- ============================================================================
+-- hrcd-rekap : 0022_bentuk_bertingkat.sql
+--
+-- Bentuk konversi keenam: `bertingkat` — tangga poin, bukan garis lurus.
+--
+-- Kenapa perlu. Pos 4 menilai KECEPATAN praktik kesehatan, dan lembar yang
+-- dipakai panitia memberi poin seperti ini:
+--
+--   sampai 1 menit  -> 50      1 menit 1 detik - 1 menit 30  -> 30
+--   1:31 - 2:00     -> 15      lebih dari 2 menit            -> 0
+--
+-- Itu bukan interpolasi. `kecil_baik` dengan terbaik 60 detik dan terburuk
+-- 180 detik memberi 37,5 poin untuk 90 detik, bukan 30 — jadi seluruh Pos 4
+-- meleset kalau dipaksa masuk ke bentuk yang sudah ada. Panitia memang
+-- menilai bertingkat: yang dihargai adalah masuk ke pita waktu berikutnya,
+-- bukan tiap detik.
+--
+-- Bentuknya sengaja "kecil lebih baik": tiap tingkat menyebut batas ATASNYA,
+-- dan yang berlaku adalah tingkat pertama yang masih memuat nilai mentahnya.
+-- Di luar semua tingkat = 0 poin.
+--
+--   [{"sampai": 60, "poin": 50}, {"sampai": 90, "poin": 30},
+--    {"sampai": 120, "poin": 15}]
+--
+-- Ditambah juga `wahana.satuan`, supaya layar tahu satu angka mentah itu
+-- DETIK dan boleh menampilkannya sebagai dua kotak (Menit | Detik) seperti di
+-- lembar kertas. Yang tersimpan tetap satu angka — satuan hanya mengatur cara
+-- mengetiknya, bukan cara menghitungnya.
+-- ============================================================================
+
+-- 1. Kolom konfigurasi -----------------------------------------------------
+alter table wahana add column tingkat jsonb;
+alter table wahana add column satuan  text;
+
+comment on column wahana.tingkat is
+  'Tangga poin untuk form=bertingkat: [{"sampai": <nilai mentah maksimum>, '
+  '"poin": <poin>}, ...]. Tingkat pertama yang masih memuat nilai mentahnya '
+  'yang berlaku; di luar semuanya = 0.';
+comment on column wahana.satuan is
+  'Satuan nilai mentah, untuk tampilan saja: detik, kali, poin, ... '
+  'satuan=detik membuat layar menampilkan dua kotak Menit + Detik.';
+
+-- 2. Daftar bentuk yang sah ------------------------------------------------
+-- Constraint ini lahir di 0001 sebagai check kolom `bentuk`; 0014 mengganti
+-- nama kolomnya jadi `form` tapi TIDAK mengganti nama constraint-nya —
+-- karena itu yang di-drop bernama `wahana_bentuk_check`, bukan
+-- `wahana_form_check`. Yang dipasang di sini memakai nama yang benar.
+alter table wahana drop constraint if exists wahana_bentuk_check;
+alter table wahana add constraint wahana_form_check check (form in
+  ('kecil_baik', 'besar_baik', 'biner',
+   'benar_per_total', 'benar_kurang_salah', 'bertingkat'));
+
+do $$
+begin
+  if exists (
+    select 1 from pg_constraint
+    where conrelid = 'wahana'::regclass and contype = 'c'
+      and pg_get_constraintdef(oid) like '%benar_kurang_salah%'
+      and pg_get_constraintdef(oid) not like '%bertingkat%'
+      and pg_get_constraintdef(oid) not like '%<>%') then
+    raise exception 'daftar bentuk lama masih terpasang dengan nama constraint yang berbeda — cari namanya lewat \d wahana lalu drop manual';
+  end if;
+end;
+$$;
+
+-- Parameter wajib sesuai bentuk, sama seperti empat check sebelumnya di 0001:
+-- konfigurasi setengah jadi tertolak sejak insert, bukan menghasilkan poin
+-- null diam-diam saat lomba berjalan.
+alter table wahana add constraint wahana_tingkat_check check (
+  form <> 'bertingkat'
+  or (tingkat is not null
+      and jsonb_typeof(tingkat) = 'array'
+      and jsonb_array_length(tingkat) > 0));
+
+-- 3. Mesin konversi --------------------------------------------------------
+-- hitung_poin bertambah satu argumen, jadi ini FUNGSI BARU, bukan pengganti.
+-- Urutannya: buat yang baru -> arahkan view ke sana -> baru buang yang lama.
+-- Dibalik, DROP-nya akan ditolak karena view masih memakainya; dan kalau yang
+-- lama dibiarkan hidup berdampingan, panggilan 9 argumen tetap sah dan
+-- diam-diam melewatkan seluruh tangga poin.
+create or replace function hitung_poin(
+  p_bentuk       text,
+  p_nilai_1      numeric,
+  p_nilai_2      numeric,
+  p_poin_maks    numeric,
+  p_raw_terbaik  numeric,
+  p_raw_terburuk numeric,
+  p_poin_benar   numeric,
+  p_poin_salah   numeric,
+  p_total_soal   numeric,
+  p_tingkat      jsonb
+) returns numeric
+language sql immutable
+as $$
+  select round(case p_bentuk
+    -- Interpolasi linear raw_terburuk→0 .. raw_terbaik→poin_maks, di-clamp.
+    -- Satu rumus untuk dua arah: kecil_baik punya terbaik < terburuk,
+    -- besar_baik sebaliknya — pembaginya ikut bertanda.
+    when 'kecil_baik' then
+      least(greatest(
+        p_poin_maks * (p_nilai_1 - p_raw_terburuk) / (p_raw_terbaik - p_raw_terburuk),
+        0), p_poin_maks)
+    when 'besar_baik' then
+      least(greatest(
+        p_poin_maks * (p_nilai_1 - p_raw_terburuk) / (p_raw_terbaik - p_raw_terburuk),
+        0), p_poin_maks)
+    -- Biner: kena/benar (nilai_1 > 0) atau tidak.
+    when 'biner' then
+      case when p_nilai_1 > 0 then p_poin_benar else p_poin_salah end
+    -- Proporsi jawaban benar.
+    when 'benar_per_total' then
+      least(greatest(p_poin_maks * p_nilai_1 / p_total_soal, 0), p_poin_maks)
+    -- Benar menambah, salah mengurangi (poin_salah disimpan negatif);
+    -- di-clamp supaya tidak minus.
+    when 'benar_kurang_salah' then
+      least(greatest(
+        p_poin_benar * p_nilai_1 + p_poin_salah * coalesce(p_nilai_2, 0),
+        0), p_poin_maks)
+    -- Tangga poin: tingkat pertama (batas atas terkecil) yang masih memuat
+    -- nilai mentahnya. Lebih besar dari semua batas = 0 — itu sebabnya
+    -- coalesce ada di luar, bukan nilai default di dalam sub-query.
+    when 'bertingkat' then
+      coalesce((
+        select (t ->> 'poin')::numeric
+        from jsonb_array_elements(p_tingkat) t
+        where p_nilai_1 <= (t ->> 'sampai')::numeric
+        order by (t ->> 'sampai')::numeric
+        limit 1), 0)
+  end, 2)
+$$;
+
+-- View memakai bentuk 10 argumen. Daftar kolom keluarannya TIDAK berubah,
+-- jadi v_poin_pos yang bertumpu padanya tidak perlu ikut dibuat ulang.
+create or replace view v_poin_wahana with (security_invoker = on) as
+select
+  n.regu_id,
+  w.pos,
+  w.id   as wahana_id,
+  w.kode,
+  n.nilai_1,
+  n.nilai_2,
+  hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+              w.raw_terbaik, w.raw_terburuk,
+              w.poin_benar, w.poin_salah, w.total_soal, w.tingkat) as poin
+from nilai_mentah n
+join wahana w on w.id = n.wahana_id
+where w.edisi = edisi_aktif();
+
+drop function hitung_poin(text, numeric, numeric, numeric,
+                          numeric, numeric, numeric, numeric, numeric);
+
+grant execute on function hitung_poin(text, numeric, numeric, numeric,
+  numeric, numeric, numeric, numeric, numeric, jsonb) to authenticated, service_role;

--- a/supabase/migrations/0023_lembar_pos.sql
+++ b/supabase/migrations/0023_lembar_pos.sql
@@ -1,0 +1,157 @@
+-- ============================================================================
+-- hrcd-rekap : 0023_lembar_pos.sql
+--
+-- Bahan layar Input Pos: satu baris per regu, persis sebentuk lembar kertas
+-- yang dipegang petugas lapangan — identitas regu di kiri, kotak nilai di
+-- tengah, Nilai Pos di kanan.
+--
+-- KENAPA VIEW INI BUKAN `security_invoker`
+--
+-- Semua view lain di sistem ini tunduk pada RLS pemanggilnya. Yang ini tidak
+-- bisa, dan alasannya ada di 0003: `sel_pendaftaran` hanya mengizinkan admin
+-- dan meja, karena `pendaftaran.kontak_wa` adalah nomor WhatsApp — PII yang
+-- tidak ada urusannya dengan operator pos. Padahal jalan menuju NAMA SEKOLAH
+-- melewati tabel itu (regu -> pendaftaran -> sekolah), dan nama sekolah harus
+-- tampil: itu kolom "Organisasi" di lembar, dan itu yang dipakai petugas
+-- memastikan sedang menilai regu yang benar.
+--
+-- Kalau view ini invoker, operator pos membacanya dan mendapat NOL BARIS —
+-- bukan galat, sekadar lembar kosong yang terlihat seperti "belum ada regu
+-- yang daftar ulang". Kegagalan paling buruk bentuknya: tenang dan salah.
+--
+-- Jadi view ini definer (seperti v_progres_publik), dan pagarnya dipasang
+-- sendiri di dalam WHERE:
+--   - `peran() is not null`         -> hanya panitia berakun aktif
+--   - operator pos hanya pos-nya    -> sama ketatnya dengan RLS nilai_mentah
+-- Yang ditembus hanyalah jalur ke nama sekolah. `kontak_wa` tidak pernah
+-- muncul di daftar kolom, jadi tidak ada yang bisa dimintanya.
+--
+-- Nilai Pos DIHITUNG DI SINI, bukan disimpan, dan rumusnya sama persis dengan
+-- v_poin_pos — jumlah poin komponen dikali bobot pos. Layar tidak menghitung
+-- sendiri: angka yang ditampilkan selalu datang dari database, supaya tidak
+-- pernah ada dua mesin skor yang bisa berbeda pendapat.
+-- ============================================================================
+
+create view v_lembar_pos as
+select
+  p.nomor       as pos,
+  p.name        as nama_pos,
+  p.bayangan,
+  r.id          as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name        as nama_sekolah,
+  r.golongan,
+
+  -- Nilai mentah yang sudah tersimpan, dikunci nama komponen:
+  --   {"semaphore": {"nilai_1": 5, "nilai_2": null}, ...}
+  -- Bentuk objek, bukan larik, supaya layar bisa langsung mencari kolomnya
+  -- tanpa memindai apa pun.
+  coalesce((
+    select jsonb_object_agg(w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), '{}'::jsonb) as nilai,
+
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_terisi,
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_komponen,
+
+  -- Sama dengan v_poin_pos. Komponen yang belum diisi tidak menyumbang apa
+  -- pun (bukan nol yang menghukum) — lembar setengah terisi adalah keadaan
+  -- normal sepanjang lomba, bukan kesalahan.
+  round(coalesce((
+    select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                           w.raw_terbaik, w.raw_terburuk,
+                           w.poin_benar, w.poin_salah, w.total_soal, w.tingkat))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), 0) * p.bobot, 2) as nilai_pos
+
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  -- Pagar pengganti RLS — lihat catatan panjang di kepala berkas.
+  and peran() is not null
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya());
+
+grant select on v_lembar_pos to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- hapus_nilai_pos — mengosongkan satu sel yang sudah terlanjur tersimpan.
+--
+-- simpan_nilai_massal tidak bisa dipakai untuk ini: ia menolak nilai kosong
+-- (itu memang benar untuk paste dari Excel — sel kosong berarti "belum
+-- dinilai", bukan "hapus"). Tapi di layar tabel, mengosongkan kotak adalah
+-- gerakan yang wajar dan artinya jelas: angka tadi salah orang.
+--
+-- Pagarnya sama dengan simpan_nilai_massal: operator hanya pos sendiri, admin
+-- wajib menyebut pos, dan penghapusannya terekam trigger audit seperti
+-- perubahan nilai lainnya.
+-- ---------------------------------------------------------------------------
+
+create or replace function hapus_nilai_pos(
+  p_nomor_dada integer,
+  p_kode       text,
+  p_pos        smallint default null   -- wajib untuk admin
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_pos    smallint;
+  v_regu   uuid;
+  v_wahana uuid;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+
+  select id into v_regu from regu
+  where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    -- Tiga digit seperti di kain nomor dadanya (migrasi 0020). Nomor di luar
+    -- 0-999 dicetak apa adanya: lpad MEMOTONG string yang lebih panjang dari
+    -- targetnya, jadi salah ketik "9999" akan dilaporkan sebagai "999" —
+    -- petugas lalu mencari nomor yang tidak pernah diketiknya.
+    raise exception 'nomor dada % tidak dikenal / regu batal',
+      case when p_nomor_dada between 0 and 999
+        then lpad(p_nomor_dada::text, 3, '0')
+        else p_nomor_dada::text end;
+  end if;
+
+  -- Normalisasi kode disamakan dengan simpan_nilai_massal, supaya kolom yang
+  -- bisa DIISI lewat satu pintu selalu bisa DIKOSONGKAN lewat pintu ini.
+  select w.id into v_wahana from wahana w
+  where w.edisi = edisi_aktif()
+    and w.pos = v_pos
+    and regexp_replace(lower(coalesce(p_kode, '')), '[^a-z0-9]', '', 'g')
+        = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+  if not found then
+    raise exception 'kode komponen tidak dikenal di pos %', v_pos;
+  end if;
+
+  delete from nilai_mentah where regu_id = v_regu and wahana_id = v_wahana;
+end;
+$$;
+
+grant execute on function hapus_nilai_pos(integer, text, smallint) to authenticated;

--- a/supabase/migrations/0024_komponen_pos.sql
+++ b/supabase/migrations/0024_komponen_pos.sql
@@ -1,0 +1,174 @@
+-- ============================================================================
+-- hrcd-rekap : 0024_komponen_pos.sql
+--
+-- Konfigurasi komponen penilaian tiap pos, disalin dari lembar Google Sheets
+-- yang benar-benar dipakai panitia di HRCD XXXVI.
+--
+-- INI DATA, BUKAN ATURAN. `docs/alur-lomba.md` bagian 9.1 menegaskan aturan
+-- penilaian berubah setiap tahun. Yang ditulis di sini adalah TITIK AWAL —
+-- angka tahun lalu, supaya layar Input Pos punya sesuatu yang nyata untuk
+-- ditampilkan sejak hari pertama. Panitia mengubahnya lewat baris konfigurasi,
+-- bukan lewat migrasi baru.
+--
+-- BOBOT TIAP KOLOM DIHITUNG MUNDUR DARI SHEET, bukan ditanyakan. Kolom Nilai
+-- Pos di sheet berisi angka jadi; poin_maks di sini dipilih supaya rumus
+-- `besar_baik` menghasilkan angka yang sama persis. Contoh Pos 1, regu 002
+-- (SATE TUSUK) dengan 6 / 5 / 0 / v / 1:
+--
+--   kepramukaan 6  -> 200 x 6/20  =  60
+--   semaphore   5  -> 100 x 5/10  =  50
+--   tebak sandi 0  -> 100 x 0/5   =   0
+--   kompas      v  -> biner        = 100
+--   tebak simpul 1 -> 100 x 1/5   =  20
+--                                   ----
+--                                    230   <- sama dengan sheet
+--
+-- Dua sel di sheet TIDAK cocok dengan rumusnya (Pos 3 regu 016 tertulis 380,
+-- rumusnya 355; Pos 4 regu 009 tertulis 100, rumusnya 80). Keduanya kemungkinan
+-- besar ketikan tangan di atas formula. Angka di sini mengikuti RUMUS, bukan
+-- kedua sel itu — 20 baris lain di kedua pos cocok tanpa sisa.
+--
+-- Kolom "Keunikan" di lembar Pos Bayangan sengaja tidak dibuat: rentangnya
+-- tertulis (0 - 0) dan seluruh isinya nol, jadi ia kolom mati. Buat lewat
+-- layar konfigurasi kalau tahun ini benar-benar dipakai.
+--
+-- Migrasi ini AMAN DIJALANKAN ULANG: pos dan komponen yang sudah ada di-update
+-- di tempat, sehingga nilai yang terlanjur masuk tidak kehilangan induknya.
+-- ============================================================================
+
+do $$
+declare
+  v_edisi smallint;
+  v_sisa  text;
+begin
+  select nomor into v_edisi from edisi where is_active;
+
+  -- Berkas ini menyentuh DATA edisi, bukan bentuk tabel. Di database uji ia
+  -- dijalankan sebelum seed.sql sempat membuat edisinya — itu bukan galat,
+  -- cukup dilewati. Di produksi edisinya sudah lama ada.
+  if v_edisi is null then
+    raise notice 'belum ada edisi aktif — komponen pos dilewati';
+    return;
+  end if;
+
+  if (select konfigurasi_terkunci from status_acara) then
+    raise exception 'konfigurasi sedang terkunci — buka kuncinya di status_acara dulu, lalu jalankan ulang migrasi ini';
+  end if;
+
+  -- 1. Pos ------------------------------------------------------------------
+  -- Pos 5 tidak ikut diberi nama: lembarnya tidak ada di antara yang
+  -- diserahkan panitia, jadi menebak namanya hanya akan menanamkan tebakan
+  -- ke dalam database.
+  insert into pos (edisi, nomor, name, bobot, bayangan) values
+    (v_edisi, 1, 'Keagamaan dan Kepramukaan',     1.00, false),
+    (v_edisi, 2, 'Kesehatan dan Pengetahuan Umum', 1.00, false),
+    (v_edisi, 3, 'Games',                          1.00, false),
+    (v_edisi, 4, 'Praktik Kesehatan',              1.00, false),
+    (v_edisi, 6, 'Kostum',                         1.00, true)
+  on conflict (edisi, nomor) do update
+    set name = excluded.name, bayangan = excluded.bayangan;
+
+  -- 2. Komponen -------------------------------------------------------------
+  insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk, poin_benar, poin_salah,
+                      total_soal, tingkat, satuan,
+                      rentang_mentah_min, rentang_mentah_maks, sort_order)
+  values
+    -- ---- Pos 1 — Keagamaan dan Kepramukaan (maks 600) ----
+    -- Pos 1 tidak menerima soal dari pos manapun (alur-lomba.md 7.5), jadi
+    -- seluruh komponennya bertipe wahana.
+    (v_edisi, 1, 'kepramukaan_keagamaan', 'Kepramukaan Keagamaan', 'wahana', 'besar_baik',
+     200, 20, 0, null, null, null, null, null, 0, 20, 1),
+    (v_edisi, 1, 'semaphore', 'Semaphore', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 0, 10, 2),
+    (v_edisi, 1, 'tebak_sandi', 'Tebak Sandi', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 0, 5, 3),
+    (v_edisi, 1, 'kompas', 'Kompas', 'wahana', 'biner',
+     100, null, null, 100, 0, null, null, null, 0, 1, 4),
+    (v_edisi, 1, 'tebak_simpul', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 0, 5, 5),
+
+    -- ---- Pos 2 — Kesehatan dan Pengetahuan Umum (maks 300) ----
+    -- Soalnya dibagikan di Pos 1 dan dikoreksi di sini (alur-lomba.md 7.4),
+    -- karena itu type='soal'.
+    (v_edisi, 2, 'soal_kesehatan_pengetahuan_umum', 'Soal Kesehatan dan Pengetahuan Umum',
+     'soal', 'besar_baik', 200, 20, 0, null, null, null, null, null, 0, 20, 1),
+    (v_edisi, 2, 'pbb_dasar', 'PBB Dasar', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 0, 10, 2),
+
+    -- ---- Pos 3 — Games (maks 475) ----
+    (v_edisi, 3, 'logika', 'Logika', 'soal', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 0, 10, 1),
+    -- Merayap dinilai berjenjang 1,5 — nilai mentahnya boleh pecahan.
+    (v_edisi, 3, 'merayap', 'Merayap', 'wahana', 'besar_baik',
+     100, 6, 0, null, null, null, null, null, 0, 6, 2),
+    (v_edisi, 3, 'balap_karung', 'Balap Karung', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 0, 10, 3),
+    -- Lempar pisau: poin = nilai mentahnya sendiri (sheet menulis 40 -> 40).
+    -- Judul kolom di sheet berbunyi (10 - 100), tapi isinya banyak yang 0,
+    -- jadi batas bawah yang diterima di sini 0 — menolak angka yang benar-
+    -- benar tertulis di kertas bukan validasi, itu kehilangan data.
+    (v_edisi, 3, 'lempar_pisau', 'Lempar Pisau', 'wahana', 'besar_baik',
+     100, 100, 0, null, null, null, null, null, 0, 100, 4),
+    (v_edisi, 3, 'poros_bumi', 'Poros Bumi', 'wahana', 'besar_baik',
+     75, 3, 0, null, null, null, null, null, 0, 3, 5),
+
+    -- ---- Pos 4 — Praktik Kesehatan (maks 300) ----
+    (v_edisi, 4, 'praktik_kesehatan', 'Praktik Kesehatan (Ketepatan)', 'wahana', 'biner',
+     50, null, null, 50, 0, null, null, null, 0, 1, 1),
+    -- Kecepatan praktik: tangga poin, bukan garis lurus (lihat 0022).
+    -- satuan=detik membuat layar menampilkan kotak Menit + Detik seperti di
+    -- lembar; yang tersimpan tetap satu angka dalam detik.
+    (v_edisi, 4, 'waktu_praktik', 'Waktu Praktik', 'wahana', 'bertingkat',
+     50, null, null, null, null, null,
+     '[{"sampai": 60, "poin": 50}, {"sampai": 90, "poin": 30}, {"sampai": 120, "poin": 15}]'::jsonb,
+     'detik', 0, 900, 2),
+    (v_edisi, 4, 'kim_cium', 'Kim Cium', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 0, 5, 3),
+    (v_edisi, 4, 'kim_lihat', 'Kim Lihat', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 0, 5, 4),
+
+    -- ---- Pos 6 — Kostum, pos bayangan (maks 100) ----
+    (v_edisi, 6, 'kreativitas', 'Kreativitas', 'wahana', 'besar_baik',
+     40, 40, 0, null, null, null, null, null, 0, 40, 1),
+    (v_edisi, 6, 'kekompakan', 'Kekompakan', 'wahana', 'besar_baik',
+     30, 30, 0, null, null, null, null, null, 0, 30, 2),
+    (v_edisi, 6, 'kesopanan', 'Kesopanan', 'wahana', 'besar_baik',
+     30, 30, 0, null, null, null, null, null, 0, 30, 3)
+
+  on conflict (edisi, pos, kode) do update set
+    name = excluded.name,
+    type = excluded.type,
+    form = excluded.form,
+    poin_maks = excluded.poin_maks,
+    raw_terbaik = excluded.raw_terbaik,
+    raw_terburuk = excluded.raw_terburuk,
+    poin_benar = excluded.poin_benar,
+    poin_salah = excluded.poin_salah,
+    total_soal = excluded.total_soal,
+    tingkat = excluded.tingkat,
+    satuan = excluded.satuan,
+    rentang_mentah_min = excluded.rentang_mentah_min,
+    rentang_mentah_maks = excluded.rentang_mentah_maks,
+    sort_order = excluded.sort_order;
+
+  -- 3. Komponen contoh dari seed.sql ---------------------------------------
+  -- seed.sql memasang lima komponen contoh (satu per bentuk konversi) supaya
+  -- tes bisa mencocokkan hasil hitung dengan angka di rancangan-b.md. Di
+  -- lapangan mereka hanya jadi kolom asing di lembar pos. Dibuang di sini —
+  -- TAPI hanya yang belum pernah dipakai. Yang sudah punya nilai adalah
+  -- riwayat penilaian sungguhan; menghapusnya akan menghapus nilai regu.
+  delete from wahana w
+  where w.edisi = v_edisi
+    and w.kode in ('lari_zigzag', 'lempar_sasaran', 'impk', 'soal_umum', 'sandi_morse')
+    and not exists (select 1 from nilai_mentah n where n.wahana_id = w.id);
+
+  select string_agg(w.kode, ', ' order by w.kode) into v_sisa
+  from wahana w
+  where w.edisi = v_edisi
+    and w.kode in ('lari_zigzag', 'lempar_sasaran', 'impk', 'soal_umum', 'sandi_morse');
+  if v_sisa is not null then
+    raise notice 'komponen contoh masih terpakai dan tidak dihapus: %', v_sisa;
+  end if;
+end;
+$$;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -19,18 +19,17 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 run() { echo "-- $1"; "$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q -f "$ROOT/$1"; }
 
 run tests/sql/00_harness.sql
-run supabase/migrations/0001_schema.sql
-run supabase/migrations/0002_functions.sql
-run supabase/migrations/0003_rls.sql
-run supabase/migrations/0004_rpcs.sql
-run supabase/migrations/0005_views.sql
-run supabase/migrations/0006_idempotensi.sql
-run supabase/migrations/0007_kunci_daftar_ulang.sql
-run supabase/migrations/0008_cetak_kloter.sql
-run supabase/migrations/0009_sisip_kloter.sql
-run supabase/migrations/0010_lookup_finish.sql
-run supabase/migrations/0011_nomor_dada_manual.sql
+# Seluruh migrasi, urut nomor, tanpa dilewat satu pun. Daftar ini pernah
+# berhenti di 0011 sementara migrasinya sudah sampai 0020 — akibatnya layar
+# yang dicoba di dev berbicara dengan skema yang tidak pernah ada di
+# produksi, dan galatnya baru muncul setelah deploy.
+for m in "$ROOT"/supabase/migrations/*.sql; do
+  run "supabase/migrations/$(basename "$m")"
+done
 run supabase/seed.sql
+# Konfigurasi komponen pos butuh edisinya sudah ada — lihat catatan panjang
+# yang sama di tests/run.sh.
+run supabase/migrations/0024_komponen_pos.sql
 run tests/sql/01_seed_uji.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -35,6 +35,7 @@ RPC = {
     "ceklis_berangkat":      ["p_nomor_dada"],
     "batal_ceklis_berangkat":["p_nomor_dada"],
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
+    "hapus_nilai_pos":       ["p_nomor_dada", "p_kode", "p_pos"],
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
     "susun_barak":           [],
     "tandai_kloter_dicetak": ["p_kloter"],
@@ -108,9 +109,34 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select * from v_regu_ringkas where kloter = %s order by nomor_dada",
                     (p.get("kloter") or 0,), uid=p.get("uid")))
             elif u.path == "/kontrak":
+                # sort_order, bukan urutan — kolomnya berganti nama di 0014.
                 self._kirim(200, q(
                     "select label, menit from kontrak_opsi "
-                    "where edisi = edisi_aktif() order by urutan",
+                    "where edisi = edisi_aktif() order by sort_order",
+                    uid=p.get("uid")))
+            elif u.path == "/pos":
+                self._kirim(200, q(
+                    "select nomor, name, bobot, bayangan from pos "
+                    "where edisi = edisi_aktif() order by nomor",
+                    uid=p.get("uid")))
+            elif u.path == "/komponen-pos":
+                self._kirim(200, q(
+                    "select kode, name, type, form, poin_maks, raw_terbaik, "
+                    "       raw_terburuk, poin_benar, poin_salah, total_soal, "
+                    "       tingkat, satuan, rentang_mentah_min, "
+                    "       rentang_mentah_maks, sort_order "
+                    "from wahana where edisi = edisi_aktif() and pos = %s "
+                    "order by sort_order",
+                    (p.get("pos") or 0,), uid=p.get("uid")))
+            elif u.path == "/lembar-pos":
+                # dada opsional: kosong = seluruh lembar, isi = satu baris
+                # yang dibaca ulang sesudah menyimpan.
+                self._kirim(200, q(
+                    "select * from v_lembar_pos where pos = %s "
+                    "  and (%s::text = '' "
+                    "       or nomor_dada = nullif(%s::text, '')::integer) "
+                    "order by nomor_dada",
+                    (p.get("pos") or 0, p.get("dada") or "", p.get("dada") or ""),
                     uid=p.get("uid")))
             elif u.path == "/daftar-pendaftaran":
                 self._kirim(200, q("""

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -15,12 +15,28 @@
 
 import json
 import http.server
+import os
 import urllib.parse
 
 import psycopg2
 import psycopg2.extras
 
-DSN = "host=127.0.0.1 port=55432 dbname=hrcd_dev user=postgres password=hrcd"
+# Sambungan database dibaca dari environment, dengan Postgres portable di
+# port 55432 sebagai bawaannya. Angka-angka itu dulu ditulis mati di sini,
+# dan siapa pun yang memakai PostgreSQL biasa — port 5432, password sendiri —
+# harus menyunting berkas ini lebih dulu, lalu hati-hati tidak ikut
+# meng-commit passwordnya. Nama variabelnya sama dengan yang sudah dipakai
+# tests/run.sh dan tests/dev_database.sh, jadi satu set export cukup untuk
+# ketiganya:
+#
+#   PGPORT=5432 PGUSER=postgres PGPASSWORD=... python tests/dev_server.py
+DSN = " ".join([
+    f"host={os.environ.get('PGHOST', '127.0.0.1')}",
+    f"port={os.environ.get('PGPORT', '55432')}",
+    f"dbname={os.environ.get('PGDATABASE', 'hrcd_dev')}",
+    f"user={os.environ.get('PGUSER', 'postgres')}",
+    f"password={os.environ.get('PGPASSWORD', 'hrcd')}",
+])
 PORT = 8787
 
 # RPC yang boleh dipanggil layar, beserta urutan argumennya.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -43,6 +43,10 @@ run supabase/migrations/0017_koreksi_jam_berangkat.sql
 run supabase/migrations/0018_pindah_setelah_berangkat.sql
 run supabase/migrations/0019_tukar_nomor_patokan_cetak.sql
 run supabase/migrations/0020_nomor_dada_tiga_digit.sql
+run supabase/migrations/0021_pos_bayangan.sql
+run supabase/migrations/0022_bentuk_bertingkat.sql
+run supabase/migrations/0023_lembar_pos.sql
+run supabase/migrations/0024_komponen_pos.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -51,5 +55,23 @@ run tests/sql/04_cetak_kloter.sql
 run tests/sql/05_pindah_kloter.sql
 run tests/sql/06_koreksi_jam_berangkat.sql
 run tests/sql/07_pindah_setelah_berangkat.sql
+
+# 0024 dijalankan DUA KALI, dan itu disengaja.
+#
+# Ia satu-satunya migrasi yang mengubah DATA edisi, bukan bentuk tabel. Pada
+# giliran pertama (di atas, sesuai nomornya) seed.sql belum jalan, jadi belum
+# ada edisi aktif dan isinya dilewati — persis seperti yang tertulis di
+# kepalanya. Kalau ia hanya dijalankan di sana, seluruh konfigurasi komponen
+# pos tidak pernah tersentuh tes sama sekali.
+#
+# Giliran kedua di sini, setelah 02-07 selesai memakai lima komponen contoh
+# dari seed.sql. Urutan itu penting: dijalankan lebih awal, komponen contoh
+# yang belum berisi nilai akan dibuang dan tes 03 kehilangan bahannya.
+#
+# Menjalankannya dua kali sekaligus membuktikan migrasinya memang aman
+# diulang — yang perlu dipastikan, karena workflow Apply migration bisa saja
+# ditekan dua kali dari HP.
+run supabase/migrations/0024_komponen_pos.sql
+run tests/sql/08_lembar_pos.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/08_lembar_pos.sql
+++ b/tests/sql/08_lembar_pos.sql
@@ -1,0 +1,256 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/08_lembar_pos.sql
+-- Layar Input Pos: bentuk konversi bertingkat, view v_lembar_pos, pos
+-- bayangan, dan pengosongan sel.
+--
+-- Angka yang diuji BUKAN karangan. Semuanya baris nyata dari lembar Google
+-- Sheets HRCD XXXVI yang diserahkan panitia — kalau mesin skor di sini
+-- menghasilkan angka lain, yang salah adalah kodenya, bukan lembarnya.
+--
+-- Identitas berpindah lewat app.uid + set role, sama seperti 03_alur.sql.
+-- Dijalankan SETELAH 0024_komponen_pos.sql (lihat catatan urutan di run.sh).
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 8.1 Konfigurasi komponen benar-benar terpasang.
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  assert (select count(*) from wahana
+          where edisi = edisi_aktif() and pos = 1
+            and kode in ('kepramukaan_keagamaan', 'semaphore', 'tebak_sandi',
+                         'kompas', 'tebak_simpul')) = 5,
+         'komponen Pos 1 tidak lengkap';
+  assert (select bayangan from pos where edisi = edisi_aktif() and nomor = 6),
+         'Pos 6 bukan pos bayangan';
+  assert (select satuan from wahana
+          where edisi = edisi_aktif() and kode = 'waktu_praktik') = 'detik',
+         'satuan waktu_praktik bukan detik';
+  -- Komponen contoh seed.sql yang SUDAH dipakai 03_alur.sql tidak boleh
+  -- terhapus 0024 — menghapusnya akan menghapus nilai regu bersamanya.
+  assert exists (select 1 from wahana where edisi = edisi_aktif()
+                 and kode = 'lari_zigzag'),
+         '0024 menghapus komponen yang masih memegang nilai';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8.2 Tangga poin (bentuk bertingkat) — batas pitanya harus tepat.
+--     Lembar Pos 4: <=60 detik = 50, <=90 = 30, <=120 = 15, lebih = 0.
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  v_tangga jsonb := '[{"sampai": 60, "poin": 50}, {"sampai": 90, "poin": 30},
+                      {"sampai": 120, "poin": 15}]'::jsonb;
+  v_poin   numeric;
+  v_detik  numeric;
+  v_harap  numeric;
+begin
+  foreach v_detik in array array[0, 60, 61, 90, 91, 120, 121, 900]::numeric[] loop
+    v_harap := case
+      when v_detik <=  60 then 50
+      when v_detik <=  90 then 30
+      when v_detik <= 120 then 15
+      else 0 end;
+    v_poin := hitung_poin('bertingkat', v_detik, null, 50,
+                          null, null, null, null, null, v_tangga);
+    assert v_poin = v_harap,
+      v_detik || ' detik = ' || v_poin || ' poin, harusnya ' || v_harap;
+  end loop;
+
+  -- Konfigurasi bertingkat tanpa tangga tertolak sejak insert, bukan
+  -- menghasilkan poin kosong diam-diam di tengah lomba.
+  begin
+    insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                        rentang_mentah_min, rentang_mentah_maks)
+    values (edisi_aktif(), 1, 'tanpa_tangga', 'Tanpa Tangga', 'wahana',
+            'bertingkat', 10, 0, 10);
+    raise exception 'GAGAL: bertingkat tanpa tingkat diterima';
+  exception when check_violation then null;
+  end;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8.3 Nilai Pos cocok dengan sheet, di empat pos sekaligus.
+--     Regu dada 13 dipakai karena belum punya nilai apa pun dari tes lain.
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- Pos 1, baris 002 SATE TUSUK: 6 / 5 / 0 / v / 1 -> 230
+select simpan_nilai_massal('[
+  {"nomor_dada": 13, "kode": "kepramukaan_keagamaan", "nilai_1": 6},
+  {"nomor_dada": 13, "kode": "semaphore",             "nilai_1": 5},
+  {"nomor_dada": 13, "kode": "tebak_sandi",           "nilai_1": 0},
+  {"nomor_dada": 13, "kode": "kompas",                "nilai_1": 1},
+  {"nomor_dada": 13, "kode": "tebak_simpul",          "nilai_1": 1}
+]'::jsonb, 'manual', 1::smallint);
+
+-- Pos 3, baris 004 RIMBA KUYY: 4 / 4,5 / 8 / 40 / 2 -> 285
+select simpan_nilai_massal('[
+  {"nomor_dada": 13, "kode": "logika",       "nilai_1": 4},
+  {"nomor_dada": 13, "kode": "merayap",      "nilai_1": 4.5},
+  {"nomor_dada": 13, "kode": "balap_karung", "nilai_1": 8},
+  {"nomor_dada": 13, "kode": "lempar_pisau", "nilai_1": 40},
+  {"nomor_dada": 13, "kode": "poros_bumi",   "nilai_1": 2}
+]'::jsonb, 'manual', 3::smallint);
+
+-- Pos 4, baris 004 RIMBA KUYY: v / 2 menit 0 detik / 2 / 1 -> 125
+select simpan_nilai_massal('[
+  {"nomor_dada": 13, "kode": "praktik_kesehatan", "nilai_1": 1},
+  {"nomor_dada": 13, "kode": "waktu_praktik",     "nilai_1": 120},
+  {"nomor_dada": 13, "kode": "kim_cium",          "nilai_1": 2},
+  {"nomor_dada": 13, "kode": "kim_lihat",         "nilai_1": 1}
+]'::jsonb, 'manual', 4::smallint);
+
+-- Pos Bayangan (Kostum), baris 003 KAMBING HITAM: 20 / 30 / 15 -> 65
+select simpan_nilai_massal('[
+  {"nomor_dada": 13, "kode": "kreativitas", "nilai_1": 20},
+  {"nomor_dada": 13, "kode": "kekompakan",  "nilai_1": 30},
+  {"nomor_dada": 13, "kode": "kesopanan",   "nilai_1": 15}
+]'::jsonb, 'manual', 6::smallint);
+
+do $$
+declare l record;
+begin
+  select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 1;
+  assert l.nilai_pos = 230, 'Pos 1 dada 13 = ' || l.nilai_pos || ', sheet bilang 230';
+  assert l.jumlah_terisi = 5, 'Pos 1 dada 13 terisi ' || l.jumlah_terisi || ', harusnya 5';
+  -- Identitas ikut terbawa — inilah yang dibaca petugas sebelum menilai.
+  assert l.nama_sekolah is not null and l.nama_regu is not null,
+         'identitas regu kosong di lembar pos';
+  -- Nilai mentah dikembalikan sebagai objek berkunci kode komponen.
+  assert (l.nilai -> 'semaphore' ->> 'nilai_1')::numeric = 5,
+         'nilai mentah semaphore tidak terbaca dari kolom nilai';
+  assert l.nilai -> 'tidak_ada_kolom_ini' is null, 'kolom asing muncul di nilai';
+
+  select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 3;
+  assert l.nilai_pos = 285, 'Pos 3 dada 13 = ' || l.nilai_pos || ', sheet bilang 285';
+
+  select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 4;
+  assert l.nilai_pos = 125, 'Pos 4 dada 13 = ' || l.nilai_pos || ', sheet bilang 125';
+
+  select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 6;
+  assert l.nilai_pos = 65, 'Pos bayangan dada 13 = ' || l.nilai_pos || ', sheet bilang 65';
+  assert l.bayangan, 'pos 6 tidak ditandai bayangan di lembar';
+
+  -- Pos yang belum dinilai sama sekali tetap muncul sebagai baris kosong —
+  -- lembar harus utuh, bukan hanya berisi regu yang sudah dinilai.
+  select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 5;
+  assert l.nilai_pos = 0 and l.jumlah_terisi = 0, 'pos kosong tidak nol';
+end;
+$$;
+
+-- Pos bayangan ikut masuk total skor, sama seperti pos utama.
+do $$
+declare v_total numeric;
+begin
+  select total_pos into v_total from v_total_skor where nomor_dada = 13;
+  assert v_total = 705,
+    'total pos dada 13 = ' || v_total || ', harusnya 230+285+125+65 = 705';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8.4 Operator pos: hanya pos sendiri, TAPI tetap melihat nama sekolah.
+--
+--     Baris kedua itu yang penting. Jalan menuju nama sekolah melewati tabel
+--     pendaftaran, yang tertutup untuk operator pos karena memuat nomor
+--     WhatsApp. Kalau v_lembar_pos ikut tunduk RLS, operator mendapat lembar
+--     KOSONG — dan lembar kosong terbaca sebagai "belum ada peserta", bukan
+--     sebagai galat hak akses.
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+
+do $$
+begin
+  assert exists (select 1 from v_lembar_pos where pos = 1),
+         'operator pos 1 tidak melihat lembar pos-nya sendiri';
+  assert not exists (select 1 from v_lembar_pos where pos <> 1),
+         'operator pos 1 melihat lembar pos lain';
+  assert not exists (select 1 from v_lembar_pos where nama_sekolah is null),
+         'operator pos tidak melihat nama sekolah — RLS pendaftaran menggigit view';
+  -- Nomor WhatsApp tetap tidak terjangkau lewat jalur mana pun.
+  assert not exists (select 1 from pendaftaran), 'operator pos membaca pendaftaran';
+end;
+$$;
+
+-- Akun nonaktif / bukan panitia tidak melihat apa pun.
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000ff', false);
+do $$
+begin
+  assert not exists (select 1 from v_lembar_pos), 'akun nonaktif membaca lembar pos';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8.5 Mengosongkan sel yang salah orang.
+-- ---------------------------------------------------------------------------
+
+select set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+
+do $$
+begin
+  -- Operator pos 1 mengosongkan kolomnya sendiri: boleh.
+  perform hapus_nilai_pos(13, 'semaphore');
+  assert (select nilai -> 'semaphore' from v_lembar_pos
+          where nomor_dada = 13 and pos = 1) is null,
+         'sel semaphore tidak terhapus';
+  assert (select nilai_pos from v_lembar_pos where nomor_dada = 13 and pos = 1) = 180,
+         'Nilai Pos tidak turun 50 setelah semaphore dihapus';
+
+  -- Kolom milik pos lain: ditolak.
+  begin
+    perform hapus_nilai_pos(13, 'kim_cium');
+    raise exception 'GAGAL: operator pos 1 menghapus nilai pos 4';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+
+  -- Nomor dada asing: ditolak, dan nomornya dicetak apa adanya (bukan
+  -- dipotong jadi tiga digit oleh lpad).
+  begin
+    perform hapus_nilai_pos(9999, 'semaphore');
+    raise exception 'GAGAL: nomor dada asing diterima';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    assert sqlerrm like '%9999%', 'pesan galat memotong nomor dada: ' || sqlerrm;
+  end;
+end;
+$$;
+
+-- Dikembalikan seperti semula supaya berkas tes berikutnya berangkat dari
+-- keadaan yang sama.
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+select simpan_nilai_massal('[{"nomor_dada": 13, "kode": "semaphore", "nilai_1": 5}]'::jsonb,
+                           'manual', 1::smallint);
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- 8.6 Batas nomor pos: longgar, tapi tetap batas.
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  begin
+    insert into pos (edisi, nomor, name) values (edisi_aktif(), 21, 'Pos Ngawur');
+    raise exception 'GAGAL: pos nomor 21 diterima';
+  exception when check_violation then null;
+  end;
+end;
+$$;
+
+-- Akun operator untuk pos bayangan harus bisa dibuat — tanpa pelonggaran di
+-- 0021 baris ini gagal, dan pos bayangan jadi pos tanpa petugas.
+insert into auth.users (id, email)
+values ('00000000-0000-0000-0000-0000000000c6', 'pos6hrcd37@uji.local');
+insert into akun_panitia (user_id, username, peran, pos)
+values ('00000000-0000-0000-0000-0000000000c6', 'pos6hrcd37', 'operator_pos', 6);
+
+select '08_lembar_pos OK' as hasil;

--- a/web/config.js
+++ b/web/config.js
@@ -7,6 +7,12 @@
 
 window.HRCD = {
   mode: "supabase",
+  // Dipakai HANYA saat mode "dev". Ditulis di sini supaya mengganti satu kata
+  // di baris atas benar-benar cukup untuk mencoba layar secara lokal — persis
+  // seperti yang dijanjikan README. Tanpa baris ini, api.js memakai devUrl
+  // yang kosong dan setiap permintaan mendarat di penyaji berkas statis, yang
+  // menjawabnya dengan "501 Unsupported method ('POST')".
+  devUrl: "http://127.0.0.1:8787",
   supabaseUrl: "https://pwszijhnftvqjkdldqrf.supabase.co",
   anonKey: "sb_publishable_fVRvaYucCPJxOiphJWC_ZQ_8hgFKDsi",
   gatewayUrl: "https://gateway.ciradyka.workers.dev",

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -392,3 +392,61 @@ export const berangkatkanKloter = (kloter, jam) =>
  *  tercatat di history bersama jam lamanya. */
 export const koreksiJamBerangkat = (kloter, jam, alasan) =>
   rpc("koreksi_jam_berangkat", { p_kloter: kloter, p_jam: jam, p_alasan: alasan });
+
+/* ============================ INPUT POS ================================= */
+
+/** Daftar pos edisi aktif — dipakai admin untuk memilih pos mana yang
+ *  sedang diinput. Operator pos tidak memerlukannya (posnya sudah melekat
+ *  di akunnya), tapi namanya tetap dibaca untuk judul layar. */
+export async function daftarPos(edisi) {
+  if (K.mode === "dev") return baca("/pos");
+  return baca(null,
+    `pos?edisi=eq.${encodeURIComponent(edisi)}` +
+    `&select=nomor,name,bobot,bayangan&order=nomor.asc`);
+}
+
+/** Kolom penilaian satu pos. INILAH yang menentukan bentuk tabelnya — nama
+ *  kolom, rentang yang boleh diketik, dan jenis kotaknya semua datang dari
+ *  sini, tidak satu pun ditulis di JavaScript. Tahun depan panitia mengubah
+ *  barisnya, dan lembar di layar ikut berubah tanpa menyentuh kode. */
+export async function komponenPos(edisi, pos) {
+  if (K.mode === "dev") return baca(`/komponen-pos?pos=${encodeURIComponent(pos)}`);
+  return baca(null,
+    `wahana?edisi=eq.${encodeURIComponent(edisi)}&pos=eq.${encodeURIComponent(pos)}` +
+    `&select=kode,name,type,form,poin_maks,raw_terbaik,raw_terburuk,poin_benar,` +
+    `poin_salah,total_soal,tingkat,satuan,rentang_mentah_min,rentang_mentah_maks,sort_order` +
+    `&order=sort_order.asc`);
+}
+
+/** Seluruh regu + nilai yang sudah tersimpan untuk satu pos. Satu permintaan
+ *  untuk seluruh lembar: ~300 baris, dimuat sekali lalu disaring di browser,
+ *  sama seperti layar meja. */
+export async function lembarPos(pos) {
+  if (K.mode === "dev") return baca(`/lembar-pos?pos=${encodeURIComponent(pos)}`);
+  return baca(null,
+    `v_lembar_pos?pos=eq.${encodeURIComponent(pos)}&select=*&order=nomor_dada.asc`);
+}
+
+/** Satu baris saja, dibaca ulang sesudah menyimpan. Nilai Pos yang tampil di
+ *  layar SELALU angka dari database — layar tidak pernah menghitung skor
+ *  sendiri, supaya tidak ada mesin skor kedua yang bisa berbeda pendapat
+ *  dengan v_poin_pos. */
+export async function lembarPosSatu(pos, nomorDada) {
+  const d = K.mode === "dev"
+    ? await baca(`/lembar-pos?pos=${encodeURIComponent(pos)}&dada=${encodeURIComponent(nomorDada)}`)
+    : await baca(null, `v_lembar_pos?pos=eq.${encodeURIComponent(pos)}` +
+                       `&nomor_dada=eq.${encodeURIComponent(nomorDada)}&select=*`);
+  return d.length ? d[0] : null;
+}
+
+/** baris: [{ nomor_dada, kode, nilai_1, nilai_2 }]. Pintu tulis nilai yang
+ *  sama dengan upload massal — layar ini sekadar mengisinya satu regu
+ *  sekaligus. Mengembalikan status per baris (tersimpan / ditolak + alasan). */
+export const simpanNilaiPos = (baris, pos) =>
+  rpc("simpan_nilai_massal", { p_baris: baris, p_sumber: "manual", p_pos: pos });
+
+/** Mengosongkan satu sel yang sudah terlanjur tersimpan — angka yang masuk ke
+ *  regu yang salah. simpan_nilai_massal tidak bisa dipakai untuk ini: di sana
+ *  sel kosong berarti "belum dinilai", bukan "hapus". */
+export const hapusNilaiPos = (nomorDada, kode, pos) =>
+  rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -17,6 +17,7 @@ import {
   papanKeberangkatan, reguKloter, kontrakOpsi,
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
   koreksiJamBerangkat,
+  daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -136,13 +137,21 @@ async function layarHome() {
 
   // Operator pos tidak berhak atas layar meja — RLS akan mengosongkan
   // datanya dan itu tampak seperti "tidak ada antrean" (temuan review).
+  // Tapi ia punya satu layar sendiri, dan Home-nya harus menunjukkan layar
+  // itu: sebelumnya halaman ini buntu, dan akun pos tidak punya jalan ke
+  // mana pun kecuali mengetik alamatnya sendiri.
   if (peran === "operator_pos") {
     LAYAR.replaceChildren(h(html`
-      <div class="card">
-        <h2>Akun pos, bukan akun meja</h2>
-        <p class="description">Akun ${sesi().username} dipakai untuk input nilai di
-           Pos ${sesi().pos}. Layar meja belum bisa dibuka dengan akun ini.</p>
-      </div>`));
+      <div class="function-menu">
+        <a href="#/pos">
+          <div class="function-name">📋 Input Nilai Pos ${sesi().pos}</div>
+          <div class="description">Isi nilai tiap regu di pos ini —
+             tabelnya sama seperti lembar kertasnya</div>
+        </a>
+      </div>
+      <p class="description" style="margin-top:1.2rem">Akun ${sesi().username}
+         hanya menyentuh nilai Pos ${sesi().pos}. Layar meja (pembayaran,
+         daftar ulang, keberangkatan) memakai akun yang lain.</p>`));
     return;
   }
 
@@ -179,6 +188,11 @@ async function layarHome() {
         <div class="function-name">🏁 Kedatangan</div>
         <div class="description">Ketik nomor dada, tekan Sampai — catat kedatangan regu</div>
       </a>
+      ${peran === "admin" ? `
+      <a href="#/pos">
+        <div class="function-name">📋 Input Nilai Pos</div>
+        <div class="description">Lembar penilaian tiap pos — admin boleh membuka pos mana pun</div>
+      </a>` : ""}
     </div>
     <p class="description" style="margin-top:1.2rem">Angka kuning = masih ada antrean.
        Meja boleh berganti fungsi kapan saja — cukup pilih dari sini.</p>
@@ -253,13 +267,14 @@ function layarGantiPassword() {
  *  Menyaring di browser (data sudah dimuat semua) supaya hasilnya berubah
  *  seketika sambil mengetik — di meja, menunggu server tiap huruf terasa
  *  seperti aplikasi macet. */
-function alatTabel({ saringan, saringAktif, jumlah }) {
+function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "" }) {
   return `
     <div class="table-toolbar">
+      ${kiri}
       <div class="field" style="margin:0;flex:1;min-width:220px">
         <label for="cari-tabel" class="visually-hidden">Cari</label>
         <input type="text" id="cari-tabel" autocomplete="off"
-               placeholder="Cari kode, sekolah, atau nama regu…">
+               placeholder="${esc(cariContoh || "Cari kode, sekolah, atau nama regu…")}">
       </div>
       <div class="filter-row">
         ${saringan.map(s => `
@@ -1774,6 +1789,416 @@ function kartuReguFinish(r) {
     </div>`;
 }
 
+/* ============================ INPUT POS ================================== */
+
+/** Pos yang sedang dibuka admin. Operator pos tidak memakainya — posnya
+ *  melekat di akun dan tidak bisa dipindah dari layar. */
+const posDipilih = { nomor: null };
+
+const judulPos = (p) => p
+  ? (p.bayangan ? `Pos Bayangan — ${p.name}` : `Pos ${p.nomor} — ${p.name}`)
+  : "Pos";
+
+/** Angka dari database datang sebagai teks ("6.00"). Yang muncul di kotak
+ *  isian harus persis seperti yang diketik petugas: 6, bukan 6.00. */
+const angkaRapi = (v) =>
+  v === null || v === undefined || v === "" ? "" : String(Number(v));
+
+/** Kotak isian satu komponen. BENTUKNYA DITENTUKAN KONFIGURASI, bukan ditulis
+ *  per pos di sini — itu sebabnya tabel ini bisa mengikuti lembar mana pun
+ *  tanpa menyentuh JavaScript:
+ *
+ *    form=biner        -> satu centang        (kolom "Kompas (v)")
+ *    satuan=detik      -> Menit : Detik       (kolom "Menit | Detik" di Pos 4)
+ *    benar_kurang_salah-> Benar / Salah
+ *    sisanya           -> satu kotak angka, batasnya dari rentang wajar
+ */
+function selKomponen(k, nilai) {
+  const n1 = nilai ? nilai.nilai_1 : null;
+  const n2 = nilai ? nilai.nilai_2 : null;
+  const kode = esc(k.kode);
+
+  if (k.form === "biner") {
+    return `<input type="checkbox" class="checkbox" data-kode="${kode}"
+                   ${Number(n1) > 0 ? "checked" : ""}
+                   aria-label="${esc(k.name)}">`;
+  }
+  if (k.satuan === "detik") {
+    const total = n1 === null || n1 === undefined ? null : Number(n1);
+    return `<span class="pos-pasangan">
+      <input type="number" class="small-input" inputmode="numeric" min="0"
+             data-kode="${kode}" data-slot="menit"
+             value="${total === null ? "" : Math.floor(total / 60)}"
+             aria-label="${esc(k.name)} — menit">
+      <span class="pos-pemisah" aria-hidden="true">:</span>
+      <input type="number" class="small-input" inputmode="numeric" min="0" max="59"
+             data-kode="${kode}" data-slot="detik"
+             value="${total === null ? "" : total % 60}"
+             aria-label="${esc(k.name)} — detik">
+    </span>`;
+  }
+  if (k.form === "benar_kurang_salah") {
+    return `<span class="pos-pasangan">
+      <input type="number" class="small-input" inputmode="numeric" min="0"
+             data-kode="${kode}" data-slot="benar" value="${esc(angkaRapi(n1))}"
+             aria-label="${esc(k.name)} — jumlah benar">
+      <span class="pos-pemisah" aria-hidden="true">/</span>
+      <input type="number" class="small-input" inputmode="numeric" min="0"
+             data-kode="${kode}" data-slot="salah" value="${esc(angkaRapi(n2))}"
+             aria-label="${esc(k.name)} — jumlah salah">
+    </span>`;
+  }
+  return `<input type="number" class="small-input" inputmode="decimal" step="any"
+                 min="${esc(k.rentang_mentah_min)}" max="${esc(k.rentang_mentah_maks)}"
+                 data-kode="${kode}" value="${esc(angkaRapi(n1))}"
+                 aria-label="${esc(k.name)}">`;
+}
+
+/** Keterangan kecil di bawah judul kolom — rentang yang boleh diketik,
+ *  diambil dari konfigurasi supaya tidak pernah berbeda dengan yang divalidasi
+ *  server. Persis angka yang tercetak di judul kolom lembar kertas. */
+function petunjukKolom(k) {
+  if (k.form === "biner") return "centang bila benar";
+  if (k.satuan === "detik") return "menit : detik";
+  if (k.form === "benar_kurang_salah") return "benar / salah";
+  if (k.form === "benar_per_total") return `0 – ${angkaRapi(k.total_soal)}`;
+  return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
+}
+
+/** Membaca satu komponen dari barisnya. null = kotaknya kosong, artinya
+ *  komponen ini BELUM dinilai — bukan "dinilai nol".
+ *
+ *  Centang adalah pengecualian, dan sengaja: sebuah kotak centang tidak punya
+ *  keadaan kosong, hanya dicentang atau tidak. Jadi aturannya "menyimpan satu
+ *  baris berarti mengesahkan seluruh isinya" — centang yang dibiarkan kosong
+ *  di baris yang disimpan berarti benar-benar tidak kena, dan tersimpan
+ *  sebagai 0. Baris yang tidak disentuh tidak pernah dikirim sama sekali,
+ *  jadi tidak ada regu yang mendadak "dinilai nol" karena tetangganya diisi. */
+function bacaSel(tr, k) {
+  const kotak = tr.querySelectorAll(`[data-kode="${CSS.escape(k.kode)}"]`);
+  if (k.form === "biner") return { nilai_1: kotak[0].checked ? 1 : 0, nilai_2: null };
+
+  if (k.satuan === "detik") {
+    const m = kotak[0].value.trim(), d = kotak[1].value.trim();
+    if (m === "" && d === "") return null;
+    return { nilai_1: (Number(m) || 0) * 60 + (Number(d) || 0), nilai_2: null };
+  }
+  if (k.form === "benar_kurang_salah") {
+    const b = kotak[0].value.trim(), sa = kotak[1].value.trim();
+    if (b === "") return null;
+    return { nilai_1: Number(b), nilai_2: sa === "" ? null : Number(sa) };
+  }
+  const v = kotak[0].value.trim();
+  return v === "" ? null : { nilai_1: Number(v), nilai_2: null };
+}
+
+/** Layar Input Pos — lembar kertas yang dipindah ke layar.
+ *
+ *  Bentuknya sengaja SAMA dengan lembar Google Sheets yang dipakai panitia
+ *  selama ini: identitas regu di kiri, satu kolom per hal yang dinilai, Nilai
+ *  Pos di kanan. Petugas yang menyalin dari foto lembar tidak perlu belajar
+ *  bentuk baru — matanya sudah tahu di mana harus mendarat.
+ *
+ *  Nilai Pos TIDAK dihitung di browser. Angkanya dibaca ulang dari database
+ *  tiap kali satu baris tersimpan, supaya tidak pernah ada mesin skor kedua
+ *  yang bisa berbeda pendapat dengan v_poin_pos — dan supaya angka yang
+ *  dilihat petugas adalah angka yang benar-benar tersimpan, bukan tebakan
+ *  layar tentang apa yang akan tersimpan.
+ */
+async function layarInputPos() {
+  const s = sesi();
+  if (s.peran === "meja") {
+    pasangKepala("Input Nilai Pos");
+    LAYAR.replaceChildren(h(html`
+      <div class="card">
+        <h2>Akun meja, bukan akun pos</h2>
+        <p class="description">Akun ${s.username} dipakai di meja. Input nilai
+           pos memakai akun posnya sendiri — hubungi koordinator.</p>
+      </div>`));
+    return;
+  }
+
+  pasangKepala("Input Nilai Pos", true);
+  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+
+  const layarIni = location.hash;
+  let semuaPos;
+  try { semuaPos = await daftarPos(EDISI.nomor); }
+  catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarInputPos)); return; }
+  if (location.hash !== layarIni) return;
+
+  // Operator pos tidak memilih apa pun — posnya sudah melekat di akunnya, dan
+  // RLS akan menolak pos lain seandainya layar ini mencoba.
+  const nomorPos = s.peran === "operator_pos"
+    ? Number(s.pos)
+    : (posDipilih.nomor ?? (semuaPos.length ? semuaPos[0].nomor : null));
+  const pos = semuaPos.find(p => Number(p.nomor) === Number(nomorPos));
+
+  if (!pos) {
+    LAYAR.replaceChildren(h(kartuGalat(
+      "Edisi ini belum punya pos sama sekali. Admin harus mengisinya dulu.")));
+    return;
+  }
+  posDipilih.nomor = pos.nomor;
+  pasangKepala(`Input ${judulPos(pos)}`, true);
+
+  let komponen, lembar;
+  try {
+    [komponen, lembar] = await Promise.all([
+      komponenPos(EDISI.nomor, pos.nomor),
+      lembarPos(pos.nomor),
+    ]);
+  } catch (e) {
+    LAYAR.replaceChildren(kartuGagalMuat(e.message, layarInputPos)); return;
+  }
+  if (location.hash !== layarIni) return;
+
+  if (!komponen.length) {
+    LAYAR.replaceChildren(h(`
+      <div class="card">${pilihPosHtml(s, semuaPos)}</div>
+      ${kartuGalat(`${judulPos(pos)} belum punya kolom penilaian. Admin harus `
+        + `mengisi komponennya dulu sebelum pos ini bisa dinilai.`)}`));
+    pasangPilihPos(s);
+    return;
+  }
+
+  // Cermin nilai yang ADA DI DATABASE, bukan yang ada di kotak isian. Yang
+  // dikirim ke server hanya selisih antara keduanya — kotak yang tidak diubah
+  // tidak pernah ditulis ulang, jadi kepengarangan nilai tidak bergeser dan
+  // riwayat tidak dibanjiri baris yang tidak mengubah apa-apa.
+  const asli = new Map(lembar.map(r => [Number(r.nomor_dada), r.nilai || {}]));
+
+  LAYAR.replaceChildren(h(`
+    <div class="card">
+      ${alatTabel({
+        kiri: pilihPosHtml(s, semuaPos),
+        cariContoh: "Cari nomor dada, nama regu, atau organisasi…",
+        saringan: [
+          { kode: "belum", label: "Belum lengkap" },
+          { kode: "sudah", label: "Sudah lengkap" },
+          { kode: "semua", label: "Semua" },
+        ],
+        saringAktif: "semua",
+        jumlah: lembar.length,
+      })}
+      <!-- table-tetap: di HP lembar ini TETAP tabel dan digeser ke samping,
+           tidak ditumpuk jadi kartu seperti layar meja. Alasannya di
+           style.css, bagian LEMBAR INPUT POS. -->
+      <div class="table-wrapper table-wrapper-tetap">
+        <table class="table data-table table-tetap table-pos"
+               ${lembar.length ? "" : "hidden"}>
+          <thead>
+            <tr>
+              <th class="text-center">Nomor<br>Dada</th>
+              <th>Nama Regu</th>
+              <th>Organisasi</th>
+              <th>Golongan</th>
+              ${komponen.map(k => `
+                <th class="text-center">${esc(k.name)}
+                  <span class="kolom-petunjuk">${esc(petunjukKolom(k))}</span></th>`).join("")}
+              <th class="text-center">Nilai<br>${esc(pos.bayangan ? pos.name : `Pos ${pos.nomor}`)}</th>
+              <th class="text-center"><span class="visually-hidden">Status simpan</span></th>
+            </tr>
+          </thead>
+          <tbody id="isi-tabel"></tbody>
+        </table>
+        ${lembar.length ? "" : `<p class="table-empty">Belum ada regu yang
+          menerima nomor dada. Lembar pos ini terisi sendiri begitu meja
+          daftar ulang mulai jalan.</p>`}
+      </div>
+    </div>
+    <p class="description" style="margin-top:.8rem">
+      Nilainya tersimpan sendiri begitu kamu pindah ke baris berikutnya —
+      tidak ada tombol Simpan yang bisa lupa ditekan. Tanda ✓ hijau di ujung
+      kanan berarti sudah masuk; tanda merah berarti belum, dan bisa dicoba
+      lagi dari situ. Enter = turun ke regu berikutnya di kolom yang sama.
+    </p>
+  `));
+
+  const tbody = document.getElementById("isi-tabel");
+  tbody.replaceChildren(h(lembar.map(r => `
+    <tr data-dada="${esc(r.nomor_dada)}" data-terisi="${esc(r.jumlah_terisi)}">
+      <td class="angka text-center" data-label="Nomor Dada">${esc(String(r.nomor_dada).padStart(3, "0"))}</td>
+      <td data-label="Nama Regu"><strong>${esc(r.nama_regu)}</strong></td>
+      <td data-label="Organisasi">${esc(r.nama_sekolah)}</td>
+      <td data-label="Golongan">${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}</td>
+      ${komponen.map(k => `
+        <td class="text-center" data-label="${esc(k.name)}">
+          ${selKomponen(k, (r.nilai || {})[k.kode])}</td>`).join("")}
+      <td class="text-center pos-nilai" data-label="Nilai Pos">${esc(angkaRapi(r.nilai_pos))}</td>
+      <td class="text-center pos-status" data-label=""></td>
+    </tr>`).join("")));
+
+  /* ---------- menyimpan satu baris ---------- */
+
+  const statusBaris = (tr, keadaan, pesan) => {
+    const sel = tr.querySelector(".pos-status");
+    tr.classList.toggle("baris-gagal", keadaan === "gagal");
+    if (keadaan === "menyimpan") { sel.textContent = "…"; return; }
+    if (keadaan === "tersimpan") {
+      sel.replaceChildren(h(`<span class="badge badge-green">✓</span>`));
+      return;
+    }
+    if (keadaan === "gagal") {
+      sel.replaceChildren(h(html`<button class="button button-secondary button-mini"
+        type="button" data-ulang title="${pesan}">Coba lagi</button>`));
+      sel.querySelector("[data-ulang]").addEventListener("click", () => simpanBaris(tr));
+      return;
+    }
+    sel.replaceChildren();
+  };
+
+  async function simpanBaris(tr) {
+    // Satu baris punya banyak kotak, dan tiap kotak yang ditinggalkan memicu
+    // simpanan sendiri. Petugas yang mengetik cepat menghasilkan lima
+    // panggilan beruntun, dan yang kedua sampai kelima datang selagi yang
+    // pertama masih di jalan.
+    //
+    // MENOLAKNYA adalah kesalahan yang sempat ada di sini: barisnya tetap
+    // diberi ✓ hijau — karena simpanan pertama memang berhasil — sementara
+    // empat angka berikutnya tidak pernah terkirim. Petugas melihat tanda
+    // berhasil untuk nilai yang hilang. Jadi yang datang saat sibuk DIANTRE,
+    // lalu dijalankan sekali lagi sesudahnya; putaran kedua membaca ulang
+    // seluruh baris, sehingga berapa pun ketukan yang menumpuk cukup
+    // diselesaikan satu kali.
+    if (tr.dataset.jalan === "1") { tr.dataset.antre = "1"; return; }
+    const dada = Number(tr.dataset.dada);
+    const lama = asli.get(dada) || {};
+    const baris = [], dihapus = [];
+
+    for (const k of komponen) {
+      const baru = bacaSel(tr, k);
+      const ada = lama[k.kode] || null;
+      if (baru === null) {
+        // Kotak dikosongkan padahal sebelumnya ada isinya = angka itu masuk ke
+        // regu yang salah. Dihapus, bukan ditimpa nol.
+        if (ada) dihapus.push(k.kode);
+        continue;
+      }
+      const samaSaja = ada
+        && Number(ada.nilai_1) === baru.nilai_1
+        && (ada.nilai_2 === null || ada.nilai_2 === undefined
+              ? null : Number(ada.nilai_2)) === baru.nilai_2;
+      if (!samaSaja) {
+        baris.push({ nomor_dada: dada, kode: k.kode,
+                     nilai_1: baru.nilai_1, nilai_2: baru.nilai_2 });
+      }
+    }
+    if (!baris.length && !dihapus.length) return;
+
+    tr.dataset.jalan = "1";
+    statusBaris(tr, "menyimpan");
+    try {
+      if (baris.length) {
+        const hasil = await simpanNilaiPos(baris, pos.nomor);
+        // Server memeriksa ulang tiap baris dan menolaknya satu per satu;
+        // yang pertama ditolak sudah cukup menjelaskan apa yang salah.
+        const ditolak = (hasil || []).find(x => x.status === "ditolak");
+        if (ditolak) throw new ErrorApi(ditolak.alasan || "nilai ditolak server");
+      }
+      for (const kode of dihapus) await hapusNilaiPos(dada, kode, pos.nomor);
+
+      const segar = await lembarPosSatu(pos.nomor, dada);
+      if (segar) {
+        asli.set(dada, segar.nilai || {});
+        tr.querySelector(".pos-nilai").textContent = angkaRapi(segar.nilai_pos);
+        tr.dataset.terisi = String(segar.jumlah_terisi);
+      }
+      statusBaris(tr, "tersimpan");
+      hitungUlangJumlah();
+    } catch (err) {
+      statusBaris(tr, "gagal", err.message);
+      notif(`${String(dada).padStart(3, "0")}: ${err.message}`, true);
+    } finally {
+      tr.dataset.jalan = "";
+      // Ketukan yang menumpuk selagi baris ini sibuk. Dijalankan juga setelah
+      // GAGAL: yang tersimpan sebagian lalu ditinggalkan adalah keadaan
+      // terburuk dari semuanya.
+      if (tr.dataset.antre === "1") { tr.dataset.antre = ""; simpanBaris(tr); }
+    }
+  }
+
+  /* ---------- perilaku isian ---------- */
+
+  tbody.addEventListener("change", (e) => {
+    const tr = e.target.closest("tr");
+    if (tr) simpanBaris(tr);
+  });
+
+  // Enter = turun satu regu di kolom yang sama, seperti menyalin dari kertas
+  // ke bawah. Berpindah fokus memicu change-nya sendiri, jadi barisnya
+  // tersimpan tanpa perlu dipanggil dua kali.
+  tbody.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter" || e.target.tagName !== "INPUT") return;
+    e.preventDefault();
+    const tr = e.target.closest("tr");
+    const kotak = [...tr.querySelectorAll("input")];
+    const kolom = kotak.indexOf(e.target);
+    let lanjut = tr.nextElementSibling;
+    while (lanjut && lanjut.hidden) lanjut = lanjut.nextElementSibling;
+    const tujuan = lanjut && lanjut.querySelectorAll("input")[kolom];
+    if (tujuan) { tujuan.focus(); if (tujuan.select) tujuan.select(); }
+    else e.target.blur();
+  });
+
+  /* ---------- cari & saring ---------- */
+
+  // Baris DISEMBUNYIKAN, bukan dibangun ulang. Menggambar ulang tabel akan
+  // membuang isi kotak yang belum sempat tersimpan — dan petugas tidak akan
+  // sadar angkanya hilang, karena yang ia lihat hanyalah daftar yang menyusut.
+  const cocok = (tr, cari) => !cari
+    || tr.dataset.dada.padStart(3, "0").includes(cari)
+    || tr.children[1].textContent.toLowerCase().includes(cari)
+    || tr.children[2].textContent.toLowerCase().includes(cari);
+
+  const lengkap = (tr) => Number(tr.dataset.terisi) >= komponen.length;
+
+  function hitungUlangJumlah() {
+    const baris = [...tbody.children];
+    const tampil = baris.filter(tr => !tr.hidden).length;
+    const sudah = baris.filter(lengkap).length;
+    document.getElementById("tabel-jumlah").textContent =
+      `${tampil} ditampilkan · ${sudah}/${baris.length} lengkap`;
+  }
+
+  pasangAlatTabel((cari, saring) => {
+    [...tbody.children].forEach(tr => {
+      const lolosSaring = saring === "semua"
+        || (saring === "sudah" ? lengkap(tr) : !lengkap(tr));
+      tr.hidden = !(cocok(tr, cari) && lolosSaring);
+    });
+    hitungUlangJumlah();
+  });
+
+  pasangPilihPos(s);
+}
+
+/** Pemilih pos — hanya untuk admin. Operator pos melihat namanya saja, karena
+ *  memberinya daftar pos lain hanya menawarkan sesuatu yang pasti ditolak
+ *  server (RLS nilai_mentah) — pintu yang terkunci lebih baik tidak digambar. */
+function pilihPosHtml(s, semuaPos) {
+  if (s.peran !== "admin") return "";
+  return `
+    <div class="field" style="margin:0;min-width:210px">
+      <label for="pilih-pos" class="visually-hidden">Pos yang diinput</label>
+      <select id="pilih-pos" class="select-small">
+        ${semuaPos.map(p => `<option value="${esc(p.nomor)}"
+          ${Number(p.nomor) === Number(posDipilih.nomor) ? "selected" : ""}
+          >${esc(judulPos(p))}</option>`).join("")}
+      </select>
+    </div>`;
+}
+
+function pasangPilihPos(s) {
+  if (s.peran !== "admin") return;
+  const sel = document.getElementById("pilih-pos");
+  if (!sel) return;
+  sel.addEventListener("change", () => {
+    posDipilih.nomor = Number(sel.value);
+    layarInputPos();
+  });
+}
+
 /* ============================ PINDAH KLOTER (HARI-H) ===================== */
 
 /** Daftar sisipan: nomor-nomor yang TIDAK ADA di kertas petugas staging.
@@ -1817,6 +2242,7 @@ const RUTE = {
   "#/cetak-kloter": layarCetakKloter,
   "#/keberangkatan": layarKeberangkatan,
   "#/finish": layarFinish,
+  "#/pos": layarInputPos,
   "#/ganti-password": layarGantiPassword,
 };
 

--- a/web/style.css
+++ b/web/style.css
@@ -1172,3 +1172,76 @@ input.small-input { text-align: center; }
      menu bawah, dan menu bawah hanya muncul di HP. */
   .header .icon-button, .header .button-small { display: none; }
 }
+
+/* ============================================================================
+   LEMBAR INPUT POS
+
+   Layar terlebar di seluruh sistem: empat kolom identitas + satu kolom per hal
+   yang dinilai + Nilai Pos + status simpan. Pos 1 sudah 11 kolom, dan
+   jumlahnya ditentukan konfigurasi — bisa bertambah tahun depan tanpa ada
+   yang menyentuh berkas ini.
+
+   Karena itu tabel ini SATU-SATUNYA yang memang boleh menggeser ke samping.
+   Aturan "kolom paling kanan tidak boleh hilang" di layar meja berlaku karena
+   di sana kolom terakhir berisi tombol; di sini kolom terakhir hanya penanda
+   tersimpan, dan yang dikerjakan petugas ada di tengah. Yang dijaga justru
+   nomor dada: ia dipatok di tepi kiri supaya tetap terlihat sejauh apa pun
+   tabelnya digeser — tanpa itu, petugas yang menggulir ke kolom kelima tidak
+   lagi tahu sedang menilai regu yang mana.
+   ========================================================================== */
+
+.table-pos { table-layout: auto; min-width: 100%; }
+.table-pos th, .table-pos td { padding: .4rem .45rem; white-space: nowrap; }
+/* Nama regu dan organisasi boleh membungkus — keduanya satu-satunya isi yang
+   panjangnya tak terduga, dan tanpa ini merekalah yang mendorong seluruh
+   kolom nilai keluar layar. */
+.table-pos td:nth-child(2), .table-pos td:nth-child(3) {
+  white-space: normal; min-width: 9rem;
+}
+
+/* Rentang yang boleh diketik, di bawah nama kolomnya — sama seperti "(0 - 20)"
+   yang tercetak di judul kolom lembar kertas. */
+.kolom-petunjuk {
+  display: block; font-weight: 500; font-size: .72rem;
+  color: var(--tinta-lembut); text-transform: none; letter-spacing: 0;
+}
+
+/* Nomor dada dipatok di tepi kiri. z-index 2 supaya ia lewat DI ATAS sel
+   biasa saat digeser, tapi tetap DI BAWAH kepala tabel yang juga menempel
+   (z-index 1 pada .data-table thead th, jadi kepalanya diberi 3 di bawah). */
+.table-pos td:first-child, .table-pos th:first-child {
+  position: sticky; left: 0; z-index: 2; background: var(--kartu);
+  box-shadow: 1px 0 0 var(--garis);
+}
+.table-pos thead th:first-child { z-index: 3; background: var(--kertas); }
+.table-pos tbody tr:hover td:first-child { background: var(--utama-muda); }
+
+/* Dua kotak yang sebenarnya satu nilai: Menit : Detik, atau Benar / Salah. */
+.pos-pasangan { display: inline-flex; align-items: center; gap: .25rem; }
+.pos-pasangan input.small-input { width: 3.4rem; }
+.pos-pemisah { color: var(--tinta-lembut); font-weight: 700; }
+
+/* Nilai Pos: angka yang dicari mata saat menyapu tabel dari atas ke bawah. */
+.pos-nilai {
+  font-weight: 800; font-variant-numeric: tabular-nums; font-size: 1.05rem;
+}
+.pos-status { width: 5rem; }
+
+/* Baris yang gagal tersimpan. Diberi warna SEBARIS PENUH, bukan hanya di
+   kolom statusnya: petugas sedang menatap kolom nilai di tengah tabel, dan
+   tanda sebesar satu sel di ujung kanan tidak akan pernah tertangkap. */
+.table-pos tbody tr.baris-gagal td { background: var(--bahaya-muda); }
+.table-pos tbody tr.baris-gagal td:first-child { background: var(--bahaya-muda); }
+
+@media (max-width: 560px) {
+  /* Lembar ini memakai .table-tetap (lihat blok "tabel BERHENTI jadi tabel"
+     di atas), jadi di HP ia TIDAK ditumpuk jadi kartu. Itu disengaja: satu
+     regu di Pos 1 akan jadi kartu setinggi 11 baris, dan menilai 300 regu
+     berarti menggulir 3.300 baris. Bentuk tabel itulah yang membuat "isi
+     kolom Semaphore, turun ke regu berikutnya" masuk akal. Yang dikecilkan
+     di sini hanya jaraknya. */
+  .table-pos th, .table-pos td { padding: .3rem .3rem; }
+  .table-pos input.small-input { width: 3.6rem; }
+  .table-pos .pos-pasangan input.small-input { width: 2.9rem; }
+  .table-pos td:nth-child(2), .table-pos td:nth-child(3) { min-width: 7.5rem; }
+}


### PR DESCRIPTION
## What

The screen the panitia have been asking for: the Google Sheet they already use for scoring, moved into the app. Nomor Dada · Nama Regu · Organisasi · Golongan, one column per thing being scored, Nilai Pos at the right. It sits at `#/pos`, and an operator pos account now lands on it from Home instead of a dead end.

Four migrations make it possible:

- **`0021`** — pos bayangan is scored after all. `alur-lomba.md` said it is not, and the schema locked pos numbers to 1–5 on that basis; the real score sheets have Kreativitas, Kekompakan, Kesopanan, a Nilai Pos, and a RANK column. The document was wrong and is corrected. Pos bayangan is now an ordinary pos carrying a flag, not a branch in the scoring engine.
- **`0022`** — a sixth conversion form, `bertingkat`. Pos 4 scores speed in bands (≤1:00 → 50, ≤1:30 → 30, ≤2:00 → 15, beyond → 0). That is not interpolation: `kecil_baik` gives 37.5 for 90 seconds, so all of Pos 4 would be wrong if forced into an existing form. `wahana.satuan` comes along so seconds can be typed as Menit : Detik.
- **`0023`** — `v_lembar_pos`, one row per regu per pos, and `hapus_nilai_pos` for clearing a single cell.
- **`0024`** — the components themselves, taken from the HRCD XXXVI sheets.

Everything on screen comes from the `wahana` rows: column names and order, the range that may be typed, and the kind of box. Nothing is written per pos in JavaScript.

## Why

The scoring engine could already turn raw marks into points, but nothing described what a pos actually scores, and there was no way to enter a mark. This closes both.

Three decisions worth keeping:

1. **No Simpan button.** A row saves itself when the operator leaves it and gets a green tick. A button that can be forgotten is a score that is lost.
2. **Saves that pile up are queued, not dropped.** A row has many boxes and each fires its own save; rejecting the ones that arrive while another is in flight gave the row a green tick while four of its five values never reached the server. Found by filling a row fast in a real browser.
3. **The screen never computes a score.** Nilai Pos is read back from the database after each row saves. Computing it in the browser would create a second scoring engine that eventually disagrees with `v_poin_pos`.

`v_lembar_pos` is the only view in the system that is not `security_invoker`. The path to the school name runs through `pendaftaran`, which operator pos accounts cannot read because it holds WhatsApp numbers; under RLS the sheet would come back empty, and an empty sheet reads as "nobody has registered yet". The guard is inside the view instead, and `kontak_wa` is not among its columns.

## Notes

**Verified against the real sheets, not invented numbers.** All 77 readable rows from the five screenshots were run through the configured engine: 75 reproduce the printed Nilai Pos exactly. The two that do not are single cells that look hand-typed over their formula (Pos 3 regu 016 reads 380, the formula gives 355; Pos 4 regu 009 reads 100, the formula gives 80). The configuration follows the formula, and both are recorded in `docs/final-architecture.md` §8. `tests/sql/08_lembar_pos.sql` asserts the real sheet numbers.

Test suite passes on PostgreSQL 16.4 and 18.6.

**`0024` is data, not rules.** Scoring changes every year (`alur-lomba.md` 9.1). These are last year's numbers as a starting point — the panitia should check them for this edition. Pos 5 is deliberately left without a name or components: its sheet was not among those handed over, and guessing would plant a guess in the database.

Also fixed along the way, both quiet failures: `dev_database.sh` listed migrations by hand and stopped at 0011 while they had reached 0020, and `config.js` had no `devUrl`, so switching to dev mode sent every request to the static file server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)