### PR TITLE
fix: tighten the pos sheet and drop unscored pos from the picker

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1999,7 +1999,10 @@ async function layarInputPos() {
     <div class="card">
       ${alatTabel({
         kiri: pilihPosHtml(s, semuaPos),
-        cariContoh: "Cari nomor dada, nama regu, atau organisasi…",
+        // Pendek dengan sengaja: kartunya kini selebar tabel, dan petunjuk
+        // panjang terpotong di tengah kata — yang justru lebih buruk daripada
+        // petunjuk singkat, karena terlihat seperti layar yang rusak.
+        cariContoh: "Cari nomor dada / regu / organisasi…",
         saringan: [
           { kode: "belum", label: "Belum lengkap" },
           { kode: "sudah", label: "Sudah lengkap" },
@@ -2030,7 +2033,8 @@ async function layarInputPos() {
               <th>Organisasi</th>
               <th>Golongan</th>
               ${komponen.map(k => `
-                <th class="text-center">${esc(k.name)}
+                <th class="text-center">
+                  <span class="kolom-nama">${esc(k.name)}</span>
                   <span class="kolom-petunjuk">${esc(petunjukKolom(k))}</span></th>`).join("")}
               <th class="text-center">Nilai<br>${esc(pos.bayangan ? pos.name : `Pos ${pos.nomor}`)}</th>
               <th class="text-center"><span class="visually-hidden">Status simpan</span></th>
@@ -2042,17 +2046,20 @@ async function layarInputPos() {
           menerima nomor dada. Lembar pos ini terisi sendiri begitu meja
           daftar ulang mulai jalan.</p>`}
       </div>
+      <!-- Keterangan duduk DI DALAM kartu. Di luar, ia melebar sendiri
+           mengikuti layar sementara kartunya menyusut mengikuti tabel, dan
+           dua tepi yang tidak sejajar terbaca seperti ada yang salah muat. -->
+      <p class="description" style="margin-top:.8rem">
+        Nilainya tersimpan sendiri begitu kamu pindah ke baris berikutnya —
+        tidak ada tombol Simpan yang bisa lupa ditekan. <strong>Baris hijau di
+        atas tabel adalah jawabannya:</strong> selama tulisannya "Data
+        Tersimpan" beserta jam sinkronisasinya, semua angka di layar ini sudah
+        ada di database. Kalau ia berubah merah, ada yang belum masuk —
+        angkanya tetap aman di layar dan dikirim sendiri begitu internet
+        kembali, jadi jangan tutup halaman ini sampai hijau lagi.
+        Enter = turun ke regu berikutnya di kolom yang sama.
+      </p>
     </div>
-    <p class="description" style="margin-top:.8rem">
-      Nilainya tersimpan sendiri begitu kamu pindah ke baris berikutnya —
-      tidak ada tombol Simpan yang bisa lupa ditekan. <strong>Baris hijau di
-      atas tabel adalah jawabannya:</strong> selama tulisannya "Semua
-      tersimpan" beserta jamnya, semua angka di layar ini sudah ada di
-      database. Kalau ia berubah merah, ada yang belum masuk — angkanya tetap
-      aman di layar dan dikirim sendiri begitu internet kembali, jadi jangan
-      tutup halaman ini sampai hijau lagi. Enter = turun ke regu berikutnya di
-      kolom yang sama.
-    </p>
   `));
 
   const tbody = document.getElementById("isi-tabel");
@@ -2142,7 +2149,7 @@ async function layarInputPos() {
     const gagal = baris.filter(t => t.dataset.keadaan === "gagal").length;
     const sibuk = baris.some(t => t.dataset.keadaan === "menyimpan");
     const putus = !navigator.onLine;
-    const cap = `Tersimpan terakhir ${jamDetik(jamSinkron)}`;
+    const cap = `Sinkronisasi Terakhir: ${jamDetik(jamSinkron)}`;
 
     if (gagal || putus) {
       // Keadaan paling berbahaya, jadi capnya diberi umur: "14:12:40
@@ -2162,7 +2169,7 @@ async function layarInputPos() {
     if (sibuk)  { pita.className = "pos-simpan menunggu"; pita.textContent = `Menyimpan… ${cap}`; return; }
     if (belum)  { pita.className = "pos-simpan menunggu"; pita.textContent = `${belum} baris belum tersimpan. ${cap}`; return; }
     pita.className = "pos-simpan aman";
-    pita.textContent = `✓ Semua tersimpan · ${cap}`;
+    pita.textContent = `✓ Data Tersimpan · ${cap}`;
   }
 
   function ulangYangGagal() {
@@ -2345,17 +2352,24 @@ async function layarInputPos() {
 
 /** Pemilih pos — hanya untuk admin. Operator pos melihat namanya saja, karena
  *  memberinya daftar pos lain hanya menawarkan sesuatu yang pasti ditolak
- *  server (RLS nilai_mentah) — pintu yang terkunci lebih baik tidak digambar. */
+ *  server (RLS nilai_mentah) — pintu yang terkunci lebih baik tidak digambar.
+ *
+ *  Yang muncul HANYA pos yang benar-benar dinilai. Pos 0 (Keberangkatan) dan
+ *  Pos 5 (Kedatangan) adalah garis start dan garis finish; yang dicatat di
+ *  sana waktu, lewat layar Keberangkatan dan Kedatangan. Menawarkannya di
+ *  sini berarti menawarkan lembar yang tidak akan pernah punya kolom — dan
+ *  daftar yang memuat pilihan tanpa isi mengajari orang bahwa daftar itu
+ *  tidak bisa dipercaya. */
 function pilihPosHtml(s, semuaPos) {
   if (s.peran !== "admin") return "";
+  const dinilai = semuaPos.filter(p => Number(p.jumlah_komponen) > 0);
   return `
     <div class="field" style="margin:0;min-width:210px">
       <label for="pilih-pos" class="visually-hidden">Pos yang diinput</label>
       <select id="pilih-pos" class="select-small">
-        ${semuaPos.map(p => `<option value="${esc(p.nomor)}"
+        ${dinilai.map(p => `<option value="${esc(p.nomor)}"
           ${Number(p.nomor) === Number(posDipilih.nomor) ? "selected" : ""}
-          >${esc(judulPos(p))}${
-            Number(p.jumlah_komponen) > 0 ? "" : " · tanpa penilaian"}</option>`).join("")}
+          >${esc(judulPos(p))}</option>`).join("")}
       </select>
     </div>`;
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2046,19 +2046,6 @@ async function layarInputPos() {
           menerima nomor dada. Lembar pos ini terisi sendiri begitu meja
           daftar ulang mulai jalan.</p>`}
       </div>
-      <!-- Keterangan duduk DI DALAM kartu. Di luar, ia melebar sendiri
-           mengikuti layar sementara kartunya menyusut mengikuti tabel, dan
-           dua tepi yang tidak sejajar terbaca seperti ada yang salah muat. -->
-      <p class="description" style="margin-top:.8rem">
-        Nilainya tersimpan sendiri begitu kamu pindah ke baris berikutnya —
-        tidak ada tombol Simpan yang bisa lupa ditekan. <strong>Baris hijau di
-        atas tabel adalah jawabannya:</strong> selama tulisannya "Data
-        Tersimpan" beserta jam sinkronisasinya, semua angka di layar ini sudah
-        ada di database. Kalau ia berubah merah, ada yang belum masuk —
-        angkanya tetap aman di layar dan dikirim sendiri begitu internet
-        kembali, jadi jangan tutup halaman ini sampai hijau lagi.
-        Enter = turun ke regu berikutnya di kolom yang sama.
-      </p>
     </div>
   `));
 

--- a/web/style.css
+++ b/web/style.css
@@ -79,6 +79,17 @@ body {
    sampai 1720px: masih ada tepi di monitor lebar, dan di laptop 1366px
    max-width tidak memaksa apa pun, ia hanya berhenti membatasi. */
 .isi.lembar { max-width: 1720px; }
+/* Kartunya menyusut mengikuti isinya lalu ditengahkan. Tanpa ini, tabel
+   ramping (Pos 2 cuma dua kolom nilai) duduk sendirian di dalam kartu putih
+   selebar 1720px, dan lahan kosong di kiri-kanannya terbaca seperti sesuatu
+   yang gagal dimuat. max-width menjaga kartu tetap menyusut di layar sempit. */
+.isi.lembar .card { width: fit-content; max-width: 100%; margin-inline: auto; }
+/* Paragraf keterangan DIBATASI, kalau tidak ia yang menentukan lebar kartu.
+   `width: fit-content` mengukur dari isi TERLEBAR, dan satu paragraf panjang
+   yang boleh berbaris tunggal jauh lebih lebar daripada tabelnya — kartunya
+   pun kembali melar ke batas atas, persis yang ingin dihindari. 62ch juga
+   kebetulan panjang baris yang enak dibaca. */
+.isi.lembar .card > p.description { max-width: 62ch; }
 
 /* ---------- kartu ---------- */
 
@@ -1196,13 +1207,39 @@ input.small-input { text-align: center; }
    lagi tahu sedang menilai regu yang mana.
    ========================================================================== */
 
-.table-pos { table-layout: auto; min-width: 100%; }
-.table-pos th, .table-pos td { padding: .4rem .45rem; white-space: nowrap; }
+/* Tabel selebar ISINYA, lalu ditengahkan — TIDAK diregangkan memenuhi kartu.
+   Sempat sebaliknya (min-width: 100%), dan akibatnya terasa persis di tangan:
+   lebar sisa dibagi rata ke semua kolom, jadi kotak isian saling menjauh dan
+   perjalanan dari kolom pertama ke kolom terakhir jadi jauh lebih panjang
+   daripada yang dibutuhkan. Yang dikerjakan petugas adalah deretan kotak itu;
+   mereka harus berdempetan, bukan tersebar selebar layar. */
+.table-pos { table-layout: auto; width: auto; min-width: 0; margin: 0 auto; }
+.table-pos th, .table-pos td { padding: .4rem .45rem; }
+/* Isi sel tidak membungkus; JUDUL kolom justru harus. */
+.table-pos td { white-space: nowrap; }
+.table-pos thead th { white-space: normal; }
 /* Nama regu dan organisasi boleh membungkus — keduanya satu-satunya isi yang
    panjangnya tak terduga, dan tanpa ini merekalah yang mendorong seluruh
    kolom nilai keluar layar. */
 .table-pos td:nth-child(2), .table-pos td:nth-child(3) {
-  white-space: normal; min-width: 9rem;
+  white-space: normal; min-width: 8rem;
+}
+
+/* Nama kolom penilaian dipatok 6rem lalu dibiarkan membungkus. Tanpa patokan
+   ini "BALAP KARUNG" dan "KEPRAMUKAAN KEAGAMAAN" berdiri satu baris dan
+   MEREKALAH yang menentukan lebar kolomnya — kotak isian selebar 4,5rem lalu
+   mengambang di tengah petak dua kali lebarnya. Block, bukan inline: hanya
+   block yang menghormati max-width di dalam sel tabel. */
+/* 7,25rem = 116px, cukup untuk kata terpanjang yang ada sekarang
+   ("KEPRAMUKAAN" butuh 113px). Patokan ini TIDAK melebarkan kolom lain:
+   tiap kolom tetap seukuran judulnya sendiri, dan "SEMAPHORE" berhenti di
+   91px. overflow-wrap adalah jaring pengamannya — nama komponen ditulis
+   panitia tiap tahun, dan kata yang lebih panjang lagi harus memotong diri
+   sendiri, bukan meluap menabrak kolom sebelahnya (yang persis terjadi saat
+   patokannya masih 6rem). */
+.kolom-nama {
+  display: block; max-width: 7.25rem; margin: 0 auto;
+  overflow-wrap: break-word;
 }
 
 /* Rentang yang boleh diketik, di bawah nama kolomnya — sama seperti "(0 - 20)"

--- a/web/style.css
+++ b/web/style.css
@@ -84,12 +84,6 @@ body {
    selebar 1720px, dan lahan kosong di kiri-kanannya terbaca seperti sesuatu
    yang gagal dimuat. max-width menjaga kartu tetap menyusut di layar sempit. */
 .isi.lembar .card { width: fit-content; max-width: 100%; margin-inline: auto; }
-/* Paragraf keterangan DIBATASI, kalau tidak ia yang menentukan lebar kartu.
-   `width: fit-content` mengukur dari isi TERLEBAR, dan satu paragraf panjang
-   yang boleh berbaris tunggal jauh lebih lebar daripada tabelnya — kartunya
-   pun kembali melar ke batas atas, persis yang ingin dihindari. 62ch juga
-   kebetulan panjang baris yang enak dibaca. */
-.isi.lembar .card > p.description { max-width: 62ch; }
 
 /* ---------- kartu ---------- */
 


### PR DESCRIPTION
## What

Four things asked for after using the widened screen.

**The score boxes now sit together.** Widening the container to 1720px was only half the fix — `min-width: 100%` on the table then stretched it to fill, and the leftover width was shared out to every column. The table takes its content width and centres; the card shrinks with it.

| Pos | Card before | Card after |
| --- | --- | --- |
| 1 — Keagamaan dan Kepramukaan | 1694px | 1210px |
| 2 — Kesehatan dan Pengetahuan Umum | 1694px | 1138px |
| 3 — Games | 1694px | 1160px |
| 4 — Praktik Kesehatan | 1694px | 1138px |
| Bayangan — Kostum | 1694px | 1138px |

No horizontal scroll on any of them. Component headers wrap inside a 7.25rem block instead of each standing on one line and setting the column width from the label rather than from the input.

**Pos 0 (Keberangkatan) and Pos 5 (Kedatangan) are gone from the pos picker.** They will never have a column to fill, and a list that offers choices with nothing in them teaches people the list cannot be trusted.

**Wording, from the panitia:** `Data Tersimpan · Sinkronisasi Terakhir: 04:08:35`.

**The help paragraph under the table is gone.** Not needed: the green line already says what it says, and the panitia check the sheet themselves at the end — which is what the "Belum lengkap" filter is for.

## Why

The effect of a stretched table is felt in the hand, not the eye: the run from the first score box to the last was much longer than it needed to be, on the one screen where somebody types across a row three hundred times.

## Notes

Two defects found by looking rather than by reasoning:

- **"KEPRAMUKAAN" needs 113px** and was overflowing its 96px box into the neighbouring column. The cap is now 7.25rem, with `overflow-wrap` as the safety net — component names are written fresh by the panitia every year, and a longer one must break itself rather than collide.
- **Putting the help text inside the card made that paragraph set the card's width.** `width: fit-content` measures the widest child, and one long paragraph allowed to sit on a single line is far wider than the table — which put the card straight back at the 1720px it had just been taken off. Removing the paragraph removed the problem with it.

**Access is unchanged, and was already right.** An operator pos account never sees a picker at all; which pos it may touch is decided by the database — `pos_saya()`, the RLS policy on `nilai_mentah`, and the guards inside `simpan_nilai_massal` and `hapus_nilai_pos` — not by what the screen draws. `tests/sql/08` asserts both halves: pos 1 sees only pos 1 rows, and pos 1 is refused when it tries to clear a pos 4 value.

Nothing here touches the database. The SQL suite still passes on PostgreSQL 18.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)