### PR TITLE
feat: form tabel turun jadi cadangan; melintang, nama utuh, baris rata

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -417,6 +417,25 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    huruf-hurufnya menutup sendiri oleh serbuk toner. Kotak yang ditulisi selalu
    putih polos. Aturan lengkapnya di `CLAUDE.md` bagian 8.
 
+   **Form tabel memuat nomor dada 001 sampai batas stok, BERURUTAN tanpa
+   lompatan** — termasuk nomor yang belum ada regunya. Tiga sebab, dan
+   ketiganya terjadi:
+
+   - Tim IT menyortir tumpukan slip menurut nomor dada lalu menyusurinya dari
+     atas. Lembar yang melompati satu nomor menghentikan pekerjaan itu:
+     *"slip 012 hilang, atau memang tidak pernah ada?"* — pertanyaan yang
+     tidak bisa dijawab dari kertas.
+   - Sebagian sekolah **mendaftar offline**. Regunya memakai nomor dada fisik
+     yang nyata, tetapi belum ada di database.
+   - **Kertasnya dicetak lebih dulu**, sebelum pendaftaran ditutup, dan regu
+     yang menyusul tetap harus punya tempat.
+
+   Karena itu baris tanpa regu dibiarkan **kosong dan siap ditulisi**, bukan
+   ditandai "tidak dipakai": petugas menuliskan nama regu dan sekolahnya di
+   situ, dan meja daftar ulang memakainya untuk melengkapi data belakangan.
+   Batasnya diambil dari **stok** nomor dada — nomor fisik yang benar-benar
+   dibawa panitia — bukan dari jumlah regu yang sudah terdaftar.
+
    Satu kolom sengaja **tidak** ikut dicetak di bentuk mana pun: **Nilai Pos**.
    Petugas lapangan hanya menulis data mentah dan tidak pernah menjumlahkan
    sendiri (poin 1) — kotak berjudul Nilai Pos justru mengundang hitungan

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -383,7 +383,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    | Bentuk | Isi | Dipakai |
    | --- | --- | --- |
    | **Form per lomba** | **A5 melintang**, satu lomba, **satu regu** | di wahana, lalu masuk kotak (poin 3) |
-   | **Form tabel per pos** | satu halaman, semua lomba, 30 regu | pos yang dinilai satu meja |
+   | **Form tabel per pos** | satu halaman, semua lomba, 30 regu | **cadangan** — slip habis atau sinyal mati |
    | **Form tabel per pos online** | layar Input Pos | tim IT memasukkan isi kotak |
 
    **Form per lomba adalah bentuk yang paling banyak dicetak, dan jumlahnya
@@ -405,9 +405,19 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - **Golongan yang tidak berhak tidak dapat kertasnya sama sekali** — bukan
      dapat lalu dicoret.
 
-   Form tabel tidak digantikan. Pos yang dinilai satu meja oleh satu juri —
-   PBB, Yel-Yel — lebih cepat dengan satu halaman berisi 30 regu, dan di sana
-   tidak ada kertas yang perlu berpindah di tengah lomba.
+   **Form tabel turun jadi cadangan, dan itu keputusan.** Ia sempat
+   dipertahankan untuk pos yang dinilai satu meja — PBB, Yel-Yel — dengan
+   alasan satu halaman berisi 30 regu lebih cepat. Alasan itu keliru, dan
+   sebabnya sama dengan yang membuat kertas per lomba dibuat kosong: **regu
+   datang acak**. Di form tabel yang urut nomor dada, petugas harus MENCARI
+   baris 005 setiap kali satu regu masuk — pekerjaan yang persis dihapus oleh
+   blangko. Tabel mengembalikannya, termasuk di pos berjuri satu.
+
+   Yang tersisa untuknya adalah keadaan yang tidak bisa dilayani kertas lain:
+   **blangko habis di tengah lomba, atau sinyal mati sehingga layar tidak bisa
+   dibuka**. Untuk itu ia dicetak lebih dulu dan disimpan, tidak dibagikan.
+   Kepala halamannya berbunyi LEMBAR CADANGAN supaya petugas yang memegangnya
+   tahu itu bukan lembar utama.
 
    **Semua kertas ini digandakan dengan mesin fotokopi, dan itu menentukan
    bentuknya.** Tidak ada blok hitam, tidak ada tulisan putih di atas gelap,

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -482,6 +482,24 @@ export async function lembarPos(pos) {
     `v_lembar_pos?pos=eq.${encodeURIComponent(pos)}&select=*&order=nomor_dada.asc`);
 }
 
