### PR TITLE
feat: one live board for panitia, a search-first recap for peserta

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -1,16 +1,16 @@
 # ============================================================================
-# hrcd-rekap : publish-live.yml — tulis live.json lalu deploy halaman rekap.
+# hrcd-rekap : publish-live.yml — tulis live.json + rekap.json lalu deploy.
 #
 # Halaman rekap peserta TIDAK membaca database. Workflow inilah yang membaca,
-# menulis hasilnya jadi satu berkas statis, lalu men-deploy folder live/ —
+# menulis hasilnya jadi DUA berkas statis, lalu men-deploy folder live/ —
 # yang sejak 14 Agustus 2026 juga memuat FORM PENDAFTARAN. Artinya workflow
 # ini satu-satunya jalur deploy situs peserta, termasuk saat yang berubah
 # hanya daftar.html.
 #
 # PROJECT `hrcd37` DI CLOUDFLARE TIDAK BOLEH TERSAMBUNG GIT. Kalau tersambung,
-# tiap push ke main akan menimpa live.json dengan berkas contoh fase 'pra'
+# tiap push ke main akan menimpa kedua berkas itu dengan contoh fase 'pra'
 # yang ada di repo, dan rekap peserta mendadak kosong tanpa ada yang gagal.
-# Ratusan HP peserta hanya menyentuh hosting statis Cloudflare — nol
+# 1.500-3.000 HP peserta hanya menyentuh hosting statis Cloudflare — nol
 # permintaan ke Supabase, dan halaman itu tidak perlu membawa kunci apa pun
 # (docs/rancangan-b.md bagian 7).
 #
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Tulis live.json dari database
+      - name: Tulis live.json + rekap.json dari database
         env:
           DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
@@ -62,20 +62,68 @@ jobs:
           # -A -t: keluaran mentah tanpa bingkai tabel dan tanpa judul kolom,
           # sehingga yang tertulis ke berkas benar-benar JSON saja.
           psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
-            -f supabase/checks/live_json.sql > live/live.json
+            -f supabase/checks/live_json.sql > /tmp/rekap-utuh.json
 
