### PR TITLE
feat: reconfigure scoring for HRCD XXXVII

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0029
+│   ├── migrations/           # skema database, urut 0001..0032
 │   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
 │   │                         # data; live_json.sql dipakai Publish rekap live
 │   └── seed.sql              # konfigurasi edisi + baris wajib

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0029`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0032`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-29 migrasi, `0001` sampai `0029`, dijalankan berurutan tanpa lubang penomoran.
+32 migrasi, `0001` sampai `0032`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0030_komponen_per_golongan.sql
+++ b/supabase/migrations/0030_komponen_per_golongan.sql
@@ -1,0 +1,207 @@
+-- ============================================================================
+-- hrcd-rekap : 0030_komponen_per_golongan.sql
+--
+-- Satu kolom baru: `wahana.golongan`. Null = berlaku untuk semua golongan
+-- (itu keadaan hampir semua komponen). Diisi = komponen ini HANYA milik
+-- golongan itu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA INI PERLU ADA
+--
+-- Format HRCD XXXVII memuat satu komponen yang tidak bisa dinyatakan tabel
+-- ini apa adanya: **Tebak Simpul**.
+--
+--   Penggalang :  5 objek simpul, 1 benar = 20 poin, maksimum 100
+--   Penegak    : 10 objek simpul, 1 benar = 10 poin, maksimum 100
+--
+-- Petugas menulis JUMLAH SIMPUL BENAR — data mentah yang sama untuk keduanya.
+-- Yang berbeda penyebutnya. Satu baris `wahana` hanya punya satu
+-- `raw_terbaik`, jadi apa pun yang dipilih akan salah untuk separuh peserta:
+-- dengan raw_terbaik=10, regu Penggalang yang benar SEMUA (5 dari 5) dinilai
+-- 50, bukan 100. Kesalahan itu tidak menimbulkan galat apa pun — ia hanya
+-- memangkas separuh nilai satu golongan penuh, diam-diam, sampai ada yang
+-- menghitung ulang dengan tangan.
+--
+-- Jalan keluarnya dua baris `wahana` yang saling melengkapi, satu per
+-- golongan — dan kolom inilah yang memberi tahu sistem bahwa keduanya BUKAN
+-- dua kolom yang dua-duanya harus diisi.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG IKUT BERUBAH, DAN KENAPA HARUS IKUT
+--
+-- "Berapa komponen yang harus diisi" berhenti menjadi sifat POS dan menjadi
+-- sifat POS UNTUK REGU INI. Tanpa itu:
+--
+--   · lembar Input Pos menghitung 4 komponen di Pos 1 padahal tiap regu cuma
+--     bisa mengisi 3, sehingga tidak satu baris pun pernah berstatus lengkap;
+--   · panel kelengkapan (0028) melaporkan `lengkap = 0` selamanya, dan panel
+--     yang selalu merah adalah panel yang berhenti dibaca orang;
+--   · `simpan_nilai_massal` menerima nilai Tebak Simpul Penegak untuk regu
+--     Penggalang — dua kolom terisi, dan totalnya 200 dari maksimum 100.
+--
+-- Yang terakhir itu yang paling berbahaya, jadi servernya ikut menolak.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kolomnya
+-- ---------------------------------------------------------------------------
+alter table wahana add column if not exists golongan text;
+
+alter table wahana drop constraint if exists wahana_golongan_check;
+alter table wahana add constraint wahana_golongan_check check (
+  golongan is null
+  or golongan in ('penggalang_pa', 'penggalang_pi', 'penegak_pa', 'penegak_pi'));
+
+comment on column wahana.golongan is
+  'NULL = komponen berlaku untuk semua golongan (hampir selalu begitu). '
+  'Diisi = komponen ini hanya milik golongan tersebut, dipakai saat satu '
+  'lomba dinilai dengan skala berbeda per golongan (mis. Tebak Simpul: '
+  '5 objek untuk penggalang, 10 untuk penegak).';
+
+-- Penyaring yang sama dipakai di empat tempat. Ditulis sekali sebagai fungsi
+-- supaya tidak ada satu pun tempat yang lupa ikut diperbarui — itulah cara
+-- kolom seperti ini biasanya membocorkan kesalahan setahun kemudian.
+create or replace function komponen_berlaku(p_golongan_wahana text,
+                                            p_golongan_regu   text)
+returns boolean
+language sql immutable
+as $$ select p_golongan_wahana is null or p_golongan_wahana = p_golongan_regu $$;
+
+comment on function komponen_berlaku(text, text) is
+  'Apakah satu komponen berlaku untuk regu bergolongan ini. Dipakai '
+  'v_lembar_pos, v_kelengkapan_pos, dan simpan_nilai_massal — jangan '
+  'menyalin logikanya, panggil fungsinya.';
+
+-- ---------------------------------------------------------------------------
+-- 2. v_lembar_pos — `jumlah_komponen` jadi milik REGU, bukan milik pos
+--
+-- Kolom lain tidak berubah sama sekali; `create or replace` menuntut daftar
+-- kolom yang persis sama, jadi seluruh definisinya disalin dari 0023 dengan
+-- satu subquery yang diganti.
+-- ---------------------------------------------------------------------------
+create or replace view v_lembar_pos as
+select
+  p.nomor       as pos,
+  p.name        as nama_pos,
+  p.bayangan,
+  r.id          as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name        as nama_sekolah,
+  r.golongan,
+
+  coalesce((
+    select jsonb_object_agg(w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), '{}'::jsonb) as nilai,
+
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_terisi,
+
+  -- INI yang berubah: hanya komponen yang berlaku untuk golongan regu ini.
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor
+     and komponen_berlaku(w.golongan, r.golongan))::int
+                as jumlah_komponen,
+
+  round(coalesce((
+    select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                           w.raw_terbaik, w.raw_terburuk,
+                           w.poin_benar, w.poin_salah, w.total_soal, w.tingkat))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), 0) * p.bobot, 2) as nilai_pos
+
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and peran() is not null
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya());
+
+-- ---------------------------------------------------------------------------
+-- 3. v_kelengkapan_pos — "lengkap" dihitung per regu
+--
+-- Seluruh definisi disalin dari 0028; yang berubah hanya `terisi` yang kini
+-- ikut membawa jumlah komponen yang berlaku untuk tiap regu.
+-- ---------------------------------------------------------------------------
+drop view if exists v_kelengkapan_pos;
+
+create view v_kelengkapan_pos as
+with regu_ikut as (
+  select
+    r.id,
+    r.golongan,
+    (k.jam_berangkat is not null)                                as sudah_berangkat,
+    exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+  from regu r
+  join pendaftaran d  on d.id = r.pendaftaran_id
+  left join kloter k  on k.nomor = r.kloter_nomor
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor                       as pos,
+  p.name                        as nama_pos,
+  p.bayangan,
+  p.jumlah_komponen,
+
+  count(ri.id)::int                                      as regu_total,
+  count(ri.id) filter (where ri.sudah_berangkat)::int    as regu_berangkat,
+  count(ri.id) filter (where ri.sudah_closing)::int      as regu_closing,
+
+  -- Pembandingnya `harus` — jumlah komponen yang berlaku untuk golongan regu
+  -- itu — bukan `p.jumlah_komponen` yang menghitung seluruh baris.
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) = harus.n)::int           as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0) < harus.n)::int           as sebagian,
+  count(ri.id) filter (where coalesce(t.jumlah, 0) = 0)::int as kosong,
+  count(ri.id) filter (
+    where ri.sudah_closing
+      and coalesce(t.jumlah, 0) < harus.n)::int           as hilang,
+
+  (select max(n.created_at)
+   from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where w.edisi = edisi_aktif() and w.pos = p.nomor)     as terakhir_masuk
+
+from v_pos p
+left join regu_ikut ri on true
+left join lateral (
+  select count(*)::int as n from wahana w
+  where w.edisi = edisi_aktif() and w.pos = p.nomor
+    and komponen_berlaku(w.golongan, ri.golongan)
+) harus on true
+left join terisi t on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and peran() is not null
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya())
+group by p.nomor, p.name, p.bayangan, p.jumlah_komponen;
+
+grant select on v_kelengkapan_pos to authenticated;
+
+comment on view v_kelengkapan_pos is
+  'Kelengkapan input per pos: lengkap / sebagian / kosong, ditambah `hilang` '
+  '(regu yang sudah closing tapi nilainya belum lengkap) dan '
+  '`terakhir_masuk`. Sejak 0030 "lengkap" dihitung terhadap komponen yang '
+  'BERLAKU untuk golongan tiap regu. Operator pos hanya melihat posnya.';

