### PR TITLE
docs: correct every claim the code no longer supports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,10 +111,13 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
     Migrations are *applied*, not "implemented"; tests *run*; servers *start*.
     Translating word-for-word from Indonesian produces names that are English
     but still unsearchable, which defeats the entire point of rule 5.
-11. Rule 9 stops where the domain begins. `0011_nomor_dada_manual.sql` and
-    `05_pindah_kloter.sql` keep their Indonesian parts, because `nomor dada`
-    and `kloter` are rule 3 terms — only the surrounding technical words
-    (`print`, `move`, `seed`, `test`) turn English.
+11. Rule 9 stops where the domain begins. `0011_nomor_dada_manual.sql`,
+    `0008_cetak_kloter.sql` and `05_pindah_kloter.sql` keep their Indonesian
+    parts, because `nomor dada`, `kloter`, `cetak kloter` and `pindah kloter`
+    are all things the panitia say — only the surrounding words that already
+    have an industry name turn English (`seed`, `test`, `rename`,
+    `migration`), as in `supabase/seed.sql` and
+    `0012_rename_audit_columns.sql`.
 12. **A workflow's `name:` field is UI text, so rule 1 decides it — by
     audience, not by file.** A workflow a panitia runs from the Actions tab on
     their phone keeps an Indonesian name ("Ganti password akun panitia",
@@ -141,5 +144,11 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    something GitHub enforces. Follow it deliberately.
 3. Git identity is configured **repo-locally**, not globally:
    `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
-4. PR #1 predates this convention and was squash-merged. It is the one commit on
-   `main` without a merge point; leave it as is.
+4. PR #1 predates this convention and was squash-merged. Apart from the root
+   `Initial commit`, it is the only commit on `main` without a merge point;
+   leave both as they are.
+5. `CLAUDE.md` and `AGENTS.md` are the same document twice — byte-identical
+   apart from the first heading and the intro paragraph. Every edit to one
+   lands in the other in the same commit. No workflow checks this
+   (`shared-files.yml` only compares `web/` against `live/`), and the pair has
+   already drifted 21 lines once, losing all of section 5's rules 9-12.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,13 @@ Guidance for Claude Code when working in this repository.
     Migrations are *applied*, not "implemented"; tests *run*; servers *start*.
     Translating word-for-word from Indonesian produces names that are English
     but still unsearchable, which defeats the entire point of rule 5.
-11. Rule 9 stops where the domain begins. `0011_nomor_dada_manual.sql` and
-    `05_pindah_kloter.sql` keep their Indonesian parts, because `nomor dada`
-    and `kloter` are rule 3 terms — only the surrounding technical words
-    (`print`, `move`, `seed`, `test`) turn English.
+11. Rule 9 stops where the domain begins. `0011_nomor_dada_manual.sql`,
+    `0008_cetak_kloter.sql` and `05_pindah_kloter.sql` keep their Indonesian
+    parts, because `nomor dada`, `kloter`, `cetak kloter` and `pindah kloter`
+    are all things the panitia say — only the surrounding words that already
+    have an industry name turn English (`seed`, `test`, `rename`,
+    `migration`), as in `supabase/seed.sql` and
+    `0012_rename_audit_columns.sql`.
 12. **A workflow's `name:` field is UI text, so rule 1 decides it — by
     audience, not by file.** A workflow a panitia runs from the Actions tab on
     their phone keeps an Indonesian name ("Ganti password akun panitia",
@@ -139,5 +142,11 @@ Guidance for Claude Code when working in this repository.
    something GitHub enforces. Follow it deliberately.
 3. Git identity is configured **repo-locally**, not globally:
    `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
-4. PR #1 predates this convention and was squash-merged. It is the one commit on
-   `main` without a merge point; leave it as is.
+4. PR #1 predates this convention and was squash-merged. Apart from the root
+   `Initial commit`, it is the only commit on `main` without a merge point;
+   leave both as they are.
+5. `CLAUDE.md` and `AGENTS.md` are the same document twice — byte-identical
+   apart from the first heading and the intro paragraph. Every edit to one
+   lands in the other in the same commit. No workflow checks this
+   (`shared-files.yml` only compares `web/` against `live/`), and the pair has
+   already drifted 21 lines once, losing all of section 5's rules 9-12.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 ├── docs/                     # spesifikasi, catatan keputusan, arsitektur
 ├── web/                      # SPA statis — layar panitia (panitia-hrcd37)
 │   ├── index.html            # layar panitia (butuh login)
-│   ├── js/                   # api.js, app.js, daftar.js, util.js
+│   ├── js/                   # api.js, app.js, util.js
 │   ├── style.css             # seluruh gaya, termasuk aturan cetak
 │   ├── config.js             # URL Supabase + gateway (bukan rahasia)
 │   ├── _headers              # aturan cache Cloudflare
@@ -39,22 +39,28 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 ├── live/                     # situs PESERTA (hrcd37) — Worker TERPISAH:
 │   ├── daftar.html           # form pendaftaran publik
 │   ├── index.html            # rekap live (centang per pos, isinya live.json)
-│   └── js/, style.css, …     # SALINAN dari web/ — jangan disunting di sini,
+│   ├── live.js, live.css     # halaman rekap — tidak ada di web/
+│   ├── js/daftar.js          # logika form pendaftaran — tidak ada di web/
+│   └── config.js, style.css, js/api.js, js/util.js
+│                             # SALINAN dari web/ — jangan diedit di sini,
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
 │   ├── migrations/           # skema database, urut 0001..0026
-│   ├── checks/               # SQL pemeriksaan manual (row_counts, smoke, dst.)
+│   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
+│   │                         # data; live_json.sql dipakai Publish rekap live
 │   └── seed.sql              # konfigurasi edisi + baris wajib
 ├── scripts/                  # provision_accounts.py, change_password.py
 ├── tests/
 │   ├── sql/                  # harness + tes constraint, alur, skor, kloter, rekap
 │   ├── run.sh                # jalankan semuanya di database lokal
+│   ├── dev_database.sh       # siapkan database hrcd_dev untuk dicoba manual
 │   ├── dev_server.py         # tiruan Supabase untuk mencoba layar
-│   └── static_server.py      # penyaji web/ tanpa cache
+│   ├── static_server.py      # penyaji web/ tanpa cache
+│   └── concurrency_test.py   # uji daftar ulang serentak dari banyak meja
 ├── .github/workflows/        # 7 workflow (lihat final-architecture.md)
 ├── CLAUDE.md                 # konvensi kerja
-└── AGENTS.md                 # salinan identik CLAUDE.md
+└── AGENTS.md                 # aturan sama dengan CLAUDE.md (judul + pembuka beda)
 ```
 
 ## Menjalankan tes
@@ -72,6 +78,15 @@ bash tests/dev_database.sh     # siapkan database hrcd_dev
 python tests/dev_server.py     # tiruan Supabase di :8787
 python tests/static_server.py  # layar panitia di :8788 (tanpa cache)
 ```
+
+Sebelum membuka `:8788`, ganti `mode: "supabase"` jadi `mode: "dev"` di
+`web/config.js` — tanpa itu layar lokal tetap berbicara dengan Supabase
+**produksi**, bukan `dev_server.py` di `:8787`. Kembalikan ke `"supabase"`
+sebelum commit: nilai itu ikut ter-deploy, dan `shared-files.yml` juga
+membandingkan `web/config.js` dengan salinannya di `live/`.
+
+`dev_server.py` dan `concurrency_test.py` butuh `psycopg2`. Tidak ada
+requirements.txt di repo — pasang sekali saja: `pip install psycopg2-binary`.
 
 Runner membuat ulang database `hrcd_test` setiap kali — aman diulang. Tes
 mencakup: nomor dada ganda tertolak, kapasitas kloter, RLS per pos, alur
@@ -92,6 +107,11 @@ bash tests/dev_database.sh        # siapkan database hrcd_dev
 python tests/concurrency_test.py  # 30 meja serentak, 300 nomor diperebutkan
 ```
 
+**Catatan:** `tests/concurrency_test.py` belum diperbarui sejak migrasi `0014`
+mengganti nama kolom (`sekolah.nama` → `name`, `edisi.aktif` → `is_active`,
+`regu.batal` → `is_cancelled`), jadi saat ini ia berhenti di langkah
+`siapkan()`. Perbaiki nama kolomnya dulu sebelum menjalankan.
+
 ## Menerapkan migrasi ke produksi
 
 Merge TIDAK menerapkan migrasi. Jalankan workflow-nya sendiri:
@@ -104,6 +124,11 @@ gh workflow run "Apply migration to Supabase" --ref main \
 Atau dari HP: **Actions → Apply migration to Supabase → Run workflow**. Pastikan
 log-nya mencetak `MIGRASI BERHASIL`.
 
+Merge juga TIDAK men-deploy folder `live/`. Situs peserta — form pendaftaran
+dan rekap live — hanya terbit lewat **Actions → Publish rekap live**, termasuk
+kalau yang berubah cuma `daftar.html`. Yang otomatis terbit tiap push ke `main`
+hanya `web/`, lewat koneksi Git Cloudflare.
+
 ## Kontribusi
 
 Semua perubahan lewat branch + pull request — konvensi lengkap di `CLAUDE.md`.
@@ -112,7 +137,10 @@ Semua perubahan lewat branch + pull request — konvensi lengkap di `CLAUDE.md`.
 git checkout -b <type>/<deskripsi-singkat>
 # ...ubah...
 git push -u origin HEAD
-gh pr create --fill
+gh pr create --base main --title "<type>: <apa yang berubah>" --body "..."
 ```
+
+Isi body-nya dengan bagian **What** dan **Why** — `--fill` mengambilnya dari
+pesan commit dan menghasilkan PR tanpa keduanya.
 
 PR di-merge dengan merge commit (`--no-ff`) bersubjek `Judul (#nomor)`.

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -4,7 +4,8 @@ Dokumen ini merekam alur penyelenggaraan dan aturan penilaian Hiking Rally
 Ciradyka (HRCD) sebagai dasar perancangan sistem `hrcd-rekap`.
 
 Isinya adalah hasil penjelasan panitia, bukan rancangan teknis. Keputusan
-teknologi belum diambil dan sengaja tidak dibahas di sini.
+teknologi sudah diambil dan sudah berjalan, tetapi perbandingan dan alasannya
+sengaja tidak dibahas di sini — lihat bagian 13.5 dan `final-architecture.md`.
 
 > **Penting:** aturan penilaian **berubah setiap tahun**. Semua angka di dokumen
 > ini adalah konfigurasi edisi berjalan, bukan spesifikasi permanen. Lihat
@@ -39,8 +40,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
      akses yang dibedakan per akun (bagian 8.8).
    - **Tampilan live untuk peserta** — halaman publik tanpa login, berisi
      **klasemen penuh empat golongan**, dibuka **bertahap**: selama lomba
-     hanya progres tanpa angka (regu X sudah melewati pos Y), nilai dan
-     peringkat lengkap baru tampil setelah closing. Halaman ini **disajikan
+     hanya progres tanpa angka nilai — centang per pos, ditambah kloter,
+     kontrak waktu, jam berangkat, dan jam datang regu itu sendiri, supaya
+     jamnya bisa dicocokkan sebelum hasilnya final — nilai dan peringkat
+     lengkap baru tampil setelah closing. Halaman ini **disajikan
      statis dan diperbarui berkala**, tidak pernah membaca database langsung —
      ratusan HP penonton tidak boleh bisa membebani jalur input panitia.
 
@@ -115,7 +118,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
 1. Berlangsung 1–2 hari sebelum lomba.
 2. Regu yang sudah membayar langsung menuju meja daftar ulang. Regu yang belum
-   mendaftar diarahkan ke meja pendaftaran offline lebih dulu (bagian 3.5).
+   mendaftar diarahkan ke meja pendaftaran offline lebih dulu (bagian 3.6).
 3. Di meja daftar ulang, regu menyebutkan **kode pembayaran** sebagai ID.
    Panitia mengonfirmasi **nama regu** dan **asal sekolah**.
 4. Panitia lalu menyandingkan regu dengan sebuah **nomor dada**, diambil dari
@@ -136,12 +139,12 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    nomor dadanya; penyebaran kloter justru tidak boleh diserahkan ke petugas
    karena bertumpu pada keadaan seluruh sekolah, bukan satu meja saja.
 8. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
-   petugas lapangan (bagian 8.4).
+   petugas lapangan (bagian 8.6).
 
 ## 5. Kloter dan kontrak waktu
 
 1. Satu kloter berisi **paling banyak 10 regu**. Jumlahnya dapat kurang dari 10
-   bila ada regu yang batal setelah membayar (bagian 3.6).
+   bila ada regu yang batal setelah membayar (bagian 3.7).
 2. **30 kloter selalu ada**, karena jumlah peserta konsisten di kisaran 300
    regu. Kloter 31–40 dibuka hanya jika terisi, dan kloter terakhir boleh tidak
    penuh.
@@ -216,10 +219,13 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
     - **Petugas staging** — ada kolom centang kehadiran dan tempat menulis jam
       berangkat sebenarnya.
     - **Papan pengumuman utama dan barak** — dibaca peserta, memuat perkiraan
-      jam berangkat. Lembar ini juga menyediakan kotak bagi **pembina regu
-      untuk mencatat jam berangkat sebenarnya**, karena pembina biasa
-      mencatatnya sebagai bahan klarifikasi bila penilaian ketepatan waktu
-      dipersoalkan (target datang = jam berangkat + kontrak waktu).
+      jam berangkat saja; tidak ada kolom centang maupun kotak jam, karena
+      keduanya tidak berguna bagi peserta. Kebiasaan **pembina regu mencatat
+      jam berangkat sebenarnya** sebagai bahan klarifikasi bila penilaian
+      ketepatan waktu dipersoalkan (target datang = jam berangkat + kontrak
+      waktu) kini dilayani halaman rekap live, yang menampilkan kloter,
+      kontrak waktu, jam berangkat, dan jam datang tiap regu selama lomba
+      berjalan.
 11. **Peserta yang terlambat masuk kloternya** diberangkatkan di **kloter
     terakhir**. Bila keadaannya mendesak, panitia dapat memaksa nomor dada
     tertentu masuk kloter mana pun — termasuk kloter yang kertasnya sudah
@@ -345,6 +351,11 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    001 - Rajawali - SMPN 1 Purwadadi - Penggalang PA - V
    ```
 
+   Satu kolom sengaja **tidak** ikut dicetak: **Nilai Pos**. Petugas lapangan
+   hanya menulis data mentah dan tidak pernah menjumlahkan sendiri (poin 1) —
+   kotak berjudul Nilai Pos justru mengundang hitungan tangan yang berbeda
+   dengan angka sistem.
+
 7. Sebuah **server pemantau** menampilkan status kelengkapan input — pos mana
    yang sudah menyetor dan pos mana yang belum.
 8. **Satu link untuk semua panitia, akses dibedakan per akun.** Setiap akun
@@ -359,15 +370,17 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    Ada tiga peran: `admin`, `meja` (petugas pembayaran / daftar ulang /
    keberangkatan), dan `operator_pos`. Akun hanya diberikan kepada admin tiap
    pos, petugas meja, dan tim IT. Operator sebuah pos tidak dapat menyentuh
-   nilai pos lain, dan akun pos ditolak masuk ke layar meja dengan pesan "Akun
-   pos, bukan akun meja" — ditegakkan oleh sistem, bukan sekadar disembunyikan
-   dari layar.
+   nilai pos lain, dan akun meja ditolak masuk ke layar input pos dengan pesan
+   "Akun meja, bukan akun pos" — ditegakkan oleh sistem, bukan sekadar
+   disembunyikan dari layar. Sebaliknya akun pos tidak diberi jalan ke layar
+   meja: Home-nya hanya memuat satu kartu, "Input Nilai Pos N", dan RLS
+   mengosongkan data meja seandainya alamatnya diketik langsung.
 9. Pola nama akun mengikuti edisi (`hrcd37` = edisi ke-37), sehingga akun dan
    password dapat diganti bersih setiap tahun tanpa membongkar sistem.
-9. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap
-   dicatat**: siapa memasukkan atau mengubah nilai apa, dan kapan. Tujuannya
-   bukan mengawasi orang, melainkan agar setiap angka dapat ditelusuri kembali
-   ketika ada yang janggal.
+10. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap
+    dicatat**: siapa memasukkan atau mengubah nilai apa, dan kapan. Tujuannya
+    bukan mengawasi orang, melainkan agar setiap angka dapat ditelusuri kembali
+    ketika ada yang janggal.
 
 ## 9. Perhitungan skor
 
@@ -407,7 +420,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
      penalti dibulatkan per 10 menit.
      Targetnya ±3 detik per regu, sehingga 20 regu yang datang bersamaan pun
      tidak menumpuk. Jam yang tersimpan adalah **jam saat tombol ditekan di
-     laptop panitia**, bukan cap waktu server saat data sampai — dan tetap
+     laptop panitia**, bukan timestamp server saat data sampai — dan tetap
      dapat diubah manual untuk pencatatan susulan dari kertas (bagian 12.3).
 3. Penalti dihitung dari selisih mutlak antara jam datang dan target:
 
@@ -485,7 +498,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    jumlah jalur >= (10 * batas waktu wahana) / interval keberangkatan
    ```
 
-   Karena penumpukan sedang memang ditoleransi (bagian 7.5), kapasitas boleh
+   Karena penumpukan sedang memang ditoleransi (bagian 7.10), kapasitas boleh
    sedikit di bawah angka itu — tetapi kekurangan kapasitas berdampak
    berlipat pada kloter belakang, sehingga besarnya toleransi perlu dihitung,
    bukan dikira-kira.
@@ -495,9 +508,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
    Besar lompatan kloter (bagian 5.6) juga ditentukan di analisis yang sama,
    karena bergantung pada interval keberangkatan.
-2. **Bentuk rumus konversi data mentah menjadi poin.** Belum ditentukan, dan
-   panitia menegaskan **semua kombinasi mungkin terjadi**. Bentuk yang sudah
-   disebut:
+2. **Angka rumus konversi data mentah menjadi poin.** Bentuk-bentuknya sudah
+   selesai dirancang dan berjalan; yang belum ditentukan tinggal angkanya
+   untuk edisi berjalan. Panitia menegaskan **semua kombinasi mungkin
+   terjadi**, dan keenam bentuk berikut sudah terpasang:
 
    | Bentuk | Contoh data mentah |
    | --- | --- |
@@ -506,11 +520,14 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    | Biner | kena / tidak, benar / salah |
    | Benar dibagi total | `7` dari `10` soal |
    | Benar dikurangi salah | jawaban salah mengurangi nilai |
+   | Bertingkat | tangga poin per pita waktu — sampai 1 menit = 50, sampai 1,5 menit = 30, sampai 2 menit = 15, lebih dari itu = 0 |
 
    Karena bentuknya bisa berubah tiap tahun dan tiap wahana, konfigurasi
-   konversi harus dirancang cukup luwes untuk menampung semuanya. Perancangan
-   detailnya ditunda.
-3. **Arti singkatan `IMPK`** pada contoh lembar nilai di bagian 8.4.
+   konversi dirancang luwes untuk menampung semuanya: keenam bentuk di atas
+   ada di fungsi `hitung_poin()`, dan tiap komponen pos diatur lewat satu
+   baris konfigurasi, bukan lewat kode. Angka yang terpasang sekarang adalah
+   angka HRCD XXXVI sebagai titik awal.
+3. **Arti singkatan `IMPK`** pada contoh lembar nilai di bagian 8.6.
 4. **Dua pembacaan pada bagian 10 yang belum dipastikan:**
    - Pengurangan −100 karena tidak checkout — apakah menggantikan penalti waktu,
      atau ditambahkan padanya? Tanpa checkout tidak ada jam datang, sehingga

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -4,11 +4,13 @@
 > Dokumen ini ditulis SEBELUM sistemnya dibangun, untuk memilih arsitektur.
 > Kandidat B dipilih (bagian 8) dan sudah lama berjalan di produksi.
 >
-> Isinya sengaja **tidak** diperbarui: nilainya justru pada rekaman apa yang
-> diketahui dan dipertimbangkan saat keputusan diambil. Maka kalimat di bagian
-> 4 seperti "Cloudflare Pages", "tanpa server custom", `FOR UPDATE SKIP LOCKED`,
-> atau tabel `riwayat` menggambarkan RENCANA saat itu — beberapa di antaranya
-> memang berubah saat dibangun.
+> Analisisnya sengaja **tidak** diperbarui mengikuti sistem yang akhirnya
+> dibangun: nilainya justru pada rekaman apa yang diketahui dan dipertimbangkan
+> saat keputusan diambil. Yang ditambahkan belakangan hanya penanda hasil —
+> blok keputusan di bagian 8, catatan di bagian 7.1, dan tanda **Selesai** di
+> bagian 9. Maka kalimat di bagian 4 seperti "Cloudflare Pages", "tanpa server
+> custom", `FOR UPDATE SKIP LOCKED`, atau tabel `riwayat` menggambarkan RENCANA
+> saat itu — beberapa di antaranya memang berubah saat dibangun.
 >
 > **Untuk keadaan sistem sekarang, baca `final-architecture.md`.**
 
@@ -104,8 +106,9 @@ Ringkasan dari `alur-lomba.md` — setiap kandidat dipetakan ke daftar ini:
    polling hanya untuk operator.
 2. **Latensi 1–4 detik per aksi server** — setiap layar terasa berat, tidak
    bisa diperbaiki.
-3. Keamanan setara "sistem kepercayaan": password di sheet, tidak ada isolasi
-   server sejati — cukup untuk model kepercayaan panitia, tapi tidak lebih.
+3. Keamanan setara "sistem kepercayaan": password di sheet, isolasinya hidup di
+   kode aplikasi dan bukan di platform — cukup untuk model kepercayaan panitia,
+   tapi tidak lebih. Lihat koreksi di bagian 8.3.
 4. Database bisa rusak oleh tangan: satu kali sort tidak sengaja oleh
    kolaborator di tengah lomba = insiden data. Restore versi Sheets bersifat
    **seluruh file** — mengembalikan satu kesalahan ikut menghapus semua input
@@ -281,7 +284,7 @@ kloter, validasi upload — semuanya berjalan di browser.
 | Untuk pemelihara pelajar | Sedang | Sedang | Sulit | Sedang |
 | Risiko 10 bulan idle | **Nol** | Kecil (perlu keep-alive) | Kecil | **Nol** |
 | Nomor dada anti-ganda (R3) | Lock aplikasi | **Transaksi DB** | Transaksi klien | **UNIQUE index** |
-| Isolasi per pos (R6) | Kepercayaan | **Ditegakkan server** | Ditegakkan server | Ditegakkan server |
+| Isolasi per pos (R6) | Kode aplikasi (koreksi di bagian 8.3) | **Ditegakkan server** | Ditegakkan server | Ditegakkan server |
 | Riwayat perubahan (R13) | Konvensi kode | **Trigger otomatis** | Konvensi kode | Hook server |
 | Konfigurasi skor oleh panitia (R7) | **Edit cell langsung** | Layar admin | Layar admin | Layar admin |
 | Kecepatan layar | Lambat (1–4 dtk) | Cepat | Cepat | **Paling cepat** |
@@ -423,7 +426,9 @@ tahun kebiasaan panitia, dan keputusan sepenuhnya milik panitia.
 > sisanya masih relevan.
 
 1. ~~Pilih kandidat (bagian 8).~~ **Selesai: B.** Sudah berjalan di produksi —
-   Supabase, situs statis Cloudflare Workers, Worker gateway, 20 migrasi.
+   Supabase, dua situs statis Cloudflare Workers, Worker gateway, dan skema
+   database yang terus bertambah (hitungan migrasi terkini di
+   `final-architecture.md`).
 2. Siapa yang memegang akun-akun gratis (Google/Supabase/Cloudflare/GitHub) —
    disarankan akun organisasi ambalan, bukan akun pribadi pengurus, dengan
    minimal dua orang tahu password-nya.

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -11,7 +11,7 @@ Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0026`.
 
 ## 1. Bentuk sistem
 
-Tiga bagian, dan hanya satu di antaranya kode yang kita tulis dan jalankan
+Empat bagian, dan hanya satu di antaranya kode yang kita tulis dan jalankan
 sendiri di server:
 
 | Bagian | Isi | Di mana |
@@ -53,8 +53,10 @@ karena form pendaftaran disajikan dari sana.
 
 Nama project situs memuat nomor edisi (`hrcd37`) dan berganti tiap tahun.
 Gateway dan project Supabase sengaja TIDAK memuat nomor edisi supaya bisa
-dipakai lintas tahun. Kalau `name` di `web/wrangler.toml` diubah, `ALLOWED_ORIGIN`
-di `workers/gateway/worker.js` wajib ikut diubah.
+dipakai lintas tahun. Kalau `name` di `live/wrangler.toml` diubah,
+`ALLOWED_ORIGIN` di `workers/gateway/worker.js` wajib ikut diubah — form
+pendaftaran disajikan dari situs peserta, jadi itulah origin yang dipagari.
+Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ---
 
@@ -64,7 +66,7 @@ di `workers/gateway/worker.js` wajib ikut diubah.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
-**Migrasi tidak pernah disunting setelah diterapkan.** Perubahan atas fungsi
+**Migrasi tidak pernah diedit setelah diterapkan.** Perubahan atas fungsi
 yang sudah ada ditulis sebagai migrasi baru berisi `create or replace function`
 lengkap. Itu sebabnya definisi terbaru sebuah RPC sering berada di berkas
 bernomor besar, bukan di `0004_rpcs.sql`.
@@ -76,13 +78,14 @@ Operasional: `pendaftaran`, `regu`, `sekolah`, `pembayaran`, `kloter`,
 `nomor_dada_stok`, `nomor_dada_pensiun`.
 
 Konfigurasi per edisi: `edisi`, `pos`, `wahana`, `kontrak_opsi`,
-`konfig_penalti`, `ruangan`, `status_acara`.
+`konfig_penalti`, `room`, `status_acara`.
 
 Akun & jejak: `akun_panitia`, `history`.
 
 > Tabel jejak audit bernama **`history`** dengan kolom `table_name`, `row_id`,
 > `action`, `old_value`, `new_value`, `changed_by`, `changed_at`. Dokumen lama
-> menyebutnya `riwayat` — itu nama sebelum migrasi `0012`.
+> menyebutnya `riwayat` — itu nama sebelum migrasi `0012`. Migrasi `0014`
+> melakukan hal yang sama pada `ruangan`, yang sejak itu bernama `room`.
 
 ### Cara skor dihitung
 
@@ -140,7 +143,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 
 | Rute | Layar | Kerjanya |
 | --- | --- | --- |
-| `#/home` | Beranda | menu + dua lencana angka: menunggu pembayaran, lunas belum bernomor |
+| `#/home` | Home | menu + dua lencana angka: menunggu pembayaran, lunas belum bernomor |
 | `#/pembayaran` | Meja Pembayaran | tabel semua invoice, tandai lunas, cetak kwitansi |
 | `#/daftar-ulang` | Meja Daftar Ulang | isi nomor dada per regu, tukar nomor rusak |
 | `#/cetak-kloter` | Cetak Daftar Kloter | lembar per kloter untuk petugas start |
@@ -150,10 +153,11 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/ganti-password` | Ganti Password | — |
 
 Peran akun: `admin`, `meja`, `operator_pos`. Seluruh RPC meja menuntut
-`peran() in ('admin','meja')`; akun `operator_pos` ditolak di layar meja dengan
-pesan "Akun pos, bukan akun meja", dan sebaliknya akun `meja` ditolak di
-`#/pos`. Home menampilkan menu yang berbeda per peran — akun pos hanya melihat
-layar posnya sendiri.
+`peran() in ('admin','meja')`; akun `meja` yang membuka `#/pos` ditolak dengan
+kartu "Akun meja, bukan akun pos". Sebaliknya akun `operator_pos` tidak diberi
+kartu penolakan di layar meja — Home-nya memang hanya memuat satu jalan, layar
+posnya sendiri, dan RLS yang mengosongkan data meja seandainya alamatnya
+diketik langsung.
 
 ### Layar Input Pos
 
@@ -187,9 +191,10 @@ Tiga hal yang menentukan layar ini benar atau tidak:
 
 Tombol **Cetak Lembar** mengeluarkan versi kertas dari pos yang sedang dibuka
 (`alur-lomba.md` 8.6): identitas regu sudah tercetak, kolom nilainya kosong,
-dan judul posnya ikut di dalam `<thead>` sehingga terulang di tiap halaman —
-kertas ini beredar sebagai lembaran lepas yang berpindah tangan lewat foto,
-dan halaman yang tidak menyebutkan posnya sendiri bisa dinilaikan ke pos yang
+dan judul posnya dicetak sebagai `<h1>` di tiap lembar. Halamannya dipotong di
+JS — 30 regu per lembar — jadi tiap potongan membawa judulnya sendiri. Kertas
+ini beredar sebagai lembaran lepas yang berpindah tangan lewat foto, dan
+halaman yang tidak menyebutkan posnya sendiri bisa dinilaikan ke pos yang
 salah.
 
 Dua keputusan yang membentuknya:
@@ -235,10 +240,13 @@ panitia sudah terbiasa dengannya:
 
 | Keadaan | Yang tertulis |
 | --- | --- |
-| aman | `✓ Semua tersimpan · Tersimpan terakhir 14:32:07` |
-| sedang diketik | `2 baris belum tersimpan. Tersimpan terakhir 14:32:07` |
-| gagal | merah — `1 baris gagal terkirim dan 1 baris masih diketik — dicoba lagi sendiri tiap 15 detik… Tersimpan terakhir 14:12:40 (23 menit lalu).` |
+| aman | `✓ Data Tersimpan · Sinkronisasi Terakhir: 14:32 (barusan)` |
+| sedang diketik | `2 baris belum tersimpan. Sinkronisasi Terakhir: 14:32 (barusan)` |
+| gagal | merah — `1 baris gagal terkirim dan 1 baris masih diketik — dicoba lagi sendiri tiap 15 detik. Jangan tutup halaman ini. Sinkronisasi Terakhir: 14:12 (23 menit lalu).` |
 | internet putus | merah — angkanya aman di layar, dikirim sendiri saat internet kembali |
+
+Capnya `jamMenit` — jam dan menit saja, tanpa detik — ditambah umurnya dalam
+kurung, mengikuti standar waktu di bagian 3b.
 
 Empat hal yang membuatnya bisa dipercaya:
 
@@ -258,7 +266,10 @@ membuangnya kini dijaga: `beforeunload` menahan tab yang ditutup, dan muat
 ulang otomatis saat layar dilihat kembali dilewati selama masih ada baris yang
 belum tersimpan.
 
-`v_lembar_pos` adalah **satu-satunya view yang bukan `security_invoker`**.
+`v_lembar_pos` adalah **satu-satunya view PANITIA yang bukan
+`security_invoker`** — empat view publik (`v_progres_publik`,
+`v_klasemen_publik`, `v_publik_ringkas`, `v_edisi_publik`) juga bukan, tapi
+mereka hanya dibaca service role saat menerbitkan `live.json`.
 Alasannya ada di kepala migrasi `0023`: jalan menuju nama sekolah melewati
 tabel `pendaftaran`, yang tertutup untuk operator pos karena memuat nomor
 WhatsApp. Kalau view-nya tunduk RLS, operator mendapat lembar kosong — dan
@@ -298,8 +309,11 @@ tahun depan belum tentu ingat janji ini.
 Memisahkan URL **tidak** mencegah orang mencoba masuk — alamat panitia tetap
 ada. Yang benar-benar didapat tiga hal:
 
-1. Halaman rekap tidak memuat **kunci apa pun**. `web/config.js` membawa anon
-   key dan alamat Supabase; `live/` cuma HTML, CSS, dan satu berkas JSON.
+1. Halaman rekap tidak memuat **kunci apa pun**: `live/index.html` hanya
+   memanggil `live.css` dan `live.js`, dan `live.js` cuma membaca
+   `live.json`. Anon key memang ikut tersalin ke `live/config.js` — form
+   pendaftaran di folder yang sama memakainya — tapi halaman rekapnya sendiri
+   tidak pernah menyentuhnya.
 2. Link yang disebar ke ratusan peserta tidak sekaligus menyebarkan alamat
    login panitia.
 3. Ratusan HP yang me-refresh tidak menyentuh Worker yang sedang dipakai
@@ -374,7 +388,8 @@ Jumlah regu tidak punya kolom sendiri — angkanya sudah tercetak di dalam tombo
 
 ## 4. Form pendaftaran publik
 
-`web/daftar.html` + `web/js/daftar.js`, tanpa login. Kiriman tidak langsung ke
+`live/daftar.html` + `live/js/daftar.js`, tanpa login — keduanya tinggal di
+situs peserta, bukan di `web/`. Kiriman tidak langsung ke
 Supabase melainkan ke gateway, yang memanggil `submit_pendaftaran` memakai
 service role.
 
@@ -396,7 +411,7 @@ Service key hidup sebagai `wrangler secret` di Worker, tidak pernah di SPA.
 | Yang di-deploy | Cara | Pemicu |
 | --- | --- | --- |
 | Layar panitia (`web/`) | Cloudflare Workers, tersambung Git | otomatis tiap push ke `main` |
-| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | manual + cron 5 menit (dimatikan di luar minggu lomba) |
+| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | manual saja — cron 5 menit masih dikomentari, nyalakan pada minggu lomba (bagian 8) |
 | Gateway Worker | GitHub Actions `deploy-gateway.yml` | manual |
 | Migrasi database | GitHub Actions `apply-migration.yml` | manual, satu berkas per jalan |
 
@@ -419,11 +434,12 @@ Jadi salinannya dititipkan di git, dan workflow `shared-files.yml` yang
 membuatnya tidak bisa membusuk: tiap PR membandingkan `live/` dengan acuannya
 di `web/` dan gagal kalau menyimpang. Duplikasi yang diam adalah bug yang
 menunggu; duplikasi yang berteriak tiap kali menyimpang cuma sedikit berisik.
-**`web/` yang jadi acuan** — jangan pernah menyunting salinannya.
+**`web/` yang jadi acuan** — jangan pernah mengedit salinannya.
 
-**Merge ke `main` = deploy situs.** Tidak ada build step; berkas di `web/`
-disajikan apa adanya, dengan `web/wrangler.toml` menyetel root proyek ke folder
-itu.
+**Merge ke `main` = deploy layar panitia.** Tidak ada build step; berkas di
+`web/` disajikan apa adanya — asalkan kotak "Root directory" di dashboard
+Cloudflare masih berisi `web` (bagian 7 nomor 8; setelan itu tidak ada di git).
+Situs peserta tidak ikut: `live/` hanya terbit lewat workflow-nya sendiri.
 
 **Merge TIDAK menerapkan migrasi.** Migrasi dijalankan terpisah:
 
@@ -443,9 +459,9 @@ saat layar memanggil RPC lama dan gagal.
 ### Cache
 
 `web/_headers` menyetel `Cache-Control: no-cache` untuk semua aset: browser
-boleh menyimpan, tapi wajib bertanya dulu. Asetnya kecil (<100 KB seluruhnya),
-jadi biayanya hampir nol — dan tanpa itu, perbaikan mendadak pagi hari-H tidak
-akan sampai ke panitia.
+boleh menyimpan, tapi wajib bertanya dulu. Asetnya kecil (±220 KB seluruhnya,
+`js/app.js` sendiri 119 KB), jadi biayanya hampir nol — dan tanpa itu,
+perbaikan mendadak pagi hari-H tidak akan sampai ke panitia.
 
 ### Workflow lain
 
@@ -528,7 +544,7 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
 
 - **`docs/arsitektur-hrcd.svg` dan `.png`** masih menggambarkan Google Sheets
   sebagai bagian arsitektur, dan angkanya sudah bergeser: tertulis "18 view
-  berlapis" (sekarang 17) dan "24 RPC bertransaksi" (sekarang 26 fungsi, 14 di
+  berlapis" (sekarang 19) dan "24 RPC bertransaksi" (sekarang 27 fungsi, 15 di
   antaranya dipanggil layar). Diagramnya tidak dirujuk dari dokumen mana pun,
   jadi dibiarkan sampai ada yang menggambar ulang.
 - **Beberapa RPC masih mencetak nomor dada mentah** di pesan galatnya
