### PR TITLE
feat: kriteria Bidai memakai lima kriteria P3K yang ditetapkan panitia

### DIFF
--- a/supabase/migrations/0036_kriteria_bidai.sql
+++ b/supabase/migrations/0036_kriteria_bidai.sql
@@ -1,0 +1,149 @@
+-- ============================================================================
+-- hrcd-rekap : 0036_kriteria_bidai.sql
+--
+-- Kriteria penilaian Bidai (Pos 3 — P3K) sebagaimana ditetapkan panitia:
+--
+--   1. Diagnosis dan Penanganan Awal      20
+--   2. Posisi Bidai                       20
+--   3. Teknik Bidai                       20
+--   4. Kerapihan dan Kebersihan           20
+--   5. Kecepatan dan Kerja Sama           20
+--                                        ---
+--                                        100
+--
+-- ---------------------------------------------------------------------------
+-- INI BUKAN SEKADAR MENAMBAH SATU KOLOM
+--
+-- Jumlah kriterianya tetap lima, jadi angka 20 dan total 100 tidak berubah dan
+-- selisihnya mudah terlewat. Yang berubah adalah CARA JURI MENIMBANG:
+--
+--   sebelum : Kecepatan 20  +  Kerja Sama 20   = 40 poin untuk dua hal itu
+--   sesudah : Kecepatan dan Kerja Sama 20      = 20 poin, dan 20 sisanya
+--                                                pindah ke Diagnosis
+--
+-- Kecepatan dan kerja sama dulu bisa saling menutupi — regu yang lambat tapi
+-- kompak tetap memanen 20. Sekarang keduanya satu penilaian, dan bobot yang
+-- terbebas dipakai untuk hal yang sebelumnya tidak dinilai sama sekali:
+-- apakah reguya benar mengenali cedera dan menanganinya lebih dulu.
+--
+-- Kriteria yang tidak dinilai bukan sekadar kehilangan poin — ia hilang dari
+-- kertas, jadi jurinya pun tidak diminta melihatnya.
+--
+-- ---------------------------------------------------------------------------
+-- DUA PENJAGA, MASING-MASING UNTUK BAHAYA YANG BERBEDA
+--
+-- 1. Berkas ini menyentuh Pos 3 berdasarkan NOMORNYA. Di database yang tata
+--    letak XXXVII-nya belum terpasang — database uji, misalnya — pos 3 adalah
+--    pos yang sama sekali lain, dan menambahkan kriteria bidai ke sana
+--    menyelundupkan komponen asing tanpa satu galat pun. Jadi yang diperiksa
+--    bukan "edisi keberapa", melainkan apakah `bidai_posisi` memang ada:
+--    tanda paling langsung bahwa Pos 3 di sini benar-benar P3K.
+--
+-- 2. `bidai_kerja_sama` DIHAPUS, dan menghapus komponen ikut menghapus nilai
+--    yang menempel padanya. Kalau sudah ada nilai bidai tersimpan, berkas ini
+--    berhenti dengan galat — bukan notice. Notice berarti "dilewati, semua
+--    aman"; di sini yang terjadi justru sebaliknya, dan konfigurasi setengah
+--    berubah lebih berbahaya daripada tidak berubah sama sekali.
+--
+--    Kalau memang harus diubah setelah ada nilai, itu keputusan sadar: catat
+--    dulu nilai bidai yang ada, jalankan, lalu masukkan ulang. Nilai lama
+--    TIDAK bisa dipetakan otomatis — 20 untuk "Kecepatan" bukan 20 untuk
+--    "Kecepatan dan Kerja Sama", dan yang hilang bukan angkanya melainkan
+--    artinya.
+--
+-- ---------------------------------------------------------------------------
+-- SATU PENYERAGAMAN KECIL
+--
+-- Panitia menulis "Diagnosis & Penanganan Awal" dan "Kerapihan / Kebersihan".
+-- Kata-katanya dipakai apa adanya; hanya penyambungnya diseragamkan jadi "dan"
+-- supaya kelima label yang berdiri berdampingan di satu lembar tidak memakai
+-- tiga gaya sekaligus (&, /, dan). Ini nama yang dibaca juri di kertas dan di
+-- layar (CLAUDE.md aturan 5.1).
+-- ============================================================================
+
+do $$
+declare
+  v_edisi  smallint;
+  v_ada    boolean;
+  v_nilai  int;
+  v_jumlah int;
+  v_total  numeric;
+begin
+  select nomor into v_edisi from edisi where is_active;
+  if v_edisi is null then
+    raise notice '0036: belum ada edisi aktif — kriteria bidai dilewati.';
+    return;
+  end if;
+
+  -- Penjaga 1: Pos 3 di edisi ini benar-benar P3K?
+  select exists (select 1 from wahana
+                 where edisi = v_edisi and pos = 3 and kode = 'bidai_posisi')
+    into v_ada;
+  if not v_ada then
+    raise notice '0036: `bidai_posisi` tidak ada di edisi % — tata letak '
+                 'XXXVII tidak terpasang, kriteria bidai TIDAK diubah.',
+                 v_edisi;
+    return;
+  end if;
+
+  -- Penjaga 2: ada nilai bidai tersimpan?
+  select count(*) into v_nilai
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = v_edisi and w.pos = 3 and w.kode like 'bidai%';
+
+  if v_nilai > 0 then
+    raise exception
+      '0036: ada % nilai bidai tersimpan di edisi %. Mengubah kriteria akan '
+      'menghapus sebagian di antaranya dan membuat sisanya berarti lain. '
+      'Catat dulu nilainya, baru jalankan ulang.', v_nilai, v_edisi;
+  end if;
+
+  -- Kriteria baru, di urutan pertama — juri menilai diagnosis SEBELUM memasang
+  -- bidai, jadi kertasnya pun harus bertanya dalam urutan itu.
+  insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk, poin_benar, poin_salah,
+                      total_soal, tingkat, satuan, golongan,
+                      rentang_mentah_min, rentang_mentah_maks, sort_order)
+  values
+    (v_edisi, 3, 'bidai_diagnosis', 'Diagnosis dan Penanganan Awal',
+     'wahana', 'besar_baik',
+     20, 20, 0, null, null, null, null, null, null, 0, 20, 1)
+  on conflict (edisi, pos, kode) do update set
+    name = excluded.name, sort_order = excluded.sort_order;
+
+  -- Kecepatan dan Kerja Sama menyatu. Barisnya diganti nama, bukan dihapus
+  -- lalu dibuat ulang — supaya `id`-nya tetap, dan supaya jelas di riwayat
+  -- bahwa yang terjadi adalah penggabungan, bukan pergantian.
+  update wahana set kode = 'bidai_kecepatan_kerja_sama',
+                    name = 'Kecepatan dan Kerja Sama'
+  where edisi = v_edisi and pos = 3 and kode = 'bidai_kecepatan';
+
+  delete from wahana
+  where edisi = v_edisi and pos = 3 and kode = 'bidai_kerja_sama';
+
+  -- Urutan di kertas dan di layar. Ditulis semuanya, bukan hanya yang
+  -- bergeser: satu daftar utuh lebih mudah dicocokkan dengan aturan panitia
+  -- daripada tiga UPDATE yang harus dibaca sebagai selisih.
+  update wahana set sort_order = 1 where edisi = v_edisi and pos = 3 and kode = 'bidai_diagnosis';
+  update wahana set sort_order = 2 where edisi = v_edisi and pos = 3 and kode = 'bidai_posisi';
+  update wahana set sort_order = 3 where edisi = v_edisi and pos = 3 and kode = 'bidai_teknik';
+  update wahana set sort_order = 4 where edisi = v_edisi and pos = 3 and kode = 'bidai_kerapihan';
+  update wahana set sort_order = 5 where edisi = v_edisi and pos = 3 and kode = 'bidai_kecepatan_kerja_sama';
+
+  -- Diperiksa, bukan diandaikan: lima kriteria, seratus poin. Kalau salah satu
+  -- UPDATE di atas tidak mengenai apa pun karena kodenya berbeda dari dugaan,
+  -- yang muncul di sini adalah galat — bukan lembar penilaian bernilai 80.
+  -- Keduanya diperiksa, karena jumlah baris yang benar dengan poin yang salah
+  -- (atau sebaliknya) sama-sama menghasilkan rekap yang tidak ada yang curigai.
+  select count(*), coalesce(sum(poin_maks), 0) into v_jumlah, v_total
+  from wahana
+  where edisi = v_edisi and pos = 3 and kode like 'bidai%';
+
+  if v_jumlah <> 5 or v_total <> 100 then
+    raise exception '0036: kriteria bidai berjumlah % senilai % poin, '
+                    'seharusnya 5 kriteria senilai 100.', v_jumlah, v_total;
+  end if;
+
+  raise notice '0036: lima kriteria bidai terpasang, total % poin.', v_total;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -110,5 +110,10 @@ run tests/sql/13_komponen_per_golongan.sql
 # dan tidak mengenai apa pun, karena `menaksir` memang tidak ada di sini.
 run supabase/migrations/0035_tangga_menaksir.sql
 run tests/sql/14_tangga_menaksir.sql
