### PR TITLE
fix: let the Rekapitulasi table be wider than the screen, and tick with a tick

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -321,13 +321,19 @@ satu.** Kelasnya sama persis — `.table-pos` beserta `.kolom-nama`,
 kolom datang dari `petunjukKolom()` yang sama, bukan salinannya: kalau rentang
 di satu layar berbeda dengan layar lain, panitia akan percaya yang salah.
 
-Tiga hal yang ditambahkan, dan hanya tiga:
+Lima hal yang ditambahkan, dan hanya lima:
 
 | Yang ditambah | Kenapa tidak ada di lembar satu pos |
 | --- | --- |
+| `width: max-content` | `.table` dan `.table-pos` sama-sama `width: 100%`, yang benar untuk ±11 kolom dan bencana untuk ±38: tabelnya tidak pernah melebihi layar, jadi ia tidak menggeser melainkan **mengempis** — judul pecah jadi tumpukan huruf dan angkanya berdesakan |
+| Kolom terakhir tidak lagi menyerap sisa lebar | Di Input Pos yang terakhir adalah kolom status simpan, jadi lahan kosongnya jatuh di tempat yang tidak dikerjakan siapa pun. Di sini yang terakhir Nilai Total — dibiarkan menyerap, ia melayang sendirian jauh dari Penalti yang seharusnya dibaca bersamanya |
 | **Dua** kolom dipatok di tepi kiri, bukan satu | Rank berdiri di depan Nomor Dada; barisnya baru bisa dikenali kalau keduanya ikut menempel saat digeser |
 | Garis pemisah di tiap Nilai Pos | Dengan lima kelompok kolom bersambung, salah membaca kolom Pos 3 sebagai Pos 2 adalah satu-satunya cara layar ini bisa menyesatkan |
 | Baris lebih rapat | Tidak ada kotak isian sama sekali, jadi tingginya tidak perlu memuat sasaran sentuh setinggi jempol |
+
+Kolom biner memakai **ikon centang**, bukan huruf. Sebaris `v v v v` harus
+dieja satu per satu; centang tertangkap sekali sapu — bentuk yang sama dengan
+kotak centang di Input Pos dan centang per pos di halaman peserta.
 
 Seperti lembar Input Pos, tabel ini **digeser ke samping, bukan ditumpuk jadi
 kartu** — di layar meja geser samping justru dilarang karena menyembunyikan

--- a/live/style.css
+++ b/live/style.css
@@ -1452,6 +1452,29 @@ input.small-input { text-align: center; }
       lembar Input Pos yang harus memuat input setinggi jempol.
    ------------------------------------------------------------------------- */
 
+/* INI perbaikan yang paling menentukan bentuk layar ini.
+
+   .table dan .table-pos sama-sama menyetel `width: 100%`, yang benar untuk
+   lembar satu pos (±11 kolom) dan bencana untuk rekap (±38). Dengan lebar
+   dipatok ke lebar wadahnya, tabel tidak pernah melebihi layar — jadi ia
+   tidak menggeser, melainkan MENGEMPIS: tiap kolom diperas sampai judulnya
+   pecah jadi tumpukan huruf dan angkanya berdesakan. Yang terlihat bukan
+   tabel lebar yang bisa digulir, melainkan tabel sempit yang rusak.
+
+   `max-content` membalikkannya: tabel selebar isinya, wadahnya yang
+   menggeser (.table-wrapper sudah `overflow-x: auto`). `min-width: 100%`
+   menjaga agar saringan yang menyisakan dua baris tidak membuat tabelnya
+   menciut ke tengah kartu. */
+.table-rekap { width: max-content; min-width: 100%; }
+
+/* Input Pos memakai kolom TERAKHIR sebagai penyerap sisa lebar (.table-pos
+   th:last-child), dan di sana itu benar: yang terakhir adalah kolom status
+   simpan, sehingga lahan kosongnya jatuh di tempat yang tidak dikerjakan
+   siapa pun. Di rekap kolom terakhir adalah NILAI TOTAL — angka yang paling
+   dicari mata — dan membiarkannya menyerap membuatnya melayang sendirian
+   jauh di kanan, terpisah dari Penalti yang seharusnya dibacanya bersama. */
+.table-rekap th:last-child, .table-rekap td:last-child { width: auto; }
+
 /* Rank dipatok lebih dulu, lalu Nomor Dada menempel tepat di belakangnya.
    Lebar kolom pertama HARUS pasti, kalau tidak `left` kolom kedua meleset —
    isinya cuma satu sampai tiga digit, jadi mematoknya tidak merugikan. */
