### PR TITLE
feat: form per lomba — satu kertas, satu lomba, satu regu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,3 +152,31 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    lands in the other in the same commit. No workflow checks this
    (`shared-files.yml` only compares `web/` against `live/`), and the pair has
    already drifted 21 lines once, losing all of section 5's rules 9-12.
+
+## 8. Printed forms
+
+1. **Every printed form is photocopied, not printed once per copy.** One master
+   goes to a field copier and comes back multiplied — often a copy of a copy.
+   Every rule below follows from that, and none of them are cosmetic.
+2. **No solid black fills.** A filled bar looks emphatic on screen and prints
+   fine on a laser printer, but a copier renders it blotchy or streaked, and it
+   drinks toner. Use a heavy rule instead: a line survives copying, a block
+   does not.
+3. **No reversed text.** White type on a dark ground is the first thing to
+   disappear when a copy is copied — the fill closes over the letters. Black on
+   white only.
+4. **No grey, and no tints.** Grey is what copiers handle worst: they turn it
+   into a dot screen that either drops out on a tired machine or darkens into
+   dirt. Where something must recede, make it **small and solid black** rather
+   than faint. Small and out of the way achieves the same thing as pale, and
+   survives being copied a fourth time.
+5. **Rules at least `0.75pt`.** Hairlines below that vanish entirely on a copy,
+   and a form whose boxes have no edges is not a form.
+6. **Type at least `7pt`.** Below that a copier fills in the counters — the
+   holes in `a`, `e`, `o` — and toner speckle turns the word into a smudge.
+7. **Nothing behind a writing area.** Boxes people write into stay white: no
+   tint, no watermark, no example number printed inside. Speckle on white is
+   still readable; speckle over a tint is not.
+8. These rules live in `web/style.css` under `@media print`, and `live/` holds
+   a byte-identical copy — section 7.5 applies to CSS the same way, and
+   `shared-files.yml` enforces that pair.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,3 +180,14 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 8. These rules live in `web/style.css` under `@media print`, and `live/` holds
    a byte-identical copy — section 7.5 applies to CSS the same way, and
    `shared-files.yml` enforces that pair.
+9. **Form per lomba is A5 landscape — 210 × 148 mm, one form per page.**
+   Half an A4 cut across, so any copier can duplicate it 2-up onto A4 and the
+   stack is separated by a single straight cut. Landscape is not a preference:
+   the two things that must be written large — nomor dada and the raw value —
+   sit side by side with real room, and on A5 portrait they crowd downward
+   until the value box is half its size.
+10. **What the screen prints is the master, not the stack.** Blangko are
+    multiplied on a copier, so a pos with three lomba prints three pages, not
+    1.500. Printing the stack from a browser spends a whole office toner on
+    work a copier finishes in minutes — and the count is decided at the copier
+    anyway, since the forms are blank.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,31 @@ Guidance for Claude Code when working in this repository.
    lands in the other in the same commit. No workflow checks this
    (`shared-files.yml` only compares `web/` against `live/`), and the pair has
    already drifted 21 lines once, losing all of section 5's rules 9-12.
+
+## 8. Printed forms
+
+1. **Every printed form is photocopied, not printed once per copy.** One master
+   goes to a field copier and comes back multiplied — often a copy of a copy.
+   Every rule below follows from that, and none of them are cosmetic.
+2. **No solid black fills.** A filled bar looks emphatic on screen and prints
+   fine on a laser printer, but a copier renders it blotchy or streaked, and it
+   drinks toner. Use a heavy rule instead: a line survives copying, a block
+   does not.
+3. **No reversed text.** White type on a dark ground is the first thing to
+   disappear when a copy is copied — the fill closes over the letters. Black on
+   white only.
+4. **No grey, and no tints.** Grey is what copiers handle worst: they turn it
+   into a dot screen that either drops out on a tired machine or darkens into
+   dirt. Where something must recede, make it **small and solid black** rather
+   than faint. Small and out of the way achieves the same thing as pale, and
+   survives being copied a fourth time.
+5. **Rules at least `0.75pt`.** Hairlines below that vanish entirely on a copy,
+   and a form whose boxes have no edges is not a form.
+6. **Type at least `7pt`.** Below that a copier fills in the counters — the
+   holes in `a`, `e`, `o` — and toner speckle turns the word into a smudge.
+7. **Nothing behind a writing area.** Boxes people write into stay white: no
+   tint, no watermark, no example number printed inside. Speckle on white is
+   still readable; speckle over a tint is not.
+8. These rules live in `web/style.css` under `@media print`, and `live/` holds
+   a byte-identical copy — section 7.5 applies to CSS the same way, and
+   `shared-files.yml` enforces that pair.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,3 +178,14 @@ Guidance for Claude Code when working in this repository.
 8. These rules live in `web/style.css` under `@media print`, and `live/` holds
    a byte-identical copy — section 7.5 applies to CSS the same way, and
    `shared-files.yml` enforces that pair.
+9. **Form per lomba is A5 landscape — 210 × 148 mm, one form per page.**
+   Half an A4 cut across, so any copier can duplicate it 2-up onto A4 and the
+   stack is separated by a single straight cut. Landscape is not a preference:
+   the two things that must be written large — nomor dada and the raw value —
+   sit side by side with real room, and on A5 portrait they crowd downward
+   until the value box is half its size.
+10. **What the screen prints is the master, not the stack.** Blangko are
+    multiplied on a copier, so a pos with three lomba prints three pages, not
+    1.500. Printing the stack from a browser spends a whole office toner on
+    work a copier finishes in minutes — and the count is decided at the copier
+    anyway, since the forms are blank.

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -327,38 +327,80 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Wahana lari — ditulis `40` untuk 40 detik.
    - Wahana lempar — ditulis `3` untuk 3 kali kena.
    - Soal — jumlah jawaban benar, ditandai centang, atau waktu penyelesaian.
-3. **Lembar nilai tidak berpindah tangan secara fisik.** Petugas lapangan
-   **memfoto lembar secara berkala** dan mengirimkan fotonya ke operator IT di
-   pos. Dengan begitu nilai mengalir sepanjang lomba, bukan menumpuk sampai pos
-   tutup.
-4. Operator IT memasukkannya ke sistem dengan kunci **nomor dada**, melalui dua
+3. **Kertas penilaian dibuat per lomba per regu, bukan satu lembar berisi
+   banyak regu.** Alurnya di lapangan:
+
+   1. Regu masuk ke wahana.
+   2. Petugas mengambil **satu kertas soal untuk lomba itu** — misalnya Tebak
+      Simpul — beserta kertas penilaiannya.
+   3. Regu mengerjakan.
+   4. Petugas menuliskan nilai mentahnya di kertas itu, mengikuti skala lomba
+      tersebut (Tebak Simpul Penggalang `0–5`, Penegak `0–10`).
+   5. Kertas dimasukkan ke **kotak penilaian** di pos itu.
+   6. Kotaknya diserahkan ke tim IT untuk diinput.
+   7. Tim IT **mengurutkan kertasnya menurut nomor dada**, 001 sampai 500,
+      lalu memasukkannya berurutan.
+
+   Bentuk ini bukan selera, melainkan tuntutan dua hal yang terjadi bersamaan.
+   Di satu pos, beberapa lomba berjalan **serentak di titik yang berbeda** —
+   Semaphore di satu sudut, Menaksir di sudut lain. Satu lembar berisi ketiga
+   lomba berarti ketiga petugas memperebutkan kertas yang sama, dan yang
+   terjadi bukan penilaian bergantian melainkan angka dicatat di kertas lain
+   lalu disalin belakangan. Salinan itulah yang hilang.
+
+   Dan satu regu **tidak pernah selesai di semua lomba pada saat yang sama**.
+   Lembar berisi 30 regu baru bisa berpindah setelah baris terakhir terisi;
+   kertas per regu berpindah begitu regunya selesai.
+
+4. **Nomor dada adalah kepala kertas itu, bukan salah satu kolomnya.** Seluruh
+   langkah 7 di atas — mengurutkan ratusan lembar lepas — bertumpu pada satu
+   angka yang harus terbaca sambil menyortir cepat. Karena itu nomor dada
+   dicetak besar di pojok kiri atas, dan tetap terbaca walau kertasnya
+   ditumpuk hanya dengan sudut terlihat.
+5. **Kertasnya berpindah tangan secara fisik**, dan itu memang jalurnya. Foto
+   berkala tetap berguna sebagai cadangan sebelum kotak berpindah — kotak yang
+   hilang atau tertinggal di pos adalah satu-satunya cara nilai lenyap tanpa
+   jejak — tetapi apakah foto diwajibkan atau tidak belum diputuskan
+   (bagian 13).
+6. Operator IT memasukkannya ke sistem dengan kunci **nomor dada**, melalui dua
    jalur:
    - **Input manual**, satu regu satu kali.
    - **Upload massal.** Tim IT boleh memakai AI untuk mengubah foto lembar
      menjadi tabel Excel, lalu meng-copy atau meng-upload-nya ke sistem.
-5. Karena jalur kedua bergantung pada pembacaan otomatis yang bisa salah,
+7. Karena jalur kedua bergantung pada pembacaan otomatis yang bisa salah,
    **upload massal wajib melewati layar preview** yang menampilkan apa saja
    yang akan berubah dan menandai kejanggalan — nomor dada tidak dikenal, nilai
    di luar rentang wajar, atau baris ganda. Data hasil transkripsi otomatis
    tidak boleh masuk langsung ke perhitungan skor tanpa dikonfirmasi manusia.
-6. Lembar nilai **dicetak sistem** setelah daftar ulang ditutup, sudah terisi
-   identitas regu, menyisakan kolom kosong untuk diisi petugas. Formatnya
-   seperti:
+8. Semua kertas **dicetak sistem** dari layar Input Pos setelah daftar ulang
+   ditutup, sudah terisi identitas regu dan menyisakan kotak kosong untuk
+   diisi petugas. Kolomnya tidak pernah ditulis tangan di berkas mana pun — ia
+   lahir dari tabel `wahana`, sehingga kertas tahun depan ikut berubah sendiri
+   begitu konfigurasi penilaiannya diganti.
 
-   ```
-   No Dada - Nama Regu - Nama Sekolah - Golongan | Penilaian (Ikuti Skala) | IMPK (benar = v) - Nilai Pos 3
+   Ada tiga bentuk, dan hanya dua yang sudah jadi:
 
-   001 - Rajawali - SMPN 1 Purwadadi - Penggalang PA - V
-   ```
+   | Bentuk | Isi | Untuk |
+   | --- | --- | --- |
+   | **Lembar pos** | satu halaman, semua lomba, 30 regu | pos yang dinilai satu meja |
+   | **Lembar per lomba** | satu set halaman tiap lomba, 30 regu | menyiapkan lomba paralel |
+   | **Slip per regu** *(belum ada)* | satu kertas kecil, satu lomba, satu regu | alur poin 3 |
 
-   Satu kolom sengaja **tidak** ikut dicetak: **Nilai Pos**. Petugas lapangan
-   hanya menulis data mentah dan tidak pernah menjumlahkan sendiri (poin 1) —
-   kotak berjudul Nilai Pos justru mengundang hitungan tangan yang berbeda
-   dengan angka sistem.
+   **Alur poin 3 membutuhkan bentuk ketiga**, dan itu belum dibuat. Dua yang
+   pertama sama-sama memuat 30 regu dalam satu halaman, jadi keduanya baru
+   bisa berpindah ke kotak setelah baris terakhirnya terisi — persis yang
+   dihindari alur ini.
 
-7. Sebuah **server pemantau** menampilkan status kelengkapan input — pos mana
+   Satu kolom sengaja **tidak** ikut dicetak di bentuk mana pun: **Nilai Pos**.
+   Petugas lapangan hanya menulis data mentah dan tidak pernah menjumlahkan
+   sendiri (poin 1) — kotak berjudul Nilai Pos justru mengundang hitungan
+   tangan yang berbeda dengan angka sistem. Di lembar per lomba dan slip per
+   regu alasannya bertambah satu: kertas yang hanya memuat sebagian pos tidak
+   punya cukup bahan untuk menghitungnya.
+
+9. Sebuah **server pemantau** menampilkan status kelengkapan input — pos mana
    yang sudah menyetor dan pos mana yang belum.
-8. **Satu link untuk semua panitia, akses dibedakan per akun.** Setiap akun
+10. **Satu link untuk semua panitia, akses dibedakan per akun.** Setiap akun
    hanya melihat dan menyentuh bagiannya sendiri:
 
    | Contoh akun | Akses |
@@ -375,9 +417,9 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    disembunyikan dari layar. Sebaliknya akun pos tidak diberi jalan ke layar
    meja: Home-nya hanya memuat satu kartu, "Input Nilai Pos N", dan RLS
    mengosongkan data meja seandainya alamatnya diketik langsung.
-9. Pola nama akun mengikuti edisi (`hrcd37` = edisi ke-37), sehingga akun dan
+11. Pola nama akun mengikuti edisi (`hrcd37` = edisi ke-37), sehingga akun dan
    password dapat diganti bersih setiap tahun tanpa membongkar sistem.
-10. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap
+12. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap
     dicatat**: siapa memasukkan atau mengubah nilai apa, dan kapan. Tujuannya
     bukan mengawasi orang, melainkan agar setiap angka dapat ditelusuri kembali
     ketika ada yang janggal.
@@ -565,8 +607,23 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    ada di fungsi `hitung_poin()`, dan tiap komponen pos diatur lewat satu
    baris konfigurasi, bukan lewat kode. Angka yang terpasang sekarang adalah
    angka HRCD XXXVI sebagai titik awal.
