### PR TITLE
feat: print a blank score sheet for writing at the pos

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -169,6 +169,47 @@ Tiga hal yang menentukan layar ini benar atau tidak:
    database. Menghitungnya di browser akan melahirkan mesin skor kedua yang
    suatu hari berbeda pendapat dengan `v_poin_pos`.
 
+#### Lembar cetak untuk ditulis tangan
+
+Tombol **Cetak Lembar** mengeluarkan versi kertas dari pos yang sedang dibuka
+(`alur-lomba.md` 8.6): identitas regu sudah tercetak, kolom nilainya kosong,
+dan judul posnya ikut di dalam `<thead>` sehingga terulang di tiap halaman —
+kertas ini beredar sebagai lembaran lepas yang berpindah tangan lewat foto,
+dan halaman yang tidak menyebutkan posnya sendiri bisa dinilaikan ke pos yang
+salah.
+
+Dua keputusan yang membentuknya:
+
+- **Tidak ada kolom Nilai Pos di kertas.** Petugas lapangan hanya mencatat
+  data mentah dan tidak pernah menghitung poin (`alur-lomba.md` 8.1);
+  menyediakan kotak berjudul "Nilai Pos" mengundang mereka menjumlahkan
+  sendiri, dan angka tangan yang berbeda dengan angka sistem adalah sengketa
+  yang tidak perlu ada.
+- **Yang dicetak adalah baris yang sedang TAMPIL.** Satu tombol melayani dua
+  kebutuhan: sebelum lomba saring "Semua" untuk lembar kosong; di tengah
+  lomba saring "Belum lengkap" dulu supaya kertas susulan hanya memuat regu
+  yang memang belum dinilai.
+
+Kalau `daftar_ulang_ditutup` masih `false`, kertasnya membawa peringatan
+tercetak bahwa regu yang mendaftar ulang setelahnya tidak ada di sana.
+
+**A4 landscape, 12pt, 20 regu per lembar.** Ketiganya terikat satu sama lain
+dan angkanya hasil ukur, bukan pilihan:
+
+- Panitia meminta huruf 12pt, sama dengan cetakan Excel yang selama ini
+  dipakai — yang tertulis di sana dibaca lagi dari **foto**, oleh orang lain,
+  di layar laptop.
+- Di 12pt tabel Pos 1 selebar 201mm, sedangkan A4 potret hanya menyediakan
+  180mm. Karena itu lembar ini memakai halaman bernama (`@page lembar-pos`)
+  supaya **hanya ia** yang berputar; kwitansi dan daftar kloter tetap potret.
+- Tinggi barisnya ternyata ditentukan `line-height`, bukan tinggi kotak
+  isiannya. Dirapatkan ke 1,15, satu halaman memuat 21–23 baris — 21 di pos
+  yang kepala halamannya paling tinggi. Dipatok **20**, satu baris di bawah
+  yang paling sesak, karena halaman yang tumpah tidak menimbulkan galat apa
+  pun: ia hanya menghasilkan setumpuk kertas yang salah.
+
+Tiga puluh baris per lembar sempat dicoba dan hanya mungkin pada huruf 8,5pt.
+
 #### Pita keadaan simpan
 
 Di pos, internet putus adalah kejadian biasa — dan angka yang hanya ada di

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -130,6 +130,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select label, menit from kontrak_opsi "
                     "where edisi = edisi_aktif() order by sort_order",
                     uid=p.get("uid")))
+            elif u.path == "/status":
+                self._kirim(200, q(
+                    "select * from status_acara", uid=p.get("uid"), fetch="one"))
             elif u.path == "/pos":
                 self._kirim(200, q(
                     "select * from v_pos order by nomor", uid=p.get("uid")))

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -327,6 +327,16 @@ export async function cariRegu(nomorDada) {
   return d.length ? d[0] : null;
 }
 
