### PR TITLE
feat: show whether each pos is fully entered, and drop the "Semua" filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0027
+│   ├── migrations/           # skema database, urut 0001..0028
 │   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
 │   │                         # data; live_json.sql dipakai Publish rekap live
 │   └── seed.sql              # konfigurasi edisi + baris wajib

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0027`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0028`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-27 migrasi, `0001` sampai `0027`, dijalankan berurutan tanpa lubang penomoran.
+28 migrasi, `0001` sampai `0028`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -314,6 +314,49 @@ Rank kosong berarti kloter regu itu belum tercatat berangkat, jadi ia belum
 masuk klasemen resmi (`rancangan-b.md` 11.12). Barisnya tidak dibuang; ia
 turun ke bawah kelompoknya dan tetap terurut menurut total, supaya papan ini
 sudah terbaca sebagai klasemen sementara sejak nilai pertama masuk.
+
+**Selalu satu golongan, tidak pernah gabungan** — dan karena itu tidak ada
+pilihan "Semua". Keempat golongan dinilai terpisah (`alur-lomba.md` 2.3),
+jadi satu daftar berisi keempatnya menampilkan peringkat 1 empat kali dan
+menyandingkan angka yang tidak pernah diperlombakan satu sama lain.
+
+#### Panel kelengkapan tiap pos
+
+Di atas tabel, satu kartu per pos menjawab "datanya sudah masuk semua belum?"
+Bahannya `v_kelengkapan_pos` (migrasi `0028`), satu baris per pos.
+
+Angkanya tiga, bukan satu, karena "90% terisi" sendirian tidak bisa dibedakan
+antara tiga keadaan yang sangat berbeda:
+
+| Angka | Artinya | Perlu dikejar? |
+| --- | --- | --- |
+| `kosong` | regunya belum sampai di pos itu | tidak — ini keadaan normal sepanjang lomba |
+| `sebagian` | barisnya terisi separuh | ya — hampir selalu transkripsi dari foto yang terpotong |
+| **`hilang`** | regu **sudah closing** tapi nilainya belum lengkap | **ya** — ia pasti melewati pos itu, jadi tidak ada penjelasan yang tidak buruk |
+
+`hilang` satu-satunya yang berwarna merah. Ia disandarkan pada **closing**,
+bukan pada tebakan tentang sudah sampai mana regunya — itulah yang membuatnya
+bisa dipercaya.
+
+Penyebutnya **regu yang kloternya sudah berangkat**, bukan seluruh regu: yang
+belum berangkat tidak mungkin dinilai di mana pun, dan memasukkannya membuat
+tiap pos terlihat merah sepanjang pagi sampai panelnya berhenti dibaca.
+
+Kartu juga membawa `terakhir_masuk` — jam nilai terakhir yang menyentuh pos
+itu. **Inilah pendeteksi "tidak sync" yang sebenarnya:** kalau empat pos
+menyetor terus dan satu diam 30 menit, yang rusak hampir pasti sambungan atau
+laptop di pos itu, dan itu ketahuan berjam-jam sebelum angka kelengkapan
+bergerak — angka itu baru berubah setelah regunya selesai.
+
+Mengetuk satu kartu menyaring tabel di bawahnya ke regu yang belum lengkap di
+pos itu, jadi "siapa yang kurang" tidak perlu dicari sendiri. Angka di kartu
+menghitung seluruh golongan sementara tabelnya satu golongan, dan layar
+menyebutkan itu apa adanya saat saringannya menyala.
+
+Berbeda dengan `v_rekap_penuh`, **operator pos boleh membuka panel ini** —
+posnya sendiri saja. Angkanya jujur untuknya karena RLS memang mengizinkan ia
+membaca seluruh `nilai_mentah` pos-nya, dan "lembar saya sudah lengkap belum?"
+justru pertanyaannya sendiri.
 
 **Tabelnya adalah lembar Input Pos, hanya saja seluruh pos disambung jadi
 satu.** Kelasnya sama persis — `.table-pos` beserta `.kolom-nama`,
@@ -684,7 +727,7 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
 
 - **`docs/arsitektur-hrcd.svg` dan `.png`** masih menggambarkan Google Sheets
   sebagai bagian arsitektur, dan angkanya sudah bergeser: tertulis "18 view
-  berlapis" (sekarang 20) dan "24 RPC bertransaksi" (sekarang 27 fungsi, 15 di
+  berlapis" (sekarang 21) dan "24 RPC bertransaksi" (sekarang 27 fungsi, 15 di
   antaranya dipanggil layar). Diagramnya tidak dirujuk dari dokumen mana pun,
   jadi dibiarkan sampai ada yang menggambar ulang.
 - **Beberapa RPC masih mencetak nomor dada mentah** di pesan galatnya

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -354,9 +354,23 @@ menghitung seluruh golongan sementara tabelnya satu golongan, dan layar
 menyebutkan itu apa adanya saat saringannya menyala.
 
 Berbeda dengan `v_rekap_penuh`, **operator pos boleh membuka panel ini** —
-posnya sendiri saja. Angkanya jujur untuknya karena RLS memang mengizinkan ia
-membaca seluruh `nilai_mentah` pos-nya, dan "lembar saya sudah lengkap belum?"
-justru pertanyaannya sendiri.
+posnya sendiri saja, karena "lembar saya sudah lengkap belum?" justru
+pertanyaannya sendiri.
+
+Itu sebabnya `v_kelengkapan_pos` **bukan `security_invoker`**, satu-satunya
+view panitia selain `v_lembar_pos` yang begitu. Menghitung regu mana yang ikut
+menuntut `pendaftaran.status = 'lunas'`, dan `sel_pendaftaran` hanya
+mengizinkan admin dan meja — tabel itu memuat nomor WhatsApp. Dengan
+`security_invoker`, operator pos mendapat nol baris: bukan panel kosong yang
+jujur, melainkan panel yang lenyap, dan lenyapnya terbaca sebagai "belum ada
+data" alih-alih "kamu tidak boleh". Pagarnya karena itu dipindahkan ke dalam
+view, persis seperti `0023` — dan yang keluar lewat sini cuma hitungan agregat
+pos itu sendiri.
+
+> Terjaring saat menulis tesnya: `v_monitoring_input` (`0025`) memakai join
+> yang sama dengan `security_invoker`, jadi ia pun mengembalikan nol baris
+> untuk operator pos. Belum ada layar yang memanggilnya, jadi belum pernah
+> ketahuan — dan sekarang tercatat di sini sebelum ada yang memakainya.
 
 **Tabelnya adalah lembar Input Pos, hanya saja seluruh pos disambung jadi
 satu.** Kelasnya sama persis — `.table-pos` beserta `.kolom-nama`,

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -444,6 +444,18 @@ export async function komponenSemua(edisi) {
     `&order=pos.asc,sort_order.asc`);
 }
 