@@ -1479,3 +1502,12 @@ input.small-input { text-align: center; }
    lapang yang tidak ada yang menyentuhnya. */
 .table-rekap th, .table-rekap td { padding: .28rem .4rem; }
 .table-rekap { font-size: .86rem; }
+
+/* Kolom biner: ikon, bukan huruf. Sebaris "v v v v" harus dieja satu per
+   satu; centang tertangkap sekali sapu. Hijau dipakai untuk "ada", sama
+   seperti centang per pos di halaman peserta dan pita simpan di Input Pos —
+   satu arti, satu warna, di seluruh sistem. */
+.table-rekap .rekap-ya {
+  color: var(--hijau); font-weight: 800; font-size: 1.05rem; line-height: 1;
+}
+.table-rekap .rekap-tidak { color: var(--garis); font-weight: 700; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2585,23 +2585,43 @@ const NAMA_GOLONGAN = {
 };
 const URUTAN_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
 
-/** Sel nilai mentah, dibaca sebagaimana panitia menuliskannya di kertas.
- *  Bentuknya mengikuti `wahana.form`, bukan tipe datanya: kolom biner di
- *  lembar Excel berisi "v", bukan "1", dan menampilkan angka di situ membuat
- *  panitia mengira ada nilai yang salah ketik. */
+/** Satu sel nilai mentah, digambar seperti kotaknya di layar Input Pos —
+ *  hanya saja mati, karena layar ini tidak pernah menulis.
+ *
+ *  Mengembalikan HTML yang SUDAH aman; pemanggilnya tidak boleh meng-esc
+ *  lagi. Isinya cuma angka dari database dan penanda tetap, tidak ada teks
+ *  bebas dari siapa pun.
+ *
+ *  Kolom biner memakai ikon centang, bukan huruf "v". Sebaris "v v v v"
+ *  terbaca sebagai teks yang harus dieja satu per satu; centang tertangkap
+ *  sekali sapu, dan itu bentuk yang sama dengan kotak centang di Input Pos
+ *  dan dengan centang per pos di halaman peserta. */
 function selRekap(w, isi) {
-  if (!isi) return "";
-  const a = isi.nilai_1, b = isi.nilai_2;
-  if (a === null || a === undefined) return "";
-  if (w.form === "biner") return Number(a) ? "v" : "–";
+  const a = isi ? isi.nilai_1 : null;
+  const b = isi ? isi.nilai_2 : null;
+
+  // Belum dinilai — kosong, bukan nol. Kecuali biner: kotak centang tidak
+  // punya keadaan kosong, jadi baris yang tersimpan berarti "tidak kena".
+  if (a === null || a === undefined) {
+    return w.form === "biner" && isi
+      ? `<span class="rekap-tidak" aria-label="tidak">–</span>` : "";
+  }
+  if (w.form === "biner") {
+    return Number(a) > 0
+      ? `<span class="rekap-ya" aria-label="ya">✓</span>`
+      : `<span class="rekap-tidak" aria-label="tidak">–</span>`;
+  }
   if (w.form === "benar_kurang_salah") {
-    return `${a}${b === null || b === undefined ? "" : ` / ${b}`}`;
+    return b === null || b === undefined
+      ? esc(angkaRapi(a))
+      : `${esc(angkaRapi(a))}<span class="pos-pemisah"> / </span>${esc(angkaRapi(b))}`;
   }
   if (w.satuan === "detik") {
     const d = Number(a);
-    return `${Math.floor(d / 60)}:${String(d % 60).padStart(2, "0")}`;
+    return `${Math.floor(d / 60)}<span class="pos-pemisah">:</span>${
+      String(d % 60).padStart(2, "0")}`;
   }
-  return String(a);
+  return esc(angkaRapi(a));
 }
 
 const angka = (n) => n === null || n === undefined ? "—"
@@ -2706,7 +2726,7 @@ async function layarRekap() {
     const poin = b.poin_pos || {};
     const perPos = kolomPos.map(p => `
       ${p.komponen.map(w => `<td class="text-center">${
-        esc(selRekap(w, nilai[`${p.nomor}.${w.kode}`]))}</td>`).join("")}
+        selRekap(w, nilai[`${p.nomor}.${w.kode}`])}</td>`).join("")}
       <td class="text-center pos-nilai rekap-batas">${poin[String(p.nomor)] === undefined
         ? "" : esc(angka(poin[String(p.nomor)]))}</td>`).join("");
     const penalti = Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)

--- a/web/style.css
+++ b/web/style.css
@@ -1452,6 +1452,29 @@ input.small-input { text-align: center; }
       lembar Input Pos yang harus memuat input setinggi jempol.
    ------------------------------------------------------------------------- */
 
+/* INI perbaikan yang paling menentukan bentuk layar ini.
+
+   .table dan .table-pos sama-sama menyetel `width: 100%`, yang benar untuk
+   lembar satu pos (±11 kolom) dan bencana untuk rekap (±38). Dengan lebar
+   dipatok ke lebar wadahnya, tabel tidak pernah melebihi layar — jadi ia
+   tidak menggeser, melainkan MENGEMPIS: tiap kolom diperas sampai judulnya
+   pecah jadi tumpukan huruf dan angkanya berdesakan. Yang terlihat bukan
+   tabel lebar yang bisa digulir, melainkan tabel sempit yang rusak.
+
+   `max-content` membalikkannya: tabel selebar isinya, wadahnya yang
+   menggeser (.table-wrapper sudah `overflow-x: auto`). `min-width: 100%`
+   menjaga agar saringan yang menyisakan dua baris tidak membuat tabelnya
+   menciut ke tengah kartu. */
+.table-rekap { width: max-content; min-width: 100%; }
+
+/* Input Pos memakai kolom TERAKHIR sebagai penyerap sisa lebar (.table-pos
+   th:last-child), dan di sana itu benar: yang terakhir adalah kolom status
+   simpan, sehingga lahan kosongnya jatuh di tempat yang tidak dikerjakan
+   siapa pun. Di rekap kolom terakhir adalah NILAI TOTAL — angka yang paling
+   dicari mata — dan membiarkannya menyerap membuatnya melayang sendirian
+   jauh di kanan, terpisah dari Penalti yang seharusnya dibacanya bersama. */
+.table-rekap th:last-child, .table-rekap td:last-child { width: auto; }
+
 /* Rank dipatok lebih dulu, lalu Nomor Dada menempel tepat di belakangnya.
    Lebar kolom pertama HARUS pasti, kalau tidak `left` kolom kedua meleset —
    isinya cuma satu sampai tiga digit, jadi mematoknya tidak merugikan. */
@@ -1479,3 +1502,12 @@ input.small-input { text-align: center; }
    lapang yang tidak ada yang menyentuhnya. */
 .table-rekap th, .table-rekap td { padding: .28rem .4rem; }
 .table-rekap { font-size: .86rem; }
+
+/* Kolom biner: ikon, bukan huruf. Sebaris "v v v v" harus dieja satu per
+   satu; centang tertangkap sekali sapu. Hijau dipakai untuk "ada", sama
+   seperti centang per pos di halaman peserta dan pita simpan di Input Pos —
+   satu arti, satu warna, di seluruh sistem. */
+.table-rekap .rekap-ya {
+  color: var(--hijau); font-weight: 800; font-size: 1.05rem; line-height: 1;
+}
+.table-rekap .rekap-tidak { color: var(--garis); font-weight: 700; }


### PR DESCRIPTION
## What

Sharing `.table-pos`'s classes was not enough — two of its rules are right for eleven columns and wrong for thirty-eight.

| | Was | Now |
| --- | --- | --- |
| Table width | `width: 100%` inherited from `.table` and `.table-pos` | `width: max-content; min-width: 100%` |
| Last column | absorbs leftover width (`.table-pos th:last-child`) | `width: auto` |
| Binary components | the letter `v` | a green ✓ |

**Width is the one that made it look broken.** With 38 columns and a width pinned to the container, the table never exceeds the screen — so it does not scroll, it **compresses**: every column squeezed until headers break into stacks of single letters and numbers collide. It was not a wide table you could scroll; it was a narrow table that had fallen apart.

**Last column**: absorbing is right in Input Pos, where the last column is the save-status marker and the empty land falls somewhere nobody works. Here it is Nilai Total, which floated off alone at the far right, away from the Penalti it is read beside.

**Checks**: a row of `v v v v` has to be spelled out one at a time; a tick is caught in one sweep. Same mark as the Input Pos checkbox and the per-pos ticks on the peserta page.

## Why

Horizontal scrolling is fine for this sheet — it is genuinely long, and the frozen Rank + Nomor Dada keep every row identifiable. What was not fine was never getting the scroll in the first place.

## Notes

Verified by rendering the exact markup `app.js` emits against the real `style.css`, using a sample of the actual HRCD XXXVI recap (5 pos groups, 24 components, 38 columns), at 1568 px, scrolled to both ends. Both `.table-pos` rules are left untouched for Input Pos itself; the overrides are scoped to `.table-rekap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)