### PR TITLE
fix: coming back from another tab no longer wipes the recap

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -329,6 +329,14 @@ yang ikut tergambar ulang. Hasilnya layar yang boleh dibiarkan terbuka
 seharian dan tetap diam di tempat yang ditinggalkan — seperti spreadsheet,
 yang memang bentuk yang dikenal panitia.
 
+Aturan yang sama berlaku untuk **kembali dari tab lain**. Bagian 7 nomor 10
+menjelaskan bahwa seluruh SPA memuat ulang dirinya saat layarnya dilihat
+kembali; layar ini dikecualikan lewat `segarkanDiTempat`, sebuah kait yang
+boleh diisi layar mana pun yang sanggup memperbarui angkanya sendiri.
+Berpindah tab adalah gerakan yang paling sering dilakukan orang yang sedang
+memantau, dan menggambar ulang di situ membuang persis keadaan yang sedang
+dipakai memantau.
+
 Rank kosong berarti kloter regu itu belum tercatat berangkat, jadi ia belum
 masuk klasemen resmi (`rancangan-b.md` 11.12). Barisnya tidak dibuang; ia
 turun ke bawah kelompoknya dan tetap terurut menurut total, supaya papan ini
@@ -751,6 +759,16 @@ Dikumpulkan dari kesalahan yang benar-benar terjadi, bukan daftar teoretis.
    berlaku untuk build BERIKUTNYA. Selama belum ada push atau "Retry
    deployment", yang tersaji tetap hasil build lama dengan folder lama —
    setelan sudah benar di layar, produksi masih salah.
+10. **SPA ini memuat ulang layarnya sendiri saat tab-nya dilihat kembali**,
+    dan itu memang disengaja: panitia berpindah ke WhatsApp lalu kembali, dan
+    angka basi yang terlihat wajar lebih berbahaya daripada layar yang
+    berkedip. Tapi "memuat ulang" berarti **menggambar ulang dari nol**, dan
+    di layar yang keadaannya sendiri berharga — geseran samping, saringan,
+    isi kotak cari — itu membuang persis apa yang sedang dipakai orangnya.
+    Layar Rekapitulasi karena itu mendaftarkan `segarkanDiTempat`, dan yang
+    dijalankan saat tab-nya kembali hanya pengambilan angkanya. Layar baru
+    yang dipantau lama harus melakukan hal yang sama; yang tidak, tetap aman
+    dengan perilaku bawaan.
 
 ---
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -31,6 +31,16 @@ const GOLONGAN_LABEL = {
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
 };
 let EDISI = null;
+
+/* Layar yang sanggup memperbarui dirinya SENDIRI tanpa digambar ulang
+   mendaftar di sini; kembali dari tab lain memanggil INI, bukan menggambar
+   ulang layarnya. Kosong berarti "gambar ulang saja" — itu yang berlaku
+   untuk hampir semua layar, dan memang benar untuk mereka.
+
+   Dideklarasikan di atas, bersama keadaan modul yang lain, meski yang
+   memakainya jauh di bawah: yang membacanya nanti harus bisa menemukan
+   seluruh keadaan yang hidup selama satu sesi di satu tempat. */
+let segarkanDiTempat = null;
 const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
 
 /* ---------------- kerangka ---------------- */
@@ -3025,6 +3035,13 @@ async function layarRekap() {
   gambarPanel();
   gambarTabel();
 
+  /* Kembali dari tab lain TIDAK menggambar ulang layar ini. Papan ini
+     dipantau berjam-jam sambil berpindah tab, dan menggambarnya ulang tiap
+     kali berarti kehilangan seluruh keadaan yang sedang dipakai memantau:
+     geseran samping, saringan golongan, isi kotak cari, posisi gulir. Yang
+     dijalankan cukup pengambilan angkanya. */
+  segarkanDiTempat = () => refresh();
+
   jeda = setInterval(() => {
     if (location.hash !== layarIni) { clearInterval(jeda); return; }
     if (!document.hidden) refresh();
@@ -3046,6 +3063,7 @@ const RUTE = {
 };
 
 async function arahkan() {
+  segarkanDiTempat = null;
   if (!sesi()) { layarLogin(); return; }
   if (!EDISI) {
     try { EDISI = await infoEdisi(); }
@@ -3101,7 +3119,14 @@ document.addEventListener("visibilitychange", () => {
   // yang ia lihat hanyalah tabel yang tiba-tiba bersih.
   if (adaYangBelumTersimpan()) return;
   terakhirSegar = Date.now();
-  arahkan();
+  // Layar yang bisa memperbarui angkanya sendiri TIDAK digambar ulang.
+  // Rekapitulasi dipantau berjam-jam sambil berpindah tab; menggambarnya
+  // ulang tiap kali tab itu dilihat lagi berarti cincin muat, geseran
+  // samping kembali ke kolom pertama, saringan golongan kembali ke bawaan,
+  // dan kotak cari kosong — seluruh keadaan yang sedang dipakai memantau,
+  // hilang justru pada gerakan yang paling sering dilakukan orang.
+  if (segarkanDiTempat) segarkanDiTempat();
+  else arahkan();
 });
 
 /** Baris lembar pos yang isinya belum sampai ke database. */


### PR DESCRIPTION
## What

The SPA reloads the current screen whenever its tab becomes visible again. That is deliberate and right for the desk screens — panitia switch to WhatsApp and back, and stale numbers that look plausible are more dangerous than a screen that blinks.

But "reload" means **redraw from scratch**, and the recap is the one screen whose own state is worth something:

- which golongan is selected
- what is typed in the search box
- how far right it is scrolled
- where it is scrolled down to

Switching tabs is the single most common thing someone monitoring this board does, and doing it threw all of that away — plus a full-screen loading spinner on the way back.

Screens that can update their own numbers now register `segarkanDiTempat`; the visibility handler calls that instead of re-navigating. Recap registers it, every other screen keeps the old behaviour, and `arahkan()` clears the hook on every navigation so it can never be left pointing at a screen that is gone.

## Why

This completes #135. That PR stopped the 20-second auto-refresh from moving the screen; this one stops the far more disruptive version of the same thing — the one triggered by the user's own most frequent action.

## Notes

The two existing guards still run first: nothing refreshes while a field is focused, while a dialog is open, or while there are unsaved values waiting to reach the server.

The hook is declared with the rest of the module state at the top rather than beside its only user at the bottom, so everything that lives for a whole session is findable in one place.

Recorded in `final-architecture.md` as section 7 item 10 — the trap is general, and any future screen meant to be watched for a long time has to opt out the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)