--- a/supabase/migrations/0031_tolak_komponen_golongan_lain.sql
+++ b/supabase/migrations/0031_tolak_komponen_golongan_lain.sql
@@ -1,0 +1,158 @@
+-- ============================================================================
+-- hrcd-rekap : 0031_tolak_komponen_golongan_lain.sql
+--
+-- Satu pagar baru di `simpan_nilai_massal`: nilai untuk komponen yang bukan
+-- milik golongan regu itu DITOLAK.
+--
+-- Migrasi 0030 membuat satu lomba boleh punya dua baris `wahana`, satu per
+-- golongan — Tebak Simpul dinilai dari 5 objek untuk penggalang dan 10 untuk
+-- penegak. Keduanya tampil sebagai kolom di lembar pos yang sama, karena
+-- lembar itu satu untuk semua regu di pos tersebut.
+--
+-- Tanpa pagar ini, satu regu bisa terisi DUA-DUANYA. Tidak ada yang gagal:
+-- kedua nilai sah menurut rentangnya masing-masing, keduanya tersimpan,
+-- keduanya dihitung — dan Nilai Pos regu itu jadi 200 dari maksimum 100.
+-- Kesalahan yang tidak menimbulkan galat adalah kesalahan yang baru ketahuan
+-- saat juara diumumkan.
+--
+-- Pagarnya dipasang DI SERVER, bukan di layar: layar boleh saja mengaburkan
+-- kolom yang tidak berlaku, tapi jalur upload massal tidak lewat layar.
+--
+-- ---------------------------------------------------------------------------
+-- SELURUH BADAN FUNGSI DISALIN dari 0029, karena `create or replace
+-- function` menuntut definisi utuh. Yang berbeda hanya satu blok `if` di
+-- atas. Kalau fungsi ini diubah lagi nanti, yang disalin harus versi
+-- TERBARU — bukan berkas ini.
+-- ============================================================================
+
+create or replace function simpan_nilai_massal(
+  p_baris  jsonb,  -- [{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40,"nilai_2":null}, ...]
+  p_sumber text default 'upload',
+  p_pos    smallint default null  -- wajib untuk admin; operator memakai pos-nya sendiri
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_r      jsonb;
+  v_regu   regu%rowtype;
+  v_wahana wahana%rowtype;
+  v_hasil  jsonb := '[]'::jsonb;
+  v_status text;
+  v_alasan text;
+  v_idx    int := 0;
+  v_pos    smallint;
+  v_kunci  text;
+  v_sudah  text[] := '{}';
+  v_n1     numeric;
+  v_n2     numeric;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+  if p_sumber not in ('manual', 'upload') then
+    raise exception 'sumber tidak dikenal: %', p_sumber;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_baris) loop
+    v_idx := v_idx + 1;
+    v_status := 'tersimpan'; v_alasan := null;
+
+    -- Seluruh pemrosesan baris terlindungi: format angka rusak di baris 7
+    -- tidak boleh menggagalkan 26 baris lain (temuan review).
+    begin
+      v_n1 := (v_r ->> 'nilai_1')::numeric;
+      v_n2 := nullif(v_r ->> 'nilai_2', '')::numeric;
+
+      -- Baris ganda dalam SATU paste = merah (bagian 6.3) — juga di server.
+      v_kunci := (v_r ->> 'nomor_dada') || '|' ||
+                 regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g');
+      if v_kunci = any (v_sudah) then
+        raise exception 'baris ganda dalam paste (nomor dada + komponen sama)';
+      end if;
+      v_sudah := v_sudah || v_kunci;
+
+      -- Regu: harus dikenal, bernomor, tidak batal.
+      select * into v_regu from regu
+      where nomor_dada = (v_r ->> 'nomor_dada')::integer and not is_cancelled;
+      if not found then
+        raise exception 'nomor dada tidak dikenal / regu batal';
+      end if;
+
+      -- Komponen: HANYA pos ini (kode boleh kembar antar pos — temuan
+      -- review); normalisasi dua arah supaya "Lari Zigzag" dari header foto
+      -- cocok dengan kode lari_zigzag.
+      select w.* into v_wahana from wahana w
+      where w.edisi = edisi_aktif()
+        and w.pos = v_pos
+        and regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g')
+            = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+      if not found then
+        raise exception 'kode komponen tidak dikenal di pos % — mungkin ini lembar pos lain?', v_pos;
+      end if;
+
+      -- Komponen milik golongan lain: TOLAK.
+      --
+      -- Sejak 0030 satu lomba boleh punya dua baris `wahana`, satu per
+      -- golongan (Tebak Simpul: 5 objek untuk penggalang, 10 untuk penegak).
+      -- Keduanya muncul sebagai kolom di lembar yang sama, jadi tanpa pagar
+      -- ini satu regu bisa terisi DUA-DUANYA — dan totalnya 200 dari
+      -- maksimum 100, tanpa satu pun galat yang memberi tahu siapa pun.
+      if not komponen_berlaku(v_wahana.golongan, v_regu.golongan) then
+        raise exception 'Komponen ini untuk golongan lain.';
+      end if;
+
+      -- Rentang wajar dari konfigurasi (merah di preview = tolak di server).
+      if v_n1 is null
+         or v_n1 not between v_wahana.rentang_mentah_min and v_wahana.rentang_mentah_maks then
+        -- trim_scale membuang nol di belakang koma: rentang_mentah_min
+        -- bertipe numeric(10,2), jadi tanpa ini pesannya berbunyi
+        -- "antara 0.00 - 20.00" — angka yang tidak pernah ditulis siapa pun
+        -- di kertas, dan yang membacanya jadi ragu apakah pecahan diterima.
+        raise exception 'Input harus antara % - %.',
+          trim_scale(v_wahana.rentang_mentah_min),
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+      -- nilai_2 (jumlah salah) ikut divalidasi (temuan review).
+      if v_n2 is not null
+         and v_n2 not between 0 and v_wahana.rentang_mentah_maks then
+        raise exception 'Jumlah salah harus antara 0 - %.',
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+
+      insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+      values (v_regu.id, v_wahana.id, v_n1, v_n2, p_sumber, auth.uid())
+      on conflict (regu_id, wahana_id) do update set
+        nilai_1 = excluded.nilai_1,
+        nilai_2 = excluded.nilai_2,
+        source  = excluded.source,
+        created_by = excluded.created_by,
+        created_at = now()
+      -- Simpan ulang tanpa perubahan = tidak menulis apa pun: kepengarangan
+      -- tidak tergeser, riwayat tidak dibanjiri (temuan review).
+      where nilai_mentah.nilai_1 is distinct from excluded.nilai_1
+         or nilai_mentah.nilai_2 is distinct from excluded.nilai_2;
+
+    exception when others then
+      v_status := 'ditolak';
+      v_alasan := sqlerrm;
+    end;
+
+    v_hasil := v_hasil || jsonb_build_object(
+      'baris', v_idx,
+      'nomor_dada', v_r ->> 'nomor_dada',
+      'kode', v_r ->> 'kode',
+      'status', v_status,
+      'alasan', v_alasan);
+  end loop;
+
+  return v_hasil;
+end;
+$$;