@@ -546,10 +562,11 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
   kebutuhannya, karena satu layar memuat seluruh lembar sekaligus. RPC-nya
   (`simpan_nilai_massal`) memang sudah menerima banyak baris sekaligus, jadi
   yang kurang hanya pengurai tempelan dan preview-nya.
-- **Nama Pos 5 masih "Pos 5".** Lembar penilaiannya tidak ada di antara yang
-  diserahkan panitia, jadi migrasi `0024` sengaja tidak menebak nama maupun
-  komponennya. Pos 5 akan tampil di layar Input Pos sebagai pos tanpa kolom
-  penilaian sampai diisi.
+- **Pos 5 (Kedatangan) belum punya komponen penilaian.** Lembar penilaiannya
+  tidak ada di antara yang diserahkan panitia, jadi migrasi `0024` sengaja
+  tidak menebak komponennya; namanya baru diisi migrasi `0025`. Selama belum
+  punya baris `wahana`, Pos 5 tidak muncul sama sekali di pemilih pos layar
+  Input Pos.
 - **Dua sel di lembar XXXVI tidak cocok dengan rumusnya sendiri** (Pos 3 regu
   016 tertulis 380, rumus memberi 355; Pos 4 regu 009 tertulis 100, rumus
   memberi 80). 75 dari 77 baris yang bisa dibaca cocok tanpa sisa, jadi

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -6,13 +6,16 @@
 > migrasi, tes, SPA, dan Worker — menunjuk ke nomor bagian dokumen ini
 > (`rancangan-b.md 11.9`, `bagian 4`, `2.2.1`, dan seterusnya). Menulis ulang
 > isinya akan memutus seluruh penunjuk itu, termasuk yang tertanam di migrasi