-          # Pagar terakhir sebelum berkasnya di-deploy: JSON yang rusak akan
-          # membuat halaman rekap kosong tanpa pesan apa pun, dan tidak ada
-          # yang akan menyadarinya sampai ada peserta yang bertanya.
-          python3 -c "
-          import json, sys
-          d = json.load(open('live/live.json'))
-          for k in ('dibuat_pada','fase','pos','progres','klasemen'):
-              if k not in d: sys.exit(f'kunci {k} hilang dari live.json')
-          print(f\"fase={d['fase']} regu={len(d['progres'])} klasemen={len(d['klasemen'])} pos={len(d['pos'])}\")
+          # Satu query, DUA berkas. Pemisahan inilah yang menahan 3.000 HP:
+          # yang di-poll tiap menit cuma live.json yang ±1 KB, sedangkan
+          # rekap.json yang puluhan KB dialamati `?v=<versi>` dan karena itu
+          # boleh mengendap di cache browser dan cache tepi Cloudflare sampai
+          # isinya benar-benar berubah.
+          #
+          # `versi` = sidik jari isi rekap, BUKAN jam penerbitan. Menjalankan
+          # workflow ini sepuluh kali tanpa ada nilai baru menghasilkan versi
+          # yang sama sepuluh kali — dan tidak satu HP pun mengunduh ulang.
+          python3 - <<'PY'
+          import json, hashlib, sys
+
+          d = json.load(open('/tmp/rekap-utuh.json'))
+          for k in ('dibuat_pada', 'fase', 'edisi', 'ringkas', 'pos',
+                    'progres', 'klasemen'):
+              if k not in d:
+                  sys.exit(f'kunci {k} hilang dari keluaran live_json.sql')
+
+          # Pagar kebocoran, dijaga di sini SEKALIGUS di view (0005/0026).
           if d['fase'] != 'penuh' and d['klasemen']:
               sys.exit('BOCOR: klasemen ikut tertulis padahal fase belum penuh')
-          "
+          # Sebelum lomba dimulai peserta tidak boleh melihat rekap apa pun,
+          # dan v_progres_publik memang mengembalikan nol baris di fase 'pra'.
+          # Kalau suatu hari ia tidak lagi begitu, berhenti di sini.
+          if d['fase'] == 'pra' and d['progres']:
+              sys.exit('BOCOR: baris regu ikut tertulis padahal fase masih pra')
+
+          rekap = {'progres': d['progres'], 'klasemen': d['klasemen']}
+          sidik = hashlib.sha256(json.dumps(
+              rekap, sort_keys=True, separators=(',', ':'),
+              default=str).encode('utf-8')).hexdigest()[:12]
+          rekap['versi'] = sidik
+
+          meta = {
+              'dibuat_pada': d['dibuat_pada'],
+              'versi':       sidik,
+              'fase':        d['fase'],
+              'edisi':       d['edisi'],
+              'ringkas':     d['ringkas'],
+              'pos':         d['pos'],
+              'jumlah_regu': len(d['progres']),
+          }
+
+          # live.json diberi indentasi supaya bisa dibaca mata saat memeriksa;
+          # rekap.json dipadatkan karena ia yang benar-benar menyeberangi
+          # jaringan seluler ribuan kali.
+          with open('live/live.json', 'w', encoding='utf-8') as f:
+              json.dump(meta, f, ensure_ascii=False, indent=2, default=str)
+              f.write('\n')
+          with open('live/rekap.json', 'w', encoding='utf-8') as f:
+              json.dump(rekap, f, ensure_ascii=False,
+                        separators=(',', ':'), default=str)
+              f.write('\n')
+
+          import os
+          print(f"fase={d['fase']} versi={sidik} regu={len(d['progres'])} "
+                f"klasemen={len(d['klasemen'])} pos={len(d['pos'])} "
+                f"live.json={os.path.getsize('live/live.json')}B "
+                f"rekap.json={os.path.getsize('live/rekap.json')}B")
+          PY
 
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │   └── wrangler.toml         # deploy Workers static assets
 ├── live/                     # situs PESERTA (hrcd37) — Worker TERPISAH:
 │   ├── daftar.html           # form pendaftaran publik
-│   ├── index.html            # rekap live (centang per pos, isinya live.json)
+│   ├── index.html            # rekap live (cari sekolah → centang per pos)
+│   ├── live.json             # ±1 KB: fase + versi, INI yang di-poll tiap menit
+│   ├── rekap.json            # baris regu + klasemen, diambil sekali per versi
 │   ├── live.js, live.css     # halaman rekap — tidak ada di web/
 │   ├── js/daftar.js          # logika form pendaftaran — tidak ada di web/
 │   └── config.js, style.css, js/api.js, js/util.js
@@ -46,7 +48,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0026
+│   ├── migrations/           # skema database, urut 0001..0027
 │   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
 │   │                         # data; live_json.sql dipakai Publish rekap live
 │   └── seed.sql              # konfigurasi edisi + baris wajib

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0026`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0027`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-26 migrasi, `0001` sampai `0026`, dijalankan berurutan tanpa lubang penomoran.
+27 migrasi, `0001` sampai `0027`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -150,6 +150,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/keberangkatan` | Keberangkatan | ceklis hadir, kontrak waktu, pindah kloter, berangkatkan |
 | `#/finish` | Kedatangan | catat jam datang + anggota hadir |
 | `#/pos` | Input Nilai Pos | lembar penilaian satu pos, satu baris per regu |
+| `#/rekap` | Rekapitulasi | seluruh pos sekaligus + klasemen sementara — **hanya dibaca** |
 | `#/ganti-password` | Ganti Password | — |
 
 Peran akun: `admin`, `meja`, `operator_pos`. Seluruh RPC meja menuntut
@@ -279,15 +280,70 @@ hanya posnya sendiri.
 
 ---
 
+### Layar Rekapitulasi
+
+Lembar Rekapitulasi lengkap, dan bentuknya sengaja meniru spreadsheet yang
+dipakai panitia selama tujuh tahun: satu baris per regu, **satu kolom per
+komponen** — bukan satu kolom per pos — Nilai Pos di ujung tiap kelompok, lalu
+kolom waktu, lalu Nilai Total. Kolomnya dibangun dari tabel `wahana`, jadi
+penilaian tahun depan mengubah tabel dan tabelnya ikut berubah sendiri.
+
+Bahannya satu view, `v_rekap_penuh` (migrasi `0027`). Empat hal yang
+menentukannya:
+
+1. **Tidak bisa mengubah apa pun.** Satu-satunya pintu tulis nilai tetap
+   `#/pos`, yang memaksa operator menyebut posnya dan dijaga RLS. Angka yang
+   bisa diketik dari dua tempat cepat atau lambat akan melewatkan salah satu
+   pagarnya.
+2. **Tidak menghitung apa pun.** Nilai Pos, penalti, total, dan peringkat
+   semuanya datang jadi dari database — alasan yang sama dengan layar Input
+   Pos. Peringkatnya bahkan di-`left join` dari `v_klasemen`, bukan dihitung
+   ulang, supaya tidak ada mesin peringkat kedua.
+3. **Operator pos mendapat nol baris**, dan itu bukan sekadar hak akses.
+   View-nya `security_invoker`, jadi RLS memotong `nilai_mentah` pos lain —
+   kalau ia dibiarkan membuka layar ini, kolom pos lain kosong DAN Nilai
+   Totalnya ikut mengecil tanpa satu pun galat. Total yang salah lebih
+   berbahaya daripada layar yang menolak dibuka.
+4. **Menyegarkan diri tiap 20 detik.** Operator pos menyimpan satu baris, dan
+   koordinator yang menatap layar ini melihat angkanya masuk tanpa menekan
+   apa pun. Pembacanya belasan orang, bukan ribuan seperti halaman peserta,
+   jadi membaca langsung dari database di sini memang murah — pertimbangan
+   yang persis kebalikan dari bagian 3b.
+
+Rank kosong berarti kloter regu itu belum tercatat berangkat, jadi ia belum
+masuk klasemen resmi (`rancangan-b.md` 11.12). Barisnya tidak dibuang; ia
+turun ke bawah kelompoknya dan tetap terurut menurut total, supaya papan ini
+sudah terbaca sebagai klasemen sementara sejak nilai pertama masuk.
+
+Empat kolom pertama dibekukan di kiri saat tabelnya digeser. Ini
+**satu-satunya tabel di sistem yang boleh digeser ke samping** — di layar meja
+geser samping justru dilarang karena menyembunyikan kolom tombol (bagian 7
+nomor 3). Di sini tidak ada tombol sama sekali, dan ±35 kolom tidak akan
+pernah muat di layar mana pun.
+
 ## 3b. Halaman rekap live untuk peserta
 
 Satu pertanyaan yang dijawab halaman ini sepanjang lomba, dan hanya itu:
 **"nilai regu saya sudah masuk belum, atau hilang?"** Jawabannya centang per
-pos, ditambah fakta operasional yang memang sudah diketahui regunya sendiri —
-kloter, kontrak waktu, jam berangkat, jam datang. Menerbitkan jam justru
-layanan: regu bisa memastikan yang tercatat panitia sama dengan catatan
-mereka SEBELUM hasilnya final, dan sengketa yang ketahuan pagi hari jauh
-lebih murah daripada yang ketahuan saat pengumuman.
+pos — bukan angka.
+
+Tiga aturan membentuk seluruh halaman ini:
+
+1. **Sebelum lomba dimulai, tidak ada rekap sama sekali.** Selama
+   `fase_live` masih `pra`, `v_progres_publik` mengembalikan nol baris dan
+   yang tampil hanya jumlah pendaftar plus jalan ke formulir. Peserta tidak
+   melihat apa pun tentang regu mana pun, termasuk regunya sendiri.
+2. **Selama lomba, peserta mengetik nama sekolahnya dulu.** Tidak ada daftar
+   300 regu yang bisa disapu mata. Yang tampil sesudah pencarian adalah
+   seluruh regu sekolah itu, urut nomor dada, dengan centang per pos.
+   Batasnya sengaja nama sekolah dan hanya nama sekolah: itu satu-satunya
+   kata kunci yang pasti diketahui setiap pembuka halaman, dan membatasi
+   pencarian ke sana membuat halaman menjawab "bagaimana regu KAMI" alih-alih
+   berubah jadi alat mengintip nilai regu lain satu per satu.
+3. **Setelah closing, halaman yang sama berubah jadi papan hasil.** Fase
+   `penuh` membuka klasemen empat golongan — tampil tanpa perlu mencari apa
+   pun, karena itulah pengumumannya — dan menambahkan kloter, kontrak, jam
+   berangkat, dan jam datang ke tabel sekolah.
 
 ### Yang menjaga kejutan adalah database, bukan tampilan
 
@@ -310,8 +366,8 @@ Memisahkan URL **tidak** mencegah orang mencoba masuk — alamat panitia tetap
 ada. Yang benar-benar didapat tiga hal:
 
 1. Halaman rekap tidak memuat **kunci apa pun**: `live/index.html` hanya
-   memanggil `live.css` dan `live.js`, dan `live.js` cuma membaca
-   `live.json`. Anon key memang ikut tersalin ke `live/config.js` — form
+   memanggil `live.css` dan `live.js`, dan `live.js` cuma membaca `live.json`
+   dan `rekap.json`. Anon key memang ikut tersalin ke `live/config.js` — form
    pendaftaran di folder yang sama memakainya — tapi halaman rekapnya sendiri
    tidak pernah menyentuhnya.
 2. Link yang disebar ke ratusan peserta tidak sekaligus menyebarkan alamat
@@ -319,12 +375,46 @@ ada. Yang benar-benar didapat tiga hal:
 3. Ratusan HP yang me-refresh tidak menyentuh Worker yang sedang dipakai
    panitia bekerja.
 
-### Cara datanya sampai
+### Cara datanya sampai, dan kenapa dua berkas
 
 `publish-live.yml` menjalankan `supabase/checks/live_json.sql` — satu query
-yang menghasilkan seluruh berkas — lalu men-deploy folder `live/`. Halaman
-peserta hanya membaca berkas statis itu tiap 60 detik; **nol permintaan ke
-Supabase dari HP peserta**.
+yang menghasilkan seluruh isi — lalu memecah hasilnya jadi **dua berkas**
+sebelum men-deploy folder `live/`. Halaman peserta hanya membaca berkas statis
+itu; **nol permintaan ke Supabase dari HP peserta**.
+
+| Berkas | Besar | Isinya | Kapan diambil |
+| --- | --- | --- | --- |
+| `live.json` | ±1 KB | fase, edisi, daftar pos, ringkasan, dan `versi` | di-poll tiap 60 detik |
+| `rekap.json` | puluhan KB | seluruh baris regu + klasemen | sekali per `versi`, dan hanya kalau dibutuhkan |
+
+Pemisahan ini yang menahan bebannya. Pesertanya **1.500–3.000 orang** dan
+mereka membuka alamat yang sama, berkali-kali, dalam jendela waktu yang sama.
+Satu berkas gemuk yang diunduh ulang tiap menit oleh tiap HP adalah 3.000 ×
+60 KB per menit untuk data yang sebagian besar waktu tidak berubah sama
+sekali.
+
+Empat hal bekerja bersama:
+
+- **`versi` adalah sidik jari isi, bukan jam terbit.** Menjalankan workflow
+  sepuluh kali tanpa ada nilai baru menghasilkan versi yang sama sepuluh kali,
+  dan tidak satu HP pun mengunduh ulang.
+- **`rekap.json` diminta sebagai `rekap.json?v=<versi>`.** Alamatnya berubah
+  hanya ketika isinya berubah, jadi ia boleh dijawab `max-age=3600, immutable`
+  di `live/_headers` — dari cache browser atau cache tepi Cloudflare, tanpa
+  satu byte pun menyeberang.
+- **Pengambilannya ditunda sampai benar-benar dicari.** Di fase `pra` berkas
+  itu tidak pernah diambil; selama lomba ia baru diambil setelah peserta
+  mengetik nama sekolahnya. HP yang membuka halaman lalu menutupnya mengunduh
+  ±1 KB.
+- **Polling berhenti saat tab tidak terlihat**, dan menyusul sekali begitu
+  layarnya dibuka lagi. Ribuan HP yang tertinggal terbuka di saku tidak
+  menghasilkan apa-apa selain permintaan.
+
+Yang perlu diketahui sebelum menebak ada masalah kapasitas: permintaan ke
+**static assets Cloudflare Workers tidak dihitung** terhadap kuota harian
+Workers dan bandwidth-nya tidak dibatasi. Beban hari-H tidak pernah menyentuh
+Supabase, dan tidak ada satu pun kode kita yang berjalan saat peserta
+me-refresh.
 
 Cap **"Sinkronisasi terakhir"** di kepala halaman memakai jam saat berkasnya
 DIBUAT di server, bukan jam halaman dimuat — kalau workflow tersendat, peserta
@@ -349,10 +439,25 @@ di proyek lain.
 | `tanggalJam(t)` | `17 Agustus 2026 15:30` | cap yang bisa menunjuk hari lain |
 
 Aturan memilihnya satu kalimat: **pakai `jamMenit` kalau harinya sudah jelas
-dari kedudukannya, `tanggalJam` kalau tidak.** Cap "Sinkronisasi terakhir" di
+dari kedudukannya, `tanggalJam` kalau tidak.** Cap "Update terakhir" di
 halaman rekap peserta memakai bentuk penuh justru karena peserta membukanya
 kapan saja, termasuk besok paginya — `17:30` telanjang akan terbaca sebagai
 setengah jam lalu.
+
+Satu fungsi lagi menjaga arah sebaliknya — jam yang **diketik**, bukan
+ditampilkan: `jamSah(teks)` membaca `"745"`, `"0745"`, `"7:45"`, atau `"7.45"`
+dan mengembalikan `"07:45"`, atau `null` kalau di luar 00:00–23:59.
+
+Ia ada karena `<input type="time">` **tidak bisa dipaksa 24 jam.** Browser
+merendernya menurut locale BROWSER, bukan `lang="id"` halaman ini, jadi laptop
+panitia yang Chrome-nya berbahasa Inggris menampilkan `07:15 AM` — dan tidak
+ada atribut HTML mana pun yang mengubahnya. Satu meja memakai AM/PM sementara
+semua kertas dan semua layar lain memakai 00:00–23:59 adalah cara yang murah
+sekali untuk mencatat 07:15 sebagai 19:15. Karena itu jam berangkat dan jam
+datang memakai kotak ketik biasa berkelas `.jam-ketik`, bukan pemilih bawaan.
+Yang diterima sengaja longgar (pencatat menyalin dari kertas dan mengetik
+cepat); yang di luar rentang **ditolak dengan pesan**, bukan ditebak — jam
+berangkat menentukan penalti sepuluh regu sekaligus.
 
 Dua hal yang dulu berbeda-beda dan sekarang tidak lagi: jam memakai **titik
 dua, bukan titik** (`toLocaleTimeString('id-ID')` memberi `07.04`, yang mudah
@@ -463,6 +568,12 @@ boleh menyimpan, tapi wajib bertanya dulu. Asetnya kecil (±220 KB seluruhnya,
 `js/app.js` sendiri 119 KB), jadi biayanya hampir nol — dan tanpa itu,
 perbaikan mendadak pagi hari-H tidak akan sampai ke panitia.
 
+`live/_headers` **berbeda dengan sengaja**, karena pembacanya ribuan HP dan
+bukan belasan laptop: `live.json` diberi `no-store` (ia yang di-poll, jadi
+harus selalu segar) sedangkan `rekap.json` diberi `max-age=3600, immutable`.
+Yang membuat keduanya bisa berlawanan adalah `?v=<versi>` di alamat
+`rekap.json` — alasannya di bagian 3b.
+
 ### Workflow lain
 
 | Workflow | Nama di Actions | Untuk siapa |
@@ -544,7 +655,7 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
 
 - **`docs/arsitektur-hrcd.svg` dan `.png`** masih menggambarkan Google Sheets
   sebagai bagian arsitektur, dan angkanya sudah bergeser: tertulis "18 view
-  berlapis" (sekarang 19) dan "24 RPC bertransaksi" (sekarang 27 fungsi, 15 di
+  berlapis" (sekarang 20) dan "24 RPC bertransaksi" (sekarang 27 fungsi, 15 di
   antaranya dipanggil layar). Diagramnya tidak dirujuk dari dokumen mana pun,
   jadi dibiarkan sampai ada yang menggambar ulang.
 - **Beberapa RPC masih mencetak nomor dada mentah** di pesan galatnya

--- a/live/_headers
+++ b/live/_headers
@@ -1,13 +1,26 @@
 # ============================================================================
 # hrcd-rekap : live/_headers — aturan cache halaman rekap peserta.
 #
-# live.json ditulis ulang GitHub Actions tiap 5 menit, dan yang membacanya
-# ratusan HP di jaringan seluler yang gemar menyimpan berkas sendiri. no-store
-# untuk berkas itu: bukan cuma "wajib divalidasi", melainkan "jangan simpan
-# sama sekali". Halaman rekap yang menyajikan data setengah jam lalu lebih
-# buruk daripada halaman yang lambat — orang akan mengira nilainya hilang.
+# Yang membaca berkas-berkas ini 1.500-3.000 HP di jaringan seluler, sebagian
+# besar dalam jendela waktu yang sama. Dua berkas, dua aturan yang berlawanan,
+# dan justru perbedaannya yang menahan bebannya:
 #
-# Berkasnya kecil (ratusan regu ~60 KB), jadi harganya murah.
+#   live.json   ±1 KB, isinya fase + `versi` + ringkasan. INI yang di-poll
+#               tiap 60 detik, jadi ia harus selalu segar: no-store, bukan
+#               sekadar "wajib divalidasi". Rekap yang menyajikan keadaan
+#               setengah jam lalu lebih buruk daripada rekap yang lambat —
+#               orang akan mengira nilainya hilang.
+#
+#   rekap.json  puluhan KB, seluruh baris regu + klasemen. Diminta dengan
+#               `?v=<versi>`, jadi alamatnya berubah HANYA ketika isinya
+#               berubah. Karena itu ia boleh disimpan lama: selama versinya
+#               sama, jawabannya datang dari cache browser atau cache tepi
+#               Cloudflare dan tidak ada satu pun byte yang menyeberang.
+#               Begitu panitia menerbitkan ulang, versinya berganti dan tiap
+#               HP mengunduhnya sekali lagi — sekali, bukan tiap menit.
+#
+# Tanpa pemisahan ini, 3.000 HP × 60 KB tiap menit adalah 180 MB per menit
+# untuk data yang sebagian besar waktu tidak berubah sama sekali.
 # ============================================================================
 
 /*
@@ -15,6 +28,13 @@
 
 /live.json
   Cache-Control: no-store
+  Content-Type: application/json; charset=utf-8
+
+# immutable: alamatnya sudah memuat versinya, jadi isi yang sama tidak pernah
+# perlu ditanyakan ulang. Satu jam cukup panjang untuk memikul hari lomba dan
+# cukup pendek untuk tidak menghantui siapa pun sesudahnya.
+/rekap.json
+  Cache-Control: public, max-age=3600, immutable
   Content-Type: application/json; charset=utf-8
 
 /*.js

--- a/live/index.html
+++ b/live/index.html
@@ -6,10 +6,11 @@
   <title>Rekap Live — Hiking Rally Ciradyka</title>
   <meta name="description" content="Rekap live Hiking Rally Ciradyka — periksa nilai regu sudah masuk atau belum.">
   <!-- Halaman ini TIDAK memuat kunci apa pun: tidak ada anon key, tidak ada
-       alamat Supabase, tidak ada kotak login. Seluruh isinya datang dari satu
-       berkas statis (live.json) yang ditulis GitHub Actions tiap 5 menit.
-       Itu sebabnya ia berdiri di Worker sendiri, terpisah dari layar
-       panitia — lihat live/wrangler.toml. -->
+       alamat Supabase, tidak ada kotak login. Seluruh isinya datang dari dua
+       berkas statis yang ditulis GitHub Actions — live.json (kecil, di-poll)
+       dan rekap.json (besar, diambil sekali per versi). Itu sebabnya ia
+       berdiri di Worker sendiri, terpisah dari layar panitia — lihat
+       live/wrangler.toml dan kepala live.js. -->
   <link rel="stylesheet" href="live.css?v=1">
 </head>
 <body>
@@ -27,8 +28,9 @@
   <footer class="kaki">
     <p>Hiking Rally Ciradyka · Ambalan Ciung Wanara – Dyah Pitaloka,
        SMA Negeri 1 Ciamis</p>
-    <p class="kecil">Halaman ini memperbarui dirinya sendiri. Kalau angkanya
-       terasa tertinggal, tunggu sebentar — data disegarkan tiap 5 menit.</p>
+    <p class="kecil">Halaman ini memperbarui dirinya sendiri selama dibuka.
+       Jam di kepala halaman menunjukkan kapan datanya terakhir diambil dari
+       panitia.</p>
   </footer>
 
   <script src="live.js?v=1"></script>

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -431,6 +431,30 @@ export async function komponenPos(edisi, pos) {
     `&order=sort_order.asc`);
 }
 
+/** Seluruh komponen penilaian SEMUA pos sekaligus, urut pos lalu kolom.
+ *  Inilah yang menentukan bentuk tabel Rekapitulasi: satu kolom per baris di
+ *  sini, persis seperti lembar Excel yang dipakai panitia — dan sama seperti
+ *  layar Input Pos, tidak satu pun nama kolom ditulis di JavaScript. */
+export async function komponenSemua(edisi) {
+  if (K.mode === "dev") return baca("/komponen-semua");
+  return baca(null,
+    `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
+    `&select=pos,kode,name,type,form,poin_maks,satuan,` +
+    `rentang_mentah_min,rentang_mentah_maks,sort_order` +
+    `&order=pos.asc,sort_order.asc`);
+}
+
+/** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
+ *
+ *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena
+ *  RLS akan memotong nilai_mentah pos lain dan Nilai Total-nya jadi salah
+ *  (lihat kepala migrasi 0027). ~300 baris, dimuat sekali lalu disaring dan
+ *  diurutkan di browser — pola yang sama dengan seluruh layar meja. */
+export async function rekapPenuh() {
+  if (K.mode === "dev") return baca("/rekap-penuh");
+  return baca(null, "v_rekap_penuh?select=*&order=nomor_dada.asc");
+}
+
 /** Seluruh regu + nilai yang sudah tersimpan untuk satu pos. Satu permintaan
  *  untuk seluruh lembar: ~300 baris, dimuat sekali lalu disaring di browser,
  *  sama seperti layar meja. */

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -79,6 +79,51 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
+/** Membaca jam yang DIKETIK panitia dan mengembalikannya sebagai "HH:MM"
+ *  24 jam — atau `null` kalau bukan jam yang sah.
+ *
+ *  Ini menggantikan `<input type="time">` di dua meja yang mencatat jam.
+ *  Alasannya bukan selera: kotak jam bawaan browser dirender menurut locale
+ *  BROWSER, bukan `lang="id"` halaman ini, jadi laptop panitia yang Chrome-nya
+ *  berbahasa Inggris menampilkan "07:15 AM" — dan tidak ada atribut HTML mana
+ *  pun yang bisa memaksanya 24 jam. Satu meja memakai AM/PM sementara semua
+ *  kertas, semua layar lain, dan seluruh sisa sistem memakai 00:00-23:59
+ *  adalah cara yang murah sekali untuk mencatat 07:15 sebagai 19:15.
+ *
+ *  Yang diterima sengaja longgar, karena pencatat menyalin dari kertas dan
+ *  mengetik cepat: "745", "0745", "7:45", "7.45", "07 45" — semuanya jadi
+ *  "07:45". Yang di luar 00:00-23:59 ditolak, bukan dibetulkan diam-diam. */
+export function jamSah(teks) {
+  const angka = String(teks ?? "").replace(/\D/g, "");
+  if (angka.length < 3 || angka.length > 4) return null;
+  // "745" dibaca 7:45, bukan 74:5 — jam selalu bagian KIRI dan boleh satu
+  // digit; menitnya selalu dua digit terakhir.
+  const j = Number(angka.slice(0, angka.length - 2));
+  const m = Number(angka.slice(-2));
+  if (!Number.isInteger(j) || !Number.isInteger(m)) return null;
+  if (j > 23 || m > 59) return null;
+  return `${dua(j)}:${dua(m)}`;
+}
+
+/** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:
+ *  membetulkan bentuknya saat kotak ditinggalkan, dan menandainya merah kalau
+ *  isinya bukan jam. Membetulkan saat blur, BUKAN saat tiap ketukan — menata
+ *  ulang teks di tengah orang mengetik memindahkan kursornya dan membuat
+ *  angka berikutnya mendarat di tempat yang salah. */
+export function pasangKotakJam(el) {
+  if (!el) return;
+  const nilai = () => jamSah(el.value);
+  el.addEventListener("blur", () => {
+    if (!el.value.trim()) { el.classList.remove("jam-salah"); return; }
+    const v = nilai();
+    if (v) { el.value = v; el.classList.remove("jam-salah"); }
+    else el.classList.add("jam-salah");
+  });
+  el.addEventListener("input", () => {
+    if (nilai() || !el.value.trim()) el.classList.remove("jam-salah");
+  });
+}
+
 /** Notifikasi bawah layar.
  *
  *  Keduanya hilang sendiri, tapi galat diberi waktu DUA KALI LIPAT: 8 detik

--- a/live/live.js
+++ b/live/live.js
@@ -4,12 +4,45 @@
    Satu pertanyaan yang harus dijawab halaman ini sepanjang lomba: "nilai regu
    saya sudah masuk belum, atau hilang?" Jawabannya centang per pos. TIDAK ada
    angka nilai — dan itu bukan dijaga di sini, melainkan di database: selama
-   fase masih 'progres', live.json memang tidak memuat satu pun angka nilai
-   (lihat kepala migrasi 0026). Menyembunyikannya di sisi tampilan akan
+   fase masih 'progres', berkas yang terbit memang tidak memuat satu pun angka
+   nilai (lihat kepala migrasi 0026). Menyembunyikannya di sisi tampilan akan
    percuma; siapa pun bisa membuka berkas JSON-nya langsung.
 
-   Tanpa framework, tanpa build step, tanpa kunci apa pun. Satu fetch ke
-   live.json, sisanya menggambar tabel.
+   ---------------------------------------------------------------------------
+   DUA BERKAS, BUKAN SATU — INI YANG MENAHAN 3.000 HP SEKALIGUS
+
+   Pesertanya 1.500-3.000 orang dan mereka membuka alamat yang sama, berkali-
+   kali, dalam jendela waktu yang sama. Satu berkas gemuk yang diunduh ulang
+   tiap menit oleh tiap HP adalah cara paling mudah membuat halaman ini terasa
+   berat justru di jam tersibuk. Maka isinya dipecah dua:
+
+     live.json   ±1 KB   fase, edisi, daftar pos, ringkasan, dan `versi`.
+                         INI yang di-poll tiap 60 detik.
+     rekap.json  puluhan KB   seluruh baris regu + klasemen.
+                         Diambil HANYA saat benar-benar dibutuhkan, dan hanya
+                         sekali per `versi`.
+
+   `rekap.json` diminta dengan `?v=<versi>`, jadi alamatnya berubah hanya
+   ketika isinya berubah. Selama versinya sama, jawabannya datang dari cache
+   browser atau cache tepi Cloudflare — bukan dari mana-mana. Begitu panitia
+   menerbitkan ulang, `versi` di live.json berganti dan HP mengambil yang baru
+   satu kali.
+
+   Ditambah satu hal lagi: sebelum lomba dimulai `rekap.json` TIDAK PERNAH
+   diambil sama sekali, dan selama lomba ia baru diambil setelah peserta
+   benar-benar mencari sekolahnya. HP yang membuka halaman lalu menutupnya
+   mengunduh ±1 KB, bukan puluhan.
+
+   ---------------------------------------------------------------------------
+   PENCARIAN DULU, BARU TABEL
+
+   Peserta tidak pernah ingin membaca 300 baris; ia ingin melihat regunya
+   sendiri. Jadi yang tampil lebih dulu adalah kotak "ketik nama sekolahmu",
+   dan tabelnya baru muncul untuk sekolah yang cocok. Selain lebih cepat
+   dibaca di layar HP, ini juga yang membuat pengambilan `rekap.json` bisa
+   ditunda sampai orangnya benar-benar mencari sesuatu.
+
+   Tanpa framework, tanpa build step, tanpa kunci apa pun.
    ========================================================================== */
 
 const GOLONGAN = {
@@ -24,7 +57,8 @@ const esc = (v) => v === null || v === undefined ? "" : String(v)
   .replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
   .replaceAll('"', "&quot;").replaceAll("'", "&#39;");
 
-const dada = (n) => String(n).padStart(3, "0");
+const dada = (n) => n === null || n === undefined
+  ? "—" : String(n).padStart(3, "0");
 
 /* Bentuk waktu baku. Sengaja DISALIN dari web/js/util.js dan bukan diimpor:
    halaman ini di-deploy sebagai Worker terpisah dan tidak boleh bergantung
@@ -42,9 +76,9 @@ const jam = (t) => {
   return `${dua(d.getHours())}:${dua(d.getMinutes())}`;
 };
 
-/** "17 Agustus 2026 15:30" — dipakai cap sinkronisasi, yang bisa menunjuk
- *  hari lain: peserta membuka halaman ini kapan saja, termasuk besok paginya,
- *  dan "17:30" telanjang akan terbaca sebagai setengah jam lalu. */
+/** "17 Agustus 2026 15:30" — dipakai cap update, yang bisa menunjuk hari
+ *  lain: peserta membuka halaman ini kapan saja, termasuk besok paginya, dan
+ *  "17:30" telanjang akan terbaca sebagai setengah jam lalu. */
 const tanggalJam = (t) => {
   if (!t) return "—";
   const d = new Date(t);
@@ -64,41 +98,57 @@ const berapaLalu = (t) => {
   return `${Math.floor(menit / 60)} jam lalu`;
 };
 
-let DATA = null;
+let META = null;        // isi live.json
+let REKAP = null;       // isi rekap.json, kalau sudah diambil
+let versiRekap = null;  // versi milik REKAP yang sedang dipegang
+let mengambil = false;  // penjaga supaya tidak dua permintaan sekaligus
 let cari = "";
 
+const fase = () => (META && META.fase) || "pra";
+const mulai = () => fase() !== "pra";
+
 /* ---------------------------------------------------------------------------
-   Cap sinkronisasi. Yang ditampilkan adalah jam DATA DIBUAT di server, bukan
-   jam halaman ini dimuat — kalau workflow-nya tersendat, orang harus bisa
+   Cap update. Yang ditampilkan adalah jam DATA DIBUAT di server, bukan jam
+   halaman ini dimuat — kalau penerbitannya tersendat, orang harus bisa
    melihat bahwa angkanya sudah tua, bukan mengira halamannya baru.
    ------------------------------------------------------------------------- */
 function gambarSinkron() {
   const el = document.getElementById("sinkron");
-  if (!DATA) { el.textContent = "Memuat…"; return; }
-  const t = new Date(DATA.dibuat_pada);
+  if (!META) { el.textContent = "Memuat…"; return; }
+  const t = new Date(META.dibuat_pada);
   const tua = Date.now() - t.getTime() > 15 * 60000;
+  // Warnanya tetap berubah setelah 15 menit — petunjuk yang tidak menambah
+  // satu kata pun ke barisnya. Ekor "data mungkin tertinggal" dibuang:
+  // "(1 jam lalu)" sudah mengatakan hal yang sama, dan kalimat tambahan di
+  // sebelahnya membuat baris ini terbaca seperti galat padahal normal.
   el.className = `sinkron${tua ? " basi" : ""}`;
-  el.textContent = `Sinkronisasi terakhir: ${tanggalJam(DATA.dibuat_pada)}`
-    + ` (${berapaLalu(DATA.dibuat_pada)})`
-    + (tua ? " — data mungkin tertinggal" : "");
+  el.textContent = `Update terakhir: ${tanggalJam(META.dibuat_pada)}`
+    + ` (${berapaLalu(META.dibuat_pada)})`;
 }
 
 /* ---------------------------------------------------------------------------
-   Fase 'pra' — belum ada yang berjalan.
+   Fase 'pra' — rekap TIDAK dibuka untuk siapa pun.
+
+   Ini keputusan panitia, bukan kebetulan teknis: sebelum lomba dimulai tidak
+   ada yang boleh dilihat peserta. Yang tetap ada di sini hanya jalan ke
+   formulir — sebelum lomba, itu memang satu-satunya yang dicari orang di
+   alamat ini, dan halaman buntu tanpa jalan ke pendaftaran membuang tamu yang
+   paling banyak datang saat itu.
    ------------------------------------------------------------------------- */
 function gambarPra() {
-  const r = DATA.ringkas || {};
+  const r = META.ringkas || {};
   const per = r.per_golongan || {};
+  const t = META.edisi && META.edisi.tanggal_lomba
+    ? new Date(META.edisi.tanggal_lomba) : null;
   return `
     <div class="kartu tengah">
       <h2>Belum dimulai</h2>
-      <p>Rekap live akan tampil di halaman ini begitu lomba berjalan.</p>
+      <p>Rekap live terbuka saat lomba berjalan${t
+        ? ` — ${esc(String(t.getDate()))} ${esc(BULAN[t.getMonth()])} ${esc(String(t.getFullYear()))}`
+        : ""}. Saat itu kamu bisa memeriksa apakah nilai regumu sudah masuk
+        dari tiap pos.</p>
       <p class="angka-besar">${esc(String(r.jumlah_regu_lunas ?? 0))}</p>
       <p>regu terdaftar</p>
-      <!-- Sebelum lomba, yang dicari orang di alamat ini bukan rekap
-           melainkan formulirnya. Halaman rekap yang kosong tanpa jalan ke
-           pendaftaran adalah jalan buntu bagi tamu yang paling banyak
-           datang saat itu. -->
       <p><a class="tombol" href="daftar.html">Daftar Sekarang</a></p>
       <div class="pil-baris">
         ${URUT_GOLONGAN.filter(g => per[g]).map(g =>
@@ -108,76 +158,129 @@ function gambarPra() {
 }
 
 /* ---------------------------------------------------------------------------
-   Fase 'progres' dan 'penuh' — tabel centang per pos.
-
-   Kolom pos dibangun dari daftar pos di live.json, bukan ditulis di sini:
-   jumlah dan namanya berubah tiap edisi.
+   Kotak cari. Selalu digambar begitu lomba mulai, bahkan sebelum rekap.json
+   ada di tangan — kotaknya sendiri yang MEMICU pengambilan berkas itu.
    ------------------------------------------------------------------------- */
-function barisCocok(b) {
-  if (!cari) return true;
-  return dada(b.nomor_dada).includes(cari)
-    || (b.nama_regu || "").toLowerCase().includes(cari)
-    || (b.nama_sekolah || "").toLowerCase().includes(cari);
-}
-
-function gambarProgres() {
-  const pos = DATA.pos || [];
-  const baris = (DATA.progres || []).filter(barisCocok);
-
-  const kepalaPos = pos.map(p => `<th class="pos">${esc(p.bayangan ? p.name : `Pos ${p.nomor}`)}</th>`).join("");
-
-  const isi = baris.map(b => {
-    const lewat = b.pos_terlewati || {};
-    const sel = pos.map(p => {
-      const ada = lewat[String(p.nomor)];
-      return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : "–"}</td>`;
-    }).join("");
-    return `
-      <tr>
-        <td class="dada">${esc(dada(b.nomor_dada))}</td>
-        <td class="regu">${esc(b.nama_regu)}<span class="sekolah">${esc(b.nama_sekolah)}</span></td>
-        <td class="gol">${esc(GOLONGAN[b.golongan] || b.golongan)}</td>
-        <td>${b.kloter ? esc(String(b.kloter)) : "—"}</td>
-        <td>${esc(kontrak(b.kontrak_menit))}</td>
-        <td>${esc(jam(b.jam_berangkat))}</td>
-        <td>${esc(jam(b.jam_datang))}</td>
-        ${sel}
-      </tr>`;
-  }).join("");
-
+function gambarCari() {
   return `
     <div class="kartu">
-      <h2>Nilai regu sudah masuk?</h2>
-      <p class="keterangan">Centang berarti nilai regu itu sudah diterima
-         sistem dari pos tersebut. Angkanya sengaja belum ditampilkan — hasil
-         lengkapnya dibuka setelah closing.</p>
+      <h2>Cari sekolahmu</h2>
+      <p class="keterangan">Ketik nama sekolahmu — boleh sebagiannya saja,
+         misalnya "purwadadi". Seluruh regu sekolah itu akan tampil.</p>
       <div class="cari-baris">
         <input type="search" id="cari" inputmode="search"
-               placeholder="Cari nomor dada, nama regu, atau sekolah…"
+               placeholder="Nama sekolah…"
                value="${esc(cari)}" autocomplete="off">
-        <span class="hitung">${esc(String(baris.length))} regu</span>
-      </div>
-      <div class="gulir">
-        <table class="tabel">
-          <thead>
-            <tr>
-              <th>No<br>Dada</th><th>Regu</th><th>Golongan</th>
-              <th>Kloter</th><th>Kontrak</th><th>Berangkat</th><th>Datang</th>
-              ${kepalaPos}
-            </tr>
-          </thead>
-          <tbody>${isi || `<tr><td colspan="${7 + pos.length}" class="kosong">
-            Tidak ada regu yang cocok dengan pencarian.</td></tr>`}</tbody>
-        </table>
       </div>
     </div>`;
 }
 
 /* ---------------------------------------------------------------------------
-   Fase 'penuh' — klasemen per golongan, juara di atas.
+   Hasil pencarian: dikelompokkan per SEKOLAH, dan di dalamnya urut nomor
+   dada dari awal sampai akhir.
+
+   Selama lomba yang tampil hanya centang. Kolom kloter, kontrak, dan jam baru
+   ikut muncul setelah hasilnya diumumkan (fase 'penuh') — saat itu halaman
+   ini memang berubah jadi papan hasil lengkap.
+   ------------------------------------------------------------------------- */
+/** Dicocokkan ke NAMA SEKOLAH saja — bukan nama regu, bukan nomor dada.
+ *
+ *  Itu keputusan sadar, bukan penyederhanaan. Sekolah adalah satu-satunya
+ *  kata kunci yang pasti diketahui setiap orang yang membuka halaman ini,
+ *  dan membatasi pencarian ke sana membuat halaman menjawab "bagaimana regu
+ *  KAMI" alih-alih berubah jadi alat mengintip nilai regu lain satu per satu.
+ *  Yang tampil sesudahnya memang seluruh regu sekolah itu — satu sekolah
+ *  adalah satu rombongan, dan pembinanya mengurus semuanya sekaligus. */
+function cocok(b) {
+  return (b.nama_sekolah || "").toLowerCase().includes(cari);
+}
+
+function gambarHasil() {
+  const pos = (META && META.pos) || [];
+  const penuh = fase() === "penuh";
+
+  if (cari.length < 2) {
+    return `<div class="kartu tengah">
+      <p class="keterangan">Ketik minimal dua huruf nama sekolahmu untuk
+         melihat seluruh regunya.</p></div>`;
+  }
+  if (!REKAP) {
+    return `<div class="kartu tengah"><p class="keterangan">Mencari…</p></div>`;
+  }
+
+  const baris = (REKAP.progres || []).filter(cocok);
+  if (!baris.length) {
+    return `<div class="kartu tengah">
+      <h2>Sekolah tidak ditemukan</h2>
+      <p class="keterangan">Tidak ada sekolah yang cocok dengan
+         "${esc(cari)}". Coba potong jadi satu kata saja — misalnya
+         "purwadadi" alih-alih nama lengkapnya. Kalau tetap tidak muncul,
+         pembayaran sekolahmu mungkin belum diverifikasi panitia.</p></div>`;
+  }
+
+  // Dikelompokkan per sekolah supaya satu sekolah yang mengirim sepuluh regu
+  // terbaca sebagai satu blok, bukan sepuluh baris yang tercecer.
+  const sekolah = new Map();
+  for (const b of baris) {
+    const k = b.nama_sekolah || "—";
+    if (!sekolah.has(k)) sekolah.set(k, []);
+    sekolah.get(k).push(b);
+  }
+
+  const kepalaPos = pos.map(p =>
+    `<th class="pos">${esc(p.bayangan ? p.name : `Pos ${p.nomor}`)}</th>`).join("");
+
+  return [...sekolah.entries()].sort((a, b) => a[0].localeCompare(b[0], "id"))
+    .map(([nama, isi]) => {
+      isi.sort((a, b) => (a.nomor_dada ?? 1e9) - (b.nomor_dada ?? 1e9));
+      const kolomEkstra = penuh
+        ? `<th>Kloter</th><th>Kontrak</th><th>Berangkat</th><th>Datang</th>` : "";
+      return `
+        <div class="kartu">
+          <h2>${esc(nama)}</h2>
+          <p class="keterangan">${esc(String(isi.length))} regu${penuh ? "" :
+            " · centang = nilai regu itu sudah diterima sistem dari pos tersebut"}</p>
+          <div class="gulir">
+            <table class="tabel">
+              <thead>
+                <tr>
+                  <th>No<br>Dada</th><th>Regu</th><th>Golongan</th>
+                  ${kolomEkstra}${kepalaPos}
+                </tr>
+              </thead>
+              <tbody>
+                ${isi.map(b => {
+                  const lewat = b.pos_terlewati || {};
+                  const sel = pos.map(p => {
+                    const ada = lewat[String(p.nomor)];
+                    return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : "–"}</td>`;
+                  }).join("");
+                  const ekstra = penuh ? `
+                    <td>${b.kloter ? esc(String(b.kloter)) : "—"}</td>
+                    <td>${esc(kontrak(b.kontrak_menit))}</td>
+                    <td>${esc(jam(b.jam_berangkat))}</td>
+                    <td>${esc(jam(b.jam_datang))}</td>` : "";
+                  return `
+                    <tr>
+                      <td class="dada">${esc(dada(b.nomor_dada))}</td>
+                      <td class="regu">${esc(b.nama_regu)}</td>
+                      <td class="gol">${esc(GOLONGAN[b.golongan] || b.golongan)}</td>
+                      ${ekstra}${sel}
+                    </tr>`;
+                }).join("")}
+              </tbody>
+            </table>
+          </div>
+        </div>`;
+    }).join("");
+}
+
+/* ---------------------------------------------------------------------------
+   Fase 'penuh' — klasemen per golongan, juara di atas. Tampil tanpa perlu
+   mencari apa pun: inilah pengumumannya.
    ------------------------------------------------------------------------- */
 function gambarKlasemen() {
-  const semua = DATA.klasemen || [];
+  const semua = (REKAP && REKAP.klasemen) || [];
   if (!semua.length) return "";
 
   return URUT_GOLONGAN.map(g => {
@@ -227,22 +330,25 @@ function gambarKlasemen() {
    ------------------------------------------------------------------------- */
 function gambar() {
   const isi = document.getElementById("isi");
-  if (!DATA) return;
+  if (!META) return;
 
   document.getElementById("judul").textContent =
-    `Rekap Live${DATA.edisi ? ` — ${DATA.edisi.name}` : ""}`;
-  document.title = `Rekap Live — ${DATA.edisi ? DATA.edisi.name : "Hiking Rally Ciradyka"}`;
+    `Rekap Live${META.edisi ? ` — ${META.edisi.name}` : ""}`;
+  document.title = `Rekap Live — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
 
-  const fase = DATA.fase || "pra";
-  isi.innerHTML = fase === "pra"
+  isi.innerHTML = !mulai()
     ? gambarPra()
-    : (fase === "penuh" ? gambarKlasemen() : "") + gambarProgres();
+    : (fase() === "penuh" ? gambarKlasemen() : "") + gambarCari() + gambarHasil();
 
   const kotak = document.getElementById("cari");
   if (kotak) {
     kotak.addEventListener("input", () => {
       cari = kotak.value.trim().toLowerCase();
       const posisi = kotak.selectionStart;
+      // Berkas besar diambil saat orangnya benar-benar mencari, bukan saat
+      // halaman dibuka. Inilah yang membuat ribuan HP yang cuma melirik
+      // halaman ini tidak mengunduh apa pun selain live.json.
+      if (cari.length >= 2 && !REKAP) muatRekap().then(gambar);
       gambar();
       const baru = document.getElementById("cari");
       if (baru) { baru.focus(); baru.setSelectionRange(posisi, posisi); }
@@ -252,18 +358,46 @@ function gambar() {
 }
 
 /* ---------------------------------------------------------------------------
-   Muat + segarkan sendiri. Penanda waktu di URL memaksa lewat cache browser;
-   berkasnya kecil dan sudah bertanda no-cache, tapi sebagian jaringan seluler
-   tetap menyimpannya sendiri.
+   Pengambilan berkas.
+
+   live.json  : kecil, tanpa cache, tiap 60 detik.
+   rekap.json : besar, dialamati `?v=<versi>` sehingga boleh di-cache selamanya
+                oleh browser dan oleh tepi Cloudflare. Versi berganti = alamat
+                berganti = satu unduhan baru, lalu diam lagi.
    ------------------------------------------------------------------------- */
+async function muatRekap() {
+  if (!META || mengambil) return;
+  if (REKAP && versiRekap === META.versi) return;   // sudah yang terbaru
+  mengambil = true;
+  try {
+    const r = await fetch(`rekap.json?v=${encodeURIComponent(META.versi || "0")}`);
+    if (!r.ok) throw new Error(String(r.status));
+    REKAP = await r.json();
+    versiRekap = META.versi;
+  } catch {
+    // Diamkan: yang lama tetap dipakai kalau ada, dan percobaan berikutnya
+    // datang sendiri pada poll berikutnya.
+  } finally {
+    mengambil = false;
+  }
+}
+
 async function muat() {
   try {
     const r = await fetch(`live.json?t=${Date.now()}`, { cache: "no-store" });
     if (!r.ok) throw new Error(String(r.status));
-    DATA = await r.json();
+    const baru = await r.json();
+    const versiBerubah = !META || META.versi !== baru.versi;
+    META = baru;
+
+    // Rekap diambil ulang hanya kalau memang sudah dipegang (peserta sedang
+    // melihatnya) atau memang harus tampil tanpa dicari (fase 'penuh').
+    if (versiBerubah && (REKAP || fase() === "penuh")) await muatRekap();
+    else if (fase() === "penuh" && !REKAP) await muatRekap();
+
     gambar();
   } catch {
-    if (!DATA) {
+    if (!META) {
       document.getElementById("isi").innerHTML = `
         <div class="kartu tengah">
           <h2>Belum bisa dimuat</h2>
@@ -274,7 +408,22 @@ async function muat() {
 }
 
 muat();
-setInterval(muat, 60000);
+
+/* Polling hanya berjalan saat halamannya benar-benar dilihat. Ribuan HP yang
+   tertinggal terbuka di saku adalah beban yang tidak menghasilkan apa pun —
+   dan mereka tetap mendapat data segar begitu layarnya dibuka lagi. */
+let denyut = null;
+const nyalakan = () => {
+  if (denyut === null) denyut = setInterval(muat, 60000);
+};
+const matikan = () => {
+  if (denyut !== null) { clearInterval(denyut); denyut = null; }
+};
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) matikan();
+  else { nyalakan(); muat(); }
+});
+if (!document.hidden) nyalakan();
+
 // Cap "berapa menit lalu" ikut berjalan meski datanya belum berubah.
 setInterval(gambarSinkron, 30000);
-document.addEventListener("visibilitychange", () => { if (!document.hidden) muat(); });

--- a/live/live.json
+++ b/live/live.json
@@ -1,5 +1,6 @@
 {
   "dibuat_pada": "2026-08-14T00:00:00+07:00",
+  "versi": "525bad4fc81d",
   "fase": "pra",
   "edisi": null,
   "ringkas": {
@@ -8,6 +9,5 @@
     "per_golongan": null
   },
   "pos": [],
-  "progres": [],
-  "klasemen": []
+  "jumlah_regu": 0
 }

--- a/live/rekap.json
+++ b/live/rekap.json
@@ -1,0 +1,1 @@
+{"progres":[],"klasemen":[],"versi":"525bad4fc81d"}

--- a/live/style.css
+++ b/live/style.css
@@ -194,6 +194,26 @@ input[type=number]::-webkit-outer-spin-button,
 input[type=number]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 
 input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min-height: 54px; }
+
+/* Kotak jam yang diketik. Menggantikan input[type=time], yang dirender
+   browser menurut locale-nya sendiri dan bisa muncul sebagai AM/PM di laptop
+   berbahasa Inggris — lihat jamSah() di js/util.js.
+
+   Lebarnya dipatok: "HH:MM" tidak akan pernah lebih dari lima huruf, dan
+   kotak selebar layar mengundang orang mengetik kalimat ke dalamnya. Angka
+   tabular supaya "11:11" dan "07:45" sama lebarnya dan kolomnya tidak
+   bergoyang saat diketik. */
+input.jam-ketik {
+  width: 7.5em;
+  max-width: 100%;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: .08em;
+  text-align: center;
+}
+input.jam-ketik.jam-salah {
+  border-color: var(--bahaya);
+  background: var(--bahaya-muda);
+}
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }
 
@@ -1413,3 +1433,91 @@ input.small-input { text-align: center; }
    dilihat saat mata menyapu, tidak cukup untuk mengaburkan angkanya. */
 .table-pos tbody tr.baris-belum td { background: var(--kuning-muda); }
 .table-pos tbody tr.baris-belum td:first-child { background: var(--kuning-muda); }
+
+/* ---------------------------------------------------------------------------
+   Rekapitulasi (#/rekap) — tabel terlebar di seluruh sistem.
+
+   Lembar aslinya punya ±35 kolom, dan itu tidak akan pernah muat di layar
+   mana pun. Jadi tabel ini SATU-SATUNYA yang sengaja digeser ke samping —
+   di semua layar meja, geser samping justru dilarang karena menyembunyikan
+   kolom tombol. Di sini tidak ada tombol sama sekali, jadi yang hilang dari
+   pandangan cuma angka yang bisa digeser kembali.
+
+   Empat kolom pertama dibekukan di kiri supaya identitas regu tetap terlihat
+   saat isinya digeser jauh ke kanan. Tanpa itu, mata kehilangan barisnya di
+   kolom Pos 3 dan orang membaca nilai regu yang salah.
+   ------------------------------------------------------------------------- */
+.gulir-rekap {
+  overflow-x: auto;
+  overflow-y: visible;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rekap-tabel {
+  font-size: .82rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+.rekap-tabel th, .rekap-tabel td {
+  padding: .3rem .45rem;
+  text-align: center;
+  border-bottom: 1px solid var(--garis);
+}
+.rekap-tabel th {
+  position: sticky; top: 0; z-index: 2;
+  background: var(--kertas);
+  font-size: .74rem; line-height: 1.15;
+  vertical-align: bottom;
+}
+.rekap-tabel th .kolom-petunjuk {
+  display: block; font-weight: 400; font-size: .66rem;
+  color: var(--tinta-lembut);
+}
+
+/* Empat kolom identitas ikut menempel saat digeser. Angka `left` ditumpuk
+   tangan karena lebarnya dipatok tepat di bawah — kolom beku menuntut lebar
+   yang pasti, kalau tidak posisinya meleset saat isinya berubah panjang. */
+.rekap-tabel th:nth-child(-n+4), .rekap-tabel td:nth-child(-n+4) {
+  position: sticky; z-index: 1; background: #fff;
+}
+.rekap-tabel th:nth-child(-n+4) { z-index: 3; background: var(--kertas); }
+.rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1) { left: 0;      width: 46px; }
+.rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) { left: 46px;   width: 56px; }
+.rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3) { left: 102px;  width: 150px; text-align: left; }
+.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) { left: 252px;  width: 160px; text-align: left; }
+.rekap-tabel td:nth-child(4) {
+  max-width: 160px; overflow: hidden; text-overflow: ellipsis;
+}
+/* Garis pemisah antara blok beku dan blok yang bergeser — tanpa ini
+   keduanya terbaca sebagai satu tabel dan geserannya membingungkan. */
+.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
+  border-right: 2px solid var(--garis);
+}
+
+.rekap-tabel .rekap-komponen { min-width: 58px; }
+/* Nilai Pos dan Nilai Total adalah angka yang dicari orang; sisanya bahan
+   mentah. Latar tipis memisahkan keduanya tanpa menambah garis. */
+.rekap-tabel .rekap-nilai-pos {
+  font-weight: 600;
+  background: var(--kertas);
+  min-width: 62px;
+}
+.rekap-tabel .rekap-total {
+  font-weight: 700;
+  background: var(--hijau-muda);
+  min-width: 76px;
+}
+.rekap-tabel tbody tr:hover td { background: var(--kuning-muda); }
+
+@media (max-width: 700px) {
+  .rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3),
+  .rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
+    position: static; width: auto;
+  }
+  .rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1),
+  .rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) {
+    position: static;
+  }
+}

--- a/supabase/migrations/0027_rekap_penuh.sql
+++ b/supabase/migrations/0027_rekap_penuh.sql
@@ -1,0 +1,133 @@
+-- ============================================================================
+-- hrcd-rekap : 0027_rekap_penuh.sql
+--
+-- Dua hal, dan keduanya soal "siapa boleh melihat apa, kapan":
+--
+--   1. `v_rekap_penuh` — lembar Rekapitulasi lengkap untuk PANITIA. Bentuknya
+--      meniru spreadsheet yang dipakai panitia selama tujuh tahun: satu baris
+--      per regu, SATU KOLOM PER KOMPONEN (bukan per pos), Nilai Pos di ujung
+--      tiap kelompok, lalu kolom waktu, lalu Nilai Total.
+--
+--   2. `v_progres_publik` dibuka sejak hari pertama, bukan sejak fase
+--      'progres'.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA REKAP PANITIA TIDAK MEMAKAI v_lembar_pos SAJA
+--
+-- `v_lembar_pos` melayani satu pos dan sengaja begitu: operator pos hanya
+-- boleh melihat posnya sendiri. Rekap ini kebalikannya — ia hanya berguna
+-- kalau memuat SELURUH pos sekaligus, dan itu berarti ia bukan untuk operator
+-- pos. Pagarnya dipasang di dalam view: `peran() in ('admin','meja')`.
+--
+-- Itu bukan sekadar soal hak akses melainkan soal angka yang jujur. View ini
+-- `security_invoker`, jadi RLS `sel_nilai` ikut menggigit: operator pos hanya
+-- membaca `nilai_mentah` pos-nya sendiri. Kalau ia dibiarkan membuka rekap,
+-- kolom pos lain kosong DAN Nilai Total ikut mengecil — bukan tampilan sempit
+-- melainkan tampilan PALSU, yang justru dilarang rancangan-b.md 14.6. Lebih
+-- baik nol baris daripada total yang salah.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA PERINGKAT DIAMBIL DARI v_klasemen, BUKAN DIHITUNG ULANG DI SINI
+--
+-- Menulis `rank() over (...)` sekali lagi di berkas ini akan melahirkan mesin
+-- peringkat kedua yang suatu hari berbeda pendapat dengan yang pertama —
+-- persis kesalahan yang dijaga ketat di layar Input Pos (layar tidak pernah
+-- menghitung skor sendiri). Jadi peringkat di-LEFT JOIN dari `v_klasemen`.
+--
+-- Akibatnya yang harus dipahami pembaca: regu yang belum diceklis berangkat,
+-- atau yang kloternya belum berangkat, TIDAK punya peringkat — kolomnya
+-- kosong. Itu memang aturan klasemen (rancangan-b.md 11.12), dan sepanjang
+-- lomba berjalan sebagian besar baris memang belum berperingkat. Nilainya
+-- tetap terlihat; yang belum ada hanya nomor urutnya.
+--
+-- ---------------------------------------------------------------------------
+-- HALAMAN PESERTA TIDAK DISENTUH BERKAS INI
+--
+-- `v_progres_publik` tetap terkunci di fase 'progres'/'penuh' (0026): sebelum
+-- lomba dimulai, peserta tidak melihat rekap apa pun. Itu keputusan panitia,
+-- dan berkas ini sengaja tidak melonggarkannya — satu-satunya yang ditambahkan
+-- di sini adalah layar untuk panitia sendiri.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Rekapitulasi lengkap untuk panitia
+--
+-- `nilai` dan `poin_pos` berbentuk objek JSON, bukan larik, supaya layar bisa
+-- langsung mencari kolomnya tanpa memindai apa pun — pola yang sama dengan
+-- v_lembar_pos (0023).
+--
+--   nilai    = {"1.semaphore": {"nilai_1": 5, "nilai_2": null}, ...} SEMUA pos
+--   poin_pos = {"1": 260.00, "2": 220.00, ...}
+--
+-- Kuncinya diberi awalan nomor pos, dan itu bukan hiasan: `wahana.kode` hanya
+-- unik per (edisi, pos, kode), bukan per edisi. Dua pos yang kebetulan memakai
+-- kode yang sama akan saling menimpa kalau kuncinya cuma kodenya — dan yang
+-- hilang adalah kolom nilai, tanpa satu pun galat.
+-- ---------------------------------------------------------------------------
+create view v_rekap_penuh with (security_invoker = on) as
+select
+  r.id            as regu_id,
+  kl.peringkat,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name          as nama_sekolah,
+  r.golongan,
+
+  coalesce((
+    select jsonb_object_agg(w.pos || '.' || w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = edisi_aktif()
+  ), '{}'::jsonb) as nilai,
+
+  coalesce((
+    select jsonb_object_agg(pp.pos::text, pp.poin_pos)
+    from v_poin_pos pp
+    where pp.regu_id = r.id
+  ), '{}'::jsonb) as poin_pos,
+
+  r.kloter_nomor  as kloter,
+  k.jam_berangkat,
+  c.jam_datang,
+  r.kontrak_menit,
+  pw.selisih_menit,
+  -- Lama tempuh sebenarnya, dalam menit. Panitia memakainya untuk membaca
+  -- selisih tanpa menghitung di kepala: tempuh 245 menit dengan kontrak 240
+  -- berarti telat 5. Spreadsheet lama memecahnya jadi kolom jam dan kolom
+  -- menit terpisah karena rumusnya butuh begitu; di sini satu angka cukup.
+  case when k.jam_berangkat is not null and c.jam_datang is not null
+    then round(extract(epoch from (c.jam_datang - k.jam_berangkat)) / 60)::int
+  end             as tempuh_menit,
+  c.anggota_hadir,
+
+  t.total_pos,
+  pw.penalti_waktu,
+  t.penalti_checkout,
+  t.penalti_anggota,
+  t.total,
+
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                  as sudah_berangkat,
+  (c.regu_id is not null) as sudah_closing
+
+from regu r
+join pendaftaran d      on d.id = r.pendaftaran_id
+join sekolah s          on s.id = d.sekolah_id
+join v_total_skor t     on t.regu_id = r.id
+join v_penalti_waktu pw on pw.regu_id = r.id
+left join v_klasemen kl on kl.regu_id = r.id
+left join kloter k      on k.nomor = r.kloter_nomor
+left join closing_regu c on c.regu_id = r.id
+where peran() in ('admin', 'meja');
+
+-- Grant per-view, bukan massal — pola yang sama dengan 0005 dan 0023. `anon`
+-- sengaja TIDAK disebut: rekap ini memuat angka nilai sebelum diumumkan, dan
+-- satu-satunya jalur anon ke database memang tidak boleh menyentuhnya.
+grant select on v_rekap_penuh to authenticated;
+
+comment on view v_rekap_penuh is
+  'Lembar Rekapitulasi lengkap untuk panitia: satu baris per regu, nilai '
+  'mentah tiap komponen SELURUH pos, Nilai Pos per pos, kolom waktu, dan '
+  'Nilai Total. Hanya admin dan meja — operator pos akan mendapat total yang '
+  'salah karena RLS memotong nilai_mentah pos lain.';

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -145,6 +145,18 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "from wahana where edisi = edisi_aktif() and pos = %s "
                     "order by sort_order",
                     (p.get("pos") or 0,), uid=p.get("uid")))
+            elif u.path == "/komponen-semua":
+                # Seluruh kolom penilaian semua pos — pembangun tabel
+                # Rekapitulasi (#/rekap).
+                self._kirim(200, q(
+                    "select pos, kode, name, type, form, poin_maks, satuan, "
+                    "       rentang_mentah_min, rentang_mentah_maks, sort_order "
+                    "from wahana where edisi = edisi_aktif() "
+                    "order by pos, sort_order", uid=p.get("uid")))
+            elif u.path == "/rekap-penuh":
+                self._kirim(200, q(
+                    "select * from v_rekap_penuh order by nomor_dada",
+                    uid=p.get("uid")))
             elif u.path == "/lembar-pos":
                 # dada opsional: kosong = seluruh lembar, isi = satu baris
                 # yang dibaca ulang sesudah menyimpan.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -49,6 +49,7 @@ run supabase/migrations/0023_lembar_pos.sql
 run supabase/migrations/0024_komponen_pos.sql
 run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run supabase/migrations/0026_rekap_publik.sql
+run supabase/migrations/0027_rekap_penuh.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -81,5 +82,9 @@ run tests/sql/07_pindah_setelah_berangkat.sql
 run supabase/migrations/0024_komponen_pos.sql
 run tests/sql/08_lembar_pos.sql
 run tests/sql/09_rekap_publik.sql
+# 10 dijalankan PALING AKHIR, dan itu perlu: ia membandingkan rekap panitia
+# dengan v_poin_pos, v_total_skor, dan v_klasemen, jadi ia butuh database yang
+# sudah berisi nilai, keberangkatan, dan closing dari seluruh tes di atasnya.
+run tests/sql/10_rekap_penuh.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/10_rekap_penuh.sql
+++ b/tests/sql/10_rekap_penuh.sql
@@ -1,0 +1,153 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/10_rekap_penuh.sql
+-- Lembar Rekapitulasi panitia (v_rekap_penuh, migrasi 0027).
+--
+-- Dua hal yang diuji, dan keduanya soal yang sama: layar ini menampilkan
+-- ANGKA AKHIR, jadi ia hanya boleh dibuka oleh orang yang bisa melihat
+-- SELURUH bahannya.
+--
+--   1. Operator pos mendapat NOL BARIS. Bukan tampilan sempit — kalau ia
+--      diberi baris, RLS memotong nilai_mentah pos lain dan Nilai Total-nya
+--      mengecil tanpa satu pun galat. Total yang salah lebih berbahaya
+--      daripada layar yang menolak dibuka.
+--
+--   2. Angkanya sama persis dengan mesin skor yang sudah ada. View ini tidak
+--      boleh menghitung apa pun sendiri; kalau suatu hari ia menyimpang dari
+--      v_poin_pos / v_total_skor / v_klasemen, ada dua mesin skor di sistem
+--      ini dan salah satunya berbohong.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 10.1 Admin melihat seluruh regu.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- Pembandingnya dibaca dari tabel dasar DI DALAM peran yang sama — admin
+-- memang boleh membaca regu dan pendaftaran. Berpindah peran di tengah blok
+-- plpgsql sengaja dihindari: itu bukan yang sedang diuji, dan blok yang
+-- separuhnya berjalan sebagai orang lain sulit dibaca ulang setahun lagi.
+do $$
+declare v_admin int; v_semua int;
+begin
+  select count(*) into v_admin from v_rekap_penuh;
+  select count(*) into v_semua
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled and d.status = 'lunas';
+  assert v_admin > 0, 'admin tidak melihat satu baris pun di rekap';
+  assert v_admin = v_semua,
+    format('admin melihat %s regu, seharusnya %s', v_admin, v_semua);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 10.2 Meja juga boleh — ia memang sudah boleh membaca seluruh nilai_mentah
+--      (policy sel_nilai), jadi totalnya utuh.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+do $$
+begin
+  assert (select count(*) from v_rekap_penuh) > 0, 'akun meja tidak melihat apa pun';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 10.3 Operator pos: NOL BARIS. Inilah pagarnya.
+-- ---------------------------------------------------------------------------
+reset role;
+select set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+set role authenticated;
+
+do $$
+begin
+  assert (select count(*) from v_rekap_penuh) = 0,
+    'operator pos mendapat baris rekap — Nilai Total-nya pasti salah, '
+    'karena RLS memotong nilai_mentah pos lain';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 10.4 Angkanya sama dengan mesin skor yang sudah ada — tidak ada mesin kedua.
+-- ---------------------------------------------------------------------------
+reset role;
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+do $$
+declare r record; v_beda int;
+begin
+  -- Nilai Pos per pos harus identik dengan v_poin_pos, kunci demi kunci.
+  select count(*) into v_beda
+  from v_rekap_penuh k
+  join lateral jsonb_each_text(k.poin_pos) e(pos, poin) on true
+  left join v_poin_pos pp
+         on pp.regu_id = k.regu_id and pp.pos = e.pos::smallint
+  where pp.poin_pos is null
+     or round(pp.poin_pos, 2) <> round(e.poin::numeric, 2);
+  assert v_beda = 0,
+    format('%s Nilai Pos di rekap tidak sama dengan v_poin_pos', v_beda);
+
+  -- Total, penalti, dan peringkat diambil, bukan dihitung ulang.
+  select count(*) into v_beda
+  from v_rekap_penuh k
+  join v_total_skor t on t.regu_id = k.regu_id
+  where k.total <> t.total
+     or k.total_pos <> t.total_pos
+     or k.penalti_checkout <> t.penalti_checkout
+     or k.penalti_anggota <> t.penalti_anggota;
+  assert v_beda = 0,
+    format('%s baris rekap berbeda angka dengan v_total_skor', v_beda);
+
+  select count(*) into v_beda
+  from v_rekap_penuh k
+  join v_klasemen kl on kl.regu_id = k.regu_id
+  where k.peringkat is distinct from kl.peringkat;
+  assert v_beda = 0,
+    format('%s peringkat di rekap berbeda dengan v_klasemen', v_beda);
+
+  -- Regu yang belum berangkat tetap muncul, hanya tanpa peringkat: sepanjang
+  -- lomba sebagian besar baris memang begitu, dan membuangnya akan membuat
+  -- papan ini kosong justru saat paling dibutuhkan.
+  select * into r from v_rekap_penuh where peringkat is null limit 1;
+  if found then
+    assert not r.sudah_berangkat or r.jam_berangkat is null,
+      format('regu %s tidak berperingkat padahal kloternya sudah berangkat',
+             r.nomor_dada);
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 10.5 Nilai mentah SELURUH pos ada di satu baris, berkunci "<pos>.<kode>".
+--      Awalan nomor pos itu bukan hiasan: `wahana.kode` hanya unik per
+--      (edisi, pos), jadi dua pos yang memakai kode sama akan saling menimpa
+--      kalau kuncinya cuma kodenya.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_baris record; v_harus int; v_ada int;
+begin
+  select * into v_baris from v_rekap_penuh
+  where nilai <> '{}'::jsonb
+  order by nomor_dada
+  limit 1;
+  assert found, 'tidak ada satu pun baris rekap yang memuat nilai mentah';
+
+  select count(*) into v_harus
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where n.regu_id = v_baris.regu_id and w.edisi = edisi_aktif();
+  select count(*) into v_ada from jsonb_object_keys(v_baris.nilai);
+  assert v_ada = v_harus,
+    format('regu %s punya %s nilai mentah tapi rekap memuat %s',
+           v_baris.nomor_dada, v_harus, v_ada);
+
+  assert (select bool_and(k ~ '^[0-9]+\.[a-z0-9_]+$')
+          from jsonb_object_keys(v_baris.nilai) k),
+    'kunci nilai tidak berbentuk "<pos>.<kode>": '
+    || (select string_agg(k, ', ') from jsonb_object_keys(v_baris.nilai) k);
+end;
+$$;
+
+reset role;
+select '10_rekap_penuh OK' as hasil;

--- a/web/index.html
+++ b/web/index.html
@@ -3,13 +3,18 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Hiking Rally Ciradyka</title>
+  <!-- Judul sebelum JavaScript jalan. Sesudahnya app.js menggantinya jadi
+       "<nama layar> — HRCD XXXVII". Yang penting muncul di potongan judul tab
+       adalah "Sistem Panitia": alamat ini dibuka berdampingan dengan situs
+       peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
+       yang salah. -->
+  <title>Sistem Panitia — HRCD</title>
   <link rel="stylesheet" href="style.css?v=3">
 </head>
 <body>
   <header class="header" id="kepala" hidden>
     <button class="icon-button" id="btn-home" type="button" aria-label="Home" title="Home">🏠</button>
-    <span class="title" id="judul-layar">HRCD Rekap</span>
+    <span class="title" id="judul-layar">Sistem Panitia</span>
     <span class="spacer"></span>
     <span class="user-info" id="siapa"></span>
     <button class="icon-button" id="ganti-password" type="button" aria-label="Ganti Password" title="Ganti Password">⚙️</button>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -431,6 +431,30 @@ export async function komponenPos(edisi, pos) {
     `&order=sort_order.asc`);
 }
 
+/** Seluruh komponen penilaian SEMUA pos sekaligus, urut pos lalu kolom.
+ *  Inilah yang menentukan bentuk tabel Rekapitulasi: satu kolom per baris di
+ *  sini, persis seperti lembar Excel yang dipakai panitia — dan sama seperti
+ *  layar Input Pos, tidak satu pun nama kolom ditulis di JavaScript. */
+export async function komponenSemua(edisi) {
+  if (K.mode === "dev") return baca("/komponen-semua");
+  return baca(null,
+    `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
+    `&select=pos,kode,name,type,form,poin_maks,satuan,` +
+    `rentang_mentah_min,rentang_mentah_maks,sort_order` +
+    `&order=pos.asc,sort_order.asc`);
+}
+
+/** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
+ *
+ *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena
+ *  RLS akan memotong nilai_mentah pos lain dan Nilai Total-nya jadi salah
+ *  (lihat kepala migrasi 0027). ~300 baris, dimuat sekali lalu disaring dan
+ *  diurutkan di browser — pola yang sama dengan seluruh layar meja. */
+export async function rekapPenuh() {
+  if (K.mode === "dev") return baca("/rekap-penuh");
+  return baca(null, "v_rekap_penuh?select=*&order=nomor_dada.asc");
+}
+
 /** Seluruh regu + nilai yang sudah tersimpan untuk satu pos. Satu permintaan
  *  untuk seluruh lembar: ~300 baris, dimuat sekali lalu disaring di browser,
  *  sama seperti layar meja. */

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -18,10 +18,11 @@ import {
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
+  komponenSemua, rekapPenuh,
   statusAcara,
 } from "./api.js";
-import { esc, h, html, rupiah, jamMenit, tanggalPanjang, notif, dialog,
-         kartuGagalMuat } from "./util.js";
+import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
+         dialog, kartuGagalMuat, jamSah, pasangKotakJam } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -42,15 +43,16 @@ const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
  *               ditentukan konfigurasi dan bisa bertambah tahun depan, jadi
  *               patokan 1080px yang pas untuk tabel meja justru memaksanya
  *               menggeser ke samping padahal layarnya masih lapang. */
-/** Nama acara untuk judul tab: "Hiking Rally Ciradyka XXXVII".
- *  Angka romawinya DIAMBIL dari nama edisi di database ("HRCD XXXVII"),
- *  bukan ditulis di sini — tahun depan cukup mengubah satu baris di tabel
- *  edisi, tidak ada yang perlu mencarinya di dalam JavaScript. Sebelum edisi
- *  termuat (layar masuk), angkanya dilewati saja. */
-const namaAcara = () => {
-  const romawi = EDISI ? String(EDISI.name || "").replace(/^HRCD\s*/i, "").trim() : "";
-  return `Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
-};
+/** Nama acara untuk judul tab: "HRCD XXXVII" — diambil apa adanya dari nama
+ *  edisi di database, bukan ditulis di sini. Tahun depan cukup mengubah satu
+ *  baris di tabel edisi.
+ *
+ *  Bentuk pendek, bukan "Hiking Rally Ciradyka XXXVII": judul tab dipotong
+ *  browser di sekitar 25 huruf, dan panitia membuka layar ini bersama belasan
+ *  tab lain di HP. Yang harus terbaca di potongan itu adalah "Sistem
+ *  Panitia", bukan nama acara yang sudah mereka tahu. Sebelum edisi termuat
+ *  (layar masuk), sisakan "HRCD" saja. */
+const namaAcara = () => (EDISI && EDISI.name) ? String(EDISI.name) : "HRCD";
 
 function pasangKepala(judul, lebar = false) {
   const s = sesi();
@@ -95,7 +97,7 @@ function catatTerakhir(fungsi, apa, detail) {
 /* ============================ LOGIN ===================================== */
 
 function layarLogin(pesan) {
-  pasangKepala("HRCD Rekap");
+  pasangKepala("Sistem Panitia");
   LAYAR.replaceChildren(h(`
     <div class="card" style="max-width:480px;margin:2rem auto">
       <h2>Masuk Panitia</h2>
@@ -202,6 +204,10 @@ async function layarHome() {
         <div class="function-name">📋 Input Nilai Pos</div>
         <div class="description">Lembar penilaian tiap pos — admin boleh membuka pos mana pun</div>
       </a>` : ""}
+      <a href="#/rekap">
+        <div class="function-name">📊 Rekapitulasi</div>
+        <div class="description">Nilai seluruh pos dan klasemen sementara, hidup mengikuti input — hanya dibaca</div>
+      </a>
     </div>
     <p class="description" style="margin-top:1.2rem">Angka kuning = masih ada antrean.
        Meja boleh berganti fungsi kapan saja — cukup pilih dari sini.</p>
@@ -1131,7 +1137,16 @@ async function layarKeberangkatan() {
           <div class="departure-bar">
             <div class="field" style="margin:0">
               <label for="jam-berangkat">Jam berangkat (diketik pencatat)</label>
-              <input type="time" id="jam-berangkat" step="60" value="${jamMenit(new Date())}">
+              <!-- Kotak ketik, bukan <input type="time">: pemilih bawaan
+                   browser merender AM/PM kalau locale browsernya Inggris, dan
+                   tidak ada atribut yang bisa memaksanya 24 jam. Lihat
+                   jamSah() di util.js. -->
+              <input type="text" id="jam-berangkat" class="jam-ketik"
+                     inputmode="numeric" maxlength="5" autocomplete="off"
+                     spellcheck="false" placeholder="HH:MM"
+                     aria-describedby="hint-jam-berangkat"
+                     value="${jamMenit(new Date())}">
+              <div class="hint" id="hint-jam-berangkat">24 jam · 00:00–23:59</div>
             </div>
             <button class="button button-primary" id="aksi-berangkat" type="button">
               🚩 Berangkatkan Kloter ${kloterAktif}
@@ -1306,11 +1321,24 @@ async function layarKeberangkatan() {
       gambarKloter();
     });
 
+    const kotakJamBerangkat = document.getElementById("jam-berangkat");
+    pasangKotakJam(kotakJamBerangkat);
+
     const tombol = document.getElementById("aksi-berangkat");
     if (tombol) tombol.addEventListener("click", async () => {
       if (tombol.dataset.jalan === "1") return;
-      const hhmm = document.getElementById("jam-berangkat").value;
-      if (!hhmm) { notif("Jam berangkat wajib diisi.", true); return; }
+      const mentah = kotakJamBerangkat.value.trim();
+      if (!mentah) { notif("Jam berangkat wajib diisi.", true); return; }
+      // Ditolak, bukan ditebak. Jam berangkat menentukan penalti seluruh
+      // kloter — menebak maksud "1975" akan menghukum sepuluh regu sekaligus.
+      const hhmm = jamSah(mentah);
+      if (!hhmm) {
+        kotakJamBerangkat.classList.add("jam-salah");
+        kotakJamBerangkat.focus();
+        notif(`"${mentah}" bukan jam yang sah. Pakai 00:00–23:59, misalnya 07:15.`, true);
+        return;
+      }
+      kotakJamBerangkat.value = hhmm;
       tombol.dataset.jalan = "1"; tombol.disabled = true; tombol.textContent = "Menyimpan…";
       try {
         await berangkatkanKloter(kloterAktif, jamHariIni(hhmm).toISOString());
@@ -1538,8 +1566,12 @@ function layarFinish() {
         <div class="two-column" style="margin-top:.5rem">
           <div class="field" style="margin:0">
             <label for="jam">Jam datang</label>
-            <input type="time" id="jam" step="60">
-            <div class="hint">Kosong = jam saat tombol ditekan.</div>
+            <!-- Kotak ketik, alasan sama dengan jam berangkat: pemilih bawaan
+                 browser bisa muncul sebagai AM/PM. Lihat jamSah() di util.js. -->
+            <input type="text" id="jam" class="jam-ketik" inputmode="numeric"
+                   maxlength="5" autocomplete="off" spellcheck="false"
+                   placeholder="HH:MM">
+            <div class="hint">24 jam · kosong = jam saat tombol ditekan.</div>
           </div>
           <div class="field" style="margin:0">
             <label for="hadir">Anggota hadir</label>
@@ -1594,12 +1626,16 @@ function layarFinish() {
     // yang tersimpan — itulah angka yang sedang diverifikasi terhadap kertas.
     const dasar = regu.sudah_finish && regu.jam_datang
       ? new Date(regu.jam_datang) : new Date();
-    const jamIsi = inpJam.value ? jamHariIni(inpJam.value) : dasar;
+    // Setengah jam yang sedang diketik ("07" menuju "07:15") bukan jam, dan
+    // menghitung dampak dari angka setengah jadi membuat lencananya
+    // berkedip-kedip menampilkan penalti yang tidak pernah berlaku.
+    const isi = jamSah(inpJam.value);
+    const jamIsi = isi ? jamHariIni(isi) : dasar;
     const pDasar = hitungPenalti(dasar, regu.target_datang);
     const pIsi = hitungPenalti(jamIsi, regu.target_datang);
     const tulis = (n) => n === 0 ? "0" : `−${n}`;
 
-    if (!inpJam.value) {
+    if (!isi) {
       el.innerHTML = html`<span class="badge badge-gray">Penalti waktu: ${tulis(pDasar)}</span>`;
       return;
     }
@@ -1614,6 +1650,11 @@ function layarFinish() {
       : html`<span class="badge badge-yellow">${arah} — penalti berubah ${tulis(pDasar)} → ${tulis(pIsi)}</span>`;
   };
   inpJam.addEventListener("input", perbaruiDampak);
+  pasangKotakJam(inpJam);
+  // Bentuknya dirapikan saat kotak ditinggalkan, jadi lencana dampaknya ikut
+  // dihitung ulang sesudah itu — tanpa ini "745" yang jadi "07:45" saat blur
+  // meninggalkan lencana menampilkan hitungan dari teks yang sudah tidak ada.
+  inpJam.addEventListener("blur", perbaruiDampak);
 
   const bersihkan = () => {
     regu = null;
@@ -1695,11 +1736,24 @@ function layarFinish() {
       notif("Nomor berubah — tunggu detailnya muncul dulu.", true);
       return;
     }
+    // Kolom jam susulan kosong = jalur cepat, itu keadaan normal. Tapi kolom
+    // yang DIISI dan tidak terbaca sebagai jam harus menghentikan langkah,
+    // bukan diam-diam dilewati: petugas mengetiknya justru karena jam tombol
+    // salah, dan menyimpan jam tombol setelah ia mengetik yang lain adalah
+    // membuang koreksi yang sedang dia kerjakan.
+    const jamKetikan = inpJam.value.trim();
+    const jamIsi = jamKetikan ? jamSah(jamKetikan) : null;
+    if (jamKetikan && !jamIsi) {
+      inpJam.classList.add("jam-salah");
+      inpJam.focus();
+      notif(`"${jamKetikan}" bukan jam yang sah. Pakai 00:00–23:59, atau kosongkan.`, true);
+      return;
+    }
     tombol.dataset.jalan = "1"; tombol.disabled = true;
 
     // Jam dikunci DI SINI — saat tombol ditekan, dari jam laptop panitia.
     // Kolom jam hanya dipakai bila memang diisi (koreksi hasil verifikasi).
-    const jam = inpJam.value ? jamHariIni(inpJam.value) : new Date();
+    const jam = jamIsi ? jamHariIni(jamIsi) : new Date();
     const hadir = Math.max(0, Math.min(5, Number(inpHadir.value) || 0));
     const dada = regu.nomor_dada;
     const nama = regu.nama_regu;
@@ -2495,6 +2549,238 @@ function layarButuhEdisi(judul) {
     async () => { try { EDISI = await infoEdisi(); } catch {} arahkan(); }));
 }
 
+/* ============================ REKAPITULASI (baca saja) ===================
+   Lembar Rekapitulasi lengkap — bentuk yang sama dengan spreadsheet yang
+   dipakai panitia selama tujuh tahun: satu baris per regu, SATU KOLOM PER
+   KOMPONEN, Nilai Pos di ujung tiap kelompok, lalu kolom waktu, lalu Nilai
+   Total. Kolomnya dibangun dari tabel `wahana`, bukan ditulis di sini, jadi
+   penilaian tahun depan mengubah tabel ini tanpa menyentuh kode.
+
+   LAYAR INI TIDAK BISA MENGUBAH APA PUN, dan itu disengaja. Satu-satunya
+   pintu tulis nilai tetap layar Input Pos, yang memaksa operator menyebut
+   posnya dan dijaga RLS. Kalau angka bisa diketik dari dua tempat, yang
+   kedua cepat atau lambat akan melewatkan salah satu pagarnya.
+
+   Angka-angkanya juga tidak dihitung di browser. Nilai Pos, penalti, total,
+   dan peringkat semuanya datang jadi dari `v_rekap_penuh` — alasan yang sama
+   dengan layar Input Pos: mesin skor kedua adalah mesin skor yang suatu hari
+   berbeda pendapat dengan yang pertama.
+   ------------------------------------------------------------------------ */
+
+const NAMA_GOLONGAN = {
+  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
+  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
+};
+const URUTAN_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
+
+/** Sel nilai mentah, dibaca sebagaimana panitia menuliskannya di kertas.
+ *  Bentuknya mengikuti `wahana.form`, bukan tipe datanya: kolom biner di
+ *  lembar Excel berisi "v", bukan "1", dan menampilkan angka di situ membuat
+ *  panitia mengira ada nilai yang salah ketik. */
+function selRekap(w, isi) {
+  if (!isi) return "";
+  const a = isi.nilai_1, b = isi.nilai_2;
+  if (a === null || a === undefined) return "";
+  if (w.form === "biner") return Number(a) ? "v" : "–";
+  if (w.form === "benar_kurang_salah") {
+    return `${a}${b === null || b === undefined ? "" : ` / ${b}`}`;
+  }
+  if (w.satuan === "detik") {
+    const d = Number(a);
+    return `${Math.floor(d / 60)}:${String(d % 60).padStart(2, "0")}`;
+  }
+  return String(a);
+}
+
+/** "0 - 20" di bawah nama kolom — persis petunjuk rentang yang tercetak di
+ *  lembar kertas, supaya mata panitia mendarat di tempat yang sama. */
+const petunjukRentang = (w) => w.form === "biner"
+  ? "(v)"
+  : (w.satuan === "detik" ? "(menit:detik)"
+     : `(${Number(w.rentang_mentah_min)} - ${Number(w.rentang_mentah_maks)})`);
+
+const angka = (n) => n === null || n === undefined ? "—"
+  : String(Math.round(Number(n) * 100) / 100);
+
+async function layarRekap() {
+  const s = sesi();
+  if (s.peran === "operator_pos") {
+    pasangKepala("Rekapitulasi");
+    LAYAR.replaceChildren(h(html`
+      <div class="card">
+        <h2>Akun pos, bukan akun rekap</h2>
+        <p class="description">Rekapitulasi memuat nilai SELURUH pos, dan akun
+           ${s.username} hanya berhak atas Pos ${s.pos}. Kalau ditampilkan
+           untuk akun ini, kolom pos lain akan kosong dan Nilai Total ikut
+           salah — lebih baik tidak ditampilkan sama sekali.</p>
+        <p><a class="button button-secondary" href="#/pos">Ke Input Nilai Pos</a></p>
+      </div>`));
+    return;
+  }
+
+  pasangKepala("Rekapitulasi", "lembar");
+  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+
+  const layarIni = location.hash;
+  let pos, wahana, baris;
+  try {
+    [pos, wahana, baris] = await Promise.all([
+      daftarPos(), komponenSemua(EDISI.nomor), rekapPenuh(),
+    ]);
+  } catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarRekap)); return; }
+  if (location.hash !== layarIni) return;
+
+  // Hanya pos yang benar-benar dinilai. Pos 0 dan Pos 5 tidak punya komponen
+  // (migrasi 0025), dan kolom yang selamanya kosong terbaca sebagai pos yang
+  // panitianya lalai — bukan sebagai garis start dan garis finish.
+  const posDinilai = pos.filter(p => (p.jumlah_komponen || 0) > 0);
+  const kolomPos = posDinilai.map(p => ({
+    ...p, komponen: wahana.filter(w => Number(w.pos) === Number(p.nomor)),
+  }));
+
+  let golongan = "";      // "" = semua
+  let cari = "";
+  let jeda = null;
+
+  const cocok = (b) => (!golongan || b.golongan === golongan)
+    && (!cari
+        || (b.nama_sekolah || "").toLowerCase().includes(cari)
+        || (b.nama_regu || "").toLowerCase().includes(cari)
+        || String(b.nomor_dada ?? "").padStart(3, "0").includes(cari));
+
+  /* Urutan: golongan dulu, lalu peringkat resmi, lalu total.
+     Peringkat datang dari v_klasemen dan hanya ada untuk regu yang kloternya
+     benar-benar berangkat — sepanjang lomba sebagian besar baris belum
+     berperingkat. Yang belum berperingkat TIDAK dibuang; ia turun ke bawah
+     kelompoknya, tetap terurut menurut total, supaya papan ini tetap terbaca
+     sebagai klasemen sementara sejak nilai pertama masuk. */
+  const urut = (a, b) => {
+    const ga = URUTAN_GOLONGAN.indexOf(a.golongan), gb = URUTAN_GOLONGAN.indexOf(b.golongan);
+    if (ga !== gb) return ga - gb;
+    const pa = a.peringkat ?? Infinity, pb = b.peringkat ?? Infinity;
+    if (pa !== pb) return pa - pb;
+    return Number(b.total ?? 0) - Number(a.total ?? 0);
+  };
+
+  const kepala = () => {
+    const perPos = kolomPos.map(p => `
+      ${p.komponen.map(w => `<th class="rekap-komponen">${esc(w.name)}
+        <span class="kolom-petunjuk">${esc(petunjukRentang(w))}</span></th>`).join("")}
+      <th class="rekap-nilai-pos">Nilai Pos<br>${esc(p.bayangan ? p.name : String(p.nomor))}</th>`).join("");
+    return `
+      <tr>
+        <th>Rank</th><th>No<br>Dada</th><th>Nama Regu</th><th>Organisasi</th>
+        <th>Golongan</th>
+        ${perPos}
+        <th>Kloter</th><th>Berangkat</th><th>Datang</th><th>Tempuh</th>
+        <th>Kontrak</th><th>Selisih</th>
+        <th>Σ Pos</th><th>Penalti</th><th class="rekap-total">Nilai Total</th>
+      </tr>`;
+  };
+
+  const barisHtml = (b) => {
+    const nilai = b.nilai || {};
+    const poin = b.poin_pos || {};
+    const perPos = kolomPos.map(p => `
+      ${p.komponen.map(w => `<td class="rekap-komponen">${
+        esc(selRekap(w, nilai[`${p.nomor}.${w.kode}`]))}</td>`).join("")}
+      <td class="rekap-nilai-pos">${poin[String(p.nomor)] === undefined
+        ? "" : esc(angka(poin[String(p.nomor)]))}</td>`).join("");
+    const penalti = Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)
+      + Number(b.penalti_anggota || 0);
+    const selisih = b.selisih_menit === null || b.selisih_menit === undefined
+      ? "—" : `${b.selisih_menit > 0 ? "+" : ""}${b.selisih_menit}`;
+    return `
+      <tr>
+        <td class="dada">${b.peringkat ?? "—"}</td>
+        <td class="dada">${esc(String(b.nomor_dada ?? "—").padStart(3, "0"))}</td>
+        <td>${esc(b.nama_regu)}</td>
+        <td class="rekap-sekolah">${esc(b.nama_sekolah)}</td>
+        <td>${esc(NAMA_GOLONGAN[b.golongan] || b.golongan)}</td>
+        ${perPos}
+        <td>${b.kloter ?? "—"}</td>
+        <td>${esc(b.jam_berangkat ? jamMenit(b.jam_berangkat) : "—")}</td>
+        <td>${esc(b.jam_datang ? jamMenit(b.jam_datang) : "—")}</td>
+        <td>${b.tempuh_menit ?? "—"}</td>
+        <td>${b.kontrak_menit ?? "—"}</td>
+        <td>${esc(selisih)}</td>
+        <td>${esc(angka(b.total_pos))}</td>
+        <td>${penalti ? `−${penalti}` : "0"}</td>
+        <td class="rekap-total">${esc(angka(b.total))}</td>
+      </tr>`;
+  };
+
+  function gambar() {
+    const tampil = baris.filter(cocok).sort(urut);
+    const lebarKolom = 15 + kolomPos.reduce((n, p) => n + p.komponen.length + 1, 0);
+    LAYAR.replaceChildren(h(`
+      <div class="card">
+        <div class="table-toolbar">
+          <div class="field" style="margin:0;flex:1;min-width:220px">
+            <label for="rekap-cari" class="visually-hidden">Cari</label>
+            <input type="text" id="rekap-cari" autocomplete="off"
+                   placeholder="Cari sekolah, regu, atau nomor dada…"
+                   value="${esc(cari)}">
+          </div>
+          <div class="filter-row">
+            <button type="button" class="option option-small" data-gol=""
+                    aria-pressed="${golongan === ""}">Semua</button>
+            ${URUTAN_GOLONGAN.map(g => `
+              <button type="button" class="option option-small" data-gol="${g}"
+                      aria-pressed="${golongan === g}">${esc(NAMA_GOLONGAN[g])}</button>`).join("")}
+          </div>
+          <span class="table-count">${esc(String(tampil.length))} regu</span>
+          <button class="button button-small button-secondary" id="rekap-segarkan"
+                  type="button">Segarkan</button>
+        </div>
+        <p class="description">Layar ini hanya menampilkan. Nilai diubah di
+           <a href="#/pos">Input Nilai Pos</a>, dan angkanya muncul di sini
+           begitu tersimpan. Rank kosong berarti kloter regu itu belum
+           tercatat berangkat, jadi ia belum masuk klasemen resmi.</p>
+        <div class="gulir-rekap">
+          <table class="table rekap-tabel">
+            <thead>${kepala()}</thead>
+            <tbody>${tampil.length ? tampil.map(barisHtml).join("")
+              : `<tr><td colspan="${lebarKolom}" style="text-align:center;padding:1.5rem">
+                   Tidak ada regu yang cocok.</td></tr>`}</tbody>
+          </table>
+        </div>
+      </div>`));
+
+    LAYAR.querySelectorAll("[data-gol]").forEach(b =>
+      b.addEventListener("click", () => { golongan = b.dataset.gol; gambar(); }));
+
+    const kotak = document.getElementById("rekap-cari");
+    kotak.addEventListener("input", () => {
+      cari = kotak.value.trim().toLowerCase();
+      const posisi = kotak.selectionStart;
+      gambar();
+      const baru = document.getElementById("rekap-cari");
+      if (baru) { baru.focus(); baru.setSelectionRange(posisi, posisi); }
+    });
+    document.getElementById("rekap-segarkan").addEventListener("click", segarkan);
+  }
+
+  /* Menyegarkan sendiri tiap 20 detik. Inilah yang membuat papan ini terasa
+     "live": operator pos menyimpan satu baris, dan koordinator yang menatap
+     layar ini melihat angkanya masuk tanpa menekan apa pun.
+     Jumlah pembacanya belasan, bukan ribuan seperti halaman peserta, jadi
+     membaca langsung dari database di sini memang murah. */
+  async function segarkan() {
+    if (location.hash !== layarIni) return;
+    try {
+      baris = await rekapPenuh();
+      if (location.hash === layarIni) gambar();
+    } catch { /* diamkan: percobaan berikutnya datang sendiri */ }
+  }
+
+  gambar();
+  jeda = setInterval(() => {
+    if (location.hash !== layarIni) { clearInterval(jeda); return; }
+    if (!document.hidden) segarkan();
+  }, 20000);
+}
+
 /* ============================ RUTE ======================================= */
 
 const RUTE = {
@@ -2505,6 +2791,7 @@ const RUTE = {
   "#/keberangkatan": layarKeberangkatan,
   "#/finish": layarFinish,
   "#/pos": layarInputPos,
+  "#/rekap": layarRekap,
   "#/ganti-password": layarGantiPassword,
 };
 
@@ -2512,7 +2799,7 @@ async function arahkan() {
   if (!sesi()) { layarLogin(); return; }
   if (!EDISI) {
     try { EDISI = await infoEdisi(); }
-    catch (e) { layarButuhEdisi("HRCD Rekap"); return; }
+    catch (e) { layarButuhEdisi("Sistem Panitia"); return; }
   }
   (RUTE[location.hash] || layarHome)();
 }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -79,6 +79,51 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
+/** Membaca jam yang DIKETIK panitia dan mengembalikannya sebagai "HH:MM"
+ *  24 jam — atau `null` kalau bukan jam yang sah.
+ *
+ *  Ini menggantikan `<input type="time">` di dua meja yang mencatat jam.
+ *  Alasannya bukan selera: kotak jam bawaan browser dirender menurut locale
+ *  BROWSER, bukan `lang="id"` halaman ini, jadi laptop panitia yang Chrome-nya
+ *  berbahasa Inggris menampilkan "07:15 AM" — dan tidak ada atribut HTML mana
+ *  pun yang bisa memaksanya 24 jam. Satu meja memakai AM/PM sementara semua
+ *  kertas, semua layar lain, dan seluruh sisa sistem memakai 00:00-23:59
+ *  adalah cara yang murah sekali untuk mencatat 07:15 sebagai 19:15.
+ *
+ *  Yang diterima sengaja longgar, karena pencatat menyalin dari kertas dan
+ *  mengetik cepat: "745", "0745", "7:45", "7.45", "07 45" — semuanya jadi
+ *  "07:45". Yang di luar 00:00-23:59 ditolak, bukan dibetulkan diam-diam. */
+export function jamSah(teks) {
+  const angka = String(teks ?? "").replace(/\D/g, "");
+  if (angka.length < 3 || angka.length > 4) return null;
+  // "745" dibaca 7:45, bukan 74:5 — jam selalu bagian KIRI dan boleh satu
+  // digit; menitnya selalu dua digit terakhir.
+  const j = Number(angka.slice(0, angka.length - 2));
+  const m = Number(angka.slice(-2));
+  if (!Number.isInteger(j) || !Number.isInteger(m)) return null;
+  if (j > 23 || m > 59) return null;
+  return `${dua(j)}:${dua(m)}`;
+}
+
+/** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:
+ *  membetulkan bentuknya saat kotak ditinggalkan, dan menandainya merah kalau
+ *  isinya bukan jam. Membetulkan saat blur, BUKAN saat tiap ketukan — menata
+ *  ulang teks di tengah orang mengetik memindahkan kursornya dan membuat
+ *  angka berikutnya mendarat di tempat yang salah. */
+export function pasangKotakJam(el) {
+  if (!el) return;
+  const nilai = () => jamSah(el.value);
+  el.addEventListener("blur", () => {
+    if (!el.value.trim()) { el.classList.remove("jam-salah"); return; }
+    const v = nilai();
+    if (v) { el.value = v; el.classList.remove("jam-salah"); }
+    else el.classList.add("jam-salah");
+  });
+  el.addEventListener("input", () => {
+    if (nilai() || !el.value.trim()) el.classList.remove("jam-salah");
+  });
+}
+
 /** Notifikasi bawah layar.
  *
  *  Keduanya hilang sendiri, tapi galat diberi waktu DUA KALI LIPAT: 8 detik

--- a/web/style.css
+++ b/web/style.css
@@ -194,6 +194,26 @@ input[type=number]::-webkit-outer-spin-button,
 input[type=number]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 
 input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min-height: 54px; }
+
+/* Kotak jam yang diketik. Menggantikan input[type=time], yang dirender
+   browser menurut locale-nya sendiri dan bisa muncul sebagai AM/PM di laptop
+   berbahasa Inggris — lihat jamSah() di js/util.js.
+
+   Lebarnya dipatok: "HH:MM" tidak akan pernah lebih dari lima huruf, dan
+   kotak selebar layar mengundang orang mengetik kalimat ke dalamnya. Angka
+   tabular supaya "11:11" dan "07:45" sama lebarnya dan kolomnya tidak
+   bergoyang saat diketik. */
+input.jam-ketik {
+  width: 7.5em;
+  max-width: 100%;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: .08em;
+  text-align: center;
+}
+input.jam-ketik.jam-salah {
+  border-color: var(--bahaya);
+  background: var(--bahaya-muda);
+}
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }
 
@@ -1413,3 +1433,91 @@ input.small-input { text-align: center; }
    dilihat saat mata menyapu, tidak cukup untuk mengaburkan angkanya. */
 .table-pos tbody tr.baris-belum td { background: var(--kuning-muda); }
 .table-pos tbody tr.baris-belum td:first-child { background: var(--kuning-muda); }
+
+/* ---------------------------------------------------------------------------
+   Rekapitulasi (#/rekap) — tabel terlebar di seluruh sistem.
+
+   Lembar aslinya punya ±35 kolom, dan itu tidak akan pernah muat di layar
+   mana pun. Jadi tabel ini SATU-SATUNYA yang sengaja digeser ke samping —
+   di semua layar meja, geser samping justru dilarang karena menyembunyikan
+   kolom tombol. Di sini tidak ada tombol sama sekali, jadi yang hilang dari
+   pandangan cuma angka yang bisa digeser kembali.
+
+   Empat kolom pertama dibekukan di kiri supaya identitas regu tetap terlihat
+   saat isinya digeser jauh ke kanan. Tanpa itu, mata kehilangan barisnya di
+   kolom Pos 3 dan orang membaca nilai regu yang salah.
+   ------------------------------------------------------------------------- */
+.gulir-rekap {
+  overflow-x: auto;
+  overflow-y: visible;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rekap-tabel {
+  font-size: .82rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+.rekap-tabel th, .rekap-tabel td {
+  padding: .3rem .45rem;
+  text-align: center;
+  border-bottom: 1px solid var(--garis);
+}
+.rekap-tabel th {
+  position: sticky; top: 0; z-index: 2;
+  background: var(--kertas);
+  font-size: .74rem; line-height: 1.15;
+  vertical-align: bottom;
+}
+.rekap-tabel th .kolom-petunjuk {
+  display: block; font-weight: 400; font-size: .66rem;
+  color: var(--tinta-lembut);
+}
+
+/* Empat kolom identitas ikut menempel saat digeser. Angka `left` ditumpuk
+   tangan karena lebarnya dipatok tepat di bawah — kolom beku menuntut lebar
+   yang pasti, kalau tidak posisinya meleset saat isinya berubah panjang. */
+.rekap-tabel th:nth-child(-n+4), .rekap-tabel td:nth-child(-n+4) {
+  position: sticky; z-index: 1; background: #fff;
+}
+.rekap-tabel th:nth-child(-n+4) { z-index: 3; background: var(--kertas); }
+.rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1) { left: 0;      width: 46px; }
+.rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) { left: 46px;   width: 56px; }
+.rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3) { left: 102px;  width: 150px; text-align: left; }
+.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) { left: 252px;  width: 160px; text-align: left; }
+.rekap-tabel td:nth-child(4) {
+  max-width: 160px; overflow: hidden; text-overflow: ellipsis;
+}
+/* Garis pemisah antara blok beku dan blok yang bergeser — tanpa ini
+   keduanya terbaca sebagai satu tabel dan geserannya membingungkan. */
+.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
+  border-right: 2px solid var(--garis);
+}
+
+.rekap-tabel .rekap-komponen { min-width: 58px; }
+/* Nilai Pos dan Nilai Total adalah angka yang dicari orang; sisanya bahan
+   mentah. Latar tipis memisahkan keduanya tanpa menambah garis. */
+.rekap-tabel .rekap-nilai-pos {
+  font-weight: 600;
+  background: var(--kertas);
+  min-width: 62px;
+}
+.rekap-tabel .rekap-total {
+  font-weight: 700;
+  background: var(--hijau-muda);
+  min-width: 76px;
+}
+.rekap-tabel tbody tr:hover td { background: var(--kuning-muda); }
+
+@media (max-width: 700px) {
+  .rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3),
+  .rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
+    position: static; width: auto;
+  }
+  .rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1),
+  .rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) {
+    position: static;
+  }
+}


