### PR TITLE
feat: fade a skeleton in instead of printing "Memuat…", and ico-nify Segarkan

### DIFF
--- a/live/daftar.html
+++ b/live/daftar.html
@@ -16,7 +16,16 @@
   </header>
 
   <main class="isi" id="layar" aria-live="polite">
-    <p>Memuat…</p>
+    <!-- Rangka yang sama dengan kartuMemuat() di js/util.js. Ditulis tangan
+         di sini karena ini isi SEBELUM JavaScript jalan — dan justru di
+         halaman inilah jedanya paling terasa: pendaftar membukanya dari
+         jaringan seluler, sekali, tanpa apa pun tersimpan di cache. -->
+    <div class="card memuat-rangka" aria-busy="true">
+      <span class="visually-hidden">Memuat…</span>
+      <div class="memuat-baris" style="width:92%"></div>
+      <div class="memuat-baris" style="width:74%"></div>
+      <div class="memuat-baris" style="width:86%"></div>
+    </div>
   </main>
 
   <script src="config.js"></script>

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -16,7 +16,8 @@
    ========================================================================== */
 
 import { daftarSekolah, kirimPendaftaran, infoEdisi, ErrorApi } from "./api.js";
-import { esc, h, html, rupiah, notif, kartuGagalMuat } from "./util.js";
+import { esc, h, html, rupiah, notif, kartuGagalMuat,
+         kartuMemuat } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN = [
@@ -594,7 +595,9 @@ function sukses(hasil) {
 /* ---------------- mulai ---------------- */
 
 async function mulai() {
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  // Rangka yang sama dengan layar panitia — daftar.html memang memuat
+  // style.css yang sama, jadi tidak ada gaya kedua yang perlu dijaga.
+  LAYAR.replaceChildren(h(kartuMemuat(4)));
   try {
     [SEKOLAH, EDISI] = await Promise.all([daftarSekolah(), infoEdisi()]);
   } catch (e) {

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -79,6 +79,32 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
+/** Rangka abu-abu yang berdenyut, menggantikan tulisan "Memuat…".
+ *
+ *  YANG PALING MENENTUKAN DI SINI BUKAN BENTUKNYA, MELAINKAN JEDANYA.
+ *
+ *  Sebagian besar layar meja terisi di bawah 200 ms. Penanda muat yang tampil
+ *  seketika karena itu lebih sering terlihat sebagai KEDIPAN — muncul dan
+ *  hilang sebelum sempat dibaca — dan kedipan terasa seperti layar yang
+ *  tersendat, bukan layar yang cepat. Maka rangka ini punya
+ *  `animation-delay` 180 ms: kalau datanya keburu datang, ia tidak pernah
+ *  terlihat sama sekali. Yang melihatnya hanya orang yang memang menunggu.
+ *
+ *  Lebar tiap batang sengaja berbeda-beda. Batang yang sama panjang terbaca
+ *  sebagai bar progres yang macet; yang tidak rata terbaca sebagai teks yang
+ *  belum datang, dan itu memang yang sedang terjadi.
+ *
+ *  `aria-busy` + satu baris tersembunyi menjaga pembaca layar tetap
+ *  mendapat kabar — bagi mereka animasi tidak berarti apa-apa. */
+export function kartuMemuat(baris = 5) {
+  const lebar = [92, 74, 86, 63, 90, 70, 82];
+  return `<div class="card memuat-rangka" aria-busy="true" aria-live="polite">
+    <span class="visually-hidden">Memuat…</span>
+    ${Array.from({ length: baris }, (_, i) =>
+      `<div class="memuat-baris" style="width:${lebar[i % lebar.length]}%"></div>`).join("")}
+  </div>`;
+}
+
 /** "barusan" · "23 menit lalu" · "2 jam lalu".
  *
  *  Umur sebuah cap, bukan jamnya. Dipakai berdampingan dengan `jamMenit`,

--- a/live/style.css
+++ b/live/style.css
@@ -1561,3 +1561,44 @@ input.small-input { text-align: center; }
    kartunya kuning, jadi ia harus ikut terlihat kuning — kalau tidak, warna
    kartunya jadi teka-teki. */
 .lengkap-diam { color: var(--kuning); font-weight: 700; }
+
+/* ---------------------------------------------------------------------------
+   RANGKA MUAT (kartuMemuat() di js/util.js)
+
+   Menggantikan tulisan "Memuat…". Yang paling menentukan bukan bentuknya
+   melainkan JEDANYA: sebagian besar layar terisi di bawah 200 ms, jadi
+   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
+   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat.
+   `animation-delay` 180 ms membuatnya tidak pernah muncul untuk muat yang
+   cepat; yang melihatnya hanya orang yang memang menunggu.
+   ------------------------------------------------------------------------- */
+@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
+@keyframes hrcd-kilau  { from { background-position: 100% 0 } to { background-position: -100% 0 } }
+
+.memuat-rangka { animation: hrcd-muncul .28s ease-out .18s both; }
+
+.memuat-baris {
+  height: 15px; border-radius: 8px; margin: .6rem 0;
+  background: linear-gradient(90deg,
+    var(--garis) 0%, var(--kertas) 45%, var(--garis) 90%);
+  background-size: 220% 100%;
+  animation: hrcd-kilau 1.5s linear infinite;
+}
+.memuat-baris:first-of-type { height: 20px; margin-top: .2rem; }
+
+/* Gerakan dimatikan, jedanya TIDAK. Durasi hampir nol menggantikan fade:
+   rangkanya tetap baru muncul setelah 180 ms, hanya tanpa animasi apa pun —
+   jadi muat yang cepat tetap tidak berkedip bagi yang menolak gerakan. */
+@media (prefers-reduced-motion: reduce) {
+  .memuat-rangka { animation: hrcd-muncul .01s linear .18s both; }
+  .memuat-baris  { animation: none; background: var(--garis); }
+}
+
+/* Ikon di dalam table-toolbar berdiri di antara kontrol setinggi 40-44px.
+   Ukuran .icon-button-inline (32px) dibuat untuk menyelip di dalam sel tabel,
+   dan di sini ia terlihat tersesat — sasaran sentuhnya pun jadi yang terkecil
+   di seluruh baris itu. Warnanya tetap warna inline: hover putih milik
+   .icon-button dibuat untuk header hijau, tidak terlihat di atas kartu. */
+.table-toolbar .icon-button-inline {
+  min-width: 40px; min-height: 40px; font-size: 1.25rem;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
   </header>
 
   <main class="isi" id="layar" aria-live="polite">
-    <p>Memuat…</p>
+    <div class="card memuat-rangka" aria-busy="true"><span class="visually-hidden">Memuat…</span><div class="memuat-baris" style="width:92%"></div><div class="memuat-baris" style="width:74%"></div><div class="memuat-baris" style="width:86%"></div></div>
   </main>
 
   <!-- Menu bawah khusus HP. Panitia memakai sistem ini sambil berdiri di

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -23,7 +23,7 @@ import {
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
-         berapaLalu } from "./util.js";
+         berapaLalu, kartuMemuat } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -152,7 +152,7 @@ function layarLogin(pesan) {
 async function layarHome() {
   pasangKepala("Home");
   const peran = sesi().peran;
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   // Operator pos tidak berhak atas layar meja — RLS akan mengosongkan
   // datanya dan itu tampak seperti "tidak ada antrean" (temuan review).
@@ -357,7 +357,7 @@ const reguAktif = (b) => (b.regu || []).filter(r => !r.is_cancelled);
 async function layarPembayaran() {
   if (!EDISI) { layarButuhEdisi("Meja Pembayaran"); return; }
   pasangKepala("Meja Pembayaran", true);
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   const layarIni = location.hash;
   let semua;
@@ -715,7 +715,7 @@ function cetakKwitansi(daftar) {
 async function layarDaftarUlang() {
   if (!EDISI) { layarButuhEdisi("Meja Daftar Ulang"); return; }
   pasangKepala("Meja Daftar Ulang", true);
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   const layarIni = location.hash;
   let semua;
@@ -1011,7 +1011,7 @@ async function layarDaftarUlang() {
 async function layarKeberangkatan() {
   if (!EDISI) { layarButuhEdisi("Keberangkatan"); return; }
   pasangKepala("Keberangkatan", true);
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   const layarIni = location.hash;
   let papan, opsi;
@@ -1376,7 +1376,7 @@ async function layarKeberangkatan() {
 
 async function layarCetakKloter() {
   pasangKepala("Cetak Daftar Kloter");
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   let baris;
   try { baris = await daftarKloter(); }
@@ -2058,7 +2058,7 @@ async function layarInputPos() {
   }
 
   pasangKepala("Input Nilai Pos", "lembar");
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   const layarIni = location.hash;
   let semuaPos;
@@ -2638,7 +2638,7 @@ async function layarRekap() {
   }
 
   pasangKepala("Rekapitulasi", "lembar");
-  LAYAR.replaceChildren(h(`<p>Memuat…</p>`));
+  LAYAR.replaceChildren(h(kartuMemuat()));
 
   const layarIni = location.hash;
   let pos, wahana, baris, kelengkapan;
@@ -2842,8 +2842,13 @@ async function layarRekap() {
                       aria-pressed="${golongan === g}">${esc(NAMA_GOLONGAN[g])}</button>`).join("")}
           </div>
           <span class="table-count">${esc(String(tampil.length))} regu</span>
-          <button class="button button-small button-secondary" id="rekap-segarkan"
-                  type="button">Segarkan</button>
+          <!-- Ikon, bukan kata: tombol ini berdiri di deretan yang sudah penuh
+               saringan golongan, dan "Segarkan" memakan lebar yang lebih
+               berguna untuk kotak cari. Judul dan aria-label tetap berbunyi
+               lengkap — yang hilang hanya tulisannya, bukan artinya. -->
+          <button class="icon-button icon-button-inline" id="rekap-segarkan"
+                  type="button" aria-label="Segarkan sekarang"
+                  title="Segarkan sekarang (otomatis tiap 20 detik)">↻</button>
         </div>
         <p class="description">Layar ini hanya menampilkan. Nilai diubah di
            <a href="#/pos">Input Nilai Pos</a>, dan angkanya muncul di sini
@@ -2889,7 +2894,8 @@ async function layarRekap() {
       const baru = document.getElementById("rekap-cari");
       if (baru) { baru.focus(); baru.setSelectionRange(posisi, posisi); }
     });
-    document.getElementById("rekap-segarkan").addEventListener("click", segarkan);
+    document.getElementById("rekap-segarkan")
+      .addEventListener("click", () => segarkan(true));
   }
 
   /* Menyegarkan sendiri tiap 20 detik. Inilah yang membuat papan ini terasa

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -79,6 +79,32 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
+/** Rangka abu-abu yang berdenyut, menggantikan tulisan "Memuat…".
+ *
+ *  YANG PALING MENENTUKAN DI SINI BUKAN BENTUKNYA, MELAINKAN JEDANYA.
+ *
+ *  Sebagian besar layar meja terisi di bawah 200 ms. Penanda muat yang tampil
+ *  seketika karena itu lebih sering terlihat sebagai KEDIPAN — muncul dan
+ *  hilang sebelum sempat dibaca — dan kedipan terasa seperti layar yang
+ *  tersendat, bukan layar yang cepat. Maka rangka ini punya
+ *  `animation-delay` 180 ms: kalau datanya keburu datang, ia tidak pernah
+ *  terlihat sama sekali. Yang melihatnya hanya orang yang memang menunggu.
+ *
+ *  Lebar tiap batang sengaja berbeda-beda. Batang yang sama panjang terbaca
+ *  sebagai bar progres yang macet; yang tidak rata terbaca sebagai teks yang
+ *  belum datang, dan itu memang yang sedang terjadi.
+ *
+ *  `aria-busy` + satu baris tersembunyi menjaga pembaca layar tetap
+ *  mendapat kabar — bagi mereka animasi tidak berarti apa-apa. */
+export function kartuMemuat(baris = 5) {
+  const lebar = [92, 74, 86, 63, 90, 70, 82];
+  return `<div class="card memuat-rangka" aria-busy="true" aria-live="polite">
+    <span class="visually-hidden">Memuat…</span>
+    ${Array.from({ length: baris }, (_, i) =>
+      `<div class="memuat-baris" style="width:${lebar[i % lebar.length]}%"></div>`).join("")}
+  </div>`;
+}
+
 /** "barusan" · "23 menit lalu" · "2 jam lalu".
  *
  *  Umur sebuah cap, bukan jamnya. Dipakai berdampingan dengan `jamMenit`,

--- a/web/style.css
+++ b/web/style.css
@@ -1561,3 +1561,44 @@ input.small-input { text-align: center; }
    kartunya kuning, jadi ia harus ikut terlihat kuning — kalau tidak, warna
    kartunya jadi teka-teki. */
 .lengkap-diam { color: var(--kuning); font-weight: 700; }
+
+/* ---------------------------------------------------------------------------
+   RANGKA MUAT (kartuMemuat() di js/util.js)
+
+   Menggantikan tulisan "Memuat…". Yang paling menentukan bukan bentuknya
+   melainkan JEDANYA: sebagian besar layar terisi di bawah 200 ms, jadi
+   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
+   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat.
+   `animation-delay` 180 ms membuatnya tidak pernah muncul untuk muat yang
+   cepat; yang melihatnya hanya orang yang memang menunggu.
+   ------------------------------------------------------------------------- */
+@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
+@keyframes hrcd-kilau  { from { background-position: 100% 0 } to { background-position: -100% 0 } }
+
+.memuat-rangka { animation: hrcd-muncul .28s ease-out .18s both; }
+
+.memuat-baris {
+  height: 15px; border-radius: 8px; margin: .6rem 0;
+  background: linear-gradient(90deg,
+    var(--garis) 0%, var(--kertas) 45%, var(--garis) 90%);
+  background-size: 220% 100%;
+  animation: hrcd-kilau 1.5s linear infinite;
+}
+.memuat-baris:first-of-type { height: 20px; margin-top: .2rem; }
+
+/* Gerakan dimatikan, jedanya TIDAK. Durasi hampir nol menggantikan fade:
+   rangkanya tetap baru muncul setelah 180 ms, hanya tanpa animasi apa pun —
+   jadi muat yang cepat tetap tidak berkedip bagi yang menolak gerakan. */
+@media (prefers-reduced-motion: reduce) {
+  .memuat-rangka { animation: hrcd-muncul .01s linear .18s both; }
+  .memuat-baris  { animation: none; background: var(--garis); }
+}
+
+/* Ikon di dalam table-toolbar berdiri di antara kontrol setinggi 40-44px.
+   Ukuran .icon-button-inline (32px) dibuat untuk menyelip di dalam sel tabel,
+   dan di sini ia terlihat tersesat — sasaran sentuhnya pun jadi yang terkecil
+   di seluruh baris itu. Warnanya tetap warna inline: hover putih milik
+   .icon-button dibuat untuk header hijau, tidak terlihat di atas kartu. */
+.table-toolbar .icon-button-inline {
+  min-width: 40px; min-height: 40px; font-size: 1.25rem;
+}


### PR DESCRIPTION
## What

**Skeleton loading.** Every screen printed a bare `Memuat…` the instant it started fetching. The problem was never the wording — it was the timing. Most desk screens fill in under 200 ms, so the marker was usually seen as a **blink**: appearing and vanishing before it could be read, which feels like a screen that stutters rather than one that is fast.

`kartuMemuat()` draws grey bars and gives them `animation-delay: .18s`. **If the data arrives first, the skeleton is never seen at all** — the only people who see it are the ones actually waiting.

Bar widths deliberately vary: equal bars read as a stuck progress bar, ragged ones read as text that has not arrived yet, which is what is happening.

Applied to all seven panitia screens, the public registration form, and both pre-JavaScript shells (`web/index.html`, `live/daftar.html`) — the shells matter most on the registration page, opened once over mobile data with nothing cached.

Reduced-motion keeps the **delay** and drops the movement: a near-zero duration replaces the fade, so fast loads still do not blink for people who asked for less animation.

**Refresh icon.** `Segarkan` → `↻`. It stands in a row already full of golongan filters, and the word ate width the search box uses better. `title` and `aria-label` still say it in full, so only the lettering went. Sized up inside `.table-toolbar`: `.icon-button-inline`'s 32 px is meant for slipping inside a table cell, and here it was both visually lost and the smallest touch target in the row.

## Why

A loading indicator that is mostly seen as a flicker is worse than none — it draws the eye to a state the user does not care about, on the screens that are already fast. Delaying it inverts that: the indicator now only ever appears when it is telling the truth.

## Notes

`aria-busy` plus one visually-hidden "Memuat…" keeps screen readers informed; the animation means nothing to them.

Verified by rendering the skeleton and the toolbar against the real stylesheet at 1568 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)