### PR TITLE
fix: fill the card width but keep the pos columns packed left

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2060,7 +2060,7 @@ async function layarInputPos() {
         <td class="text-center" data-label="${esc(k.name)}">
           ${selKomponen(k, (r.nilai || {})[k.kode])}</td>`).join("")}
       <td class="text-center pos-nilai" data-label="Nilai Pos">${esc(angkaRapi(r.nilai_pos))}</td>
-      <td class="text-center pos-status" data-label=""></td>
+      <td class="pos-status" data-label=""></td>
     </tr>`).join("")));
 
   /* ---------- keadaan simpan per baris ----------

--- a/web/style.css
+++ b/web/style.css
@@ -79,11 +79,6 @@ body {
    sampai 1720px: masih ada tepi di monitor lebar, dan di laptop 1366px
    max-width tidak memaksa apa pun, ia hanya berhenti membatasi. */
 .isi.lembar { max-width: 1720px; }
-/* Kartunya menyusut mengikuti isinya lalu ditengahkan. Tanpa ini, tabel
-   ramping (Pos 2 cuma dua kolom nilai) duduk sendirian di dalam kartu putih
-   selebar 1720px, dan lahan kosong di kiri-kanannya terbaca seperti sesuatu
-   yang gagal dimuat. max-width menjaga kartu tetap menyusut di layar sempit. */
-.isi.lembar .card { width: fit-content; max-width: 100%; margin-inline: auto; }
 
 /* ---------- kartu ---------- */
 
@@ -1201,23 +1196,34 @@ input.small-input { text-align: center; }
    lagi tahu sedang menilai regu yang mana.
    ========================================================================== */
 
-/* Tabel selebar ISINYA, lalu ditengahkan — TIDAK diregangkan memenuhi kartu.
-   Sempat sebaliknya (min-width: 100%), dan akibatnya terasa persis di tangan:
-   lebar sisa dibagi rata ke semua kolom, jadi kotak isian saling menjauh dan
-   perjalanan dari kolom pertama ke kolom terakhir jadi jauh lebih panjang
-   daripada yang dibutuhkan. Yang dikerjakan petugas adalah deretan kotak itu;
-   mereka harus berdempetan, bukan tersebar selebar layar. */
-.table-pos { table-layout: auto; width: auto; min-width: 0; margin: 0 auto; }
+/* Tabelnya MEMENUHI kartu, tapi kolomnya tetap rapat di kiri. Dua hal yang
+   kedengarannya bertentangan, dan keduanya memang dibutuhkan:
+
+   - Kalau tabel dibiarkan selebar isinya saja, kartu putihnya ikut menyusut
+     dan tepi kanannya berhenti di tengah layar.
+   - Kalau lebar sisanya dibagi rata ke semua kolom (perilaku bawaan tabel
+     selebar 100%), kotak isian saling menjauh — dan itu terasa di tangan,
+     bukan di mata: perjalanan dari kolom pertama ke kolom terakhir jadi jauh
+     lebih panjang daripada yang dibutuhkan, tiga ratus kali sehari.
+
+   Jalan keluarnya ada di kolom TERAKHIR (lihat aturan .pos-status di bawah):
+   satu kolom diberi width 100% sehingga ia menelan SELURUH sisa lebar, dan
+   kolom lain berhenti di ukuran isinya masing-masing. */
+.table-pos { table-layout: auto; width: 100%; min-width: 0; }
 .table-pos th, .table-pos td { padding: .4rem .45rem; }
 /* Isi sel tidak membungkus; JUDUL kolom justru harus. */
 .table-pos td { white-space: nowrap; }
 .table-pos thead th { white-space: normal; }