+# 0036 dijalankan di sini supaya penolakannya ikut terbukti — di database uji
+# pos 3 bukan P3K, jadi ia harus diam. Tes 15 memanggil berkas yang sama dua
+# kali lagi lewat \ir, dengan Pos 3 palsu yang dibangunnya sendiri.
+run supabase/migrations/0036_kriteria_bidai.sql
+run tests/sql/15_kriteria_bidai.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/15_kriteria_bidai.sql
+++ b/tests/sql/15_kriteria_bidai.sql
@@ -1,0 +1,174 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/15_kriteria_bidai.sql
+-- Kriteria Bidai (0036) — yang diuji PENJAGANYA, bukan daftar kriterianya.
+--
+-- Daftar kriteria berubah tiap tahun dan tidak perlu tes; ia data. Yang tidak
+-- boleh berubah adalah dua penolakan yang membuat perubahan itu aman:
+--
+--   1. 0036 menyentuh Pos 3 lewat NOMORNYA. Di edisi yang pos 3-nya bukan
+--      P3K, ia harus diam. Kalau tidak, kriteria bidai menyelinap ke pos yang
+--      sama sekali lain dan tidak ada yang gagal.
+--   2. 0036 MENGHAPUS satu komponen. Kalau sudah ada nilai bidai tersimpan, ia
+--      harus berhenti dengan galat. Nilai yang ikut terhapus tidak bisa
+--      dikembalikan oleh git revert.
+--
+-- ---------------------------------------------------------------------------
+-- BERKAS MIGRASINYA DIJALANKAN SUNGGUHAN, BUKAN DITIRU
+--
+-- Godaan besar di tes semacam ini adalah menyalin syarat penjaganya ke sini
+-- lalu memeriksa salinan itu. Tesnya akan lulus selamanya — termasuk pada hari
+-- seseorang menghapus penjaga aslinya. Jadi berkas 0036 yang sama persis
+-- dengan yang dijalankan ke produksi dipanggil dengan `\ir`, dua kali: sekali
+-- dalam keadaan yang harus ditolaknya, sekali dalam keadaan yang harus
+-- dikerjakannya.
+--
+-- Dua kali itu bukan kelebihan. Panggilan yang GAGAL saja tidak membuktikan
+-- apa-apa: berkas yang salah ketik juga gagal, dan juga tidak mengubah apa
+-- pun. Panggilan kedua yang BERHASIL-lah yang menutup celah itu — ia
+-- membuktikan berkasnya memang bisa jalan, sehingga satu-satunya penjelasan
+-- bagi kegagalan pertama adalah penjaganya.
+--
+-- Galat yang diharapkan itu akan menghentikan psql, karena run.sh memakai
+-- ON_ERROR_STOP. Jadi ia dimatikan sebentar — hanya selama satu baris itu —
+-- lalu dinyalakan lagi. Kalau lupa dinyalakan, seluruh tes SESUDAH berkas ini
+-- berubah jadi tidak bisa gagal.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 15.1 Penjaga 1, dibuktikan dari luar: 0036 sudah dijalankan sungguhan oleh
+--      run.sh beberapa baris di atas ini. Karena database uji memakai
+--      konfigurasi XXXVI dan tidak punya `bidai_posisi`, ia harus tidak
+--      meninggalkan jejak apa pun.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_selundupan int;
+begin
+  select count(*) into v_selundupan from wahana
+  where edisi = edisi_aktif() and kode like 'bidai%';
+  assert v_selundupan = 0,
+    format('0036 memasang %s komponen bidai di edisi yang bukan XXXVII',
+           v_selundupan);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 15.2 Pos 3 yang menyamar jadi P3K: kelima kriteria bidai LAMA, apa adanya
+--      seperti 0033 memasangnya, plus satu nilai tersimpan.
+--
+--      Sengaja TIDAK di dalam transaksi. Berkas 0036 harus melihat keadaan ini
+--      sudah tersimpan, dan galatnya sendiri membatalkan transaksi apa pun
+--      yang sedang berjalan — jadi rollback bukan alat yang tersedia di sini.
+--      Dibersihkan dengan tangan di 15.6.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_regu uuid;
+begin
+  insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk, rentang_mentah_min,
+                      rentang_mentah_maks, sort_order)
+  values
+    (edisi_aktif(), 3, 'bidai_posisi',     'Posisi Bidai',             'wahana', 'besar_baik', 20, 20, 0, 0, 20, 91),
+    (edisi_aktif(), 3, 'bidai_teknik',     'Teknik Bidai',             'wahana', 'besar_baik', 20, 20, 0, 0, 20, 92),
+    (edisi_aktif(), 3, 'bidai_kerapihan',  'Kerapihan dan Kebersihan', 'wahana', 'besar_baik', 20, 20, 0, 0, 20, 93),
+    (edisi_aktif(), 3, 'bidai_kecepatan',  'Kecepatan',                'wahana', 'besar_baik', 20, 20, 0, 0, 20, 94),
+    (edisi_aktif(), 3, 'bidai_kerja_sama', 'Kerja Sama',               'wahana', 'besar_baik', 20, 20, 0, 0, 20, 95);
+
+  select id into strict v_regu from regu where nomor_dada is not null
+  order by nomor_dada limit 1;
+
+  -- Nilainya ditempelkan pada kriteria yang akan DIHAPUS 0036 — itu kasus
+  -- terburuknya, dan itulah yang harus ditolak.
+  insert into nilai_mentah (regu_id, wahana_id, nilai_1, source, created_by)
+  select v_regu, id, 15, 'manual', '00000000-0000-0000-0000-00000000000a'
+  from wahana where edisi = edisi_aktif() and kode = 'bidai_kerja_sama';
+end;
+$$;
+
+\set ON_ERROR_STOP off
+\ir ../../supabase/migrations/0036_kriteria_bidai.sql
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- 15.3 Sesudah penolakan itu, semuanya HARUS masih utuh. Inilah pertanyaan
+--      sebenarnya — bukan "apakah ia berteriak", melainkan "apakah ia berhenti
+--      sebelum merusak". Migrasi yang menolak setelah menghapus separuh isi
+--      jauh lebih buruk daripada yang tidak menolak sama sekali.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_nilai int; v_lama int; v_baru int;
+begin
+  select count(*) into v_nilai
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif() and w.kode = 'bidai_kerja_sama';
+  assert v_nilai = 1,
+    format('nilai bidai hilang padahal 0036 menolak: tersisa %s', v_nilai);
+
+  select count(*) into v_lama from wahana
+  where edisi = edisi_aktif() and kode like 'bidai%';
+  assert v_lama = 5,
+    format('kriteria lama tersentuh padahal 0036 menolak: %s dari 5', v_lama);
+
+  select count(*) into v_baru from wahana
+  where edisi = edisi_aktif() and kode = 'bidai_diagnosis';
+  assert v_baru = 0, '0036 sempat memasang kriteria baru sebelum menolak';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 15.4 Nilainya dibuang, penjaga 2 tidak lagi berlaku — dan sekarang berkas
+--      yang SAMA harus bekerja. Tanpa langkah ini, 15.3 juga lulus untuk
+--      berkas yang rusak total.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  delete from nilai_mentah n using wahana w
+  where n.wahana_id = w.id and w.edisi = edisi_aktif() and w.kode like 'bidai%';
+end;
+$$;
+
+\ir ../../supabase/migrations/0036_kriteria_bidai.sql
+
+-- ---------------------------------------------------------------------------
+-- 15.5 Kelima kriteria baru, berikut urutan bacanya. Yang dijaga di sini bukan
+--      selera penamaan, melainkan dua hal yang diam-diam mengubah penilaian:
+--      `bidai_kecepatan` dan `bidai_kerja_sama` TIDAK boleh keduanya tinggal
+--      (itu berarti 40 poin untuk hal yang panitia beri 20), dan totalnya
+--      harus tetap 100.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_dapat text;
+  v_harap text := 'bidai_diagnosis, bidai_posisi, bidai_teknik, '
+                  'bidai_kerapihan, bidai_kecepatan_kerja_sama';
+  v_total numeric;
+begin
+  select string_agg(kode, ', ' order by sort_order), sum(poin_maks)
+    into v_dapat, v_total
+  from wahana where edisi = edisi_aktif() and kode like 'bidai%';
+
+  assert v_dapat = v_harap,
+    format('kriteria bidai tidak sesuai.%s  seharusnya: %s%s  ternyata  : %s',
+           chr(10), v_harap, chr(10), v_dapat);
+  assert v_total = 100,
+    format('total poin bidai %s, seharusnya 100', v_total);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 15.6 Database uji kembali seperti sebelum berkas ini dibuka. Tes 02-14 di
+--      atasnya sudah selesai, tapi urutan run.sh bisa berubah kapan saja.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_sisa int;
+begin
+  delete from nilai_mentah n using wahana w
+  where n.wahana_id = w.id and w.edisi = edisi_aktif() and w.kode like 'bidai%';
+  delete from wahana where edisi = edisi_aktif() and kode like 'bidai%';
+
+  select count(*) into v_sisa from wahana
+  where edisi = edisi_aktif() and kode like 'bidai%';
+  assert v_sisa = 0, format('pos 3 palsu tertinggal: %s baris', v_sisa);
+end;
+$$;
+
+select '15_kriteria_bidai OK' as hasil;


