### PR TITLE
fix: tangga poin Menaksir turun 20 tiap meter sampai 0

### DIFF
--- a/supabase/migrations/0033_nama_pos_xxxvii.sql
+++ b/supabase/migrations/0033_nama_pos_xxxvii.sql
@@ -105,8 +105,14 @@ begin
     (v_edisi, 1, 'tebak_simpul_pn_pi', 'Tebak Simpul', 'wahana', 'besar_baik',
      100, 10, 0, null, null, null, null, null, 'penegak_pi', 0, 10, 2),
 
-    -- Menaksir: yang ditulis SELISIH, jadi makin kecil makin baik — dan
-    -- tangganya berhenti di 20, bukan 0 (dua tingkat terakhir asumsi).
+    -- Menaksir: yang ditulis SELISIH, jadi makin kecil makin baik.
+    --
+    -- TANGGA DI BAWAH INI SUDAH USANG — lihat 0035, yang menggantinya dengan
+    -- angka dari panitia: turun 20 tiap meter sampai menyentuh 0. Dua tingkat
+    -- terakhir di sini memang ditandai asumsi sejak awal, dan asumsinya
+    -- meleset di dua hal: selisih 2 m ternyata 60 (bukan sama dengan 3 m), dan
+    -- poinnya habis di 0 (bukan berhenti di 20 seperti Pos 2). Dibiarkan apa
+    -- adanya karena migrasi adalah catatan sejarah, bukan keadaan terkini.
     (v_edisi, 1, 'menaksir', 'Menaksir', 'wahana', 'bertingkat',
      100, null, null, null, null, null,
      '[{"sampai": 0, "poin": 100}, {"sampai": 1, "poin": 80},

--- a/supabase/migrations/0035_tangga_menaksir.sql
+++ b/supabase/migrations/0035_tangga_menaksir.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- hrcd-rekap : 0035_tangga_menaksir.sql
+--
+-- Tangga poin Menaksir sebagaimana ditetapkan panitia:
+--
+--   selisih 0 m  -> 100      selisih 3 m    ->  40
+--   selisih 1 m  ->  80      selisih 4 m    ->  20
+--   selisih 2 m  ->  60      lebih dari 4 m ->   0
+--
+-- Turun 20 poin tiap meter, dan menyentuh 0.
+--
+-- Menggantikan tangga di 0033, yang dua tingkat terakhirnya memang ditandai
+-- asumsi: di sana selisih 2 m dan 3 m sama-sama bernilai 60, dan poinnya
+-- berhenti di 20 seperti Pos 2. Keduanya keliru.
+--
+-- ---------------------------------------------------------------------------
+-- SATU BARIS YANG DIBACA SEBAGAI SALAH KETIK
+--
+-- Daftar yang diberikan panitia berakhir dengan "Selisih 2m 0", padahal
+-- selisih 2 m sudah bernilai 60 di baris ketiga. Dibaca sebagai tingkat
+-- TERAKHIR — batas di mana poinnya habis — karena itu satu-satunya bacaan
+-- yang membuat daftarnya utuh: 0, 1, 2, 3, 4, lalu selesai. Polanya sendiri
+-- yang menentukan angkanya, bukan tebakan: tiap meter turun 20, jadi meter
+-- kelima jatuh ke 0.
+--
+-- Kalau yang dimaksud lain, cukup satu UPDATE pada baris `menaksir`.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TIDAK ADA TINGKAT PENUTUP
+--
+-- `bertingkat` memberi 0 untuk nilai di luar seluruh tingkat (migrasi 0022).
+-- Di Pos 2 itu justru salah, karena aturannya berhenti di 20 — ketiga lomba di
+-- sana diberi tingkat terakhir berbatas sangat besar supaya tidak jatuh ke 0.
+-- Menaksir tidak membutuhkannya: 0 di luar tangga memang jawabannya. Tingkat
+-- `{"sampai": 100000, "poin": 20}` dari 0033 karena itu dibuang, bukan diubah.
+--
+-- Tidak ada penjaga "belum ada nilai" di sini, dan itu disengaja. 0033 dan
+-- 0034 dipagari begitu karena mereka menulis ULANG tata letak — berbahaya di
+-- database yang isinya lain. Berkas ini hanya membetulkan satu aturan
+-- penilaian, dan pembetulan aturan justru harus tetap bisa dijalankan setelah
+-- ada nilai masuk. Yang perlu disadari: skor diturunkan saat DIBACA, jadi
+-- mengubah tangga ini mengubah pula peringkat yang sudah tampil di layar.
+-- ============================================================================
+
+do $$
+declare v_baris int;
+begin
+  update wahana set
+    tingkat = '[{"sampai": 0, "poin": 100},
+                {"sampai": 1, "poin": 80},
+                {"sampai": 2, "poin": 60},
+                {"sampai": 3, "poin": 40},
+                {"sampai": 4, "poin": 20}]'::jsonb
+  where edisi = edisi_aktif() and kode = 'menaksir';
+
+  get diagnostics v_baris = row_count;
+
+  -- Dilaporkan, bukan diandaikan: di database yang konfigurasi XXXVII-nya
+  -- belum terpasang, baris `menaksir` memang tidak ada dan UPDATE ini tidak
+  -- mengenai apa pun. Itu keadaan yang sah — yang tidak sah adalah mengira
+  -- tangganya sudah terpasang padahal tidak.
+  if v_baris = 0 then
+    raise notice '0035: komponen `menaksir` tidak ada di edisi aktif — '
+                 'tangga poin dilewati.';
+  else
+    raise notice '0035: tangga Menaksir diperbarui (% baris).', v_baris;
+  end if;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -105,5 +105,10 @@ run supabase/migrations/0032_konfigurasi_xxxvii.sql
 run supabase/migrations/0033_nama_pos_xxxvii.sql
 run supabase/migrations/0034_nama_pos_final.sql
 run tests/sql/13_komponen_per_golongan.sql