-> yang sudah diterapkan dan tidak boleh disunting.
+> yang sudah diterapkan dan tidak boleh diedit.
 >
 > Beberapa hal berubah saat dibangun, jadi jangan baca dokumen ini sebagai
 > gambaran layar hari ini. Yang sudah diketahui berbeda:
 >
 > - **Google Sheets tidak pernah dipakai.** Tidak ada di kode mana pun.
-> - **`live.html` / `live.json` tidak pernah dibangun** (bagian 7).
+> - **Halaman live sudah ada, tapi bentuknya lain** (bagian 7):
+>   `live/index.html` + `live/live.json` di Worker situs peserta sendiri,
+>   diterbitkan workflow `publish-live.yml` — bukan `live.html` di Cloudflare
+>   Pages seperti tertulis di bawah.
 > - **Chip "Jam sekarang" tidak ada.** Jam berangkat justru diisi otomatis;
 >   jam datang dikosongkan dengan keterangan "Kosong = jam saat tombol ditekan."
 > - **Meja Pembayaran bukan alur ketik-kode → kartu**, melainkan tabel berisi
@@ -66,7 +69,7 @@ penyelesaiannya dicatat di bagian 11.
 | `regu` | Satu baris per regu: nama, ketua, golongan, nomor dada, kloter, kontrak, batal | `UNIQUE (nomor_dada)` — nomor ganda **mustahil**, bukan dihindari; `UNIQUE (kloter_nomor, urutan_kloter)` + `CHECK (urutan 1–10)` — kapasitas kloter ditegakkan database; nomor dada & kloter lahir bersama (`CHECK` berpasangan) |
 | `nomor_dada_stok` | Stok fisik nomor yang disiapkan admin (mis. 1–500) | Nomor tersedia = belum ada di `regu.nomor_dada`; satu sumber kebenaran, tanpa flag yang bisa basi |
 | `pembayaran` | Satu pembayaran penuh per batch + nomor kwitansi | `UNIQUE (pendaftaran_id)` — verifikasi ganda dari dua meja tertolak |
