### PR TITLE
style: make Rekapitulasi the Input Pos sheet with every pos joined

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -315,11 +315,24 @@ masuk klasemen resmi (`rancangan-b.md` 11.12). Barisnya tidak dibuang; ia
 turun ke bawah kelompoknya dan tetap terurut menurut total, supaya papan ini
 sudah terbaca sebagai klasemen sementara sejak nilai pertama masuk.
 
-Empat kolom pertama dibekukan di kiri saat tabelnya digeser. Ini
-**satu-satunya tabel di sistem yang boleh digeser ke samping** — di layar meja
-geser samping justru dilarang karena menyembunyikan kolom tombol (bagian 7
-nomor 3). Di sini tidak ada tombol sama sekali, dan ±35 kolom tidak akan
-pernah muat di layar mana pun.
+**Tabelnya adalah lembar Input Pos, hanya saja seluruh pos disambung jadi
+satu.** Kelasnya sama persis — `.table-pos` beserta `.kolom-nama`,
+`.kolom-petunjuk`, dan `.pos-nilai` — dan petunjuk rentang di bawah tiap nama
+kolom datang dari `petunjukKolom()` yang sama, bukan salinannya: kalau rentang
+di satu layar berbeda dengan layar lain, panitia akan percaya yang salah.
+
+Tiga hal yang ditambahkan, dan hanya tiga:
+
+| Yang ditambah | Kenapa tidak ada di lembar satu pos |
+| --- | --- |
+| **Dua** kolom dipatok di tepi kiri, bukan satu | Rank berdiri di depan Nomor Dada; barisnya baru bisa dikenali kalau keduanya ikut menempel saat digeser |
+| Garis pemisah di tiap Nilai Pos | Dengan lima kelompok kolom bersambung, salah membaca kolom Pos 3 sebagai Pos 2 adalah satu-satunya cara layar ini bisa menyesatkan |
+| Baris lebih rapat | Tidak ada kotak isian sama sekali, jadi tingginya tidak perlu memuat sasaran sentuh setinggi jempol |
+
+Seperti lembar Input Pos, tabel ini **digeser ke samping, bukan ditumpuk jadi
+kartu** — di layar meja geser samping justru dilarang karena menyembunyikan
+kolom tombol (bagian 7 nomor 3). Di sini tidak ada tombol sama sekali, dan
+±35 kolom tidak akan pernah muat di layar mana pun.
 
 ## 3b. Halaman rekap live untuk peserta
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -439,7 +439,7 @@ export async function komponenSemua(edisi) {
   if (K.mode === "dev") return baca("/komponen-semua");
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
-    `&select=pos,kode,name,type,form,poin_maks,satuan,` +
+    `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/live/style.css
+++ b/live/style.css
@@ -1435,89 +1435,47 @@ input.small-input { text-align: center; }
 .table-pos tbody tr.baris-belum td:first-child { background: var(--kuning-muda); }
 
 /* ---------------------------------------------------------------------------
-   Rekapitulasi (#/rekap) — tabel terlebar di seluruh sistem.
+   REKAPITULASI (#/rekap)
 
-   Lembar aslinya punya ±35 kolom, dan itu tidak akan pernah muat di layar
-   mana pun. Jadi tabel ini SATU-SATUNYA yang sengaja digeser ke samping —
-   di semua layar meja, geser samping justru dilarang karena menyembunyikan
-   kolom tombol. Di sini tidak ada tombol sama sekali, jadi yang hilang dari
-   pandangan cuma angka yang bisa digeser kembali.
+   Tabelnya adalah lembar Input Pos, hanya saja SELURUH pos disambung jadi
+   satu. Karena itu ia memakai kelas yang sama persis — .table-pos beserta
+   .kolom-nama, .kolom-petunjuk, dan .pos-nilai — dan yang ditambahkan di sini
+   cuma tiga hal yang memang tidak ada di lembar satu pos.
 
-   Empat kolom pertama dibekukan di kiri supaya identitas regu tetap terlihat
-   saat isinya digeser jauh ke kanan. Tanpa itu, mata kehilangan barisnya di
-   kolom Pos 3 dan orang membaca nilai regu yang salah.
+   1. Dua kolom yang dipatok di tepi kiri, bukan satu. Di Input Pos yang perlu
+      terlihat saat digeser hanya Nomor Dada; di sini Rank berdiri di
+      depannya, dan barisnya baru bisa dikenali kalau keduanya ikut menempel.
+   2. Garis pemisah tiap Nilai Pos. Dengan lima kelompok kolom bersambung,
+      mata kehilangan batas antar pos — dan salah membaca kolom Pos 3 sebagai
+      Pos 2 adalah satu-satunya cara layar ini bisa menyesatkan.
+   3. Tidak ada kotak isian sama sekali, jadi barisnya lebih rapat daripada
+      lembar Input Pos yang harus memuat input setinggi jempol.
    ------------------------------------------------------------------------- */
-.gulir-rekap {
-  overflow-x: auto;
-  overflow-y: visible;
-  -webkit-overflow-scrolling: touch;
-}
 
-.rekap-tabel {
-  font-size: .82rem;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  border-collapse: separate;
-  border-spacing: 0;
+/* Rank dipatok lebih dulu, lalu Nomor Dada menempel tepat di belakangnya.
+   Lebar kolom pertama HARUS pasti, kalau tidak `left` kolom kedua meleset —
+   isinya cuma satu sampai tiga digit, jadi mematoknya tidak merugikan. */
+.table-rekap th:first-child, .table-rekap td:first-child {
+  width: 56px; min-width: 56px;
 }
-.rekap-tabel th, .rekap-tabel td {
-  padding: .3rem .45rem;
-  text-align: center;
-  border-bottom: 1px solid var(--garis);
+.table-rekap th:nth-child(2), .table-rekap td:nth-child(2) {
+  position: sticky; left: 56px; z-index: 2;
+  background: var(--kartu); box-shadow: 1px 0 0 var(--garis);
 }
-.rekap-tabel th {
-  position: sticky; top: 0; z-index: 2;
-  background: var(--kertas);
-  font-size: .74rem; line-height: 1.15;
-  vertical-align: bottom;
-}
-.rekap-tabel th .kolom-petunjuk {
-  display: block; font-weight: 400; font-size: .66rem;
-  color: var(--tinta-lembut);
-}
+.table-rekap thead th:nth-child(2) { z-index: 3; background: var(--kertas); }
+.table-rekap tbody tr:hover td:nth-child(2) { background: var(--utama-muda); }
 
-/* Empat kolom identitas ikut menempel saat digeser. Angka `left` ditumpuk
-   tangan karena lebarnya dipatok tepat di bawah — kolom beku menuntut lebar
-   yang pasti, kalau tidak posisinya meleset saat isinya berubah panjang. */
-.rekap-tabel th:nth-child(-n+4), .rekap-tabel td:nth-child(-n+4) {
-  position: sticky; z-index: 1; background: #fff;
-}
-.rekap-tabel th:nth-child(-n+4) { z-index: 3; background: var(--kertas); }
-.rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1) { left: 0;      width: 46px; }
-.rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) { left: 46px;   width: 56px; }
-.rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3) { left: 102px;  width: 150px; text-align: left; }
-.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) { left: 252px;  width: 160px; text-align: left; }
-.rekap-tabel td:nth-child(4) {
-  max-width: 160px; overflow: hidden; text-overflow: ellipsis;
-}
-/* Garis pemisah antara blok beku dan blok yang bergeser — tanpa ini
-   keduanya terbaca sebagai satu tabel dan geserannya membingungkan. */
-.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
-  border-right: 2px solid var(--garis);
-}
+/* Batas kanan tiap kelompok pos, dan sebelum Nilai Total. */
+.table-rekap .rekap-batas { border-right: 2px solid var(--garis); }
 
-.rekap-tabel .rekap-komponen { min-width: 58px; }
-/* Nilai Pos dan Nilai Total adalah angka yang dicari orang; sisanya bahan
-   mentah. Latar tipis memisahkan keduanya tanpa menambah garis. */
-.rekap-tabel .rekap-nilai-pos {
-  font-weight: 600;
-  background: var(--kertas);
-  min-width: 62px;
-}
-.rekap-tabel .rekap-total {
-  font-weight: 700;
-  background: var(--hijau-muda);
-  min-width: 76px;
-}
-.rekap-tabel tbody tr:hover td { background: var(--kuning-muda); }
+/* Peringkat: angka yang dicari mata saat menyapu dari atas. Yang belum
+   berperingkat sengaja dipudarkan, bukan disembunyikan — barisnya tetap
+   dibaca, hanya tidak menuntut perhatian. */
+.table-rekap .rekap-rank { font-weight: 700; font-variant-numeric: tabular-nums; }
 
-@media (max-width: 700px) {
-  .rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3),
-  .rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
-    position: static; width: auto;
-  }
-  .rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1),
-  .rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) {
-    position: static;
-  }
-}
+.table-rekap tbody td { font-variant-numeric: tabular-nums; }
+/* Tanpa kotak isian, tinggi barisnya ditentukan teks saja — dan 30 baris
+   yang muat sekaligus jauh lebih berguna di layar pemantau daripada baris
+   lapang yang tidak ada yang menyentuhnya. */
+.table-rekap th, .table-rekap td { padding: .28rem .4rem; }
+.table-rekap { font-size: .86rem; }

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -150,7 +150,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 # Rekapitulasi (#/rekap).
                 self._kirim(200, q(
                     "select pos, kode, name, type, form, poin_maks, satuan, "
-                    "       rentang_mentah_min, rentang_mentah_maks, sort_order "
+                    "       total_soal, rentang_mentah_min, "
+                    "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "
                     "order by pos, sort_order", uid=p.get("uid")))
             elif u.path == "/rekap-penuh":

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -439,7 +439,7 @@ export async function komponenSemua(edisi) {
   if (K.mode === "dev") return baca("/komponen-semua");
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
-    `&select=pos,kode,name,type,form,poin_maks,satuan,` +
+    `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2604,13 +2604,6 @@ function selRekap(w, isi) {
   return String(a);
 }
 
-/** "0 - 20" di bawah nama kolom — persis petunjuk rentang yang tercetak di
- *  lembar kertas, supaya mata panitia mendarat di tempat yang sama. */
-const petunjukRentang = (w) => w.form === "biner"
-  ? "(v)"
-  : (w.satuan === "detik" ? "(menit:detik)"
-     : `(${Number(w.rentang_mentah_min)} - ${Number(w.rentang_mentah_maks)})`);
-
 const angka = (n) => n === null || n === undefined ? "—"
   : String(Math.round(Number(n) * 100) / 100);
 
@@ -2674,19 +2667,37 @@ async function layarRekap() {
     return Number(b.total ?? 0) - Number(a.total ?? 0);
   };
 
+  /* Kepala tabel meniru lembar Input Pos huruf demi huruf — `kolom-nama` yang
+     boleh membungkus di atas `kolom-petunjuk` yang menyebut rentangnya.
+     Petunjuknya memakai `petunjukKolom()` yang SAMA, bukan salinannya: kalau
+     suatu hari rentang di satu layar berbeda dengan layar lain, panitia akan
+     percaya yang salah. Bedanya cuma satu — di sini kelompok kolomnya
+     berulang untuk tiap pos, dan tiap kelompok ditutup Nilai Pos-nya. */
   const kepala = () => {
     const perPos = kolomPos.map(p => `
-      ${p.komponen.map(w => `<th class="rekap-komponen">${esc(w.name)}
-        <span class="kolom-petunjuk">${esc(petunjukRentang(w))}</span></th>`).join("")}
-      <th class="rekap-nilai-pos">Nilai Pos<br>${esc(p.bayangan ? p.name : String(p.nomor))}</th>`).join("");
+      ${p.komponen.map(w => `
+        <th class="text-center">
+          <span class="kolom-nama">${esc(w.name)}</span>
+          <span class="kolom-petunjuk">${esc(petunjukKolom(w))}</span></th>`).join("")}
+      <th class="text-center rekap-batas">Nilai<br>${
+        esc(p.bayangan ? p.name : `Pos ${p.nomor}`)}</th>`).join("");
     return `
       <tr>
-        <th>Rank</th><th>No<br>Dada</th><th>Nama Regu</th><th>Organisasi</th>
+        <th class="text-center">Rank</th>
+        <th class="text-center">Nomor<br>Dada</th>
+        <th>Nama Regu</th>
+        <th>Organisasi</th>
         <th>Golongan</th>
         ${perPos}
-        <th>Kloter</th><th>Berangkat</th><th>Datang</th><th>Tempuh</th>
-        <th>Kontrak</th><th>Selisih</th>
-        <th>Σ Pos</th><th>Penalti</th><th class="rekap-total">Nilai Total</th>
+        <th class="text-center">Kloter</th>
+        <th class="text-center">Berangkat</th>
+        <th class="text-center">Datang</th>
+        <th class="text-center">Tempuh<br><span class="kolom-petunjuk">menit</span></th>
+        <th class="text-center">Kontrak<br><span class="kolom-petunjuk">menit</span></th>
+        <th class="text-center">Selisih<br><span class="kolom-petunjuk">menit</span></th>
+        <th class="text-center">Σ Pos</th>
+        <th class="text-center">Penalti</th>
+        <th class="text-center rekap-batas">Nilai<br>Total</th>
       </tr>`;
   };
 
@@ -2694,9 +2705,9 @@ async function layarRekap() {
     const nilai = b.nilai || {};
     const poin = b.poin_pos || {};
     const perPos = kolomPos.map(p => `
-      ${p.komponen.map(w => `<td class="rekap-komponen">${
+      ${p.komponen.map(w => `<td class="text-center">${
         esc(selRekap(w, nilai[`${p.nomor}.${w.kode}`]))}</td>`).join("")}
-      <td class="rekap-nilai-pos">${poin[String(p.nomor)] === undefined
+      <td class="text-center pos-nilai rekap-batas">${poin[String(p.nomor)] === undefined
         ? "" : esc(angka(poin[String(p.nomor)]))}</td>`).join("");
     const penalti = Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)
       + Number(b.penalti_anggota || 0);
@@ -2704,21 +2715,23 @@ async function layarRekap() {
       ? "—" : `${b.selisih_menit > 0 ? "+" : ""}${b.selisih_menit}`;
     return `
       <tr>
-        <td class="dada">${b.peringkat ?? "—"}</td>
-        <td class="dada">${esc(String(b.nomor_dada ?? "—").padStart(3, "0"))}</td>
+        <td class="text-center rekap-rank">${b.peringkat ?? "—"}</td>
+        <td class="text-center nomor-dada">${
+          b.nomor_dada === null || b.nomor_dada === undefined
+            ? "—" : esc(String(b.nomor_dada).padStart(3, "0"))}</td>
         <td>${esc(b.nama_regu)}</td>
-        <td class="rekap-sekolah">${esc(b.nama_sekolah)}</td>
+        <td>${esc(b.nama_sekolah)}</td>
         <td>${esc(NAMA_GOLONGAN[b.golongan] || b.golongan)}</td>
         ${perPos}
-        <td>${b.kloter ?? "—"}</td>
-        <td>${esc(b.jam_berangkat ? jamMenit(b.jam_berangkat) : "—")}</td>
-        <td>${esc(b.jam_datang ? jamMenit(b.jam_datang) : "—")}</td>
-        <td>${b.tempuh_menit ?? "—"}</td>
-        <td>${b.kontrak_menit ?? "—"}</td>
-        <td>${esc(selisih)}</td>
-        <td>${esc(angka(b.total_pos))}</td>
-        <td>${penalti ? `−${penalti}` : "0"}</td>
-        <td class="rekap-total">${esc(angka(b.total))}</td>
+        <td class="text-center">${b.kloter ?? "—"}</td>
+        <td class="text-center">${esc(b.jam_berangkat ? jamMenit(b.jam_berangkat) : "—")}</td>
+        <td class="text-center">${esc(b.jam_datang ? jamMenit(b.jam_datang) : "—")}</td>
+        <td class="text-center">${b.tempuh_menit ?? "—"}</td>
+        <td class="text-center">${b.kontrak_menit ?? "—"}</td>
+        <td class="text-center">${esc(selisih)}</td>
+        <td class="text-center">${esc(angka(b.total_pos))}</td>
+        <td class="text-center">${penalti ? `−${penalti}` : "0"}</td>
+        <td class="text-center pos-nilai rekap-batas">${esc(angka(b.total))}</td>
       </tr>`;
   };
 
@@ -2749,11 +2762,14 @@ async function layarRekap() {
            <a href="#/pos">Input Nilai Pos</a>, dan angkanya muncul di sini
            begitu tersimpan. Rank kosong berarti kloter regu itu belum
            tercatat berangkat, jadi ia belum masuk klasemen resmi.</p>
-        <div class="gulir-rekap">
-          <table class="table rekap-tabel">
+        <!-- Kelas tabelnya SAMA PERSIS dengan lembar Input Pos, ditambah
+             satu pengubah: di HP ia tetap tabel yang digeser ke samping,
+             tidak ditumpuk jadi kartu seperti layar meja. -->
+        <div class="table-wrapper table-wrapper-tetap">
+          <table class="table data-table table-tetap table-pos table-rekap">
             <thead>${kepala()}</thead>
             <tbody>${tampil.length ? tampil.map(barisHtml).join("")
-              : `<tr><td colspan="${lebarKolom}" style="text-align:center;padding:1.5rem">
+              : `<tr><td colspan="${lebarKolom}" class="table-empty">
                    Tidak ada regu yang cocok.</td></tr>`}</tbody>
           </table>
         </div>

--- a/web/style.css
+++ b/web/style.css
@@ -1435,89 +1435,47 @@ input.small-input { text-align: center; }
 .table-pos tbody tr.baris-belum td:first-child { background: var(--kuning-muda); }
 
 /* ---------------------------------------------------------------------------
-   Rekapitulasi (#/rekap) — tabel terlebar di seluruh sistem.
+   REKAPITULASI (#/rekap)
 
-   Lembar aslinya punya ±35 kolom, dan itu tidak akan pernah muat di layar
-   mana pun. Jadi tabel ini SATU-SATUNYA yang sengaja digeser ke samping —
-   di semua layar meja, geser samping justru dilarang karena menyembunyikan
-   kolom tombol. Di sini tidak ada tombol sama sekali, jadi yang hilang dari
-   pandangan cuma angka yang bisa digeser kembali.
+   Tabelnya adalah lembar Input Pos, hanya saja SELURUH pos disambung jadi
+   satu. Karena itu ia memakai kelas yang sama persis — .table-pos beserta
+   .kolom-nama, .kolom-petunjuk, dan .pos-nilai — dan yang ditambahkan di sini
+   cuma tiga hal yang memang tidak ada di lembar satu pos.
 
-   Empat kolom pertama dibekukan di kiri supaya identitas regu tetap terlihat
-   saat isinya digeser jauh ke kanan. Tanpa itu, mata kehilangan barisnya di
-   kolom Pos 3 dan orang membaca nilai regu yang salah.
+   1. Dua kolom yang dipatok di tepi kiri, bukan satu. Di Input Pos yang perlu
+      terlihat saat digeser hanya Nomor Dada; di sini Rank berdiri di
+      depannya, dan barisnya baru bisa dikenali kalau keduanya ikut menempel.
+   2. Garis pemisah tiap Nilai Pos. Dengan lima kelompok kolom bersambung,
+      mata kehilangan batas antar pos — dan salah membaca kolom Pos 3 sebagai
+      Pos 2 adalah satu-satunya cara layar ini bisa menyesatkan.
+   3. Tidak ada kotak isian sama sekali, jadi barisnya lebih rapat daripada
+      lembar Input Pos yang harus memuat input setinggi jempol.
    ------------------------------------------------------------------------- */
-.gulir-rekap {
-  overflow-x: auto;
-  overflow-y: visible;
-  -webkit-overflow-scrolling: touch;
-}
 
-.rekap-tabel {
-  font-size: .82rem;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  border-collapse: separate;
-  border-spacing: 0;
+/* Rank dipatok lebih dulu, lalu Nomor Dada menempel tepat di belakangnya.
+   Lebar kolom pertama HARUS pasti, kalau tidak `left` kolom kedua meleset —
+   isinya cuma satu sampai tiga digit, jadi mematoknya tidak merugikan. */
+.table-rekap th:first-child, .table-rekap td:first-child {
+  width: 56px; min-width: 56px;
 }
-.rekap-tabel th, .rekap-tabel td {
-  padding: .3rem .45rem;
-  text-align: center;
-  border-bottom: 1px solid var(--garis);
+.table-rekap th:nth-child(2), .table-rekap td:nth-child(2) {
+  position: sticky; left: 56px; z-index: 2;
+  background: var(--kartu); box-shadow: 1px 0 0 var(--garis);
 }
-.rekap-tabel th {
-  position: sticky; top: 0; z-index: 2;
-  background: var(--kertas);
-  font-size: .74rem; line-height: 1.15;
-  vertical-align: bottom;
-}
-.rekap-tabel th .kolom-petunjuk {
-  display: block; font-weight: 400; font-size: .66rem;
-  color: var(--tinta-lembut);
-}
+.table-rekap thead th:nth-child(2) { z-index: 3; background: var(--kertas); }
+.table-rekap tbody tr:hover td:nth-child(2) { background: var(--utama-muda); }
 
-/* Empat kolom identitas ikut menempel saat digeser. Angka `left` ditumpuk
-   tangan karena lebarnya dipatok tepat di bawah — kolom beku menuntut lebar
-   yang pasti, kalau tidak posisinya meleset saat isinya berubah panjang. */
-.rekap-tabel th:nth-child(-n+4), .rekap-tabel td:nth-child(-n+4) {
-  position: sticky; z-index: 1; background: #fff;
-}
-.rekap-tabel th:nth-child(-n+4) { z-index: 3; background: var(--kertas); }
-.rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1) { left: 0;      width: 46px; }
-.rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) { left: 46px;   width: 56px; }
-.rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3) { left: 102px;  width: 150px; text-align: left; }
-.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) { left: 252px;  width: 160px; text-align: left; }
-.rekap-tabel td:nth-child(4) {
-  max-width: 160px; overflow: hidden; text-overflow: ellipsis;
-}
-/* Garis pemisah antara blok beku dan blok yang bergeser — tanpa ini
-   keduanya terbaca sebagai satu tabel dan geserannya membingungkan. */
-.rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
-  border-right: 2px solid var(--garis);
-}
+/* Batas kanan tiap kelompok pos, dan sebelum Nilai Total. */
+.table-rekap .rekap-batas { border-right: 2px solid var(--garis); }
 
-.rekap-tabel .rekap-komponen { min-width: 58px; }
-/* Nilai Pos dan Nilai Total adalah angka yang dicari orang; sisanya bahan
-   mentah. Latar tipis memisahkan keduanya tanpa menambah garis. */
-.rekap-tabel .rekap-nilai-pos {
-  font-weight: 600;
-  background: var(--kertas);
-  min-width: 62px;
-}
-.rekap-tabel .rekap-total {
-  font-weight: 700;
-  background: var(--hijau-muda);
-  min-width: 76px;
-}
-.rekap-tabel tbody tr:hover td { background: var(--kuning-muda); }
+/* Peringkat: angka yang dicari mata saat menyapu dari atas. Yang belum
+   berperingkat sengaja dipudarkan, bukan disembunyikan — barisnya tetap
+   dibaca, hanya tidak menuntut perhatian. */
+.table-rekap .rekap-rank { font-weight: 700; font-variant-numeric: tabular-nums; }
 
-@media (max-width: 700px) {
-  .rekap-tabel th:nth-child(3), .rekap-tabel td:nth-child(3),
-  .rekap-tabel th:nth-child(4), .rekap-tabel td:nth-child(4) {
-    position: static; width: auto;
-  }
-  .rekap-tabel th:nth-child(1), .rekap-tabel td:nth-child(1),
-  .rekap-tabel th:nth-child(2), .rekap-tabel td:nth-child(2) {
-    position: static;
-  }
-}
+.table-rekap tbody td { font-variant-numeric: tabular-nums; }
+/* Tanpa kotak isian, tinggi barisnya ditentukan teks saja — dan 30 baris
+   yang muat sekaligus jauh lebih berguna di layar pemantau daripada baris
+   lapang yang tidak ada yang menyentuhnya. */
+.table-rekap th, .table-rekap td { padding: .28rem .4rem; }
+.table-rekap { font-size: .86rem; }


### PR DESCRIPTION
## What

Rekapitulasi showed the right numbers but wore its own clothes — a private `.rekap-tabel` with its own paddings, its own header markup, and its own copy of the range hint under each column name.

It is now literally the Input Pos sheet with every pos joined into one table: same `.table-pos`, `.kolom-nama`, `.kolom-petunjuk`, `.pos-nilai`, and the hints come from the same `petunjukKolom()` rather than a second implementation.

Three additions, all things a single-pos sheet has no reason to have:

| Added | Why |
| --- | --- |
| **Two** frozen columns, not one | Rank sits in front of Nomor Dada; both must stick or the row cannot be identified once scrolled right |
| A rule closing each Nilai Pos group | With five groups running together, misreading Pos 3 as Pos 2 is the one way this screen can mislead |
| Tighter rows | No input boxes here, so the height need not carry a thumb-sized touch target |

## Why

A range that reads `0 - 5` on one screen and `0 – 5` on another is a range panitia will eventually trust in the wrong place. Sharing the helper makes that impossible rather than unlikely.

108 lines of bespoke table CSS became 34 lines of modifiers.

## Notes

No behaviour change: same view, same query, same numbers, still read-only, still refreshing every 20 s. `total_soal` was added to the `komponenSemua` select because `petunjukKolom()` needs it for `benar_per_total` components — `dev_server.py` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)