### PR TITLE
fix: say what the value must be, not what is wrong with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0028
+│   ├── migrations/           # skema database, urut 0001..0029
 │   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
 │   │                         # data; live_json.sql dipakai Publish rekap live
 │   └── seed.sql              # konfigurasi edisi + baris wajib

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0028`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0029`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-28 migrasi, `0001` sampai `0028`, dijalankan berurutan tanpa lubang penomoran.
+29 migrasi, `0001` sampai `0029`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0029_pesan_rentang.sql
+++ b/supabase/migrations/0029_pesan_rentang.sql
@@ -1,0 +1,154 @@
+-- ============================================================================
+-- hrcd-rekap : 0029_pesan_rentang.sql
+--
+-- Satu perubahan, dan hanya itu: kalimat galat saat nilai di luar rentang.
+--
+--   sebelum   005: nilai 31 di luar rentang wajar 0.00-20.00
+--   sesudah   Nomor Dada 005: Input harus antara 0 - 20.
+--
+-- Tiga hal yang salah pada kalimat lama, dan ketiganya membebani orang yang
+-- paling sibuk di ruangan itu:
+--
+--   1. "0.00-20.00". Kolomnya bertipe numeric(10,2), jadi nol di belakang
+--      koma ikut tercetak. Tidak ada satu pun angka pecahan di kertas Pos 1,
+--      dan yang membacanya jadi ragu apakah 19,5 diterima. `trim_scale`
+--      membuangnya: 0 - 20.
+--   2. "di luar rentang wajar" memberi tahu apa yang SALAH, bukan apa yang
+--      harus dilakukan. Operator sedang menyalin dari foto sambil dikejar
+--      antrean; yang ia butuhkan batas yang sah, bukan diagnosis.
+--   3. Angka yang ditolak ("31") diulang di pesan padahal masih terlihat di
+--      kotak yang baru saja ia ketik. Mengulangnya memanjangkan kalimat tanpa
+--      menambah satu pun informasi.
+--
+-- Awalan "Nomor Dada 005:" dipasang di layar (web/js/app.js), bukan di sini —
+-- server memang sudah mengembalikan nomor dadanya sebagai kolom tersendiri,
+-- dan menempelkannya ke dalam teks galat akan membuat layar tidak bisa lagi
+-- menampilkannya secara terpisah.
+--
+-- ---------------------------------------------------------------------------
+-- SELURUH BADAN FUNGSI DISALIN APA ADANYA dari 0014, karena `create or
+-- replace function` menuntut definisi utuh — bukan tambalan. Yang berbeda
+-- dari 0014 hanya dua `raise exception` di atas. Kalau suatu hari fungsi ini
+-- diubah lagi, yang disalin harus versi TERBARU, bukan berkas ini.
+-- ============================================================================
+
+create or replace function simpan_nilai_massal(
+  p_baris  jsonb,  -- [{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40,"nilai_2":null}, ...]
+  p_sumber text default 'upload',
+  p_pos    smallint default null  -- wajib untuk admin; operator memakai pos-nya sendiri
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_r      jsonb;
+  v_regu   regu%rowtype;
+  v_wahana wahana%rowtype;
+  v_hasil  jsonb := '[]'::jsonb;
+  v_status text;
+  v_alasan text;
+  v_idx    int := 0;
+  v_pos    smallint;
+  v_kunci  text;
+  v_sudah  text[] := '{}';
+  v_n1     numeric;
+  v_n2     numeric;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+  if p_sumber not in ('manual', 'upload') then
+    raise exception 'sumber tidak dikenal: %', p_sumber;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_baris) loop
+    v_idx := v_idx + 1;
+    v_status := 'tersimpan'; v_alasan := null;
+
+    -- Seluruh pemrosesan baris terlindungi: format angka rusak di baris 7
+    -- tidak boleh menggagalkan 26 baris lain (temuan review).
+    begin
+      v_n1 := (v_r ->> 'nilai_1')::numeric;
+      v_n2 := nullif(v_r ->> 'nilai_2', '')::numeric;
+
+      -- Baris ganda dalam SATU paste = merah (bagian 6.3) — juga di server.
+      v_kunci := (v_r ->> 'nomor_dada') || '|' ||
+                 regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g');
+      if v_kunci = any (v_sudah) then
+        raise exception 'baris ganda dalam paste (nomor dada + komponen sama)';
+      end if;
+      v_sudah := v_sudah || v_kunci;
+
+      -- Regu: harus dikenal, bernomor, tidak batal.
+      select * into v_regu from regu
+      where nomor_dada = (v_r ->> 'nomor_dada')::integer and not is_cancelled;
+      if not found then
+        raise exception 'nomor dada tidak dikenal / regu batal';
+      end if;
+
+      -- Komponen: HANYA pos ini (kode boleh kembar antar pos — temuan
+      -- review); normalisasi dua arah supaya "Lari Zigzag" dari header foto
+      -- cocok dengan kode lari_zigzag.
+      select w.* into v_wahana from wahana w
+      where w.edisi = edisi_aktif()
+        and w.pos = v_pos
+        and regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g')
+            = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+      if not found then
+        raise exception 'kode komponen tidak dikenal di pos % — mungkin ini lembar pos lain?', v_pos;
+      end if;
+
+      -- Rentang wajar dari konfigurasi (merah di preview = tolak di server).
+      if v_n1 is null
+         or v_n1 not between v_wahana.rentang_mentah_min and v_wahana.rentang_mentah_maks then
+        -- trim_scale membuang nol di belakang koma: rentang_mentah_min
+        -- bertipe numeric(10,2), jadi tanpa ini pesannya berbunyi
+        -- "antara 0.00 - 20.00" — angka yang tidak pernah ditulis siapa pun
+        -- di kertas, dan yang membacanya jadi ragu apakah pecahan diterima.
+        raise exception 'Input harus antara % - %.',
+          trim_scale(v_wahana.rentang_mentah_min),
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+      -- nilai_2 (jumlah salah) ikut divalidasi (temuan review).
+      if v_n2 is not null
+         and v_n2 not between 0 and v_wahana.rentang_mentah_maks then
+        raise exception 'Jumlah salah harus antara 0 - %.',
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+
+      insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+      values (v_regu.id, v_wahana.id, v_n1, v_n2, p_sumber, auth.uid())
+      on conflict (regu_id, wahana_id) do update set
+        nilai_1 = excluded.nilai_1,
+        nilai_2 = excluded.nilai_2,
+        source  = excluded.source,
+        created_by = excluded.created_by,
+        created_at = now()
+      -- Simpan ulang tanpa perubahan = tidak menulis apa pun: kepengarangan
+      -- tidak tergeser, riwayat tidak dibanjiri (temuan review).
+      where nilai_mentah.nilai_1 is distinct from excluded.nilai_1
+         or nilai_mentah.nilai_2 is distinct from excluded.nilai_2;
+
+    exception when others then
+      v_status := 'ditolak';
+      v_alasan := sqlerrm;
+    end;
+
+    v_hasil := v_hasil || jsonb_build_object(
+      'baris', v_idx,
+      'nomor_dada', v_r ->> 'nomor_dada',
+      'kode', v_r ->> 'kode',
+      'status', v_status,
+      'alasan', v_alasan);
+  end loop;
+
+  return v_hasil;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,6 +51,7 @@ run supabase/migrations/0025_pos_keberangkatan_kedatangan.sql
 run supabase/migrations/0026_rekap_publik.sql
 run supabase/migrations/0027_rekap_penuh.sql
 run supabase/migrations/0028_kelengkapan_pos.sql