### PR DESCRIPTION
## What

Seven requests, landed together because they overlap in the same four files and any split leaves `web/` and `live/` out of sync, which fails `shared-files.yml` at every intermediate commit.

**1 · Times are 24-hour everywhere.** Every timestamp the pages *print* already was; the AM/PM came from the two `<input type="time">` boxes, which browsers render by **browser** locale — `lang="id"` never reaches them and no attribute overrides it. Both are now plain text boxes backed by `jamSah()`: `745`, `0745`, `7:45`, `7.45` all normalise to `07:45`, and anything outside 00:00–23:59 is **refused with a message rather than guessed**. Departure time sets the penalty for ten regu at once, so guessing is the wrong failure mode.

**2 · "Update terakhir: …"** replaces "Sinkronisasi terakhir: … — data mungkin tertinggal". The colour still changes after 15 minutes; only the sentence went, because `(1 jam lalu)` already says it and the extra clause read like an error during normal operation.

**3 · 6 · 6.1 · Peserta dashboard.** Shut until the race starts — at `fase_live = 'pra'` nobody sees any regu, including their own. Once running, peserta type their **school name** and get that school's regu ordered by nomor dada, as checks per pos and nothing else. Search is school-only on purpose: it is the one key every visitor knows, and it keeps the page answering "how did OUR regu do" instead of becoming a tool for looking up rivals. After closing, the same page opens into the full board — klasemen plus kloter, kontrak, and both times.

