### PR TITLE
fix: fit 30 regu on a printed sheet at 12pt

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -193,22 +193,24 @@ Dua keputusan yang membentuknya:
 Kalau `daftar_ulang_ditutup` masih `false`, kertasnya membawa peringatan
 tercetak bahwa regu yang mendaftar ulang setelahnya tidak ada di sana.
 
-**A4 landscape, 12pt, 20 regu per lembar.** Ketiganya terikat satu sama lain
-dan angkanya hasil ukur, bukan pilihan:
+**A4 landscape, 12pt, 30 regu per lembar, semua kolom ditengahkan** —
+mengikuti bentuk cetakan Excel yang selama ini dipakai panitia. Yang tertulis
+di kertas ini dibaca lagi dari **foto**, oleh orang lain, di layar laptop,
+jadi hurufnya tidak boleh dikecilkan demi memuat lebih banyak baris.
 
-- Panitia meminta huruf 12pt, sama dengan cetakan Excel yang selama ini
-  dipakai — yang tertulis di sana dibaca lagi dari **foto**, oleh orang lain,
-  di layar laptop.
-- Di 12pt tabel Pos 1 selebar 201mm, sedangkan A4 potret hanya menyediakan
-  180mm. Karena itu lembar ini memakai halaman bernama (`@page lembar-pos`)
-  supaya **hanya ia** yang berputar; kwitansi dan daftar kloter tetap potret.
-- Tinggi barisnya ternyata ditentukan `line-height`, bukan tinggi kotak
-  isiannya. Dirapatkan ke 1,15, satu halaman memuat 21–23 baris — 21 di pos
-  yang kepala halamannya paling tinggi. Dipatok **20**, satu baris di bawah
-  yang paling sesak, karena halaman yang tumpah tidak menimbulkan galat apa
-  pun: ia hanya menghasilkan setumpuk kertas yang salah.
+Ketiga angka itu terikat satu sama lain, dan semuanya ditemukan dengan
+**mengukur**, bukan menalar:
 