+run supabase/migrations/0029_pesan_rentang.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -83,10 +84,13 @@ run tests/sql/07_pindah_setelah_berangkat.sql
 run supabase/migrations/0024_komponen_pos.sql
 run tests/sql/08_lembar_pos.sql
 run tests/sql/09_rekap_publik.sql
-# 10 dijalankan PALING AKHIR, dan itu perlu: ia membandingkan rekap panitia
+# 10 dijalankan di ujung, dan itu perlu: ia membandingkan rekap panitia
 # dengan v_poin_pos, v_total_skor, dan v_klasemen, jadi ia butuh database yang
 # sudah berisi nilai, keberangkatan, dan closing dari seluruh tes di atasnya.
 run tests/sql/10_rekap_penuh.sql
 run tests/sql/11_kelengkapan_pos.sql
+# 12 butuh komponen Pos 1 yang sebenarnya (kepramukaan_keagamaan,
+# rentang 0-20), yang baru ada setelah 0024 dijalankan giliran kedua.
+run tests/sql/12_pesan_rentang.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/03_alur.sql
+++ b/tests/sql/03_alur.sql
@@ -418,10 +418,14 @@ begin
     if sqlerrm like 'GAGAL:%' then raise; end if;
   end;
   -- nilai_2 di luar rentang: tolak (temuan review).
