### PR TITLE
docs: record how two Cloudflare projects served the same folder

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -501,6 +501,24 @@ Dikumpulkan dari kesalahan yang benar-benar terjadi, bukan daftar teoretis.
    sesudahnya tanpa galat apa pun. Layout tampak jalan lewat kolom implisit.
 7. **`AGENTS.md` wajib identik dengan `CLAUDE.md`.** Ia pernah menyimpang 21
    baris dan tiga stringnya rusak oleh find-and-replace atas nama agen.
+8. **Dua project Cloudflare bisa menyajikan folder yang sama tanpa satu pun
+   galat.** Yang menentukan folder mana yang terbit adalah kotak "Root
+   directory" di dashboard — tidak terlihat dari repo, tidak ikut ter-review,
+   tidak ada di git. Saat `panitia-hrcd37` dibuat, kotak itu terisi `live`:
+   dua alamat menjawab 200 dengan halaman yang sama persis, dan layar panitia
+   tidak dilayani siapa pun. Cara memeriksanya dari luar, tanpa login:
+
+   ```bash
+   curl -sI https://panitia-hrcd37.ciradyka.workers.dev/js/app.js | head -1  # 200
+   curl -sI https://hrcd37.ciradyka.workers.dev/js/app.js | head -1          # 404
+   ```
+
+   `js/app.js` hanya ada di `web/`, `live.js` hanya ada di `live/` — keduanya
+   penanda yang cukup untuk tahu folder mana yang sedang terbit.
+9. **Mengubah "Root directory" tidak menerbitkan ulang apa pun.** Setelan itu
+   berlaku untuk build BERIKUTNYA. Selama belum ada push atau "Retry
+   deployment", yang tersaji tetap hasil build lama dengan folder lama —
+   setelan sudah benar di layar, produksi masih salah.
 
 ---
 


### PR DESCRIPTION
## What

Two entries added to `final-architecture.md` §7, the list of things that have actually gone wrong.

## Why

Which folder a project publishes is decided by a **Root directory** box in the Cloudflare dashboard. It is not in git, is not reviewed, and cannot be seen from the repo. When `panitia-hrcd37` was created that box said `live`, so both addresses answered `200` with byte-identical pages and the panitia screens were served by nobody — with nothing failing anywhere.

Recorded with the two-command check that tells the folders apart from outside, without logging in: `js/app.js` exists only in `web/`, `live.js` only in `live/`.

Also recorded that **changing the box publishes nothing by itself.** It applies to the *next* build, so between fixing the setting and the next push the dashboard looks right while production is still wrong — which is exactly the state this commit was written in.

Merging this is also the push that triggers that next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)