**4 · 6 · Panitia dashboard.** New read-only `#/rekap` reproducing the real Rekapitulasi sheet: one column **per component** (not per pos), Nilai Pos closing each group, then Kloter / Berangkat / Datang / Tempuh / Kontrak / Selisih, then Σ Pos / Penalti / Nilai Total, ranked per golongan. Columns come from `wahana`, so next year's scoring changes the table by changing data. It refreshes every 20 s, so a pos saving a row appears without anyone pressing anything.

**5 · Tab title** is now `Sistem Panitia — HRCD XXXVII`, distinguishable from the peserta site sitting in the next tab.

**7 · Built for 1,500–3,000 phones.**

| | Before | Now |
| --- | --- | --- |
| Polled every 60 s | whole file (~60 KB) | `live.json`, ~1 KB |
| Rows + klasemen | same file | `rekap.json`, fetched as `?v=<versi>` |
| Cache | `no-store` on everything | `no-store` on the small one, `max-age=3600, immutable` on the versioned one |
| Before the race | full download | big file never fetched at all |
| During the race | full download | fetched only after someone searches |
| Hidden tab | keeps polling | stops, catches up when reopened |

`versi` is a **fingerprint of the content, not the publish time** — republishing with nothing new produces the same version, and no phone re-downloads. Verified by running the workflow's own split step against sample input.

