### PR TITLE
feat: Pos 0 and Pos 5 are the start and finish, not scored pos

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │   └── wrangler.toml         # deploy Workers static assets
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0024
+│   ├── migrations/           # skema database, urut 0001..0025
 │   ├── checks/               # SQL pemeriksaan manual (row_counts, smoke, dst.)
 │   └── seed.sql              # konfigurasi edisi + baris wajib
 ├── scripts/                  # provision_accounts.py, change_password.py

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -228,8 +228,21 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
 ## 7. Rute dan pos
 
-1. Terdapat **5 pos utama** di sepanjang rute, masing-masing dengan soal dan
-   wahana yang berbeda.
+1. Terdapat **4 pos utama** di sepanjang rute (Pos 1–4), masing-masing dengan
+   soal dan wahana yang berbeda.
+
+   **Pos 0 dan Pos 5 bukan pos penilaian.** Keduanya tempat yang sama —
+   garis start dan garis finish — dan peserta menyebutnya Pos 0 saat berangkat,
+   Pos 5 saat kembali. Yang dicatat di sana **waktu**, bukan nilai: jam
+   berangkat per kloter dan jam datang per regu (bagian 6 dan 10). Tidak ada
+   wahana dan tidak ada soal yang dikoreksi di keduanya.
+
+   > Dokumen ini sempat menulis "5 pos utama" dan memasukkan Pos 5 ke dalam
+   > rantai soal. Sistem sudah ikut dibetulkan di migrasi `0025`, termasuk satu
+   > akibat yang tidak kelihatan: pos tanpa komponen penilaian sempat terhitung
+   > sebagai **pos yang dilewatkan regu**. Selama denda pos terlewat masih 0
+   > itu tidak berdampak apa-apa — dan justru itu bahayanya, karena baru
+   > muncul pada hari seseorang mengubah angka yang memang boleh diubah.
 2. Selain itu ada **pos bayangan** — pos yang tidak diberitahukan lebih dulu ke
    peserta. Pos bayangan **tetap dinilai**, hanya saja yang dinilai bukan
    wahana melainkan hal yang melekat pada regunya sepanjang perjalanan:
@@ -262,13 +275,16 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    | Pos 1 | perjalanan Pos 1 → Pos 2 | Pos 2 | **Pos 2** |
    | Pos 2 | perjalanan Pos 2 → Pos 3 | Pos 3 | **Pos 3** |
    | Pos 3 | perjalanan Pos 3 → Pos 4 | Pos 4 | **Pos 4** |
-   | Pos 4 | perjalanan Pos 4 → Pos 5 | Pos 5 | **Pos 5** |
+
+   **Tidak ada soal terakhir.** Rantainya berhenti di Pos 4: Pos 4 tidak
+   membagikan soal, karena sesudahnya regu langsung menuju garis finish dan
+   di sana tidak ada yang mengoreksi.
 
 5. Rumusnya karena itu:
 
    ```
    Nilai Pos 1 = Wahana Pos 1                       (tidak ada soal masuk)
-   Nilai Pos N = Wahana Pos N + Soal dari Pos N−1   (N = 2..5)
+   Nilai Pos N = Wahana Pos N + Soal dari Pos N−1   (N = 2..4)
    ```
 
 6. **Skor soal masuk ke pos tempat soal itu dikumpulkan, bukan tempat soal itu

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0024`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0025`.
 
 ---
 
@@ -46,7 +46,7 @@ di `workers/gateway/worker.js` wajib ikut diubah.
 
 ## 2. Database
 
-24 migrasi, `0001` sampai `0024`, dijalankan berurutan tanpa lubang penomoran.
+25 migrasi, `0001` sampai `0025`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -90,6 +90,21 @@ mengubah penilaian tahun depan tidak menyentuh kode sama sekali.
 **Pos bayangan ikut dinilai** (migrasi `0021`). Ia pos biasa dengan penanda
 `pos.bayangan`, bernomor melanjutkan pos utama — bukan cabang tersendiri di
 mesin skor.