-Tiga puluh baris per lembar sempat dicoba dan hanya mungkin pada huruf 8,5pt.
+| Yang menentukan | Temuan |
+| --- | --- |
+| Lebar | Di 12pt tabel Pos 1 selebar 201mm; A4 potret hanya menyediakan 180mm. Karena itu lembar ini memakai halaman bernama (`@page lembar-pos`) supaya **hanya ia** yang berputar — kwitansi dan daftar kloter tetap potret. |
+| Tinggi baris | Ditentukan `line-height`, **bukan** tinggi kotak isiannya: pada nilai bawaan (1,6) satu baris setinggi 32px meski kotaknya diminta 6mm. |
+| Sel tertinggi | Nomor dada sempat 14pt dan dialah yang menaikkan seluruh baris ke 21px sementara sel 12pt lain cuma butuh 18px. Selisih 3px dikali 30 baris persis yang membuat halaman tumpah. |
+
+Hasil akhirnya baris setinggi 4,8mm — kebetulan persis tinggi baris bawaan
+Excel — dengan sisa 10–21mm per halaman tergantung pos. Halaman yang tumpah
+tidak menimbulkan galat apa pun; ia hanya menghasilkan setumpuk kertas yang
+salah, dan baru ketahuan di pos.
 
 #### Pita keadaan simpan
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1933,19 +1933,21 @@ const kolomCetakPos = (komponen) => komponen.flatMap(k => {
  *  memotong satu baris di tengah, dan angka pastinya juga yang menentukan
  *  berapa lembar harus difotokopi.
  *
- *  Angkanya HASIL UKUR, bukan pilihan. Huruf 12pt (permintaan panitia, sama
- *  dengan cetakan Excel yang selama ini dipakai) memaksa dua hal sekaligus:
- *  tabel Pos 1 jadi selebar 201mm sehingga kertas harus landscape, dan
- *  tinggi baris jadi 25px sehingga satu halaman hanya memuat 21-23 baris —
- *  21 di pos yang paling sesak (Pos 2 dan Pos 4, yang kepala halamannya
- *  paling tinggi).
+ *  30 pada huruf 12pt hanya mungkin setelah tinggi barisnya ditekan ke
+ *  4,8mm — yang kebetulan persis tinggi baris bawaan Excel. Tiga hal yang
+ *  menentukannya, dan ketiganya ditemukan dengan MENGUKUR, bukan menalar:
  *
- *  Dipatok 20, satu baris di bawah yang paling sesak. Cadangan itu ada
- *  supaya nama regu yang lebih panjang atau nama pos yang lebih panjang
- *  tahun depan tidak diam-diam menumpahkan baris terakhir ke halaman
- *  berikutnya — dan halaman tumpah tidak menimbulkan galat apa pun, ia cuma
- *  menghasilkan setumpuk kertas yang salah. */
-const REGU_PER_LEMBAR = 20;
+ *    1. line-height, bukan tinggi kotak isian. Pada nilai bawaan (1,6) satu
+ *       baris setinggi 32px meski kotaknya diminta 6mm.
+ *    2. Sel TERTINGGI yang menang. Nomor dada sempat 14pt dan dialah yang
+ *       menaikkan seluruh baris jadi 21px sementara sel 12pt lain cuma butuh
+ *       18px — selisih 3px dikali 30 baris persis yang membuat halaman
+ *       tumpah.
+ *    3. Lebar. Di 12pt tabel Pos 1 selebar 201mm, sedangkan A4 potret hanya
+ *       menyediakan 180mm; karena itu lembar ini landscape.
+ *
+ *  Sisa ruang setelah semuanya: 10-21mm per halaman, tergantung pos. */
+const REGU_PER_LEMBAR = 30;
 
 function siapkanCetakLembarPos(pos, komponen, baris, daftarUlangDitutup) {
   document.getElementById("cetakan")?.remove();
@@ -1978,16 +1980,12 @@ function siapkanCetakLembarPos(pos, komponen, baris, daftarUlangDitutup) {
   // sendiri bisa dinilaikan ke pos yang salah.
   const lembar = halaman.map((grup, i) => `
     <section class="print-page lembar-pos">
-      <h1>LEMBAR NILAI · ${esc(judul)}
-        <span class="halaman">Halaman ${i + 1} dari ${halaman.length}</span></h1>
-      <p class="lembar-kepala"><strong>${esc(EDISI ? EDISI.name : "")}</strong> ·
-         ${esc(tanggal)} · nomor dada
-         ${esc(String(grup[0].nomor_dada).padStart(3, "0"))}–${esc(String(grup[grup.length - 1].nomor_dada).padStart(3, "0"))}
-         (${esc(String(grup.length))} regu) &nbsp;·&nbsp;
-         Petugas: ________________ &nbsp; Diperiksa: ________________</p>
-      ${daftarUlangDitutup ? "" : `<p class="insert-note">DAFTAR ULANG BELUM
-        DITUTUP — regu yang mendaftar ulang setelah kertas ini dicetak TIDAK
-        ada di sini. Cetak ulang setelah daftar ulang ditutup.</p>`}
+      <h1>LEMBAR NILAI · ${esc(judul)} · Halaman ${i + 1}/${halaman.length}</h1>
+      <p class="lembar-kepala">${esc(EDISI ? EDISI.name : "")} · ${esc(tanggal)} ·
+         dada ${esc(String(grup[0].nomor_dada).padStart(3, "0"))}–${esc(String(grup[grup.length - 1].nomor_dada).padStart(3, "0"))}
+         · Petugas: ______________ · Diperiksa: ______________</p>
+      ${daftarUlangDitutup ? "" : `<p class="insert-note">DAFTAR ULANG BELUM DITUTUP
+        — regu yang mendaftar ulang setelah kertas ini dicetak tidak ada di sini.</p>`}
       <table class="print-table">
         <thead>
           <tr>
@@ -1998,10 +1996,9 @@ function siapkanCetakLembarPos(pos, komponen, baris, daftarUlangDitutup) {
         </thead>
         <tbody>${grup.map(barisHtml).join("")}</tbody>
       </table>
-      ${i === 0 ? `<p class="print-note">Tulis data mentahnya apa adanya —
-         jumlah benar, jumlah kena, atau waktu. JANGAN menjumlahkan sendiri;
-         sistem yang mengubahnya jadi poin. Foto lembar ini secara berkala dan
-         kirimkan ke operator IT pos, jangan ditumpuk sampai pos tutup.</p>` : ""}
+      ${i === 0 ? `<p class="print-note">Tulis data mentahnya apa adanya.
+         JANGAN menjumlahkan sendiri — sistem yang mengubahnya jadi poin.
+         Foto lembar ini secara berkala, jangan ditumpuk sampai pos tutup.</p>` : ""}
     </section>`).join("");
 
   document.body.appendChild(h(`<div id="cetakan" class="printout">${lembar}</div>`));

--- a/web/style.css
+++ b/web/style.css
@@ -479,13 +479,6 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .print-note { font-size: 9pt; color: #333; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
 
-  /* ---- Lembar nilai pos: kertas yang ditulis tangan di lapangan ----
-     Kotak isiannya harus cukup untuk angka dua digit yang ditulis buru-buru
-     sambil berdiri, dan tingginya juga — menulis di kotak setinggi baris
-     teks memaksa orang menulis kecil, lalu angka kecil itu difoto dan harus
-     dibaca operator di layar laptop. */
-  .print-table td.isian { width: 15mm; height: 11mm; }
-  .print-table th.isian { width: 15mm; font-size: 8pt; }
   /* Rentang yang boleh ditulis, di bawah nama kolomnya — sama seperti di
      layar, supaya petugas tidak perlu mengingat skalanya. */
   .print-table th .kolom-petunjuk {
@@ -512,17 +505,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mata harus mencari-cari di mana satu kolom berakhir. Ditengahkan, tiap
      petak punya titik berat sendiri. */
   .lembar-pos .print-table th, .lembar-pos .print-table td { text-align: center; }
-  .lembar-pos h1 { font-size: 12pt; margin-bottom: 2pt; text-align: center; }
-  .lembar-pos .lembar-kepala, .lembar-pos .insert-note,
-  .lembar-pos .print-note { text-align: center; }
-  /* Nomor halaman turun jadi baris sendiri di bawah judul: float kanan di
-     judul yang ditengahkan menggeser judulnya sendiri ke kiri. */
-  .lembar-pos h1 .halaman {
-    display: block; font-size: 9pt; font-weight: 400; margin-top: 1pt;
+  /* Kepala halaman dipadatkan jadi TIGA baris. Tiap baris yang dihemat di
+     sini berarti satu baris regu lebih banyak, dan 30 regu per lembar tidak
+     menyisakan ruang untuk kepala yang lega. */
+  .lembar-pos h1 {
+    font-size: 11pt; margin: 0 0 1pt; text-align: center; line-height: 1.2;
   }
-  .lembar-pos .lembar-kepala { font-size: 8.5pt; margin: 0 0 3pt; }
-  .lembar-pos .insert-note { font-size: 8pt; margin: 0 0 3pt; }
-  .lembar-pos .print-note { font-size: 7.5pt; margin-top: 3pt; }
+  .lembar-pos .lembar-kepala, .lembar-pos .insert-note,
+  .lembar-pos .print-note { text-align: center; line-height: 1.2; }
+  .lembar-pos .lembar-kepala { font-size: 8pt; margin: 0 0 2pt; }
+  .lembar-pos .insert-note { font-size: 7.5pt; margin: 0 0 2pt; }
+  .lembar-pos .print-note { font-size: 7pt; margin-top: 2pt; }
   .lembar-pos .print-table { margin-top: 0; }
   /* 12pt untuk ISI — ukuran yang sama dengan cetakan Excel yang selama ini
      dipakai panitia, dan memang seharusnya: yang tertulis di sini dibaca
@@ -532,20 +525,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dan di 12pt "KEPRAMUKAAN KEAGAMAAN" akan memakan lebar yang dibutuhkan
      kotak isiannya. */
   .lembar-pos .print-table th, .lembar-pos .print-table td {
-    padding: 1pt 4pt; font-size: 12pt;
-    /* Jarak antarbaris huruf dirapatkan. Inilah yang sebenarnya menentukan
-       tinggi baris di sini — BUKAN tinggi kotak isiannya. Dengan line-height
-       bawaan (1,6) satu baris setinggi 32px meski kotaknya diminta 6mm, dan
-       selisih itu langsung berarti beberapa baris lebih sedikit per lembar. */
-    line-height: 1.15;
+    padding: 0.5pt 4pt; font-size: 12pt;
+    /* Jarak antarbaris huruf inilah yang sebenarnya menentukan tinggi baris
+       di sini — BUKAN tinggi kotak isiannya. Dengan line-height bawaan (1,6)
+       satu baris setinggi 32px meski kotaknya diminta 6mm.
+       1,0 supaya 30 baris muat: satu baris jadi ~5mm, dan itu kebetulan
+       persis tinggi baris bawaan Excel (15pt). Aman karena tiap sel di sini
+       hanya berisi SATU baris teks — tidak ada paragraf yang jadi rapat. */
+    line-height: 1;
   }
   .lembar-pos .print-table th { font-size: 8pt; }
-  .lembar-pos .print-table .dada { font-size: 14pt; width: 15mm; }
-  /* Tinggi kotak tulis: 6mm. Sedikit lebih rapat dari garis buku tulis
-     (7-8mm) tapi masih nyaman untuk angka dua digit — dan tiap milimeter di
-     sini berharga satu baris per halaman, yang berlipat jadi lembaran
-     fotokopi untuk 300 regu dikali lima pos. */
-  .lembar-pos .print-table td.isian { height: 6mm; }
+  /* Nomor dada TIDAK dibesarkan di lembar ini. Sempat 14pt, dan ternyata
+     dialah yang menentukan tinggi seluruh baris — satu sel 14pt membuat
+     barisnya 21px sementara sel 12pt lainnya cuma butuh 18px, dan selisih
+     3px dikali 30 baris persis yang membuat halaman tumpah. Tebalnya sudah
+     cukup membuatnya menonjol, dan di Excel pun semua kolom seukuran. */
+  .lembar-pos .print-table .dada { font-size: 12pt; width: 15mm; }
+  /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
+     ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
+     tinggi hanya akan mengurangi jumlah baris per lembar. */
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian { width: 14mm; }
   /* Identitas TIDAK boleh membungkus di sini: satu nama yang pecah dua baris
      menambah tinggi satu baris, dan tiga puluh baris yang dipatok mati tidak


### PR DESCRIPTION
## What

Thirty regu per printed sheet, still at 12pt, still centred, still A4 landscape. Row height comes down to **4.8mm** — which happens to be exactly Excel's default row height.

| Pos | Tallest page | Spare |
| --- | --- | --- |
| 2 — Kesehatan dan Pengetahuan Umum | 680px | 39px (10mm) |
| 4 — Praktik Kesehatan | 668px | 51px (13mm) |
| 1 — Keagamaan dan Kepramukaan | 648px | 71px (19mm) |
| 3 — Games | 648px | 71px (19mm) |
| Bayangan — Kostum | 637px | 81px (21mm) |

A4 landscape print area is 718px tall. Every pos fits.

## Why

Three things decided the row height, and all three were found by **measuring rather than reasoning** — each one had a plausible-sounding wrong answer.

1. **`line-height`, not the height of the writing box.** At the default 1.6 a row is 32px tall even with the box asked to be 6mm. Setting the box height was doing nothing.
2. **The tallest cell wins.** Nomor dada was 14pt, and it alone pushed every row to 21px while the 12pt cells needed 18px. Three pixels times thirty rows is exactly what made the page overflow. It is 12pt now like everything else — bold already makes it stand out, and in Excel every column is the same size anyway.
3. **A stale rule from the first portrait draft.** `.print-table td.isian` still carried `height: 11mm`, and the moment the `.lembar-pos` override was removed it took over and made rows *11mm instead of 5* — the opposite of the intended direction. It had been fully superseded by the scoped rules and is deleted.

## Notes

The page header is also compressed to three short lines, since at 30 rows there is no room for a roomy one.

Verified by applying the `@media print` rules to the screen and measuring every pos against the real A4 landscape area (277 × 190mm), with 81 regu of test data across 3 pages.

No database changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)