+/** Kelengkapan input per pos — satu baris per pos, bukan per regu.
+ *
+ *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5
+ *  baris hanya untuk menghitungnya sendiri di browser adalah pekerjaan yang
+ *  sudah bisa dilakukan database dalam satu query. Daftar regu yang belum
+ *  lengkap TIDAK perlu diambil terpisah — `v_rekap_penuh` sudah membawa
+ *  nilai tiap komponen, jadi layar bisa menyaringnya dari data yang sama. */
+export async function kelengkapanPos() {
+  if (K.mode === "dev") return baca("/kelengkapan-pos");
+  return baca(null, "v_kelengkapan_pos?select=*&order=pos.asc");
+}
+
 /** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
  *
  *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -79,6 +79,19 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
+/** "barusan" · "23 menit lalu" · "2 jam lalu".
+ *
+ *  Umur sebuah cap, bukan jamnya. Dipakai berdampingan dengan `jamMenit`,
+ *  tidak menggantikannya: "14:32" menjawab kapan, "(23 menit lalu)" menjawab
+ *  apakah itu masih baru — dan orang yang baru menoleh ke layar butuh
+ *  keduanya sekaligus. */
+export function berapaLalu(t) {
+  const menit = Math.floor((Date.now() - new Date(t).getTime()) / 60000);
+  if (menit < 1) return "barusan";
+  if (menit < 60) return `${menit} menit lalu`;
+  return `${Math.floor(menit / 60)} jam lalu`;
+}
+
 /** Membaca jam yang DIKETIK panitia dan mengembalikannya sebagai "HH:MM"
  *  24 jam — atau `null` kalau bukan jam yang sah.
  *

--- a/live/style.css
+++ b/live/style.css
@@ -1511,3 +1511,53 @@ input.small-input { text-align: center; }
   color: var(--hijau); font-weight: 800; font-size: 1.05rem; line-height: 1;
 }
 .table-rekap .rekap-tidak { color: var(--garis); font-weight: 700; }
+
+/* ---------------------------------------------------------------------------
+   PANEL KELENGKAPAN POS (#/rekap)
+
+   Satu kartu per pos, dan kartunya adalah TOMBOL: mengetuknya menyaring tabel
+   di bawah ke regu yang belum lengkap di pos itu. Membaca angka lalu harus
+   mencari sendiri regu mana yang kurang adalah pekerjaan yang justru paling
+   memakan waktu saat hari-H.
+
+   Warna dipakai hemat, dan artinya tunggal: merah HANYA untuk regu yang sudah
+   selesai lomba tapi nilainya belum lengkap. Kalau kuning dan merah sama-sama
+   berarti "kurang", panel ini akan menyala sepanjang pagi dan berhenti dibaca
+   orang justru sebelum keadaan yang sungguhan muncul.
+   ------------------------------------------------------------------------- */
+.lengkap-baris {
+  display: grid; gap: .6rem; margin-top: .6rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+.lengkap-kartu {
+  display: flex; flex-direction: column; gap: .12rem;
+  text-align: left; font: inherit; cursor: pointer;
+  padding: .6rem .7rem; min-height: 44px;
+  border: 2px solid var(--garis); border-radius: var(--radius);
+  background: var(--kartu); color: inherit;
+}
+.lengkap-kartu:hover { border-color: var(--utama); }
+.lengkap-kartu.aktif {
+  border-color: var(--utama); background: var(--utama-muda);
+  box-shadow: inset 0 0 0 1px var(--utama);
+}
+.lengkap-kartu.aman     { border-color: var(--hijau);  background: var(--hijau-muda); }
+.lengkap-kartu.menunggu { border-color: var(--kuning); background: var(--kuning-muda); }
+.lengkap-kartu.bahaya   { border-color: var(--bahaya); background: var(--bahaya-muda); }
+
+.lengkap-judul {
+  font-weight: 700; font-size: .82rem; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--tinta-lembut);
+}
+.lengkap-angka {
+  font-size: 1.6rem; font-weight: 800; line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.lengkap-dari { font-size: 1rem; font-weight: 600; color: var(--tinta-lembut); }
+.lengkap-sub, .lengkap-catatan { font-size: .78rem; color: var(--tinta-lembut); }
+/* Satu-satunya baris yang boleh berteriak. */
+.lengkap-alarm { font-size: .8rem; font-weight: 700; color: var(--bahaya); }
+/* Pos yang berhenti menyetor lebih dari 30 menit. Kalimat ini yang membuat
+   kartunya kuning, jadi ia harus ikut terlihat kuning — kalau tidak, warna
+   kartunya jadi teka-teki. */
+.lengkap-diam { color: var(--kuning); font-weight: 700; }

--- a/supabase/migrations/0028_kelengkapan_pos.sql
+++ b/supabase/migrations/0028_kelengkapan_pos.sql
@@ -1,0 +1,129 @@
+-- ============================================================================
+-- hrcd-rekap : 0028_kelengkapan_pos.sql
+--
+-- "Pos ini datanya sudah masuk semua belum?" — satu baris per pos, dan
+-- jawabannya harus bisa dipercaya tanpa membuka lembar pos satu per satu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TIDAK CUKUP SATU ANGKA PERSEN
+--
+-- Pos yang "90% terisi" bisa berarti tiga keadaan yang sangat berbeda, dan
+-- hanya satu di antaranya masalah:
+--
+--   a. 10% regunya memang belum sampai di pos itu. Normal, dan sepanjang
+--      lomba inilah keadaan yang paling sering.
+--   b. 10% regunya sudah lewat tapi barisnya baru terisi separuh. Hampir
+--      selalu berarti transkripsi dari foto terpotong di tengah.
+--   c. 10% regunya sudah SELESAI LOMBA dan tetap tidak punya nilai di pos
+--      itu. Ini kehilangan data yang sesungguhnya — mereka pasti melewati
+--      pos itu, dan angkanya tidak pernah sampai.
+--
+-- Maka view ini memisahkan ketiganya: `sebagian` menangkap (b), `hilang`
+-- menangkap (c), dan `kosong` yang bukan keduanya adalah (a).
+--
+-- `hilang` adalah satu-satunya angka yang berarti "ada yang rusak". Ia
+-- disandarkan pada CLOSING, bukan pada tebakan tentang sudah sampai mana
+-- regunya: regu yang sudah checkout pasti sudah melewati seluruh pos, jadi
+-- pos tanpa nilai untuknya tidak punya penjelasan yang tidak buruk.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA PENYEBUTNYA "SUDAH BERANGKAT", BUKAN SELURUH REGU
+--
+-- Regu yang kloternya belum berangkat tidak mungkin dinilai di mana pun.
+-- Memasukkannya ke penyebut membuat tiap pos terlihat 30% sepanjang pagi dan
+-- angka yang selalu merah berhenti dibaca orang. Penyebutnya karena itu regu
+-- yang kloternya SUDAH punya jam berangkat — dan tetap tidak sempurna
+-- (regu yang berangkat lima menit lalu belum sampai Pos 3), jadi layar
+-- menyebutkan penyebutnya apa adanya alih-alih memamerkan satu angka persen
+-- telanjang.
+--
+-- ---------------------------------------------------------------------------
+-- `terakhir_masuk` — PENDETEKSI "TIDAK SYNC" YANG SEBENARNYA
+--
+-- Jam nilai terakhir yang masuk ke pos itu. Kalau empat pos menyetor terus
+-- dan satu pos diam 40 menit, yang rusak hampir pasti sambungan atau laptop
+-- di pos itu — dan itu ketahuan di sini berjam-jam sebelum ketahuan dari
+-- angka kelengkapan, yang baru bergerak setelah regunya selesai.
+--
+-- `simpan_nilai_massal` menyetel `created_at = now()` juga saat menimpa
+-- (0014), jadi angka ini bergerak untuk perbaikan, bukan hanya untuk nilai
+-- yang benar-benar baru. Itu memang yang diinginkan: yang ditanyakan bukan
+-- "kapan nilai baru datang" melainkan "pos ini masih hidup atau tidak".
+--
+-- ---------------------------------------------------------------------------
+-- OPERATOR POS BOLEH MELIHAT — POSNYA SENDIRI SAJA
+--
+-- Berbeda dengan `v_rekap_penuh` (0027) yang menolaknya, view ini justru
+-- berguna untuk operator pos: "lembar saya sudah lengkap belum?". Angkanya
+-- pun benar untuknya, karena RLS `sel_nilai` mengizinkan ia membaca seluruh
+-- `nilai_mentah` POS-NYA — dan barisnya memang disaring ke pos itu saja,
+-- persis seperti `v_monitoring_input` (0025).
+-- ============================================================================
+
+create view v_kelengkapan_pos with (security_invoker = on) as
+with regu_ikut as (
+  -- Regu yang sudah punya nomor dada dan batch-nya lunas. Sebelum daftar
+  -- ulang tidak ada yang bisa dinilai, jadi tidak ada yang bisa hilang.
+  select
+    r.id,
+    (k.jam_berangkat is not null)                                as sudah_berangkat,
+    exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+  from regu r
+  join pendaftaran d  on d.id = r.pendaftaran_id
+  left join kloter k  on k.nomor = r.kloter_nomor
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor                       as pos,
+  p.name                        as nama_pos,
+  p.bayangan,
+  p.jumlah_komponen,
+
+  count(*)::int                                          as regu_total,
+  count(*) filter (where ri.sudah_berangkat)::int        as regu_berangkat,
+  count(*) filter (where ri.sudah_closing)::int          as regu_closing,
+
+  -- Seluruh komponen pos ini terisi.
+  count(*) filter (
+    where coalesce(t.jumlah, 0) = p.jumlah_komponen)::int as lengkap,
+  -- Terisi, tapi tidak semuanya — transkripsi yang terpotong.
+  count(*) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0) < p.jumlah_komponen)::int as sebagian,
+  count(*) filter (where coalesce(t.jumlah, 0) = 0)::int  as kosong,
+  -- SUDAH SELESAI LOMBA dan tetap belum lengkap di pos ini. Inilah alarmnya.
+  count(*) filter (
+    where ri.sudah_closing
+      and coalesce(t.jumlah, 0) < p.jumlah_komponen)::int as hilang,
+
+  (select max(n.created_at)
+   from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where w.edisi = edisi_aktif() and w.pos = p.nomor)     as terakhir_masuk
+
+from v_pos p
+cross join regu_ikut ri
+left join terisi t on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and peran() is not null
+  -- Sama seperti v_monitoring_input: operator pos hanya posnya sendiri.
+  -- Tampilan sempit lebih baik daripada tampilan palsu.
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya())
+group by p.nomor, p.name, p.bayangan, p.jumlah_komponen;
+
+grant select on v_kelengkapan_pos to authenticated;
+
+comment on view v_kelengkapan_pos is
+  'Kelengkapan input per pos: lengkap / sebagian / kosong, ditambah `hilang` '
+  '(regu yang sudah closing tapi nilainya belum lengkap — kehilangan data '
+  'yang sesungguhnya) dan `terakhir_masuk` (pendeteksi pos yang berhenti '
+  'menyetor). Operator pos hanya melihat posnya sendiri.';