-3. **Arti singkatan `IMPK`** pada contoh lembar nilai di bagian 8.6.
-4. **Dua pembacaan pada bagian 10 yang belum dipastikan:**
+3. **Arti singkatan `IMPK`.** Muncul di contoh lembar nilai yang dulu tertulis
+   di bagian 8, dan tidak pernah dijelaskan siapa pun. Contohnya sendiri sudah
+   diganti — format kertas sekarang lahir dari tabel `wahana`, bukan dari
+   contoh yang diketik tangan — jadi potongan aslinya disimpan di sini supaya
+   pertanyaannya tetap bisa dijawab:
+
+   ```
+   No Dada - Nama Regu - Nama Sekolah - Golongan | Penilaian (Ikuti Skala) | IMPK (benar = v) - Nilai Pos 3
+   ```
+4. **Apakah foto berkala tetap diwajibkan setelah kertas berpindah fisik**
+   (bagian 8.5). Alur kotak penilaian membuat foto bukan lagi jalur utama,
+   tetapi kotak yang hilang atau tertinggal di pos adalah satu-satunya cara
+   nilai lenyap tanpa jejak — dan itu justru risiko yang dulu dihindari dengan
+   tidak memindahkan kertas sama sekali. Kalau foto tidak diwajibkan, perlu
+   disepakati siapa yang bertanggung jawab atas kotak sejak pos tutup sampai
+   isinya masuk sistem.
+5. **Dua pembacaan pada bagian 10 yang belum dipastikan:**
    - Pengurangan −100 karena tidak checkout — apakah menggantikan penalti waktu,
      atau ditambahkan padanya? Tanpa checkout tidak ada jam datang, sehingga
      penalti waktu tidak dapat dihitung. Dokumen ini menuliskannya sebagai
@@ -574,7 +631,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
      yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
      Dokumen ini mengasumsikan per orang.
-5. **Teknologi yang dipakai: SUDAH DIPUTUSKAN dan sudah berjalan.** Panitia
+6. **Teknologi yang dipakai: SUDAH DIPUTUSKAN dan sudah berjalan.** Panitia
    memilih Kandidat B — Supabase + frontend statis di Cloudflare — dengan
    syarat keras UI/UX harus mudah diajarkan. Google Sheets sempat direncanakan
    sebagai jendela baca tetapi **tidak pernah dipakai**; tidak ada di kode.

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -382,15 +382,17 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
    | Bentuk | Isi | Dipakai |
    | --- | --- | --- |
-   | **Form per lomba** | satu kertas, satu lomba, **satu regu** | di wahana, lalu masuk kotak (poin 3) |
+   | **Form per lomba** | **A5 melintang**, satu lomba, **satu regu** | di wahana, lalu masuk kotak (poin 3) |
    | **Form tabel per pos** | satu halaman, semua lomba, 30 regu | pos yang dinilai satu meja |
    | **Form tabel per pos online** | layar Input Pos | tim IT memasukkan isi kotak |
 
    **Form per lomba adalah bentuk yang paling banyak dicetak, dan jumlahnya
    besar.** 500 regu di pos berisi tiga lomba berarti **1.500 kertas untuk Pos
-   1 saja**. Karena itu delapan slip dimuat dalam satu A4 potret, bukan satu:
-   pada jumlah sebesar itu, selisih empat dan delapan per halaman adalah 188
-   lembar untuk satu pos.
+   1 saja**. Karena itu yang dicetak dari layar adalah **master**-nya, bukan
+   tumpukannya: satu halaman per lomba, lalu diperbanyak dengan mesin
+   fotokopi. Ukurannya **A5 melintang** — separuh A4 dipotong mendatar,
+   sehingga mesin fotokopi mana pun dapat menggandakannya 2-up ke A4 dan
+   tumpukannya dipisah dengan satu potongan lurus.
 
    Tiga hal yang dikerjakan form per lomba dan **tidak bisa** dikerjakan form
    tabel:

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -407,6 +407,14 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    PBB, Yel-Yel — lebih cepat dengan satu halaman berisi 30 regu, dan di sana
    tidak ada kertas yang perlu berpindah di tengah lomba.
 
+   **Semua kertas ini digandakan dengan mesin fotokopi, dan itu menentukan
+   bentuknya.** Tidak ada blok hitam, tidak ada tulisan putih di atas gelap,
+   tidak ada abu-abu — ketiganya adalah hal yang paling buruk ditangani mesin
+   fotokopi, apalagi saat yang digandakan sudah berupa gandaan. Garis minimal
+   0,75pt dan huruf minimal 7pt, karena di bawah itu garisnya hilang dan
+   huruf-hurufnya menutup sendiri oleh serbuk toner. Kotak yang ditulisi selalu
+   putih polos. Aturan lengkapnya di `CLAUDE.md` bagian 8.
+
    Satu kolom sengaja **tidak** ikut dicetak di bentuk mana pun: **Nilai Pos**.
    Petugas lapangan hanya menulis data mentah dan tidak pernah menjumlahkan
    sendiri (poin 1) — kotak berjudul Nilai Pos justru mengundang hitungan

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -378,25 +378,41 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    lahir dari tabel `wahana`, sehingga kertas tahun depan ikut berubah sendiri
    begitu konfigurasi penilaiannya diganti.
 
-   Ada tiga bentuk, dan hanya dua yang sudah jadi:
+   Ada **tiga bentuk**, dan panitia menyebutnya begini:
 
-   | Bentuk | Isi | Untuk |
+   | Bentuk | Isi | Dipakai |
    | --- | --- | --- |
-   | **Lembar pos** | satu halaman, semua lomba, 30 regu | pos yang dinilai satu meja |
-   | **Lembar per lomba** | satu set halaman tiap lomba, 30 regu | menyiapkan lomba paralel |
-   | **Slip per regu** *(belum ada)* | satu kertas kecil, satu lomba, satu regu | alur poin 3 |
+   | **Form per lomba** | satu kertas, satu lomba, **satu regu** | di wahana, lalu masuk kotak (poin 3) |
+   | **Form tabel per pos** | satu halaman, semua lomba, 30 regu | pos yang dinilai satu meja |
+   | **Form tabel per pos online** | layar Input Pos | tim IT memasukkan isi kotak |
 
-   **Alur poin 3 membutuhkan bentuk ketiga**, dan itu belum dibuat. Dua yang
-   pertama sama-sama memuat 30 regu dalam satu halaman, jadi keduanya baru
-   bisa berpindah ke kotak setelah baris terakhirnya terisi — persis yang
-   dihindari alur ini.
+   **Form per lomba adalah bentuk yang paling banyak dicetak, dan jumlahnya
+   besar.** 500 regu di pos berisi tiga lomba berarti **1.500 kertas untuk Pos
+   1 saja**. Karena itu delapan slip dimuat dalam satu A4 potret, bukan satu:
+   pada jumlah sebesar itu, selisih empat dan delapan per halaman adalah 188
+   lembar untuk satu pos.
+
+   Tiga hal yang dikerjakan form per lomba dan **tidak bisa** dikerjakan form
+   tabel:
+
+   - **Nomor dada dicetak besar di pojok kiri atas** (poin 4).
+   - **Rentangnya milik regu itu.** Di tabel, kolom Tebak Simpul harus menulis
+     `0 – 10 / 0 – 5` karena satu kolom melayani empat golongan. Di form per
+     lomba, regu Penggalang melihat `0 – 5` saja dan tidak ada yang perlu
+     dipilih petugas.
+   - **Golongan yang tidak berhak tidak dapat kertasnya sama sekali** — bukan
+     dapat lalu dicoret.
+
+   Form tabel tidak digantikan. Pos yang dinilai satu meja oleh satu juri —
+   PBB, Yel-Yel — lebih cepat dengan satu halaman berisi 30 regu, dan di sana
+   tidak ada kertas yang perlu berpindah di tengah lomba.
 
    Satu kolom sengaja **tidak** ikut dicetak di bentuk mana pun: **Nilai Pos**.
    Petugas lapangan hanya menulis data mentah dan tidak pernah menjumlahkan
    sendiri (poin 1) — kotak berjudul Nilai Pos justru mengundang hitungan
