### PR TITLE
fix: kolom identitas yang mengambil sisa lebar, bukan kotak isian

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -672,7 +672,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
      ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
      tinggi hanya akan mengurangi jumlah baris per lembar. */
-  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian { width: 14mm; }
+  /* Kotak isian dipatok DUA ARAH, dan max-width itu yang penting.
+     `width` pada sel tabel cuma usulan: dengan table-layout auto, kolom
+     tumbuh mengisi sisa lebar kertas. Di Pos 1 sisa itu besar — tiga kotak
+     isian saja — jadi kotaknya melar sampai selebar dua jari sementara nama
+     regu di sebelahnya terpotong elipsis. Persis terbalik dari yang
+     dibutuhkan: yang perlu lebar adalah nama, bukan petak berisi satu angka
+     dua digit. */
+  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
+    width: 14mm; max-width: 16mm;
+  }
   /* Identitas TIDAK boleh membungkus di sini: satu nama yang pecah dua baris
      menambah tinggi satu baris, dan tiga puluh baris yang dipatok mati tidak
      punya ruang untuk itu — lembarnya akan tumpah ke halaman berikutnya. */
@@ -681,14 +690,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .lembar-pos .print-table td:nth-child(4) {
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
-     lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
-     kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
-     dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
-     cek silang. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 38mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 40mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Identitas MENGAMBIL sisa lebar, tidak lagi dipatok mati.
+     Patokan 38/40/26mm ditulis waktu kotak isian dikhawatirkan tergencet.
+     Yang terjadi justru sebaliknya: kotak isian yang melar dan nama yang
+     terpotong. Sekarang kotak isian yang dibatasi (max-width di atas), dan
+     sisa lebarnya mengalir ke tiga kolom ini.
+
+     Di A4 melintang tersedia 277mm. Pos 1 memakai 15mm nomor dada + tiga
+     kotak isian, menyisakan ~215mm untuk identitas; Pos 3 yang berkotak tujuh
+     menyisakan ~160mm. Keduanya lebih dari cukup untuk nama terpanjang di
+     daftar ("SMK SILIWANGI AMS BANJARSARI", 28 huruf ≈ 62mm di 12pt).
+
+     Elipsisnya tidak dibuang — ia tetap jaring pengaman untuk nama yang
+     benar-benar di luar dugaan, dan regu tetap dikenali dari nomor dada. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 78mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 78mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 30mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/web/style.css
+++ b/web/style.css
@@ -672,7 +672,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
      ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
      tinggi hanya akan mengurangi jumlah baris per lembar. */
-  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian { width: 14mm; }
+  /* Kotak isian dipatok DUA ARAH, dan max-width itu yang penting.
+     `width` pada sel tabel cuma usulan: dengan table-layout auto, kolom
+     tumbuh mengisi sisa lebar kertas. Di Pos 1 sisa itu besar — tiga kotak
+     isian saja — jadi kotaknya melar sampai selebar dua jari sementara nama
+     regu di sebelahnya terpotong elipsis. Persis terbalik dari yang
+     dibutuhkan: yang perlu lebar adalah nama, bukan petak berisi satu angka
+     dua digit. */
+  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
+    width: 14mm; max-width: 16mm;
+  }
   /* Identitas TIDAK boleh membungkus di sini: satu nama yang pecah dua baris
      menambah tinggi satu baris, dan tiga puluh baris yang dipatok mati tidak
      punya ruang untuk itu — lembarnya akan tumpah ke halaman berikutnya. */
@@ -681,14 +690,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .lembar-pos .print-table td:nth-child(4) {
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
-     lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
-     kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
-     dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
-     cek silang. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 38mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 40mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Identitas MENGAMBIL sisa lebar, tidak lagi dipatok mati.
+     Patokan 38/40/26mm ditulis waktu kotak isian dikhawatirkan tergencet.
+     Yang terjadi justru sebaliknya: kotak isian yang melar dan nama yang
+     terpotong. Sekarang kotak isian yang dibatasi (max-width di atas), dan
+     sisa lebarnya mengalir ke tiga kolom ini.
+
+     Di A4 melintang tersedia 277mm. Pos 1 memakai 15mm nomor dada + tiga
+     kotak isian, menyisakan ~215mm untuk identitas; Pos 3 yang berkotak tujuh
+     menyisakan ~160mm. Keduanya lebih dari cukup untuk nama terpanjang di
+     daftar ("SMK SILIWANGI AMS BANJARSARI", 28 huruf ≈ 62mm di 12pt).
+
+     Elipsisnya tidak dibuang — ia tetap jaring pengaman untuk nama yang
+     benar-benar di luar dugaan, dan regu tetap dikenali dari nomor dada. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 78mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 78mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 30mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }


### PR DESCRIPTION
## What

Nama regu dan sekolah tidak lagi terpotong di form tabel per pos. Yang dibatasi sekarang **kotak isian** (`max-width: 16mm`), dan sisa lebar kertas mengalir ke **kolom identitas** (78/78/30mm).

## Why

Melintang saja tidak menyelesaikannya — **di melintang pun terpotong**. Sebabnya bukan kekurangan lebar, melainkan lebar yang mengalir ke tempat yang salah:

```css
td:nth-child(2) { max-width: 38mm; }   /* identitas DIPATOK */
td.isian        { width: 14mm; }        /* isian cuma DIUSULKAN */
```

Pada `table-layout: auto`, `width` hanya usulan — kolom tumbuh mengisi sisa lebar, dan `max-width` yang menahan. Jadi di Pos 1, yang cuma punya tiga kotak isian di kertas 277mm, **seluruh sisa lebar masuk ke kotak isian**: petak berisi satu angka dua digit jadi selebar dua jari, sementara `SMK SILIWANGI AMS BANJARSARI` di sebelahnya dipotong elipsis.

Persis terbalik dari yang dibutuhkan.

## Notes

Setelah dibalik: Pos 1 menyisakan ~215mm untuk identitas, Pos 3 (tujuh kotak) menyisakan ~160mm. Nama terpanjang di daftar 28 huruf ≈ 62mm pada 12pt.

Elipsisnya **tidak dibuang** — tetap jaring pengaman untuk nama di luar dugaan, dan regu tetap dikenali dari nomor dada.

**Catatan kejujuran:** `max-width` pada sel tabel auto-layout dihormati browser dengan longgar, jadi ini diperiksa dengan mata pada cetakan berisi **dua belas nama terpanjang di Pos 3** — bukan disimpulkan dari aturannya. Kalau masih ada yang terpotong, langkah berikutnya `table-layout: fixed` dengan `colgroup`: deterministik, tapi menuntut tiap lebar ditulis satu per satu dan berubah tiap kali jumlah lomba berubah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)