### PR TITLE
docs: Kim Cium 10 objek bukan lagi asumsi

### DIFF
--- a/supabase/migrations/0033_nama_pos_xxxvii.sql
+++ b/supabase/migrations/0033_nama_pos_xxxvii.sql
@@ -157,7 +157,13 @@ begin
     -- 10 objek, gambar 15 detik lalu 30 detik menulis, berulang.
     (v_edisi, 3, 'kim_lihat', 'Kim Lihat', 'wahana', 'besar_baik',
      100, 10, 0, null, null, null, null, null, null, 0, 10, 6),
-    -- 3 menit bebas mencium seluruh objek. Jumlah objek ASUMSI = 10.
+    -- 3 menit bebas mencium seluruh objek. Jumlah objek 10 — semula asumsi
+    -- (menyamai Kim Lihat), dikonfirmasi panitia 14 Agustus 2026 dengan kata
+    -- "sementara", jadi angka ini boleh berubah sebelum hari lomba. Kalau
+    -- berubah: `raw_terbaik` DAN `rentang_mentah_maks` ikut, keduanya, dalam
+    -- satu UPDATE. Mengubah salah satu saja tidak menimbulkan galat — yang
+    -- terjadi hanya nilai penuh yang tidak pernah tercapai, atau petugas
+    -- ditolak saat menulis angka yang sah.
     (v_edisi, 3, 'kim_cium', 'Kim Cium', 'wahana', 'besar_baik',
      100, 10, 0, null, null, null, null, null, null, 0, 10, 7),
 


### PR DESCRIPTION
## What

Komentar `kim_cium` di `0033` tidak lagi menyebut jumlah objeknya asumsi. **Angkanya tidak berubah** — sudah 10 sejak `0033`, dan panitia mengonfirmasi 10. Tidak ada migrasi baru dan tidak ada yang perlu diterapkan ke produksi.

## Why

Kata "ASUMSI" di komentar adalah undangan: orang berikutnya yang membaca akan merasa berhak menggantinya dengan angka yang dikiranya lebih benar. Setelah dikonfirmasi, label itu justru jadi jebakan.

Konfirmasinya bersyarat — panitia menyebut **"sementara"** — jadi yang dicatat bukan cuma angkanya, melainkan cara mengubahnya kalau memang berubah:

> `raw_terbaik` **dan** `rentang_mentah_maks`, keduanya, dalam satu `UPDATE`.

Mengubah salah satu saja tidak menimbulkan galat. Yang terjadi hanya nilai penuh yang tidak pernah tercapai, atau petugas ditolak saat menulis angka yang sah — dua kerusakan yang baru ketahuan di lapangan.

## Notes

Komentar saja. Perubahan jumlah objek nanti tidak menuntut deploy apa pun: penilaian dibangun dari tabel `wahana`, jadi satu `UPDATE` sudah mengubah kertas, layar input, dan rekap sekaligus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)