-   tangan yang berbeda dengan angka sistem. Di lembar per lomba dan slip per
-   regu alasannya bertambah satu: kertas yang hanya memuat sebagian pos tidak
-   punya cukup bahan untuk menghitungnya.
+   tangan yang berbeda dengan angka sistem. Di form per lomba alasannya
+   bertambah satu: kertas yang hanya memuat satu lomba tidak punya cukup bahan
+   untuk menghitungnya.
 
 9. Sebuah **server pemantau** menampilkan status kelengkapan input — pos mana
    yang sudah menyetor dan pos mana yang belum.

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -431,7 +431,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }
@@ -445,7 +445,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
-    `golongan,petunjuk,` +
+    `golongan,petunjuk,judul_isian,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/live/style.css
+++ b/live/style.css
@@ -521,106 +521,91 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
-  /* ---- FORM PER LOMBA (blangko kosong): ENAM per A4 potret ----
-     Blangko, bukan kertas berisi identitas regu — regu datang ke pos dalam
-     urutan acak, jadi kertas yang sudah tercetak namanya harus DICARI setiap
-     kali satu regu masuk. Alasan lengkapnya di siapkanCetakBlangko().
+  /* ---- FORM PER LOMBA (blangko kosong): A5 MELINTANG, satu per halaman ----
+     Ukurannya ditetapkan panitia: A5 melintang, 210 x 148 mm — separuh A4
+     dipotong mendatar, jadi mesin fotokopi mana pun bisa menggandakannya
+     2-up ke A4 lalu dipotong sekali lurus.
 
-     Enam per halaman = 2 kolom x 3 baris = kira-kira 99 x 95 mm, hampir
-     persegi. Ukuran itu dipilih karena isinya: satu kotak nomor dada yang
-     harus ditulis besar, tiga baris identitas, satu kotak angka selebar
-     kertas, dan satu tanda tangan. Pada 500 regu, satu pos berisi tiga lomba
-     memakan 250 lembar — turun dari 375 kalau empat per halaman.
+     Satu halaman berisi SATU blangko, karena yang dicetak dari layar adalah
+     MASTER, bukan tumpukannya. Pos 1 menghasilkan tiga halaman — Semaphore,
+     Tebak Simpul, Menaksir — dan panitia menggandakan tiap halaman sebanyak
+     yang dibutuhkan. Alasannya di siapkanCetakBlangko().
 
-     Kotak nilainya sengaja jauh lebih besar daripada kotak identitas. Yang
-     dinilai adalah angka itu; identitas cuma penanda supaya kertasnya bisa
-     pulang ke regunya. */
-  @page blangko-halaman { size: A4 portrait; margin: 5mm; }
-  .blangko-halaman {
-    page: blangko-halaman;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-auto-rows: 1fr;
-    gap: 0;
-    height: 287mm;
-  }
+     Melintang bukan selera. Yang harus muat: kotak nomor dada yang ditulis
+     besar dan kotak nilai yang ditulis lebih besar lagi, keduanya bersebelahan
+     dengan ruang tulis nyata. Pada A5 potret keduanya berdesakan ke bawah dan
+     kotak nilainya tinggal setengah.
+
+     Aturan cetak fotokopi (CLAUDE.md bagian 8) berlaku penuh di sini: tanpa
+     blok, tanpa abu-abu, garis >= 0,75pt, huruf >= 7pt. */
+  @page blangko-halaman { size: A5 landscape; margin: 9mm; }
+  .blangko-halaman { page: blangko-halaman; }
   .blangko {
-    border: .75pt dashed #000;
-    padding: 3.5mm 4mm;
+    height: 130mm;
     display: flex;
     flex-direction: column;
-    font-size: 8pt;
-    line-height: 1.2;
-    overflow: hidden;
+    font-size: 10pt;
+    line-height: 1.25;
   }
   .bl-pos {
-    margin: 0; text-align: center; font-size: 7pt; font-weight: 700;
-    letter-spacing: .8pt; text-transform: uppercase;
+    margin: 0; text-align: center; font-size: 9pt; font-weight: 700;
+    letter-spacing: 1.6pt; text-transform: uppercase;
   }
   .bl-lomba {
-    margin: .4mm 0 0; text-align: center; font-size: 15pt; font-weight: 800;
-    letter-spacing: .3pt; text-transform: uppercase; line-height: 1.05;
+    margin: 1mm 0 0; text-align: center; font-size: 24pt; font-weight: 800;
+    letter-spacing: .8pt; text-transform: uppercase; line-height: 1;
   }
   .bl-acara {
-    margin: 1mm 0 0; text-align: center; font-size: 7pt;
-    border-top: 1.5pt solid #000; padding-top: 1mm;
+    margin: 2mm 0 0; text-align: center; font-size: 9pt;
+    border-top: 1.5pt solid #000; padding-top: 2mm;
   }
 
-  /* Identitas: SATU kotak besar untuk nomor dada, dan satu catatan kecil di
+  /* Identitas: SATU kotak besar untuk nomor dada, dan satu kotak catatan di
      sebelahnya. Tidak ada kolom nama regu, sekolah, atau golongan — alasannya
      di siapkanCetakBlangko(): ketiganya sudah ditentukan nomor dada, dan
-     menyalinnya 1.500 kali adalah pekerjaan tanpa informasi baru.
+     menyalinnya ribuan kali adalah pekerjaan tanpa informasi baru.
 
      Kotak nomor dada dibuat tinggi supaya angkanya bisa ditulis BESAR. Ia
      dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas
      menuliskannya di tengah antrean, dan saat tim IT mengurutkan ratusan
      lembar lepas dengan hanya melihat sudut kertas. */
-  .bl-identitas {
-    width: 100%; border-collapse: collapse; margin-top: 1.5mm;
-  }
+  .bl-identitas { width: 100%; border-collapse: collapse; margin-top: 3.5mm; }
   .bl-identitas td {
-    border: .75pt solid #000; padding: .7mm 1.2mm; height: 13mm;
+    border: 1pt solid #000; padding: 1.2mm 2mm; height: 20mm;
     vertical-align: top;
   }
-  .bl-dada { width: 34mm; }
-  .bl-catat { font-style: normal; }
+  .bl-dada { width: 58mm; }
 
-  /* Label harus tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
-     Abu-abu adalah hal yang paling buruk ditangani mesin fotokopi: ia diubah
-     jadi raster titik-titik yang bisa hilang sama sekali di mesin yang
-     tonernya menipis, atau justru menghitam jadi kotor. Yang menggantikannya:
-     hitam pekat, ukuran kecil, dan diletakkan di sudut atas sel — kecil dan
-     menepi mencapai tujuan yang sama dengan pudar, dan bertahan digandakan
-     berkali-kali. Lihat CLAUDE.md bagian 8. */
-  .bl-label { font-size: 7pt; color: #000; display: block; }
-  .bl-label em { font-style: italic; font-size: 6.5pt; }
+  /* Label tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
+     Abu-abu adalah yang paling buruk ditangani mesin fotokopi: diubah jadi
+     raster titik yang hilang di mesin bertoner tipis, atau menghitam jadi
+     kotor. Penggantinya hitam pekat, kecil, menepi di sudut sel — mencapai
+     tujuan yang sama dan bertahan digandakan berkali-kali. */
+  .bl-label { font-size: 8pt; color: #000; display: block; }
 
-  /* Kotak nilai. Kepalanya DULU blok hitam dengan tulisan putih, dan itu
+  /* Kotak nilai. Kepalanya DULU blok hitam bertulisan putih, dan itu
      kekeliruan: blok penuh boros toner, keluar belang di mesin fotokopi, dan
      tulisan putih di atasnya adalah hal PERTAMA yang hilang saat menggandakan
-     gandaan. Sekarang huruf hitam biasa, dan yang menonjolkannya adalah garis
-     tebal di bawah judul — garis bertahan, blok tidak.
+     gandaan. Sekarang huruf hitam biasa, dan yang menonjolkannya garis tebal —
+     garis bertahan, blok tidak.
 
      Contoh angka di bawah judul tetap ada. Satu contoh nyata mencegah seluruh
      kelas kesalahan yang tidak bisa dicegah kalimat mana pun: "0:47" di kotak
      berlabel DETIK, atau poin ditulis alih-alih data mentah. */
-  .bl-nilai { margin-top: 2mm; border: 1pt solid #000; }
+  .bl-nilai { margin-top: 3.5mm; border: 1.2pt solid #000; }
   .bl-nilai-kepala {
-    text-align: center; padding: 1.2mm .5mm .8mm;
-    border-bottom: 1pt solid #000;
+    text-align: center; padding: 2mm 1mm 1.5mm; border-bottom: 1.2pt solid #000;
   }
   .bl-nilai-judul {
-    display: block; font-size: 9pt; font-weight: 700;
-    text-transform: uppercase; letter-spacing: .4pt;
+    display: block; font-size: 12pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .8pt;
   }
-  .bl-nilai-contoh { display: block; font-size: 7pt; margin-top: .4mm; }
-  .bl-nilai-kotak { height: 22mm; }
+  .bl-nilai-contoh { display: block; font-size: 9pt; margin-top: .8mm; }
+  .bl-nilai-kotak { height: 30mm; }
 
-  .bl-catatan { margin: 1.5mm 0 0; font-size: 7pt; line-height: 1.25; }
-  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 7pt; }
-  .bl-garis {
-    margin: 5mm 4mm 0; border-bottom: .75pt solid #000;
-  }
+  .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
+  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 8pt; }
+  .bl-garis { margin: 7mm auto 0; width: 70mm; border-bottom: .75pt solid #000; }
 
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan

--- a/live/style.css
+++ b/live/style.css
@@ -479,7 +479,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     text-align: left;
     font-size: 11pt;
   }
-  .print-table th { background: #eee; font-size: 9pt; text-transform: uppercase; }
+  /* Kepala tabel TANPA raster abu-abu. #eee terlihat rapi di layar dan di
+     printer laser, tapi kertas ini digandakan dengan fotokopi: raster halus
+     itu keluar belang, atau menghitam sampai judul kolomnya sulit dibaca.
+     Huruf tebal dan garis bawah tebal memisahkan kepala dari isi tanpa
+     satu titik toner pun yang tidak perlu (CLAUDE.md bagian 8). */
+  .print-table th {
+    font-size: 9pt; text-transform: uppercase; font-weight: 700;
+    border-bottom-width: 1.5pt;
+  }
   /* Baris TOTAL memakai <th> juga, dan uppercase mengubah "Rp" jadi "RP" —
      jelek di kwitansi resmi. Angkanya dikembalikan ke huruf aslinya. */
   .print-table tfoot th { text-transform: none; font-size: 11pt; }
@@ -496,7 +504,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .receipt-signature { margin-top: 10mm; width: 60mm; margin-left: auto; text-align: center; }
   .receipt-line { margin-top: 14mm; border-top: 1pt solid #000; padding-top: 2mm; }
 
-  .print-note { font-size: 9pt; color: #333; margin-top: .5rem; }
+  .print-note { font-size: 9pt; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
 
   /* Rentang yang boleh ditulis, di bawah nama kolomnya — sama seperti di
@@ -513,57 +521,106 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
-  /* ---- Slip nilai: DELAPAN per A4 potret ----
-     Bentuk kertas yang paling banyak dicetak di seluruh sistem. 500 regu di
-     pos berisi tiga lomba adalah 1.500 slip; pada jumlah itu, selisih empat
-     dan delapan slip per halaman adalah 188 lembar kertas untuk satu pos saja.
+  /* ---- FORM PER LOMBA (blangko kosong): ENAM per A4 potret ----
+     Blangko, bukan kertas berisi identitas regu — regu datang ke pos dalam
+     urutan acak, jadi kertas yang sudah tercetak namanya harus DICARI setiap
+     kali satu regu masuk. Alasan lengkapnya di siapkanCetakBlangko().
 
-     Ukurannya jadi 4 baris x 2 kolom dari A4 potret = kira-kira 99 x 68 mm,
-     selebar telapak tangan. Yang harus muat di dalamnya cuma satu angka besar,
-     tiga baris identitas, satu kotak isian, dan satu tanda tangan pendek —
-     diukur pada huruf 9pt, bukan dikira.
+     Enam per halaman = 2 kolom x 3 baris = kira-kira 99 x 95 mm, hampir
+     persegi. Ukuran itu dipilih karena isinya: satu kotak nomor dada yang
+     harus ditulis besar, tiga baris identitas, satu kotak angka selebar
+     kertas, dan satu tanda tangan. Pada 500 regu, satu pos berisi tiga lomba
+     memakan 250 lembar — turun dari 375 kalau empat per halaman.
 
-     Garis putus-putus adalah panduan gunting. Border penuh akan membuat dua
-     slip bersebelahan punya garis ganda setelah dipotong, dan tumpukan yang
-     tepinya tidak rata jauh lebih sulit disortir daripada yang rata. */
-  @page slip-halaman { size: A4 portrait; margin: 6mm; }
-  .slip-halaman {
-    page: slip-halaman;
+     Kotak nilainya sengaja jauh lebih besar daripada kotak identitas. Yang
+     dinilai adalah angka itu; identitas cuma penanda supaya kertasnya bisa
+     pulang ke regunya. */
+  @page blangko-halaman { size: A4 portrait; margin: 5mm; }
+  .blangko-halaman {
+    page: blangko-halaman;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-auto-rows: 1fr;
     gap: 0;
-    height: 285mm;
+    height: 287mm;
   }
-  .slip {
-    border: 1px dashed #666;
-    padding: 3mm 3.5mm;
+  .blangko {
+    border: .75pt dashed #000;
+    padding: 3.5mm 4mm;
     display: flex;
     flex-direction: column;
-    font-size: 9pt;
-    line-height: 1.25;
+    font-size: 8pt;
+    line-height: 1.2;
     overflow: hidden;
   }
-  .slip-kepala {
-    display: flex; align-items: baseline; justify-content: space-between;
-    gap: 2mm; border-bottom: 1px solid #000; padding-bottom: 1mm;
+  .bl-pos {
+    margin: 0; text-align: center; font-size: 7pt; font-weight: 700;
+    letter-spacing: .8pt; text-transform: uppercase;
   }
-  /* Nomor dada sebesar mungkin tanpa mendorong nama lomba turun. Seluruh
-     alurnya berakhir pada mengurutkan ratusan lembar lepas, dan itu dilakukan
-     sambil melihat sudut kertas saja — lihat alur-lomba.md 8.4. */
-  .slip-dada { font-size: 20pt; font-weight: 700; letter-spacing: .5pt; }
-  .slip-lomba { font-size: 8pt; font-weight: 700; text-align: right; }
-  .slip-regu { font-weight: 700; margin: 1.5mm 0 0; }
-  .slip-asal { font-size: 8pt; margin: .5mm 0 0; }
-  /* Kotak isian didorong ke bawah supaya letaknya sama di setiap slip —
-     tangan yang menulis 1.500 kali tidak perlu mencarinya dua kali. */
-  .slip-isian { margin-top: auto; display: flex; gap: 3mm; align-items: flex-end; }
-  .slip-kotak { display: flex; flex-direction: column; gap: .8mm; flex: 1; }
-  .slip-petunjuk { font-size: 7pt; }
-  .slip-kotak .isian {
-    display: block; height: 9mm; border: 1px solid #000; border-radius: 1mm;
+  .bl-lomba {
+    margin: .4mm 0 0; text-align: center; font-size: 15pt; font-weight: 800;
+    letter-spacing: .3pt; text-transform: uppercase; line-height: 1.05;
   }
-  .slip-kaki { font-size: 7pt; margin: 2mm 0 0; }
+  .bl-acara {
+    margin: 1mm 0 0; text-align: center; font-size: 7pt;
+    border-top: 1.5pt solid #000; padding-top: 1mm;
+  }
+
+  /* Identitas: SATU kotak besar untuk nomor dada, dan satu catatan kecil di
+     sebelahnya. Tidak ada kolom nama regu, sekolah, atau golongan — alasannya
+     di siapkanCetakBlangko(): ketiganya sudah ditentukan nomor dada, dan
+     menyalinnya 1.500 kali adalah pekerjaan tanpa informasi baru.
+
+     Kotak nomor dada dibuat tinggi supaya angkanya bisa ditulis BESAR. Ia
+     dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas
+     menuliskannya di tengah antrean, dan saat tim IT mengurutkan ratusan
+     lembar lepas dengan hanya melihat sudut kertas. */
+  .bl-identitas {
+    width: 100%; border-collapse: collapse; margin-top: 1.5mm;
+  }
+  .bl-identitas td {
+    border: .75pt solid #000; padding: .7mm 1.2mm; height: 13mm;
+    vertical-align: top;
+  }
+  .bl-dada { width: 34mm; }
+  .bl-catat { font-style: normal; }
+
+  /* Label harus tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
+     Abu-abu adalah hal yang paling buruk ditangani mesin fotokopi: ia diubah
+     jadi raster titik-titik yang bisa hilang sama sekali di mesin yang
+     tonernya menipis, atau justru menghitam jadi kotor. Yang menggantikannya:
+     hitam pekat, ukuran kecil, dan diletakkan di sudut atas sel — kecil dan
+     menepi mencapai tujuan yang sama dengan pudar, dan bertahan digandakan
+     berkali-kali. Lihat CLAUDE.md bagian 8. */
+  .bl-label { font-size: 7pt; color: #000; display: block; }
+  .bl-label em { font-style: italic; font-size: 6.5pt; }
+
+  /* Kotak nilai. Kepalanya DULU blok hitam dengan tulisan putih, dan itu
+     kekeliruan: blok penuh boros toner, keluar belang di mesin fotokopi, dan
+     tulisan putih di atasnya adalah hal PERTAMA yang hilang saat menggandakan
+     gandaan. Sekarang huruf hitam biasa, dan yang menonjolkannya adalah garis
+     tebal di bawah judul — garis bertahan, blok tidak.
+
+     Contoh angka di bawah judul tetap ada. Satu contoh nyata mencegah seluruh
+     kelas kesalahan yang tidak bisa dicegah kalimat mana pun: "0:47" di kotak
+     berlabel DETIK, atau poin ditulis alih-alih data mentah. */
+  .bl-nilai { margin-top: 2mm; border: 1pt solid #000; }
+  .bl-nilai-kepala {
+    text-align: center; padding: 1.2mm .5mm .8mm;
+    border-bottom: 1pt solid #000;
+  }
+  .bl-nilai-judul {
+    display: block; font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .4pt;
+  }
+  .bl-nilai-contoh { display: block; font-size: 7pt; margin-top: .4mm; }
+  .bl-nilai-kotak { height: 22mm; }
+
+  .bl-catatan { margin: 1.5mm 0 0; font-size: 7pt; line-height: 1.25; }
+  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 7pt; }
+  .bl-garis {
+    margin: 5mm 4mm 0; border-bottom: .75pt solid #000;
+  }
 
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan

--- a/live/style.css
+++ b/live/style.css
@@ -513,6 +513,58 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
+  /* ---- Slip nilai: DELAPAN per A4 potret ----
+     Bentuk kertas yang paling banyak dicetak di seluruh sistem. 500 regu di
+     pos berisi tiga lomba adalah 1.500 slip; pada jumlah itu, selisih empat
+     dan delapan slip per halaman adalah 188 lembar kertas untuk satu pos saja.
+
+     Ukurannya jadi 4 baris x 2 kolom dari A4 potret = kira-kira 99 x 68 mm,
+     selebar telapak tangan. Yang harus muat di dalamnya cuma satu angka besar,
+     tiga baris identitas, satu kotak isian, dan satu tanda tangan pendek —
+     diukur pada huruf 9pt, bukan dikira.
+
+     Garis putus-putus adalah panduan gunting. Border penuh akan membuat dua
+     slip bersebelahan punya garis ganda setelah dipotong, dan tumpukan yang
+     tepinya tidak rata jauh lebih sulit disortir daripada yang rata. */
+  @page slip-halaman { size: A4 portrait; margin: 6mm; }
+  .slip-halaman {
+    page: slip-halaman;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: 1fr;
+    gap: 0;
+    height: 285mm;
+  }
+  .slip {
+    border: 1px dashed #666;
+    padding: 3mm 3.5mm;
+    display: flex;
+    flex-direction: column;
+    font-size: 9pt;
+    line-height: 1.25;
+    overflow: hidden;
+  }
+  .slip-kepala {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 2mm; border-bottom: 1px solid #000; padding-bottom: 1mm;
+  }
+  /* Nomor dada sebesar mungkin tanpa mendorong nama lomba turun. Seluruh
+     alurnya berakhir pada mengurutkan ratusan lembar lepas, dan itu dilakukan
+     sambil melihat sudut kertas saja — lihat alur-lomba.md 8.4. */
+  .slip-dada { font-size: 20pt; font-weight: 700; letter-spacing: .5pt; }
+  .slip-lomba { font-size: 8pt; font-weight: 700; text-align: right; }
+  .slip-regu { font-weight: 700; margin: 1.5mm 0 0; }
+  .slip-asal { font-size: 8pt; margin: .5mm 0 0; }
+  /* Kotak isian didorong ke bawah supaya letaknya sama di setiap slip —
+     tangan yang menulis 1.500 kali tidak perlu mencarinya dua kali. */
+  .slip-isian { margin-top: auto; display: flex; gap: 3mm; align-items: flex-end; }
+  .slip-kotak { display: flex; flex-direction: column; gap: .8mm; flex: 1; }
+  .slip-petunjuk { font-size: 7pt; }
+  .slip-kotak .isian {
+    display: block; height: 9mm; border: 1px solid #000; border-radius: 1mm;
+  }
+  .slip-kaki { font-size: 7pt; margin: 2mm 0 0; }
+
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan
      kaki. Karena itu SEMUANYA di lembar ini lebih rapat daripada cetakan lain

--- a/supabase/migrations/0005_views.sql
+++ b/supabase/migrations/0005_views.sql
@@ -131,7 +131,7 @@ where exists (select 1 from keberangkatan_regu kb where kb.regu_id = t.regu_id)
               where r.id = t.regu_id and k.jam_berangkat is not null);
 
 -- 6. Monitoring input: matriks regu x pos — pos mana sudah menyetor untuk
---    regu mana (alur 8.7).
+--    regu mana (alur 8.9).
 create view v_monitoring_input with (security_invoker = on) as
 select
   r.nomor_dada,

--- a/supabase/migrations/0039_judul_isian.sql
+++ b/supabase/migrations/0039_judul_isian.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- hrcd-rekap : 0039_judul_isian.sql
+--
+-- Judul besar di atas kotak isian form per lomba jadi konfigurasi, dan judul
+-- Menaksir diperbaiki jadi "Selisih taksir".
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA INI BUKAN SEKADAR SOAL KATA
+--
+-- Layar menurunkan judul itu dari bentuk komponennya: waktu jadi "Waktu
+-- tempuh", hitungan jadi "Jumlah benar". Untuk Menaksir turunannya adalah
+-- "Hasil ukur" — dan itu kata yang salah dengan cara yang paling mahal.
+--
+-- Yang harus ditulis petugas adalah SELISIH antara taksiran regu dan jarak
+-- sebenarnya. "Hasil ukur" membaca seperti perintah menulis jarak yang
+-- terukur. Kalau itu yang ditulis — 12 meter, bukan selisih 2 meter — tangga
+-- Menaksir habis di atas 4 meter, jadi hampir setiap regu mendapat 0.
+--
+-- Tidak ada galat, tidak ada yang janggal di layar. Yang terlihat hanyalah
+-- satu lomba yang seluruh pesertanya kebetulan buruk.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KOLOM BARU, BUKAN DITURUNKAN SAJA
+--
+-- Empat dari lima bentuk penilaian bisa diterjemahkan sendiri oleh layar,
+-- karena bentuknya menentukan artinya: `satuan = detik` selalu berarti waktu,
+-- `besar_baik` selalu berarti jumlah benar.
+--
+-- `bertingkat` tidak. Ia cuma tangga angka — angkanya bisa detik, meter,
+-- selisih, atau apa pun yang panitia putuskan tahun itu. Sistem TIDAK BISA
+-- tahu, dan menebak menghasilkan persis kekeliruan di atas. Jadi bentuk itu
+-- membawa judulnya sendiri, dan kalau tidak diisi layar memakai "Data mentah"
+-- yang tidak menyesatkan siapa pun karena tidak menjanjikan apa-apa.
+--
+-- Kolom ini bersaudara dengan `petunjuk` (0037), dan keduanya memang dua slot
+-- berbeda di kertas yang sama: `judul_isian` huruf besar di kepala kotak,
+-- `petunjuk` baris kecil di bawahnya.
+-- ============================================================================
+
+alter table wahana add column if not exists judul_isian text;
+
+comment on column wahana.judul_isian is
+  'Judul besar di atas kotak isian pada form per lomba. Kosong = layar '
+  'menurunkannya dari bentuk komponen. WAJIB diisi untuk form=bertingkat '
+  'tanpa satuan, karena bentuk itu tidak menentukan arti angkanya.';
+
+do $$
+declare v_baris int;
+begin
+  update wahana set judul_isian = 'Selisih taksir'
+  where edisi = edisi_aktif() and kode = 'menaksir';
+
+  get diagnostics v_baris = row_count;
+  if v_baris = 0 then
+    raise notice '0039: komponen `menaksir` tidak ada di edisi aktif — dilewati.';
+  else
+    raise notice '0039: judul isian Menaksir jadi "Selisih taksir".';
+  end if;
+end;
+$$;

--- a/supabase/migrations/0039_judul_isian.sql
+++ b/supabase/migrations/0039_judul_isian.sql
@@ -2,7 +2,7 @@
 -- hrcd-rekap : 0039_judul_isian.sql
 --
 -- Judul besar di atas kotak isian form per lomba jadi konfigurasi, dan judul
--- Menaksir diperbaiki jadi "Selisih taksir".
+-- Menaksir diperbaiki jadi "Selisih Taksir".
 --
 -- ---------------------------------------------------------------------------
 -- KENAPA INI BUKAN SEKADAR SOAL KATA
@@ -47,14 +47,14 @@ comment on column wahana.judul_isian is
 do $$
 declare v_baris int;
 begin
-  update wahana set judul_isian = 'Selisih taksir'
+  update wahana set judul_isian = 'Selisih Taksir'
   where edisi = edisi_aktif() and kode = 'menaksir';
 
   get diagnostics v_baris = row_count;
   if v_baris = 0 then
     raise notice '0039: komponen `menaksir` tidak ada di edisi aktif — dilewati.';
   else
-    raise notice '0039: judul isian Menaksir jadi "Selisih taksir".';
+    raise notice '0039: judul isian Menaksir jadi "Selisih Taksir".';
   end if;
 end;
 $$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -140,7 +140,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q(
                     "select kode, name, type, form, poin_maks, raw_terbaik, "
                     "       raw_terburuk, poin_benar, poin_salah, total_soal, "
-                    "       tingkat, satuan, golongan, petunjuk, rentang_mentah_min, "
+                    "       tingkat, satuan, golongan, petunjuk, judul_isian, "
+                    "       rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() and pos = %s "
                     "order by sort_order",
@@ -150,7 +151,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 # Rekapitulasi (#/rekap).
                 self._kirim(200, q(
                     "select pos, kode, name, type, form, poin_maks, satuan, "
-                    "       golongan, petunjuk, "
+                    "       golongan, petunjuk, judul_isian, "
                     "       total_soal, rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -123,5 +123,8 @@ run tests/sql/16_kosong_bukan_nol.sql
 # 0038 hanya mengganti bunyi satu petunjuk kolom. Dijalankan supaya berkasnya
 # tetap teruji; di database uji `menaksir` tidak ada, jadi ia melapor dilewati.
 run supabase/migrations/0038_petunjuk_menaksir.sql
+# 0039 menambah kolom `judul_isian`. Dijalankan supaya berkasnya teruji; di
+# database uji `menaksir` tidak ada, jadi UPDATE-nya melapor dilewati.
+run supabase/migrations/0039_judul_isian.sql
 
 echo "SEMUA TES LULUS"

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -431,7 +431,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }
@@ -445,7 +445,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
-    `golongan,petunjuk,` +
+    `golongan,petunjuk,judul_isian,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2122,27 +2122,50 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
 
 /** Judul besar di atas kotak isian: APA yang harus ditulis di sana.
  *
- *  Diturunkan dari bentuk komponennya, bukan ditulis per lomba, supaya lomba
- *  baru tahun depan langsung dapat judul yang benar tanpa menyentuh berkas
- *  ini. Empat cabang, semuanya kalimat yang panitia ucapkan sendiri. */
+ *  Konfigurasi menang. Empat dari lima bentuk penilaian bisa diterjemahkan
+ *  sendiri, karena bentuknya menentukan artinya — `satuan = detik` selalu
+ *  berarti waktu, `besar_baik` selalu berarti jumlah benar.
+ *
+ *  `bertingkat` tidak bisa. Ia cuma tangga angka, dan angkanya bisa detik,
+ *  meter, selisih, atau apa pun yang panitia putuskan tahun itu. Menebaknya
+ *  pernah menghasilkan "Hasil ukur" untuk Menaksir — kata yang membaca seperti
+ *  perintah menulis jarak TERUKUR, padahal yang diminta SELISIH-nya. Kalau
+ *  petugas menulis 12 alih-alih 2, tangga Menaksir habis di atas 4 meter dan
+ *  hampir setiap regu mendapat 0, tanpa satu galat pun.
+ *
+ *  Jadi bentuk itu membawa judulnya sendiri lewat `judul_isian` (0039), dan
+ *  cadangannya sengaja tidak menjanjikan apa-apa. */
 function judulIsian(k) {
+  if (k.judul_isian) return k.judul_isian;
   if (k.satuan === "detik") return "Waktu tempuh";
   if (k.form === "biner") return "Kena / tidak";
   if (k.form === "benar_kurang_salah") return "Benar dan salah";
-  if (k.form === "bertingkat") return "Hasil ukur";
+  if (k.form === "bertingkat") return "Data mentah";
   return "Jumlah benar";
 }
 
