### PR TITLE
fix: name the pos exactly as panitia say them

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tersebar di migrasi, tes, dan SPA — menunjuk ke nomor bagiannya (`rancangan-b.
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0032
+│   ├── migrations/           # skema database, urut 0001..0034
 │   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
 │   │                         # data; live_json.sql dipakai Publish rekap live
 │   └── seed.sql              # konfigurasi edisi + baris wajib

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0032`.
+Terakhir diperiksa terhadap kode: **14 Agustus 2026**, sampai migrasi `0034`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-32 migrasi, `0001` sampai `0032`, dijalankan berurutan tanpa lubang penomoran.
+34 migrasi, `0001` sampai `0034`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0034_nama_pos_final.sql
+++ b/supabase/migrations/0034_nama_pos_final.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- hrcd-rekap : 0034_nama_pos_final.sql
+--
+-- Nama pos HRCD XXXVII sebagaimana disebut panitia, kata demi kata:
+--
+--   Pos 1  Kepramukaan
+--   Pos 2  Halang Rintang
+--   Pos 3  P3K
+--   Pos 4  PBB
+--   Pos 5  Yel-Yel
+--
+-- Dua yang berubah dari 0033: Pos 3 yang tadinya 'P3K dan Kim' — nama itu
+-- saya turunkan sendiri dari isinya karena panitia belum menyebutnya — dan
+-- Pos 5 yang tadinya 'Yel-yel'.
+--
+-- ---------------------------------------------------------------------------
+-- PENJAGANYA SAMA DENGAN 0033, DAN ITU PERLU
+--
+-- Berkas ini mengganti nama BERDASARKAN NOMOR POS. Itu hanya benar kalau tata
+-- letak XXXVII memang sudah terpasang. Di database yang 0033-nya dilewati —
+-- database uji, misalnya — Pos 5 masih GARIS FINISH, dan menamainya 'Yel-Yel'
+-- membuat garis finish menyamar jadi pos penilaian. Tidak ada yang gagal; yang
+-- rusak hanya arti kata di layar, dan itu jenis kerusakan yang paling lama
+-- tidak ketahuan.
+--
+-- Jadi syaratnya disamakan: jalan hanya bila edisi belum memuat satu nilai
+-- pun — persis keadaan yang membuat 0033 jadi memasang konfigurasinya.
+--
+-- Nama pos adalah UI text: ia dibaca panitia di layar dan di kertas, jadi
+-- yang dipakai kata yang mereka ucapkan sendiri (CLAUDE.md aturan 5.1).
+-- "P3K" bukan singkatan yang perlu dipanjangkan di sini — begitulah pos itu
+-- dipanggil di lapangan.
+-- ============================================================================
+
+do $$
+declare v_edisi smallint; v_nilai int;
+begin
+  select nomor into v_edisi from edisi where is_active;
+  if v_edisi is null then
+    raise notice '0034: belum ada edisi aktif — nama pos dilewati.';
+    return;
+  end if;
+
+  select count(*) into v_nilai
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = v_edisi;
+
+  if v_nilai > 0 then
+    raise notice '0034: edisi % memuat % nilai — tata letak XXXVII tidak '
+                 'terpasang, nama pos TIDAK diubah.', v_edisi, v_nilai;
+    return;
+  end if;
+
+  update pos set name = 'Kepramukaan'    where edisi = v_edisi and nomor = 1;
+  update pos set name = 'Halang Rintang' where edisi = v_edisi and nomor = 2;
+  update pos set name = 'P3K'            where edisi = v_edisi and nomor = 3;
+  update pos set name = 'PBB'            where edisi = v_edisi and nomor = 4;
+  update pos set name = 'Yel-Yel'        where edisi = v_edisi and nomor = 5;
+
+  raise notice '0034: nama pos edisi % disesuaikan.', v_edisi;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -99,6 +99,11 @@ run tests/sql/12_pesan_rentang.sql
 # setelah database uji penuh nilai, supaya penolakan itu ikut terbukti —
 # dan supaya tes 02-12 tetap memakai konfigurasi yang mereka andalkan.
 run supabase/migrations/0032_konfigurasi_xxxvii.sql
+# 0033 menggantikan 0032 (Pos 1 = Kepramukaan); 0034 membetulkan dua nama
+# terakhir. Keduanya ikut dijalankan supaya berkasnya tetap teruji, walau
+# di database uji 0033 menolak memasang data — persis seperti 0032.
+run supabase/migrations/0033_nama_pos_xxxvii.sql
+run supabase/migrations/0034_nama_pos_final.sql
 run tests/sql/13_komponen_per_golongan.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/13_komponen_per_golongan.sql
+++ b/tests/sql/13_komponen_per_golongan.sql
@@ -22,9 +22,15 @@
 do $$
 declare v_pos5 text; v_kostum int;
 begin
+  -- Pos 5 di sini masih GARIS FINISH. Diperiksa dengan menyebut nama yang
+  -- SEHARUSNYA ada, bukan sekadar "bukan Yel-yel": 0034 mengganti nama pos
+  -- berdasarkan nomornya, jadi kalau penjaganya jebol yang tertulis di sini
+  -- akan berubah jadi nama pos penilaian — dan garis finish yang menyamar
+  -- jadi pos adalah kerusakan yang tidak menimbulkan galat apa pun.
   select name into v_pos5 from pos where edisi = edisi_aktif() and nomor = 5;
-  assert v_pos5 is distinct from 'Yel-yel',
-    '0032 mengganti konfigurasi padahal sudah ada nilai tersimpan';
+  assert v_pos5 = 'Kedatangan',
+    format('Pos 5 seharusnya masih Kedatangan, ternyata %L — konfigurasi '
+           'diganti padahal sudah ada nilai tersimpan', v_pos5);
 
   select count(*) into v_kostum from pos
   where edisi = edisi_aktif() and bayangan;


### PR DESCRIPTION
## What

```
Pos 3  P3K dan Kim  →  P3K
Pos 5  Yel-yel      →  Yel-Yel
```

Pos 3's old name was mine — derived from its contents because panitia had titled every pos but that one. They have now named it, so the guess goes.

## The guard, and why it is not optional

The migration renames **by pos number**. That is only correct where the XXXVII layout is actually installed.

In a database where `0033` was skipped — the test database, for one — **Pos 5 is still the finish line**. Renaming it "Yel-Yel" would disguise the finish line as a scored pos. Nothing fails; only the meaning of a word on screen breaks, which is the kind of damage that stays unnoticed longest.

So `0034` carries the same guard as `0033`: it runs only when the edition holds no values — exactly the condition under which `0033` installed the layout.

## Notes

`13.1` was asserting that Pos 5 is *not* `Yel-yel`. That would have passed here **by accident**, since the new name is `Yel-Yel` and the comparison is case-sensitive. It now asserts the name that should be there — `Kedatangan` — and prints what it found instead.

`0033` and `0034` are also added to `run.sh`, so both files stay under test even though both decline to touch the test database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)