--- a/supabase/migrations/0028_kelengkapan_pos.sql
+++ b/supabase/migrations/0028_kelengkapan_pos.sql
@@ -54,13 +54,37 @@
 -- OPERATOR POS BOLEH MELIHAT — POSNYA SENDIRI SAJA
 --
 -- Berbeda dengan `v_rekap_penuh` (0027) yang menolaknya, view ini justru
--- berguna untuk operator pos: "lembar saya sudah lengkap belum?". Angkanya
--- pun benar untuknya, karena RLS `sel_nilai` mengizinkan ia membaca seluruh
--- `nilai_mentah` POS-NYA — dan barisnya memang disaring ke pos itu saja,
--- persis seperti `v_monitoring_input` (0025).
+-- berguna untuk operator pos: "lembar saya sudah lengkap belum?".
+--
+-- KENAPA BUKAN `security_invoker`. Menghitung regu mana yang ikut menuntut
+-- `pendaftaran.status = 'lunas'`, dan `sel_pendaftaran` hanya mengizinkan
+-- admin dan meja — tabel itu memuat nomor WhatsApp. Dengan security_invoker,
+-- operator pos mendapat NOL BARIS: bukan panel kosong yang jujur, melainkan
+-- panel yang hilang sama sekali, dan hilangnya terbaca sebagai "belum ada
+-- data" alih-alih "kamu tidak boleh".
+--
+-- Persis persoalan `v_lembar_pos` di migrasi 0023, dan diselesaikan dengan
+-- cara yang sama: pagarnya dipindahkan KE DALAM view — `peran() is not null`
+-- ditambah penyaringan ke `pos_saya()`. Yang bocor lewat sini cuma hitungan
+-- agregat pos itu sendiri; tidak satu pun kolom `pendaftaran` keluar.
+--
+-- (Catatan: `v_monitoring_input` (0025) memakai join yang sama dengan
+-- security_invoker, jadi ia pun mengembalikan nol baris untuk operator pos.
+-- Belum ada layar yang memanggilnya, jadi belum pernah ketahuan.)
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA `left join regu_ikut ... on true`, BUKAN `cross join`
+--
+-- Sebelum daftar ulang belum ada satu pun regu bernomor dada, jadi himpunan
+-- regunya kosong. `cross join` atas himpunan kosong menghasilkan nol baris,
+-- dan `group by` tidak mengeluarkan apa-apa — panelnya lenyap justru pada
+-- hari ia pertama kali dibuka orang. Dengan left join, tiap pos tetap keluar
+-- satu baris berisi 0/0. Karena itu pula yang dihitung `count(ri.id)`, bukan
+-- `count(*)`: baris kosong hasil left join tidak boleh ikut terhitung sebagai
+-- satu regu.
 -- ============================================================================
 
