### PR TITLE
fix: do nothing in the background, catch up the moment the tab returns

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -337,6 +337,19 @@ Berpindah tab adalah gerakan yang paling sering dilakukan orang yang sedang
 memantau, dan menggambar ulang di situ membuang persis keadaan yang sedang
 dipakai memantau.
 
+Kait itu **melewati ketiga pengaman** yang mendahuluinya (jeda 5 detik, kotak
+isian yang sedang difokus, dialog yang terbuka). Pengaman-pengaman itu ada
+untuk melindungi dari gambar ulang; pembaruan di tempat tidak menghapus
+ketikan siapa pun, jadi menerapkannya di sini cuma menghasilkan satu akibat —
+refresh yang dibatalkan. Kursor tertinggal di kotak cari saat berpindah tab
+sudah cukup untuk membuat papan pantau kembali dengan angka lama, diam-diam.
+
+Di latar, layar ini **berhenti total**. Denyut 20 detiknya dimatikan begitu
+tab-nya disembunyikan, bukan sekadar dilewati: jawabannya tidak dibaca siapa
+pun, dan papan ini memang dibiarkan terbuka berjam-jam di sebelah tab lain.
+Yang menyalakannya kembali adalah kepulangan itu sendiri — `segarkanDiTempat`
+mengambil angka terbaru sekaligus menghidupkan ulang denyutnya.
+
 Rank kosong berarti kloter regu itu belum tercatat berangkat, jadi ia belum
 masuk klasemen resmi (`rancangan-b.md` 11.12). Barisnya tidak dibuang; ia
 turun ke bawah kelompoknya dan tetap terurut menurut total, supaya papan ini

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3035,17 +3035,33 @@ async function layarRekap() {
   gambarPanel();
   gambarTabel();
 
-  /* Kembali dari tab lain TIDAK menggambar ulang layar ini. Papan ini
-     dipantau berjam-jam sambil berpindah tab, dan menggambarnya ulang tiap
-     kali berarti kehilangan seluruh keadaan yang sedang dipakai memantau:
-     geseran samping, saringan golongan, isi kotak cari, posisi gulir. Yang
-     dijalankan cukup pengambilan angkanya. */
-  segarkanDiTempat = () => refresh();
+  /* -------------------------------------------------------------------------
+     TAB DI LATAR: BERHENTI TOTAL. TAB DIBUKA LAGI: LANGSUNG MENYUSUL.
 
-  jeda = setInterval(() => {
-    if (location.hash !== layarIni) { clearInterval(jeda); return; }
-    if (!document.hidden) refresh();
-  }, 20000);
+     Selama tab ini tidak dilihat, tidak ada gunanya bertanya ke database tiap
+     20 detik — jawabannya tidak dibaca siapa pun, dan papan ini memang
+     dibiarkan terbuka berjam-jam di sebelah tab lain. Jadi denyutnya
+     dimatikan, bukan sekadar dilewati.
+
+     Yang menyalakannya lagi adalah kepulangan itu sendiri: `segarkanDiTempat`
+     mengambil angka terbaru SEKALIGUS menghidupkan kembali denyutnya, jadi
+     layar yang dibuka lagi sudah menyusul sebelum mata sempat membacanya.
+     ---------------------------------------------------------------------- */
+  const mulaiDenyut = () => {
+    if (jeda !== null) return;
+    jeda = setInterval(() => {
+      // Membersihkan dirinya sendiri: satu tempat yang memutuskan berhenti,
+      // dipakai baik saat berpindah layar maupun saat tab disembunyikan.
+      if (location.hash !== layarIni || document.hidden) {
+        clearInterval(jeda); jeda = null; return;
+      }
+      refresh();
+    }, 20000);
+  };
+
+  segarkanDiTempat = () => { refresh(); mulaiDenyut(); };
+
+  mulaiDenyut();
 }
 
 /* ============================ RUTE ======================================= */
@@ -3109,6 +3125,19 @@ window.addEventListener("hashchange", arahkan);
 let terakhirSegar = Date.now();
 document.addEventListener("visibilitychange", () => {
   if (document.hidden || !sesi()) return;
+
+  /* Layar yang bisa memperbarui angkanya sendiri: LANGSUNG, tanpa satu pun
+     pengaman di bawah.
+
+     Ketiga pengaman itu ada untuk melindungi dari GAMBAR ULANG — ketikan yang
+     terhapus, dialog yang tertutup sendiri, nilai yang belum sampai server.
+     Pembaruan di tempat tidak melakukan satu pun dari itu, jadi menerapkan
+     pengaman yang sama di sini cuma menghasilkan satu akibat: refresh yang
+     DIBATALKAN pada kejadian yang paling sering terjadi. Kursor tertinggal di
+     kotak cari saat berpindah tab sudah cukup untuk membuat papan pantau
+     kembali dengan angka lama, tanpa memberi tahu siapa pun. */
+  if (segarkanDiTempat) { terakhirSegar = Date.now(); segarkanDiTempat(); return; }
+
   if (Date.now() - terakhirSegar < 5000) return;
   const fokus = document.activeElement;
   if (fokus && ["INPUT", "SELECT", "TEXTAREA"].includes(fokus.tagName)) return;
@@ -3119,14 +3148,7 @@ document.addEventListener("visibilitychange", () => {
   // yang ia lihat hanyalah tabel yang tiba-tiba bersih.
   if (adaYangBelumTersimpan()) return;
   terakhirSegar = Date.now();
-  // Layar yang bisa memperbarui angkanya sendiri TIDAK digambar ulang.
-  // Rekapitulasi dipantau berjam-jam sambil berpindah tab; menggambarnya
-  // ulang tiap kali tab itu dilihat lagi berarti cincin muat, geseran
-  // samping kembali ke kolom pertama, saringan golongan kembali ke bawaan,
-  // dan kotak cari kosong — seluruh keadaan yang sedang dipakai memantau,
-  // hilang justru pada gerakan yang paling sering dilakukan orang.
-  if (segarkanDiTempat) segarkanDiTempat();
-  else arahkan();
+  arahkan();
 });
 
 /** Baris lembar pos yang isinya belum sampai ke database. */


### PR DESCRIPTION
## What

#136 made the return from another tab update in place instead of redrawing. Two things still got in the way.

**1 · The guards cancelled the refresh.** The visibility handler skips when a field is focused, a dialog is open, there are unsaved values, or fewer than 5 seconds have passed.

All four exist to protect against a **redraw** — typing erased, a dialog closed underneath someone, values still waiting for the network. An in-place update does none of that, so applying the same guards to it produced exactly one effect: **the refresh was cancelled**. A cursor left in the search box while switching tabs was enough to bring the board back showing old numbers, silently.

Screens with an in-place hook now run it before any of those checks. Screens without one keep all four, unchanged.

**2 · The poll kept ticking in the background.** The 20-second interval ran while the tab was hidden and merely skipped its body. It now clears itself instead — nothing at all happens while nobody is looking, which is the honest reading of "leave it open next to other tabs all day".

Returning restarts it: the same hook that fetches the fresh numbers also revives the heartbeat, so a reopened tab is already caught up before the eye lands on it.

## Why

The failure mode this removes is the quiet one. A monitoring board that comes back with stale numbers and no indication looks exactly like a board that is up to date — which is worse than one that visibly reloads.

## Notes

The stop decision lives in one place — the interval's own first line, covering both "left the screen" and "tab hidden" — rather than being duplicated across a second listener that would then need removing.

Also deleted the branch left unreachable at the bottom of the handler by the new early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)