-| `kloter` | 40 baris (30 dasar + 31–40 cadangan): jam berangkat **diketik** | `CHECK`: status berangkat wajib punya jam; **tidak ada `DEFAULT now()`** |
+| `kloter` | 40 baris (30 dasar + 31–40 cadangan): jam berangkat **diketik** | Tidak ada kolom status — berangkat = `jam_berangkat` terisi (11.5); **tidak ada `DEFAULT now()`** |
 | `keberangkatan_regu` | Ceklis berangkat per regu; keberadaan baris = berangkat | `PK (regu_id)` — ceklis ganda mustahil |
 | `nilai_mentah` | Data mentah per regu per komponen: `nilai_1`, `nilai_2` (khusus benar−salah), sumber `manual/upload` | `UNIQUE (regu_id, wahana_id)`; RLS pos |
 | `closing_regu` | Checkout: `jam_datang` **diketik & bisa di-edit**, `anggota_hadir` (0–5) | `PK (regu_id)`; upsert = mekanisme edit yang sah |
@@ -584,7 +587,8 @@ dibaca dengan koreksi ini:
    `nilai_mentah`, `closing_regu`, `keberangkatan_regu`, `penempatan_barak`
    ditutup — mencegah pemalsuan kolom pencatat dan pelompatan validasi.
    `simpan_nilai_massal` menjadi `SECURITY DEFINER` dengan cek pos eksplisit