+/** Nomor dada TERTINGGI yang disiapkan admin — batas atas lembar nilai.
+ *
+ *  Lembar tabel mencetak nomor 001 sampai batas ini BERURUTAN, termasuk nomor
+ *  yang belum diberikan ke regu mana pun. Tanpa itu, tim IT yang menyortir
+ *  tumpukan slip berhenti setiap kali lembarnya melompati satu nomor: "slip
+ *  012 hilang, atau memang tidak pernah ada?" — pertanyaan yang tidak bisa
+ *  dijawab dari kertas dan menghentikan pekerjaan.
+ *
+ *  Dibaca dari stok, bukan dari regu yang sudah terdaftar: stok adalah nomor
+ *  dada FISIK yang benar-benar dicetak dan dibawa panitia, dan itulah rentang
+ *  yang mungkin muncul di kotak penilaian. */
+export async function batasNomorDada() {
+  const d = K.mode === "dev"
+    ? await baca("/batas-nomor-dada")
+    : await baca(null, "nomor_dada_stok?select=nomor&order=nomor.desc&limit=1");
+  return d.length ? Number(d[0].nomor) : 0;
+}
+
 /** Satu baris saja, dibaca ulang sesudah menyimpan. Nilai Pos yang tampil di
  *  layar SELALU angka dari database — layar tidak pernah menghitung skor
  *  sendiri, supaya tidak ada mesin skor kedua yang bisa berbeda pendapat

--- a/live/style.css
+++ b/live/style.css
@@ -513,26 +513,36 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     display: block; max-width: none; font-size: 7pt; font-weight: 400;
     text-transform: none; margin-top: 1pt;
   }
-  /* ---- Form tabel per pos: A4 MELINTANG ----
-     Halaman bernama, supaya HANYA lembar ini yang berputar — kwitansi dan
-     daftar kloter tetap potret.
+  /* ---- Form tabel per pos: A4 POTRET, DAN NAMA TIDAK DIPOTONG ----
+     Halaman bernama, supaya lembar ini bisa punya ukuran sendiri — kwitansi
+     dan daftar kloter memakai halaman lain.
 
-     Melintang bukan selera, tapi ANGKA PEMBENARNYA SUDAH BERGANTI. Dulu
-     alasannya "tabel Pos 1 selebar 201mm, potret cuma menyediakan 180mm".
-     Itu tidak lagi berlaku: sejak kolom dikelompokkan per lomba, Tebak Simpul
-     yang memakan empat kolom (satu per golongan) jadi satu, dan Pos 1 turun
-     dari enam kolom nilai ke tiga. Pos 1 sendiri sekarang muat di potret.
+     Lembar ini pernah melintang, dan alasannya lebar: dengan huruf 12pt nama
+     regu dan sekolah tidak muat di 190mm bersama tujuh kotak isian Pos 3,
+     jadi keduanya dipotong elipsis. Panitia menolak pemotongan itu — nama
+     yang terpotong membuat cek silang kehilangan gunanya, dan cek silang
+     adalah satu-satunya alasan nama sekolah ada di kertas ini.
 
-     Yang menentukan sekarang POS 3, bukan Pos 1: tujuh kolom nilai — lima
-     kriteria Bidai, Kim Lihat, Kim Cium. Tujuh kali 14mm ditambah nomor dada
-     memakan 113mm, menyisakan 77mm untuk tiga kolom identitas di kertas
-     potret. Muat di atas kertas, tapi sempit untuk ditulisi tangan di
-     lapangan, dan panitia memilih melintang setelah melihat cetakannya.
+     Jawabannya bukan memutar kertas, melainkan BERHENTI MEMOTONG DAN MULAI
+     MEMBUNGKUS. Potret memberi tinggi 277mm melawan 190mm — 87mm ruang
+     vertikal tambahan — sementara yang kurang cuma lebar. Nama yang turun ke
+     baris kedua membelanjakan yang berlimpah untuk menutup yang kurang.
 
-     Potret sudah dicoba dan ditolak. Kalau ada yang menghitung ulang lebar
-     Pos 1 lalu menyimpulkan potret cukup: benar untuk Pos 1, salah untuk
-     Pos 3, dan kelima pos memakai satu bentuk yang sama. */
-  @page lembar-pos { size: A4 landscape; margin: 10mm; }
+     Tiga penyesuaian membuatnya muat, semuanya diukur pada Pos 3 (tujuh kotak
+     isian, yang terlebar di sistem) dengan nama terpanjang di daftar:
+
+       identitas 10pt, bukan 12pt  - ia TERCETAK, bukan ditulis tangan, jadi
+                                     tidak perlu bertahan dibaca ulang dari
+                                     foto seperti angka di sebelahnya
+       kotak isian 12mm            - cukup untuk angka dua digit
+       membungkus, bukan elipsis   - dan tinggi baris ikut mengembang
+
+     Tetap 30 baris per halaman, sama dengan waktu melintang. Potret
+     menyediakan 257mm untuk baris; 30 baris satu-baris memakan 150mm, jadi
+     tersisa 107mm untuk baris yang membungkus. Cadangan sebesar itu
+     disengaja: satu baris yang tumpah ke halaman berikutnya merusak seluruh
+     penomoran halaman. */
+  @page lembar-pos { size: A4 portrait; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
   /* ---- FORM PER LOMBA (blangko kosong): A5 MELINTANG, satu per halaman ----
@@ -653,7 +663,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dan di 12pt "KEPRAMUKAAN KEAGAMAAN" akan memakan lebar yang dibutuhkan
      kotak isiannya. */
   .lembar-pos .print-table th, .lembar-pos .print-table td {
-    padding: 0.5pt 4pt; font-size: 12pt;
+    padding: 0.5pt 3pt; font-size: 12pt;
     /* Jarak antarbaris huruf inilah yang sebenarnya menentukan tinggi baris
        di sini — BUKAN tinggi kotak isiannya. Dengan line-height bawaan (1,6)
        satu baris setinggi 32px meski kotaknya diminta 6mm.
@@ -668,27 +678,46 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      barisnya 21px sementara sel 12pt lainnya cuma butuh 18px, dan selisih
      3px dikali 30 baris persis yang membuat halaman tumpah. Tebalnya sudah
      cukup membuatnya menonjol, dan di Excel pun semua kolom seukuran. */
-  .lembar-pos .print-table .dada { font-size: 12pt; width: 15mm; }
+  .lembar-pos .print-table .dada { font-size: 12pt; width: 13mm; }
   /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
      ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
      tinggi hanya akan mengurangi jumlah baris per lembar. */
-  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian { width: 14mm; }
-  /* Identitas TIDAK boleh membungkus di sini: satu nama yang pecah dua baris
-     menambah tinggi satu baris, dan tiga puluh baris yang dipatok mati tidak
-     punya ruang untuk itu — lembarnya akan tumpah ke halaman berikutnya. */
+  /* Kotak isian dipatok DUA ARAH, dan max-width itu yang penting. `width`
+     pada sel tabel cuma usulan: dengan table-layout auto, kolom tumbuh
+     mengisi sisa lebar. Tanpa max-width, di Pos 1 yang cuma punya tiga kotak,
+     seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
+     jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
+  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
+    width: 12mm; max-width: 14mm;
+  }
+  /* Identitas MEMBUNGKUS, tidak lagi dipotong — dan inilah perubahan yang
+     membuat potret mungkin.
+     Aturan lama melarangnya dengan alasan yang benar untuk kertas melintang:
+     satu nama yang pecah dua baris menambah tinggi, dan 30 baris di kertas
+     setinggi 190mm tidak punya ruang. Di potret tingginya 277mm dan 30 baris
+     hanya memakai 150mm — ruang itu justru yang dibelanjakan di sini.
+     Hurufnya 10pt: identitas TERCETAK, sementara 12pt dipilih untuk angka
+     yang DITULIS TANGAN lalu dibaca ulang dari foto. */
   .lembar-pos .print-table td:nth-child(2),
   .lembar-pos .print-table td:nth-child(3),
   .lembar-pos .print-table td:nth-child(4) {
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    white-space: normal; overflow-wrap: break-word;
+    font-size: 10pt; line-height: 1.05;
   }
   /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
      lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
      kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
      dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
      cek silang. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 38mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 40mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Di A4 potret tersedia 190mm. Pos 3 — yang terlebar — memakai 13mm nomor
+     dada dan tujuh kotak 12mm, menyisakan 93mm untuk tiga kolom ini. Pada
+     10pt satu huruf sekitar 1,75mm, jadi nama regu terpanjang (22 huruf) dan
+     sekolah terpanjang (28 huruf) muat berdampingan; yang lebih panjang lagi
+     turun ke baris kedua alih-alih hilang. Pos 1 yang cuma berkotak tiga
+     menyisakan 129mm — lega. */
+  .lembar-pos .print-table td:nth-child(2) { width: 30mm; }
+  .lembar-pos .print-table td:nth-child(3) { width: 36mm; }
+  .lembar-pos .print-table td:nth-child(4) { width: 22mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/live/style.css
+++ b/live/style.css
@@ -513,36 +513,37 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     display: block; max-width: none; font-size: 7pt; font-weight: 400;
     text-transform: none; margin-top: 1pt;
   }
-  /* ---- Form tabel per pos: A4 POTRET, DAN NAMA TIDAK DIPOTONG ----
-     Halaman bernama, supaya lembar ini bisa punya ukuran sendiri — kwitansi
-     dan daftar kloter memakai halaman lain.
+  /* ---- Form tabel per pos: A4 MELINTANG, NAMA UTUH, BARIS RATA ----
+     Tiga hal yang harus benar bersamaan, dan dua di antaranya sempat saling
+     mengalahkan:
 
-     Lembar ini pernah melintang, dan alasannya lebar: dengan huruf 12pt nama
-     regu dan sekolah tidak muat di 190mm bersama tujuh kotak isian Pos 3,
-     jadi keduanya dipotong elipsis. Panitia menolak pemotongan itu — nama
-     yang terpotong membuat cek silang kehilangan gunanya, dan cek silang
-     adalah satu-satunya alasan nama sekolah ada di kertas ini.
+       nama tidak terpotong  - nama sekolah adalah cek silang; yang terpotong
+                               kehilangan gunanya
+       tinggi baris rata     - mata menyusuri mendatar dari nomor dada ke
+                               kotak nilai, dan baris yang tingginya
+                               berbeda-beda memutus garis pandang itu.
+                               Buku besar bergaris rata bukan tanpa sebab.
+       muat di satu kertas   - Pos 3 punya tujuh kotak isian
 
-     Jawabannya bukan memutar kertas, melainkan BERHENTI MEMOTONG DAN MULAI
-     MEMBUNGKUS. Potret memberi tinggi 277mm melawan 190mm — 87mm ruang
-     vertikal tambahan — sementara yang kurang cuma lebar. Nama yang turun ke
-     baris kedua membelanjakan yang berlimpah untuk menutup yang kurang.
+     Membungkus menyelesaikan yang pertama dengan mengorbankan yang kedua.
+     Yang menyelesaikan ketiganya sekaligus adalah MELINTANG DENGAN IDENTITAS
+     10pt — diukur pada Pos 3, kondisi terlebar:
 
-     Tiga penyesuaian membuatnya muat, semuanya diukur pada Pos 3 (tujuh kotak
-     isian, yang terlebar di sistem) dengan nama terpanjang di daftar:
+       tersedia   277mm
+       dipakai     13mm nomor dada + 7 x 12mm kotak isian = 97mm
+       sisa       180mm untuk tiga kolom identitas
+       dibutuhkan 140mm  (nama regu 22 huruf + sekolah 28 huruf + golongan,
+                          pada 10pt huruf besar ~2,3mm)
 
-       identitas 10pt, bukan 12pt  - ia TERCETAK, bukan ditulis tangan, jadi
-                                     tidak perlu bertahan dibaca ulang dari
-                                     foto seperti angka di sebelahnya
-       kotak isian 12mm            - cukup untuk angka dua digit
-       membungkus, bukan elipsis   - dan tinggi baris ikut mengembang
+     Lega 40mm. Di potret sisanya cuma 93mm — kurang 47mm, dan kekurangan
+     itulah yang dulu memaksa memotong, lalu memaksa membungkus.
 
-     Tetap 30 baris per halaman, sama dengan waktu melintang. Potret
-     menyediakan 257mm untuk baris; 30 baris satu-baris memakan 150mm, jadi
-     tersisa 107mm untuk baris yang membungkus. Cadangan sebesar itu
-     disengaja: satu baris yang tumpah ke halaman berikutnya merusak seluruh
-     penomoran halaman. */
-  @page lembar-pos { size: A4 portrait; margin: 10mm; }
+     Potret sudah dicoba dua kali: sekali dengan elipsis (nama terpotong),
+     sekali dengan membungkus (baris tidak rata). Keduanya ditolak panitia.
+     Yang keliru pada versi melintang lama bukan orientasinya, melainkan
+     identitas 12pt dan kolom yang dipatok 38/40/26mm sementara kotak isian
+     dibiarkan melar. */
+  @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
   /* ---- FORM PER LOMBA (blangko kosong): A5 MELINTANG, satu per halaman ----
@@ -690,34 +691,36 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
     width: 12mm; max-width: 14mm;
   }
-  /* Identitas MEMBUNGKUS, tidak lagi dipotong — dan inilah perubahan yang
-     membuat potret mungkin.
-     Aturan lama melarangnya dengan alasan yang benar untuk kertas melintang:
-     satu nama yang pecah dua baris menambah tinggi, dan 30 baris di kertas
-     setinggi 190mm tidak punya ruang. Di potret tingginya 277mm dan 30 baris
-     hanya memakai 150mm — ruang itu justru yang dibelanjakan di sini.
-     Hurufnya 10pt: identitas TERCETAK, sementara 12pt dipilih untuk angka
-     yang DITULIS TANGAN lalu dibaca ulang dari foto. */
+  /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
+     Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
+     tingginya berbeda dari tetangganya, dan tabel yang barisnya tidak rata
+     memutus garis pandang mendatar yang dipakai membaca dari nomor dada ke
+     kotak nilai. Elipsisnya dipertahankan sebagai jaring pengaman untuk nama
+     di luar dugaan — pada 10pt di kertas melintang ia tidak pernah terpicu
+     oleh nama mana pun di daftar.
+
+     10pt, bukan 12pt: identitas TERCETAK. Angka 12pt dipilih karena ia
+     DITULIS TANGAN lalu dibaca ulang dari foto, dan nama yang sudah rapi
+     tidak menghadapi ujian itu. */
   .lembar-pos .print-table td:nth-child(2),
   .lembar-pos .print-table td:nth-child(3),
   .lembar-pos .print-table td:nth-child(4) {
-    white-space: normal; overflow-wrap: break-word;
-    font-size: 10pt; line-height: 1.05;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    font-size: 10pt;
   }
   /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
      lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
      kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
      dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
      cek silang. */
-  /* Di A4 potret tersedia 190mm. Pos 3 — yang terlebar — memakai 13mm nomor
-     dada dan tujuh kotak 12mm, menyisakan 93mm untuk tiga kolom ini. Pada
-     10pt satu huruf sekitar 1,75mm, jadi nama regu terpanjang (22 huruf) dan
-     sekolah terpanjang (28 huruf) muat berdampingan; yang lebih panjang lagi
-     turun ke baris kedua alih-alih hilang. Pos 1 yang cuma berkotak tiga
-     menyisakan 129mm — lega. */
-  .lembar-pos .print-table td:nth-child(2) { width: 30mm; }
-  .lembar-pos .print-table td:nth-child(3) { width: 36mm; }
-  .lembar-pos .print-table td:nth-child(4) { width: 22mm; }
+  /* Patokan LEBAR, bukan sempit — ia batas pengaman, bukan target. Kotak
+     isian yang dibatasi ketat (max-width di atas), jadi sisa lebar kertas
+     mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
+     Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
+     sisanya jatuh ke identitas juga. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 70mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 70mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -156,6 +156,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "
                     "order by pos, sort_order", uid=p.get("uid")))
+            elif u.path == "/batas-nomor-dada":
+                self._kirim(200, q(
+                    "select nomor from nomor_dada_stok order by nomor desc limit 1",
+                    uid=p.get("uid")))
             elif u.path == "/kelengkapan-pos":
                 self._kirim(200, q(
                     "select * from v_kelengkapan_pos order by pos",

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -482,6 +482,24 @@ export async function lembarPos(pos) {
     `v_lembar_pos?pos=eq.${encodeURIComponent(pos)}&select=*&order=nomor_dada.asc`);
 }
 
+/** Nomor dada TERTINGGI yang disiapkan admin — batas atas lembar nilai.
+ *
+ *  Lembar tabel mencetak nomor 001 sampai batas ini BERURUTAN, termasuk nomor
+ *  yang belum diberikan ke regu mana pun. Tanpa itu, tim IT yang menyortir
+ *  tumpukan slip berhenti setiap kali lembarnya melompati satu nomor: "slip
+ *  012 hilang, atau memang tidak pernah ada?" — pertanyaan yang tidak bisa
+ *  dijawab dari kertas dan menghentikan pekerjaan.
+ *
+ *  Dibaca dari stok, bukan dari regu yang sudah terdaftar: stok adalah nomor
+ *  dada FISIK yang benar-benar dicetak dan dibawa panitia, dan itulah rentang
+ *  yang mungkin muncul di kotak penilaian. */
+export async function batasNomorDada() {
+  const d = K.mode === "dev"
+    ? await baca("/batas-nomor-dada")
+    : await baca(null, "nomor_dada_stok?select=nomor&order=nomor.desc&limit=1");
+  return d.length ? Number(d[0].nomor) : 0;
+}
+
 /** Satu baris saja, dibaca ulang sesudah menyimpan. Nilai Pos yang tampil di
  *  layar SELALU angka dari database — layar tidak pernah menghitung skor
  *  sendiri, supaya tidak ada mesin skor kedua yang bisa berbeda pendapat

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2113,7 +2113,7 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
   const lembar = set.map(({ judul: judulLomba, kolom }) =>
     halaman.map((grup, i) => `
     <section class="print-page lembar-pos">
-      <h1>LEMBAR NILAI · ${esc(judul)}${judulLomba ? ` · ${esc(judulLomba)}` : ""}
+      <h1>LEMBAR CADANGAN · ${esc(judul)}${judulLomba ? ` · ${esc(judulLomba)}` : ""}
           · Halaman ${i + 1}/${halaman.length}</h1>
       <p class="lembar-kepala">${esc(EDISI ? EDISI.name : "")} · ${esc(tanggal)} ·
          dada ${esc(String(grup[0].nomor_dada).padStart(3, "0"))}–${esc(String(grup[grup.length - 1].nomor_dada).padStart(3, "0"))}
@@ -2131,9 +2131,11 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
         </thead>
         <tbody>${grup.map(barisHtml(kolom)).join("")}</tbody>
       </table>
-      ${i === 0 ? `<p class="print-note">Tulis data mentahnya apa adanya.
-         JANGAN menjumlahkan sendiri — sistem yang mengubahnya jadi poin.
-         Foto lembar ini secara berkala, jangan ditumpuk sampai pos tutup.</p>` : ""}
+      ${i === 0 ? `<p class="print-note">CADANGAN — yang dipakai sehari-hari
+         adalah form per lomba, satu kertas satu regu. Lembar ini untuk keadaan
+         slip habis atau sinyal mati. Tulis data mentahnya apa adanya, JANGAN
+         menjumlahkan sendiri. Baris tanpa nama = regu yang belum terdaftar;
+         tulis nama regu dan sekolahnya di situ.</p>` : ""}
     </section>`).join("")).join("");
 
   document.body.appendChild(h(`<div id="cetakan" class="printout">${lembar}</div>`));
@@ -2392,14 +2394,18 @@ async function layarInputPos() {
     <div class="card">
       ${alatTabel({
         kiri: pilihPosHtml(s, semuaPos),
-        // Dua bentuk kertas, dua cara kerja (alur-lomba.md 8.8). Namanya
-        // memakai kosakata panitia persis — "form tabel" dan "form per lomba"
-        // adalah kata yang mereka ucapkan sendiri, dan tombol yang bernama
-        // lain memaksa penerjemahan di kepala setiap kali dipakai.
+        // Dua bentuk kertas, dan URUTANNYA menyatakan mana yang utama.
+        // Form per lomba dipakai setiap hari lomba di setiap pos; form tabel
+        // hanya kalau slipnya habis atau sinyal mati. Tombol cadangan yang
+        // berdiri lebih dulu akan dipakai orang yang tidak tahu bedanya.
+        //
+        // Namanya memakai kosakata panitia persis — "form per lomba" dan
+        // "form tabel" adalah kata yang mereka ucapkan sendiri, dan tombol
+        // bernama lain memaksa penerjemahan di kepala setiap kali dipakai.
         kanan: `<button class="button button-secondary button-small" type="button"
-                        id="cetak-lembar">🖨️ Form Tabel</button>
+                        id="cetak-per-lomba">🖨️ Form per Lomba</button>
                 <button class="button button-secondary button-small" type="button"
-                        id="cetak-per-lomba">🖨️ Form per Lomba</button>`,
+                        id="cetak-lembar">🖨️ Form Tabel (cadangan)</button>`,
         // Pendek dengan sengaja: kartunya kini selebar tabel, dan petunjuk
         // panjang terpotong di tengah kata — yang justru lebih buruk daripada
         // petunjuk singkat, karena terlihat seperti layar yang rusak.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -18,6 +18,7 @@ import {
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
+  batasNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos,
   statusAcara,
 } from "./api.js";
@@ -2077,7 +2078,24 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
 
   // Sel identitas lewat tag html`` (isinya diketik orang luar); kotak kosong
   // ditempel sebagai HTML biasa karena memang tidak ada isinya.
-  const barisHtml = (kolom) => (r) => `
+  // Nomor yang belum ada regunya di sistem tetap mendapat barisnya, dan
+  // identitasnya dibiarkan KOSONG — bukan ditandai "tidak dipakai".
+  //
+  // Dua jalan menuju baris kosong, dan keduanya nyata. Sebagian sekolah
+  // mendaftar OFFLINE, jadi regunya memakai nomor dada fisik tanpa pernah
+  // masuk sistem sampai daftar ulang menyusulkan datanya. Dan kertas ini
+  // DICETAK LEBIH DULU, sebelum pendaftaran ditutup — regu yang menyusul
+  // sesudahnya tetap harus punya tempat.
+  // Barisnya harus bisa DITULISI: petugas mengisi nama regu dan sekolahnya di
+  // tempat itu, dan meja daftar ulang memakainya untuk melengkapi data
+  // belakangan. Garis "tidak dipakai" akan membuat petugas mencari tempat
+  // lain — biasanya pinggir kertas, tempat tidak ada yang mencarinya.
+  const barisHtml = (kolom) => (r) => r.kosong ? `
+    <tr>
+      ${html`<td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>`}
+      <td></td><td></td><td></td>
+      ${kolom.map(() => `<td class="isian"></td>`).join("")}
+    </tr>` : `
     <tr>
       ${html`<td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
       <td>${r.nama_regu}</td>
@@ -2101,7 +2119,8 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
          dada ${esc(String(grup[0].nomor_dada).padStart(3, "0"))}–${esc(String(grup[grup.length - 1].nomor_dada).padStart(3, "0"))}
          · Petugas: ______________ · Diperiksa: ______________</p>
       ${daftarUlangDitutup ? "" : `<p class="insert-note">DAFTAR ULANG BELUM DITUTUP
-        — regu yang mendaftar ulang setelah kertas ini dicetak tidak ada di sini.</p>`}
+        — regu yang menyusul BARISNYA SUDAH ADA di sini, hanya namanya yang
+        belum tercetak. Tulis nama regu dan sekolahnya di baris kosong.</p>`}
       <table class="print-table">
         <thead>
           <tr>
@@ -2771,6 +2790,39 @@ async function layarInputPos() {
       .filter(Boolean);
     if (!tampil.length) { notif("Tidak ada baris yang bisa dicetak.", true); return; }
 
+    /* NOMOR DADA BERURUTAN 001 SAMPAI BATAS STOK, TANPA LOMPATAN.
+
+       Dua sebab, dan yang kedua yang menentukan.
+
+       Tim IT menyortir tumpukan slip menurut nomor dada lalu menyusurinya dari
+       atas. Lembar yang melompati satu nomor menghentikan pekerjaan itu:
+       "slip 012 hilang, atau memang tidak pernah ada?" — pertanyaan yang tidak
+       bisa dijawab dari kertas.
+
+       Dan sebagian sekolah MENDAFTAR OFFLINE. Regunya memakai nomor dada fisik
+       yang nyata, tetapi belum ada di database saat lembar ini dicetak. Kalau
+       lembarnya hanya memuat regu yang sudah terdaftar, regu itu tidak punya
+       baris sama sekali — dan nilainya ditulis di pinggir kertas, atau tidak
+       ditulis. Barisnya karena itu dicetak kosong dan siap ditulisi.
+
+       Batasnya diambil dari STOK nomor dada, bukan dari regu terdaftar: stok
+       adalah nomor fisik yang benar-benar dibawa panitia, dan mana pun di
+       antaranya bisa muncul di kotak penilaian.
+
+       HANYA saat tidak ada saringan. Lembar susulan justru dicetak untuk
+       sebagian regu — menyisipkan seluruh nomor kosong ke dalamnya
+       mengembalikan tumpukan kertas yang tadi sengaja dipersempit. */
+    let semua = tampil;
+    if (!slip && [...tbody.children].every(tr => !tr.hidden)) {
+      let batas = 0;
+      try { batas = await batasNomorDada(); } catch { /* jatuh ke daftar apa adanya */ }
+      if (batas > 0) {
+        const peta = new Map(tampil.map(r => [Number(r.nomor_dada), r]));
+        semua = Array.from({ length: batas }, (_, i) =>
+          peta.get(i + 1) || { nomor_dada: i + 1, kosong: true });
+      }
+    }
+
     // Dibaca saat menekan, bukan saat layar dimuat: layar pos sering
     // dibiarkan terbuka berjam-jam, dan status daftar ulang berubah di
     // tengahnya. Gagal membacanya tidak boleh menghalangi cetak — paling
@@ -2787,7 +2839,7 @@ async function layarInputPos() {
       notif(`${n} master A5 melintang, satu per lomba. Perbanyak dengan `
             + `fotokopi sebanyak regu yang berlomba, tambah cadangan.`);
     } else {
-      siapkanCetakLembarPos(pos, kolom, tampil, ditutup);
+      siapkanCetakLembarPos(pos, kolom, semua, ditutup);
     }
     window.print();
   };

--- a/web/style.css
+++ b/web/style.css
@@ -513,26 +513,36 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     display: block; max-width: none; font-size: 7pt; font-weight: 400;
     text-transform: none; margin-top: 1pt;
   }
