### PR TITLE
feat: satu kotak waktu di Pos 2, dan petunjuk kolom jadi konfigurasi

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -445,6 +445,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
+    `golongan,petunjuk,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -160,6 +160,49 @@ export function jamSah(teks) {
   return `${dua(j)}:${dua(m)}`;
 }
 
+/** WAKTU LOMBA, SATU KOTAK. Menerima apa pun yang tertera di stopwatch:
+ *
+ *    "32"    -> 32 detik        "0:32"  -> 32 detik
+ *    "1:10"  -> 70 detik        "95"    -> 95 detik
+ *
+ *  Aturannya satu kalimat: ada titik dua berarti menit:detik, tanpa titik dua
+ *  berarti detik. Tidak ada tebakan di antaranya — "120" selalu 120 detik,
+ *  tidak pernah 1 menit 20.
+ *
+ *  Dulu ini dua kotak, Menit dan Detik terpisah. Yang membunuhnya bukan selera
+ *  melainkan hitungan: tangga poin Pos 2 habis di 40 detik, jadi kotak menit
+ *  berisi 0 di hampir setiap baris — 46 regu x 3 lomba = 138 ketukan hanya
+ *  untuk mengetik nol, di layar yang sudah harus digeser ke samping.
+ *
+ *  null = bukan waktu yang sah. Teks kosong juga null, dan itu BUKAN nol:
+ *  kotak kosong berarti belum dinilai (lihat bacaSel di app.js).
+ *
+ *  Menit tidak dibatasi — lomba yang molor sampai 90 menit tetap tercatat apa
+ *  adanya. Detik dibatasi 0-59: "1:75" adalah salah ketik, bukan 135 detik,
+ *  dan menerimanya diam-diam berarti mencatat waktu yang tidak pernah ada. */
+export function detikSah(teks) {
+  const t = String(teks ?? "").trim().replace(/[.\s]/g, ":");
+  if (t === "") return null;
+  if (!/^\d+(:\d{1,2})?$/.test(t)) return null;
+
+  const [a, b] = t.split(":");
+  if (b === undefined) return Number(a);
+  const d = Number(b);
+  if (d > 59) return null;
+  return Number(a) * 60 + d;
+}
+
+/** Kebalikan detikSah: bentuk yang akan diketik petugas untuk waktu ini.
+ *  Di bawah semenit ditulis polos ("32"), semenit ke atas pakai titik dua
+ *  ("1:10") — supaya angka yang tergambar ulang ke kotak persis angka yang
+ *  tadi diketik, dan menyimpan ulang baris tidak pernah mengubah apa pun. */
+export function detikTeks(total) {
+  if (total === null || total === undefined || total === "") return "";
+  const d = Math.round(Number(total));
+  if (!Number.isFinite(d)) return "";
+  return d < 60 ? String(d) : `${Math.floor(d / 60)}:${dua(d % 60)}`;
+}
+
 /** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:
  *  membetulkan bentuknya saat kotak ditinggalkan, dan menandainya merah kalau
  *  isinya bukan jam. Membetulkan saat blur, BUKAN saat tiap ketukan — menata

--- a/supabase/migrations/0037_petunjuk_kolom.sql
+++ b/supabase/migrations/0037_petunjuk_kolom.sql
@@ -1,0 +1,87 @@
+-- ============================================================================
+-- hrcd-rekap : 0037_petunjuk_kolom.sql
+--
+-- Keterangan kecil di bawah judul kolom jadi KONFIGURASI, bukan tebakan layar.
+--
+-- Selama ini layar mengarang keterangan itu sendiri dari rentang yang boleh
+-- diketik: "0 – 5", "0 – 20", dan untuk Menaksir "0 – 1000". Untuk lomba yang
+-- menghitung jumlah benar itu tepat — 0 sampai 5 kata memang seluruh
+-- ceritanya. Untuk Menaksir ia menyesatkan dua kali sekaligus:
+--
+--   * yang ditulis petugas bukan nilai melainkan SELISIH jarak, dan
+--   * 1000 bukan batas apa pun, cuma angka yang kebetulan dipilih dulu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KOLOM BARU, BUKAN MEMAKAI `satuan`
+--
+-- `satuan` kelihatan menggoda karena sudah ada dan masih kosong untuk
+-- Menaksir. Tapi ia bukan keterangan — ia SAKLAR: lima cabang di app.js
+-- membandingkannya persis dengan 'detik' untuk memutuskan kotaknya berbentuk
+-- Menit:Detik atau bukan. Menaruh kalimat manusia di sana berarti menaruh
+-- kalimat manusia di dalam sebuah if, dan yang berikutnya mengisi `satuan`
+-- pada komponen Pos 2 akan menghapus kotak Menit:Detik-nya tanpa satu galat
+-- pun. Kolom sendiri lebih jujur dan lebih murah daripada penjelasan.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA BUNYINYA "0 = tepat", BUKAN "(selisih jarak)" SAJA
+--
+-- Panitia meminta judulnya berbunyi "(selisih jarak)". Kalimat itu dipakai —
+-- tapi ditambah tiga kata, dan alasannya justru dari aturan panitia sendiri:
+-- selisih 0 berarti taksirannya TEPAT dan bernilai 100, nilai tertinggi di
+-- lomba itu.
+--
+-- Sementara kotak yang DIBIARKAN KOSONG berarti komponennya tidak dinilai:
+-- 0 poin. Jadi 0 dan kosong adalah dua ujung yang berlawanan sejauh mungkin,
+-- dan satu-satunya hal yang membedakannya di mata petugas adalah satu ketukan.
+--
+-- Yang membuat ini genting: "0 – 1000" adalah SATU-SATUNYA tempat, di layar
+-- maupun di kertas, yang memberi tahu petugas bahwa 0 itu angka yang boleh
+-- ditulis. Menggantinya dengan "(selisih jarak)" polos akan membuang
+-- pemberitahuan itu tanpa menggantinya — dan regu yang menaksir dengan
+-- sempurna adalah justru regu yang paling mungkin barisnya ditinggalkan
+-- kosong. Nilai 100 berubah jadi 0, tidak ada yang gagal, tidak ada yang
+-- ganjil di layar.
+--
+-- Kalau panitia tetap ingin "(selisih jarak)" tanpa tambahan, itu satu UPDATE
+-- pada kolom yang berkas ini buat — bukan perubahan kode.
+--
+-- ---------------------------------------------------------------------------
+-- BATAS ATAS
+--
+-- Panitia meminta validasinya cukup ">= 0". Batas atas tidak bisa dihapus:
+-- `rentang_mentah_maks` bertipe numeric(10,2) dan `not null`, jadi selalu ada
+-- angka di sana. Yang bisa dilakukan adalah menaruhnya di ujung tipe datanya,
+-- sehingga tidak ada selisih yang masuk akal maupun tidak masuk akal yang
+-- pernah tertolak — persis maksud ">= 0". Batas bawah 0 tetap berlaku, jadi
+-- angka negatif tetap ditolak.
+--
+-- Harga yang dibayar disebutkan supaya tidak jadi kejutan: salah ketik 1000
+-- untuk 10 tidak lagi tertahan di pintu. Ia tetap bernilai 0 poin — tangga
+-- Menaksir memang habis di atas 4 m — jadi yang hilang cuma peluang menangkap
+-- salah ketiknya lebih awal, bukan kebenaran skornya.
+-- ============================================================================
+
+alter table wahana add column if not exists petunjuk text;
+
+comment on column wahana.petunjuk is
+  'Keterangan kecil di bawah judul kolom, di layar dan di kertas. Kosong = '
+  'layar menyusunnya sendiri dari rentang/bentuknya. Diisi hanya bila rentang '
+  'saja menyesatkan, seperti Menaksir yang menulis selisih, bukan nilai.';
+
+do $$
+declare v_baris int;
+begin
+  update wahana set
+    petunjuk = 'selisih jarak · 0 = tepat',
+    rentang_mentah_maks = 99999999.99
+  where edisi = edisi_aktif() and kode = 'menaksir';
+
+  get diagnostics v_baris = row_count;
+  if v_baris = 0 then
+    raise notice '0037: komponen `menaksir` tidak ada di edisi aktif — '
+                 'petunjuk kolom dilewati.';
+  else
+    raise notice '0037: petunjuk kolom Menaksir dipasang.';
+  end if;
+end;
+$$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -140,7 +140,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q(
                     "select kode, name, type, form, poin_maks, raw_terbaik, "
                     "       raw_terburuk, poin_benar, poin_salah, total_soal, "
-                    "       tingkat, satuan, rentang_mentah_min, "
+                    "       tingkat, satuan, golongan, petunjuk, rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() and pos = %s "
                     "order by sort_order",
@@ -150,6 +150,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 # Rekapitulasi (#/rekap).
                 self._kirim(200, q(
                     "select pos, kode, name, type, form, poin_maks, satuan, "
+                    "       golongan, petunjuk, "
                     "       total_soal, rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -115,5 +115,10 @@ run tests/sql/14_tangga_menaksir.sql
 # kali lagi lewat \ir, dengan Pos 3 palsu yang dibangunnya sendiri.
 run supabase/migrations/0036_kriteria_bidai.sql
 run tests/sql/15_kriteria_bidai.sql
+# 0037 menambah kolom `petunjuk` dan melebarkan rentang Menaksir. Kolomnya
+# dipakai seluruh tes di bawahnya lewat v_lembar_pos, jadi ia harus sudah
+# terpasang sebelum 16 berjalan.
+run supabase/migrations/0037_petunjuk_kolom.sql
+run tests/sql/16_kosong_bukan_nol.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/16_kosong_bukan_nol.sql
+++ b/tests/sql/16_kosong_bukan_nol.sql
@@ -20,6 +20,14 @@
 -- akibatnya diperiksa, lalu dikembalikan.
 -- ============================================================================
 
+-- Dijalankan sebagai ADMIN, bukan tanpa peran. `v_lembar_pos` dipagari
+-- `peran() is not null` (0023), jadi sesi tanpa identitas mendapat NOL BARIS —
+-- dan nol baris di sini terbaca sebagai "nilainya hilang", yaitu persis
+-- kesimpulan yang sedang diuji. Menulis langsung ke nilai_mentah juga menuntut
+-- admin (policy adm_nilai, 0003). Jebakan yang sama pernah menjatuhkan 13.3.
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
 -- ---------------------------------------------------------------------------
 -- 16.1 Baris yang HILANG menyumbang tepat nol — tidak lebih, tidak kurang.
 --
@@ -150,4 +158,5 @@ begin
 end;
 $$;
 
+reset role;
 select '16_kosong_bukan_nol OK' as hasil;

--- a/tests/sql/16_kosong_bukan_nol.sql
+++ b/tests/sql/16_kosong_bukan_nol.sql
@@ -1,0 +1,153 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/16_kosong_bukan_nol.sql
+-- Dua aturan panitia yang saling berlawanan, dan harus tetap berlawanan.
+--
+--   KOSONG (tidak ada baris nilai_mentah)  ->  0 poin, komponen tidak dinilai
+--   NOL    (ada baris, nilai_1 = 0)        ->  poin penuh, kalau tangganya
+--                                              memang menghargai nol
+--
+-- Untuk Menaksir keduanya adalah dua ujung terjauh yang mungkin: selisih 0 m
+-- berarti taksirannya TEPAT dan bernilai 100, sementara kotak yang dibiarkan
+-- kosong bernilai 0. Satu ketukan memisahkan nilai tertinggi dari nilai
+-- terendah.
+--
+-- Yang menakutkan dari kekeliruan di sini adalah ia TIDAK menimbulkan galat.
+-- Satu `coalesce(nilai_1, 0)` yang tampak ramah, atau satu `where nilai_1 > 0`
+-- yang tampak seperti pembersihan, sudah cukup — dan yang berubah cuma angka
+-- di kolom paling kanan, yang tidak ada seorang pun hitung ulang dengan tangan.
+--
+-- Berkas ini menguji aturannya lewat data sungguhan: satu baris nilai dihapus,
+-- akibatnya diperiksa, lalu dikembalikan.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 16.1 Baris yang HILANG menyumbang tepat nol — tidak lebih, tidak kurang.
+--
+--      Bukan sekadar "nilainya turun". Diperiksa turunnya PERSIS sebesar poin
+--      komponen itu: kalau baris yang hilang malah dihitung sebagai nol mentah
+--      dan tetap masuk agregasi, angkanya juga turun — tapi turunnya salah.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_regu    uuid;
+  v_wahana  uuid;
+  v_pos     smallint;
+  v_n1      numeric;
+  v_n2      numeric;
+  v_sumber  text;
+  v_oleh    uuid;
+  v_poin    numeric;
+  v_sebelum numeric;
+  v_sesudah numeric;
+  v_terisi1 int;
+  v_terisi2 int;
+begin
+  -- Satu nilai apa pun yang benar-benar ada di database uji.
+  select n.regu_id, n.wahana_id, w.pos, n.nilai_1, n.nilai_2, n.source, n.created_by
+    into strict v_regu, v_wahana, v_pos, v_n1, v_n2, v_sumber, v_oleh
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  order by n.id limit 1;
+
+  select poin into strict v_poin from v_poin_wahana
+  where regu_id = v_regu and wahana_id = v_wahana;
+
+  select nilai_pos, jumlah_terisi into v_sebelum, v_terisi1
+  from v_lembar_pos where pos = v_pos and regu_id = v_regu;
+
+  delete from nilai_mentah where regu_id = v_regu and wahana_id = v_wahana;
+
+  select nilai_pos, jumlah_terisi into v_sesudah, v_terisi2
+  from v_lembar_pos where pos = v_pos and regu_id = v_regu;
+
+  assert v_sesudah = v_sebelum - v_poin,
+    format('baris hilang seharusnya mengurangi %s poin: %s -> %s',
+           v_poin, v_sebelum, v_sesudah);
+  assert v_terisi2 = v_terisi1 - 1,
+    format('jumlah_terisi tidak berkurang: %s -> %s', v_terisi1, v_terisi2);
+
+  -- Dikembalikan persis seperti semula, termasuk sumber dan penginputnya.
+  insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+  values (v_regu, v_wahana, v_n1, v_n2, v_sumber, v_oleh);
+
+  select nilai_pos into v_sesudah from v_lembar_pos
+  where pos = v_pos and regu_id = v_regu;
+  assert v_sesudah = v_sebelum,
+    format('nilai tidak kembali seperti semula: %s <> %s', v_sesudah, v_sebelum);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 16.2 Nilai mentah NOL adalah nilai, bukan ketiadaan nilai.
+--
+--      Barisnya harus tetap tercacah sebagai terisi, dan poinnya harus
+--      mengikuti aturan komponennya — untuk tangga Menaksir itu berarti 100,
+--      justru yang tertinggi.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_regu   uuid;
+  v_wahana uuid;
+  v_pos    smallint;
+  v_n1     numeric;
+  v_n2     numeric;
+  v_terisi int;
+  v_ada    int;
+begin
+  select n.regu_id, n.wahana_id, w.pos, n.nilai_1, n.nilai_2
+    into strict v_regu, v_wahana, v_pos, v_n1, v_n2
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif() and w.rentang_mentah_min <= 0
+  order by n.id limit 1;
+
+  update nilai_mentah set nilai_1 = 0, nilai_2 = case when nilai_2 is null then null else 0 end
+  where regu_id = v_regu and wahana_id = v_wahana;
+
+  select jumlah_terisi into v_terisi from v_lembar_pos
+  where pos = v_pos and regu_id = v_regu;
+  select count(*) into v_ada from v_poin_wahana
+  where regu_id = v_regu and wahana_id = v_wahana;
+
+  assert v_ada = 1, 'baris bernilai 0 hilang dari v_poin_wahana';
+  assert v_terisi > 0, 'baris bernilai 0 tidak dihitung terisi';
+
+  update nilai_mentah set nilai_1 = v_n1, nilai_2 = v_n2
+  where regu_id = v_regu and wahana_id = v_wahana;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 16.3 Tangga Menaksir: 0 mentah adalah poin TERTINGGI, dan tidak adanya baris
+--      adalah poin terendah. Diuji lewat hitung_poin langsung, karena di
+--      database uji komponen `menaksir` memang tidak ada (konfigurasi XXXVI).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_tangga jsonb := '[{"sampai": 0, "poin": 100},
+                      {"sampai": 1, "poin": 80},
+                      {"sampai": 2, "poin": 60},
+                      {"sampai": 3, "poin": 40},
+                      {"sampai": 4, "poin": 20}]'::jsonb;
+begin
+  assert hitung_poin('bertingkat', 0, null, 100,
+                     null, null, null, null, null, v_tangga) = 100,
+    'selisih 0 m harus 100 poin — itu taksiran yang TEPAT, bukan kosong';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 16.4 Kolom `petunjuk` (0037) ada, boleh kosong, dan kosong berarti layar
+--      menyusun keterangannya sendiri. Yang dijaga cuma keberadaannya:
+--      isinya kalimat untuk manusia, dan itu bukan urusan tes.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_nullable text;
+begin
+  select is_nullable into v_nullable from information_schema.columns
+  where table_name = 'wahana' and column_name = 'petunjuk';
+  assert v_nullable = 'YES',
+    format('wahana.petunjuk seharusnya boleh kosong, ternyata %L', v_nullable);
+end;
+$$;
+
+select '16_kosong_bukan_nol OK' as hasil;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -445,6 +445,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
+    `golongan,petunjuk,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -23,7 +23,7 @@ import {
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
-         berapaLalu, pemuat, ikonRefresh } from "./util.js";
+         berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -1872,18 +1872,13 @@ function selKomponen(k, nilai) {
                    aria-label="${esc(k.name)}">`;
   }
   if (k.satuan === "detik") {
-    const total = n1 === null || n1 === undefined ? null : Number(n1);
-    return `<span class="pos-pasangan">
-      <input type="number" class="small-input" inputmode="numeric" min="0"
-             data-kode="${kode}" data-slot="menit"
-             value="${total === null ? "" : Math.floor(total / 60)}"
-             aria-label="${esc(k.name)} — menit">
-      <span class="pos-pemisah" aria-hidden="true">:</span>
-      <input type="number" class="small-input" inputmode="numeric" min="0" max="59"
-             data-kode="${kode}" data-slot="detik"
-             value="${total === null ? "" : total % 60}"
-             aria-label="${esc(k.name)} — detik">
-    </span>`;
+    // SATU kotak, dan bertipe text — bukan number — karena isinya boleh
+    // memuat titik dua. inputmode="numeric" tetap memanggil papan angka di HP,
+    // jadi yang hilang cuma tombol panah naik-turun yang memang tidak pernah
+    // dipakai untuk mencatat waktu.
+    return `<input type="text" class="small-input input-waktu" inputmode="numeric"
+                   data-kode="${kode}" value="${esc(detikTeks(n1))}"
+                   aria-label="${esc(k.name)} — detik, atau menit:detik">`;
   }
   if (k.form === "benar_kurang_salah") {
     return `<span class="pos-pasangan">
@@ -1906,8 +1901,13 @@ function selKomponen(k, nilai) {
  *  diambil dari konfigurasi supaya tidak pernah berbeda dengan yang divalidasi
  *  server. Persis angka yang tercetak di judul kolom lembar kertas. */
 function petunjukKolom(k) {
+  // Keterangan dari konfigurasi selalu menang. Untuk sebagian besar komponen
+  // rentangnya sudah menjelaskan segalanya — "0 – 5 kata benar" tidak butuh
+  // kalimat. Tapi Menaksir menulis SELISIH, bukan nilai, dan rentangnya justru
+  // menyesatkan; kolom `petunjuk` (0037) ada untuk kasus seperti itu.
+  if (k.petunjuk) return k.petunjuk;
   if (k.form === "biner") return "centang bila benar";
-  if (k.satuan === "detik") return "menit : detik";
+  if (k.satuan === "detik") return "detik, atau m:dd";
   if (k.form === "benar_kurang_salah") return "benar / salah";
   if (k.form === "benar_per_total") return `0 – ${angkaRapi(k.total_soal)}`;
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
@@ -1927,9 +1927,12 @@ function bacaSel(tr, k) {
   if (k.form === "biner") return { nilai_1: kotak[0].checked ? 1 : 0, nilai_2: null };
 
   if (k.satuan === "detik") {
-    const m = kotak[0].value.trim(), d = kotak[1].value.trim();
-    if (m === "" && d === "") return null;
-    return { nilai_1: (Number(m) || 0) * 60 + (Number(d) || 0), nilai_2: null };
+    const detik = detikSah(kotak[0].value);
+    // null menutupi dua hal yang berbeda: kotak kosong, dan isi yang bukan
+    // waktu. Keduanya sengaja diperlakukan sama — TIDAK DIKIRIM. Menebak
+    // maksud "1:75" berarti mencatat waktu yang tidak pernah terjadi, dan
+    // kotaknya sendiri sudah memerah lewat .input-waktu:invalid.
+    return detik === null ? null : { nilai_1: detik, nilai_2: null };
   }
   if (k.form === "benar_kurang_salah") {
     const b = kotak[0].value.trim(), sa = kotak[1].value.trim();
@@ -1994,8 +1997,10 @@ const kolomCetakPos = (kolom) => kolom.flatMap(kol => {
   // Bentuk isian sama untuk semua varian satu lomba — yang berbeda antar
   // golongan hanya skalanya, bukan cara menulisnya.
   const k = kol.varian[0];
-  if (k.satuan === "detik") return [
-    { nama: kol.nama, petunjuk: "menit" }, { nama: "", petunjuk: "detik" }];
+  // Waktu memakan SATU petak di kertas juga. Dua petak Menit|Detik memaksa
+  // petugas memecah angka stopwatch sebelum menuliskannya; satu petak
+  // menerima "32" maupun "1:10" apa adanya, persis seperti kotak di layar.
+  if (k.satuan === "detik") return [{ nama: kol.nama, petunjuk: kol.petunjuk }];
   if (k.form === "benar_kurang_salah") return [
     { nama: kol.nama, petunjuk: "benar" }, { nama: "", petunjuk: "salah" }];
   return [{ nama: kol.nama, petunjuk: kol.petunjuk }];
@@ -2497,6 +2502,48 @@ async function layarInputPos() {
     if (tr) simpanBaris(tr);
   });
 
+  /* Kotak waktu: dirapikan dan diperiksa saat DITINGGALKAN.
+
+     Satu kotak yang menerima "32" maupun "1:10" punya satu kelemahan yang
+     tidak dimiliki dua kotak angka: isinya bisa BUKAN waktu. "1:75" terbaca
+     wajar oleh mata, tapi bukan waktu mana pun, dan bacaSel() menolaknya
+     dengan mengembalikan null — yang di jalur simpan berarti "kotak kosong",
+     alias tidak dikirim.
+
+     Tanpa penanda, itu jenis kegagalan yang paling buruk: petugas mengetik
+     angka, tidak ada yang merah, tidak ada yang gagal, dan nilainya tidak
+     pernah ada. Jadi kotaknya diberi aria-invalid, yang sudah punya gaya merah
+     sendiri di style.css dan sekaligus terbaca pembaca layar.
+
+     Dirapikan saat blur, bukan tiap ketukan: menata angka sementara orang
+     masih mengetiknya memindahkan kursor di bawah jarinya. Pola dan alasannya
+     sama dengan pasangKotakJam() di util.js. */
+  tbody.addEventListener("focusout", (e) => {
+    const el = e.target;
+    if (!el.classList || !el.classList.contains("input-waktu")) return;
+    const kosong = !el.value.trim();
+    const detik = detikSah(el.value);
+    if (kosong) el.removeAttribute("aria-invalid");
+    else if (detik === null) el.setAttribute("aria-invalid", "true");
+    else {
+      // "0:32" jadi "32", "95" jadi "1:35" — bentuk yang sama dengan yang
+      // digambar ulang dari database, supaya menyimpan baris yang tidak
+      // disentuh tidak pernah terlihat sebagai perubahan.
+      el.value = detikTeks(detik);
+      el.removeAttribute("aria-invalid");
+    }
+  });
+
+  // Merah hilang begitu isinya jadi waktu yang sah — menunggu blur untuk
+  // memadamkan peringatan membuat petugas mengira ketikan barunya juga salah.
+  tbody.addEventListener("input", (e) => {
+    const el = e.target;
+    if (!el.classList || !el.classList.contains("input-waktu")) return;
+    if (detikSah(el.value) !== null || !el.value.trim()) {
+      el.removeAttribute("aria-invalid");
+    }
+  });
+
   // Enter = turun satu regu di kolom yang sama, seperti menyalin dari kertas
   // ke bawah. Berpindah fokus memicu change-nya sendiri, jadi barisnya
   // tersimpan tanpa perlu dipanggil dua kali.
@@ -2696,11 +2743,10 @@ function selRekap(w, isi) {
       ? esc(angkaRapi(a))
       : `${esc(angkaRapi(a))}<span class="pos-pemisah"> / </span>${esc(angkaRapi(b))}`;
   }
-  if (w.satuan === "detik") {
-    const d = Number(a);
-    return `${Math.floor(d / 60)}<span class="pos-pemisah">:</span>${
-      String(d % 60).padStart(2, "0")}`;
-  }
+  // Bentuk yang sama dengan yang diketik di Input Pos — 32 detik tampil "32",
+  // bukan "0:32". Dua layar yang menampilkan angka sama dengan bentuk berbeda
+  // membuat orang mengira datanya yang berbeda.
+  if (w.satuan === "detik") return esc(detikTeks(a));
   return esc(angkaRapi(a));
 }
 
@@ -2739,9 +2785,14 @@ async function layarRekap() {
   // (migrasi 0025), dan kolom yang selamanya kosong terbaca sebagai pos yang
   // panitianya lalai — bukan sebagai garis start dan garis finish.
   const posDinilai = pos.filter(p => (p.jumlah_komponen || 0) > 0);
-  const kolomPos = posDinilai.map(p => ({
-    ...p, komponen: wahana.filter(w => Number(w.pos) === Number(p.nomor)),
-  }));
+  // Dikelompokkan dengan kolomPos() yang sama dengan layar Input Pos: satu
+  // kolom per LOMBA. Tanpa ini Pos 1 memakan empat kolom "Tebak Simpul" yang
+  // tiga di antaranya selalu kosong di setiap baris, dan tabel yang sudah 38
+  // kolom bertambah panjang tanpa menambah satu keterangan pun.
+  const posKolom = posDinilai.map(p => {
+    const komponen = wahana.filter(w => Number(w.pos) === Number(p.nomor));
+    return { ...p, kolom: kolomPos(komponen) };
+  });
 
   /* SELALU satu golongan, tidak pernah gabungan — dan karena itu tidak ada
      pilihan "Semua". Rekap dibaca untuk menjawab "siapa juara Penegak PA",
@@ -2759,14 +2810,21 @@ async function layarRekap() {
   /** Berapa komponen pos ini yang sudah terisi untuk satu regu. Dihitung dari
    *  `nilai` yang SUDAH ada di tangan — tidak perlu permintaan tambahan, dan
    *  angkanya pasti sama dengan yang dipakai menggambar barisnya. */
-  const terisiDiPos = (b, p) => p.komponen.reduce(
+  const komponenBaris = (p, b) =>
+    p.kolom.map(kol => varianUntuk(kol, b.golongan)).filter(Boolean);
+
+  const terisiDiPos = (b, p) => komponenBaris(p, b).reduce(
     (n, w) => n + ((b.nilai || {})[`${p.nomor}.${w.kode}`] ? 1 : 0), 0);
 
   const cocok = (b) => {
     if (golongan && b.golongan !== golongan) return false;
     if (posBelum !== null) {
-      const p = kolomPos.find(x => Number(x.nomor) === Number(posBelum));
-      if (p && terisiDiPos(b, p) >= p.komponen.length) return false;
+      const p = posKolom.find(x => Number(x.nomor) === Number(posBelum));
+      // Pembandingnya komponen yang berlaku untuk regu INI, bukan jumlah kolom
+      // tabel. Regu Penggalang di Pos 1 punya tiga komponen sementara tabelnya
+      // berkolom empat — dibandingkan dengan empat, saringan "belum lengkap"
+      // tidak pernah menyembunyikan siapa pun dan jadi tidak berguna.
+      if (p && terisiDiPos(b, p) >= komponenBaris(p, b).length) return false;
     }
     return !cari
       || (b.nama_sekolah || "").toLowerCase().includes(cari)
@@ -2795,11 +2853,11 @@ async function layarRekap() {
      percaya yang salah. Bedanya cuma satu — di sini kelompok kolomnya
      berulang untuk tiap pos, dan tiap kelompok ditutup Nilai Pos-nya. */
   const kepala = () => {
-    const perPos = kolomPos.map(p => `
-      ${p.komponen.map(w => `
+    const perPos = posKolom.map(p => `
+      ${p.kolom.map(kol => `
         <th class="text-center">
-          <span class="kolom-nama">${esc(w.name)}</span>
-          <span class="kolom-petunjuk">${esc(petunjukKolom(w))}</span></th>`).join("")}
+          <span class="kolom-nama">${esc(kol.nama)}</span>
+          <span class="kolom-petunjuk">${esc(kol.petunjuk)}</span></th>`).join("")}
       <th class="text-center rekap-batas">Nilai<br>${
         esc(p.bayangan ? p.name : `Pos ${p.nomor}`)}</th>`).join("");
     return `
@@ -2825,9 +2883,13 @@ async function layarRekap() {
   const barisHtml = (b) => {
     const nilai = b.nilai || {};
     const poin = b.poin_pos || {};
-    const perPos = kolomPos.map(p => `
-      ${p.komponen.map(w => `<td class="text-center">${
-        selRekap(w, nilai[`${p.nomor}.${w.kode}`])}</td>`).join("")}
+    const perPos = posKolom.map(p => `
+      ${p.kolom.map(kol => {
+        const w = varianUntuk(kol, b.golongan);
+        return `<td class="text-center">${
+          w ? selRekap(w, nilai[`${p.nomor}.${w.kode}`])
+            : `<span class="sel-mati">–</span>`}</td>`;
+      }).join("")}
       <td class="text-center pos-nilai rekap-batas">${poin[String(p.nomor)] === undefined
         ? "" : esc(angka(poin[String(p.nomor)]))}</td>`).join("");
     const penalti = Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)
@@ -2910,7 +2972,7 @@ async function layarRekap() {
   // 5 kolom identitas + 9 kolom waktu/total, ditambah tiap komponen dan satu
   // Nilai Pos per kelompok. Dipakai colspan baris "tidak ada yang cocok" —
   // kalau meleset, barisnya tidak selebar tabelnya.
-  const lebarKolom = 14 + kolomPos.reduce((n, p) => n + p.komponen.length + 1, 0);
+  const lebarKolom = 14 + posKolom.reduce((n, p) => n + p.kolom.length + 1, 0);
 
   /* ==========================================================================
      KERANGKA DIBANGUN SEKALI, ISINYA DIPERBARUI DI TEMPAT.

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -160,6 +160,49 @@ export function jamSah(teks) {
   return `${dua(j)}:${dua(m)}`;
 }
 
+/** WAKTU LOMBA, SATU KOTAK. Menerima apa pun yang tertera di stopwatch:
+ *
+ *    "32"    -> 32 detik        "0:32"  -> 32 detik
+ *    "1:10"  -> 70 detik        "95"    -> 95 detik
+ *
+ *  Aturannya satu kalimat: ada titik dua berarti menit:detik, tanpa titik dua
+ *  berarti detik. Tidak ada tebakan di antaranya — "120" selalu 120 detik,
+ *  tidak pernah 1 menit 20.
+ *
+ *  Dulu ini dua kotak, Menit dan Detik terpisah. Yang membunuhnya bukan selera
+ *  melainkan hitungan: tangga poin Pos 2 habis di 40 detik, jadi kotak menit
+ *  berisi 0 di hampir setiap baris — 46 regu x 3 lomba = 138 ketukan hanya
+ *  untuk mengetik nol, di layar yang sudah harus digeser ke samping.
+ *
+ *  null = bukan waktu yang sah. Teks kosong juga null, dan itu BUKAN nol:
+ *  kotak kosong berarti belum dinilai (lihat bacaSel di app.js).
+ *
+ *  Menit tidak dibatasi — lomba yang molor sampai 90 menit tetap tercatat apa
+ *  adanya. Detik dibatasi 0-59: "1:75" adalah salah ketik, bukan 135 detik,
+ *  dan menerimanya diam-diam berarti mencatat waktu yang tidak pernah ada. */
+export function detikSah(teks) {
+  const t = String(teks ?? "").trim().replace(/[.\s]/g, ":");
+  if (t === "") return null;
+  if (!/^\d+(:\d{1,2})?$/.test(t)) return null;
+
+  const [a, b] = t.split(":");
+  if (b === undefined) return Number(a);
+  const d = Number(b);
+  if (d > 59) return null;
+  return Number(a) * 60 + d;
+}
+
+/** Kebalikan detikSah: bentuk yang akan diketik petugas untuk waktu ini.
+ *  Di bawah semenit ditulis polos ("32"), semenit ke atas pakai titik dua
+ *  ("1:10") — supaya angka yang tergambar ulang ke kotak persis angka yang
+ *  tadi diketik, dan menyimpan ulang baris tidak pernah mengubah apa pun. */
+export function detikTeks(total) {
+  if (total === null || total === undefined || total === "") return "";
+  const d = Math.round(Number(total));
+  if (!Number.isFinite(d)) return "";
+  return d < 60 ? String(d) : `${Math.floor(d / 60)}:${dua(d % 60)}`;
+}
+
 /** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:
  *  membetulkan bentuknya saat kotak ditinggalkan, dan menandainya merah kalau
  *  isinya bukan jam. Membetulkan saat blur, BUKAN saat tiap ketukan — menata


### PR DESCRIPTION
## What

**Satu kotak waktu** di Pos 2, menerima apa yang tertera di stopwatch:

| Diketik | Terbaca |
|---|---|
| `32` · `0:32` | 32 detik |
| `1:10` | 70 detik |
| `95` | 95 detik |
| `1:75` | **ditolak** |

Ada titik dua berarti menit:detik, tanpa titik dua berarti detik — `120` selalu 120 detik, tidak pernah 1 menit 20.

**Petunjuk kolom jadi konfigurasi** lewat `wahana.petunjuk` (0037). Menaksir: `selisih jarak · 0 = tepat`, dan batas atasnya dilepas (praktis `>= 0` saja).

## Why

Kolom Menit berisi `0` di hampir setiap baris, dan akan begitu selamanya — tangga poin Pos 2 habis di 40 detik. **46 regu × 3 lomba = 138 ketukan hanya untuk mengetik nol**, di layar yang memang harus digeser ke samping.

Untuk Menaksir, `0 – 1000` menyesatkan dua kali: yang ditulis **selisih**, bukan nilai, dan 1000 bukan batas apa pun.

## Notes — kenapa bukan "(selisih jarak)" polos

Panitia meminta `(selisih jarak)`. Kalimatnya dipakai, ditambah tiga kata, dan alasannya dari aturan panitia sendiri:

> selisih **0** = tepat = **100 poin** · kotak **kosong** = tidak dinilai = **0 poin**

Dua ujung terjauh yang mungkin, dipisahkan satu ketukan. Dan `0 – 1000` adalah **satu-satunya tempat, di layar maupun di kertas, yang memberi tahu petugas bahwa 0 boleh ditulis.** Membuangnya tanpa pengganti membuat regu yang menaksir dengan sempurna justru barisnya ditinggalkan kosong — 100 jadi 0, tanpa galat. Kalau tetap ingin tanpa tambahan: satu `UPDATE`, bukan perubahan kode.

Penelusuran enam ruas (layar → simpan → server → skor → kelengkapan → kertas) memastikan jalur `0` vs kosong **sudah benar di mana-mana**: `angkaRapi` memakai perbandingan ketat, `v_lembar_pos` membungkus nilai dalam objek jsonb, `bacaSel` memakai `v === ""`, server memakai `between` inklusif, dan baris yang tidak ada menyumbang tepat 0.

## Notes — lainnya

**`satuan` tidak dipakai** walau kelihatan cocok. Ia bukan keterangan melainkan saklar — lima cabang membandingkannya persis dengan `'detik'`. Kalimat manusia di dalam sebuah `if` adalah jebakan bagi orang berikutnya.

**Layar Rekap ikut dirapikan.** Ia punya cacat yang sama dengan Input Pos sebelum #148: kolom per baris wahana, dan saringan "belum lengkap per pos" membandingkan dengan jumlah kolom sehingga tidak pernah menyembunyikan siapa pun.

**Kotak invalid diberi `aria-invalid`** saat blur. Tanpanya, "1:75" gagal senyap: petugas mengetik, tidak ada yang merah, nilainya tidak pernah ada.

`tests/dev_server.py` ikut mengambil `golongan` dan `petunjuk`, supaya mode dev tidak memperlihatkan perilaku lama yang sudah diperbaiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)