+
+**Tidak semua baris `pos` dinilai** (migrasi `0025`). Pos 0 (Keberangkatan) dan
+Pos 5 (Kedatangan) adalah garis start dan garis finish; yang dicatat di sana
+waktu, bukan nilai. Yang menentukan sebuah pos dinilai atau tidak adalah
+**punya tidaknya baris `wahana`** — bukan kolom penanda tersendiri, supaya
+tidak ada dua sumber kebenaran untuk satu fakta. `v_pos` mengekspos
+`jumlah_komponen` untuk layar yang perlu membedakan keduanya.
+
+Konsekuensi yang sempat luput: `v_total_skor` menghitung pos terlewat sebagai
+`(jumlah seluruh pos − pos yang punya nilai)`. Begitu Pos 0 dan Pos 5 masuk
+tabel, setiap regu selamanya terhitung melewatkan dua pos yang memang tidak
+bisa dinilai siapa pun. Dampaknya nol selama `nilai_pos_terlewat` masih 0 —
+dan justru itu yang berbahaya, karena cacatnya menunggu sampai angka itu
+diubah. `v_total_skor`, `v_monitoring_input`, dan `v_progres_publik` kini
+hanya menghitung pos yang punya komponen.
 
 ### Kunci daftar ulang
 

--- a/supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
+++ b/supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
@@ -1,0 +1,193 @@
+-- ============================================================================
+-- hrcd-rekap : 0025_pos_keberangkatan_kedatangan.sql
+--
+-- Pos 0 dan Pos 5 adalah garis start dan garis finish.
+--
+-- Selama ini `pos` berisi lima baris bernama "Pos 1".."Pos 5", dan Pos 5
+-- dianggap pos penilaian seperti empat lainnya. Ternyata bukan: Pos 0 adalah
+-- Keberangkatan dan Pos 5 adalah Kedatangan. Keduanya tempat nyata di rute
+-- yang disebut peserta, tapi tidak ada yang dinilai di sana — yang dicatat
+-- adalah WAKTU, dan itu sudah punya rumahnya sendiri sejak awal
+-- (`kloter.jam_berangkat` dan `closing_regu.jam_datang`, lalu
+-- `v_penalti_waktu`).
+--
+-- Rantai soal ikut berubah. `docs/alur-lomba.md` 7.4 menulis soal berjalan
+-- satu pos ke depan sampai "Pos 4 -> dinilai di Pos 5". Tidak ada soal
+-- terakhir: rantainya berhenti di Pos 4, dan Pos 5 tidak mengoreksi apa pun.
+-- Tabelnya sudah dibetulkan di dokumen.
+--
+-- ----------------------------------------------------------------------------
+-- YANG SEBENARNYA BERBAHAYA DI SINI, DAN KENAPA VIEW IKUT DIBUAT ULANG
+--
+-- `v_total_skor` menghitung pos terlewat begini:
+--
+--     (jumlah SELURUH pos - jumlah pos yang punya nilai) * nilai_pos_terlewat
+--
+-- Pos 0 dan Pos 5 tidak akan pernah punya nilai, karena tidak punya komponen
+-- penilaian sama sekali. Jadi begitu keduanya masuk tabel `pos`, setiap regu
+-- selamanya terhitung melewatkan dua pos.
+--
+-- Hari ini akibatnya nol, karena `nilai_pos_terlewat` bawaannya 0. Justru itu
+-- masalahnya: kesalahannya tidak terlihat sekarang, dan baru meledak pada
+-- hari seseorang mengubah satu angka konfigurasi yang memang boleh diubah —
+-- lalu SELURUH peserta kehilangan poin untuk dua pos yang memang tidak
+-- pernah bisa dinilai siapa pun.
+--
+-- Perbaikannya tidak menambah kolom penanda. "Pos yang dinilai" sudah bisa
+-- dijawab dari data yang ada: pos yang punya minimal satu baris `wahana`.
+-- Menambah kolom `dinilai` berarti dua sumber kebenaran untuk satu fakta,
+-- dan suatu hari keduanya akan berbeda pendapat.
+-- ============================================================================
+
+-- 1. Nomor pos boleh 0 --------------------------------------------------------
+alter table pos drop constraint if exists pos_nomor_check;
+alter table pos add constraint pos_nomor_check check (nomor between 0 and 20);
+
+-- `akun_panitia.pos` sengaja TIDAK ikut dilonggarkan ke 0. Akun operator pos
+-- gunanya satu-satunya adalah mengisi nilai; akun untuk pos yang tidak
+-- dinilai adalah akun yang tidak bisa melakukan apa pun. Kalau suatu hari
+-- Pos 0 benar-benar menilai sesuatu, longgarkan di migrasi yang sama dengan
+-- yang menambahkan komponennya.
+
+-- 2. Pos terlewat hanya dihitung dari pos yang MEMANG dinilai -----------------
+-- Daftar kolomnya tidak berubah, jadi v_klasemen dan v_klasemen_publik yang
+-- bertumpu di atasnya tidak perlu ikut dibuat ulang.
+create or replace view v_total_skor with (security_invoker = on) as
+select
+  r.id            as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name          as nama_sekolah,
+  r.golongan,
+  -- Pos terlewat menyumbang nilai_pos_terlewat per pos (knob konfigurasi;
+  -- default 0). Hanya pos yang punya komponen penilaian yang ikut dihitung —
+  -- garis start dan garis finish bukan pos yang bisa dilewatkan.
+  coalesce(pp.total_pos, 0)
+    + (( (select count(*) from pos p
+          where p.edisi = edisi_aktif()
+            and exists (select 1 from wahana w
+                        where w.edisi = p.edisi and w.pos = p.nomor))
+         - coalesce(pp.jumlah_pos, 0) ) * kp.nilai_pos_terlewat)
+                                                  as total_pos,
+  pw.penalti_waktu,
+  case when c.regu_id is null then kp.penalti_tanpa_checkout else 0 end
+                                                  as penalti_checkout,
+  case when c.regu_id is not null
+    then (5 - c.anggota_hadir) * kp.penalti_per_anggota_hilang else 0 end
+                                                  as penalti_anggota,
+  coalesce(pp.total_pos, 0)
+    + (( (select count(*) from pos p
+          where p.edisi = edisi_aktif()
+            and exists (select 1 from wahana w
+                        where w.edisi = p.edisi and w.pos = p.nomor))
+         - coalesce(pp.jumlah_pos, 0) ) * kp.nilai_pos_terlewat)
+    - pw.penalti_waktu
+    - case when c.regu_id is null then kp.penalti_tanpa_checkout else 0 end
+    - case when c.regu_id is not null
+        then (5 - c.anggota_hadir) * kp.penalti_per_anggota_hilang else 0 end
+                                                  as total,
+  pw.selisih_menit
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join (select regu_id, sum(poin_pos) as total_pos, count(*) as jumlah_pos
+           from v_poin_pos group by regu_id) pp on pp.regu_id = r.id
+join v_penalti_waktu pw  on pw.regu_id = r.id
+left join closing_regu c on c.regu_id = r.id
+cross join konfig_penalti kp
+where kp.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas';
+
+-- 3. Matriks pemantauan: kolom untuk pos yang tidak dinilai selalu kosong,
+--    dan kolom yang selamanya kosong terbaca sebagai pekerjaan yang belum
+--    selesai. Dibuang dari matriksnya.
+create or replace view v_monitoring_input with (security_invoker = on) as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  r.golongan,
+  r.kloter_nomor,
+  p.nomor as pos,
+  exists (select 1 from nilai_mentah n
+          join wahana w on w.id = n.wahana_id
+          where n.regu_id = r.id and w.pos = p.nomor) as sudah_input,
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.pos = p.nomor) as jumlah_komponen_terisi,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and exists (select 1 from wahana w where w.edisi = p.edisi and w.pos = p.nomor)
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  -- Operator pos hanya melihat kolom pos-nya: RLS nilai_mentah membuat
+  -- kolom pos lain SELALU tampak kosong — tampilan palsu lebih buruk
+  -- daripada tampilan sempit (temuan review).
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya());
+
+-- 4. Halaman live publik: "sudah lewat pos mana" tidak boleh menampilkan pos
+--    yang tidak pernah menghasilkan tanda apa pun.
+create or replace view v_progres_publik as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.name as nama_sekolah,
+  r.golongan,
+  (select jsonb_object_agg(p.nomor::text,
+            exists (select 1 from nilai_mentah n
+                    join wahana w on w.id = n.wahana_id
+                    where n.regu_id = r.id and w.pos = p.nomor))
+   from pos p
+   where p.edisi = edisi_aktif()
+     and exists (select 1 from wahana w
+                 where w.edisi = p.edisi and w.pos = p.nomor)) as pos_terlewati,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+where not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+  and (select fase_live from status_acara) in ('progres', 'penuh');
+
+-- 5. Daftar pos + jumlah komponennya, untuk pemilih pos di layar Input Pos.
+--    Tanpa angka ini layar tidak bisa membedakan "pos yang belum dikonfigurasi
+--    admin" dari "pos yang memang tidak dinilai", dan menuduh yang kedua
+--    sebagai yang pertama.
+create or replace view v_pos with (security_invoker = on) as
+select
+  p.nomor,
+  p.name,
+  p.bobot,
+  p.bayangan,
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor)::int as jumlah_komponen
+from pos p
+where p.edisi = edisi_aktif();
+
+grant select on v_pos to authenticated, service_role;
+
+-- 6. Nama kedua pos ----------------------------------------------------------
+do $$
+declare v_edisi smallint;
+begin
+  select nomor into v_edisi from edisi where is_active;
+  if v_edisi is null then
+    raise notice 'belum ada edisi aktif — nama pos dilewati';
+    return;
+  end if;
+  if (select konfigurasi_terkunci from status_acara) then
+    raise exception 'konfigurasi sedang terkunci — buka kuncinya di status_acara dulu, lalu jalankan ulang migrasi ini';
+  end if;
+
+  insert into pos (edisi, nomor, name, bobot, bayangan) values
+    (v_edisi, 0, 'Keberangkatan', 1.00, false),
+    (v_edisi, 5, 'Kedatangan',    1.00, false)
+  on conflict (edisi, nomor) do update set name = excluded.name;
+end;
+$$;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -27,9 +27,10 @@ for m in "$ROOT"/supabase/migrations/*.sql; do
   run "supabase/migrations/$(basename "$m")"
 done
 run supabase/seed.sql
-# Konfigurasi komponen pos butuh edisinya sudah ada — lihat catatan panjang
-# yang sama di tests/run.sh.
+# Konfigurasi pos butuh edisinya sudah ada — lihat catatan panjang yang sama
+# di tests/run.sh.
 run supabase/migrations/0024_komponen_pos.sql
+run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run tests/sql/01_seed_uji.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -132,9 +132,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     uid=p.get("uid")))
             elif u.path == "/pos":
                 self._kirim(200, q(
-                    "select nomor, name, bobot, bayangan from pos "
-                    "where edisi = edisi_aktif() order by nomor",
-                    uid=p.get("uid")))
+                    "select * from v_pos order by nomor", uid=p.get("uid")))
             elif u.path == "/komponen-pos":
                 self._kirim(200, q(
                     "select kode, name, type, form, poin_maks, raw_terbaik, "

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,6 +47,7 @@ run supabase/migrations/0021_pos_bayangan.sql
 run supabase/migrations/0022_bentuk_bertingkat.sql
 run supabase/migrations/0023_lembar_pos.sql
 run supabase/migrations/0024_komponen_pos.sql
+run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -56,12 +57,12 @@ run tests/sql/05_pindah_kloter.sql
 run tests/sql/06_koreksi_jam_berangkat.sql
 run tests/sql/07_pindah_setelah_berangkat.sql
 
-# 0024 dijalankan DUA KALI, dan itu disengaja.
+# 0024 dan 0025 dijalankan DUA KALI, dan itu disengaja.
 #
-# Ia satu-satunya migrasi yang mengubah DATA edisi, bukan bentuk tabel. Pada
-# giliran pertama (di atas, sesuai nomornya) seed.sql belum jalan, jadi belum
-# ada edisi aktif dan isinya dilewati — persis seperti yang tertulis di
-# kepalanya. Kalau ia hanya dijalankan di sana, seluruh konfigurasi komponen
+# Keduanya mengubah DATA edisi, bukan hanya bentuk tabel. Pada giliran pertama
+# (di atas, sesuai nomornya) seed.sql belum jalan, jadi belum ada edisi aktif
+# dan bagian datanya dilewati — persis seperti yang tertulis di kepala
+# masing-masing. Kalau keduanya hanya dijalankan di sana, seluruh konfigurasi
 # pos tidak pernah tersentuh tes sama sekali.
 #
 # Giliran kedua di sini, setelah 02-07 selesai memakai lima komponen contoh
@@ -72,6 +73,7 @@ run tests/sql/07_pindah_setelah_berangkat.sql
 # diulang — yang perlu dipastikan, karena workflow Apply migration bisa saja
 # ditekan dua kali dari HP.
 run supabase/migrations/0024_komponen_pos.sql
+run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run tests/sql/08_lembar_pos.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/08_lembar_pos.sql
+++ b/tests/sql/08_lembar_pos.sql
@@ -233,7 +233,54 @@ select simpan_nilai_massal('[{"nomor_dada": 13, "kode": "semaphore", "nilai_1": 
 reset role;
 
 -- ---------------------------------------------------------------------------
--- 8.6 Batas nomor pos: longgar, tapi tetap batas.
+-- 8.6 Pos 0 dan Pos 5 = garis start dan garis finish, tidak dinilai.
+--
+--     Yang diuji di sini bukan namanya, melainkan JEBAKAN-nya: keduanya tidak
+--     punya komponen, jadi tidak ada regu yang bisa punya nilai di sana. Kalau
+--     "pos terlewat" dihitung dari SELURUH baris pos, setiap regu selamanya
+--     terhitung melewatkan dua pos — tak terlihat selama nilai_pos_terlewat
+--     masih 0, lalu menghukum seluruh peserta pada hari angka itu diubah.
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  v_dengan_pos numeric;
+  v_tanpa_pos  numeric;
+begin
+  assert (select name from pos where edisi = edisi_aktif() and nomor = 0)
+         = 'Keberangkatan', 'Pos 0 bukan Keberangkatan';
+  assert (select name from pos where edisi = edisi_aktif() and nomor = 5)
+         = 'Kedatangan', 'Pos 5 bukan Kedatangan';
+  assert (select jumlah_komponen from v_pos where nomor = 0) = 0,
+         'garis start punya komponen penilaian';
+
+  -- Denda pos terlewat DINYALAKAN — tanpa itu cacatnya tidak kelihatan sama
+  -- sekali, dan justru itu bahayanya: ia menunggu sampai seseorang mengubah
+  -- satu angka konfigurasi yang memang boleh diubah.
+  update konfig_penalti set nilai_pos_terlewat = 100 where edisi = edisi_aktif();
+  select total_pos into v_tanpa_pos from v_total_skor where nomor_dada = 13;
+
+  -- Menambah pos yang TIDAK dinilai tidak boleh mengubah skor siapa pun.
+  -- Inilah aturan sebenarnya; Pos 0 dan Pos 5 hanya contoh pertamanya.
+  insert into pos (edisi, nomor, name) values (edisi_aktif(), 19, 'Pos Tanpa Nilai');
+  select total_pos into v_dengan_pos from v_total_skor where nomor_dada = 13;
+
+  assert v_dengan_pos = v_tanpa_pos,
+    'menambah satu pos tanpa komponen mengubah total pos dari ' || v_tanpa_pos
+    || ' jadi ' || v_dengan_pos || ' — pos yang tidak dinilai ikut dihitung terlewat';
+
+  -- Matriks pemantauan juga: kolom yang selamanya kosong terbaca sebagai
+  -- pekerjaan yang belum selesai.
+  assert not exists (select 1 from v_monitoring_input where pos in (0, 19)),
+         'v_monitoring_input memuat pos yang tidak dinilai';
+
+  delete from pos where edisi = edisi_aktif() and nomor = 19;
+  update konfig_penalti set nilai_pos_terlewat = 0 where edisi = edisi_aktif();
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8.7 Batas nomor pos: longgar, tapi tetap batas.
 -- ---------------------------------------------------------------------------
 
 do $$

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -397,12 +397,15 @@ export const koreksiJamBerangkat = (kloter, jam, alasan) =>
 
 /** Daftar pos edisi aktif — dipakai admin untuk memilih pos mana yang
  *  sedang diinput. Operator pos tidak memerlukannya (posnya sudah melekat
- *  di akunnya), tapi namanya tetap dibaca untuk judul layar. */
-export async function daftarPos(edisi) {
+ *  di akunnya), tapi namanya tetap dibaca untuk judul layar.
+ *
+ *  `jumlah_komponen` ikut terbawa karena tidak semua pos dinilai: Pos 0
+ *  (Keberangkatan) dan Pos 5 (Kedatangan) adalah garis start dan finish, dan
+ *  yang dicatat di sana waktu, bukan nilai. Tanpa angka itu layar tidak bisa
+ *  membedakan pos semacam itu dari pos yang komponennya belum diisi admin. */
+export async function daftarPos() {
   if (K.mode === "dev") return baca("/pos");
-  return baca(null,
-    `pos?edisi=eq.${encodeURIComponent(edisi)}` +
-    `&select=nomor,name,bobot,bayangan&order=nomor.asc`);
+  return baca(null, "v_pos?select=*&order=nomor.asc");
 }
 
 /** Kolom penilaian satu pos. INILAH yang menentukan bentuk tabelnya — nama

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1923,15 +1923,23 @@ async function layarInputPos() {
 
   const layarIni = location.hash;
   let semuaPos;
-  try { semuaPos = await daftarPos(EDISI.nomor); }
+  try { semuaPos = await daftarPos(); }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarInputPos)); return; }
   if (location.hash !== layarIni) return;
+
+  // Tidak semua pos dinilai. Pos 0 (Keberangkatan) dan Pos 5 (Kedatangan)
+  // adalah garis start dan garis finish — yang dicatat di sana waktu, lewat
+  // layar Keberangkatan dan Kedatangan. Admin dibuka di pos yang benar-benar
+  // bisa diisi, bukan di pos pertama menurut nomor.
+  const posDinilai = semuaPos.filter(p => Number(p.jumlah_komponen) > 0);
 
   // Operator pos tidak memilih apa pun — posnya sudah melekat di akunnya, dan
   // RLS akan menolak pos lain seandainya layar ini mencoba.
   const nomorPos = s.peran === "operator_pos"
     ? Number(s.pos)
-    : (posDipilih.nomor ?? (semuaPos.length ? semuaPos[0].nomor : null));
+    : (posDipilih.nomor
+       ?? (posDinilai.length ? posDinilai[0].nomor
+                             : (semuaPos.length ? semuaPos[0].nomor : null)));
   const pos = semuaPos.find(p => Number(p.nomor) === Number(nomorPos));
 
   if (!pos) {
@@ -1954,10 +1962,21 @@ async function layarInputPos() {
   if (location.hash !== layarIni) return;
 
   if (!komponen.length) {
+    // Dua sebab yang berbeda, dan layar tidak bisa membedakannya dari data:
+    // pos yang MEMANG tidak dinilai, dan pos yang komponennya belum diisi.
+    // Jadi keduanya disebut, alih-alih menuduh salah satunya.
+    // Template BIASA, bukan tag html`` — pilihPosHtml sudah berupa HTML dan
+    // akan tampil apa adanya sebagai teks kalau ikut di-escape. Nama pos
+    // datang dari database, jadi ia lewat esc() sendiri.
     LAYAR.replaceChildren(h(`
       <div class="card">${pilihPosHtml(s, semuaPos)}</div>
-      ${kartuGalat(`${judulPos(pos)} belum punya kolom penilaian. Admin harus `
-        + `mengisi komponennya dulu sebelum pos ini bisa dinilai.`)}`));
+      <div class="card">
+        <h2>${esc(judulPos(pos))} tidak punya kolom penilaian</h2>
+        <p class="description">Garis start dan garis finish memang tidak
+           dinilai — yang dicatat di sana waktu, lewat layar Keberangkatan dan
+           Kedatangan. Kalau pos ini seharusnya dinilai, komponennya belum
+           diisi admin.</p>
+      </div>`));
     pasangPilihPos(s);
     return;
   }
@@ -2184,7 +2203,8 @@ function pilihPosHtml(s, semuaPos) {
       <select id="pilih-pos" class="select-small">
         ${semuaPos.map(p => `<option value="${esc(p.nomor)}"
           ${Number(p.nomor) === Number(posDipilih.nomor) ? "selected" : ""}
-          >${esc(judulPos(p))}</option>`).join("")}
+          >${esc(judulPos(p))}${
+            Number(p.jumlah_komponen) > 0 ? "" : " · tanpa penilaian"}</option>`).join("")}
       </select>
     </div>`;
 }


### PR DESCRIPTION
## What

Pos 0 is **Keberangkatan** and Pos 5 is **Kedatangan** — the same place, called Pos 0 on the way out and Pos 5 on the way back. Nothing is scored there. What is recorded is time, which already has its home: `kloter.jam_berangkat`, `closing_regu.jam_datang`, and `v_penalti_waktu`.

The soal relay also stops one pos earlier than `alur-lomba.md` claimed. Pos 4 hands out nothing, because after it the regu walks straight to the finish and there is nobody there to mark a paper. The estafet table and the `N = 2..5` formula are corrected.

## Why

The naming was the easy half. The half that matters is this:

`v_total_skor` counts missed pos as `(all pos − pos with a score)`. The moment Pos 0 and Pos 5 exist as rows, **every regu is counted as having skipped two pos that nobody can ever score.** Today that costs nothing, because `nilai_pos_terlewat` defaults to 0 — which is precisely what makes it dangerous. The fault sits quiet until someone changes a configuration number they are entitled to change, and then every participant loses points at once, for a reason that would take a long time to find.

The fix adds **no marker column**. "A pos that is scored" is already answerable from data that exists: a pos with at least one `wahana` row. A `dinilai` column would be a second source of truth for one fact, and one day the two would disagree. `v_total_skor`, `v_monitoring_input` and `v_progres_publik` now count only pos that have components.

`v_pos` exposes `jumlah_komponen` so the Input Pos screen can tell "not scored" from "not configured yet". Before this it told an operator opening Pos 0 that *"Admin harus mengisi komponennya dulu"* — accusing the first of being the second.

## Notes

The test guards the trap, not the symptom: **adding any pos without components must not change anyone's score.** Pos 0 and Pos 5 are only its first instance. Run against the old view definition it fails, with the numbers in the message:

```
ERROR: menambah satu pos tanpa komponen mengubah total pos dari 1005.00
       jadi 1105.00 — pos yang tidak dinilai ikut dihitung terlewat
```

`akun_panitia.pos` is deliberately *not* relaxed to accept 0. An operator pos account exists to enter scores; an account for a pos that is never scored is an account that can do nothing.

Full suite passes on PostgreSQL 18.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)