-/** Contoh angka di bawah judul. Bukan hiasan: satu contoh nyata mencegah
- *  seluruh kelas kesalahan yang tidak bisa dicegah kalimat mana pun — petugas
- *  yang menulis "0:47" di kotak berlabel DETIK, atau menulis poin alih-alih
- *  data mentah. Angkanya diambil dari rentang komponen itu sendiri, jadi ia
- *  selalu masuk akal untuk lomba yang bersangkutan. */
-function contohIsian(k) {
+/** Keterangan di bawah judul: rentang yang boleh ditulis, dan untuk waktu satu
+ *  contoh nyata. Contoh itu bukan hiasan — ia mencegah seluruh kelas kesalahan
+ *  yang tidak bisa dicegah kalimat mana pun: petugas yang menulis "0:47" di
+ *  kotak berlabel DETIK, atau menulis poin alih-alih data mentah.
+ *
+ *  Menerima KOLOM, bukan komponen tunggal, dan itu yang penting. Satu blangko
+ *  dipakai regu golongan mana pun, sementara Tebak Simpul punya dua skala —
+ *  5 simpul untuk Penggalang, 10 untuk Penegak. Mengambil rentang dari varian
+ *  pertama saja akan mencetak "0 – 10" di kertas yang separuhnya dipegang regu
+ *  Penggalang: bukan sekadar kurang lengkap, tapi salah.
+ *
+ *  `kol.petunjuk` sudah menggabungkan rentang yang berbeda jadi
+ *  "0 – 10 / 0 – 5", sama persis dengan yang tercetak di form tabel. Keduanya
+ *  benar, tergantung golongan, dan petugas lomba itu tahu yang mana. */
+function contohIsian(kol) {
+  const k = kol.varian[0];
   if (k.satuan === "detik") return "dalam DETIK · contoh: 47";
   if (k.form === "biner") return "centang bila kena";
-  if (k.petunjuk) return k.petunjuk;
-  return `angka ${petunjukKolom(k)}`;
+  // Keterangan yang ditulis panitia sendiri dipakai apa adanya — ia sudah
+  // berupa kalimat, bukan rentang yang perlu diberi kata "angka".
+  if (k.petunjuk) return kol.petunjuk;
+  return `angka ${kol.petunjuk}`;
 }
 
 /** FORM PER LOMBA — BLANGKO KOSONG, satu lembar untuk satu regu di satu lomba
@@ -2183,11 +2206,10 @@ function contohIsian(k) {
  *  atau petugas ragu antara 6 dan 8. Tanpa tempatnya, catatan itu tetap
  *  ditulis, hanya saja di pinggir kertas tempat tidak ada yang mencarinya.
  */
-function siapkanCetakBlangko(pos, kolomLayar, jumlah) {
+function siapkanCetakBlangko(pos, kolomLayar) {
   document.getElementById("cetakan")?.remove();
 
-  const judulPos = pos.bayangan ? pos.name : `POS ${pos.nomor} · ${pos.name}`;
-  const BLANGKO_PER_HALAMAN = 6;
+  const judulPos = pos.bayangan ? pos.name : `Pos ${pos.nomor} · ${pos.name}`;
 
   const satuBlangko = (kol) => {
     // Varian mana pun boleh dipakai untuk menurunkan bentuknya: yang berbeda
@@ -2204,15 +2226,14 @@ function siapkanCetakBlangko(pos, kolomLayar, jumlah) {
       <table class="bl-identitas"><tbody>
         <tr>
           <td class="bl-dada"><span class="bl-label">No Dada</span></td>
-          <td class="bl-catat"><span class="bl-label">Regu / sekolah —
-            <em>hanya bila nomor dada tidak terbaca</em></span></td>
+          <td class="bl-catat"><span class="bl-label">Regu / sekolah</span></td>
         </tr>
       </tbody></table>
 
       <div class="bl-nilai">
         <div class="bl-nilai-kepala">
           <span class="bl-nilai-judul">${esc(judulIsian(k))}</span>
-          <span class="bl-nilai-contoh">${esc(contohIsian(k))}</span>
+          <span class="bl-nilai-contoh">${esc(contohIsian(kol))}</span>
         </div>
         <div class="bl-nilai-kotak"></div>
       </div>
@@ -2224,21 +2245,22 @@ function siapkanCetakBlangko(pos, kolomLayar, jumlah) {
     </article>`;
   };
 
-  // Satu tumpukan per lomba, dan tiap tumpukan dimulai di HALAMAN BARU.
-  // Halaman campuran akan memaksa seseorang memilah guntingan sebelum
-  // membagikannya — pekerjaan yang tidak perlu ada, dan harganya cuma
-  // beberapa blangko kosong di halaman terakhir tiap lomba.
-  const cetakan = kolomLayar.map(kol => {
-    const isi = satuBlangko(kol);
-    const halaman = Math.ceil(jumlah / BLANGKO_PER_HALAMAN);
-    return Array.from({ length: halaman }, () => `
-      <section class="print-page blangko-halaman">
-        ${isi.repeat(BLANGKO_PER_HALAMAN)}
-      </section>`).join("");
-  }).join("");
+  // SATU HALAMAN A5 MELINTANG PER LOMBA, bukan sebanyak jumlah regu.
+  //
+  // Yang dicetak dari sini adalah MASTER, bukan tumpukannya. Blangko
+  // diperbanyak dengan mesin fotokopi — 500 regu di pos berisi tiga lomba
+  // membutuhkan 1.500 lembar, dan mencetak sebanyak itu lewat browser berarti
+  // menghabiskan satu toner printer kantor untuk pekerjaan yang diselesaikan
+  // mesin fotokopi dalam beberapa menit.
+  //
+  // Jadi keluarannya tiga halaman untuk Pos 1: Semaphore, Tebak Simpul,
+  // Menaksir. Panitia menggandakan tiap halaman sebanyak yang dibutuhkan, dan
+  // tiap tumpukan otomatis berisi satu lomba saja.
+  const cetakan = kolomLayar.map(kol => `
+    <section class="print-page blangko-halaman">${satuBlangko(kol)}</section>`).join("");
 
   document.body.appendChild(h(`<div id="cetakan" class="printout">${cetakan}</div>`));
-  return kolomLayar.length * Math.ceil(jumlah / BLANGKO_PER_HALAMAN);
+  return kolomLayar.length;
 }
 
 /** Layar Input Pos — lembar kertas yang dipindah ke layar.
@@ -2757,16 +2779,13 @@ async function layarInputPos() {
     try { ditutup = !!(await statusAcara()).daftar_ulang_ditutup; } catch { /* cetak tetap jalan */ }
 
     if (slip) {
-      // Blangkonya KOSONG, jadi jumlah regu cuma menentukan BERAPA BANYAK yang
-      // dicetak — bukan isinya. Karena itu daftar ulang yang belum ditutup
-      // tidak lagi berbahaya di sini: regu yang menyusul tetap kebagian
-      // kertas, asal jumlahnya cukup. Ditambah seperlima sebagai cadangan,
-      // karena kertas rusak, basah, dan salah tulis adalah kejadian biasa di
-      // lapangan — dan blangko yang habis di tengah lomba menghentikan pos.
-      const perlu = Math.ceil(tampil.length * 1.2);
-      const lembar = siapkanCetakBlangko(pos, kolom, perlu);
-      notif(`${lembar} lembar A4 — ${perlu} blangko × ${kolom.length} lomba `
-            + `(${tampil.length} regu + cadangan).`);
+      // Yang dicetak MASTER, bukan tumpukannya — jadi daftar ulang yang belum
+      // ditutup tidak berpengaruh di sini, dan jumlah regu yang sedang tampil
+      // pun tidak. Blangkonya kosong; berapa banyak yang dibutuhkan diputuskan
+      // di mesin fotokopi, bukan di layar ini.
+      const n = siapkanCetakBlangko(pos, kolom);
+      notif(`${n} master A5 melintang, satu per lomba. Perbanyak dengan `
+            + `fotokopi sebanyak regu yang berlomba, tambah cadangan.`);
     } else {
       siapkanCetakLembarPos(pos, kolom, tampil, ditutup);
     }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2120,84 +2120,125 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
   document.body.appendChild(h(`<div id="cetakan" class="printout">${lembar}</div>`));
 }
 
-/** SLIP NILAI — satu kertas, satu lomba, SATU REGU (alur-lomba.md 8.3).
+/** Judul besar di atas kotak isian: APA yang harus ditulis di sana.
  *
- *  Bentuk ketiga, dan yang paling banyak dipakai di lapangan. Regu masuk
- *  wahana, petugas mengambil slip lombanya, regu mengerjakan, petugas menulis
- *  angkanya, slip masuk kotak penilaian. Kotaknya diserahkan ke tim IT, yang
- *  mengurutkannya menurut nomor dada sebelum memasukkannya.
+ *  Diturunkan dari bentuk komponennya, bukan ditulis per lomba, supaya lomba
+ *  baru tahun depan langsung dapat judul yang benar tanpa menyentuh berkas
+ *  ini. Empat cabang, semuanya kalimat yang panitia ucapkan sendiri. */
+function judulIsian(k) {
+  if (k.satuan === "detik") return "Waktu tempuh";
+  if (k.form === "biner") return "Kena / tidak";
+  if (k.form === "benar_kurang_salah") return "Benar dan salah";
+  if (k.form === "bertingkat") return "Hasil ukur";
+  return "Jumlah benar";
+}
+
+/** Contoh angka di bawah judul. Bukan hiasan: satu contoh nyata mencegah
+ *  seluruh kelas kesalahan yang tidak bisa dicegah kalimat mana pun — petugas
+ *  yang menulis "0:47" di kotak berlabel DETIK, atau menulis poin alih-alih
+ *  data mentah. Angkanya diambil dari rentang komponen itu sendiri, jadi ia
+ *  selalu masuk akal untuk lomba yang bersangkutan. */
+function contohIsian(k) {
+  if (k.satuan === "detik") return "dalam DETIK · contoh: 47";
+  if (k.form === "biner") return "centang bila kena";
+  if (k.petunjuk) return k.petunjuk;
+  return `angka ${petunjukKolom(k)}`;
+}
+
+/** FORM PER LOMBA — BLANGKO KOSONG, satu lembar untuk satu regu di satu lomba
+ *  (alur-lomba.md 8.3).
  *
- *  Kenapa bukan tabel 30 regu, padahal tabel jauh lebih hemat kertas: sebuah
- *  tabel baru bisa berpindah ke kotak setelah baris TERAKHIR-nya terisi, dan
- *  satu regu tidak pernah selesai di semua lomba pada saat yang sama. Slip
- *  berpindah begitu regunya selesai. Tabelnya tetap ada untuk pos yang dinilai
- *  satu meja — dua bentuk untuk dua cara kerja, bukan satu menggantikan yang
- *  lain.
+ *  KENAPA KOSONG, PADAHAL SISTEM TAHU SEMUA NAMA REGUNYA.
  *
- *  JUMLAHNYA BESAR, dan itu memang begitu adanya: 500 regu di pos berisi tiga
- *  lomba berarti 1.500 slip. Karena itu delapan slip per A4, bukan satu — pada
- *  1.500 slip, selisih empat dan delapan per halaman adalah 188 lembar kertas.
- *  Ukurannya masih selebar telapak tangan, cukup untuk satu angka besar dan
- *  satu tanda tangan pendek.
+ *  Karena regu datang ke pos dalam urutan ACAK. Kloter berangkat berurutan,
+ *  tetapi rute, kecepatan, dan antrean membuat siapa yang muncul berikutnya
+ *  tidak bisa ditebak. Kalau tiap kertas sudah tercetak identitasnya, petugas
+ *  harus MENCARI kertas nomor 005 di tumpukan berisi ratusan lembar setiap
+ *  kali satu regu masuk — pekerjaan yang lebih lama daripada lombanya sendiri,
+ *  dilakukan sambil regu menunggu.
  *
- *  Tiga hal yang dikerjakan bentuk ini dan tidak bisa dikerjakan tabel:
+ *  Jadi semua kertas identik, dan petugas menulis "005" di kotak paling kiri
+ *  atas. Yang dicetak sistem bukan datanya, melainkan BENTUKNYA: nama lomba,
+ *  satuan yang benar, contoh angkanya, dan tempat tanda tangan.
  *
- *    - Nomor dada dicetak BESAR di pojok kiri atas. Seluruh alurnya berujung
- *      pada mengurutkan ratusan lembar lepas, dan itu dilakukan sambil melihat
- *      sudut kertas saja.
- *    - Rentangnya milik regu ITU. Di tabel, Tebak Simpul harus menulis
- *      "0 – 10 / 0 – 5" karena satu kolom melayani empat golongan; di slip,
- *      regu Penggalang melihat "0 – 5" saja dan tidak ada yang perlu dipilih.
- *    - Slip untuk golongan yang tidak berhak TIDAK dicetak sama sekali —
- *      bukan dicetak lalu dicoret.
+ *  YANG DITULIS TANGAN HANYA NOMOR DADA.
+ *
+ *  Tidak ada kolom nama regu, sekolah, atau golongan — dan itu keputusan,
+ *  bukan kelalaian. Ketiganya sudah ditentukan oleh nomor dada, jadi
+ *  menuliskannya berarti menyalin ~30 huruf sebanyak 1.500 kali untuk
+ *  informasi yang sudah dimiliki sistem. Di pos yang sedang mengantre, itu
+ *  pekerjaan yang memakan waktu lomba itu sendiri.
+ *
+ *  Lebih buruk lagi: kolom yang terlalu mahal untuk diisi AKAN dikosongkan,
+ *  dan kolom kosong yang bernama "konfirmasi" adalah pengaman palsu — ia
+ *  membuat orang merasa ada pengecekan padahal tidak ada.
+ *
+ *  Pengecekannya memang ada, tapi bukan di kertas. Saat tim IT mengetik 005,
+ *  baris di layar Input Pos langsung menampilkan nama regu, sekolahnya, dan
+ *  golongannya. Salah ketik ketahuan di sana — tanpa satu huruf pun ditulis
+ *  di lapangan.
+ *
+ *  Satu baris kecil tetap disediakan untuk keadaan yang benar-benar
+ *  membutuhkan tulisan: nomor dadanya TIDAK TERBACA — robek, tertutup jaket,
+ *  atau petugas ragu antara 6 dan 8. Tanpa tempatnya, catatan itu tetap
+ *  ditulis, hanya saja di pinggir kertas tempat tidak ada yang mencarinya.
  */
-function siapkanCetakSlipPos(pos, kolomLayar, baris) {
+function siapkanCetakBlangko(pos, kolomLayar, jumlah) {
   document.getElementById("cetakan")?.remove();
 
-  const judulPos = pos.bayangan ? pos.name : `POS ${pos.nomor}`;
-  const tanggal = tanggalPanjang(new Date());
+  const judulPos = pos.bayangan ? pos.name : `POS ${pos.nomor} · ${pos.name}`;
+  const BLANGKO_PER_HALAMAN = 6;
 
-  // Dikelompokkan per lomba, bukan per regu: tiap petugas mengambil satu
-  // tumpukan utuh untuk lombanya sendiri, dan tumpukan itu sudah urut nomor
-  // dada sejak dari printer.
-  const slip = [];
-  for (const kol of kolomLayar) {
-    for (const r of baris) {
-      const k = varianUntuk(kol, r.golongan);
-      if (k) slip.push({ kol, k, r });
-    }
-  }
+  const satuBlangko = (kol) => {
+    // Varian mana pun boleh dipakai untuk menurunkan bentuknya: yang berbeda
+    // antar golongan hanya skalanya, dan skala tidak dicetak di blangko —
+    // justru itu gunanya. Petugas menulis jumlah benar apa adanya, dan sistem
+    // yang tahu 5 simpul untuk Penggalang, 10 untuk Penegak.
+    const k = kol.varian[0];
+    return `
+    <article class="blangko">
+      <p class="bl-pos">${esc(judulPos)}</p>
+      <h2 class="bl-lomba">${esc(kol.nama)}</h2>
+      <p class="bl-acara">${esc(EDISI ? EDISI.name : "")} · Petugas: ____________</p>
 
-  const SLIP_PER_HALAMAN = 8;
-  const halaman = [];
-  for (let i = 0; i < slip.length; i += SLIP_PER_HALAMAN) {
-    halaman.push(slip.slice(i, i + SLIP_PER_HALAMAN));
-  }
+      <table class="bl-identitas"><tbody>
+        <tr>
+          <td class="bl-dada"><span class="bl-label">No Dada</span></td>
+          <td class="bl-catat"><span class="bl-label">Regu / sekolah —
+            <em>hanya bila nomor dada tidak terbaca</em></span></td>
+        </tr>
+      </tbody></table>
 
-  const satuSlip = ({ kol, k, r }) => `
-    <article class="slip">
-      <div class="slip-kepala">
-        ${html`<span class="slip-dada">${String(r.nomor_dada).padStart(3, "0")}</span>`}
-        <span class="slip-lomba">${esc(judulPos)} · ${esc(kol.nama)}</span>
+      <div class="bl-nilai">
+        <div class="bl-nilai-kepala">
+          <span class="bl-nilai-judul">${esc(judulIsian(k))}</span>
+          <span class="bl-nilai-contoh">${esc(contohIsian(k))}</span>
+        </div>
+        <div class="bl-nilai-kotak"></div>
       </div>
-      ${html`<p class="slip-regu">${r.nama_regu}</p>
-      <p class="slip-asal">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</p>`}
-      <div class="slip-isian">
-        ${kolomCetakPos([{ ...kol, varian: [k], petunjuk: petunjukKolom(k) }])
-          .map(c => `<span class="slip-kotak">
-            <span class="slip-petunjuk">${esc(c.petunjuk)}</span>
-            <span class="isian"></span></span>`).join("")}
-      </div>
-      <p class="slip-kaki">Petugas: ____________</p>
+
+      <p class="bl-catatan"><strong>Tulis angkanya saja — jangan menghitung
+         poin.</strong> Sistem yang mengubahnya jadi nilai.</p>
+      <p class="bl-ttd">Petugas ${esc(kol.nama)}</p>
+      <p class="bl-garis"></p>
     </article>`;
+  };
 
-  const cetakan = halaman.map(grup => `
-    <section class="print-page slip-halaman">
-      ${grup.map(satuSlip).join("")}
-    </section>`).join("");
+  // Satu tumpukan per lomba, dan tiap tumpukan dimulai di HALAMAN BARU.
+  // Halaman campuran akan memaksa seseorang memilah guntingan sebelum
+  // membagikannya — pekerjaan yang tidak perlu ada, dan harganya cuma
+  // beberapa blangko kosong di halaman terakhir tiap lomba.
+  const cetakan = kolomLayar.map(kol => {
+    const isi = satuBlangko(kol);
+    const halaman = Math.ceil(jumlah / BLANGKO_PER_HALAMAN);
+    return Array.from({ length: halaman }, () => `
+      <section class="print-page blangko-halaman">
+        ${isi.repeat(BLANGKO_PER_HALAMAN)}
+      </section>`).join("");
+  }).join("");
 
   document.body.appendChild(h(`<div id="cetakan" class="printout">${cetakan}</div>`));
-  return slip.length;
+  return kolomLayar.length * Math.ceil(jumlah / BLANGKO_PER_HALAMAN);
 }
 
 /** Layar Input Pos — lembar kertas yang dipindah ke layar.
@@ -2716,16 +2757,16 @@ async function layarInputPos() {
     try { ditutup = !!(await statusAcara()).daftar_ulang_ditutup; } catch { /* cetak tetap jalan */ }
 
     if (slip) {
-      // Peringatannya diucapkan, bukan dicetak. Slip dipotong-potong, jadi
-      // catatan kaki di halaman justru terbuang bersama guntingan — dan
-      // catatan yang pasti hilang lebih buruk daripada tidak ada, karena ia
-      // membuat orang mengira sudah memperingatkan.
-      if (!ditutup) {
-        notif("Daftar ulang belum ditutup — regu yang mendaftar setelah ini "
-              + "tidak ikut tercetak.", true);
-      }
-      const n = siapkanCetakSlipPos(pos, kolom, tampil);
-      notif(`${n} slip disiapkan — ${Math.ceil(n / 8)} lembar A4.`);
+      // Blangkonya KOSONG, jadi jumlah regu cuma menentukan BERAPA BANYAK yang
+      // dicetak — bukan isinya. Karena itu daftar ulang yang belum ditutup
+      // tidak lagi berbahaya di sini: regu yang menyusul tetap kebagian
+      // kertas, asal jumlahnya cukup. Ditambah seperlima sebagai cadangan,
+      // karena kertas rusak, basah, dan salah tulis adalah kejadian biasa di
+      // lapangan — dan blangko yang habis di tengah lomba menghentikan pos.
+      const perlu = Math.ceil(tampil.length * 1.2);
+      const lembar = siapkanCetakBlangko(pos, kolom, perlu);
+      notif(`${lembar} lembar A4 — ${perlu} blangko × ${kolom.length} lomba `
+            + `(${tampil.length} regu + cadangan).`);
     } else {
       siapkanCetakLembarPos(pos, kolom, tampil, ditutup);
     }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2028,7 +2028,7 @@ const kolomCetakPos = (kolom) => kolom.flatMap(kol => {
   return [{ nama: kol.nama, petunjuk: kol.petunjuk }];
 });
 
-/** Lembar nilai untuk DITULIS TANGAN di pos (alur-lomba.md 8.6).
+/** Lembar nilai untuk DITULIS TANGAN di pos (alur-lomba.md 8.8).
  *
  *  Identitas regu sudah tercetak, kolom nilainya kosong. Satu hal yang
  *  sengaja TIDAK ada di kertas ini: kolom Nilai Pos. Petugas lapangan hanya

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2063,28 +2063,9 @@ const kolomCetakPos = (kolom) => kolom.flatMap(kol => {
  *  Sisa ruang setelah semuanya: 10-21mm per halaman, tergantung pos. */
 const REGU_PER_LEMBAR = 30;
 
-function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup,
-                               perLomba = false) {
+function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
   document.getElementById("cetakan")?.remove();
-
-  /* SATU LEMBAR PER LOMBA.
-
-     Di Pos 1 dan Pos 2 lombanya berjalan bersamaan di titik yang berbeda —
-     Semaphore di satu sudut, Menaksir di sudut lain. Satu kertas berisi
-     ketiganya berarti ketiga petugas memperebutkan lembar yang sama, dan yang
-     terjadi bukan penilaian bergantian melainkan angka yang dicatat di kertas
-     lain lalu disalin belakangan.
-
-     Jadi mode ini menerbitkan satu SET halaman untuk tiap lomba, masing-masing
-     dengan judul lombanya sendiri. Identitas regunya diulang di setiap set —
-     itu memang tujuannya, karena tiap set berpindah tangan sendiri-sendiri.
-
-     Yang TIDAK diulang: Nilai Pos. Lembar per lomba tidak punya cukup bahan
-     untuk menghitungnya, dan kolom bernama Nilai Pos di kertas yang hanya
-     memuat sepertiga posnya adalah undangan menjumlahkan yang salah. */
-  const set = perLomba
-    ? kolomLayar.map(kol => ({ judul: kol.nama, kolom: kolomCetakPos([kol]) }))
-    : [{ judul: null, kolom: kolomCetakPos(kolomLayar) }];
+  const set = [{ judul: null, kolom: kolomCetakPos(kolomLayar) }];
   const judul = pos.bayangan ? `POS BAYANGAN — ${pos.name}`
                              : `POS ${pos.nomor} — ${pos.name}`;
   const tanggal = tanggalPanjang(new Date());
@@ -2137,6 +2118,86 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup,
     </section>`).join("")).join("");
 
   document.body.appendChild(h(`<div id="cetakan" class="printout">${lembar}</div>`));
+}
+
+/** SLIP NILAI — satu kertas, satu lomba, SATU REGU (alur-lomba.md 8.3).
+ *
+ *  Bentuk ketiga, dan yang paling banyak dipakai di lapangan. Regu masuk
+ *  wahana, petugas mengambil slip lombanya, regu mengerjakan, petugas menulis
+ *  angkanya, slip masuk kotak penilaian. Kotaknya diserahkan ke tim IT, yang
+ *  mengurutkannya menurut nomor dada sebelum memasukkannya.
+ *
+ *  Kenapa bukan tabel 30 regu, padahal tabel jauh lebih hemat kertas: sebuah
+ *  tabel baru bisa berpindah ke kotak setelah baris TERAKHIR-nya terisi, dan
+ *  satu regu tidak pernah selesai di semua lomba pada saat yang sama. Slip
+ *  berpindah begitu regunya selesai. Tabelnya tetap ada untuk pos yang dinilai
+ *  satu meja — dua bentuk untuk dua cara kerja, bukan satu menggantikan yang
+ *  lain.
+ *
+ *  JUMLAHNYA BESAR, dan itu memang begitu adanya: 500 regu di pos berisi tiga
+ *  lomba berarti 1.500 slip. Karena itu delapan slip per A4, bukan satu — pada
+ *  1.500 slip, selisih empat dan delapan per halaman adalah 188 lembar kertas.
+ *  Ukurannya masih selebar telapak tangan, cukup untuk satu angka besar dan
+ *  satu tanda tangan pendek.
+ *
+ *  Tiga hal yang dikerjakan bentuk ini dan tidak bisa dikerjakan tabel:
+ *
+ *    - Nomor dada dicetak BESAR di pojok kiri atas. Seluruh alurnya berujung
+ *      pada mengurutkan ratusan lembar lepas, dan itu dilakukan sambil melihat
+ *      sudut kertas saja.
+ *    - Rentangnya milik regu ITU. Di tabel, Tebak Simpul harus menulis
+ *      "0 – 10 / 0 – 5" karena satu kolom melayani empat golongan; di slip,
+ *      regu Penggalang melihat "0 – 5" saja dan tidak ada yang perlu dipilih.
+ *    - Slip untuk golongan yang tidak berhak TIDAK dicetak sama sekali —
+ *      bukan dicetak lalu dicoret.
+ */
+function siapkanCetakSlipPos(pos, kolomLayar, baris) {
+  document.getElementById("cetakan")?.remove();
+
+  const judulPos = pos.bayangan ? pos.name : `POS ${pos.nomor}`;
+  const tanggal = tanggalPanjang(new Date());
+
+  // Dikelompokkan per lomba, bukan per regu: tiap petugas mengambil satu
+  // tumpukan utuh untuk lombanya sendiri, dan tumpukan itu sudah urut nomor
+  // dada sejak dari printer.
+  const slip = [];
+  for (const kol of kolomLayar) {
+    for (const r of baris) {
+      const k = varianUntuk(kol, r.golongan);
+      if (k) slip.push({ kol, k, r });
+    }
+  }
+
+  const SLIP_PER_HALAMAN = 8;
+  const halaman = [];
+  for (let i = 0; i < slip.length; i += SLIP_PER_HALAMAN) {
+    halaman.push(slip.slice(i, i + SLIP_PER_HALAMAN));
+  }
+
+  const satuSlip = ({ kol, k, r }) => `
+    <article class="slip">
+      <div class="slip-kepala">
+        ${html`<span class="slip-dada">${String(r.nomor_dada).padStart(3, "0")}</span>`}
+        <span class="slip-lomba">${esc(judulPos)} · ${esc(kol.nama)}</span>
+      </div>
+      ${html`<p class="slip-regu">${r.nama_regu}</p>
+      <p class="slip-asal">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</p>`}
+      <div class="slip-isian">
+        ${kolomCetakPos([{ ...kol, varian: [k], petunjuk: petunjukKolom(k) }])
+          .map(c => `<span class="slip-kotak">
+            <span class="slip-petunjuk">${esc(c.petunjuk)}</span>
+            <span class="isian"></span></span>`).join("")}
+      </div>
+      <p class="slip-kaki">Petugas: ____________</p>
+    </article>`;
+
+  const cetakan = halaman.map(grup => `
+    <section class="print-page slip-halaman">
+      ${grup.map(satuSlip).join("")}
+    </section>`).join("");
+
+  document.body.appendChild(h(`<div id="cetakan" class="printout">${cetakan}</div>`));
+  return slip.length;
 }
 
 /** Layar Input Pos — lembar kertas yang dipindah ke layar.
@@ -2249,14 +2310,14 @@ async function layarInputPos() {
     <div class="card">
       ${alatTabel({
         kiri: pilihPosHtml(s, semuaPos),
-        // Dua tombol, karena keduanya menjawab hari yang berbeda. Satu lembar
-        // berisi semua lomba untuk pos yang dinilai satu meja; satu lembar per
-        // lomba untuk pos yang lombanya berjalan BERSAMAAN di beberapa titik —
-        // dan di sana satu kertas keliling adalah antrean, bukan lembar nilai.
+        // Dua bentuk kertas, dua cara kerja (alur-lomba.md 8.8). Namanya
+        // memakai kosakata panitia persis — "form tabel" dan "form per lomba"
+        // adalah kata yang mereka ucapkan sendiri, dan tombol yang bernama
+        // lain memaksa penerjemahan di kepala setiap kali dipakai.
         kanan: `<button class="button button-secondary button-small" type="button"
-                        id="cetak-lembar">🖨️ Cetak Lembar</button>
+                        id="cetak-lembar">🖨️ Form Tabel</button>
                 <button class="button button-secondary button-small" type="button"
-                        id="cetak-per-lomba">🖨️ Cetak per Lomba</button>`,
+                        id="cetak-per-lomba">🖨️ Form per Lomba</button>`,
         // Pendek dengan sengaja: kartunya kini selebar tabel, dan petunjuk
         // panjang terpotong di tengah kata — yang justru lebih buruk daripada
         // petunjuk singkat, karena terlihat seperti layar yang rusak.
@@ -2641,7 +2702,7 @@ async function layarInputPos() {
   // Dua kebutuhan berbeda terlayani satu tombol: sebelum lomba cetak "Semua"
   // untuk lembar kosong, dan di tengah lomba saring "Belum lengkap" dulu
   // supaya kertas susulan hanya memuat regu yang memang belum dinilai.
-  const cetak = async (perLomba) => {
+  const cetak = async (slip) => {
     const tampil = [...tbody.children].filter(tr => !tr.hidden)
       .map(tr => lembar.find(r => Number(r.nomor_dada) === Number(tr.dataset.dada)))
       .filter(Boolean);
@@ -2654,20 +2715,31 @@ async function layarInputPos() {
     let ditutup = false;
     try { ditutup = !!(await statusAcara()).daftar_ulang_ditutup; } catch { /* cetak tetap jalan */ }
 
-    siapkanCetakLembarPos(pos, kolom, tampil, ditutup, perLomba);
+    if (slip) {
+      // Peringatannya diucapkan, bukan dicetak. Slip dipotong-potong, jadi
+      // catatan kaki di halaman justru terbuang bersama guntingan — dan
+      // catatan yang pasti hilang lebih buruk daripada tidak ada, karena ia
+      // membuat orang mengira sudah memperingatkan.
+      if (!ditutup) {
+        notif("Daftar ulang belum ditutup — regu yang mendaftar setelah ini "
+              + "tidak ikut tercetak.", true);
+      }
+      const n = siapkanCetakSlipPos(pos, kolom, tampil);
+      notif(`${n} slip disiapkan — ${Math.ceil(n / 8)} lembar A4.`);
+    } else {
+      siapkanCetakLembarPos(pos, kolom, tampil, ditutup);
+    }
     window.print();
   };
 
   document.getElementById("cetak-lembar")
     .addEventListener("click", () => cetak(false));
 
-  // Pos berkolom satu tidak punya "per lomba" — lembarnya akan sama persis,
-  // dan dua tombol yang menghasilkan kertas identik membuat orang mengira
-  // salah satunya rusak. Tombolnya dibuang, bukan dinonaktifkan: tombol mati
-  // menimbulkan pertanyaan yang tidak ada jawabannya.
-  const tombolLomba = document.getElementById("cetak-per-lomba");
-  if (kolom.length < 2) tombolLomba.remove();
-  else tombolLomba.addEventListener("click", () => cetak(true));
+  // Tombolnya ada di SEMUA pos, termasuk yang berlomba satu. Di Pos 4 dan
+  // Pos 5 slipnya memang cuma satu per regu, tapi bentuknya tetap berbeda dari
+  // tabel — dan alur kotak penilaian berlaku di sana juga.
+  document.getElementById("cetak-per-lomba")
+    .addEventListener("click", () => cetak(true));
 
   pasangAlatTabel((cari, saring) => {
     [...tbody.children].forEach(tr => {

--- a/web/style.css
+++ b/web/style.css
@@ -521,106 +521,91 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
-  /* ---- FORM PER LOMBA (blangko kosong): ENAM per A4 potret ----
-     Blangko, bukan kertas berisi identitas regu — regu datang ke pos dalam
-     urutan acak, jadi kertas yang sudah tercetak namanya harus DICARI setiap
-     kali satu regu masuk. Alasan lengkapnya di siapkanCetakBlangko().
+  /* ---- FORM PER LOMBA (blangko kosong): A5 MELINTANG, satu per halaman ----
+     Ukurannya ditetapkan panitia: A5 melintang, 210 x 148 mm — separuh A4
+     dipotong mendatar, jadi mesin fotokopi mana pun bisa menggandakannya
+     2-up ke A4 lalu dipotong sekali lurus.
 
-     Enam per halaman = 2 kolom x 3 baris = kira-kira 99 x 95 mm, hampir
-     persegi. Ukuran itu dipilih karena isinya: satu kotak nomor dada yang
-     harus ditulis besar, tiga baris identitas, satu kotak angka selebar
-     kertas, dan satu tanda tangan. Pada 500 regu, satu pos berisi tiga lomba
-     memakan 250 lembar — turun dari 375 kalau empat per halaman.
+     Satu halaman berisi SATU blangko, karena yang dicetak dari layar adalah
+     MASTER, bukan tumpukannya. Pos 1 menghasilkan tiga halaman — Semaphore,
+     Tebak Simpul, Menaksir — dan panitia menggandakan tiap halaman sebanyak
+     yang dibutuhkan. Alasannya di siapkanCetakBlangko().
 
-     Kotak nilainya sengaja jauh lebih besar daripada kotak identitas. Yang
-     dinilai adalah angka itu; identitas cuma penanda supaya kertasnya bisa
-     pulang ke regunya. */
-  @page blangko-halaman { size: A4 portrait; margin: 5mm; }
-  .blangko-halaman {
-    page: blangko-halaman;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-auto-rows: 1fr;
-    gap: 0;
-    height: 287mm;
-  }
+     Melintang bukan selera. Yang harus muat: kotak nomor dada yang ditulis
+     besar dan kotak nilai yang ditulis lebih besar lagi, keduanya bersebelahan
+     dengan ruang tulis nyata. Pada A5 potret keduanya berdesakan ke bawah dan
+     kotak nilainya tinggal setengah.
+
+     Aturan cetak fotokopi (CLAUDE.md bagian 8) berlaku penuh di sini: tanpa
+     blok, tanpa abu-abu, garis >= 0,75pt, huruf >= 7pt. */
+  @page blangko-halaman { size: A5 landscape; margin: 9mm; }
+  .blangko-halaman { page: blangko-halaman; }
   .blangko {
-    border: .75pt dashed #000;
-    padding: 3.5mm 4mm;
+    height: 130mm;
     display: flex;
     flex-direction: column;
-    font-size: 8pt;
-    line-height: 1.2;
-    overflow: hidden;
+    font-size: 10pt;
+    line-height: 1.25;
   }
   .bl-pos {
-    margin: 0; text-align: center; font-size: 7pt; font-weight: 700;
-    letter-spacing: .8pt; text-transform: uppercase;
+    margin: 0; text-align: center; font-size: 9pt; font-weight: 700;
+    letter-spacing: 1.6pt; text-transform: uppercase;
   }
   .bl-lomba {
-    margin: .4mm 0 0; text-align: center; font-size: 15pt; font-weight: 800;
-    letter-spacing: .3pt; text-transform: uppercase; line-height: 1.05;
+    margin: 1mm 0 0; text-align: center; font-size: 24pt; font-weight: 800;
+    letter-spacing: .8pt; text-transform: uppercase; line-height: 1;
   }
   .bl-acara {
-    margin: 1mm 0 0; text-align: center; font-size: 7pt;
-    border-top: 1.5pt solid #000; padding-top: 1mm;
+    margin: 2mm 0 0; text-align: center; font-size: 9pt;
+    border-top: 1.5pt solid #000; padding-top: 2mm;
   }
 
-  /* Identitas: SATU kotak besar untuk nomor dada, dan satu catatan kecil di
+  /* Identitas: SATU kotak besar untuk nomor dada, dan satu kotak catatan di
      sebelahnya. Tidak ada kolom nama regu, sekolah, atau golongan — alasannya
      di siapkanCetakBlangko(): ketiganya sudah ditentukan nomor dada, dan
-     menyalinnya 1.500 kali adalah pekerjaan tanpa informasi baru.
+     menyalinnya ribuan kali adalah pekerjaan tanpa informasi baru.
 
      Kotak nomor dada dibuat tinggi supaya angkanya bisa ditulis BESAR. Ia
      dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas
      menuliskannya di tengah antrean, dan saat tim IT mengurutkan ratusan
      lembar lepas dengan hanya melihat sudut kertas. */
-  .bl-identitas {
-    width: 100%; border-collapse: collapse; margin-top: 1.5mm;
-  }
+  .bl-identitas { width: 100%; border-collapse: collapse; margin-top: 3.5mm; }
   .bl-identitas td {
-    border: .75pt solid #000; padding: .7mm 1.2mm; height: 13mm;
+    border: 1pt solid #000; padding: 1.2mm 2mm; height: 20mm;
     vertical-align: top;
   }
-  .bl-dada { width: 34mm; }
-  .bl-catat { font-style: normal; }
+  .bl-dada { width: 58mm; }
 
-  /* Label harus tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
-     Abu-abu adalah hal yang paling buruk ditangani mesin fotokopi: ia diubah
-     jadi raster titik-titik yang bisa hilang sama sekali di mesin yang
-     tonernya menipis, atau justru menghitam jadi kotor. Yang menggantikannya:
-     hitam pekat, ukuran kecil, dan diletakkan di sudut atas sel — kecil dan
-     menepi mencapai tujuan yang sama dengan pudar, dan bertahan digandakan
-     berkali-kali. Lihat CLAUDE.md bagian 8. */
-  .bl-label { font-size: 7pt; color: #000; display: block; }
-  .bl-label em { font-style: italic; font-size: 6.5pt; }
+  /* Label tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
+     Abu-abu adalah yang paling buruk ditangani mesin fotokopi: diubah jadi
+     raster titik yang hilang di mesin bertoner tipis, atau menghitam jadi
+     kotor. Penggantinya hitam pekat, kecil, menepi di sudut sel — mencapai
+     tujuan yang sama dan bertahan digandakan berkali-kali. */
+  .bl-label { font-size: 8pt; color: #000; display: block; }
 
-  /* Kotak nilai. Kepalanya DULU blok hitam dengan tulisan putih, dan itu
+  /* Kotak nilai. Kepalanya DULU blok hitam bertulisan putih, dan itu
      kekeliruan: blok penuh boros toner, keluar belang di mesin fotokopi, dan
      tulisan putih di atasnya adalah hal PERTAMA yang hilang saat menggandakan
-     gandaan. Sekarang huruf hitam biasa, dan yang menonjolkannya adalah garis
-     tebal di bawah judul — garis bertahan, blok tidak.
+     gandaan. Sekarang huruf hitam biasa, dan yang menonjolkannya garis tebal —
+     garis bertahan, blok tidak.
 
      Contoh angka di bawah judul tetap ada. Satu contoh nyata mencegah seluruh
      kelas kesalahan yang tidak bisa dicegah kalimat mana pun: "0:47" di kotak
      berlabel DETIK, atau poin ditulis alih-alih data mentah. */
-  .bl-nilai { margin-top: 2mm; border: 1pt solid #000; }
+  .bl-nilai { margin-top: 3.5mm; border: 1.2pt solid #000; }
   .bl-nilai-kepala {
-    text-align: center; padding: 1.2mm .5mm .8mm;
-    border-bottom: 1pt solid #000;
+    text-align: center; padding: 2mm 1mm 1.5mm; border-bottom: 1.2pt solid #000;
   }
   .bl-nilai-judul {
-    display: block; font-size: 9pt; font-weight: 700;
-    text-transform: uppercase; letter-spacing: .4pt;
+    display: block; font-size: 12pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .8pt;
   }
-  .bl-nilai-contoh { display: block; font-size: 7pt; margin-top: .4mm; }
-  .bl-nilai-kotak { height: 22mm; }
+  .bl-nilai-contoh { display: block; font-size: 9pt; margin-top: .8mm; }
+  .bl-nilai-kotak { height: 30mm; }
 
-  .bl-catatan { margin: 1.5mm 0 0; font-size: 7pt; line-height: 1.25; }
-  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 7pt; }
-  .bl-garis {
-    margin: 5mm 4mm 0; border-bottom: .75pt solid #000;
-  }
+  .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
+  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 8pt; }
+  .bl-garis { margin: 7mm auto 0; width: 70mm; border-bottom: .75pt solid #000; }
 
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan

--- a/web/style.css
+++ b/web/style.css
@@ -479,7 +479,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     text-align: left;
     font-size: 11pt;
   }
-  .print-table th { background: #eee; font-size: 9pt; text-transform: uppercase; }
+  /* Kepala tabel TANPA raster abu-abu. #eee terlihat rapi di layar dan di
+     printer laser, tapi kertas ini digandakan dengan fotokopi: raster halus
+     itu keluar belang, atau menghitam sampai judul kolomnya sulit dibaca.
+     Huruf tebal dan garis bawah tebal memisahkan kepala dari isi tanpa
+     satu titik toner pun yang tidak perlu (CLAUDE.md bagian 8). */
+  .print-table th {
+    font-size: 9pt; text-transform: uppercase; font-weight: 700;
+    border-bottom-width: 1.5pt;
+  }
   /* Baris TOTAL memakai <th> juga, dan uppercase mengubah "Rp" jadi "RP" —
      jelek di kwitansi resmi. Angkanya dikembalikan ke huruf aslinya. */
   .print-table tfoot th { text-transform: none; font-size: 11pt; }
@@ -496,7 +504,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .receipt-signature { margin-top: 10mm; width: 60mm; margin-left: auto; text-align: center; }
   .receipt-line { margin-top: 14mm; border-top: 1pt solid #000; padding-top: 2mm; }
 
-  .print-note { font-size: 9pt; color: #333; margin-top: .5rem; }
+  .print-note { font-size: 9pt; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
 
   /* Rentang yang boleh ditulis, di bawah nama kolomnya — sama seperti di
@@ -513,57 +521,106 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
-  /* ---- Slip nilai: DELAPAN per A4 potret ----
-     Bentuk kertas yang paling banyak dicetak di seluruh sistem. 500 regu di
-     pos berisi tiga lomba adalah 1.500 slip; pada jumlah itu, selisih empat
-     dan delapan slip per halaman adalah 188 lembar kertas untuk satu pos saja.
+  /* ---- FORM PER LOMBA (blangko kosong): ENAM per A4 potret ----
+     Blangko, bukan kertas berisi identitas regu — regu datang ke pos dalam
+     urutan acak, jadi kertas yang sudah tercetak namanya harus DICARI setiap
+     kali satu regu masuk. Alasan lengkapnya di siapkanCetakBlangko().
 
-     Ukurannya jadi 4 baris x 2 kolom dari A4 potret = kira-kira 99 x 68 mm,
-     selebar telapak tangan. Yang harus muat di dalamnya cuma satu angka besar,
-     tiga baris identitas, satu kotak isian, dan satu tanda tangan pendek —
-     diukur pada huruf 9pt, bukan dikira.
+     Enam per halaman = 2 kolom x 3 baris = kira-kira 99 x 95 mm, hampir
+     persegi. Ukuran itu dipilih karena isinya: satu kotak nomor dada yang
+     harus ditulis besar, tiga baris identitas, satu kotak angka selebar
+     kertas, dan satu tanda tangan. Pada 500 regu, satu pos berisi tiga lomba
+     memakan 250 lembar — turun dari 375 kalau empat per halaman.
 
-     Garis putus-putus adalah panduan gunting. Border penuh akan membuat dua
-     slip bersebelahan punya garis ganda setelah dipotong, dan tumpukan yang
-     tepinya tidak rata jauh lebih sulit disortir daripada yang rata. */
-  @page slip-halaman { size: A4 portrait; margin: 6mm; }
-  .slip-halaman {
-    page: slip-halaman;
+     Kotak nilainya sengaja jauh lebih besar daripada kotak identitas. Yang
+     dinilai adalah angka itu; identitas cuma penanda supaya kertasnya bisa
+     pulang ke regunya. */
+  @page blangko-halaman { size: A4 portrait; margin: 5mm; }
+  .blangko-halaman {
+    page: blangko-halaman;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-auto-rows: 1fr;
     gap: 0;
-    height: 285mm;
+    height: 287mm;
   }
-  .slip {
-    border: 1px dashed #666;
-    padding: 3mm 3.5mm;
+  .blangko {
+    border: .75pt dashed #000;
+    padding: 3.5mm 4mm;
     display: flex;
     flex-direction: column;
-    font-size: 9pt;
-    line-height: 1.25;
+    font-size: 8pt;
+    line-height: 1.2;
     overflow: hidden;
   }
-  .slip-kepala {
-    display: flex; align-items: baseline; justify-content: space-between;
-    gap: 2mm; border-bottom: 1px solid #000; padding-bottom: 1mm;
+  .bl-pos {
+    margin: 0; text-align: center; font-size: 7pt; font-weight: 700;
+    letter-spacing: .8pt; text-transform: uppercase;
   }
-  /* Nomor dada sebesar mungkin tanpa mendorong nama lomba turun. Seluruh
-     alurnya berakhir pada mengurutkan ratusan lembar lepas, dan itu dilakukan
-     sambil melihat sudut kertas saja — lihat alur-lomba.md 8.4. */
-  .slip-dada { font-size: 20pt; font-weight: 700; letter-spacing: .5pt; }
-  .slip-lomba { font-size: 8pt; font-weight: 700; text-align: right; }
-  .slip-regu { font-weight: 700; margin: 1.5mm 0 0; }
-  .slip-asal { font-size: 8pt; margin: .5mm 0 0; }
-  /* Kotak isian didorong ke bawah supaya letaknya sama di setiap slip —
-     tangan yang menulis 1.500 kali tidak perlu mencarinya dua kali. */
-  .slip-isian { margin-top: auto; display: flex; gap: 3mm; align-items: flex-end; }
-  .slip-kotak { display: flex; flex-direction: column; gap: .8mm; flex: 1; }
-  .slip-petunjuk { font-size: 7pt; }
-  .slip-kotak .isian {
-    display: block; height: 9mm; border: 1px solid #000; border-radius: 1mm;
+  .bl-lomba {
+    margin: .4mm 0 0; text-align: center; font-size: 15pt; font-weight: 800;
+    letter-spacing: .3pt; text-transform: uppercase; line-height: 1.05;
   }
-  .slip-kaki { font-size: 7pt; margin: 2mm 0 0; }
+  .bl-acara {
+    margin: 1mm 0 0; text-align: center; font-size: 7pt;
+    border-top: 1.5pt solid #000; padding-top: 1mm;
+  }
+
+  /* Identitas: SATU kotak besar untuk nomor dada, dan satu catatan kecil di
+     sebelahnya. Tidak ada kolom nama regu, sekolah, atau golongan — alasannya
+     di siapkanCetakBlangko(): ketiganya sudah ditentukan nomor dada, dan
+     menyalinnya 1.500 kali adalah pekerjaan tanpa informasi baru.
+
+     Kotak nomor dada dibuat tinggi supaya angkanya bisa ditulis BESAR. Ia
+     dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas
+     menuliskannya di tengah antrean, dan saat tim IT mengurutkan ratusan
+     lembar lepas dengan hanya melihat sudut kertas. */
+  .bl-identitas {
+    width: 100%; border-collapse: collapse; margin-top: 1.5mm;
+  }
+  .bl-identitas td {
+    border: .75pt solid #000; padding: .7mm 1.2mm; height: 13mm;
+    vertical-align: top;
+  }
+  .bl-dada { width: 34mm; }
+  .bl-catat { font-style: normal; }
+
+  /* Label harus tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
+     Abu-abu adalah hal yang paling buruk ditangani mesin fotokopi: ia diubah
+     jadi raster titik-titik yang bisa hilang sama sekali di mesin yang
+     tonernya menipis, atau justru menghitam jadi kotor. Yang menggantikannya:
+     hitam pekat, ukuran kecil, dan diletakkan di sudut atas sel — kecil dan
+     menepi mencapai tujuan yang sama dengan pudar, dan bertahan digandakan
+     berkali-kali. Lihat CLAUDE.md bagian 8. */
+  .bl-label { font-size: 7pt; color: #000; display: block; }
+  .bl-label em { font-style: italic; font-size: 6.5pt; }
+
+  /* Kotak nilai. Kepalanya DULU blok hitam dengan tulisan putih, dan itu
+     kekeliruan: blok penuh boros toner, keluar belang di mesin fotokopi, dan
+     tulisan putih di atasnya adalah hal PERTAMA yang hilang saat menggandakan
+     gandaan. Sekarang huruf hitam biasa, dan yang menonjolkannya adalah garis
+     tebal di bawah judul — garis bertahan, blok tidak.
+
+     Contoh angka di bawah judul tetap ada. Satu contoh nyata mencegah seluruh
+     kelas kesalahan yang tidak bisa dicegah kalimat mana pun: "0:47" di kotak
+     berlabel DETIK, atau poin ditulis alih-alih data mentah. */
+  .bl-nilai { margin-top: 2mm; border: 1pt solid #000; }
+  .bl-nilai-kepala {
+    text-align: center; padding: 1.2mm .5mm .8mm;
+    border-bottom: 1pt solid #000;
+  }
+  .bl-nilai-judul {
+    display: block; font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .4pt;
+  }
+  .bl-nilai-contoh { display: block; font-size: 7pt; margin-top: .4mm; }
+  .bl-nilai-kotak { height: 22mm; }
+
+  .bl-catatan { margin: 1.5mm 0 0; font-size: 7pt; line-height: 1.25; }
+  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 7pt; }
+  .bl-garis {
+    margin: 5mm 4mm 0; border-bottom: .75pt solid #000;
+  }
 
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan

--- a/web/style.css
+++ b/web/style.css
@@ -513,6 +513,58 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
+  /* ---- Slip nilai: DELAPAN per A4 potret ----
+     Bentuk kertas yang paling banyak dicetak di seluruh sistem. 500 regu di
+     pos berisi tiga lomba adalah 1.500 slip; pada jumlah itu, selisih empat
+     dan delapan slip per halaman adalah 188 lembar kertas untuk satu pos saja.
+
+     Ukurannya jadi 4 baris x 2 kolom dari A4 potret = kira-kira 99 x 68 mm,
+     selebar telapak tangan. Yang harus muat di dalamnya cuma satu angka besar,
+     tiga baris identitas, satu kotak isian, dan satu tanda tangan pendek —
+     diukur pada huruf 9pt, bukan dikira.
+
+     Garis putus-putus adalah panduan gunting. Border penuh akan membuat dua
+     slip bersebelahan punya garis ganda setelah dipotong, dan tumpukan yang
+     tepinya tidak rata jauh lebih sulit disortir daripada yang rata. */
+  @page slip-halaman { size: A4 portrait; margin: 6mm; }
+  .slip-halaman {
+    page: slip-halaman;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: 1fr;
+    gap: 0;
+    height: 285mm;
+  }
+  .slip {
+    border: 1px dashed #666;
+    padding: 3mm 3.5mm;
+    display: flex;
+    flex-direction: column;
+    font-size: 9pt;
+    line-height: 1.25;
+    overflow: hidden;
+  }
+  .slip-kepala {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 2mm; border-bottom: 1px solid #000; padding-bottom: 1mm;
+  }
+  /* Nomor dada sebesar mungkin tanpa mendorong nama lomba turun. Seluruh
+     alurnya berakhir pada mengurutkan ratusan lembar lepas, dan itu dilakukan
+     sambil melihat sudut kertas saja — lihat alur-lomba.md 8.4. */
+  .slip-dada { font-size: 20pt; font-weight: 700; letter-spacing: .5pt; }
+  .slip-lomba { font-size: 8pt; font-weight: 700; text-align: right; }
+  .slip-regu { font-weight: 700; margin: 1.5mm 0 0; }
+  .slip-asal { font-size: 8pt; margin: .5mm 0 0; }
+  /* Kotak isian didorong ke bawah supaya letaknya sama di setiap slip —
+     tangan yang menulis 1.500 kali tidak perlu mencarinya dua kali. */
+  .slip-isian { margin-top: auto; display: flex; gap: 3mm; align-items: flex-end; }
+  .slip-kotak { display: flex; flex-direction: column; gap: .8mm; flex: 1; }
+  .slip-petunjuk { font-size: 7pt; }
+  .slip-kotak .isian {
+    display: block; height: 9mm; border: 1px solid #000; border-radius: 1mm;
+  }
+  .slip-kaki { font-size: 7pt; margin: 2mm 0 0; }
+
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan
      kaki. Karena itu SEMUANYA di lembar ini lebih rapat daripada cetakan lain


### PR DESCRIPTION
## What

Panitia mengenal **tiga bentuk** kertas penilaian. PR ini menuliskannya di `alur-lomba.md` dan membuat yang pertama, yang selama ini belum ada:

| Bentuk | Isi | Status |
| --- | --- | --- |
| **Form per lomba** | satu kertas, satu lomba, **satu regu** | **baru** |
| **Form tabel per pos** | satu halaman, semua lomba, 30 regu | sudah ada |
| **Form tabel per pos online** | layar Input Pos | sudah ada |

Alur lapangannya, yang juga baru tertulis:

```
regu masuk wahana → petugas mengambil kertas soal lomba itu → regu mengerjakan
  → petugas menulis nilai mentah di kertas itu → kertas masuk KOTAK PENILAIAN
  → kotak diserahkan ke tim IT → diurutkan menurut nomor dada 001–500 → diinput
```

## Why

Kemarin nama "per lomba" saya pakai untuk lembar tabel 30 regu yang hanya memuat satu kolom lomba — **bentuk keempat yang tidak ada di kosakata panitia**. Diganti, bukan ditambah.

Bentuknya per regu karena dua hal yang terjadi bersamaan: beberapa lomba berjalan **serentak di titik berbeda** dalam satu pos, dan satu regu **tidak pernah selesai di semua lomba pada saat yang sama**. Tabel baru bisa berpindah ke kotak setelah baris terakhirnya terisi; slip berpindah begitu regunya selesai.

## Notes

**Jumlahnya besar dan itu memang begitu adanya.** 500 regu × 3 lomba = **1.500 kertas untuk Pos 1 saja**. Karena itu **delapan slip per A4 potret** — pada jumlah itu, selisih 4 dan 8 per halaman adalah 188 lembar untuk satu pos. Ukurannya ±99 × 68 mm, diukur pada huruf 9pt.

Tiga hal yang dikerjakan slip dan **tidak bisa** dikerjakan tabel:

- **Nomor dada 20pt di pojok kiri atas** — seluruh alurnya berakhir pada mengurutkan ratusan lembar lepas sambil melihat sudut kertas saja.
- **Rentangnya milik regu itu.** Di tabel, Tebak Simpul harus menulis `0 – 10 / 0 – 5` karena satu kolom melayani empat golongan; di slip, regu Penggalang melihat `0 – 5` saja.
- **Golongan yang tidak berhak tidak dapat kertasnya sama sekali** — bukan dapat lalu dicoret.

**Form tabel tidak digantikan.** PBB dan Yel-Yel dinilai satu meja oleh satu juri; di sana 30 regu per halaman lebih cepat dan tidak ada kertas yang perlu berpindah di tengah lomba.

Peringatan "daftar ulang belum ditutup" **diucapkan lewat notifikasi, bukan dicetak**: slip dipotong-potong, jadi catatan kaki terbuang bersama guntingan — dan catatan yang pasti hilang lebih buruk daripada tidak ada.

Garis potongnya **putus-putus**, bukan penuh: dua slip bersebelahan dengan border penuh menghasilkan garis ganda setelah digunting, dan tumpukan bertepi tidak rata jauh lebih sulit disortir.

Dua pertanyaan terbuka masuk bagian 13 — apakah foto berkala tetap wajib sekarang kertas berpindah fisik, dan arti singkatan `IMPK` (contoh yang memuatnya diganti, potongan aslinya disimpan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)