### PR TITLE
fix: centre the printed score form

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -505,8 +505,21 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kaki. Karena itu SEMUANYA di lembar ini lebih rapat daripada cetakan lain
      di sistem — kwitansi dan daftar kloter tidak dibatasi jumlah barisnya,
      lembar ini iya. Angka-angka di bawah hasil pengukuran, bukan perkiraan. */
-  .lembar-pos h1 { font-size: 12pt; margin-bottom: 2pt; }
-  .lembar-pos h1 .halaman { float: right; font-size: 9pt; font-weight: 400; }
+  /* Semuanya DITENGAHKAN, mengikuti bentuk lembar Excel yang selama ini
+     dipakai panitia. Bukan sekadar selera: kolom identitas di sini lebarnya
+     dipatok dan isinya jauh lebih pendek dari patokannya ("Penegak PA" di
+     petak 26mm), jadi rata kiri meninggalkan pita kosong di tiap kolom dan
+     mata harus mencari-cari di mana satu kolom berakhir. Ditengahkan, tiap
+     petak punya titik berat sendiri. */
+  .lembar-pos .print-table th, .lembar-pos .print-table td { text-align: center; }
+  .lembar-pos h1 { font-size: 12pt; margin-bottom: 2pt; text-align: center; }
+  .lembar-pos .lembar-kepala, .lembar-pos .insert-note,
+  .lembar-pos .print-note { text-align: center; }
+  /* Nomor halaman turun jadi baris sendiri di bawah judul: float kanan di
+     judul yang ditengahkan menggeser judulnya sendiri ke kiri. */
+  .lembar-pos h1 .halaman {
+    display: block; font-size: 9pt; font-weight: 400; margin-top: 1pt;
+  }
   .lembar-pos .lembar-kepala { font-size: 8.5pt; margin: 0 0 3pt; }
   .lembar-pos .insert-note { font-size: 8pt; margin: 0 0 3pt; }
   .lembar-pos .print-note { font-size: 7.5pt; margin-top: 3pt; }


### PR DESCRIPTION
## What

Every column on the printed score form is now centred, following the Excel sheet the panitia already use. The page number moves onto its own line under the title.

## Why

Not only a matter of taste. The identity columns on this sheet have pinned widths and their contents are much shorter than the pin — "Penegak PA" sitting in a 26mm cell — so left alignment leaves a ragged strip of white in every column, and the eye has to hunt for where one column ends and the next begins.

The page number had to move because floating it right inside a centred heading shifts the heading itself off centre.

## Notes

Pages still fit: 665px tall against the 718px A4 landscape print area, still 20 regu per sheet. Verified by applying the `@media print` rules to the screen and measuring, as with the sheet itself.

No database changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)