### PR TITLE
docs: the unit of scoring is the lomba, not the pos

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -387,7 +387,45 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 1. **Aturan penilaian berubah setiap tahun.** Sistem harus dapat diubah tanpa
    mengubah kode. Yang berikut ini adalah konfigurasi edisi berjalan, bukan
    aturan tetap.
-2. Bobot setiap pos **sama rata**.
+2. **Yang setara adalah LOMBA, bukan pos.** Satuan penilaian adalah lomba, dan
+   tiap lomba bernilai maksimum **100**. Maksimum sebuah pos karena itu bukan
+   angka tetap melainkan hasil hitungan:
+
+   ```
+   maksimum pos = 100 × jumlah lomba di pos itu
+   ```
+
+   Pos berisi tiga lomba bernilai 300; pos berisi satu lomba bernilai 100; pos
+   berisi lima lomba bernilai 500. Tidak ada batas atas yang perlu dijaga —
+   angkanya mengikuti apa pun yang panitia susun tahun itu.
+
+   Edisi XXXVII kebetulan begini:
+
+   | Pos | Lomba | Maksimum |
+   | --- | --- | --- |
+   | 1 Kepramukaan | Semaphore, Tebak Simpul, Menaksir | 300 |
+   | 2 Halang Rintang | Bakiak, Lari Balok, Balap Karung | 300 |
+   | 3 P3K | Bidai, Kim Lihat, Kim Cium | 300 |
+   | 4 PBB | PBB | 100 |
+   | 5 Yel-Yel | Yel-Yel | 100 |
+
+   Akibatnya nyata dan disengaja: regu yang sempurna di Pos 1 mendapat 300,
+   yang sempurna di PBB mendapat 100 — Pos 1 tiga kali lebih menentukan
+   peringkat. Itu bukan ketimpangan, melainkan cara menghitung yang mengikuti
+   jumlah lomba yang benar-benar dikerjakan regu di sana.
+
+   Satu hal yang perlu diperhatikan saat menyusun pos tahun depan: **memindah
+   satu lomba dari satu pos ke pos lain mengubah bobot keduanya**, karena
+   bobot pos tidak pernah ditulis — ia lahir dari jumlah lombanya.
+
+   > Sampai HRCD XXXVI baris ini berbunyi "bobot setiap pos sama rata", dan
+   > waktu itu benar: tiap pos memang satu paket penilaian. Format XXXVII
+   > memecah pos menjadi beberapa lomba yang berjalan bersamaan, dan sejak itu
+   > "pos" berhenti menjadi satuan yang bisa disetarakan.
+   >
+   > Kolom `pos.bobot` tetap ada dan tetap 1,00 untuk semua. Ia masih jalan
+   > keluar bila suatu tahun panitia ingin menyetarakan pos — tidak perlu
+   > mengubah kode, cukup mengubah angkanya.
 3. Total skor = **jumlah skor seluruh pos − seluruh penalti** (bagian 10).
 4. **Penentu peringkat saat skor seri: ketepatan waktu.** Regu dengan selisih
    waktu lebih kecil terhadap targetnya menempati peringkat lebih tinggi. Ini

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -104,9 +104,19 @@ poin per pita, dipakai kolom waktu yang menilai "masuk pita 1 menit", bukan
 tiap detik). Layar Input Pos membangun kolomnya dari baris-baris itu, jadi
 mengubah penilaian tahun depan tidak menyentuh kode sama sekali.
 
+**Bobot pos tidak pernah ditulis; ia lahir dari jumlah lombanya.** Satuan
+penilaian adalah lomba, dan tiap lomba bernilai maksimum 100 — jadi pos
+berisi tiga lomba bernilai 300, pos berisi lima lomba bernilai 500
+(`alur-lomba.md` 9.2). `pos.bobot` tetap 1,00 untuk semua dan hanya dipakai
+kalau suatu tahun panitia ingin menyetarakan pos secara paksa.
+
+Konsekuensi yang mudah terlewat saat menyusun pos tahun depan: **memindah
+satu lomba dari satu pos ke pos lain mengubah bobot keduanya**, tanpa satu
+angka pun diubah.
+
 **Pos bayangan ikut dinilai** (migrasi `0021`). Ia pos biasa dengan penanda
 `pos.bayangan`, bernomor melanjutkan pos utama — bukan cabang tersendiri di
-mesin skor.
+mesin skor. Format XXXVII tidak memakainya.
 
 **Tidak semua baris `pos` dinilai** (migrasi `0025`). Pos 0 (Keberangkatan) dan
 Pos 5 (Kedatangan) adalah garis start dan garis finish; yang dicatat di sana


### PR DESCRIPTION
## What

`alur-lomba.md` 9.2 said **"bobot setiap pos sama rata"**. That was true through HRCD XXXVI, where a pos was one package of judging. XXXVII splits a pos into several lomba running side by side, and from then on "pos" stopped being a thing that can be made equal.

Written as a rule rather than as this year's numbers:

```
maksimum pos = 100 × jumlah lomba di pos itu
```

Three lomba is 300, one is 100, **five is 500**. No ceiling to maintain — the figure follows whatever the panitia arrange that year. XXXVII's layout stays underneath as an example, not as the definition.

## Why spell out the consequence

A team perfect at Pos 1 gains 300; perfect at PBB gains 100. **Pos 1 weighs three times as much in the ranking.** That is deliberate, and it follows the number of lomba a team actually competes in there — but it is the kind of thing that gets discovered mid-event by someone recomputing a ranking by hand, so it is stated rather than left implicit.

With it, the trap: **moving one lomba between pos changes the weight of both**, without a single number being edited, because pos weight is never written down — it is derived from the component rows.

## Notes

Docs only — the configuration already matches and was not touched. `pos.bobot` stays 1.00 everywhere and stays documented as the escape hatch if a future year does want pos forced level.

`final-architecture.md` section 2 gains the same rule, since that is where someone reading the database looks first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)