### PR TITLE
chore: clear the test edition and install the XXXVII pos names

### DIFF
--- a/supabase/checks/cleanup_data_uji.sql
+++ b/supabase/checks/cleanup_data_uji.sql
@@ -1,0 +1,91 @@
+-- ============================================================================
+-- hrcd-rekap : cleanup_data_uji.sql
+--
+-- MENGHAPUS SELURUH DATA PESERTA EDISI AKTIF. Tidak bisa dibatalkan.
+--
+-- Dijalankan sekali, atas permintaan pemilik, setelah `isi_edisi.sql`
+-- membuktikan bahwa seluruh 16 sekolah di produksi memang sisa pengetesan:
+-- nama bergenerator ("SMA Tabel 054155", "SMK Uji Produksi", "SMP Uji
+-- Deploy") dan alamat isian asal ("ABC", "HEHe", "Jl"), semuanya terdaftar
+-- 12-13 Agustus 2026 — jendela pengetesan, sementara lombanya Februari 2027
+-- dan pendaftaran belum dibuka.
+--
+-- JANGAN dijalankan lagi setelah pendaftaran sungguhan dibuka. Berkas ini
+-- tidak bisa membedakan sekolah uji dari sekolah asli; ia menghapus
+-- SEMUANYA. Yang membedakan hanya orang yang menjalankannya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA HARUS BERSIH SEBELUM KONFIGURASI DIGANTI
+--
+-- `0033` menolak memasang format XXXVII selama edisi aktif masih memuat satu
+-- nilai pun. Nilai yang kehilangan komponen induknya bukan kehilangan angka,
+-- melainkan kehilangan arti — dan itu tidak menimbulkan galat apa pun.
+--
+-- ---------------------------------------------------------------------------
+-- YANG TIDAK DIHAPUS, DAN KENAPA
+--
+--   history          Jejak audit bersifat append-only dan tidak menunjuk
+--                    baris lain lewat foreign key. Ia justru merekam
+--                    penghapusan ini; membuangnya berarti membuang satu-
+--                    satunya catatan bahwa pembersihan pernah terjadi.
+--   nomor_dada_stok  Stok nomor fisik adalah konfigurasi, bukan data peserta.
+--   akun_panitia     Akun panitia tidak ada hubungannya dengan pendaftaran.
+--   pos / wahana     Konfigurasi penilaian; itu urusan 0033.
+--
+-- Urutannya mengikuti foreign key dari daun ke akar. Dijalankan lewat
+-- workflow "Apply migration to Supabase", yang membungkusnya dalam SATU
+-- transaksi: kalau ada satu statement gagal, tidak ada yang terhapus.
+-- ============================================================================
+
+\echo '=== SEBELUM ==='
+select 'sekolah' as tabel, count(*) from sekolah
+union all select 'pendaftaran',        count(*) from pendaftaran
+union all select 'regu',               count(*) from regu
+union all select 'pembayaran',         count(*) from pembayaran
+union all select 'nilai_mentah',       count(*) from nilai_mentah
+union all select 'keberangkatan_regu', count(*) from keberangkatan_regu
+union all select 'closing_regu',       count(*) from closing_regu
+union all select 'penempatan_barak',   count(*) from penempatan_barak
+union all select 'nomor_dada_pensiun', count(*) from nomor_dada_pensiun
+union all select 'kloter berangkat',   count(*) from kloter where jam_berangkat is not null
+order by 1;
+
+-- ---------------------------------------------------------------------------
+-- Hapus, dari daun ke akar.
+-- ---------------------------------------------------------------------------
+delete from nilai_mentah;
+delete from closing_regu;
+delete from keberangkatan_regu;
+delete from penempatan_barak;
+delete from pembayaran;
+delete from regu;
+delete from pendaftaran;
+delete from sekolah;
+
+-- Nomor dada yang dipensiunkan saat menguji penukaran: dikembalikan ke
+-- antrean, karena regu yang pernah memakainya sudah tidak ada.
+delete from nomor_dada_pensiun;
+
+-- Jam berangkat kloter ikut lahir dari pengetesan. Dibiarkan, garis start
+-- akan menganggap seluruh kloter sudah berangkat sebelum ada yang datang.
+update kloter set jam_berangkat = null where jam_berangkat is not null;
+
+-- Saklar hari-H dikembalikan ke keadaan sebelum lomba.
+update status_acara set
+  daftar_ulang_ditutup = false,
+  fase_live            = 'pra',
+  konfigurasi_terkunci = false;
+
+\echo ''
+\echo '=== SESUDAH ==='
+select 'sekolah' as tabel, count(*) from sekolah
+union all select 'pendaftaran',        count(*) from pendaftaran
+union all select 'regu',               count(*) from regu
+union all select 'pembayaran',         count(*) from pembayaran
+union all select 'nilai_mentah',       count(*) from nilai_mentah
+union all select 'keberangkatan_regu', count(*) from keberangkatan_regu
+union all select 'closing_regu',       count(*) from closing_regu
+union all select 'penempatan_barak',   count(*) from penempatan_barak
+union all select 'nomor_dada_pensiun', count(*) from nomor_dada_pensiun
+union all select 'kloter berangkat',   count(*) from kloter where jam_berangkat is not null
+order by 1;

--- a/supabase/checks/isi_edisi.sql
+++ b/supabase/checks/isi_edisi.sql
@@ -49,3 +49,16 @@ union all select 'keberangkatan tercatat', count(*) from keberangkatan_regu
 union all select 'closing tercatat',       count(*) from closing_regu
 union all select 'sekolah SMOKE TEST',     count(*) from sekolah where name like 'SMOKE TEST%'
 union all select 'sekolah UJI',            count(*) from sekolah where name like 'UJI%';
+
+\echo ''
+\echo '=== SELURUH SEKOLAH + PENDAFTARAN (untuk memastikan mana yang uji) ==='
+select s.name as sekolah, s.address,
+       count(distinct d.id) as batch,
+       count(r.id)          as regu,
+       string_agg(distinct d.status, ', ') as status,
+       min(d.created_at)::date as terdaftar
+from sekolah s
+left join pendaftaran d on d.sekolah_id = s.id
+left join regu r        on r.pendaftaran_id = d.id
+group by s.name, s.address
+order by s.name;

--- a/supabase/checks/isi_edisi.sql
+++ b/supabase/checks/isi_edisi.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- hrcd-rekap : isi_edisi.sql — apa yang sebenarnya ada di edisi aktif.
+--
+-- HANYA MEMBACA. Tidak ada satu pun DELETE, UPDATE, atau INSERT di sini, jadi
+-- aman dijalankan kapan saja — termasuk lewat workflow "Apply migration to
+-- Supabase", yang memang menjalankan berkas apa pun yang disebut.
+--
+-- Dibuat saat konfigurasi HRCD XXXVII menolak dipasang karena edisi aktif
+-- sudah memuat nilai. Pertanyaannya waktu itu satu: nilai siapa? Menghapus
+-- data produksi tanpa tahu asalnya adalah cara paling cepat kehilangan
+-- sesuatu yang ternyata bukan sampah.
+--
+--   psql "$SUPABASE_DB_URL" -f supabase/checks/isi_edisi.sql
+-- ============================================================================
+
+\echo '=== EDISI AKTIF ==='
+select nomor, name, tanggal_lomba, is_active from edisi where is_active;
+
+\echo ''
+\echo '=== POS ==='
+select nomor, name, bobot, bayangan,
+       (select count(*) from wahana w
+        where w.edisi = p.edisi and w.pos = p.nomor) as komponen
+from pos p where p.edisi = edisi_aktif() order by nomor;
+
+\echo ''
+\echo '=== NILAI MENTAH: dari pos mana, regu mana, siapa yang memasukkan ==='
+select w.pos, w.kode, count(*) as baris,
+       min(n.created_at) as pertama, max(n.created_at) as terakhir
+from nilai_mentah n join wahana w on w.id = n.wahana_id
+where w.edisi = edisi_aktif()
+group by w.pos, w.kode order by w.pos, w.kode;
+
+\echo ''
+\echo '=== REGU yang punya nilai — dari sekolah mana ==='
+select distinct r.nomor_dada, r.nama_regu, s.name as sekolah, r.golongan
+from nilai_mentah n
+join wahana w on w.id = n.wahana_id
+join regu r   on r.id = n.regu_id
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s on s.id = d.sekolah_id
+where w.edisi = edisi_aktif()
+order by r.nomor_dada;
+
+\echo ''
+\echo '=== JEJAK LAIN yang ikut menahan konfigurasi ==='
+select 'regu bernomor dada' as apa, count(*) from regu where nomor_dada is not null
+union all select 'keberangkatan tercatat', count(*) from keberangkatan_regu
+union all select 'closing tercatat',       count(*) from closing_regu
+union all select 'sekolah SMOKE TEST',     count(*) from sekolah where name like 'SMOKE TEST%'
+union all select 'sekolah UJI',            count(*) from sekolah where name like 'UJI%';

--- a/supabase/migrations/0033_nama_pos_xxxvii.sql
+++ b/supabase/migrations/0033_nama_pos_xxxvii.sql
@@ -1,0 +1,180 @@
+-- ============================================================================
+-- hrcd-rekap : 0033_nama_pos_xxxvii.sql
+--
+-- MENGGANTIKAN 0032. Isinya sama persis kecuali satu nama: Pos 1 adalah
+-- **Kepramukaan**, bukan "Teknik Kepramukaan". Panitia menyebutnya begitu,
+-- dan nama pos adalah teks yang dibaca di lapangan — bukan istilah teknis.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA BERKAS BARU, BUKAN 0032 YANG DISUNTING
+--
+-- 0032 sudah pernah DITERAPKAN — ia berjalan, mencetak alasannya menolak
+-- memasang data, dan tercatat sebagai migrasi yang sudah jalan. Menyuntingnya
+-- sekarang membuat berkas di git berbeda dari yang benar-benar dijalankan,
+-- dan itu tepat yang dilarang final-architecture.md bagian 2.
+--
+-- JANGAN MENJALANKAN 0032 LAGI. Kalau dijalankan setelah berkas ini, ia
+-- memasang kembali nama yang lama. Berkas inilah yang berlaku.
+--
+-- ---------------------------------------------------------------------------
+-- PENJAGANYA SAMA: hanya jalan kalau edisi aktif BELUM memuat satu nilai pun.
+-- Mengganti aturan penilaian di tengah lomba membuat nilai yang sudah masuk
+-- kehilangan komponen induknya — yang hilang bukan angkanya, melainkan
+-- artinya.
+--
+-- Nama Pos 3 ('P3K dan Kim') TIDAK disebut panitia; ia diturunkan dari isinya.
+-- Empat nama lain diambil apa adanya: Kepramukaan, Halang Rintang, PBB,
+-- Yel-yel.
+-- ============================================================================
+
+do $$
+declare
+  v_edisi smallint;
+  v_nilai int;
+begin
+  select nomor into v_edisi from edisi where is_active;
+  if v_edisi is null then
+    raise notice '0033: belum ada edisi aktif — bagian data dilewati.';
+    return;
+  end if;
+
+  select count(*) into v_nilai
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = v_edisi;
+
+  if v_nilai > 0 then
+    raise notice '0033: edisi % sudah memuat % nilai — konfigurasi TIDAK diubah.',
+      v_edisi, v_nilai;
+    return;
+  end if;
+
+  -- ---------------------------------------------------------------------
+  -- 1. Bersihkan konfigurasi lama edisi ini
+  -- ---------------------------------------------------------------------
+  delete from wahana where edisi = v_edisi;
+  -- Kostum (pos bayangan XXXVI) tidak ada di format baru, dan nomornya
+  -- dibutuhkan garis finish.
+  delete from pos where edisi = v_edisi and nomor = 6;
+
+  -- ---------------------------------------------------------------------
+  -- 2. Pos
+  -- ---------------------------------------------------------------------
+  -- Garis finish dipindah lebih dulu supaya nomor 5 kosong untuk Yel-yel.
+  update pos set nomor = 6 where edisi = v_edisi and nomor = 5;
+
+  insert into pos (edisi, nomor, name, bobot, bayangan) values
+    (v_edisi, 0, 'Keberangkatan',      1.00, false),
+    (v_edisi, 1, 'Kepramukaan',        1.00, false),
+    (v_edisi, 2, 'Halang Rintang',     1.00, false),
+    (v_edisi, 3, 'P3K dan Kim',        1.00, false),
+    (v_edisi, 4, 'PBB',                1.00, false),
+    (v_edisi, 5, 'Yel-yel',            1.00, false),
+    (v_edisi, 6, 'Kedatangan',         1.00, false)
+  on conflict (edisi, nomor) do update
+    set name = excluded.name, bobot = excluded.bobot,
+        bayangan = excluded.bayangan;
+
+  -- ---------------------------------------------------------------------
+  -- 3. Komponen
+  --
+  -- Yang ditulis petugas selalu DATA MENTAH di tempat data mentah memang ada
+  -- (jumlah benar, waktu, selisih), dan POIN hanya di tempat penilaiannya
+  -- memang penghakiman juri (bidai, PBB, yel-yel). Yang kedua dinyatakan
+  -- sebagai `besar_baik` dengan raw_terbaik = poin_maks: nilai mentahnya
+  -- sama dengan poinnya, satu lawan satu.
+  -- ---------------------------------------------------------------------
+  insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk, poin_benar, poin_salah,
+                      total_soal, tingkat, satuan, golongan,
+                      rentang_mentah_min, rentang_mentah_maks, sort_order)
+  values
+    -- ---- Pos 1 — Teknik Kepramukaan (maks 300) ----
+    -- 5 kata, 1 kata = 20 poin.
+    (v_edisi, 1, 'semaphore', 'Semaphore', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, null, 0, 5, 1),
+
+    -- Tebak Simpul: SATU lomba, DUA baris — skalanya berbeda per golongan
+    -- (0030). Tiap regu hanya bisa mengisi barisnya sendiri; server menolak
+    -- yang lain.
+    (v_edisi, 1, 'tebak_simpul_pg_pa', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 'penggalang_pa', 0, 5, 2),
+    (v_edisi, 1, 'tebak_simpul_pg_pi', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 5, 0, null, null, null, null, null, 'penggalang_pi', 0, 5, 2),
+    (v_edisi, 1, 'tebak_simpul_pn_pa', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 'penegak_pa', 0, 10, 2),
+    (v_edisi, 1, 'tebak_simpul_pn_pi', 'Tebak Simpul', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, 'penegak_pi', 0, 10, 2),
+
+    -- Menaksir: yang ditulis SELISIH, jadi makin kecil makin baik — dan
+    -- tangganya berhenti di 20, bukan 0 (dua tingkat terakhir asumsi).
+    (v_edisi, 1, 'menaksir', 'Menaksir', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 0, "poin": 100}, {"sampai": 1, "poin": 80},
+       {"sampai": 3, "poin": 60}, {"sampai": 5, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     null, null, 0, 1000, 3),
+
+    -- ---- Pos 2 — Halang Rintang (maks 300) ----
+    -- Waktu dalam DETIK. Tingkat terakhir berbatas besar karena aturannya
+    -- berhenti di 20 poin, bukan 0.
+    (v_edisi, 2, 'bakiak', 'Bakiak', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 30, "poin": 100}, {"sampai": 40, "poin": 80},
+       {"sampai": 50, "poin": 60}, {"sampai": 60, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     'detik', null, 0, 3600, 1),
+    (v_edisi, 2, 'lari_balok', 'Lari Balok', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 30, "poin": 100}, {"sampai": 40, "poin": 80},
+       {"sampai": 50, "poin": 60}, {"sampai": 60, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     'detik', null, 0, 3600, 2),
+    (v_edisi, 2, 'balap_karung', 'Balap Karung', 'wahana', 'bertingkat',
+     100, null, null, null, null, null,
+     '[{"sampai": 20, "poin": 100}, {"sampai": 25, "poin": 80},
+       {"sampai": 30, "poin": 60}, {"sampai": 40, "poin": 40},
+       {"sampai": 100000, "poin": 20}]'::jsonb,
+     'detik', null, 0, 3600, 3),
+
+    -- ---- Pos 3 — P3K dan Kim (maks 300) ----
+    -- Bidai: penilaian juri, jadi mentah = poin (raw_terbaik = poin_maks).
+    (v_edisi, 3, 'bidai_posisi', 'Posisi Bidai', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 1),
+    (v_edisi, 3, 'bidai_teknik', 'Teknik Bidai', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 2),
+    (v_edisi, 3, 'bidai_kerapihan', 'Kerapihan dan Kebersihan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 3),
+    (v_edisi, 3, 'bidai_kecepatan', 'Kecepatan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 4),
+    (v_edisi, 3, 'bidai_kerja_sama', 'Kerja Sama', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 5),
+    -- 10 objek, gambar 15 detik lalu 30 detik menulis, berulang.
+    (v_edisi, 3, 'kim_lihat', 'Kim Lihat', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, null, 0, 10, 6),
+    -- 3 menit bebas mencium seluruh objek. Jumlah objek ASUMSI = 10.
+    (v_edisi, 3, 'kim_cium', 'Kim Cium', 'wahana', 'besar_baik',
+     100, 10, 0, null, null, null, null, null, null, 0, 10, 7),
+
+    -- ---- Pos 4 — PBB (maks 100) ----
+    (v_edisi, 4, 'pbb_sikap', 'Sikap Sempurna', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 1),
+    (v_edisi, 4, 'pbb_gerakan', 'Gerakan Dasar', 'wahana', 'besar_baik',
+     30, 30, 0, null, null, null, null, null, null, 0, 30, 2),
+    (v_edisi, 4, 'pbb_kekompakan', 'Kekompakan', 'wahana', 'besar_baik',
+     30, 30, 0, null, null, null, null, null, null, 0, 30, 3),
+    (v_edisi, 4, 'pbb_kerapihan', 'Kerapihan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 4),
+
+    -- ---- Pos 5 — Yel-yel (maks 100) ----
+    (v_edisi, 5, 'yel_kreativitas', 'Kreativitas', 'wahana', 'besar_baik',
+     35, 35, 0, null, null, null, null, null, null, 0, 35, 1),
+    (v_edisi, 5, 'yel_kekompakan', 'Kekompakan', 'wahana', 'besar_baik',
+     25, 25, 0, null, null, null, null, null, null, 0, 25, 2),
+    (v_edisi, 5, 'yel_semangat', 'Semangat', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 3),
+    (v_edisi, 5, 'yel_penampilan', 'Penampilan', 'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 4);
+
+  raise notice '0033: konfigurasi HRCD XXXVII terpasang untuk edisi %.', v_edisi;
+end;
+$$;


### PR DESCRIPTION
## What

Three files, all downstream of one finding.

**`isi_edisi.sql`** — read-only. Asks what the active edition actually holds, because `0032` refused to install the new configuration while values existed, and deleting production data without knowing its origin is the fastest way to lose something that turns out not to be rubbish.

It answered plainly. **All 16 schools are testing residue:**

| Evidence | |
| --- | --- |
| Generated names | `SMA Tabel 054155`, `SMK Uji Produksi`, `SMP Uji Deploy`, `UJI MEJA PEMBAYARAN` |
| Placeholder addresses | `ABC`, `HEHe`, `Jl`, `Jl ABC` |
| Registered | 12–13 Aug 2026 — our testing window |
| Race date | 21 Feb 2027; registration has not opened |

**`cleanup_data_uji.sql`** — removes every participant row for the edition, leaf to root, in one transaction. Leaves `history` alone: append-only, no foreign keys to break, and the only record that the clearing happened. Stock numbers, panitia accounts and scoring configuration are untouched — none are participant data. Also resets kloter departure times and the hari-H switches.

**`0033_nama_pos_xxxvii.sql`** — same configuration as `0032` with one word changed: **Pos 1 is `Kepramukaan`**, not "Teknik Kepramukaan".

## Why a new migration instead of editing 0032

`0032` has already been applied — it ran, printed why it declined to install data, and is recorded as run. Editing it now would make the file in git differ from what actually executed, which is what `final-architecture.md` section 2 forbids.

**`0032` must not be re-run after this** — it would put the old name back. `0033` is the one that counts, and it carries the same guard: it refuses if the edition holds any value.

## Notes

Pos 3's name is derived, not given. Panitia titled Pos 1, 2, 4 and 5 but left 3 unnamed, so it reads **"P3K dan Kim"** after its contents. Say the word and it changes with a one-line `UPDATE`.

`cleanup_data_uji.sql` cannot tell a test school from a real one — it deletes all of them. The only thing that distinguishes them is the person running it. That warning is in the file header, not just here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)