-/* Nama regu dan organisasi boleh membungkus — keduanya satu-satunya isi yang
-   panjangnya tak terduga, dan tanpa ini merekalah yang mendorong seluruh
-   kolom nilai keluar layar. */
-.table-pos td:nth-child(2), .table-pos td:nth-child(3) {
-  white-space: normal; min-width: 8rem;
-}
+/* Nama regu dan organisasi TIDAK membungkus. Sempat boleh, dan begitu kolom
+   terakhir jadi serakah merekalah yang membayar: keduanya menyusut sampai
+   batas bawahnya dan "KALAKI RACING" pecah jadi dua baris, sementara 695px
+   menganggur di ujung kanan. Kolom yang boleh membungkus selalu kalah dari
+   kolom yang menuntut lebar.
+
+   Aman karena sisa lebarnya besar: nama harus mencapai ~90 huruf sebelum
+   tabelnya benar-benar meluap, dan kalaupun itu terjadi, kolom Nomor Dada
+   sudah dipatok di tepi kiri sehingga barisnya tetap bisa dikenali. */
+.table-pos td:nth-child(2), .table-pos td:nth-child(3) { white-space: nowrap; }
 
 /* Nama kolom penilaian dipatok 6rem lalu dibiarkan membungkus. Tanpa patokan
    ini "BALAP KARUNG" dan "KEPRAMUKAAN KEAGAMAAN" berdiri satu baris dan
@@ -1262,7 +1268,13 @@ input.small-input { text-align: center; }
 .pos-nilai {
   font-weight: 800; font-variant-numeric: tabular-nums; font-size: 1.05rem;
 }
-.pos-status { width: 5rem; }
+/* Kolom penyerap. width 100% pada SATU kolom tabel auto-layout membuatnya
+   mengambil semua lebar yang tersisa, sehingga kolom lain tidak ikut melar.
+   Isinya (tanda ✓ / tombol Ulangi) tetap menempel kiri, jadi ia berdiri
+   persis di sebelah Nilai Pos dan lahan kosongnya jatuh di ujung kanan —
+   tempat yang memang tidak dikerjakan siapa pun. */
+.table-pos th:last-child, .table-pos td:last-child { width: 100%; }
+.pos-status { text-align: left; padding-left: .8rem; }
 
 /* Baris yang gagal tersimpan. Diberi warna SEBARIS PENUH, bukan hanya di
    kolom statusnya: petugas sedang menatap kolom nilai di tengah tabel, dan


### PR DESCRIPTION
## What

Two things that sound contradictory and are both wanted: the table should reach the right edge of the card, and the score boxes should stay close together.

- Table at its content width satisfied the second and broke the first — the white card stopped in the middle of the screen.
- Table stretched to 100% satisfies the first and breaks the second — the leftover width is shared out to every column and the boxes drift apart again.

The slack now goes to **one** column. `width: 100%` on the last column of an auto-layout table makes it swallow everything left over, so every other column stops at its own content width. The empty space lands at the far right, where nobody is working, and the ✓ sits immediately after Nilai Pos because that column's content stays left-aligned.

```
Pos 1:  70  152 137 115 | 125 102 86 74 86 | 53 | 663 kosong
Pos 2:  70  152 137 115 | 121  86          | 53 | 930 kosong
Pos 3:  70  152 137 115 |  86  86 86 86 86 | 53 | 705 kosong
```

Card is 1694px on every pos, table 1664px, horizontal scroll 0.

## Why

The card had to stay full width — a white panel ending mid-screen looks like something failed to load. But the run from the first score box to the last is walked three hundred times a day, so it has to stay short. Giving the slack to a single trailing column is what satisfies both.

## Notes

**A regression came with it and is fixed here too.** Nama regu and organisasi were allowed to wrap, and a column that *may* wrap always loses to a column that *demands* width: both shrank to their floor and "KALAKI RACING" broke across two lines while 695px sat idle at the right. They are `nowrap` now — safe, because a name would have to reach ~90 characters before the table genuinely overflows, and the nomor dada column is pinned to the left edge so a row stays identifiable even then.

**Not verified this round: the phone layout.** The browser window refused to resize (viewport stayed at 1920 despite the tool reporting success), so the ≤560px path was reasoned about rather than looked at. The only change reaching it is `nowrap` on two columns, on a screen that is already designed to scroll sideways there — but it was not seen, and this note is here so nobody assumes it was.

Nothing here touches the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)