### PR TITLE
fix: stop the catch-all header rule from cancelling the immutable cache

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -574,6 +574,16 @@ harus selalu segar) sedangkan `rekap.json` diberi `max-age=3600, immutable`.
 Yang membuat keduanya bisa berlawanan adalah `?v=<versi>` di alamat
 `rekap.json` — alasannya di bagian 3b.
 
+Dan karena itu `live/_headers` **tidak punya aturan `/*`**, tidak seperti
+`web/_headers`. Cloudflare MENGGABUNGKAN header dari semua aturan yang cocok,
+bukan menimpanya dengan yang paling spesifik: selama `/*` masih menyetel
+`no-cache`, `rekap.json` terbit sebagai
+`no-cache, public, max-age=3600, immutable` — dan `no-cache` yang menang,
+sehingga berkasnya ditanyakan ulang tiap kali walau alamatnya sudah memuat
+versinya. Tiap jenis berkas di folder itu karena itu menyebut aturannya
+sendiri, termasuk halaman HTML yang disebut dua kali karena Workers
+menyajikannya di dua alamat (`/` dan `/index.html`).
+
 ### Workflow lain
 
 | Workflow | Nama di Actions | Untuk siapa |

--- a/live/_headers
+++ b/live/_headers
@@ -21,9 +21,36 @@
 #
 # Tanpa pemisahan ini, 3.000 HP × 60 KB tiap menit adalah 180 MB per menit
 # untuk data yang sebagian besar waktu tidak berubah sama sekali.
+#
+# ----------------------------------------------------------------------------
+# TIDAK ADA ATURAN `/*` DI SINI, DAN ITU DISENGAJA.
+#
+# Cloudflare MENGGABUNGKAN header dari semua aturan yang cocok, bukan
+# menimpanya dengan yang paling spesifik. Selama `/*` masih menyetel
+# `Cache-Control: no-cache`, rekap.json terbit dengan
+# `no-cache, public, max-age=3600, immutable` — dan `no-cache` yang menang.
+# Berkasnya jadi ditanyakan ulang tiap kali padahal alamatnya sudah memuat
+# versinya, yang persis menghapus penghematan yang dikejar seluruh pemecahan
+# di atas. Ini benar-benar terjadi dan baru ketahuan dari `curl -I` setelah
+# tayang, bukan dari mana pun di dalam repo.
+#
+# Jadi tiap jenis berkas menyebut aturannya sendiri. Halaman HTML disebut
+# empat kali karena Workers menyajikan satu berkas di dua alamat: `/` dan
+# `/index.html`, `/daftar` dan `/daftar.html`. Isi folder ini cuma sebelas
+# berkas — menyebutkannya satu per satu lebih murah daripada satu aturan
+# menyapu yang diam-diam merusak aturan lain.
 # ============================================================================
 
-/*
+/
+  Cache-Control: no-cache
+
+/index.html
+  Cache-Control: no-cache
+
+/daftar
+  Cache-Control: no-cache
+
+/daftar.html
   Cache-Control: no-cache
 
 /live.json

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -132,6 +132,18 @@ function layarLogin(pesan) {
   document.getElementById("masuk").addEventListener("click", aksi);
   LAYAR.querySelectorAll("input").forEach(i =>
     i.addEventListener("keydown", e => { if (e.key === "Enter") aksi(); }));
+
+  // Nomor edisi diambil SEBELUM login, supaya judul tab sudah berbunyi
+  // "Sistem Panitia — HRCD XXXVII" di layar masuk, bukan "Sistem Panitia —
+  // HRCD" yang menggantung. Boleh: v_edisi_publik memang di-grant ke anon
+  // (migrasi 0005) — halaman pendaftaran publik membacanya dengan cara yang
+  // sama persis. Gagalnya diabaikan; judul yang kurang satu kata bukan
+  // alasan menahan kotak login.
+  if (!EDISI) {
+    infoEdisi()
+      .then(e => { EDISI = e; if (!sesi()) pasangKepala("Sistem Panitia"); })
+      .catch(() => {});
+  }
 }
 
 /* ============================ BERANDA MEJA (home) ========================= */


### PR DESCRIPTION
## What

Two defects in #127 that were only visible once it was serving traffic.

**1 · The `immutable` cache on `rekap.json` did nothing.** Cloudflare *merges* the headers of every matching `_headers` rule instead of letting the most specific one win, so with `/*` still setting `Cache-Control: no-cache` the file went out as:

```
Cache-Control: no-cache, public, max-age=3600, immutable
```

`no-cache` wins, so every phone revalidated a file whose address already carries its version — undoing precisely the saving the two-file split exists for. `live/_headers` now names each kind of file itself and has no `/*` rule. The HTML pages are listed twice each because Workers serves one file at two addresses (`/` and `/index.html`, `/daftar` and `/daftar.html`).

**2 · The login screen title was missing the edition number.** It read `Sistem Panitia — HRCD` because `EDISI` is only fetched once a session exists. It is readable before login — `v_edisi_publik` is granted to `anon`, and the public registration page reads it the same way — so the login screen fetches it and the tab now reads `Sistem Panitia — HRCD XXXVII` from the start.

## Why

The header bug is the kind this repo keeps getting bitten by: a setting that looks right in the file, produces no error anywhere, and is only falsifiable from outside with `curl -I`. Same shape as the Cloudflare "Root directory" trap already recorded in `final-architecture.md` section 7.

## Notes

Verified against production before and after. `final-architecture.md` section 5 now records the merge behaviour, so the next person to add a `/*` rule to `live/_headers` has a reason not to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)