-  /* ---- Form tabel per pos: A4 MELINTANG ----
-     Halaman bernama, supaya HANYA lembar ini yang berputar — kwitansi dan
-     daftar kloter tetap potret.
+  /* ---- Form tabel per pos: A4 POTRET, DAN NAMA TIDAK DIPOTONG ----
+     Halaman bernama, supaya lembar ini bisa punya ukuran sendiri — kwitansi
+     dan daftar kloter memakai halaman lain.
 
-     Melintang bukan selera, tapi ANGKA PEMBENARNYA SUDAH BERGANTI. Dulu
-     alasannya "tabel Pos 1 selebar 201mm, potret cuma menyediakan 180mm".
-     Itu tidak lagi berlaku: sejak kolom dikelompokkan per lomba, Tebak Simpul
-     yang memakan empat kolom (satu per golongan) jadi satu, dan Pos 1 turun
-     dari enam kolom nilai ke tiga. Pos 1 sendiri sekarang muat di potret.
+     Lembar ini pernah melintang, dan alasannya lebar: dengan huruf 12pt nama
+     regu dan sekolah tidak muat di 190mm bersama tujuh kotak isian Pos 3,
+     jadi keduanya dipotong elipsis. Panitia menolak pemotongan itu — nama
+     yang terpotong membuat cek silang kehilangan gunanya, dan cek silang
+     adalah satu-satunya alasan nama sekolah ada di kertas ini.
 
-     Yang menentukan sekarang POS 3, bukan Pos 1: tujuh kolom nilai — lima
-     kriteria Bidai, Kim Lihat, Kim Cium. Tujuh kali 14mm ditambah nomor dada
-     memakan 113mm, menyisakan 77mm untuk tiga kolom identitas di kertas
-     potret. Muat di atas kertas, tapi sempit untuk ditulisi tangan di
-     lapangan, dan panitia memilih melintang setelah melihat cetakannya.
+     Jawabannya bukan memutar kertas, melainkan BERHENTI MEMOTONG DAN MULAI
+     MEMBUNGKUS. Potret memberi tinggi 277mm melawan 190mm — 87mm ruang
+     vertikal tambahan — sementara yang kurang cuma lebar. Nama yang turun ke
+     baris kedua membelanjakan yang berlimpah untuk menutup yang kurang.
 
-     Potret sudah dicoba dan ditolak. Kalau ada yang menghitung ulang lebar
-     Pos 1 lalu menyimpulkan potret cukup: benar untuk Pos 1, salah untuk
-     Pos 3, dan kelima pos memakai satu bentuk yang sama. */
-  @page lembar-pos { size: A4 landscape; margin: 10mm; }
+     Tiga penyesuaian membuatnya muat, semuanya diukur pada Pos 3 (tujuh kotak
+     isian, yang terlebar di sistem) dengan nama terpanjang di daftar:
+
+       identitas 10pt, bukan 12pt  - ia TERCETAK, bukan ditulis tangan, jadi
+                                     tidak perlu bertahan dibaca ulang dari
+                                     foto seperti angka di sebelahnya
+       kotak isian 12mm            - cukup untuk angka dua digit
+       membungkus, bukan elipsis   - dan tinggi baris ikut mengembang
+
+     Tetap 30 baris per halaman, sama dengan waktu melintang. Potret
+     menyediakan 257mm untuk baris; 30 baris satu-baris memakan 150mm, jadi
+     tersisa 107mm untuk baris yang membungkus. Cadangan sebesar itu
+     disengaja: satu baris yang tumpah ke halaman berikutnya merusak seluruh
+     penomoran halaman. */
+  @page lembar-pos { size: A4 portrait; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
   /* ---- FORM PER LOMBA (blangko kosong): A5 MELINTANG, satu per halaman ----
@@ -653,7 +663,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dan di 12pt "KEPRAMUKAAN KEAGAMAAN" akan memakan lebar yang dibutuhkan
      kotak isiannya. */
   .lembar-pos .print-table th, .lembar-pos .print-table td {
-    padding: 0.5pt 4pt; font-size: 12pt;
+    padding: 0.5pt 3pt; font-size: 12pt;
     /* Jarak antarbaris huruf inilah yang sebenarnya menentukan tinggi baris
        di sini — BUKAN tinggi kotak isiannya. Dengan line-height bawaan (1,6)
        satu baris setinggi 32px meski kotaknya diminta 6mm.
@@ -668,27 +678,46 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      barisnya 21px sementara sel 12pt lainnya cuma butuh 18px, dan selisih
      3px dikali 30 baris persis yang membuat halaman tumpah. Tebalnya sudah
      cukup membuatnya menonjol, dan di Excel pun semua kolom seukuran. */
-  .lembar-pos .print-table .dada { font-size: 12pt; width: 15mm; }
+  .lembar-pos .print-table .dada { font-size: 12pt; width: 13mm; }
   /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
      ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
      tinggi hanya akan mengurangi jumlah baris per lembar. */
-  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian { width: 14mm; }
-  /* Identitas TIDAK boleh membungkus di sini: satu nama yang pecah dua baris
-     menambah tinggi satu baris, dan tiga puluh baris yang dipatok mati tidak
-     punya ruang untuk itu — lembarnya akan tumpah ke halaman berikutnya. */
+  /* Kotak isian dipatok DUA ARAH, dan max-width itu yang penting. `width`
+     pada sel tabel cuma usulan: dengan table-layout auto, kolom tumbuh
+     mengisi sisa lebar. Tanpa max-width, di Pos 1 yang cuma punya tiga kotak,
+     seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
+     jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
+  .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
+    width: 12mm; max-width: 14mm;
+  }
+  /* Identitas MEMBUNGKUS, tidak lagi dipotong — dan inilah perubahan yang
+     membuat potret mungkin.
+     Aturan lama melarangnya dengan alasan yang benar untuk kertas melintang:
+     satu nama yang pecah dua baris menambah tinggi, dan 30 baris di kertas
+     setinggi 190mm tidak punya ruang. Di potret tingginya 277mm dan 30 baris
+     hanya memakai 150mm — ruang itu justru yang dibelanjakan di sini.
+     Hurufnya 10pt: identitas TERCETAK, sementara 12pt dipilih untuk angka
+     yang DITULIS TANGAN lalu dibaca ulang dari foto. */
   .lembar-pos .print-table td:nth-child(2),
   .lembar-pos .print-table td:nth-child(3),
   .lembar-pos .print-table td:nth-child(4) {
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    white-space: normal; overflow-wrap: break-word;
+    font-size: 10pt; line-height: 1.05;
   }
   /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
      lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
      kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
      dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
      cek silang. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 38mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 40mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Di A4 potret tersedia 190mm. Pos 3 — yang terlebar — memakai 13mm nomor
+     dada dan tujuh kotak 12mm, menyisakan 93mm untuk tiga kolom ini. Pada
+     10pt satu huruf sekitar 1,75mm, jadi nama regu terpanjang (22 huruf) dan
+     sekolah terpanjang (28 huruf) muat berdampingan; yang lebih panjang lagi
+     turun ke baris kedua alih-alih hilang. Pos 1 yang cuma berkotak tiga
+     menyisakan 129mm — lega. */
+  .lembar-pos .print-table td:nth-child(2) { width: 30mm; }
+  .lembar-pos .print-table td:nth-child(3) { width: 36mm; }
+  .lembar-pos .print-table td:nth-child(4) { width: 22mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/web/style.css
+++ b/web/style.css
@@ -513,36 +513,37 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     display: block; max-width: none; font-size: 7pt; font-weight: 400;
     text-transform: none; margin-top: 1pt;
   }
-  /* ---- Form tabel per pos: A4 POTRET, DAN NAMA TIDAK DIPOTONG ----
-     Halaman bernama, supaya lembar ini bisa punya ukuran sendiri — kwitansi
-     dan daftar kloter memakai halaman lain.
+  /* ---- Form tabel per pos: A4 MELINTANG, NAMA UTUH, BARIS RATA ----
+     Tiga hal yang harus benar bersamaan, dan dua di antaranya sempat saling
+     mengalahkan:
 
-     Lembar ini pernah melintang, dan alasannya lebar: dengan huruf 12pt nama
-     regu dan sekolah tidak muat di 190mm bersama tujuh kotak isian Pos 3,
-     jadi keduanya dipotong elipsis. Panitia menolak pemotongan itu — nama
-     yang terpotong membuat cek silang kehilangan gunanya, dan cek silang
-     adalah satu-satunya alasan nama sekolah ada di kertas ini.
+       nama tidak terpotong  - nama sekolah adalah cek silang; yang terpotong
+                               kehilangan gunanya
+       tinggi baris rata     - mata menyusuri mendatar dari nomor dada ke
+                               kotak nilai, dan baris yang tingginya
+                               berbeda-beda memutus garis pandang itu.
+                               Buku besar bergaris rata bukan tanpa sebab.
+       muat di satu kertas   - Pos 3 punya tujuh kotak isian
 
-     Jawabannya bukan memutar kertas, melainkan BERHENTI MEMOTONG DAN MULAI
-     MEMBUNGKUS. Potret memberi tinggi 277mm melawan 190mm — 87mm ruang
-     vertikal tambahan — sementara yang kurang cuma lebar. Nama yang turun ke
-     baris kedua membelanjakan yang berlimpah untuk menutup yang kurang.
+     Membungkus menyelesaikan yang pertama dengan mengorbankan yang kedua.
+     Yang menyelesaikan ketiganya sekaligus adalah MELINTANG DENGAN IDENTITAS
+     10pt — diukur pada Pos 3, kondisi terlebar:
 
-     Tiga penyesuaian membuatnya muat, semuanya diukur pada Pos 3 (tujuh kotak
-     isian, yang terlebar di sistem) dengan nama terpanjang di daftar:
+       tersedia   277mm
+       dipakai     13mm nomor dada + 7 x 12mm kotak isian = 97mm
+       sisa       180mm untuk tiga kolom identitas
+       dibutuhkan 140mm  (nama regu 22 huruf + sekolah 28 huruf + golongan,
+                          pada 10pt huruf besar ~2,3mm)
 
-       identitas 10pt, bukan 12pt  - ia TERCETAK, bukan ditulis tangan, jadi
-                                     tidak perlu bertahan dibaca ulang dari
-                                     foto seperti angka di sebelahnya
-       kotak isian 12mm            - cukup untuk angka dua digit
-       membungkus, bukan elipsis   - dan tinggi baris ikut mengembang
+     Lega 40mm. Di potret sisanya cuma 93mm — kurang 47mm, dan kekurangan
+     itulah yang dulu memaksa memotong, lalu memaksa membungkus.
 
-     Tetap 30 baris per halaman, sama dengan waktu melintang. Potret
-     menyediakan 257mm untuk baris; 30 baris satu-baris memakan 150mm, jadi
-     tersisa 107mm untuk baris yang membungkus. Cadangan sebesar itu
-     disengaja: satu baris yang tumpah ke halaman berikutnya merusak seluruh
-     penomoran halaman. */
-  @page lembar-pos { size: A4 portrait; margin: 10mm; }
+     Potret sudah dicoba dua kali: sekali dengan elipsis (nama terpotong),
+     sekali dengan membungkus (baris tidak rata). Keduanya ditolak panitia.
+     Yang keliru pada versi melintang lama bukan orientasinya, melainkan
+     identitas 12pt dan kolom yang dipatok 38/40/26mm sementara kotak isian
+     dibiarkan melar. */
+  @page lembar-pos { size: A4 landscape; margin: 10mm; }
   .lembar-pos { page: lembar-pos; }
 
   /* ---- FORM PER LOMBA (blangko kosong): A5 MELINTANG, satu per halaman ----
@@ -690,34 +691,36 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
     width: 12mm; max-width: 14mm;
   }
-  /* Identitas MEMBUNGKUS, tidak lagi dipotong — dan inilah perubahan yang
-     membuat potret mungkin.
-     Aturan lama melarangnya dengan alasan yang benar untuk kertas melintang:
-     satu nama yang pecah dua baris menambah tinggi, dan 30 baris di kertas
-     setinggi 190mm tidak punya ruang. Di potret tingginya 277mm dan 30 baris
-     hanya memakai 150mm — ruang itu justru yang dibelanjakan di sini.
-     Hurufnya 10pt: identitas TERCETAK, sementara 12pt dipilih untuk angka
-     yang DITULIS TANGAN lalu dibaca ulang dari foto. */
+  /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
+     Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
+     tingginya berbeda dari tetangganya, dan tabel yang barisnya tidak rata
+     memutus garis pandang mendatar yang dipakai membaca dari nomor dada ke
+     kotak nilai. Elipsisnya dipertahankan sebagai jaring pengaman untuk nama
+     di luar dugaan — pada 10pt di kertas melintang ia tidak pernah terpicu
+     oleh nama mana pun di daftar.
+
+     10pt, bukan 12pt: identitas TERCETAK. Angka 12pt dipilih karena ia
+     DITULIS TANGAN lalu dibaca ulang dari foto, dan nama yang sudah rapi
+     tidak menghadapi ujian itu. */
   .lembar-pos .print-table td:nth-child(2),
   .lembar-pos .print-table td:nth-child(3),
   .lembar-pos .print-table td:nth-child(4) {
-    white-space: normal; overflow-wrap: break-word;
-    font-size: 10pt; line-height: 1.05;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    font-size: 10pt;
   }
   /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
      lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
      kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
      dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
      cek silang. */
-  /* Di A4 potret tersedia 190mm. Pos 3 — yang terlebar — memakai 13mm nomor
-     dada dan tujuh kotak 12mm, menyisakan 93mm untuk tiga kolom ini. Pada
-     10pt satu huruf sekitar 1,75mm, jadi nama regu terpanjang (22 huruf) dan
-     sekolah terpanjang (28 huruf) muat berdampingan; yang lebih panjang lagi
-     turun ke baris kedua alih-alih hilang. Pos 1 yang cuma berkotak tiga
-     menyisakan 129mm — lega. */
-  .lembar-pos .print-table td:nth-child(2) { width: 30mm; }
-  .lembar-pos .print-table td:nth-child(3) { width: 36mm; }
-  .lembar-pos .print-table td:nth-child(4) { width: 22mm; }
+  /* Patokan LEBAR, bukan sempit — ia batas pengaman, bukan target. Kotak
+     isian yang dibatasi ketat (max-width di atas), jadi sisa lebar kertas
+     mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
+     Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
+     sisanya jatuh ke identitas juga. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 70mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 70mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }


### PR DESCRIPTION
## What

**Form tabel per pos bukan lagi lembar lapangan — ia cadangan.** Dan bentuknya diperbaiki supaya tiga hal benar bersamaan.

| | Sebelum | Sekarang |
|---|---|---|
| Peran | lembar lapangan untuk pos berjuri satu | **cadangan**: slip habis / sinyal mati |
| Kepala halaman | LEMBAR NILAI | **LEMBAR CADANGAN** |
| Urutan tombol | Form Tabel, lalu Form per Lomba | **Form per Lomba** dulu |
| Orientasi | melintang | melintang (tetap) |
| Identitas | 12pt, dipotong elipsis | **10pt, utuh, satu baris** |
| Kotak isian | melar mengisi sisa | dibatasi 14mm |
| Nomor dada | hanya yang terdaftar | **001 sampai batas stok** |

## Why — kenapa turun jadi cadangan

Form tabel punya **cacat yang sama persis dengan slip pra-cetak yang kita buang**: regu datang acak, jadi petugas harus MENCARI baris 005 setiap kali satu regu masuk. Blangko per lomba menghapus pencarian itu; tabel mengembalikannya — termasuk di PBB dan Yel-Yel, tempat saya sempat berargumen tabel lebih cepat. Argumen itu keliru.

Yang tersisa untuknya: **blangko habis di tengah lomba, atau sinyal mati**. Untuk itu ia dicetak lebih dulu lalu disimpan, bukan dibagikan.

## Why — kenapa melintang, bukan potret

Tiga hal harus benar bersamaan, dan dua sempat saling mengalahkan:

| | Melintang 12pt | Potret + bungkus | **Melintang 10pt** |
|---|---|---|---|
| Nama utuh | ✗ | ✓ | **✓** |
| Baris rata | ✓ | ✗ | **✓** |
| Muat Pos 3 | ✓ | ✓ | **✓** |

Diukur di Pos 3 (terlebar): tersedia **277mm**, dipakai 97mm oleh nomor dada + tujuh kotak isian, sisa **180mm** untuk identitas yang butuh **140mm**. Lega 40mm. Potret menyisakan 93mm — kurang 47mm, dan kekurangan itulah yang memaksa memotong lalu memaksa membungkus.

Baris yang tingginya tidak rata memutus garis pandang mendatar dari nomor dada ke kotak nilai. Buku besar bergaris rata bukan tanpa sebab.

**Potret dicoba dua kali dan ditolak dua kali** — sekali dengan elipsis, sekali dengan membungkus. Keduanya dicatat di CSS supaya tidak dicoba ketiga kalinya.

## Notes

Nomor dada berurutan karena tiga sebab yang ketiganya terjadi: penyortiran slip berhenti kalau ada nomor yang dilompati; sebagian sekolah **mendaftar offline**; dan kertasnya **dicetak sebelum pendaftaran ditutup**. Baris tanpa regu dibiarkan kosong dan siap ditulisi — bukan ditandai "tidak dipakai", karena tanda itu memberi tahu petugas bahwa regunya tidak ada padahal justru ada.

Menggantikan #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)