+/** Saklar hari-H: daftar_ulang_ditutup, fase_live, konfigurasi_terkunci.
+ *  Dipakai layar cetak untuk memperingatkan bahwa kertas yang dicetak
+ *  sebelum daftar ulang ditutup pasti kehilangan regu yang datang setelahnya. */
+export async function statusAcara() {
+  const d = K.mode === "dev"
+    ? await baca("/status")
+    : await baca(null, "status_acara?select=*");
+  return Array.isArray(d) ? d[0] : d;
+}
+
 /** Angka penalti edisi aktif — dipakai layar finish untuk menunjukkan apakah
  *  selisih jam kertas vs laptop benar-benar mengubah penalti. */
 export async function infoPenalti() {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -18,6 +18,7 @@ import {
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
+  statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamSekarang, notif, dialog, kartuGagalMuat } from "./util.js";
 
@@ -275,7 +276,7 @@ function layarGantiPassword() {
  *  Menyaring di browser (data sudah dimuat semua) supaya hasilnya berubah
  *  seketika sambil mengetik — di meja, menunggu server tiap huruf terasa
  *  seperti aplikasi macet. */
-function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "" }) {
+function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "", kanan = "" }) {
   return `
     <div class="table-toolbar">
       ${kiri}
@@ -290,6 +291,7 @@ function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "" }) {
                   aria-pressed="${s.kode === saringAktif}">${esc(s.label)}</button>`).join("")}
       </div>
       <span class="table-count" id="tabel-jumlah">${jumlah} baris</span>