### PR DESCRIPTION
## What

Kriteria penilaian Bidai (Pos 3 — P3K):

| # | Kriteria | Poin |
|---|---|---|
| 1 | Diagnosis dan Penanganan Awal | 20 |
| 2 | Posisi Bidai | 20 |
| 3 | Teknik Bidai | 20 |
| 4 | Kerapihan dan Kebersihan | 20 |
| 5 | Kecepatan dan Kerja Sama | 20 |
| | **Total** | **100** |

## Why

Jumlahnya tetap lima dan totalnya tetap 100, jadi ini mudah terlewat kalau hanya angkanya yang dilihat. Yang berubah adalah **cara juri menimbang**:

```
sebelum : Kecepatan 20  +  Kerja Sama 20   = 40 poin untuk dua hal itu
sesudah : Kecepatan dan Kerja Sama 20      = 20, dan 20 sisanya ke Diagnosis
```

Kecepatan dan kerja sama dulu bisa saling menutupi — regu yang lambat tapi kompak tetap memanen penuh. Bobot yang terbebas dipakai untuk hal yang sebelumnya **tidak dinilai sama sekali**: apakah regunya benar mengenali cedera dan menanganinya lebih dulu.

Kriteria yang tidak dinilai bukan sekadar kehilangan poin — ia hilang dari kertas, jadi jurinya pun tidak pernah diminta melihatnya.