-create view v_kelengkapan_pos with (security_invoker = on) as
+create view v_kelengkapan_pos as
 with regu_ikut as (
   -- Regu yang sudah punya nomor dada dan batch-nya lunas. Sebelum daftar
   -- ulang tidak ada yang bisa dinilai, jadi tidak ada yang bisa hilang.
@@ -88,20 +112,20 @@ select
   p.bayangan,
   p.jumlah_komponen,
 
-  count(*)::int                                          as regu_total,
-  count(*) filter (where ri.sudah_berangkat)::int        as regu_berangkat,
-  count(*) filter (where ri.sudah_closing)::int          as regu_closing,
+  count(ri.id)::int                                      as regu_total,
+  count(ri.id) filter (where ri.sudah_berangkat)::int    as regu_berangkat,
+  count(ri.id) filter (where ri.sudah_closing)::int      as regu_closing,
 
   -- Seluruh komponen pos ini terisi.
-  count(*) filter (
+  count(ri.id) filter (
     where coalesce(t.jumlah, 0) = p.jumlah_komponen)::int as lengkap,
   -- Terisi, tapi tidak semuanya — transkripsi yang terpotong.
-  count(*) filter (
+  count(ri.id) filter (
     where coalesce(t.jumlah, 0) > 0
       and coalesce(t.jumlah, 0) < p.jumlah_komponen)::int as sebagian,
-  count(*) filter (where coalesce(t.jumlah, 0) = 0)::int  as kosong,
+  count(ri.id) filter (where coalesce(t.jumlah, 0) = 0)::int as kosong,
   -- SUDAH SELESAI LOMBA dan tetap belum lengkap di pos ini. Inilah alarmnya.
-  count(*) filter (
+  count(ri.id) filter (
     where ri.sudah_closing
       and coalesce(t.jumlah, 0) < p.jumlah_komponen)::int as hilang,
 
@@ -111,7 +135,7 @@ select
    where w.edisi = edisi_aktif() and w.pos = p.nomor)     as terakhir_masuk
 
 from v_pos p
-cross join regu_ikut ri
+left join regu_ikut ri on true
 left join terisi t on t.regu_id = ri.id and t.pos = p.nomor
 where p.jumlah_komponen > 0
   and peran() is not null

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -154,6 +154,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "
                     "order by pos, sort_order", uid=p.get("uid")))
+            elif u.path == "/kelengkapan-pos":
+                self._kirim(200, q(
+                    "select * from v_kelengkapan_pos order by pos",
+                    uid=p.get("uid")))
             elif u.path == "/rekap-penuh":
                 self._kirim(200, q(
                     "select * from v_rekap_penuh order by nomor_dada",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -50,6 +50,7 @@ run supabase/migrations/0024_komponen_pos.sql
 run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run supabase/migrations/0026_rekap_publik.sql
 run supabase/migrations/0027_rekap_penuh.sql
+run supabase/migrations/0028_kelengkapan_pos.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -86,5 +87,6 @@ run tests/sql/09_rekap_publik.sql
 # dengan v_poin_pos, v_total_skor, dan v_klasemen, jadi ia butuh database yang
 # sudah berisi nilai, keberangkatan, dan closing dari seluruh tes di atasnya.
 run tests/sql/10_rekap_penuh.sql
+run tests/sql/11_kelengkapan_pos.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/11_kelengkapan_pos.sql
+++ b/tests/sql/11_kelengkapan_pos.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/11_kelengkapan_pos.sql
+-- Panel kelengkapan per pos (v_kelengkapan_pos, migrasi 0028).
+--
+-- Yang dijaga di sini satu kalimat: angka di panel harus BERARTI apa yang
+-- tertulis di labelnya. Panel yang menghitung sedikit meleset lebih buruk
+-- daripada panel yang tidak ada — panitia akan mengejar regu yang sebenarnya
+-- lengkap, dan berhenti mengejar yang benar-benar hilang.
+-- ============================================================================
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 11.1 Ketiga golongan angka menjumlah persis ke populasinya, dan tiap pos
+--      muncul tepat sekali.
+-- ---------------------------------------------------------------------------
+do $$
+declare k record; v_pos_dinilai int;
+begin
+  select count(*) into v_pos_dinilai from v_pos where jumlah_komponen > 0;
+  assert (select count(*) from v_kelengkapan_pos) = v_pos_dinilai,
+    format('panel memuat %s baris, pos yang dinilai ada %s',
+           (select count(*) from v_kelengkapan_pos), v_pos_dinilai);
+
+  -- Pos tanpa komponen (garis start & finish) tidak boleh muncul: kolom yang
+  -- selamanya 0/0 terbaca sebagai pos yang panitianya lalai.
+  assert not exists (
+    select 1 from v_kelengkapan_pos k
+    join v_pos p on p.nomor = k.pos where p.jumlah_komponen = 0),
+    'pos tanpa komponen ikut masuk panel kelengkapan';
+
+  for k in select * from v_kelengkapan_pos loop
+    assert k.lengkap + k.sebagian + k.kosong = k.regu_total,
+      format('Pos %s: %s + %s + %s <> %s regu',
+             k.pos, k.lengkap, k.sebagian, k.kosong, k.regu_total);
+    assert k.regu_berangkat <= k.regu_total, format('Pos %s: berangkat > total', k.pos);
+    assert k.regu_closing   <= k.regu_total, format('Pos %s: closing > total', k.pos);
+    assert k.hilang         <= k.regu_closing,
+      format('Pos %s: hilang (%s) > yang sudah closing (%s)',
+             k.pos, k.hilang, k.regu_closing);
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 11.2 `lengkap` benar-benar berarti SELURUH komponen pos itu terisi —
+--      dihitung ulang dari nilai_mentah, bukan dipercaya begitu saja.
+-- ---------------------------------------------------------------------------
+do $$
+declare k record; v_hitung int;
+begin
+  for k in select * from v_kelengkapan_pos loop
+    select count(*) into v_hitung
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is not null
+      and (select count(*) from nilai_mentah n
+           join wahana w on w.id = n.wahana_id
+           where n.regu_id = r.id and w.edisi = edisi_aktif()
+             and w.pos = k.pos) = k.jumlah_komponen;
+    assert v_hitung = k.lengkap,
+      format('Pos %s: panel bilang %s lengkap, hitungan ulang %s',
+             k.pos, k.lengkap, v_hitung);
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 11.3 `hilang` HANYA menghitung regu yang sudah closing. Inilah bedanya
+--      dengan "belum sampai", dan seluruh nilai panel ini bergantung padanya.
+-- ---------------------------------------------------------------------------
+do $$
+declare k record; v_hitung int;
+begin
+  for k in select * from v_kelengkapan_pos loop
+    select count(*) into v_hitung
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is not null
+      and exists (select 1 from closing_regu c where c.regu_id = r.id)
+      and (select count(*) from nilai_mentah n
+           join wahana w on w.id = n.wahana_id
+           where n.regu_id = r.id and w.edisi = edisi_aktif()
+             and w.pos = k.pos) < k.jumlah_komponen;
+    assert v_hitung = k.hilang,
+      format('Pos %s: panel bilang %s hilang, hitungan ulang %s',
+             k.pos, k.hilang, v_hitung);
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 11.4 Operator pos melihat POSNYA SENDIRI saja — satu baris, nomornya benar.
+--      Berbeda dengan v_rekap_penuh yang menolaknya sama sekali (0027):
+--      di sini angkanya jujur untuk pos itu, karena RLS mengizinkan ia
+--      membaca seluruh nilai_mentah pos-nya.
+-- ---------------------------------------------------------------------------
+reset role;
+select set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+set role authenticated;
+
+do $$
+declare v_baris int; v_pos int;
+begin
+  select count(*) into v_baris from v_kelengkapan_pos;
+  assert v_baris = 1,
+    format('operator pos 1 melihat %s baris panel, seharusnya 1', v_baris);
+  select pos into v_pos from v_kelengkapan_pos;
+  assert v_pos = 1, format('operator pos 1 melihat panel pos %s', v_pos);
+end;
+$$;
+
+reset role;
+select '11_kelengkapan_pos OK' as hasil;

--- a/tests/sql/11_kelengkapan_pos.sql
+++ b/tests/sql/11_kelengkapan_pos.sql
@@ -25,9 +25,14 @@ begin
 
   -- Pos tanpa komponen (garis start & finish) tidak boleh muncul: kolom yang
   -- selamanya 0/0 terbaca sebagai pos yang panitianya lalai.
+  --
+  -- Aliasnya SENGAJA bukan `k` atau `p`. Blok ini punya variabel `k record`,
+  -- dan plpgsql memenangkan variabel di atas alias SQL — `k.pos` di dalam
+  -- subquery akan dibaca sebagai variabel yang belum terisi, dan galatnya
+  -- ("record k is not assigned yet") sama sekali tidak menunjuk ke sini.
   assert not exists (
-    select 1 from v_kelengkapan_pos k
-    join v_pos p on p.nomor = k.pos where p.jumlah_komponen = 0),
+    select 1 from v_kelengkapan_pos kel
+    join v_pos vp on vp.nomor = kel.pos where vp.jumlah_komponen = 0),
     'pos tanpa komponen ikut masuk panel kelengkapan';
 
   for k in select * from v_kelengkapan_pos loop

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -444,6 +444,18 @@ export async function komponenSemua(edisi) {
     `&order=pos.asc,sort_order.asc`);
 }
 
+/** Kelengkapan input per pos — satu baris per pos, bukan per regu.
+ *
+ *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5
+ *  baris hanya untuk menghitungnya sendiri di browser adalah pekerjaan yang
+ *  sudah bisa dilakukan database dalam satu query. Daftar regu yang belum
+ *  lengkap TIDAK perlu diambil terpisah — `v_rekap_penuh` sudah membawa
+ *  nilai tiap komponen, jadi layar bisa menyaringnya dari data yang sama. */
+export async function kelengkapanPos() {
+  if (K.mode === "dev") return baca("/kelengkapan-pos");
+  return baca(null, "v_kelengkapan_pos?select=*&order=pos.asc");
+}
+
 /** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
  *
  *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -18,11 +18,12 @@ import {
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
-  komponenSemua, rekapPenuh,
+  komponenSemua, rekapPenuh, kelengkapanPos,
   statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
-         dialog, kartuGagalMuat, jamSah, pasangKotakJam } from "./util.js";
+         dialog, kartuGagalMuat, jamSah, pasangKotakJam,
+         berapaLalu } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -2254,13 +2255,6 @@ async function layarInputPos() {
   // dimuat, karena saat itu angka di layar memang baru dibaca dari sana.
   let jamSinkron = new Date();
 
-  const berapaLalu = (d) => {
-    const menit = Math.floor((Date.now() - d.getTime()) / 60000);
-    if (menit < 1) return "barusan";
-    if (menit < 60) return `${menit} menit lalu`;
-    return `${Math.floor(menit / 60)} jam lalu`;
-  };
-
   function perbaruiRingkasan() {
     const baris = [...tbody.children];
     const belum = baris.filter(t => t.dataset.keadaan === "belum").length;
@@ -2647,10 +2641,10 @@ async function layarRekap() {
   LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
 
   const layarIni = location.hash;
-  let pos, wahana, baris;
+  let pos, wahana, baris, kelengkapan;
   try {
-    [pos, wahana, baris] = await Promise.all([
-      daftarPos(), komponenSemua(EDISI.nomor), rekapPenuh(),
+    [pos, wahana, baris, kelengkapan] = await Promise.all([
+      daftarPos(), komponenSemua(EDISI.nomor), rekapPenuh(), kelengkapanPos(),
     ]);
   } catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarRekap)); return; }
   if (location.hash !== layarIni) return;
@@ -2663,15 +2657,35 @@ async function layarRekap() {
     ...p, komponen: wahana.filter(w => Number(w.pos) === Number(p.nomor)),
   }));
 
-  let golongan = "";      // "" = semua
+  /* SELALU satu golongan, tidak pernah gabungan — dan karena itu tidak ada
+     pilihan "Semua". Rekap dibaca untuk menjawab "siapa juara Penegak PA",
+     bukan "siapa juara seluruhnya": keempat golongan dinilai terpisah
+     (alur-lomba.md 2.3), jadi satu daftar berisi keempatnya menampilkan
+     peringkat 1 empat kali dan menyandingkan angka yang tidak pernah
+     diperlombakan satu sama lain. Menggabungkannya juga melipatempatkan
+     panjang tabel tanpa menjawab pertanyaan siapa pun. */
+  let golongan = URUTAN_GOLONGAN[0];
   let cari = "";
+  let posBelum = null;    // nomor pos yang sedang disaring "belum lengkap"
   let jeda = null;
 
-  const cocok = (b) => (!golongan || b.golongan === golongan)
-    && (!cari
-        || (b.nama_sekolah || "").toLowerCase().includes(cari)
-        || (b.nama_regu || "").toLowerCase().includes(cari)
-        || String(b.nomor_dada ?? "").padStart(3, "0").includes(cari));
+  /** Berapa komponen pos ini yang sudah terisi untuk satu regu. Dihitung dari
+   *  `nilai` yang SUDAH ada di tangan — tidak perlu permintaan tambahan, dan
+   *  angkanya pasti sama dengan yang dipakai menggambar barisnya. */
+  const terisiDiPos = (b, p) => p.komponen.reduce(
+    (n, w) => n + ((b.nilai || {})[`${p.nomor}.${w.kode}`] ? 1 : 0), 0);
+
+  const cocok = (b) => {
+    if (golongan && b.golongan !== golongan) return false;
+    if (posBelum !== null) {
+      const p = kolomPos.find(x => Number(x.nomor) === Number(posBelum));
+      if (p && terisiDiPos(b, p) >= p.komponen.length) return false;
+    }
+    return !cari
+      || (b.nama_sekolah || "").toLowerCase().includes(cari)
+      || (b.nama_regu || "").toLowerCase().includes(cari)
+      || String(b.nomor_dada ?? "").padStart(3, "0").includes(cari);
+  };
 
   /* Urutan: golongan dulu, lalu peringkat resmi, lalu total.
      Peringkat datang dari v_klasemen dan hanya ada untuk regu yang kloternya
@@ -2755,10 +2769,65 @@ async function layarRekap() {
       </tr>`;
   };
 
+  /* Panel kelengkapan. Tiga angka per pos, karena "90% terisi" sendirian
+     tidak bisa dibedakan antara "regunya memang belum sampai" dan "datanya
+     hilang" — lihat kepala migrasi 0028.
+
+     Yang merah cuma satu hal: `hilang`, yaitu regu yang SUDAH selesai lomba
+     tapi nilainya di pos itu belum lengkap. Mereka pasti melewati pos itu,
+     jadi tidak ada penjelasan yang tidak buruk. */
+  function kartuKelengkapan() {
+    if (!kelengkapan.length) return "";
+    const kartu = kelengkapan.map(k => {
+      const penyebut = k.regu_berangkat;
+      const persen = penyebut ? Math.round((k.lengkap / penyebut) * 100) : null;
+      const diam = k.terakhir_masuk
+        && Date.now() - new Date(k.terakhir_masuk).getTime() > 30 * 60000;
+      const keadaan = k.hilang > 0 ? "bahaya"
+        : (k.sebagian > 0 || diam) ? "menunggu"
+        : (penyebut && k.lengkap === penyebut) ? "aman" : "";
+      const aktif = Number(posBelum) === Number(k.pos);
+      return `
+        <button type="button" class="lengkap-kartu ${keadaan}${aktif ? " aktif" : ""}"
+                data-pos-belum="${esc(String(k.pos))}"
+                aria-pressed="${aktif}">
+          <span class="lengkap-judul">${esc(k.bayangan ? k.nama_pos : `Pos ${k.pos}`)}</span>
+          <span class="lengkap-angka">${penyebut
+            ? `${esc(String(k.lengkap))}<span class="lengkap-dari">/${esc(String(penyebut))}</span>`
+            : "—"}</span>
+          <span class="lengkap-sub">${penyebut
+            ? `${esc(String(persen))}% dari yang sudah berangkat`
+            : "belum ada kloter berangkat"}</span>
+          ${k.hilang > 0 ? `<span class="lengkap-alarm">⚠ ${esc(String(k.hilang))} sudah closing tapi belum lengkap</span>` : ""}
+          ${k.sebagian > 0 ? `<span class="lengkap-catatan">${esc(String(k.sebagian))} baris terisi separuh</span>` : ""}
+          <!-- Kalau pos ini yang membuat kartunya kuning, kalimat inilah
+               alasannya — jadi ia ikut menguning. Warna yang alasannya harus
+               ditebak sama saja dengan warna yang tidak ada. -->
+          <span class="lengkap-catatan${diam ? " lengkap-diam" : ""}">${k.terakhir_masuk
+            ? `nilai terakhir ${esc(jamMenit(k.terakhir_masuk))} (${esc(berapaLalu(k.terakhir_masuk))})`
+            : "belum ada nilai masuk"}</span>
+        </button>`;
+    }).join("");
+
+    return `
+      <div class="card">
+        <h2 style="font-size:1rem">Kelengkapan tiap pos</h2>
+        <p class="description">Ketuk satu pos untuk menyaring tabel di bawah ke
+           regu yang belum lengkap di pos itu. <strong>Merah</strong> berarti ada
+           regu yang sudah selesai lomba tapi nilainya belum masuk — itu data
+           yang benar-benar hilang, bukan regu yang belum sampai.</p>
+        <div class="lengkap-baris">${kartu}</div>
+      </div>`;
+  }
+
   function gambar() {
     const tampil = baris.filter(cocok).sort(urut);
-    const lebarKolom = 15 + kolomPos.reduce((n, p) => n + p.komponen.length + 1, 0);
+    // 5 kolom identitas + 9 kolom waktu/total, ditambah tiap komponen dan
+    // satu Nilai Pos per kelompok. Dipakai colspan baris "tidak ada yang
+    // cocok" — kalau meleset, barisnya tidak selebar tabelnya.
+    const lebarKolom = 14 + kolomPos.reduce((n, p) => n + p.komponen.length + 1, 0);
     LAYAR.replaceChildren(h(`
+      ${kartuKelengkapan()}
       <div class="card">
         <div class="table-toolbar">
           <div class="field" style="margin:0;flex:1;min-width:220px">
@@ -2768,8 +2837,6 @@ async function layarRekap() {
                    value="${esc(cari)}">
           </div>
           <div class="filter-row">
-            <button type="button" class="option option-small" data-gol=""
-                    aria-pressed="${golongan === ""}">Semua</button>
             ${URUTAN_GOLONGAN.map(g => `
               <button type="button" class="option option-small" data-gol="${g}"
                       aria-pressed="${golongan === g}">${esc(NAMA_GOLONGAN[g])}</button>`).join("")}
@@ -2781,7 +2848,12 @@ async function layarRekap() {
         <p class="description">Layar ini hanya menampilkan. Nilai diubah di
            <a href="#/pos">Input Nilai Pos</a>, dan angkanya muncul di sini
            begitu tersimpan. Rank kosong berarti kloter regu itu belum
-           tercatat berangkat, jadi ia belum masuk klasemen resmi.</p>
+           tercatat berangkat, jadi ia belum masuk klasemen resmi.
+           ${posBelum !== null ? `<strong>Sedang disaring:
+             ${esc(NAMA_GOLONGAN[golongan] || "")} yang belum lengkap di Pos
+             ${esc(String(posBelum))}.</strong> Angka di kartu pos menghitung
+             SELURUH golongan, jadi wajar kalau lebih banyak daripada baris
+             yang tampil di sini.` : ""}</p>
         <!-- Kelas tabelnya SAMA PERSIS dengan lembar Input Pos, ditambah
              satu pengubah: di HP ia tetap tabel yang digeser ke samping,
              tidak ditumpuk jadi kartu seperti layar meja. -->
@@ -2790,13 +2862,24 @@ async function layarRekap() {
             <thead>${kepala()}</thead>
             <tbody>${tampil.length ? tampil.map(barisHtml).join("")
               : `<tr><td colspan="${lebarKolom}" class="table-empty">
-                   Tidak ada regu yang cocok.</td></tr>`}</tbody>
+                   Tidak ada regu ${esc(NAMA_GOLONGAN[golongan] || "")} yang cocok${
+                     posBelum !== null ? ` dan belum lengkap di Pos ${esc(String(posBelum))}` : ""
+                   }.</td></tr>`}</tbody>
           </table>
         </div>
       </div>`));
 
     LAYAR.querySelectorAll("[data-gol]").forEach(b =>
       b.addEventListener("click", () => { golongan = b.dataset.gol; gambar(); }));
+
+    // Mengetuk pos yang sedang aktif MEMATIKAN saringannya. Tanpa itu tidak
+    // ada jalan kembali ke seluruh regu selain menebak-nebak tombol lain.
+    LAYAR.querySelectorAll("[data-pos-belum]").forEach(b =>
+      b.addEventListener("click", () => {
+        const n = Number(b.dataset.posBelum);
+        posBelum = Number(posBelum) === n ? null : n;
+        gambar();
+      }));
 
     const kotak = document.getElementById("rekap-cari");
     kotak.addEventListener("input", () => {
@@ -2817,7 +2900,8 @@ async function layarRekap() {
   async function segarkan() {
     if (location.hash !== layarIni) return;
     try {
-      baris = await rekapPenuh();
+      const [b, k] = await Promise.all([rekapPenuh(), kelengkapanPos()]);
+      baris = b; kelengkapan = k;
       if (location.hash === layarIni) gambar();
     } catch { /* diamkan: percobaan berikutnya datang sendiri */ }
   }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -79,6 +79,19 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
+/** "barusan" · "23 menit lalu" · "2 jam lalu".
+ *
+ *  Umur sebuah cap, bukan jamnya. Dipakai berdampingan dengan `jamMenit`,
+ *  tidak menggantikannya: "14:32" menjawab kapan, "(23 menit lalu)" menjawab
+ *  apakah itu masih baru — dan orang yang baru menoleh ke layar butuh
+ *  keduanya sekaligus. */
+export function berapaLalu(t) {
+  const menit = Math.floor((Date.now() - new Date(t).getTime()) / 60000);
+  if (menit < 1) return "barusan";
+  if (menit < 60) return `${menit} menit lalu`;
+  return `${Math.floor(menit / 60)} jam lalu`;
+}
+
 /** Membaca jam yang DIKETIK panitia dan mengembalikannya sebagai "HH:MM"
  *  24 jam — atau `null` kalau bukan jam yang sah.
  *

--- a/web/style.css
+++ b/web/style.css
@@ -1511,3 +1511,53 @@ input.small-input { text-align: center; }
   color: var(--hijau); font-weight: 800; font-size: 1.05rem; line-height: 1;
 }
 .table-rekap .rekap-tidak { color: var(--garis); font-weight: 700; }
+
+/* ---------------------------------------------------------------------------
+   PANEL KELENGKAPAN POS (#/rekap)
+
+   Satu kartu per pos, dan kartunya adalah TOMBOL: mengetuknya menyaring tabel
+   di bawah ke regu yang belum lengkap di pos itu. Membaca angka lalu harus
+   mencari sendiri regu mana yang kurang adalah pekerjaan yang justru paling
+   memakan waktu saat hari-H.
+
+   Warna dipakai hemat, dan artinya tunggal: merah HANYA untuk regu yang sudah
+   selesai lomba tapi nilainya belum lengkap. Kalau kuning dan merah sama-sama
+   berarti "kurang", panel ini akan menyala sepanjang pagi dan berhenti dibaca
+   orang justru sebelum keadaan yang sungguhan muncul.
+   ------------------------------------------------------------------------- */
+.lengkap-baris {
+  display: grid; gap: .6rem; margin-top: .6rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+.lengkap-kartu {
+  display: flex; flex-direction: column; gap: .12rem;
+  text-align: left; font: inherit; cursor: pointer;
+  padding: .6rem .7rem; min-height: 44px;
+  border: 2px solid var(--garis); border-radius: var(--radius);
+  background: var(--kartu); color: inherit;
+}
+.lengkap-kartu:hover { border-color: var(--utama); }
+.lengkap-kartu.aktif {
+  border-color: var(--utama); background: var(--utama-muda);
+  box-shadow: inset 0 0 0 1px var(--utama);
+}
+.lengkap-kartu.aman     { border-color: var(--hijau);  background: var(--hijau-muda); }
+.lengkap-kartu.menunggu { border-color: var(--kuning); background: var(--kuning-muda); }
+.lengkap-kartu.bahaya   { border-color: var(--bahaya); background: var(--bahaya-muda); }
+
+.lengkap-judul {
+  font-weight: 700; font-size: .82rem; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--tinta-lembut);
+}
+.lengkap-angka {
+  font-size: 1.6rem; font-weight: 800; line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.lengkap-dari { font-size: 1rem; font-weight: 600; color: var(--tinta-lembut); }
+.lengkap-sub, .lengkap-catatan { font-size: .78rem; color: var(--tinta-lembut); }
+/* Satu-satunya baris yang boleh berteriak. */
+.lengkap-alarm { font-size: .8rem; font-weight: 700; color: var(--bahaya); }
+/* Pos yang berhenti menyetor lebih dari 30 menit. Kalimat ini yang membuat
+   kartunya kuning, jadi ia harus ikut terlihat kuning — kalau tidak, warna
+   kartunya jadi teka-teki. */
+.lengkap-diam { color: var(--kuning); font-weight: 700; }


### PR DESCRIPTION
## What

### 1 · Kelengkapan per pos

A card per pos above the recap table, answering "is this pos fully in?". Backed by `v_kelengkapan_pos` (migration `0028`), one row per pos.

**One percentage cannot answer it.** A pos that is 90% filled is three very different situations, and only one is a problem:

| Number | Meaning | Chase it? |
| --- | --- | --- |
| `kosong` | those regu have not reached the pos yet | no — the normal state all day |
| `sebagian` | the row is half filled | yes — almost always a transcription from a photo that got cut off |
| **`hilang`** | regu **already closed out** and still has no complete score there | **yes** — they certainly passed the pos |

Only `hilang` turns a card red, and it is anchored on **closing** rather than on a guess about how far each regu has walked. That is what makes it trustworthy.

The denominator is regu whose kloter has **departed**, not all regu — nobody can be scored before they start, and counting them makes every pos look red all morning until the panel stops being read.

Each card also carries `terakhir_masuk`. **This is the real "not syncing" detector:** if four pos keep submitting and one goes quiet for 30 minutes, the broken thing is that pos's connection or laptop — visible hours before the completeness numbers move, since those only shift once regu finish.

Tapping a card filters the table to the regu incomplete at that pos, computed from the `nilai` already in hand — no extra request.

**Operator pos may open this panel**, their own pos only. Unlike `v_rekap_penuh` their numbers are honest here, because RLS already lets them read all of their own pos' `nilai_mentah` — and "is my sheet complete?" is their question.

### 2 · No "Semua" filter

The four golongan are judged separately (`alur-lomba.md` 2.3), so one list containing all of them shows rank 1 four times and puts numbers side by side that never competed against each other. Rekap is now always exactly one golongan, defaulting to Penegak PA.

## Why

Without this, "data hilang" is only discovered when someone notices a blank cell while scrolling a 38-column table — or after the results are announced. The three-way split is what makes the panel worth glancing at rather than a number that is always short and therefore always ignored.

## Notes

- `tests/sql/11_kelengkapan_pos.sql` recomputes `lengkap` and `hilang` from `nilai_mentah` independently and asserts the panel matches, checks `lengkap + sebagian + kosong = regu_total` for every pos, and pins that an operator pos sees exactly one row — their own.
- `berapaLalu()` moved from inside `layarInputPos` to `util.js`; the panel needs the same phrasing, and two copies of "23 menit lalu" is how they drift apart.
- The Golongan column is now constant within a view. Left in place because it is in the panitia's reference sheet — say the word and I will drop it, it is one column of 38.
- Card counts span all golongan while the table shows one; the screen says so explicitly when the pos filter is on.

**Migration `0028` must be applied before merge** — the panel calls a view that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)