### PR TITLE
feat: publish a live recap page for participants

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -1,0 +1,86 @@
+# ============================================================================
+# hrcd-rekap : publish-live.yml — tulis live.json lalu deploy halaman rekap.
+#
+# Halaman rekap peserta TIDAK membaca database. Workflow inilah yang membaca,
+# menulis hasilnya jadi satu berkas statis, lalu men-deploy folder live/.
+# Ratusan HP peserta hanya menyentuh hosting statis Cloudflare — nol
+# permintaan ke Supabase, dan halaman itu tidak perlu membawa kunci apa pun
+# (docs/rancangan-b.md bagian 7).
+#
+# YANG MENJAGA KEJUTAN ADA DI DATABASE, BUKAN DI SINI.
+# Selama status_acara.fase_live masih 'progres', v_klasemen_publik memang
+# mengembalikan nol baris dan v_progres_publik tidak memuat satu pun angka
+# nilai. Jadi live.json yang dihasilkan workflow ini memang TIDAK BERISI
+# nilai — bukan berisi nilai yang disembunyikan tampilan. Admin memindah fase
+# ke 'penuh' saat hasil diumumkan, dan jalan berikutnya klasemennya ikut.
+#
+# CRON SENGAJA DIMATIKAN (baris `schedule` dikomentari). Nyalakan pada minggu
+# lomba, matikan lagi sesudahnya — repo ini privat, dan menit Actions
+# terpakai walau tidak ada yang berubah. Tombol Run workflow tetap bisa
+# ditekan kapan pun, termasuk dari HP.
+#
+# Butuh repository secret (dua-duanya sudah dipakai workflow lain):
+#   SUPABASE_DB_URL       connection string Postgres (Session pooler, 5432)
+#   CLOUDFLARE_API_TOKEN  template "Edit Cloudflare Workers"
+# ============================================================================
+
+name: Publish rekap live
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '*/5 * * * *'   # nyalakan pada minggu lomba
+
+# Dua jalan yang bertumpuk akan saling menimpa live.json di Cloudflare, dan
+# yang menang belum tentu yang terbaru. Satu jalan saja pada satu waktu.
+concurrency:
+  group: publish-live
+  cancel-in-progress: false
+
+jobs:
+  terbitkan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tulis live.json dari database
+        env:
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DB_URL" ]; then
+            echo "Secret SUPABASE_DB_URL belum diisi."
+            exit 1
+          fi
+          # -A -t: keluaran mentah tanpa bingkai tabel dan tanpa judul kolom,
+          # sehingga yang tertulis ke berkas benar-benar JSON saja.
+          psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
+            -f supabase/checks/live_json.sql > live/live.json
+
+          # Pagar terakhir sebelum berkasnya di-deploy: JSON yang rusak akan
+          # membuat halaman rekap kosong tanpa pesan apa pun, dan tidak ada
+          # yang akan menyadarinya sampai ada peserta yang bertanya.
+          python3 -c "
+          import json, sys
+          d = json.load(open('live/live.json'))
+          for k in ('dibuat_pada','fase','pos','progres','klasemen'):
+              if k not in d: sys.exit(f'kunci {k} hilang dari live.json')
+          print(f\"fase={d['fase']} regu={len(d['progres'])} klasemen={len(d['klasemen'])} pos={len(d['pos'])}\")
+          if d['fase'] != 'penuh' and d['klasemen']:
+              sys.exit('BOCOR: klasemen ikut tertulis padahal fase belum penuh')
+          "
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm install -g wrangler
+
+      - name: Deploy halaman rekap
+        working-directory: live
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: wrangler deploy
+
+      - name: Ringkasan
+        run: echo "REKAP TERBIT — $(date -u '+%Y-%m-%d %H:%M UTC')"

--- a/README.md
+++ b/README.md
@@ -37,18 +37,20 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │   ├── config.js             # URL Supabase + gateway (bukan rahasia)
 │   ├── _headers              # aturan cache Cloudflare
 │   └── wrangler.toml         # deploy Workers static assets
+├── live/                     # halaman rekap live peserta (Worker TERPISAH,
+│                             # tanpa kunci apa pun, isinya dari live.json)
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0025
+│   ├── migrations/           # skema database, urut 0001..0026
 │   ├── checks/               # SQL pemeriksaan manual (row_counts, smoke, dst.)
 │   └── seed.sql              # konfigurasi edisi + baris wajib
 ├── scripts/                  # provision_accounts.py, change_password.py
 ├── tests/
-│   ├── sql/                  # harness + tes constraint, alur, skor, kloter
+│   ├── sql/                  # harness + tes constraint, alur, skor, kloter, rekap
 │   ├── run.sh                # jalankan semuanya di database lokal
 │   ├── dev_server.py         # tiruan Supabase untuk mencoba layar
 │   └── static_server.py      # penyaji web/ tanpa cache
-├── .github/workflows/        # 5 workflow (lihat final-architecture.md)
+├── .github/workflows/        # 6 workflow (lihat final-architecture.md)
 ├── CLAUDE.md                 # konvensi kerja
 └── AGENTS.md                 # salinan identik CLAUDE.md
 ```

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0025`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0026`.
 
 ---
 
@@ -19,6 +19,7 @@ sendiri di server:
 | Database | Postgres + Auth + RLS + seluruh logika | Supabase |
 | Tampilan | SPA statis, tanpa build step | Cloudflare Workers static assets |
 | Gateway | Penerima form pendaftaran publik | Cloudflare Worker |
+| Rekap live | Halaman peserta, statis, tanpa kunci apa pun | Cloudflare Worker TERPISAH |
 
 **Tidak ada server aplikasi.** Layar panitia berbicara langsung ke Supabase
 lewat PostgREST memakai anon key; yang menjaga data bukan lapisan tengah,
@@ -26,14 +27,17 @@ melainkan RLS dan RPC di database. Satu-satunya kode server adalah gateway,
 dan ia hanya menangani satu hal: form pendaftaran publik, yang harus bisa
 dikirim tanpa login.
 
-Yang **tidak** dipakai, meski disebut di dokumen lama: Google Sheets, Cloudflare
-Pages, halaman `live.json`/`live.html`. Tidak ada satu pun di kode.
+Yang **tidak** dipakai, meski disebut di dokumen lama: Google Sheets dan
+Cloudflare Pages. Halaman live publik SUDAH ada sejak 14 Agustus 2026, tapi
+bentuknya `live/index.html` + `live/live.json` di Worker sendiri — bukan
+`live.html` di proyek yang sama seperti tertulis di `rancangan-b.md` bagian 7.
 
 ### Alamat produksi
 
 | Apa | Alamat |
 | --- | --- |
 | Layar panitia + form daftar | `https://hrcd37.ciradyka.workers.dev` |
+| Rekap live peserta | `https://hrcd37-rekap.ciradyka.workers.dev` |
 | Gateway pendaftaran | `https://gateway.ciradyka.workers.dev` |
 | Supabase | `https://pwszijhnftvqjkdldqrf.supabase.co` |
 
@@ -46,7 +50,7 @@ di `workers/gateway/worker.js` wajib ikut diubah.
 
 ## 2. Database
 
-25 migrasi, `0001` sampai `0025`, dijalankan berurutan tanpa lubang penomoran.
+26 migrasi, `0001` sampai `0026`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -252,6 +256,62 @@ lembar kosong terbaca sebagai "belum ada peserta", bukan sebagai galat hak
 akses. Pagarnya dipasang di dalam view: `peran() is not null`, dan operator
 hanya posnya sendiri.
 
+---
+
+## 3b. Halaman rekap live untuk peserta
+
+Satu pertanyaan yang dijawab halaman ini sepanjang lomba, dan hanya itu:
+**"nilai regu saya sudah masuk belum, atau hilang?"** Jawabannya centang per
+pos, ditambah fakta operasional yang memang sudah diketahui regunya sendiri —
+kloter, kontrak waktu, jam berangkat, jam datang. Menerbitkan jam justru
+layanan: regu bisa memastikan yang tercatat panitia sama dengan catatan
+mereka SEBELUM hasilnya final, dan sengketa yang ketahuan pagi hari jauh
+lebih murah daripada yang ketahuan saat pengumuman.
+
+### Yang menjaga kejutan adalah database, bukan tampilan
+
+Selama `status_acara.fase_live` masih `progres`, `v_klasemen_publik`
+mengembalikan **nol baris** dan `v_progres_publik` tidak punya satu pun kolom
+berisi angka nilai. Jadi `live.json` yang terbit memang **tidak memuat**
+nilai — bukan memuatnya lalu disembunyikan CSS, yang bisa dibuka siapa pun
+dengan membuka alamat berkasnya langsung. Admin memindah fase ke `penuh` saat
+hasil diumumkan, dan jalan berikutnya klasemen empat golongan beserta juaranya
+ikut terbit.
+
+`tests/sql/09_rekap_publik.sql` menjaga janji itu dari dua arah: klasemen
+harus nol baris di fase progres, dan `v_progres_publik` diperiksa **lewat
+katalog** supaya kolom baru yang berbau nilai tertangkap — yang menambahkannya
+tahun depan belum tentu ingat janji ini.
+
+### Kenapa Worker sendiri
+
+Memisahkan URL **tidak** mencegah orang mencoba masuk — alamat panitia tetap
+ada. Yang benar-benar didapat tiga hal:
+
+1. Halaman rekap tidak memuat **kunci apa pun**. `web/config.js` membawa anon
+   key dan alamat Supabase; `live/` cuma HTML, CSS, dan satu berkas JSON.
+2. Link yang disebar ke ratusan peserta tidak sekaligus menyebarkan alamat
+   login panitia.
+3. Ratusan HP yang me-refresh tidak menyentuh Worker yang sedang dipakai
+   panitia bekerja.
+
+### Cara datanya sampai
+
+`publish-live.yml` menjalankan `supabase/checks/live_json.sql` — satu query
+yang menghasilkan seluruh berkas — lalu men-deploy folder `live/`. Halaman
+peserta hanya membaca berkas statis itu tiap 60 detik; **nol permintaan ke
+Supabase dari HP peserta**.
+
+Cap **"Sinkronisasi terakhir"** di kepala halaman memakai jam saat berkasnya
+DIBUAT di server, bukan jam halaman dimuat — kalau workflow tersendat, peserta
+harus bisa melihat bahwa angkanya tua. Lewat 15 menit, capnya berubah warna
+dan menambahkan "data mungkin tertinggal".
+
+Sebelum di-deploy, workflow memeriksa berkasnya sendiri: JSON harus terurai,
+kunci wajib harus ada, dan **klasemen harus kosong selama fase belum `penuh`**.
+JSON yang rusak akan membuat halaman rekap kosong tanpa pesan apa pun, dan
+tidak ada yang menyadarinya sampai ada peserta yang bertanya.
+
 ### Bentuk tabel meja menurut lebar layar
 
 Meja Pembayaran dan Meja Daftar Ulang berganti bentuk di dua ambang. Angkanya
@@ -297,8 +357,14 @@ Service key hidup sebagai `wrangler secret` di Worker, tidak pernah di SPA.
 | Yang di-deploy | Cara | Pemicu |
 | --- | --- | --- |
 | Situs statis (`web/`) | Cloudflare Workers, tersambung Git | otomatis tiap push ke `main` |
+| Rekap live (`live/`) | GitHub Actions `publish-live.yml` | manual + cron 5 menit (dimatikan di luar minggu lomba) |
 | Gateway Worker | GitHub Actions `deploy-gateway.yml` | manual |
 | Migrasi database | GitHub Actions `apply-migration.yml` | manual, satu berkas per jalan |
+
+`live/` **sengaja TIDAK tersambung Git.** Yang di-deploy bukan isi repo
+melainkan `live.json` yang baru saja ditulis workflow dari database; kalau ia
+juga tersambung Git, tiap push ke `main` akan menimpanya dengan berkas contoh
+fase `pra` yang ada di repo.
 
 **Merge ke `main` = deploy situs.** Tidak ada build step; berkas di `web/`
 disajikan apa adanya, dengan `web/wrangler.toml` menyetel root proyek ke folder
@@ -397,9 +463,10 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
   lain), padahal di layar selalu tiga digit. Migrasi `0020` baru membetulkan
   `berangkatkan_kloter`; sisanya menunggu karena tiap perbaikan menuntut
   seluruh badan fungsinya disalin ulang.