+# 0035 hanya membetulkan satu tangga poin, jadi TIDAK dipagari "belum ada
+# nilai" seperti tiga berkas di atasnya — di database uji ia berjalan sungguhan
+# dan tidak mengenai apa pun, karena `menaksir` memang tidak ada di sini.
+run supabase/migrations/0035_tangga_menaksir.sql
+run tests/sql/14_tangga_menaksir.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/14_tangga_menaksir.sql
+++ b/tests/sql/14_tangga_menaksir.sql
@@ -1,0 +1,110 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/14_tangga_menaksir.sql
+-- Tangga poin Menaksir (0035).
+--
+-- Yang dijaga di sini bukan angkanya, melainkan SATU KEPUTUSAN: tangga ini
+-- sengaja tidak diberi tingkat penutup, karena `bertingkat` memberi 0 untuk
+-- nilai di luar semua tingkat dan 0 memang jawaban yang benar untuk selisih
+-- lebih dari 4 m.
+--
+-- Ketiga lomba Pos 2 mengambil keputusan SEBALIKNYA — di sana aturannya
+-- berhenti di 20, jadi masing-masing diberi tingkat terakhir berbatas sangat
+-- besar. Dua kebiasaan yang berlawanan hidup berdampingan di satu tabel, dan
+-- itulah kenapa yang satu bisa tanpa sengaja disamakan dengan yang lain oleh
+-- orang yang merapikan konfigurasi setahun kemudian. Kalau itu terjadi pada
+-- Menaksir, regu yang menaksir sejauh 40 m dari jarak sebenarnya tetap dapat
+-- 20 poin — tidak ada yang gagal, tidak ada yang aneh di layar.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 14.1 Tangganya, meter demi meter — termasuk yang jatuh ke luar tangga.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_tangga jsonb := '[{"sampai": 0, "poin": 100},
+                      {"sampai": 1, "poin": 80},
+                      {"sampai": 2, "poin": 60},
+                      {"sampai": 3, "poin": 40},
+                      {"sampai": 4, "poin": 20}]'::jsonb;
+  v_harap  numeric;
+  v_dapat  numeric;
+  v_uji    record;
+begin
+  for v_uji in
+    select * from (values
+      (0,   100), (1,    80), (2,    60), (3,    40), (4,    20),
+      -- Di luar tangga. Yang pertama adalah meter kelima — batas persis di
+      -- mana poinnya habis. Dua sisanya memastikan tidak ada tingkat penutup
+      -- yang diam-diam menahan nilainya di 20.
+      (5,     0), (12,    0), (1000,  0)
+    ) as t(selisih, poin)
+  loop
+    v_harap := v_uji.poin;
+    v_dapat := hitung_poin('bertingkat', v_uji.selisih, null, 100,
+                           null, null, null, null, null, v_tangga);
+    assert v_dapat = v_harap,
+      format('selisih %s m: seharusnya %s poin, ternyata %s',
+             v_uji.selisih, v_harap, v_dapat);
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 14.2 Selisih pecahan. Petugas menulis angka, bukan bilangan bulat, dan
+--      2,5 m BUKAN 50 poin — tangga adalah anak tangga, bukan garis miring.
+--      Dites supaya perilakunya tercatat: yang menentukan adalah tingkat
+--      PERTAMA yang masih memuatnya, jadi 2,5 ikut pita "sampai 3" = 40.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_tangga jsonb := '[{"sampai": 0, "poin": 100},
+                      {"sampai": 1, "poin": 80},
+                      {"sampai": 2, "poin": 60},
+                      {"sampai": 3, "poin": 40},
+                      {"sampai": 4, "poin": 20}]'::jsonb;
+  v_dapat  numeric;
+begin
+  v_dapat := hitung_poin('bertingkat', 2.5, null, 100,
+                         null, null, null, null, null, v_tangga);
+  assert v_dapat = 40,
+    format('selisih 2,5 m seharusnya 40 poin (pita "sampai 3"), ternyata %s',
+           v_dapat);
+
+  -- Tepat di batas masuk ke pita itu sendiri, bukan pita berikutnya.
+  v_dapat := hitung_poin('bertingkat', 2.0, null, 100,
+                         null, null, null, null, null, v_tangga);
+  assert v_dapat = 60,
+    format('selisih 2 m tepat di batas seharusnya 60 poin, ternyata %s',
+           v_dapat);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 14.3 Kalau konfigurasi XXXVII memang terpasang, tangga yang TERSIMPAN wajib
+--      sama dengan yang diuji di atas. Di database uji ini konfigurasinya
+--      masih XXXVI (lihat 13.1), jadi bagian ini melapor dilewati — bukan
+--      lulus diam-diam.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_tersimpan jsonb;
+begin
+  select tingkat into v_tersimpan from wahana
+  where edisi = edisi_aktif() and kode = 'menaksir';
+
+  if not found then
+    raise notice '14.3 dilewati: komponen `menaksir` tidak ada di edisi aktif.';
+    return;
+  end if;
+
+  assert v_tersimpan = '[{"sampai": 0, "poin": 100},
+                         {"sampai": 1, "poin": 80},
+                         {"sampai": 2, "poin": 60},
+                         {"sampai": 3, "poin": 40},
+                         {"sampai": 4, "poin": 20}]'::jsonb,
+    format('tangga Menaksir tersimpan tidak sesuai 0035: %s', v_tersimpan);
+
+  raise notice '14.3: tangga Menaksir tersimpan sesuai 0035.';
+end;
+$$;
+
+select '14_tangga_menaksir OK' as hasil;