-   (pilihan kedua di bagian 4); admin wajib menyebut pos.
+   (pilihan kedua — bagian 4 menuliskan `SECURITY INVOKER`); admin wajib
+   menyebut pos.
 3. **Nomor dada bekas tukar PENSIUN permanen** (tabel `nomor_dada_pensiun`) —
    foto lembar lama yang masih menuliskan nomor itu tidak akan pernah menilai
    regu lain. Penukaran setelah kloter berangkat hanya oleh admin.


### PR DESCRIPTION
## What

Re-audited all seven markdown documents against the code that actually runs, and fixed the 48 claims that survived verification.

Ground truth was built by four agents reading the migrations, the tests and scripts, both static sites, and the workflows; one auditor per document extracted every checkable claim and checked it; an adversarial verifier then tried to kill each finding. 7 findings were rejected as wrong or as "true but brief" and are not in this PR.

The corrections that would have cost someone real time:

| Document | Was | Is |
| --- | --- | --- |
| `final-architecture.md` | change `ALLOWED_ORIGIN` when `web/wrangler.toml` is renamed | it tracks `live/wrangler.toml` — the old advice would have broken CORS on the registration form |
| `final-architecture.md`, `README.md` | `daftar.html` + `js/daftar.js` live in `web/` | both moved to `live/` |
| `final-architecture.md` | `web/wrangler.toml` sets the deploy root | the dashboard "Root directory" box does — section 7 already said so, section 5 contradicted it |
| `final-architecture.md` | live recap publishes on a 5-minute cron | the schedule is commented out; `workflow_dispatch` only |
| `README.md` | three terminals and the local screens work | not without switching `web/config.js` to `mode: "dev"` — as written it points at production Supabase |
| `README.md` | `concurrency_test.py` runs as shown | broken since migration `0014` renamed its columns |
| `alur-lomba.md` | two points numbered 9; five cross-references off by one | renumbered, all references resolve |
| `alur-lomba.md` | five conversion forms, design deferred | six forms, `bertingkat` shipped in `0022` and is in use at Pos 4 |
| `alur-lomba.md`, `final-architecture.md` | rejection message "Akun pos, bukan akun meja" | the message is "Akun meja, bukan akun pos", and it guards the other direction |