## Notes

**Dua penjaga, untuk dua bahaya berbeda.**

1. Yang diperiksa adalah keberadaan `bidai_posisi`, bukan nomor edisi. `0036` menyentuh Pos 3 lewat nomornya, dan di database yang tata letaknya lain itu menyelundupkan komponen asing tanpa satu galat pun.
2. Kalau sudah ada nilai bidai tersimpan, `0036` berhenti dengan **galat, bukan notice**. `bidai_kerja_sama` dihapus, dan menghapus komponen ikut menghapus nilai yang menempel padanya. Notice berarti "dilewati, semua aman"; di sini yang terjadi sebaliknya. Nilai lama tidak bisa dipetakan otomatis — 20 untuk "Kecepatan" bukan 20 untuk "Kecepatan dan Kerja Sama".

**Tes 15 menjalankan berkas migrasinya sungguhan lewat `\ir`, dua kali** — sekali dalam keadaan yang harus ditolaknya, sekali dalam keadaan yang harus dikerjakannya. Panggilan yang gagal saja tidak membuktikan apa-apa: berkas yang salah ketik juga gagal, dan juga tidak mengubah apa pun. Yang berhasil itulah yang menutup celahnya.

Penyambung nama diseragamkan jadi "dan" — panitia menulis "&" dan "/"; kata-katanya dipakai apa adanya, hanya supaya kelima label yang berdampingan di satu lembar tidak memakai tiga gaya sekaligus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)