-- **Halaman live publik belum ada.** `live.html` + `live.json` di
-  `rancangan-b.md` bagian 7 tidak pernah dibangun, dan tidak ada workflow yang
-  menghasilkannya.
+- **Cron rekap live masih dimatikan.** `publish-live.yml` punya jadwal 5
+  menit yang sengaja dikomentari; nyalakan pada minggu lomba dan matikan lagi
+  sesudahnya. Sampai dinyalakan, halaman rekap hanya diperbarui saat tombol
+  Run workflow ditekan.
 - **Upload massal nilai belum ada.** `rancangan-b.md` bagian 6 menjelaskan
   jalur tempel-dari-Excel lengkap dengan layar preview. Yang sudah dibangun
   baru input tabelnya (`#/pos`) — yang sebenarnya sudah menutup sebagian besar

--- a/live/_headers
+++ b/live/_headers
@@ -1,0 +1,26 @@
+# ============================================================================
+# hrcd-rekap : live/_headers — aturan cache halaman rekap peserta.
+#
+# live.json ditulis ulang GitHub Actions tiap 5 menit, dan yang membacanya
+# ratusan HP di jaringan seluler yang gemar menyimpan berkas sendiri. no-store
+# untuk berkas itu: bukan cuma "wajib divalidasi", melainkan "jangan simpan
+# sama sekali". Halaman rekap yang menyajikan data setengah jam lalu lebih
+# buruk daripada halaman yang lambat — orang akan mengira nilainya hilang.
+#
+# Berkasnya kecil (ratusan regu ~60 KB), jadi harganya murah.
+# ============================================================================
+
+/*
+  Cache-Control: no-cache
+
+/live.json
+  Cache-Control: no-store
+  Content-Type: application/json; charset=utf-8
+
+/*.js
+  Cache-Control: no-cache
+  Content-Type: text/javascript; charset=utf-8
+
+/*.css
+  Cache-Control: no-cache
+  Content-Type: text/css; charset=utf-8

--- a/live/index.html
+++ b/live/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="id">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rekap Live — Hiking Rally Ciradyka</title>
+  <meta name="description" content="Rekap live Hiking Rally Ciradyka — periksa nilai regu sudah masuk atau belum.">
+  <!-- Halaman ini TIDAK memuat kunci apa pun: tidak ada anon key, tidak ada
+       alamat Supabase, tidak ada kotak login. Seluruh isinya datang dari satu
+       berkas statis (live.json) yang ditulis GitHub Actions tiap 5 menit.
+       Itu sebabnya ia berdiri di Worker sendiri, terpisah dari layar
+       panitia — lihat live/wrangler.toml. -->
+  <link rel="stylesheet" href="live.css?v=1">
+</head>
+<body>
+  <header class="kepala">
+    <div class="kepala-isi">
+      <h1 id="judul">Rekap Live</h1>
+      <p class="sinkron" id="sinkron">Memuat…</p>
+    </div>
+  </header>
+
+  <main id="isi">
+    <p class="memuat">Memuat rekap…</p>
+  </main>
+
+  <footer class="kaki">
+    <p>Hiking Rally Ciradyka · Ambalan Ciung Wanara – Dyah Pitaloka,
+       SMA Negeri 1 Ciamis</p>
+    <p class="kecil">Halaman ini memperbarui dirinya sendiri. Kalau angkanya
+       terasa tertinggal, tunggu sebentar — data disegarkan tiap 5 menit.</p>
+  </footer>
+
+  <script src="live.js?v=1"></script>
+</body>
+</html>

--- a/live/live.css
+++ b/live/live.css
@@ -1,0 +1,141 @@
+/* ============================================================================
+   hrcd-rekap : live.css — gaya halaman rekap peserta.
+
+   SENGAJA berdiri sendiri, tidak berbagi berkas dengan style.css layar
+   panitia. Dua alasan: halaman ini di-deploy sebagai Worker terpisah (tidak
+   boleh bergantung pada berkas di proyek lain), dan pembacanya berbeda —
+   peserta dan pembina, hampir semuanya di HP, sambil berdiri, kadang di bawah
+   matahari. Yang dikejar di sini keterbacaan, bukan kerapatan.
+   ========================================================================== */
+
+:root {
+  --tinta:        #1a1a1a;
+  --tinta-lembut: #5c5c5c;
+  --kertas:       #f7f6f3;
+  --kartu:        #ffffff;
+  --garis:        #dcdcd7;
+  --utama:        #00695c;   /* hijau tua HRCD */
+  --hijau:        #2e7d32;
+  --hijau-muda:   #e8f5e9;
+  --kuning:       #b26a00;
+  --kuning-muda:  #fff3e0;
+  --emas:         #b8860b;
+  --radius:       14px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--kertas);
+  color: var(--tinta);
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+}
+
+.kepala {
+  background: var(--utama); color: #fff;
+  padding: .9rem 1rem;
+  position: sticky; top: 0; z-index: 10;
+}
+.kepala-isi { max-width: 1200px; margin: 0 auto; }
+.kepala h1 { font-size: 1.15rem; font-weight: 800; }
+/* Cap sinkronisasi: kecil tapi selalu ada. Halaman yang menyegarkan dirinya
+   sendiri harus bisa dibedakan dari halaman yang berhenti bekerja. */
+.sinkron { font-size: .8rem; opacity: .9; margin-top: .15rem; }
+.sinkron.basi { opacity: 1; font-weight: 700; color: #ffd9a0; }
+
+main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
+.memuat { text-align: center; color: var(--tinta-lembut); padding: 2rem 0; }
+
+.kartu {
+  background: var(--kartu); border: 1px solid var(--garis);
+  border-radius: var(--radius); padding: .9rem; margin-bottom: 1rem;
+}
+.kartu h2 { font-size: 1.05rem; margin-bottom: .35rem; }
+.kartu .keterangan { color: var(--tinta-lembut); font-size: .88rem; margin-bottom: .7rem; }
+.tengah { text-align: center; }
+.angka-besar { font-size: 2.6rem; font-weight: 800; color: var(--utama); line-height: 1.1; margin-top: .6rem; }
+.pil-baris { display: flex; gap: .4rem; flex-wrap: wrap; justify-content: center; margin-top: .8rem; }
+.pil { background: var(--kertas); border-radius: 999px; padding: .2rem .7rem; font-size: .85rem; }
+
+.cari-baris { display: flex; gap: .6rem; align-items: center; margin-bottom: .7rem; }
+.cari-baris input {
+  flex: 1; min-width: 0;
+  /* 16px, bukan lebih kecil: di bawah itu iOS Safari memaksa zoom setiap kali
+     kotaknya disentuh, dan halaman melompat — cacat yang sama sudah pernah
+     dibayar di layar panitia. */
+  font-size: 16px; padding: .5rem .7rem; min-height: 44px;
+  border: 1px solid var(--garis); border-radius: 10px; background: #fff;
+  font-family: inherit;
+}
+.hitung { color: var(--tinta-lembut); font-size: .85rem; white-space: nowrap; }
+
+/* Tabel digeser ke samping, TIDAK ditumpuk jadi kartu. Yang dicari orang di
+   sini deretan centang per pos — bentuk baris itulah isinya, dan menumpuknya
+   membuat satu regu memakan satu layar penuh. */
+.gulir { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.tabel { width: 100%; border-collapse: collapse; font-size: .9rem; white-space: nowrap; }
+.tabel th {
+  text-align: left; font-size: .7rem; text-transform: uppercase;
+  letter-spacing: .03em; color: var(--tinta-lembut);
+  padding: .4rem .5rem; border-bottom: 2px solid var(--garis);
+  position: sticky; top: 0; background: var(--kartu);
+}
+.tabel td { padding: .45rem .5rem; border-bottom: 1px solid var(--garis); }
+.tabel tbody tr:nth-child(even) { background: #fafaf8; }
+
+/* Nomor dada dipatok di tepi kiri: tabelnya digeser ke samping untuk melihat
+   kolom pos, dan tanpa ini orang kehilangan jejak baris siapa yang sedang
+   dilihatnya persis saat ia menemukan centangnya. */
+.tabel td.dada, .tabel th:first-child {
+  position: sticky; left: 0; z-index: 2;
+  background: var(--kartu); font-weight: 800; font-variant-numeric: tabular-nums;
+  box-shadow: 1px 0 0 var(--garis);
+}
+.tabel tbody tr:nth-child(even) td.dada { background: #fafaf8; }
+.tabel th:first-child { z-index: 3; }
+
+.tabel .regu { white-space: normal; min-width: 11rem; font-weight: 600; }
+.tabel .regu .sekolah {
+  display: block; font-weight: 400; font-size: .78rem; color: var(--tinta-lembut);
+}
+.tabel .gol { font-size: .82rem; color: var(--tinta-lembut); }
+.tabel .kosong { text-align: center; color: var(--tinta-lembut); padding: 1.5rem; white-space: normal; }
+
+/* Centang pos — satu-satunya hal yang dicari orang di halaman ini selama
+   lomba, jadi ia yang paling besar dan paling berwarna. */
+.tabel th.pos { text-align: center; }
+.tabel td.pos { text-align: center; font-size: 1.05rem; font-weight: 800; width: 3.2rem; }
+.tabel td.pos.ada { color: var(--hijau); background: var(--hijau-muda); }
+.tabel td.pos.belum { color: #c7c7c2; }
+.tabel tbody tr:nth-child(even) td.pos.ada { background: #dfeee0; }
+
+/* ---- klasemen (fase penuh) ---- */
+.podium { display: grid; gap: .6rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin-bottom: .9rem; }
+.juara {
+  border: 2px solid var(--garis); border-radius: var(--radius);
+  padding: .7rem; text-align: center; background: var(--kertas);
+}
+.juara.j1 { border-color: var(--emas); background: #fdf6e3; }
+.juara .peringkat { font-size: 1.5rem; font-weight: 800; color: var(--utama); }
+.juara.j1 .peringkat { color: var(--emas); }
+.juara .nama { font-weight: 800; }
+.juara .sekolah { font-size: .8rem; color: var(--tinta-lembut); }
+.juara .total { font-size: 1.35rem; font-weight: 800; margin-top: .2rem; }
+.tabel td.total { font-weight: 800; font-variant-numeric: tabular-nums; }
+.tabel tr.atas { background: #fdf6e3; }
+.tabel tr.atas td.dada { background: #fdf6e3; }
+
+.kaki {
+  max-width: 1200px; margin: 0 auto; padding: 0 .7rem 2rem;
+  color: var(--tinta-lembut); font-size: .82rem; text-align: center;
+}
+.kaki .kecil { font-size: .76rem; margin-top: .3rem; }
+
+@media (max-width: 560px) {
+  .kepala h1 { font-size: 1rem; }
+  .kartu { padding: .7rem .5rem; }
+  .tabel { font-size: .85rem; }
+  .tabel .regu { min-width: 9rem; }
+}

--- a/live/live.js
+++ b/live/live.js
@@ -1,0 +1,256 @@
+/* ============================================================================
+   hrcd-rekap : live.js — halaman rekap untuk PESERTA dan PEMBINA.
+
+   Satu pertanyaan yang harus dijawab halaman ini sepanjang lomba: "nilai regu
+   saya sudah masuk belum, atau hilang?" Jawabannya centang per pos. TIDAK ada
+   angka nilai — dan itu bukan dijaga di sini, melainkan di database: selama
+   fase masih 'progres', live.json memang tidak memuat satu pun angka nilai
+   (lihat kepala migrasi 0026). Menyembunyikannya di sisi tampilan akan
+   percuma; siapa pun bisa membuka berkas JSON-nya langsung.
+
+   Tanpa framework, tanpa build step, tanpa kunci apa pun. Satu fetch ke
+   live.json, sisanya menggambar tabel.
+   ========================================================================== */
+
+const GOLONGAN = {
+  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
+  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
+};
+const URUT_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
+
+/** Peserta menyalin nama regu dan nama sekolah dari formulir yang mereka isi
+ *  sendiri — teks dari luar, dan halaman ini dibaca ratusan orang. */
+const esc = (v) => v === null || v === undefined ? "" : String(v)
+  .replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+  .replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+
+const dada = (n) => String(n).padStart(3, "0");
+
+const jam = (t) => {
+  if (!t) return "—";
+  const d = new Date(t);
+  return `${String(d.getHours()).padStart(2, "0")}.${String(d.getMinutes()).padStart(2, "0")}`;
+};
+
+const kontrak = (menit) => {
+  if (!menit) return "—";
+  const j = Math.floor(menit / 60), m = menit % 60;
+  return m ? `${j},${m === 30 ? "5" : m} jam` : `${j} jam`;
+};
+
+const berapaLalu = (t) => {
+  const menit = Math.floor((Date.now() - new Date(t).getTime()) / 60000);
+  if (menit < 1) return "barusan";
+  if (menit < 60) return `${menit} menit lalu`;
+  return `${Math.floor(menit / 60)} jam lalu`;
+};
+
+let DATA = null;
+let cari = "";
+
+/* ---------------------------------------------------------------------------
+   Cap sinkronisasi. Yang ditampilkan adalah jam DATA DIBUAT di server, bukan
+   jam halaman ini dimuat — kalau workflow-nya tersendat, orang harus bisa
+   melihat bahwa angkanya sudah tua, bukan mengira halamannya baru.
+   ------------------------------------------------------------------------- */
+function gambarSinkron() {
+  const el = document.getElementById("sinkron");
+  if (!DATA) { el.textContent = "Memuat…"; return; }
+  const t = new Date(DATA.dibuat_pada);
+  const jj = `${String(t.getHours()).padStart(2, "0")}.${String(t.getMinutes()).padStart(2, "0")}.${String(t.getSeconds()).padStart(2, "0")}`;
+  const tua = Date.now() - t.getTime() > 15 * 60000;
+  el.className = `sinkron${tua ? " basi" : ""}`;
+  el.textContent = `Sinkronisasi terakhir: ${jj} (${berapaLalu(DATA.dibuat_pada)})`
+    + (tua ? " — data mungkin tertinggal" : "");
+}
+
+/* ---------------------------------------------------------------------------
+   Fase 'pra' — belum ada yang berjalan.
+   ------------------------------------------------------------------------- */
+function gambarPra() {
+  const r = DATA.ringkas || {};
+  const per = r.per_golongan || {};
+  return `
+    <div class="kartu tengah">
+      <h2>Belum dimulai</h2>
+      <p>Rekap live akan tampil di halaman ini begitu lomba berjalan.</p>
+      <p class="angka-besar">${esc(String(r.jumlah_regu_lunas ?? 0))}</p>
+      <p>regu terdaftar</p>
+      <div class="pil-baris">
+        ${URUT_GOLONGAN.filter(g => per[g]).map(g =>
+          `<span class="pil">${esc(GOLONGAN[g])}: ${esc(String(per[g]))}</span>`).join("")}
+      </div>
+    </div>`;
+}
+
+/* ---------------------------------------------------------------------------
+   Fase 'progres' dan 'penuh' — tabel centang per pos.
+
+   Kolom pos dibangun dari daftar pos di live.json, bukan ditulis di sini:
+   jumlah dan namanya berubah tiap edisi.
+   ------------------------------------------------------------------------- */
+function barisCocok(b) {
+  if (!cari) return true;
+  return dada(b.nomor_dada).includes(cari)
+    || (b.nama_regu || "").toLowerCase().includes(cari)
+    || (b.nama_sekolah || "").toLowerCase().includes(cari);
+}
+
+function gambarProgres() {
+  const pos = DATA.pos || [];
+  const baris = (DATA.progres || []).filter(barisCocok);
+
+  const kepalaPos = pos.map(p => `<th class="pos">${esc(p.bayangan ? p.name : `Pos ${p.nomor}`)}</th>`).join("");
+
+  const isi = baris.map(b => {
+    const lewat = b.pos_terlewati || {};
+    const sel = pos.map(p => {
+      const ada = lewat[String(p.nomor)];
+      return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : "–"}</td>`;
+    }).join("");
+    return `
+      <tr>
+        <td class="dada">${esc(dada(b.nomor_dada))}</td>
+        <td class="regu">${esc(b.nama_regu)}<span class="sekolah">${esc(b.nama_sekolah)}</span></td>
+        <td class="gol">${esc(GOLONGAN[b.golongan] || b.golongan)}</td>
+        <td>${b.kloter ? esc(String(b.kloter)) : "—"}</td>
+        <td>${esc(kontrak(b.kontrak_menit))}</td>
+        <td>${esc(jam(b.jam_berangkat))}</td>
+        <td>${esc(jam(b.jam_datang))}</td>
+        ${sel}
+      </tr>`;
+  }).join("");
+
+  return `
+    <div class="kartu">
+      <h2>Nilai regu sudah masuk?</h2>
+      <p class="keterangan">Centang berarti nilai regu itu sudah diterima
+         sistem dari pos tersebut. Angkanya sengaja belum ditampilkan — hasil
+         lengkapnya dibuka setelah closing.</p>
+      <div class="cari-baris">
+        <input type="search" id="cari" inputmode="search"
+               placeholder="Cari nomor dada, nama regu, atau sekolah…"
+               value="${esc(cari)}" autocomplete="off">
+        <span class="hitung">${esc(String(baris.length))} regu</span>
+      </div>
+      <div class="gulir">
+        <table class="tabel">
+          <thead>
+            <tr>
+              <th>No<br>Dada</th><th>Regu</th><th>Golongan</th>
+              <th>Kloter</th><th>Kontrak</th><th>Berangkat</th><th>Datang</th>
+              ${kepalaPos}
+            </tr>
+          </thead>
+          <tbody>${isi || `<tr><td colspan="${7 + pos.length}" class="kosong">
+            Tidak ada regu yang cocok dengan pencarian.</td></tr>`}</tbody>
+        </table>
+      </div>
+    </div>`;
+}
+
+/* ---------------------------------------------------------------------------
+   Fase 'penuh' — klasemen per golongan, juara di atas.
+   ------------------------------------------------------------------------- */
+function gambarKlasemen() {
+  const semua = DATA.klasemen || [];
+  if (!semua.length) return "";
+
+  return URUT_GOLONGAN.map(g => {
+    const baris = semua.filter(k => k.golongan === g);
+    if (!baris.length) return "";
+    const juara = baris.filter(k => k.peringkat <= 3);
+    return `
+      <div class="kartu">
+        <h2>${esc(GOLONGAN[g])}</h2>
+        <div class="podium">
+          ${juara.map(k => `
+            <div class="juara j${esc(String(k.peringkat))}">
+              <div class="peringkat">${esc(String(k.peringkat))}</div>
+              <div class="nama">${esc(k.nama_regu)}</div>
+              <div class="sekolah">${esc(k.nama_sekolah)}</div>
+              <div class="total">${esc(String(k.total))}</div>
+            </div>`).join("")}
+        </div>
+        <div class="gulir">
+          <table class="tabel">
+            <thead>
+              <tr><th>#</th><th>No<br>Dada</th><th>Regu</th>
+                  <th>Nilai Pos</th><th>Penalti</th><th>Total</th></tr>
+            </thead>
+            <tbody>
+              ${baris.map(k => `
+                <tr class="${k.peringkat <= 3 ? "atas" : ""}">
+                  <td class="dada">${esc(String(k.peringkat))}</td>
+                  <td class="dada">${esc(dada(k.nomor_dada))}</td>
+                  <td class="regu">${esc(k.nama_regu)}<span class="sekolah">${esc(k.nama_sekolah)}</span></td>
+                  <td>${esc(String(k.total_pos))}</td>
+                  <td>${esc(String(
+                       Number(k.penalti_waktu) + Number(k.penalti_checkout) + Number(k.penalti_anggota)))}</td>
+                  <td class="total">${esc(String(k.total))}</td>
+                </tr>`).join("")}
+            </tbody>
+          </table>
+        </div>
+      </div>`;
+  }).join("");
+}
+
+/* ---------------------------------------------------------------------------
+   Menggambar ulang. Kotak cari dipasang ulang tiap kali, dan posisi kursornya
+   dikembalikan — tanpa itu, mengetik satu huruf membuat fokusnya lepas dan
+   huruf kedua hilang.
+   ------------------------------------------------------------------------- */
+function gambar() {
+  const isi = document.getElementById("isi");
+  if (!DATA) return;
+
+  document.getElementById("judul").textContent =
+    `Rekap Live${DATA.edisi ? ` — ${DATA.edisi.name}` : ""}`;
+  document.title = `Rekap Live — ${DATA.edisi ? DATA.edisi.name : "Hiking Rally Ciradyka"}`;
+
+  const fase = DATA.fase || "pra";
+  isi.innerHTML = fase === "pra"
+    ? gambarPra()
+    : (fase === "penuh" ? gambarKlasemen() : "") + gambarProgres();
+
+  const kotak = document.getElementById("cari");
+  if (kotak) {
+    kotak.addEventListener("input", () => {
+      cari = kotak.value.trim().toLowerCase();
+      const posisi = kotak.selectionStart;
+      gambar();
+      const baru = document.getElementById("cari");
+      if (baru) { baru.focus(); baru.setSelectionRange(posisi, posisi); }
+    });
+  }
+  gambarSinkron();
+}
+
+/* ---------------------------------------------------------------------------
+   Muat + segarkan sendiri. Penanda waktu di URL memaksa lewat cache browser;
+   berkasnya kecil dan sudah bertanda no-cache, tapi sebagian jaringan seluler
+   tetap menyimpannya sendiri.
+   ------------------------------------------------------------------------- */
+async function muat() {
+  try {
+    const r = await fetch(`live.json?t=${Date.now()}`, { cache: "no-store" });
+    if (!r.ok) throw new Error(String(r.status));
+    DATA = await r.json();
+    gambar();
+  } catch {
+    if (!DATA) {
+      document.getElementById("isi").innerHTML = `
+        <div class="kartu tengah">
+          <h2>Belum bisa dimuat</h2>
+          <p>Periksa sambungan internetmu, lalu muat ulang halaman ini.</p>
+        </div>`;
+    }
+  }
+}
+
+muat();
+setInterval(muat, 60000);
+// Cap "berapa menit lalu" ikut berjalan meski datanya belum berubah.
+setInterval(gambarSinkron, 30000);
+document.addEventListener("visibilitychange", () => { if (!document.hidden) muat(); });

--- a/live/live.json
+++ b/live/live.json
@@ -1,0 +1,13 @@
+{
+  "dibuat_pada": "2026-08-14T00:00:00+07:00",
+  "fase": "pra",
+  "edisi": null,
+  "ringkas": {
+    "fase_live": "pra",
+    "jumlah_regu_lunas": 0,
+    "per_golongan": null
+  },
+  "pos": [],
+  "progres": [],
+  "klasemen": []
+}

--- a/live/wrangler.toml
+++ b/live/wrangler.toml
@@ -1,0 +1,31 @@
+# ============================================================================
+# hrcd-rekap : live/wrangler.toml — Worker TERPISAH untuk halaman rekap
+# peserta.
+#
+# KENAPA BUKAN SATU PROYEK DENGAN LAYAR PANITIA
+#
+# Bukan karena memisahkan URL mencegah orang mencoba masuk — alamat panitia
+# tetap ada dan tetap bisa dibuka siapa pun. Yang benar-benar didapat:
+#
+#   1. Halaman ini tidak memuat KUNCI apa pun. web/config.js membawa anon key
+#      dan alamat Supabase; halaman rekap cuma berisi HTML, CSS, dan satu
+#      berkas JSON statis. Tidak ada jalur ke database sama sekali.
+#   2. Link yang dibagikan ke ratusan peserta di grup WhatsApp tidak
+#      sekaligus menyebarkan alamat login panitia.
+#   3. Ratusan HP yang me-refresh tidak menyentuh Worker yang sedang dipakai
+#      panitia bekerja.
+#
+# JANGAN SAMBUNGKAN KE GIT. Berbeda dari web/, proyek ini di-deploy oleh
+# .github/workflows/publish-live.yml — workflow itu menulis live.json yang
+# baru lalu men-deploy seluruh folder. Kalau ia juga tersambung Git, tiap
+# push ke main akan menimpa live.json dengan berkas contoh di repo.
+#
+# Nama memuat nomor edisi, sama seperti web/ — tiap tahun ganti nama + URL
+# (hrcd37-rekap -> hrcd38-rekap), proyek lama dihapus dari dashboard.
+# ============================================================================
+
+name = "hrcd37-rekap"
+compatibility_date = "2026-08-14"
+
+[assets]
+directory = "."

--- a/supabase/checks/live_json.sql
+++ b/supabase/checks/live_json.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- hrcd-rekap : live_json.sql — seluruh isi halaman rekap peserta, satu query.
+--
+-- Dipakai .github/workflows/publish-live.yml, yang mengarahkan keluarannya
+-- langsung ke live/live.json. Ditaruh di supabase/checks/ dan bukan di dalam
+-- berkas workflow supaya bisa dijalankan tangan saat memeriksa apa yang
+-- SEBENARNYA akan terbit:
+--
+--   psql "$SUPABASE_DB_URL" -A -t -f supabase/checks/live_json.sql | less
+--
+-- Tidak ada penyaring fase di sini. Itu disengaja: penggerbangnya ada di
+-- dalam view (0026 dan 0005), jadi tidak ada cara menerbitkan klasemen lebih
+-- awal dengan salah menyunting berkas ini. Selama fase masih 'progres',
+-- v_klasemen_publik memang mengembalikan nol baris.
+-- ============================================================================
+
+select jsonb_pretty(jsonb_build_object(
+
+  -- Cap sinkronisasi yang ditampilkan halaman rekap. Sengaja waktu SERVER
+  -- saat berkas dibuat, bukan waktu halaman dimuat — kalau workflow tersendat,
+  -- peserta harus bisa melihat bahwa datanya tua.
+  'dibuat_pada', now(),
+  'fase',        (select fase_live from status_acara),
+
+  'edisi', (select jsonb_build_object(
+              'nomor', nomor, 'name', name, 'tanggal_lomba', tanggal_lomba)
+            from edisi where is_active),
+
+  'ringkas', (select to_jsonb(r) from v_publik_ringkas r),
+
+  -- Hanya pos yang benar-benar dinilai: garis start dan finish tidak punya
+  -- kolom centang, dan kolom yang selamanya kosong di halaman peserta
+  -- terbaca seperti pos yang panitianya lalai.
+  'pos', (select coalesce(jsonb_agg(jsonb_build_object(
+                   'nomor', nomor, 'name', name, 'bayangan', bayangan)
+                 order by nomor), '[]'::jsonb)
+          from v_pos where jumlah_komponen > 0),
+
+  'progres', (select coalesce(jsonb_agg(to_jsonb(p) order by p.nomor_dada),
+                     '[]'::jsonb)
+              from v_progres_publik p),
+
+  'klasemen', (select coalesce(jsonb_agg(to_jsonb(k)
+                        order by k.golongan, k.peringkat), '[]'::jsonb)
+               from v_klasemen_publik k)
+));

--- a/supabase/migrations/0026_rekap_publik.sql
+++ b/supabase/migrations/0026_rekap_publik.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- hrcd-rekap : 0026_rekap_publik.sql
+--
+-- Bahan halaman rekap live untuk PESERTA (alur-lomba.md 1.5, rancangan-b.md
+-- bagian 7). Halaman itu menjawab satu pertanyaan sepanjang lomba: "nilai
+-- regu saya sudah masuk belum?" — centang per pos, TANPA angka.
+--
+-- YANG MENJAGA KEJUTAN BUKAN TAMPILANNYA, MELAINKAN VIEW INI.
+--
+-- Selama `status_acara.fase_live` masih 'progres', `v_progres_publik` hanya
+-- mengembalikan centang dan `v_klasemen_publik` mengembalikan NOL BARIS. Jadi
+-- angka nilai tidak pernah ikut tertulis ke berkas publik sama sekali — bukan
+-- dikirim lalu disembunyikan CSS, yang bisa dibuka siapa pun lewat devtools.
+-- Admin memindah fase ke 'penuh' saat hasilnya diumumkan, dan barulah
+-- klasemennya ada untuk ditulis.
+--
+-- Yang ditambahkan di sini: fakta OPERASIONAL yang memang sudah diketahui
+-- regunya sendiri — kloter, kontrak waktu, jam berangkat, jam datang.
+-- Menerbitkannya bukan kebocoran, melainkan layanan: regu bisa memastikan
+-- jam yang tercatat panitia sama dengan yang mereka catat sendiri, SEBELUM
+-- hasilnya final. Itu persis kebiasaan pembina di alur-lomba.md 6.10, dan
+-- sengketa yang ketahuan pagi hari jauh lebih murah daripada yang ketahuan
+-- saat pengumuman.
+--
+-- Syarat "sudah tercatat berangkat" DIBUANG. Sebelumnya regu baru muncul di
+-- halaman publik setelah diceklis berangkat; akibatnya regu yang sedang
+-- menunggu di staging membuka halaman itu dan tidak menemukan dirinya sama
+-- sekali — terbaca sebagai "saya tidak terdaftar", padahal justru kloter dan
+-- kontraknya yang ingin ia periksa saat itu.
+--
+-- URUTAN TERHADAP 0025. Migrasi ini menambahkan kolom ke v_progres_publik,
+-- dan 0025 membuat ulang view yang sama tanpa kolom-kolom itu. Menjalankan
+-- 0025 SESUDAH berkas ini berarti meminta Postgres menghapus kolom dari view
+-- — ditolak keras dengan "cannot drop columns from view", seluruh berkas
+-- di-rollback, dan tidak ada yang rusak. Kalau 0025 memang perlu dijalankan
+-- ulang, jalankan berkas ini lagi tepat sesudahnya.
+-- ============================================================================
+
+create or replace view v_progres_publik as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.name as nama_sekolah,
+  r.golongan,
+  -- Hanya pos yang benar-benar dinilai (migrasi 0025): garis start dan garis
+  -- finish tidak punya komponen, dan kolom yang selamanya kosong di halaman
+  -- peserta terbaca sebagai pos yang panitianya lalai.
+  (select jsonb_object_agg(p.nomor::text,
+            exists (select 1 from nilai_mentah n
+                    join wahana w on w.id = n.wahana_id
+                    where n.regu_id = r.id and w.pos = p.nomor))
+   from pos p
+   where p.edisi = edisi_aktif()
+     and exists (select 1 from wahana w
+                 where w.edisi = p.edisi and w.pos = p.nomor)) as pos_terlewati,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing,
+
+  -- Kolom baru. Ditambahkan DI BELAKANG supaya create or replace diterima:
+  -- PostgreSQL mengizinkan kolom baru di ujung, tapi menolak kalau urutan
+  -- atau tipe kolom yang sudah ada ikut bergeser.
+  r.kloter_nomor                              as kloter,
+  r.kontrak_menit,
+  k.jam_berangkat,
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+    then k.jam_berangkat + make_interval(mins => r.kontrak_menit)
+  end                                         as target_datang,
+  c.jam_datang,
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                                              as sudah_berangkat
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join kloter k        on k.nomor = r.kloter_nomor
+left join closing_regu c  on c.regu_id = r.id
+where not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and (select fase_live from status_acara) in ('progres', 'penuh');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -9,12 +9,19 @@ insert into edisi (nomor, name, tahun, tanggal_lomba, biaya_per_regu,
                    lompatan_kloter, interval_berangkat_menit, is_active)
 values (37, 'HRCD XXXVII', 2027, date '2027-02-21', 250000, 10, 30, 40, 2, 4, true);
 
+-- Pos 0 dan Pos 5 adalah garis start dan garis finish (migrasi 0025): tempat
+-- yang sama, disebut Pos 0 saat berangkat dan Pos 5 saat kembali. Keduanya
+-- TIDAK dinilai — tidak punya baris wahana — dan yang dicatat di sana waktu.
+-- Namanya ditulis di sini, bukan hanya di migrasi 0025, supaya database yang
+-- disiapkan dari nol sudah benar tanpa perlu menjalankan ulang migrasi mana
+-- pun. (Migrasi 0025 tetap ada untuk database yang sudah terlanjur berjalan.)
 insert into pos (edisi, nomor, name, bobot) values
+  (37, 0, 'Keberangkatan', 1.00),
   (37, 1, 'Pos 1', 1.00),
   (37, 2, 'Pos 2', 1.00),
   (37, 3, 'Pos 3', 1.00),
   (37, 4, 'Pos 4', 1.00),
-  (37, 5, 'Pos 5', 1.00);
+  (37, 5, 'Kedatangan', 1.00);
 
 -- Satu contoh per bentuk konversi — angka persis dari rancangan-b.md supaya
 -- tes bisa mencocokkan hasil hitung dengan dokumen.

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -30,7 +30,6 @@ run supabase/seed.sql
 # Konfigurasi pos butuh edisinya sudah ada — lihat catatan panjang yang sama
 # di tests/run.sh.
 run supabase/migrations/0024_komponen_pos.sql
-run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run tests/sql/01_seed_uji.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -48,6 +48,7 @@ run supabase/migrations/0022_bentuk_bertingkat.sql
 run supabase/migrations/0023_lembar_pos.sql
 run supabase/migrations/0024_komponen_pos.sql
 run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
+run supabase/migrations/0026_rekap_publik.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -57,13 +58,18 @@ run tests/sql/05_pindah_kloter.sql
 run tests/sql/06_koreksi_jam_berangkat.sql
 run tests/sql/07_pindah_setelah_berangkat.sql
 
-# 0024 dan 0025 dijalankan DUA KALI, dan itu disengaja.
+# 0024 dijalankan DUA KALI, dan itu disengaja.
 #
-# Keduanya mengubah DATA edisi, bukan hanya bentuk tabel. Pada giliran pertama
+# Ia mengubah DATA edisi, bukan hanya bentuk tabel. Pada giliran pertama
 # (di atas, sesuai nomornya) seed.sql belum jalan, jadi belum ada edisi aktif
-# dan bagian datanya dilewati — persis seperti yang tertulis di kepala
-# masing-masing. Kalau keduanya hanya dijalankan di sana, seluruh konfigurasi
-# pos tidak pernah tersentuh tes sama sekali.
+# dan bagian datanya dilewati — persis seperti yang tertulis di kepalanya.
+# Kalau ia hanya dijalankan di sana, seluruh konfigurasi komponen pos tidak
+# pernah tersentuh tes sama sekali.
+#
+# 0025 TIDAK ikut dijalankan ulang. Nama Pos 0 dan Pos 5 sekarang sudah ada di
+# seed.sql, jadi tidak ada lagi yang perlu diulang — dan mengulangnya justru
+# gagal, karena 0026 sudah menambah kolom ke view yang sama dan Postgres
+# menolak menghapus kolom dari view.
 #
 # Giliran kedua di sini, setelah 02-07 selesai memakai lima komponen contoh
 # dari seed.sql. Urutan itu penting: dijalankan lebih awal, komponen contoh
@@ -73,7 +79,7 @@ run tests/sql/07_pindah_setelah_berangkat.sql
 # diulang — yang perlu dipastikan, karena workflow Apply migration bisa saja
 # ditekan dua kali dari HP.
 run supabase/migrations/0024_komponen_pos.sql
-run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run tests/sql/08_lembar_pos.sql
+run tests/sql/09_rekap_publik.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/03_alur.sql
+++ b/tests/sql/03_alur.sql
@@ -587,9 +587,14 @@ update status_acara set fase_live = 'progres';
 set role service_role;
 do $$
 begin
-  -- 5 regu ter-ceklis berangkat: dada 1, 13, 18, 19, dan 14 (menyusul).
-  assert (select count(*) from v_progres_publik) = 5,
-         'fase progres: harusnya 5 regu yang berangkat';
+  -- SELURUH regu lunas yang bernomor dada, bukan hanya yang sudah berangkat
+  -- (migrasi 0026). Syarat "sudah berangkat" dibuang dengan sengaja: regu
+  -- yang sedang menunggu di staging membuka halaman rekap dan tidak
+  -- menemukan dirinya sama sekali, padahal justru kloter dan kontraknya yang
+  -- ingin ia periksa saat itu.
+  assert (select count(*) from v_progres_publik) = 20,
+         'fase progres: harusnya 20 regu lunas bernomor, dapat '
+         || (select count(*) from v_progres_publik);
   assert (select count(*) from v_klasemen_publik) = 0, 'klasemen bocor di fase progres';
 end;
 $$;

--- a/tests/sql/09_rekap_publik.sql
+++ b/tests/sql/09_rekap_publik.sql
@@ -1,0 +1,154 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/09_rekap_publik.sql
+-- Halaman rekap live untuk peserta.
+--
+-- Yang diuji di sini bukan tampilannya, melainkan SATU JANJI: selama lomba
+-- berjalan, angka nilai tidak pernah ikut keluar dari database. Kalau janji
+-- itu patah, tidak ada yang akan menyadarinya — halamannya tetap terlihat
+-- benar, dan yang bocor cuma isi berkas JSON yang bisa dibuka siapa pun
+-- langsung dari alamatnya.
+-- ============================================================================
+
+set role service_role;
+
+-- ---------------------------------------------------------------------------
+-- 9.1 Fase 'pra': belum ada apa-apa.
+-- ---------------------------------------------------------------------------
+reset role;
+update status_acara set fase_live = 'pra';
+set role service_role;
+
+do $$
+begin
+  assert (select count(*) from v_progres_publik) = 0, 'progres bocor di fase pra';
+  assert (select count(*) from v_klasemen_publik) = 0, 'klasemen bocor di fase pra';
+  -- Hitungan pendaftar tetap boleh tampil — itulah isi halaman fase pra.
+  assert (select jumlah_regu_lunas from v_publik_ringkas) > 0,
+         'jumlah pendaftar ikut hilang di fase pra';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 9.2 Fase 'progres': centang dan fakta operasional, TANPA satu pun angka.
+-- ---------------------------------------------------------------------------
+reset role;
+update status_acara set fase_live = 'progres';
+set role service_role;
+
+do $$
+declare p record;
+begin
+  assert (select count(*) from v_progres_publik) > 0, 'fase progres kosong';
+
+  -- INILAH janjinya. Selama fase progres, klasemen tidak boleh punya satu
+  -- baris pun — bukan disembunyikan tampilan, tapi memang tidak ada.
+  assert (select count(*) from v_klasemen_publik) = 0,
+         'BOCOR: klasemen keluar di fase progres';
+
+  -- Dan tidak ada kolom bernilai angka skor di view progres. Diperiksa dari
+  -- katalog, bukan dari mata: kolom baru bisa ditambahkan orang lain nanti,
+  -- dan yang menambahkannya belum tentu ingat janji ini.
+  assert not exists (
+    select 1 from information_schema.columns
+    where table_name = 'v_progres_publik'
+      and (column_name like '%total%' or column_name like '%poin%'
+           or column_name like '%nilai%' or column_name like '%penalti%'
+           or column_name like '%peringkat%')),
+    'BOCOR: v_progres_publik punya kolom berbau nilai — '
+    || (select string_agg(column_name, ', ') from information_schema.columns
+        where table_name = 'v_progres_publik');
+
+  -- Fakta operasional yang memang diminta panitia ikut terbawa.
+  select * into strict p from v_progres_publik where nomor_dada = 1;
+  assert p.kloter is not null,        'kloter tidak ikut di rekap publik';
+  assert p.kontrak_menit is not null, 'kontrak waktu tidak ikut di rekap publik';
+  assert p.jam_berangkat is not null, 'jam berangkat tidak ikut di rekap publik';
+  assert p.jam_datang is not null,    'jam datang tidak ikut di rekap publik';
+  assert p.target_datang = p.jam_berangkat + make_interval(mins => p.kontrak_menit),
+         'target datang tidak sama dengan jam berangkat + kontrak';
+
+  -- Centang per pos: objek berkunci nomor pos, isinya boolean.
+  assert jsonb_typeof(p.pos_terlewati) = 'object', 'pos_terlewati bukan objek';
+  assert (p.pos_terlewati ->> '1')::boolean, 'dada 1 sudah dinilai di pos 1, tapi tidak tercentang';
+  -- Pos yang tidak punya komponen penilaian tidak boleh jadi kolom centang —
+  -- kolom yang selamanya kosong di halaman peserta terbaca seperti pos yang
+  -- panitianya lalai. Dihitung dari data, BUKAN dengan menyebut nomor pos:
+  -- di database uji, Pos 5 kebetulan masih memegang satu komponen contoh
+  -- yang tidak boleh dihapus (lihat 0024), sedangkan di produksi ia kosong.
+  assert not exists (
+    select 1 from v_pos where jumlah_komponen = 0
+      and p.pos_terlewati -> nomor::text is not null),
+    'pos tanpa penilaian ikut jadi kolom centang: '
+    || (select string_agg(nomor::text, ', ') from v_pos
+        where jumlah_komponen = 0 and p.pos_terlewati -> nomor::text is not null);
+end;
+$$;
+
+-- Regu yang BELUM berangkat tetap muncul — justru merekalah yang paling
+-- ingin memeriksa kloter dan kontraknya (migrasi 0026).
+do $$
+declare v_belum int;
+begin
+  select count(*) into v_belum
+  from v_progres_publik where not sudah_berangkat;
+  assert v_belum > 0, 'regu yang belum berangkat hilang dari halaman rekap';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 9.3 Fase 'penuh': klasemen terbuka, lengkap dengan juaranya.
+-- ---------------------------------------------------------------------------
+reset role;
+update status_acara set fase_live = 'penuh';
+set role service_role;
+
+do $$
+declare v_juara record;
+begin
+  assert (select count(*) from v_klasemen_publik) > 0, 'klasemen kosong di fase penuh';
+  -- Tiap golongan punya peringkat 1 sendiri — empat klasemen terpisah
+  -- (alur-lomba.md 2.3), bukan satu daftar panjang.
+  for v_juara in select golongan, min(peringkat) as teratas
+                 from v_klasemen_publik group by golongan loop
+    assert v_juara.teratas = 1,
+      'golongan ' || v_juara.golongan || ' tidak punya peringkat 1';
+  end loop;
+  -- Progres tetap ada di fase penuh: halaman rekap menampilkan keduanya.
+  assert (select count(*) from v_progres_publik) > 0,
+         'centang progres hilang setelah fase penuh';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 9.4 Berkas yang benar-benar diterbitkan.
+--     Query yang sama persis dengan yang dipakai publish-live.yml.
+-- ---------------------------------------------------------------------------
+
+reset role;
+update status_acara set fase_live = 'progres';
+set role service_role;
+
+do $$
+declare v jsonb;
+begin
+  select jsonb_build_object(
+    'dibuat_pada', now(),
+    'fase', (select fase_live from status_acara),
+    'pos', (select coalesce(jsonb_agg(jsonb_build_object('nomor', nomor) order by nomor), '[]'::jsonb)
+            from v_pos where jumlah_komponen > 0),
+    'progres', (select coalesce(jsonb_agg(to_jsonb(p)), '[]'::jsonb) from v_progres_publik p),
+    'klasemen', (select coalesce(jsonb_agg(to_jsonb(k)), '[]'::jsonb) from v_klasemen_publik k)
+  ) into v;
+
+  assert jsonb_array_length(v -> 'klasemen') = 0,
+         'BOCOR: berkas terbitan memuat klasemen di fase progres';
+  assert jsonb_array_length(v -> 'progres') > 0, 'berkas terbitan kosong';
+  -- Tidak ada satu pun angka nilai di seluruh berkas. Dicari sebagai TEKS,
+  -- karena itulah bentuk yang benar-benar dikirim ke HP peserta.
+  assert v::text not like '%total%' and v::text not like '%peringkat%',
+         'BOCOR: kata bernuansa nilai muncul di berkas terbitan fase progres';
+end;
+$$;
+
+reset role;
+select '09_rekap_publik OK' as hasil;


### PR DESCRIPTION
## What

The public page promised in `alur-lomba.md` 1.5 and `rancangan-b.md` 7, never built until now. It answers one question for peserta and pembina all day: **"has my regu's score been entered, or is it lost?"**

A tick per pos, plus the operational facts the regu already knows — kloter, kontrak waktu, jam berangkat, jam datang. Search by nomor dada, regu name or school. After closing, the admin moves the phase and the same page shows the four standings with their champions.

## Why

**What keeps the surprise is the database, not the screen.**

While `fase_live` is `progres`, `v_klasemen_publik` returns zero rows and `v_progres_publik` has no column carrying a score at all. So the published `live.json` **does not contain** scores — it is not carrying them hidden behind CSS, which anyone could defeat by opening the JSON URL directly.

`tests/sql/09` guards that promise from both sides: standings must be empty during `progres`, and `v_progres_publik` is checked **through the catalog** so a score-ish column added next year is caught — whoever adds it will not remember this promise.

Publishing the times is a service rather than a leak: a regu can check that what the panitia recorded matches what they wrote down themselves, **before** the results are final. A dispute found in the morning is far cheaper than one found at the announcement.

## Its own Worker

Not because a separate URL stops anyone trying to log in — the panitia address still exists and always will. What it actually buys:

1. The recap page carries **no keys**. `web/config.js` carries the anon key and the Supabase URL; `live/` is HTML, CSS and one JSON file, with no path to the database at all.
2. A link forwarded around WhatsApp does not also spread the panitia login address.
3. Hundreds of refreshing phones never touch the Worker the panitia are working in.

`live/` is deliberately **not** connected to Git: what gets deployed is the `live.json` the workflow just built from the database, and a Git connection would overwrite it with the placeholder in the repo on every push to `main`.

## Notes

`publish-live.yml` runs one query that produces the whole file, checks it before deploying — valid JSON, required keys, and **standings empty unless the phase says otherwise** — then deploys. The page reads that static file every 60 seconds: zero Supabase requests from participants' phones.

The **"Sinkronisasi terakhir"** stamp uses the time the file was *built on the server*, not the time the page loaded, so a stalled workflow is visible rather than disguised as fresh data. Past 15 minutes it changes colour and says so.

**The cron is committed switched off.** Turn it on for the week of the event and off again afterwards; the repo is private and Actions minutes are spent whether or not anything changed.

Two things came along:

- **`v_progres_publik` no longer requires the regu to have departed.** A regu waiting in staging opened the page and could not find itself at all — read as "I am not registered" — when kloter and kontrak were exactly what it wanted to check.
- **Pos 0 and Pos 5 are named in `seed.sql` now**, not only in migration 0025. Without that, `run.sh` had to re-run 0025 after the seed, and re-running it after 0026 asks Postgres to drop columns from a view, which it refuses.

Verified end to end against a real database: the generator query run against 81 regu, both phases rendered in a browser, search and the sync stamp exercised, no console errors. SQL suite passes on PostgreSQL 18.6.

## Before this can go live

Two things need you, both one-off:

1. **Create the Cloudflare Worker** named `hrcd37-rekap` — do *not* connect it to Git.
2. Confirm `CLOUDFLARE_API_TOKEN` and `SUPABASE_DB_URL` exist as repository secrets (both are already used by other workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)