### PR TITLE
feat: a real refresh control — icon, last-refresh stamp, and it spins

### DIFF
--- a/live/daftar.html
+++ b/live/daftar.html
@@ -16,15 +16,13 @@
   </header>
 
   <main class="isi" id="layar" aria-live="polite">
-    <!-- Rangka yang sama dengan kartuMemuat() di js/util.js. Ditulis tangan
-         di sini karena ini isi SEBELUM JavaScript jalan — dan justru di
-         halaman inilah jedanya paling terasa: pendaftar membukanya dari
-         jaringan seluler, sekali, tanpa apa pun tersimpan di cache. -->
-    <div class="card memuat-rangka" aria-busy="true">
+    <!-- Cincin yang sama dengan pemuat() di js/util.js. Ditulis tangan di
+         sini karena ini isi SEBELUM JavaScript jalan — dan justru di halaman
+         inilah jedanya paling terasa: pendaftar membukanya dari jaringan
+         seluler, sekali, tanpa apa pun tersimpan di cache. -->
+    <div class="pemuat" role="status">
+      <span class="pemuat-cincin" aria-hidden="true"></span>
       <span class="visually-hidden">Memuat…</span>
-      <div class="memuat-baris" style="width:92%"></div>
-      <div class="memuat-baris" style="width:74%"></div>
-      <div class="memuat-baris" style="width:86%"></div>
     </div>
   </main>
 

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -17,7 +17,7 @@
 
 import { daftarSekolah, kirimPendaftaran, infoEdisi, ErrorApi } from "./api.js";
 import { esc, h, html, rupiah, notif, kartuGagalMuat,
-         kartuMemuat } from "./util.js";
+         pemuat } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN = [
@@ -597,7 +597,7 @@ function sukses(hasil) {
 async function mulai() {
   // Rangka yang sama dengan layar panitia — daftar.html memang memuat
   // style.css yang sama, jadi tidak ada gaya kedua yang perlu dijaga.
-  LAYAR.replaceChildren(h(kartuMemuat(4)));
+  LAYAR.replaceChildren(h(pemuat()));
   try {
     [SEKOLAH, EDISI] = await Promise.all([daftarSekolah(), infoEdisi()]);
   } catch (e) {

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -79,31 +79,46 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
-/** Rangka abu-abu yang berdenyut, menggantikan tulisan "Memuat…".
+/** Cincin berputar di tengah layar, menggantikan tulisan "Memuat…".
  *
  *  YANG PALING MENENTUKAN DI SINI BUKAN BENTUKNYA, MELAINKAN JEDANYA.
  *
  *  Sebagian besar layar meja terisi di bawah 200 ms. Penanda muat yang tampil
  *  seketika karena itu lebih sering terlihat sebagai KEDIPAN — muncul dan
  *  hilang sebelum sempat dibaca — dan kedipan terasa seperti layar yang
- *  tersendat, bukan layar yang cepat. Maka rangka ini punya
+ *  tersendat, bukan layar yang cepat. Maka cincin ini punya
  *  `animation-delay` 180 ms: kalau datanya keburu datang, ia tidak pernah
  *  terlihat sama sekali. Yang melihatnya hanya orang yang memang menunggu.
  *
- *  Lebar tiap batang sengaja berbeda-beda. Batang yang sama panjang terbaca
- *  sebagai bar progres yang macet; yang tidak rata terbaca sebagai teks yang
- *  belum datang, dan itu memang yang sedang terjadi.
- *
- *  `aria-busy` + satu baris tersembunyi menjaga pembaca layar tetap
- *  mendapat kabar — bagi mereka animasi tidak berarti apa-apa. */
-export function kartuMemuat(baris = 5) {
-  const lebar = [92, 74, 86, 63, 90, 70, 82];
-  return `<div class="card memuat-rangka" aria-busy="true" aria-live="polite">
-    <span class="visually-hidden">Memuat…</span>
-    ${Array.from({ length: baris }, (_, i) =>
-      `<div class="memuat-baris" style="width:${lebar[i % lebar.length]}%"></div>`).join("")}
+ *  `role="status"` + satu baris tersembunyi menjaga pembaca layar tetap
+ *  mendapat kabar — bagi mereka perputaran tidak berarti apa-apa. */
+export function pemuat(teks = "Memuat…") {
+  return `<div class="pemuat" role="status" aria-live="polite">
+    <span class="pemuat-cincin" aria-hidden="true"></span>
+    <span class="visually-hidden">${esc(teks)}</span>
   </div>`;
 }
+
+/** Ikon refresh — dua panah melingkar, sama seperti yang dipakai dashboard
+ *  pada umumnya.
+ *
+ *  SVG, bukan huruf Unicode dan bukan emoji, dan itu keputusan sadar: `↻`
+ *  tampil berbeda-beda tebal di tiap sistem dan hilang sama sekali di
+ *  sebagian font Android, sedangkan `🔄` datang dengan warnanya sendiri yang
+ *  bertabrakan dengan deretan tombol abu-abu di sekitarnya. Yang ini
+ *  mengikuti `currentColor`, jadi ia mewarisi warna tombolnya — termasuk saat
+ *  tombolnya dipudarkan sedang berputar.
+ *
+ *  Tanpa ukuran tetap: mengikuti `font-size` tombolnya lewat `1em`. */
+export const ikonRefresh = `
+  <svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"
+       aria-hidden="true" focusable="false">
+    <path d="M21 12a9 9 0 0 1-9 9 9 9 0 0 1-7.4-3.9"/>
+    <path d="M3 12a9 9 0 0 1 9-9 9 9 0 0 1 7.4 3.9"/>
+    <polyline points="19.6 2.6 19.6 7 15.2 7"/>
+    <polyline points="4.4 21.4 4.4 17 8.8 17"/>
+  </svg>`;
 
 /** "barusan" · "23 menit lalu" · "2 jam lalu".
  *

--- a/live/style.css
+++ b/live/style.css
@@ -1562,38 +1562,6 @@ input.small-input { text-align: center; }
    kartunya jadi teka-teki. */
 .lengkap-diam { color: var(--kuning); font-weight: 700; }
 
-/* ---------------------------------------------------------------------------
-   RANGKA MUAT (kartuMemuat() di js/util.js)
-
-   Menggantikan tulisan "Memuat…". Yang paling menentukan bukan bentuknya
-   melainkan JEDANYA: sebagian besar layar terisi di bawah 200 ms, jadi
-   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
-   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat.
-   `animation-delay` 180 ms membuatnya tidak pernah muncul untuk muat yang
-   cepat; yang melihatnya hanya orang yang memang menunggu.
-   ------------------------------------------------------------------------- */
-@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
-@keyframes hrcd-kilau  { from { background-position: 100% 0 } to { background-position: -100% 0 } }
-
-.memuat-rangka { animation: hrcd-muncul .28s ease-out .18s both; }
-
-.memuat-baris {
-  height: 15px; border-radius: 8px; margin: .6rem 0;
-  background: linear-gradient(90deg,
-    var(--garis) 0%, var(--kertas) 45%, var(--garis) 90%);
-  background-size: 220% 100%;
-  animation: hrcd-kilau 1.5s linear infinite;
-}
-.memuat-baris:first-of-type { height: 20px; margin-top: .2rem; }
-
-/* Gerakan dimatikan, jedanya TIDAK. Durasi hampir nol menggantikan fade:
-   rangkanya tetap baru muncul setelah 180 ms, hanya tanpa animasi apa pun —
-   jadi muat yang cepat tetap tidak berkedip bagi yang menolak gerakan. */
-@media (prefers-reduced-motion: reduce) {
-  .memuat-rangka { animation: hrcd-muncul .01s linear .18s both; }
-  .memuat-baris  { animation: none; background: var(--garis); }
-}
-
 /* Ikon di dalam table-toolbar berdiri di antara kontrol setinggi 40-44px.
    Ukuran .icon-button-inline (32px) dibuat untuk menyelip di dalam sel tabel,
    dan di sini ia terlihat tersesat — sasaran sentuhnya pun jadi yang terkecil
@@ -1601,4 +1569,64 @@ input.small-input { text-align: center; }
    .icon-button dibuat untuk header hijau, tidak terlihat di atas kartu. */
 .table-toolbar .icon-button-inline {
   min-width: 40px; min-height: 40px; font-size: 1.25rem;
+}
+
+/* ---------------------------------------------------------------------------
+   PEMUAT (pemuat() di js/util.js) DAN TOMBOL SEGARKAN
+
+   Cincin berputar di tengah layar, dengan JEDA 180 ms sebelum ia muncul.
+   Jedanya yang penting: sebagian besar layar terisi di bawah 200 ms, jadi
+   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
+   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat. Yang
+   melihat cincin ini hanya orang yang memang menunggu.
+   ------------------------------------------------------------------------- */
+@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
+@keyframes hrcd-putar  { to { transform: rotate(360deg) } }
+
+.pemuat {
+  display: flex; align-items: center; justify-content: center;
+  padding: 3.5rem 1rem;
+  animation: hrcd-muncul .28s ease-out .18s both;
+}
+.pemuat-cincin {
+  width: 36px; height: 36px; border-radius: 50%;
+  border: 3px solid var(--garis);
+  border-top-color: var(--utama);
+  animation: hrcd-putar .8s linear infinite;
+}
+
+/* Tombol Refresh saat ditekan. TANPA ini tombolnya terasa mati: datanya
+   sering kembali dalam puluhan milidetik, tidak ada satu pun angka yang
+   berubah, dan orang yang menekan tidak punya cara tahu bahwa sesuatu
+   memang terjadi. Yang berputar ikonnya sendiri — ↻ memang sudah bentuk
+   lingkaran, jadi tidak perlu penanda kedua. */
+.icon-button.berputar {
+  animation: hrcd-putar .7s linear infinite;
+  opacity: .65; cursor: default;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Jedanya TETAP, fade-nya yang hilang — muat cepat tetap tidak berkedip. */
+  .pemuat { animation: hrcd-muncul .01s linear .18s both; }
+  /* Perputaran TIDAK dimatikan: di sini gerakan itulah seluruh maknanya,
+     dan cincin diam sama saja dengan tidak ada penanda. Dipelankan saja. */
+  .pemuat-cincin        { animation-duration: 2.2s; }
+  .icon-button.berputar { animation-duration: 1.8s; }
+}
+
+/* Ikon SVG di dalam tombol: mengikuti font-size tombolnya, bukan ukuran
+   tetap, supaya satu ikon melayani tombol besar dan kecil sekaligus. */
+.icon-button .ikon { width: 1em; height: 1em; display: block; }
+
+/* Cap "Refresh terakhir" mendahului tombolnya. Di layar sempit ia yang
+   pertama dibuang — jamnya berguna, tapi tombolnya yang harus selalu ada. */
+.refresh-cap { font-variant-numeric: tabular-nums; }
+@media (max-width: 640px) { .refresh-cap { display: none; } }
+
+/* Jumlah baris, cap refresh, dan tombolnya berjalan bersama. Sebagai anak
+   lepas dari .table-toolbar, tombol itu jatuh sendirian ke baris baru begitu
+   deretan saringan penuh — terpisah dari jam yang menerangkannya. */
+.toolbar-kanan {
+  display: flex; align-items: center; gap: .5rem;
+  margin-left: auto; flex-wrap: nowrap;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
   </header>
 
   <main class="isi" id="layar" aria-live="polite">
-    <div class="card memuat-rangka" aria-busy="true"><span class="visually-hidden">Memuat…</span><div class="memuat-baris" style="width:92%"></div><div class="memuat-baris" style="width:74%"></div><div class="memuat-baris" style="width:86%"></div></div>
+    <div class="pemuat" role="status"><span class="pemuat-cincin" aria-hidden="true"></span><span class="visually-hidden">Memuat…</span></div>
   </main>
 
   <!-- Menu bawah khusus HP. Panitia memakai sistem ini sambil berdiri di

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -23,7 +23,7 @@ import {
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
-         berapaLalu, kartuMemuat } from "./util.js";
+         berapaLalu, pemuat, ikonRefresh } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -152,7 +152,7 @@ function layarLogin(pesan) {
 async function layarHome() {
   pasangKepala("Home");
   const peran = sesi().peran;
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   // Operator pos tidak berhak atas layar meja — RLS akan mengosongkan
   // datanya dan itu tampak seperti "tidak ada antrean" (temuan review).
@@ -357,7 +357,7 @@ const reguAktif = (b) => (b.regu || []).filter(r => !r.is_cancelled);
 async function layarPembayaran() {
   if (!EDISI) { layarButuhEdisi("Meja Pembayaran"); return; }
   pasangKepala("Meja Pembayaran", true);
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
   let semua;
@@ -715,7 +715,7 @@ function cetakKwitansi(daftar) {
 async function layarDaftarUlang() {
   if (!EDISI) { layarButuhEdisi("Meja Daftar Ulang"); return; }
   pasangKepala("Meja Daftar Ulang", true);
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
   let semua;
@@ -1011,7 +1011,7 @@ async function layarDaftarUlang() {
 async function layarKeberangkatan() {
   if (!EDISI) { layarButuhEdisi("Keberangkatan"); return; }
   pasangKepala("Keberangkatan", true);
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
   let papan, opsi;
@@ -1376,7 +1376,7 @@ async function layarKeberangkatan() {
 
 async function layarCetakKloter() {
   pasangKepala("Cetak Daftar Kloter");
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   let baris;
   try { baris = await daftarKloter(); }
@@ -2058,7 +2058,7 @@ async function layarInputPos() {
   }
 
   pasangKepala("Input Nilai Pos", "lembar");
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
   let semuaPos;
@@ -2638,7 +2638,7 @@ async function layarRekap() {
   }
 
   pasangKepala("Rekapitulasi", "lembar");
-  LAYAR.replaceChildren(h(kartuMemuat()));
+  LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
   let pos, wahana, baris, kelengkapan;
@@ -2667,6 +2667,7 @@ async function layarRekap() {
   let golongan = URUTAN_GOLONGAN[0];
   let cari = "";
   let posBelum = null;    // nomor pos yang sedang disaring "belum lengkap"
+  let jamRefresh = new Date();
   let jeda = null;
 
   /** Berapa komponen pos ini yang sudah terisi untuk satu regu. Dihitung dari
@@ -2841,14 +2842,26 @@ async function layarRekap() {
               <button type="button" class="option option-small" data-gol="${g}"
                       aria-pressed="${golongan === g}">${esc(NAMA_GOLONGAN[g])}</button>`).join("")}
           </div>
-          <span class="table-count">${esc(String(tampil.length))} regu</span>
-          <!-- Ikon, bukan kata: tombol ini berdiri di deretan yang sudah penuh
-               saringan golongan, dan "Segarkan" memakan lebar yang lebih
-               berguna untuk kotak cari. Judul dan aria-label tetap berbunyi
-               lengkap — yang hilang hanya tulisannya, bukan artinya. -->
-          <button class="icon-button icon-button-inline" id="rekap-segarkan"
-                  type="button" aria-label="Segarkan sekarang"
-                  title="Segarkan sekarang (otomatis tiap 20 detik)">↻</button>
+          <!-- Ketiganya SATU kelompok, bukan tiga anak lepas dari toolbar.
+               Sebagai anak lepas, tombolnya jatuh sendirian ke baris baru
+               begitu deretan saringan penuh — terpisah dari jam yang
+               menerangkannya, dan terlihat seperti tombol nyasar. -->
+          <div class="toolbar-kanan">
+            <span class="table-count">${esc(String(tampil.length))} regu</span>
+            <!-- Cap waktunya BUKAN hiasan. Data ini sering kembali tanpa satu
+                 angka pun berubah, jadi tanpa jam yang bergerak, menekan
+                 tombol refresh terasa seperti menekan tombol mati. Jam inilah
+                 buktinya bahwa layar ini baru saja bertanya ke database. -->
+            <span class="table-count refresh-cap">Refresh terakhir
+              ${esc(jamMenit(jamRefresh))}</span>
+            <!-- Ikon, bukan kata: tombol ini berdiri di deretan yang sudah
+                 penuh saringan golongan, dan satu kata lagi memakan lebar
+                 yang lebih berguna untuk kotak cari. Judul dan aria-label
+                 tetap berbunyi lengkap — yang hilang hanya tulisannya. -->
+            <button class="icon-button icon-button-inline" id="rekap-refresh"
+                    type="button" aria-label="Refresh sekarang"
+                    title="Refresh sekarang (otomatis tiap 20 detik)">${ikonRefresh}</button>
+          </div>
         </div>
         <p class="description">Layar ini hanya menampilkan. Nilai diubah di
            <a href="#/pos">Input Nilai Pos</a>, dan angkanya muncul di sini
@@ -2894,8 +2907,8 @@ async function layarRekap() {
       const baru = document.getElementById("rekap-cari");
       if (baru) { baru.focus(); baru.setSelectionRange(posisi, posisi); }
     });
-    document.getElementById("rekap-segarkan")
-      .addEventListener("click", () => segarkan(true));
+    document.getElementById("rekap-refresh")
+      .addEventListener("click", () => refresh(true));
   }
 
   /* Menyegarkan sendiri tiap 20 detik. Inilah yang membuat papan ini terasa
@@ -2903,19 +2916,41 @@ async function layarRekap() {
      layar ini melihat angkanya masuk tanpa menekan apa pun.
      Jumlah pembacanya belasan, bukan ribuan seperti halaman peserta, jadi
      membaca langsung dari database di sini memang murah. */
-  async function segarkan() {
+  async function refresh(manual = false) {
     if (location.hash !== layarIni) return;
+    // Hanya klik yang diberi putaran. Segaran otomatis tiap 20 detik dibiarkan
+    // diam-diam: penanda yang berkedip sendiri tiap 20 detik sepanjang hari
+    // akan berhenti diperhatikan justru saat ia dibutuhkan.
+    const tombol = manual ? document.getElementById("rekap-refresh") : null;
+    if (tombol) { tombol.classList.add("berputar"); tombol.disabled = true; }
+    const mulai = Date.now();
     try {
       const [b, k] = await Promise.all([rekapPenuh(), kelengkapanPos()]);
       baris = b; kelengkapan = k;
-      if (location.hash === layarIni) gambar();
-    } catch { /* diamkan: percobaan berikutnya datang sendiri */ }
+      // Dipasang SETELAH datanya benar-benar sampai, bukan saat permintaan
+      // dikirim: yang dijanjikan cap ini "angka di layar ini seumur jam itu".
+      jamRefresh = new Date();
+      // Klik HARUS terasa dijawab. Datanya sering kembali dalam puluhan
+      // milidetik dan sering tidak mengubah satu angka pun — putaran yang
+      // berhenti seketika karena itu terbaca sebagai tombol yang tidak
+      // bekerja sama sekali. Setengah detik cukup untuk terlihat berputar.
+      if (manual) {
+        const sisa = 500 - (Date.now() - mulai);
+        if (sisa > 0) await new Promise(r => setTimeout(r, sisa));
+      }
+      if (location.hash === layarIni) gambar();   // menggambar ulang = putaran berhenti
+    } catch (e) {
+      if (tombol) { tombol.classList.remove("berputar"); tombol.disabled = false; }
+      // api.js sudah melewatkan pesannya lewat pesanRamah() sebelum melempar,
+      // jadi yang sampai di sini memang kalimat yang boleh dibaca panitia.
+      if (manual) notif(e.message, true);
+    }
   }
 
   gambar();
   jeda = setInterval(() => {
     if (location.hash !== layarIni) { clearInterval(jeda); return; }
-    if (!document.hidden) segarkan();
+    if (!document.hidden) refresh();
   }, 20000);
 }
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -79,31 +79,46 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
-/** Rangka abu-abu yang berdenyut, menggantikan tulisan "Memuat…".
+/** Cincin berputar di tengah layar, menggantikan tulisan "Memuat…".
  *
  *  YANG PALING MENENTUKAN DI SINI BUKAN BENTUKNYA, MELAINKAN JEDANYA.
  *
  *  Sebagian besar layar meja terisi di bawah 200 ms. Penanda muat yang tampil
  *  seketika karena itu lebih sering terlihat sebagai KEDIPAN — muncul dan
  *  hilang sebelum sempat dibaca — dan kedipan terasa seperti layar yang
- *  tersendat, bukan layar yang cepat. Maka rangka ini punya
+ *  tersendat, bukan layar yang cepat. Maka cincin ini punya
  *  `animation-delay` 180 ms: kalau datanya keburu datang, ia tidak pernah
  *  terlihat sama sekali. Yang melihatnya hanya orang yang memang menunggu.
  *
- *  Lebar tiap batang sengaja berbeda-beda. Batang yang sama panjang terbaca
- *  sebagai bar progres yang macet; yang tidak rata terbaca sebagai teks yang
- *  belum datang, dan itu memang yang sedang terjadi.
- *
- *  `aria-busy` + satu baris tersembunyi menjaga pembaca layar tetap
- *  mendapat kabar — bagi mereka animasi tidak berarti apa-apa. */
-export function kartuMemuat(baris = 5) {
-  const lebar = [92, 74, 86, 63, 90, 70, 82];
-  return `<div class="card memuat-rangka" aria-busy="true" aria-live="polite">
-    <span class="visually-hidden">Memuat…</span>
-    ${Array.from({ length: baris }, (_, i) =>
-      `<div class="memuat-baris" style="width:${lebar[i % lebar.length]}%"></div>`).join("")}
+ *  `role="status"` + satu baris tersembunyi menjaga pembaca layar tetap
+ *  mendapat kabar — bagi mereka perputaran tidak berarti apa-apa. */
+export function pemuat(teks = "Memuat…") {
+  return `<div class="pemuat" role="status" aria-live="polite">
+    <span class="pemuat-cincin" aria-hidden="true"></span>
+    <span class="visually-hidden">${esc(teks)}</span>
   </div>`;
 }
+
+/** Ikon refresh — dua panah melingkar, sama seperti yang dipakai dashboard
+ *  pada umumnya.
+ *
+ *  SVG, bukan huruf Unicode dan bukan emoji, dan itu keputusan sadar: `↻`
+ *  tampil berbeda-beda tebal di tiap sistem dan hilang sama sekali di
+ *  sebagian font Android, sedangkan `🔄` datang dengan warnanya sendiri yang
+ *  bertabrakan dengan deretan tombol abu-abu di sekitarnya. Yang ini
+ *  mengikuti `currentColor`, jadi ia mewarisi warna tombolnya — termasuk saat
+ *  tombolnya dipudarkan sedang berputar.
+ *
+ *  Tanpa ukuran tetap: mengikuti `font-size` tombolnya lewat `1em`. */
+export const ikonRefresh = `
+  <svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"
+       aria-hidden="true" focusable="false">
+    <path d="M21 12a9 9 0 0 1-9 9 9 9 0 0 1-7.4-3.9"/>
+    <path d="M3 12a9 9 0 0 1 9-9 9 9 0 0 1 7.4 3.9"/>
+    <polyline points="19.6 2.6 19.6 7 15.2 7"/>
+    <polyline points="4.4 21.4 4.4 17 8.8 17"/>
+  </svg>`;
 
 /** "barusan" · "23 menit lalu" · "2 jam lalu".
  *

--- a/web/style.css
+++ b/web/style.css
@@ -1562,38 +1562,6 @@ input.small-input { text-align: center; }
    kartunya jadi teka-teki. */
 .lengkap-diam { color: var(--kuning); font-weight: 700; }
 
-/* ---------------------------------------------------------------------------
-   RANGKA MUAT (kartuMemuat() di js/util.js)
-
-   Menggantikan tulisan "Memuat…". Yang paling menentukan bukan bentuknya
-   melainkan JEDANYA: sebagian besar layar terisi di bawah 200 ms, jadi
-   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
-   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat.
-   `animation-delay` 180 ms membuatnya tidak pernah muncul untuk muat yang
-   cepat; yang melihatnya hanya orang yang memang menunggu.
-   ------------------------------------------------------------------------- */
-@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
-@keyframes hrcd-kilau  { from { background-position: 100% 0 } to { background-position: -100% 0 } }
-
-.memuat-rangka { animation: hrcd-muncul .28s ease-out .18s both; }
-
-.memuat-baris {
-  height: 15px; border-radius: 8px; margin: .6rem 0;
-  background: linear-gradient(90deg,
-    var(--garis) 0%, var(--kertas) 45%, var(--garis) 90%);
-  background-size: 220% 100%;
-  animation: hrcd-kilau 1.5s linear infinite;
-}
-.memuat-baris:first-of-type { height: 20px; margin-top: .2rem; }
-
-/* Gerakan dimatikan, jedanya TIDAK. Durasi hampir nol menggantikan fade:
-   rangkanya tetap baru muncul setelah 180 ms, hanya tanpa animasi apa pun —
-   jadi muat yang cepat tetap tidak berkedip bagi yang menolak gerakan. */
-@media (prefers-reduced-motion: reduce) {
-  .memuat-rangka { animation: hrcd-muncul .01s linear .18s both; }
-  .memuat-baris  { animation: none; background: var(--garis); }
-}
-
 /* Ikon di dalam table-toolbar berdiri di antara kontrol setinggi 40-44px.
    Ukuran .icon-button-inline (32px) dibuat untuk menyelip di dalam sel tabel,
    dan di sini ia terlihat tersesat — sasaran sentuhnya pun jadi yang terkecil
@@ -1601,4 +1569,64 @@ input.small-input { text-align: center; }
    .icon-button dibuat untuk header hijau, tidak terlihat di atas kartu. */
 .table-toolbar .icon-button-inline {
   min-width: 40px; min-height: 40px; font-size: 1.25rem;
+}
+
+/* ---------------------------------------------------------------------------
+   PEMUAT (pemuat() di js/util.js) DAN TOMBOL SEGARKAN
+
+   Cincin berputar di tengah layar, dengan JEDA 180 ms sebelum ia muncul.
+   Jedanya yang penting: sebagian besar layar terisi di bawah 200 ms, jadi
+   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
+   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat. Yang
+   melihat cincin ini hanya orang yang memang menunggu.
+   ------------------------------------------------------------------------- */
+@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
+@keyframes hrcd-putar  { to { transform: rotate(360deg) } }
+
+.pemuat {
+  display: flex; align-items: center; justify-content: center;
+  padding: 3.5rem 1rem;
+  animation: hrcd-muncul .28s ease-out .18s both;
+}
+.pemuat-cincin {
+  width: 36px; height: 36px; border-radius: 50%;
+  border: 3px solid var(--garis);
+  border-top-color: var(--utama);
+  animation: hrcd-putar .8s linear infinite;
+}
+
+/* Tombol Refresh saat ditekan. TANPA ini tombolnya terasa mati: datanya
+   sering kembali dalam puluhan milidetik, tidak ada satu pun angka yang
+   berubah, dan orang yang menekan tidak punya cara tahu bahwa sesuatu
+   memang terjadi. Yang berputar ikonnya sendiri — ↻ memang sudah bentuk
+   lingkaran, jadi tidak perlu penanda kedua. */
+.icon-button.berputar {
+  animation: hrcd-putar .7s linear infinite;
+  opacity: .65; cursor: default;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Jedanya TETAP, fade-nya yang hilang — muat cepat tetap tidak berkedip. */
+  .pemuat { animation: hrcd-muncul .01s linear .18s both; }
+  /* Perputaran TIDAK dimatikan: di sini gerakan itulah seluruh maknanya,
+     dan cincin diam sama saja dengan tidak ada penanda. Dipelankan saja. */
+  .pemuat-cincin        { animation-duration: 2.2s; }
+  .icon-button.berputar { animation-duration: 1.8s; }
+}
+
+/* Ikon SVG di dalam tombol: mengikuti font-size tombolnya, bukan ukuran
+   tetap, supaya satu ikon melayani tombol besar dan kecil sekaligus. */
+.icon-button .ikon { width: 1em; height: 1em; display: block; }
+
+/* Cap "Refresh terakhir" mendahului tombolnya. Di layar sempit ia yang
+   pertama dibuang — jamnya berguna, tapi tombolnya yang harus selalu ada. */
+.refresh-cap { font-variant-numeric: tabular-nums; }
+@media (max-width: 640px) { .refresh-cap { display: none; } }
+
+/* Jumlah baris, cap refresh, dan tombolnya berjalan bersama. Sebagai anak
+   lepas dari .table-toolbar, tombol itu jatuh sendirian ke baris baru begitu
+   deretan saringan penuh — terpisah dari jam yang menerangkannya. */
+.toolbar-kanan {
+  display: flex; align-items: center; gap: .5rem;
+  margin-left: auto; flex-wrap: nowrap;
 }


### PR DESCRIPTION
## What

Three complaints with one cause: the control gave no evidence it had done anything.

| | Was | Now |
| --- | --- | --- |
| Clicking it | nothing visible | icon **spins**, held ≥500 ms so the click is always answered |
| Proof it ran | none | **"Refresh terakhir 16:17"** beside it |
| Loading state | grey skeleton bars | **rotating ring** |
| The word | "Segarkan" | **"Refresh"** — text, tooltip, aria-label, function name, element id |
| The icon | `↻` | inline SVG, two circular arrows |

**Why the click felt dead:** the data usually returns in tens of milliseconds and usually changes no number at all. A button that neither moves nor leaves a trace is indistinguishable from a broken one. The stamp is set **after** the data lands, not when the request goes out — what it promises is "the numbers you see are as of that minute". Auto-refresh every 20 s stays silent on purpose: a marker that blinks by itself all day stops being noticed exactly when it matters.

**Why the ring keeps the 180 ms delay:** most screens fill in under 200 ms, so a marker shown instantly is usually seen as a *blink* — and a blink reads as a screen that stutters rather than one that is fast. Only people actually waiting ever see it.

**Why SVG and not a glyph:** `↻` renders at wildly different weights across systems and is missing from some Android fonts; `🔄` arrives with its own colour, fighting the grey controls beside it. The SVG follows `currentColor`, so it inherits the button's colour — including while dimmed and spinning.

**Why the group wrapper:** left loose in `.table-toolbar`, the button dropped alone onto a second line once the filter chips filled the row, separated from the clock that explains it.

## Why

"Segarkan" for refresh is exactly the translation language rule 5 forbids — technical vocabulary stays English. Renaming the identifier and element id too, not just the label.

## Notes

Reduced-motion keeps the delay and drops the fade, but **not** the rotation: for a spinner the movement is the entire meaning, and a still ring is the same as no indicator. It is slowed instead.

Verified by rendering the ring, the idle button, and the spinning button against the real stylesheet, and by confirming all three toolbar items stay on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)