Smaller ones: table `ruangan` is `room` since `0014`; `v_lembar_pos` is the only *panitia* view without `security_invoker`, not the only view; `live/config.js` does carry the anon key, so "`live/` is only HTML, CSS and one JSON" was wrong; assets are ~220 KB, not under 100 KB; 19 views and 27 functions, not 17 and 26; Pos 5 has been named "Kedatangan" since `0025`. Also removed three uses of `sunting` and one `cap waktu`, which rule 5.7 forbids and which `alur-lomba.md`'s own glossary lists as words not to use.

`CLAUDE.md` and `AGENTS.md` gain a rule that they must be edited together — nothing enforces it, and they have already drifted 21 lines once.

## Why

The docs are the only onboarding the next ambalan gets, and several of these errors pointed at the wrong file, the wrong folder, or a command that fails. A document that has to be double-checked against the code is not doing its job.

## Notes

The two decision records stay frozen on purpose. Only statements that were never true, internal contradictions, and the present-tense notes that annotate them were touched — the 43 section numbers cited from code comments all still resolve, and no section was renumbered or reordered.

No code changed, so nothing deploys from this PR. Both sites were verified live and byte-identical to `main` before it was opened: `hrcd37` serves `live/` (`/live.js` 200, `/js/app.js` 404) and `panitia-hrcd37` serves `web/` (the reverse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)