### PR TITLE
fix: show the spinner immediately, and put it in the middle of the screen

### DIFF
--- a/live/daftar.html
+++ b/live/daftar.html
@@ -18,7 +18,7 @@
   <main class="isi" id="layar" aria-live="polite">
     <!-- Cincin yang sama dengan pemuat() di js/util.js. Ditulis tangan di
          sini karena ini isi SEBELUM JavaScript jalan — dan justru di halaman
-         inilah jedanya paling terasa: pendaftar membukanya dari jaringan
+         inilah ia paling terasa: pendaftar membukanya dari jaringan
          seluler, sekali, tanpa apa pun tersimpan di cache. -->
     <div class="pemuat" role="status">
       <span class="pemuat-cincin" aria-hidden="true"></span>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -79,16 +79,17 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
-/** Cincin berputar di tengah layar, menggantikan tulisan "Memuat…".
+/** Cincin berputar di TENGAH layar, menggantikan tulisan "Memuat…".
  *
- *  YANG PALING MENENTUKAN DI SINI BUKAN BENTUKNYA, MELAINKAN JEDANYA.
+ *  Tampil SEKETIKA, tanpa jeda. Versi sebelumnya menahannya 180 ms supaya
+ *  muat yang cepat tidak berkedip; akibatnya layar terlihat kosong dulu
+ *  sebelum apa pun terjadi, dan diam itu justru terbaca sebagai macet.
+ *  Kedipan sesekali ternyata harga yang lebih murah daripada keraguan
+ *  "ini jalan atau tidak" pada tiap perpindahan layar.
  *
- *  Sebagian besar layar meja terisi di bawah 200 ms. Penanda muat yang tampil
- *  seketika karena itu lebih sering terlihat sebagai KEDIPAN — muncul dan
- *  hilang sebelum sempat dibaca — dan kedipan terasa seperti layar yang
- *  tersendat, bukan layar yang cepat. Maka cincin ini punya
- *  `animation-delay` 180 ms: kalau datanya keburu datang, ia tidak pernah
- *  terlihat sama sekali. Yang melihatnya hanya orang yang memang menunggu.
+ *  Letaknya di tengah, bukan menempel di bawah header — mata mencari
+ *  penanda muat di tempat isi halaman akan muncul, bukan di baris pertama.
+ *  Tingginya diatur `.pemuat` di style.css.
  *
  *  `role="status"` + satu baris tersembunyi menjaga pembaca layar tetap
  *  mendapat kabar — bagi mereka perputaran tidak berarti apa-apa. */

--- a/live/style.css
+++ b/live/style.css
@@ -1572,21 +1572,35 @@ input.small-input { text-align: center; }
 }
 
 /* ---------------------------------------------------------------------------
-   PEMUAT (pemuat() di js/util.js) DAN TOMBOL SEGARKAN
+   PEMUAT (pemuat() di js/util.js) DAN TOMBOL REFRESH
 
-   Cincin berputar di tengah layar, dengan JEDA 180 ms sebelum ia muncul.
-   Jedanya yang penting: sebagian besar layar terisi di bawah 200 ms, jadi
-   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
-   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat. Yang
-   melihat cincin ini hanya orang yang memang menunggu.
+   Cincin berputar di TENGAH layar, tampil SEKETIKA.
+
+   Sempat ditahan 180 ms supaya muat yang cepat tidak sempat berkedip.
+   Ditinggalkan: yang didapat justru layar kosong sesaat pada tiap
+   perpindahan, dan diam itu terbaca sebagai macet. Kedipan sesekali ternyata
+   harga yang lebih murah daripada keraguan "ini jalan atau tidak".
    ------------------------------------------------------------------------- */