## Why

Item 7 is the one that would have hurt. The architecture already sent zero traffic to Supabase, but every phone was re-downloading the entire recap every minute for data that mostly does not change. Splitting the payload and versioning the big half removes ~30× of that at the cost of one extra file.

Item 4 is what panitia have actually been doing in a spreadsheet for seven years; this is that sheet, live, with the arithmetic done by the database.

## Notes

- **`v_rekap_penuh` (migration `0027`) returns zero rows for `operator_pos`, deliberately.** The view is `security_invoker`, so RLS trims other pos' `nilai_mentah` — showing it to a pos account would quietly shrink Nilai Total with no error at all. A wrong total is worse than a screen that refuses to open. `tests/sql/10_rekap_penuh.sql` pins this, and also pins that every number matches `v_poin_pos` / `v_total_skor` / `v_klasemen` so no second scoring engine can drift in.
- Rank is `left join`ed from `v_klasemen`, never recomputed. Regu whose kloter has not departed have no official rank; they sink to the bottom of their golongan still sorted by total, so the board reads as a running klasemen from the first score onward.
- `#/rekap` is the **only** table in the system allowed to scroll sideways — every desk table forbids it because it hides the action column. This one has no buttons, and ±35 columns will never fit any screen. First four columns are frozen.
- Publishing the recap now writes **two** files. `live/rekap.json` is committed as an empty sample so the folder deploys before the first run.
- Docs updated in the same commit: new screen in the route table, the two-file mechanism, `jamSah`, migration count 27, view count 20.

**Migration `0027` must be applied before this is merged** — `#/rekap` calls a view that does not exist yet:

```bash
gh workflow run "Apply migration to Supabase" --ref main \
  -f berkas=supabase/migrations/0027_rekap_penuh.sql
```

The peserta site does not deploy on merge; it needs **Actions → Publish rekap live**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)