+      ${kanan}
     </div>`;
 }
 
@@ -1900,6 +1902,111 @@ function bacaSel(tr, k) {
   return v === "" ? null : { nilai_1: Number(v), nilai_2: null };
 }
 
+/** Kolom KERTAS untuk satu komponen. Sebagian komponen memakan dua kolom,
+ *  dan pembagiannya sama persis dengan kotak di layar — supaya petugas yang
+ *  menyalin dari kertas ke layar menemukan urutan yang sama, tidak perlu
+ *  mencocokkan apa pun di kepalanya. */
+const kolomCetakPos = (komponen) => komponen.flatMap(k => {
+  if (k.satuan === "detik") return [
+    { nama: k.name, petunjuk: "menit" }, { nama: "", petunjuk: "detik" }];
+  if (k.form === "benar_kurang_salah") return [
+    { nama: k.name, petunjuk: "benar" }, { nama: "", petunjuk: "salah" }];
+  return [{ nama: k.name, petunjuk: petunjukKolom(k) }];
+});
+
+/** Lembar nilai untuk DITULIS TANGAN di pos (alur-lomba.md 8.6).
+ *
+ *  Identitas regu sudah tercetak, kolom nilainya kosong. Satu hal yang
+ *  sengaja TIDAK ada di kertas ini: kolom Nilai Pos. Petugas lapangan hanya
+ *  mencatat data mentah dan tidak pernah menghitung poin (alur-lomba.md 8.1)
+ *  — menyediakan kotak berjudul "Nilai Pos" justru mengundang mereka
+ *  menjumlahkan sendiri, dan angka hasil hitungan tangan yang berbeda dengan
+ *  angka sistem adalah sengketa yang tidak perlu ada.
+ *
+ *  Nama pos ikut di dalam <thead>, bukan hanya di judul halaman pertama.
+ *  Kertas ini beredar sebagai lembaran lepas yang berpindah tangan lewat
+ *  foto; halaman yang tidak menyebutkan posnya sendiri bisa dinilaikan ke
+ *  pos yang salah. Browser mengulang <thead> di tiap halaman, jadi itu
+ *  gratis. */
+/** Regu per lembar A4 landscape. Dipatok, bukan diserahkan ke pemenggalan
+ *  otomatis browser: dengan 300 regu, halaman yang dipenggal sendiri bisa
+ *  memotong satu baris di tengah, dan angka pastinya juga yang menentukan
+ *  berapa lembar harus difotokopi.
+ *
+ *  Angkanya HASIL UKUR, bukan pilihan. Huruf 12pt (permintaan panitia, sama
+ *  dengan cetakan Excel yang selama ini dipakai) memaksa dua hal sekaligus:
+ *  tabel Pos 1 jadi selebar 201mm sehingga kertas harus landscape, dan
+ *  tinggi baris jadi 25px sehingga satu halaman hanya memuat 21-23 baris —
+ *  21 di pos yang paling sesak (Pos 2 dan Pos 4, yang kepala halamannya
+ *  paling tinggi).
+ *
+ *  Dipatok 20, satu baris di bawah yang paling sesak. Cadangan itu ada
+ *  supaya nama regu yang lebih panjang atau nama pos yang lebih panjang
+ *  tahun depan tidak diam-diam menumpahkan baris terakhir ke halaman
+ *  berikutnya — dan halaman tumpah tidak menimbulkan galat apa pun, ia cuma
+ *  menghasilkan setumpuk kertas yang salah. */
+const REGU_PER_LEMBAR = 20;
+
+function siapkanCetakLembarPos(pos, komponen, baris, daftarUlangDitutup) {
+  document.getElementById("cetakan")?.remove();
+
+  const kolom = kolomCetakPos(komponen);
+  const judul = pos.bayangan ? `POS BAYANGAN — ${pos.name}`
+                             : `POS ${pos.nomor} — ${pos.name}`;
+  const tanggal = new Date().toLocaleDateString("id-ID",
+    { day: "numeric", month: "long", year: "numeric" });
+
+  const halaman = [];
+  for (let i = 0; i < baris.length; i += REGU_PER_LEMBAR) {
+    halaman.push(baris.slice(i, i + REGU_PER_LEMBAR));
+  }
+
+  // Sel identitas lewat tag html`` (isinya diketik orang luar); kotak kosong
+  // ditempel sebagai HTML biasa karena memang tidak ada isinya.
+  const barisHtml = (r) => `
+    <tr>
+      ${html`<td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
+      <td>${r.nama_regu}</td>
+      <td>${r.nama_sekolah}</td>
+      <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>`}
+      ${kolom.map(() => `<td class="isian"></td>`).join("")}
+    </tr>`;
+
+  // Tiap lembar berdiri sendiri: judul pos, nomor halaman, dan baris tanda
+  // tangannya sendiri. Kertas ini beredar sebagai lembaran lepas yang
+  // berpindah tangan lewat foto — halaman yang tidak menyebutkan posnya
+  // sendiri bisa dinilaikan ke pos yang salah.
+  const lembar = halaman.map((grup, i) => `
+    <section class="print-page lembar-pos">
+      <h1>LEMBAR NILAI · ${esc(judul)}
+        <span class="halaman">Halaman ${i + 1} dari ${halaman.length}</span></h1>
+      <p class="lembar-kepala"><strong>${esc(EDISI ? EDISI.name : "")}</strong> ·
+         ${esc(tanggal)} · nomor dada
+         ${esc(String(grup[0].nomor_dada).padStart(3, "0"))}–${esc(String(grup[grup.length - 1].nomor_dada).padStart(3, "0"))}
+         (${esc(String(grup.length))} regu) &nbsp;·&nbsp;
+         Petugas: ________________ &nbsp; Diperiksa: ________________</p>
+      ${daftarUlangDitutup ? "" : `<p class="insert-note">DAFTAR ULANG BELUM
+        DITUTUP — regu yang mendaftar ulang setelah kertas ini dicetak TIDAK
+        ada di sini. Cetak ulang setelah daftar ulang ditutup.</p>`}
+      <table class="print-table">
+        <thead>
+          <tr>
+            <th>No Dada</th><th>Nama Regu</th><th>Organisasi</th><th>Golongan</th>
+            ${kolom.map(c => `<th class="isian">${esc(c.nama)}
+              <span class="kolom-petunjuk">${esc(c.petunjuk)}</span></th>`).join("")}
+          </tr>
+        </thead>
+        <tbody>${grup.map(barisHtml).join("")}</tbody>
+      </table>
+      ${i === 0 ? `<p class="print-note">Tulis data mentahnya apa adanya —
+         jumlah benar, jumlah kena, atau waktu. JANGAN menjumlahkan sendiri;
+         sistem yang mengubahnya jadi poin. Foto lembar ini secara berkala dan
+         kirimkan ke operator IT pos, jangan ditumpuk sampai pos tutup.</p>` : ""}
+    </section>`).join("");
+
+  document.body.appendChild(h(`<div id="cetakan" class="printout">${lembar}</div>`));
+}
+
 /** Layar Input Pos — lembar kertas yang dipindah ke layar.
  *
  *  Bentuknya sengaja SAMA dengan lembar Google Sheets yang dipakai panitia
@@ -1999,6 +2106,8 @@ async function layarInputPos() {
     <div class="card">
       ${alatTabel({
         kiri: pilihPosHtml(s, semuaPos),
+        kanan: `<button class="button button-secondary button-small" type="button"
+                        id="cetak-lembar">🖨️ Cetak Lembar</button>`,
         // Pendek dengan sengaja: kartunya kini selebar tabel, dan petunjuk
         // panjang terpotong di tengah kata — yang justru lebih buruk daripada
         // petunjuk singkat, karena terlihat seperti layar yang rusak.
@@ -2324,6 +2433,29 @@ async function layarInputPos() {
     document.getElementById("tabel-jumlah").textContent =
       `${tampil} ditampilkan · ${sudah}/${baris.length} lengkap`;
   }
+
+  /* ---------- cetak lembar kosong ---------- */
+
+  // Yang dicetak adalah baris yang SEDANG TAMPIL, bukan selalu semuanya.
+  // Dua kebutuhan berbeda terlayani satu tombol: sebelum lomba cetak "Semua"
+  // untuk lembar kosong, dan di tengah lomba saring "Belum lengkap" dulu
+  // supaya kertas susulan hanya memuat regu yang memang belum dinilai.
+  document.getElementById("cetak-lembar").addEventListener("click", async () => {
+    const tampil = [...tbody.children].filter(tr => !tr.hidden)
+      .map(tr => lembar.find(r => Number(r.nomor_dada) === Number(tr.dataset.dada)))
+      .filter(Boolean);
+    if (!tampil.length) { notif("Tidak ada baris yang bisa dicetak.", true); return; }
+
+    // Dibaca saat menekan, bukan saat layar dimuat: layar pos sering
+    // dibiarkan terbuka berjam-jam, dan status daftar ulang berubah di
+    // tengahnya. Gagal membacanya tidak boleh menghalangi cetak — paling
+    // buruk peringatannya ikut tercetak padahal sudah tidak berlaku.
+    let ditutup = false;
+    try { ditutup = !!(await statusAcara()).daftar_ulang_ditutup; } catch { /* cetak tetap jalan */ }
+
+    siapkanCetakLembarPos(pos, komponen, tampil, ditutup);
+    window.print();
+  });
 
   pasangAlatTabel((cari, saring) => {
     [...tbody.children].forEach(tr => {

--- a/web/style.css
+++ b/web/style.css
@@ -478,6 +478,81 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
   .print-note { font-size: 9pt; color: #333; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
+
+  /* ---- Lembar nilai pos: kertas yang ditulis tangan di lapangan ----
+     Kotak isiannya harus cukup untuk angka dua digit yang ditulis buru-buru
+     sambil berdiri, dan tingginya juga — menulis di kotak setinggi baris
+     teks memaksa orang menulis kecil, lalu angka kecil itu difoto dan harus
+     dibaca operator di layar laptop. */
+  .print-table td.isian { width: 15mm; height: 11mm; }
+  .print-table th.isian { width: 15mm; font-size: 8pt; }
+  /* Rentang yang boleh ditulis, di bawah nama kolomnya — sama seperti di
+     layar, supaya petugas tidak perlu mengingat skalanya. */
+  .print-table th .kolom-petunjuk {
+    display: block; max-width: none; font-size: 7pt; font-weight: 400;
+    text-transform: none; margin-top: 1pt;
+  }
+  /* ---- Lembar nilai pos: A4 LANDSCAPE ----
+     Halaman bernama, supaya HANYA lembar ini yang berputar — kwitansi dan
+     daftar kloter tetap potret. Landscape bukan selera: dengan huruf 12pt,
+     tabel Pos 1 selebar 201mm dan kertas potret cuma menyediakan 180mm.
+     Diukur, bukan dikira. */
+  @page lembar-pos { size: A4 landscape; margin: 10mm; }
+  .lembar-pos { page: lembar-pos; }
+
+  /* ---- kerapatan baris ----
+     Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan
+     kaki. Karena itu SEMUANYA di lembar ini lebih rapat daripada cetakan lain
+     di sistem — kwitansi dan daftar kloter tidak dibatasi jumlah barisnya,
+     lembar ini iya. Angka-angka di bawah hasil pengukuran, bukan perkiraan. */
+  .lembar-pos h1 { font-size: 12pt; margin-bottom: 2pt; }
+  .lembar-pos h1 .halaman { float: right; font-size: 9pt; font-weight: 400; }
+  .lembar-pos .lembar-kepala { font-size: 8.5pt; margin: 0 0 3pt; }
+  .lembar-pos .insert-note { font-size: 8pt; margin: 0 0 3pt; }
+  .lembar-pos .print-note { font-size: 7.5pt; margin-top: 3pt; }
+  .lembar-pos .print-table { margin-top: 0; }
+  /* 12pt untuk ISI — ukuran yang sama dengan cetakan Excel yang selama ini
+     dipakai panitia, dan memang seharusnya: yang tertulis di sini dibaca
+     lagi dari FOTO, oleh orang lain, di layar laptop. Tinggi baris tidak
+     ikut bertambah karena yang menentukannya kotak 7mm, bukan hurufnya
+     (12pt hanya ~4,2mm). JUDUL kolom tetap kecil — ia label, bukan data,
+     dan di 12pt "KEPRAMUKAAN KEAGAMAAN" akan memakan lebar yang dibutuhkan
+     kotak isiannya. */
+  .lembar-pos .print-table th, .lembar-pos .print-table td {
+    padding: 1pt 4pt; font-size: 12pt;
+    /* Jarak antarbaris huruf dirapatkan. Inilah yang sebenarnya menentukan
+       tinggi baris di sini — BUKAN tinggi kotak isiannya. Dengan line-height
+       bawaan (1,6) satu baris setinggi 32px meski kotaknya diminta 6mm, dan
+       selisih itu langsung berarti beberapa baris lebih sedikit per lembar. */
+    line-height: 1.15;
+  }
+  .lembar-pos .print-table th { font-size: 8pt; }
+  .lembar-pos .print-table .dada { font-size: 14pt; width: 15mm; }
+  /* Tinggi kotak tulis: 6mm. Sedikit lebih rapat dari garis buku tulis
+     (7-8mm) tapi masih nyaman untuk angka dua digit — dan tiap milimeter di
+     sini berharga satu baris per halaman, yang berlipat jadi lembaran
+     fotokopi untuk 300 regu dikali lima pos. */
+  .lembar-pos .print-table td.isian { height: 6mm; }
+  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian { width: 14mm; }
+  /* Identitas TIDAK boleh membungkus di sini: satu nama yang pecah dua baris
+     menambah tinggi satu baris, dan tiga puluh baris yang dipatok mati tidak
+     punya ruang untuk itu — lembarnya akan tumpah ke halaman berikutnya. */
+  .lembar-pos .print-table td:nth-child(2),
+  .lembar-pos .print-table td:nth-child(3),
+  .lembar-pos .print-table td:nth-child(4) {
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
+     lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
+     kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
+     dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
+     cek silang. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 38mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 40mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
+     tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
+  .print-table td { overflow-wrap: break-word; }
 }
 
 @page { margin: 12mm; }


### PR DESCRIPTION
## What

The paper form promised in `alur-lomba.md` 8.6 and never built. A **Cetak Lembar** button on the pos screen produces the paper version of the pos that is open: regu identity already printed, score columns empty.

- **The pos name rides in the header of every sheet**, not just the first. These pages circulate as loose paper that changes hands by photograph, and a page that does not name its own pos can be scored into the wrong one. Each sheet also carries its nomor dada range and `Halaman N dari M`.
- **What gets printed is what is currently shown.** One button serves two needs: before the event filter "Semua" for blank forms; during the event filter "Belum lengkap" first, so catch-up sheets carry only the regu still unscored.
- If `daftar_ulang_ditutup` is still `false`, the sheet carries a printed warning that regu registering later are not on it.

## Why

**No Nilai Pos column on the paper.** Field officers only record raw data and never compute points (`alur-lomba.md` 8.1). Printing a box headed "Nilai Pos" invites them to add it up themselves, and a hand-computed number that disagrees with the system's is a dispute that never needed to exist.

## Notes

**A4 landscape, 12pt, 20 regu per sheet — three numbers tied to each other, measured rather than chosen.**

| | |
| --- | --- |
| 12pt | What the panitia asked for, matching the Excel printout they already use. What is written there gets read again from a photo, by somebody else, on a laptop screen. |
| Landscape | At 12pt the Pos 1 table is **201mm** wide; A4 portrait offers **180mm**. So this sheet uses a named page (`@page lembar-pos`) and turns on its own — receipts and kloter lists stay portrait. |
| 20 rows | Row height turned out to be set by `line-height`, not by the height of the writing box — 32px at the default 1.6 even with a 6mm box. Tightened to 1.15, a page holds 21–23 rows; **21** at the pos with the tallest header. Pinned to 20, one row below the tightest. |

The margin of one row exists because **a page that overflows raises no error at all** — it just produces a stack of wrong paper, discovered at the pos.

Thirty rows per sheet was tried first and is only possible at 8.5pt, which is what prompted the 12pt request.

Verified by applying the `@media print` rules to the screen and measuring every pos against the real A4 landscape print area (277 × 190mm): every page fits in both directions, on all five scored pos, with 81 regu of test data.

No database changes. SQL suite still passes on PostgreSQL 18.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)