--- a/supabase/migrations/0032_konfigurasi_xxxvii.sql
+++ b/supabase/migrations/0032_konfigurasi_xxxvii.sql
@@ -1,0 +1,207 @@
+-- ============================================================================
+-- hrcd-rekap : 0032_konfigurasi_xxxvii.sql
+--
+-- Format penilaian HRCD XXXVII. Seluruhnya DATA — tidak satu baris kode pun
+-- ikut berubah, karena layar Input Pos dan Rekapitulasi memang membangun
+-- kolomnya dari tabel `pos` dan `wahana`.
+--
+--   Pos 0  Keberangkatan        garis start, tidak dinilai
+--   Pos 1  Teknik Kepramukaan   Semaphore, Tebak Simpul, Menaksir
+--   Pos 2  Halang Rintang       Bakiak, Lari Balok, Balap Karung
+--   Pos 3  P3K & Kim            Bidai (5 bagian), Kim Lihat, Kim Cium
+--   Pos 4  PBB                  4 bagian
+--   Pos 5  Yel-yel              4 bagian
+--   Pos 6  Kedatangan           garis finish, tidak dinilai
+--
+-- ---------------------------------------------------------------------------
+-- DIJAGA: HANYA JALAN KALAU BELUM ADA SATU NILAI PUN
+--
+-- Migrasi ini MENGGANTI seluruh konfigurasi penilaian satu edisi. Kalau
+-- dijalankan setelah lomba mulai, nilai yang sudah masuk kehilangan komponen
+-- induknya — dan yang hilang bukan angkanya saja, melainkan artinya.
+--
+-- Jadi bagian datanya dilewati bila `nilai_mentah` edisi ini sudah berisi.
+-- Itu juga yang membuatnya aman di database uji, yang memang penuh nilai dari
+-- tes 02-09: di sana migrasi ini tidak melakukan apa-apa, dan seluruh tes
+-- yang bersandar pada konfigurasi XXXVI tetap hijau. Pola yang sama dipakai
+-- 0024 ("bagian datanya dilewati").
+--
+-- ---------------------------------------------------------------------------
+-- KEDATANGAN PINDAH DARI POS 5 KE POS 6
+--
+-- Format lama memakai Pos 5 sebagai garis finish. Format baru memakai Pos 5
+-- untuk Yel-yel, jadi salah satunya harus mengalah. Yang pindah garis
+-- finishnya, karena nomor pos penilaian disebut panitia di lapangan
+-- ("Pos 5 yel-yel") sedangkan nomor garis finish tidak pernah disebut siapa
+-- pun — ia dikenal sebagai "finish", bukan sebagai angka.
+--
+-- Pos 6 sebelumnya dipakai Kostum (pos bayangan XXXVI). Format XXXVII tidak
+-- memuat pos bayangan, jadi barisnya dibuang lebih dulu.
+--
+-- ---------------------------------------------------------------------------
+-- TIGA ANGKA YANG BELUM DITETAPKAN PANITIA — DITANDAI, BUKAN DISEMBUNYIKAN
+--
+-- 1. Tangga Menaksir baru disebut sampai "selisih 2-3 m = 60". Diteruskan di
+--    sini mengikuti bentuk tangga Pos 2 yang memang sudah pasti (lima tingkat,
+--    berhenti di 20): <=5 m = 40, lebih dari itu = 20.
+-- 2. Kim Cium belum disebut berapa objeknya. Disamakan dengan Kim Lihat: 10.
+-- 3. Bidai memakai daftar INPUT yang diberikan panitia (Posisi, Teknik,
+--    Kerapihan & Kebersihan, Kecepatan, Kerja Sama). Uraian panitia menyebut
+--    "diagnosis dan penanganan awal" sebagai kriteria pertama dan menggabung
+--    kecepatan dengan kerja sama; keduanya sama-sama lima bagian x 20 = 100,
+--    tapi isinya berbeda.
+--
+-- Ketiganya diubah dengan satu UPDATE satu baris — tidak perlu migrasi baru.
+-- ============================================================================
+
+do $$
+declare
+  v_edisi smallint;
+  v_nilai int;
+begin
+  select nomor into v_edisi from edisi where is_active;
+  if v_edisi is null then
+    raise notice '0032: belum ada edisi aktif — bagian data dilewati.';
+    return;
+  end if;
+
+  select count(*) into v_nilai
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = v_edisi;
+
+  if v_nilai > 0 then
+    raise notice '0032: edisi % sudah memuat % nilai — konfigurasi TIDAK diubah.',
+      v_edisi, v_nilai;
+    return;
+  end if;
+
+  -- ---------------------------------------------------------------------
+  -- 1. Bersihkan konfigurasi lama edisi ini
+  -- ---------------------------------------------------------------------
+  delete from wahana where edisi = v_edisi;
+  -- Kostum (pos bayangan XXXVI) tidak ada di format baru, dan nomornya
+  -- dibutuhkan garis finish.
+  delete from pos where edisi = v_edisi and nomor = 6;
+
+  -- ---------------------------------------------------------------------
+  -- 2. Pos
+  -- ---------------------------------------------------------------------
+  -- Garis finish dipindah lebih dulu supaya nomor 5 kosong untuk Yel-yel.
+  update pos set nomor = 6 where edisi = v_edisi and nomor = 5;
+
+  insert into pos (edisi, nomor, name, bobot, bayangan) values
+    (v_edisi, 0, 'Keberangkatan',      1.00, false),
+    (v_edisi, 1, 'Teknik Kepramukaan', 1.00, false),
+    (v_edisi, 2, 'Halang Rintang',     1.00, false),
+    (v_edisi, 3, 'P3K dan Kim',        1.00, false),
+    (v_edisi, 4, 'PBB',                1.00, false),
+    (v_edisi, 5, 'Yel-yel',            1.00, false),
+    (v_edisi, 6, 'Kedatangan',         1.00, false)
+  on conflict (edisi, nomor) do update
+    set name = excluded.name, bobot = excluded.bobot,
+        bayangan = excluded.bayangan;
+
+  -- ---------------------------------------------------------------------
+  -- 3. Komponen
+  --
+  -- Yang ditulis petugas selalu DATA MENTAH di tempat data mentah memang ada
+  -- (jumlah benar, waktu, selisih), dan POIN hanya di tempat penilaiannya
+  -- memang penghakiman juri (bidai, PBB, yel-yel). Yang kedua dinyatakan
+  -- sebagai `besar_baik` dengan raw_terbaik = poin_maks: nilai mentahnya
+  -- sama dengan poinnya, satu lawan satu.
+  -- ---------------------------------------------------------------------
+  insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk, poin_benar, poin_salah,
+                      total_soal, tingkat, satuan, golongan,
+                      rentang_mentah_min, rentang_mentah_maks, sort_order)
+  values
+    -- ---- Pos 1 — Teknik Kepramukaan (maks 300) ----
+    -- 5 kata, 1 kata = 20 poin.
+    (v_edisi, 1, 'semaphore', 'Semaphore', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, null, 0, 5, 1),
+
+    -- Tebak Simpul: SATU lomba, DUA baris — skalanya berbeda per golongan
+    -- (0030). Tiap regu hanya bisa mengisi barisnya sendiri; server menolak
+    -- yang lain.
+    (v_edisi, 1, 'tebak_simpul_pg_pa', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 'penggalang_pa', 0, 5, 2),
+    (v_edisi, 1, 'tebak_simpul_pg_pi', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 'penggalang_pi', 0, 5, 2),
+    (v_edisi, 1, 'tebak_simpul_pn_pa', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 'penegak_pa', 0, 10, 2),
+    (v_edisi, 1, 'tebak_simpul_pn_pi', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 'penegak_pi', 0, 10, 2),
+
+    -- Menaksir: yang ditulis SELISIH, jadi makin kecil makin baik — dan
+    -- tangganya berhenti di 20, bukan 0 (dua tingkat terakhir asumsi).
+    (v_edisi, 1, 'menaksir', 'Menaksir', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 0, "poin": 100}, {"sampai": 1, "poin": 80},
+       {"sampai": 3, "poin": 60}, {"sampai": 5, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     null, null, 0, 1000, 3),
+
+    -- ---- Pos 2 — Halang Rintang (maks 300) ----
+    -- Waktu dalam DETIK. Tingkat terakhir berbatas besar karena aturannya
+    -- berhenti di 20 poin, bukan 0.
+    (v_edisi, 2, 'bakiak', 'Bakiak', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 30, "poin": 100}, {"sampai": 40, "poin": 80},
+       {"sampai": 50, "poin": 60}, {"sampai": 60, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     'detik', null, 0, 3600, 1),
+    (v_edisi, 2, 'lari_balok', 'Lari Balok', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 30, "poin": 100}, {"sampai": 40, "poin": 80},
+       {"sampai": 50, "poin": 60}, {"sampai": 60, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     'detik', null, 0, 3600, 2),
+    (v_edisi, 2, 'balap_karung', 'Balap Karung', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 20, "poin": 100}, {"sampai": 25, "poin": 80},
+       {"sampai": 30, "poin": 60}, {"sampai": 40, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     'detik', null, 0, 3600, 3),
+
+    -- ---- Pos 3 — P3K dan Kim (maks 300) ----
+    -- Bidai: penilaian juri, jadi mentah = poin (raw_terbaik = poin_maks).
+    (v_edisi, 3, 'bidai_posisi', 'Posisi Bidai', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 1),
+    (v_edisi, 3, 'bidai_teknik', 'Teknik Bidai', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 2),
+    (v_edisi, 3, 'bidai_kerapihan', 'Kerapihan dan Kebersihan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 3),
+    (v_edisi, 3, 'bidai_kecepatan', 'Kecepatan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 4),
+    (v_edisi, 3, 'bidai_kerja_sama', 'Kerja Sama', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 5),
+    -- 10 objek, gambar 15 detik lalu 30 detik menulis, berulang.
+    (v_edisi, 3, 'kim_lihat', 'Kim Lihat', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, null, 0, 10, 6),
+    -- 3 menit bebas mencium seluruh objek. Jumlah objek ASUMSI = 10.
+    (v_edisi, 3, 'kim_cium', 'Kim Cium', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, null, 0, 10, 7),
+
+    -- ---- Pos 4 — PBB (maks 100) ----
+    (v_edisi, 4, 'pbb_sikap', 'Sikap Sempurna', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 1),
+    (v_edisi, 4, 'pbb_gerakan', 'Gerakan Dasar', 'wahana', 'besar_baik',
+     30, 30, 0, null, null, null, null, null, null, 0, 30, 2),
+    (v_edisi, 4, 'pbb_kekompakan', 'Kekompakan', 'wahana', 'besar_baik',
+     30, 30, 0, null, null, null, null, null, null, 0, 30, 3),
+    (v_edisi, 4, 'pbb_kerapihan', 'Kerapihan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 4),
+
+    -- ---- Pos 5 — Yel-yel (maks 100) ----
+    (v_edisi, 5, 'yel_kreativitas', 'Kreativitas', 'wahana', 'besar_baik',
+     35, 35, 0, null, null, null, null, null, null, 0, 35, 1),
+    (v_edisi, 5, 'yel_kekompakan', 'Kekompakan', 'wahana', 'besar_baik',
+     25, 25, 0, null, null, null, null, null, null, 0, 25, 2),
+    (v_edisi, 5, 'yel_semangat', 'Semangat', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 3),
+    (v_edisi, 5, 'yel_penampilan', 'Penampilan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 4);
+
+  raise notice '0032: konfigurasi HRCD XXXVII terpasang untuk edisi %.', v_edisi;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -52,6 +52,8 @@ run supabase/migrations/0026_rekap_publik.sql
 run supabase/migrations/0027_rekap_penuh.sql
 run supabase/migrations/0028_kelengkapan_pos.sql
 run supabase/migrations/0029_pesan_rentang.sql
+run supabase/migrations/0030_komponen_per_golongan.sql
+run supabase/migrations/0031_tolak_komponen_golongan_lain.sql
 run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
@@ -92,5 +94,11 @@ run tests/sql/11_kelengkapan_pos.sql
 # 12 butuh komponen Pos 1 yang sebenarnya (kepramukaan_keagamaan,
 # rentang 0-20), yang baru ada setelah 0024 dijalankan giliran kedua.
 run tests/sql/12_pesan_rentang.sql
+# 0032 mengganti SELURUH konfigurasi penilaian satu edisi, dan sengaja
+# menolak bekerja bila sudah ada nilai tersimpan. Dijalankan di sini,
+# setelah database uji penuh nilai, supaya penolakan itu ikut terbukti —
+# dan supaya tes 02-12 tetap memakai konfigurasi yang mereka andalkan.
+run supabase/migrations/0032_konfigurasi_xxxvii.sql
+run tests/sql/13_komponen_per_golongan.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/13_komponen_per_golongan.sql
+++ b/tests/sql/13_komponen_per_golongan.sql
@@ -1,0 +1,130 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/13_komponen_per_golongan.sql
+-- Komponen per golongan (0030/0031) dan penjaga konfigurasi (0032).
+--
+-- Dua hal yang dijaga, dan keduanya tidak menimbulkan galat kalau rusak —
+-- itulah sebabnya mereka butuh tes:
+--
+--   1. Satu lomba yang skalanya berbeda per golongan tidak boleh membuat satu
+--      regu mengisi DUA kolom. Kalau pagarnya jebol, Nilai Pos regu itu jadi
+--      dua kali lipat maksimum dan tidak ada yang gagal.
+--   2. Migrasi konfigurasi tidak boleh mengganti aturan penilaian setelah ada
+--      nilai tersimpan. Kalau penjaganya jebol, nilai yang sudah masuk
+--      kehilangan komponen induknya — dan yang hilang bukan angkanya,
+--      melainkan artinya.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 13.1 Penjaga 0032: database uji SUDAH penuh nilai, jadi konfigurasinya
+--      WAJIB tidak tersentuh. Kalau tes ini gagal, migrasi itu baru saja
+--      menghapus bahan seluruh tes di atasnya.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_pos5 text; v_kostum int;
+begin
+  select name into v_pos5 from pos where edisi = edisi_aktif() and nomor = 5;
+  assert v_pos5 is distinct from 'Yel-yel',
+    '0032 mengganti konfigurasi padahal sudah ada nilai tersimpan';
+
+  select count(*) into v_kostum from pos
+  where edisi = edisi_aktif() and bayangan;
+  assert v_kostum > 0,
+    '0032 menghapus pos bayangan padahal sudah ada nilai tersimpan';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 13.2 komponen_berlaku(): null = untuk semua, terisi = untuk satu golongan.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  assert komponen_berlaku(null, 'penegak_pa'),      'null harus berlaku untuk semua';
+  assert komponen_berlaku(null, 'penggalang_pi'),   'null harus berlaku untuk semua';
+  assert komponen_berlaku('penegak_pa', 'penegak_pa'), 'golongan sama harus berlaku';
+  assert not komponen_berlaku('penegak_pa', 'penggalang_pa'),
+    'golongan berbeda TIDAK boleh berlaku';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 13.3 Komponen bergolongan: server MENOLAK nilai dari golongan lain, dan
+--      jumlah komponen yang harus diisi ikut menyesuaikan per regu.
+--
+--      Diuji dengan menandai satu komponen yang sudah ada, lalu dikembalikan
+--      lagi — supaya tes ini tidak bergantung pada konfigurasi edisi mana pun.
+-- ---------------------------------------------------------------------------
+reset role;
+do $$
+declare
+  v_kode     text;
+  v_pos      smallint;
+  v_gol_lain text;
+  v_regu     record;
+  v_sebelum  int;
+  v_sesudah  int;
+  v_hasil    jsonb;
+begin
+  -- Satu regu yang sudah bernomor dada, dan satu komponen di posnya.
+  select r.* into strict v_regu
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where r.nomor_dada is not null and not r.is_cancelled and d.status = 'lunas'
+  order by r.nomor_dada limit 1;
+
+  select w.kode, w.pos into strict v_kode, v_pos
+  from wahana w where w.edisi = edisi_aktif() order by w.pos, w.sort_order limit 1;
+
+  v_gol_lain := case when v_regu.golongan = 'penegak_pa'
+                     then 'penegak_pi' else 'penegak_pa' end;
+
+  select jumlah_komponen into v_sebelum from v_lembar_pos
+  where pos = v_pos and regu_id = v_regu.id;
+
+  -- Tandai komponen itu milik golongan LAIN.
+  update wahana set golongan = v_gol_lain
+  where edisi = edisi_aktif() and pos = v_pos and kode = v_kode;
+
+  select jumlah_komponen into v_sesudah from v_lembar_pos
+  where pos = v_pos and regu_id = v_regu.id;
+  assert v_sesudah = v_sebelum - 1,
+    format('jumlah_komponen tidak menyusut: %s -> %s', v_sebelum, v_sesudah);
+
+  -- Server menolak nilainya.
+  v_hasil := simpan_nilai_massal(
+    jsonb_build_array(jsonb_build_object(
+      'nomor_dada', v_regu.nomor_dada, 'kode', v_kode, 'nilai_1', 1)),
+    'manual', v_pos);
+  assert v_hasil -> 0 ->> 'status' = 'ditolak',
+    'komponen golongan lain malah diterima';
+  assert v_hasil -> 0 ->> 'alasan' = 'Komponen ini untuk golongan lain.',
+    format('alasan tidak sesuai: %L', v_hasil -> 0 ->> 'alasan');
+
+  -- Kembalikan seperti semula supaya tes ini tidak meninggalkan jejak.
+  update wahana set golongan = null
+  where edisi = edisi_aktif() and pos = v_pos and kode = v_kode;
+
+  select jumlah_komponen into v_sesudah from v_lembar_pos
+  where pos = v_pos and regu_id = v_regu.id;
+  assert v_sesudah = v_sebelum, 'jumlah_komponen tidak kembali seperti semula';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 13.4 Tanpa komponen bergolongan, perilakunya HARUS sama persis dengan
+--      sebelum 0030 — panel kelengkapan tetap menjumlah ke populasinya.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+do $$
+declare k record;
+begin
+  for k in select * from v_kelengkapan_pos loop
+    assert k.lengkap + k.sebagian + k.kosong = k.regu_total,
+      format('Pos %s: %s + %s + %s <> %s',
+             k.pos, k.lengkap, k.sebagian, k.kosong, k.regu_total);
+  end loop;
+end;
+$$;
+
+reset role;
+select '13_komponen_per_golongan OK' as hasil;

--- a/tests/sql/13_komponen_per_golongan.sql
+++ b/tests/sql/13_komponen_per_golongan.sql
@@ -52,8 +52,16 @@ $$;
 --
 --      Diuji dengan menandai satu komponen yang sudah ada, lalu dikembalikan
 --      lagi — supaya tes ini tidak bergantung pada konfigurasi edisi mana pun.
+--
+--      Dijalankan sebagai ADMIN, bukan tanpa peran: `v_lembar_pos` dipagari
+--      `peran() is not null` (0023), jadi sesi tanpa identitas mendapat nol
+--      baris — dan nol baris terbaca sebagai "kolomnya menyusut" padahal
+--      viewnya cuma menolak melayani. Menulis ke `wahana` juga menuntut
+--      admin (policy adm_wahana).
 -- ---------------------------------------------------------------------------
-reset role;
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
 do $$
 declare
   v_kode     text;
@@ -111,10 +119,8 @@ $$;
 -- ---------------------------------------------------------------------------
 -- 13.4 Tanpa komponen bergolongan, perilakunya HARUS sama persis dengan
 --      sebelum 0030 — panel kelengkapan tetap menjumlah ke populasinya.
+--      Masih sebagai admin dari 13.3.
 -- ---------------------------------------------------------------------------
-select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
-set role authenticated;
-
 do $$
 declare k record;
 begin


### PR DESCRIPTION
## What

Three migrations. `0032` is pure data; `0030` and `0031` exist because one component in the new format cannot be expressed by the table as it stands.

### Tebak Simpul breaks the shape of `wahana`

Penggalang answer **5 knots at 20 points**; Penegak answer **10 at 10**. Both cap at 100, and the petugas writes the same raw thing — how many were right. What differs is the denominator, and a `wahana` row has exactly one `raw_terbaik`.

Pick 10, and a Penggalang team that gets every knot right scores **50 instead of 100**. Nothing fails. Half the field is quietly halved until somebody recomputes by hand.

| Migration | What it does |
| --- | --- |
| `0030` | adds `wahana.golongan` (null = all, the normal case) so one lomba can be two rows; makes `v_lembar_pos` and `v_kelengkapan_pos` count components **per regu** |
| `0031` | server refuses a value for a component belonging to another golongan |
| `0032` | the XXXVII configuration itself |

`0030`'s view changes are not optional: once a pos has golongan-specific components, "how many must be filled" stops being a property of the pos. Without it no row is ever complete and the completeness panel reads 0 forever.

`0031` matters because both columns appear on the same pos sheet. Without the fence one regu can fill both — two valid numbers, both stored, both counted, **Nilai Pos 200 out of 100, no error anywhere**. Server-side, because the bulk upload path never touches the screen.

### The configuration

```
Pos 0  Keberangkatan        garis start
Pos 1  Teknik Kepramukaan   Semaphore · Tebak Simpul · Menaksir
Pos 2  Halang Rintang       Bakiak · Lari Balok · Balap Karung
Pos 3  P3K dan Kim          Bidai (5 bagian) · Kim Lihat · Kim Cium
Pos 4  PBB                  4 bagian
Pos 5  Yel-yel              4 bagian
Pos 6  Kedatangan           garis finish
```

Kedatangan moved from 5 to 6 — Yel-yel needs 5, and the finish line is called "finish" by everyone, never by number. Kostum dropped; the new format has no pos bayangan.

Pos 2's time ladders turned out to be **exactly the `bertingkat` form** `0022` already added, with one adjustment: a final wide tier, because the rules floor at 20 points rather than 0.

## Why it is safe to merge

`0032` **refuses to run if the edition already holds any `nilai_mentah`**. Production has no scores yet, so it applies; the test database is full of them, so it does nothing — tests 02–12 keep the XXXVI configuration they are built on, and `13_komponen_per_golongan.sql` proves the refusal actually happens rather than assuming it.

Changing scoring rules mid-event is exactly what this guard is for.

## Notes — three numbers are assumed

Marked in the migration header, each changeable with a one-line `UPDATE`:

1. **Menaksir ladder** past "selisih 2–3 m = 60" — continued in Pos 2's five-tier shape: `≤5 m = 40`, beyond that `20`.
2. **Kim Cium object count** — matched to Kim Lihat's 10.
3. **Bidai criteria** — uses the panitia's **Input** list (Posisi, Teknik, Kerapihan & Kebersihan, Kecepatan, Kerja Sama). The prose list instead names "diagnosis dan penanganan awal" and combines kecepatan with kerja sama. Both are 5 × 20 = 100 but they are different criteria.

The screens need no changes: Input Pos and Rekapitulasi build their columns from `wahana`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)