+  -- Kalimatnya menyebut "Jumlah salah", bukan nama kolomnya: sejak migrasi
+  -- 0029 pesan galat ditulis untuk operator, bukan untuk yang membaca skema
+  -- (`nilai_2` tidak pernah muncul di kertas mana pun).
   v := simpan_nilai_massal('[{"nomor_dada":1,"kode":"sandi_morse","nilai_1":8,"nilai_2":99}]'::jsonb,
                            'upload', 5::smallint);
   assert v -> 0 ->> 'status' = 'ditolak'
-     and v -> 0 ->> 'alasan' like '%nilai_2%', 'nilai_2 liar lolos';
+     and v -> 0 ->> 'alasan' like 'Jumlah salah harus antara%',
+     'nilai_2 liar lolos: ' || coalesce(v -> 0 ->> 'alasan', '(tanpa alasan)');
 end;
 $$;
 

--- a/tests/sql/12_pesan_rentang.sql
+++ b/tests/sql/12_pesan_rentang.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/12_pesan_rentang.sql
+-- Kalimat galat saat nilai di luar rentang (migrasi 0029).
+--
+-- Kenapa sebuah KALIMAT dijaga tes: kalimat ini satu-satunya hal yang dibaca
+-- operator saat ia salah ketik di tengah antrean, dan ia gampang sekali rusak
+-- tanpa ada yang menyadarinya. Fungsi `simpan_nilai_massal` disalin utuh tiap
+-- kali ada migrasi baru yang menyentuhnya (`create or replace` menuntut
+-- definisi penuh), jadi versi lama pesannya bisa ikut tersalin balik dari
+-- berkas yang salah — dan tidak satu pun tes lain akan gagal karenanya.
+--
+-- Yang dijaga tiga hal:
+--   1. bunyinya persis "Input harus antara 0 - 20." — bukan diagnosis;
+--   2. angkanya TANPA nol di belakang koma (kolomnya numeric(10,2));
+--   3. nilai yang ditolak TIDAK diulang di dalam kalimat.
+-- ============================================================================
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+do $$
+declare
+  v_dada   int;
+  v_maks   numeric;
+  v_hasil  jsonb;
+  v_alasan text;
+begin
+  -- Komponen pertama Pos 1 apa pun namanya tahun ini — rentangnya dibaca dari
+  -- konfigurasi, bukan ditulis di sini. Tes yang menyebut "20" sendiri akan
+  -- lulus tahun depan sambil menyembunyikan pesan yang sudah salah.
+  select rentang_mentah_maks into strict v_maks
+  from wahana where edisi = edisi_aktif() and pos = 1 and kode = 'kepramukaan_keagamaan';
+
+  select min(r.nomor_dada) into strict v_dada
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where r.nomor_dada is not null and not r.is_cancelled and d.status = 'lunas';
+
+  v_hasil := simpan_nilai_massal(
+    jsonb_build_array(jsonb_build_object(
+      'nomor_dada', v_dada,
+      'kode', 'kepramukaan_keagamaan',
+      'nilai_1', v_maks + 11)),   -- jelas di luar rentang
+    'manual', 1::smallint);
+
+  assert v_hasil -> 0 ->> 'status' = 'ditolak',
+    'nilai di luar rentang malah diterima';
+
+  v_alasan := v_hasil -> 0 ->> 'alasan';
+
+  assert v_alasan = format('Input harus antara 0 - %s.', trim_scale(v_maks)),
+    format('kalimatnya berubah: %L', v_alasan);
+
+  -- Nol di belakang koma tidak boleh muncul: "0.00 - 20.00" adalah bentuk
+  -- yang membuat orang ragu apakah pecahan diterima.
+  assert v_alasan not like '%.00%',
+    format('rentang tercetak dengan nol di belakang koma: %L', v_alasan);
+
+  -- Angka yang ditolak tidak diulang — ia masih terlihat di kotak yang baru
+  -- saja diketik, dan mengulangnya cuma memanjangkan kalimat.
+  assert v_alasan not like '%' || (v_maks + 11)::text || '%',
+    format('nilai yang ditolak ikut diulang di pesan: %L', v_alasan);
+end;
+$$;
+
+reset role;
+select '12_pesan_rentang OK' as hasil;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2401,7 +2401,11 @@ async function layarInputPos() {
       hitungUlangJumlah();
     } catch (err) {
       statusBaris(tr, "gagal", err.message);
-      notif(`${String(dada).padStart(3, "0")}: ${err.message}`, true);
+      // "Nomor Dada 005: ...", bukan "005: ...". Notifikasi ini muncul di
+      // bawah layar, terlepas dari baris yang gagal — angka telanjang di
+      // depan kalimat tidak memberi tahu angka APA, dan di lembar yang penuh
+      // angka itu justru yang paling perlu disebut namanya.
+      notif(`Nomor Dada ${String(dada).padStart(3, "0")}: ${err.message}`, true);
     } finally {
       tr.dataset.jalan = "";
       // Ketukan yang menumpuk selagi baris ini sibuk. Dijalankan juga setelah


### PR DESCRIPTION
## What

```
before   005: nilai 31 di luar rentang wajar 0.00-20.00
after    Nomor Dada 005: Input harus antara 0 - 20.
```

| Problem | Fix |
| --- | --- |
| `0.00-20.00` — the column is `numeric(10,2)`, so trailing zeros printed. Nothing on the Pos 1 sheet has a decimal, and the reader is left wondering whether 19.5 is accepted | `trim_scale` → `0 - 20` |
| `di luar rentang wajar` reports the diagnosis. Someone copying from a photo with a queue behind them needs the range that **is** allowed | `Input harus antara …` |
| `31` echoed back although it is still visible in the box just typed | dropped — length without information |
| `005:` does not say a number of **what**, and this notification appears at the bottom of the screen, detached from the row that failed | `Nomor Dada 005:` |

The prefix is added **on screen**, not in the exception: the server already returns `nomor_dada` as its own field, and folding it into the message text would take away the screen's ability to show it separately.

## Why

This sentence is the only thing an operator reads when they mistype mid-queue. It should end the interruption, not start a second one.

## Notes

Migration `0029` copies the whole `simpan_nilai_massal` body because `create or replace function` demands the full definition. **Copied by script, not by hand** — 115 lines, and one slipped character produces an RPC nobody realises is different. Only the two `raise exception` lines differ from `0014`.

`tests/sql/12_pesan_rentang.sql` pins the sentence: exact wording, no trailing zeros, and the rejected value not echoed. The range is read from `wahana` rather than hardcoded, so a test asserting "20" cannot keep passing after next year's configuration changes.

The same treatment is applied to the `nilai_2` message for consistency: `Jumlah salah harus antara 0 - N.`

**Migration `0029` must be applied before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)