### PR DESCRIPTION
## What

Tangga poin Menaksir, angka dari panitia:

| Selisih | 0 m | 1 m | 2 m | 3 m | 4 m | lebih dari 4 m |
|---|---|---|---|---|---|---|
| Poin | 100 | 80 | 60 | 40 | 20 | **0** |

## Why

`0033` menandai dua tingkat terakhir Menaksir sebagai asumsi. Asumsinya meleset di dua tempat:

1. **Selisih 2 m bernilai 60 karena disamakan dengan 3 m** — meleset satu meter dan meleset tiga meter dihargai sama.
2. **Poinnya berhenti di 20**, meniru Pos 2 — regu yang meleset 40 m tetap mendapat seperlima nilai penuh.

Tingkat penutup `{"sampai": 100000, "poin": 20}` dibuang, bukan diperkecil: `bertingkat` sudah memberi 0 untuk nilai di luar semua tingkat, dan 0 memang jawabannya di sini.

## Notes

**Dua kebiasaan berlawanan kini hidup di satu tabel.** Pos 2 justru *butuh* tingkat penutup berbatas besar karena aturannya benar-benar berhenti di 20; Menaksir justru rusak kalau diberi satu. Itu jenis ketidakseragaman yang dirapikan orang setahun kemudian dengan niat baik — jadi `tests/sql/14` menjaga keputusannya, bukan cuma angkanya, dan menyebut akibatnya kalau jebol.

**Baris terakhir daftar panitia dibaca sebagai salah ketik.** Tertulis "Selisih 2m 0", padahal 2 m sudah bernilai 60 tiga baris di atasnya. Dibaca sebagai baris penutup tangga — polanya sendiri (turun 20 tiap meter) yang menentukan meter kelima jatuh ke 0, bukan tebakan.

**Tidak dipagari "belum ada nilai"**, berbeda dengan `0032`–`0034`. Ketiganya menulis ulang tata letak dan berbahaya di database yang isinya lain; yang ini membetulkan satu aturan penilaian, dan pembetulan aturan harus tetap bisa dijalankan setelah nilai masuk. Konsekuensinya disebut di kepala berkas: skor diturunkan saat dibaca, jadi menjalankannya mengubah peringkat yang sudah tampil.

Tes 14 juga mencatat perilaku pecahan: selisih 2,5 m dapat 40, bukan 50 — tangga adalah anak tangga, bukan garis miring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)