-@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
 @keyframes hrcd-putar  { to { transform: rotate(360deg) } }
 
 .pemuat {
   display: flex; align-items: center; justify-content: center;
-  padding: 3.5rem 1rem;
-  animation: hrcd-muncul .28s ease-out .18s both;
+  /* Di TENGAH layar, bukan menempel di bawah header. Tanpa tinggi minimum,
+     satu cincin 36px di dalam wadah yang isinya belum ada akan berdiri di
+     baris paling atas — mata mencarinya di tengah, tempat isi halaman akan
+     muncul sebentar lagi.
+
+     10rem yang dipotong itu kepala halaman ditambah padding atas-bawah
+     `.isi`. Dengan begitu titik tengah kotak ini jatuh hampir persis di
+     tengah layar, dan totalnya tetap lebih pendek daripada satu layar —
+     jadi tidak ada scrollbar yang muncul lalu hilang lagi begitu isinya
+     datang, yang membuat seluruh halaman tersentak ke samping. */
+  min-height: calc(100vh - 10rem);
+  padding: 1rem;
+  /* TANPA jeda dan tanpa fade: penanda muat harus tampil seketika. Versi
+     sebelumnya menahannya 180 ms supaya muat yang cepat tidak berkedip, dan
+     akibatnya layar terlihat kosong dulu sebelum apa pun terjadi — diam yang
+     justru terbaca sebagai macet. */
 }
 .pemuat-cincin {
   width: 36px; height: 36px; border-radius: 50%;
@@ -1606,8 +1620,6 @@ input.small-input { text-align: center; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* Jedanya TETAP, fade-nya yang hilang — muat cepat tetap tidak berkedip. */
-  .pemuat { animation: hrcd-muncul .01s linear .18s both; }
   /* Perputaran TIDAK dimatikan: di sini gerakan itulah seluruh maknanya,
      dan cincin diam sama saja dengan tidak ada penanda. Dipelankan saja. */
   .pemuat-cincin        { animation-duration: 2.2s; }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -79,16 +79,17 @@ export function tanggalJam(t) {
   return `${tanggalPanjang(t)} ${jamMenit(t)}`;
 }
 
-/** Cincin berputar di tengah layar, menggantikan tulisan "Memuat…".
+/** Cincin berputar di TENGAH layar, menggantikan tulisan "Memuat…".
  *
- *  YANG PALING MENENTUKAN DI SINI BUKAN BENTUKNYA, MELAINKAN JEDANYA.
+ *  Tampil SEKETIKA, tanpa jeda. Versi sebelumnya menahannya 180 ms supaya
+ *  muat yang cepat tidak berkedip; akibatnya layar terlihat kosong dulu
+ *  sebelum apa pun terjadi, dan diam itu justru terbaca sebagai macet.
+ *  Kedipan sesekali ternyata harga yang lebih murah daripada keraguan
+ *  "ini jalan atau tidak" pada tiap perpindahan layar.
  *
- *  Sebagian besar layar meja terisi di bawah 200 ms. Penanda muat yang tampil
- *  seketika karena itu lebih sering terlihat sebagai KEDIPAN — muncul dan
- *  hilang sebelum sempat dibaca — dan kedipan terasa seperti layar yang
- *  tersendat, bukan layar yang cepat. Maka cincin ini punya
- *  `animation-delay` 180 ms: kalau datanya keburu datang, ia tidak pernah
- *  terlihat sama sekali. Yang melihatnya hanya orang yang memang menunggu.
+ *  Letaknya di tengah, bukan menempel di bawah header — mata mencari
+ *  penanda muat di tempat isi halaman akan muncul, bukan di baris pertama.
+ *  Tingginya diatur `.pemuat` di style.css.
  *
  *  `role="status"` + satu baris tersembunyi menjaga pembaca layar tetap
  *  mendapat kabar — bagi mereka perputaran tidak berarti apa-apa. */

--- a/web/style.css
+++ b/web/style.css
@@ -1572,21 +1572,35 @@ input.small-input { text-align: center; }
 }
 
 /* ---------------------------------------------------------------------------
-   PEMUAT (pemuat() di js/util.js) DAN TOMBOL SEGARKAN
+   PEMUAT (pemuat() di js/util.js) DAN TOMBOL REFRESH
 
-   Cincin berputar di tengah layar, dengan JEDA 180 ms sebelum ia muncul.
-   Jedanya yang penting: sebagian besar layar terisi di bawah 200 ms, jadi
-   penanda yang tampil seketika lebih sering terlihat sebagai kedipan — dan
-   kedipan terasa seperti layar yang tersendat, bukan layar yang cepat. Yang
-   melihat cincin ini hanya orang yang memang menunggu.
+   Cincin berputar di TENGAH layar, tampil SEKETIKA.
+
+   Sempat ditahan 180 ms supaya muat yang cepat tidak sempat berkedip.
+   Ditinggalkan: yang didapat justru layar kosong sesaat pada tiap
+   perpindahan, dan diam itu terbaca sebagai macet. Kedipan sesekali ternyata
+   harga yang lebih murah daripada keraguan "ini jalan atau tidak".
    ------------------------------------------------------------------------- */
-@keyframes hrcd-muncul { from { opacity: 0 } to { opacity: 1 } }
 @keyframes hrcd-putar  { to { transform: rotate(360deg) } }
 
 .pemuat {
   display: flex; align-items: center; justify-content: center;
-  padding: 3.5rem 1rem;
-  animation: hrcd-muncul .28s ease-out .18s both;
+  /* Di TENGAH layar, bukan menempel di bawah header. Tanpa tinggi minimum,
+     satu cincin 36px di dalam wadah yang isinya belum ada akan berdiri di
+     baris paling atas — mata mencarinya di tengah, tempat isi halaman akan
+     muncul sebentar lagi.
+
+     10rem yang dipotong itu kepala halaman ditambah padding atas-bawah
+     `.isi`. Dengan begitu titik tengah kotak ini jatuh hampir persis di
+     tengah layar, dan totalnya tetap lebih pendek daripada satu layar —
+     jadi tidak ada scrollbar yang muncul lalu hilang lagi begitu isinya
+     datang, yang membuat seluruh halaman tersentak ke samping. */
+  min-height: calc(100vh - 10rem);
+  padding: 1rem;
+  /* TANPA jeda dan tanpa fade: penanda muat harus tampil seketika. Versi
+     sebelumnya menahannya 180 ms supaya muat yang cepat tidak berkedip, dan
+     akibatnya layar terlihat kosong dulu sebelum apa pun terjadi — diam yang
+     justru terbaca sebagai macet. */
 }
 .pemuat-cincin {
   width: 36px; height: 36px; border-radius: 50%;
@@ -1606,8 +1620,6 @@ input.small-input { text-align: center; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* Jedanya TETAP, fade-nya yang hilang — muat cepat tetap tidak berkedip. */
-  .pemuat { animation: hrcd-muncul .01s linear .18s both; }
   /* Perputaran TIDAK dimatikan: di sini gerakan itulah seluruh maknanya,
      dan cincin diam sama saja dengan tidak ada penanda. Dipelankan saja. */
   .pemuat-cincin        { animation-duration: 2.2s; }


### PR DESCRIPTION
## What

Two things I got wrong in #133.

**No delay.** The ring was held back 180 ms so fast loads would never flicker. Wrong trade: what it actually bought was a blank screen on every navigation, and that silence reads as *stuck*. An occasional flicker is the cheaper price than a moment of "is this working or not" each time a screen opens. The delay and the fade are gone — the ring is simply there.

**Centred.** It sat just under the header, at the top of an otherwise empty page. The eye looks for a loading marker where the content is about to appear, not on the first line.

`min-height: calc(100vh - 10rem)` — the header plus `.isi`'s own vertical padding — puts the ring almost exactly at the middle of the viewport, while keeping the block **shorter than one screen**. That last part matters: a taller block would add a scrollbar that vanishes again when the data lands, jolting the whole page sideways.

`@keyframes hrcd-muncul` removed; nothing used it any more.

## Notes

CSS-only plus comment updates — no behaviour change to any query, and both `live/` copies re-synced.

Verified against the real stylesheet at 1568×772: ring lands at y≈378 of 772, no scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)