### PR TITLE
feat: golongan disingkat di kertas, dan pratinjau cetak yang tidak berbohong

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -689,7 +689,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
      jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
-    width: 12mm; max-width: 14mm;
+    width: 16mm; max-width: 18mm;
   }
   /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
      Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
@@ -713,14 +713,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
      dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
      cek silang. */
-  /* Patokan LEBAR, bukan sempit — ia batas pengaman, bukan target. Kotak
-     isian yang dibatasi ketat (max-width di atas), jadi sisa lebar kertas
-     mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
-     Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
-     sisanya jatuh ke identitas juga. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 76mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 76mm; }
-  /* Golongan disingkat di kertas — "Pgl Pa", bukan "Penggalang PA"
+  /* Identitas DIPADATKAN, dan itu keputusan panitia: lebih baik nama
+     terpotong sedikit daripada kotak nilai yang sempit.
+
+     Diukur pada 10pt huruf besar (~2,3mm per huruf) terhadap nama terpanjang
+     di daftar:
+
+       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 48mm
+       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 58mm
+
+     Keduanya sengaja sedikit di bawah kebutuhan huruf terpanjang, jadi hanya
+     segelintir nama terpanjang yang kehilangan satu-dua huruf di ujung —
+     dan regu tetap dikenali dari nomor dadanya. Yang dibeli: 46mm kembali ke
+     kotak nilai, yang naik dari 14mm ke 18mm.
+
+     Elipsisnya tetap, dan `nowrap` tetap — memotong menjaga tinggi baris
+     seragam, dan keseragaman itu yang membuat mata bisa menyusuri mendatar
+     dari nomor dada ke kotak nilai tanpa kehilangan barisnya. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 48mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 58mm; }
+  /* Golongan disingkat di kertas — "Pgl Pa" / "Pgk Pa", bukan "Penggalang PA"
      (GOLONGAN_SINGKAT di app.js). Enam huruf pada 10pt butuh ~14mm; sisanya
      dikembalikan ke dua kolom nama di sebelahnya, yang memang sedang
      kekurangan dan karena itu dipotong elipsis. */

--- a/live/style.css
+++ b/live/style.css
@@ -718,9 +718,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
      Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
      sisanya jatuh ke identitas juga. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  .lembar-pos .print-table td:nth-child(2) { max-width: 76mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 76mm; }
+  /* Golongan disingkat di kertas — "Pgl Pa", bukan "Penggalang PA"
+     (GOLONGAN_SINGKAT di app.js). Enam huruf pada 10pt butuh ~14mm; sisanya
+     dikembalikan ke dua kolom nama di sebelahnya, yang memang sedang
+     kekurangan dan karena itu dipotong elipsis. */
+  .lembar-pos .print-table td:nth-child(4) { max-width: 16mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/tools/pratinjau_cetak.py
+++ b/tools/pratinjau_cetak.py
@@ -1,0 +1,63 @@
+r"""Bangkitkan pratinjau cetak dari @media print di web/style.css.
+
+KENAPA BERKAS INI ADA, DAN KENAPA PENYARINGNYA BUKAN REGEX.
+
+Pratinjau ini dipakai memutuskan bentuk kertas — potret atau melintang,
+memotong nama atau membungkusnya — jadi ia HARUS memakai CSS yang sama persis
+dengan yang dicetak. Versi sebelumnya membuang aturan layar dengan regex
+`\.(header|isi|notification|overlay)[^{]*\{[^}]*\}`, dan `.isi` di dalamnya
+ikut menangkap `.isian` — kelas kotak nilai.
+
+Akibatnya dua lapis. Aturan lebar kotak isian hilang, jadi kotaknya melar dan
+menggencet kolom nama. Dan potongannya meninggalkan selektor menggantung
+(`.lembar-pos .print-table th`) yang menempel ke aturan berikutnya, sehingga
+`white-space: nowrap` tidak pernah berlaku — nama membungkus di pratinjau
+padahal di cetakan sungguhan ia satu baris.
+
+Keputusan bentuk kertas diambil beberapa putaran atas dasar pratinjau itu.
+Karena itu penyaringnya sekarang mencocokkan SATU aturan yang diketahui, apa
+adanya, dan berhenti dengan galat kalau aturan itu tidak ditemukan — lebih
+baik gagal daripada diam-diam menghapus yang salah.
+"""
+import re
+from pathlib import Path
+
+AKAR = Path(__file__).resolve().parent.parent
+# Satu-satunya aturan yang memang tidak boleh ikut: penyembunyi layar.
+SEMBUNYI = ".header, .isi, .notification, .overlay { display: none !important; }"
+
+
+def css_cetak() -> str:
+    """Isi blok @media print, siap ditempel ke halaman pratinjau."""
+    css = (AKAR / "web" / "style.css").read_text(encoding="utf-8")
+    i = css.index("@media print {")
+    dalam = 0
+    for j in range(i, len(css)):
+        if css[j] == "{":
+            dalam += 1
+        elif css[j] == "}":
+            dalam -= 1
+            if dalam == 0:
+                break
+    blok = css[i + len("@media print {"):j]
+
+    if SEMBUNYI not in blok:
+        raise SystemExit(
+            "Aturan penyembunyi layar tidak ditemukan apa adanya di @media print.\n"
+            "Jangan tebak — buka web/style.css, cocokkan teksnya, lalu perbarui\n"
+            "SEMBUNYI di berkas ini. Menghapus yang salah membuat pratinjau\n"
+            "berbohong, dan keputusan bentuk kertas diambil dari pratinjau.")
+    blok = blok.replace(SEMBUNYI, "")
+
+    # @page tidak berlaku di layar; dibuang supaya tidak membingungkan, dan
+    # dicocokkan dengan pola yang tidak mungkin mengenai selektor kelas.
+    blok = re.sub(r"@page\s+[\w-]*\s*\{[^}]*\}", "", blok)
+
+    if ".isian" not in blok:
+        raise SystemExit("Aturan .isian ikut terbuang — persis cacat yang "
+                         "membuat berkas ini ditulis. Periksa penyaringnya.")
+    return blok
+
+
+if __name__ == "__main__":
+    print(css_cetak()[:400])

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -31,6 +31,24 @@ const GOLONGAN_LABEL = {
   penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
 };
+
+/** Golongan versi pendek, HANYA untuk kertas. Di layar tetap panjang — di
+ *  sana lebar tidak diperebutkan siapa pun.
+ *
+ *  Di lembar cadangan ia diperebutkan, dan yang kalah selama ini nama regu dan
+ *  sekolah: keduanya dipotong elipsis supaya tinggi baris tetap seragam. Lebar
+ *  yang dihemat di sini pindah ke sana. "Penggalang PA" 13 huruf jadi "Pgl Pa"
+ *  6 huruf — sekitar 10mm kembali ke kolom nama, di kertas yang memang sedang
+ *  kekurangan.
+ *
+ *  Pgl dan Png memang cuma beda satu huruf, dan itu disebut supaya tidak
+ *  dikira terlewat: kolom ini keterangan, bukan kunci. Nilai mengalir lewat
+ *  nomor dada, jadi golongan yang salah baca tidak pernah memindahkan angka ke
+ *  regu lain — paling jauh membuat petugas melihat dua kali. */
+const GOLONGAN_SINGKAT = {
+  penggalang_pa: "Pgl Pa", penggalang_pi: "Pgl Pi",
+  penegak_pa: "Png Pa", penegak_pi: "Png Pi",
+};
 let EDISI = null;
 
 /* Layar yang sanggup memperbarui dirinya SENDIRI tanpa digambar ulang
@@ -2100,7 +2118,7 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
       ${html`<td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
       <td>${r.nama_regu}</td>
       <td>${r.nama_sekolah}</td>
-      <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>`}
+      <td>${GOLONGAN_SINGKAT[r.golongan] || r.golongan}</td>`}
       ${kolom.map(() => `<td class="isian"></td>`).join("")}
     </tr>`;
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -41,13 +41,18 @@ const GOLONGAN_LABEL = {
  *  6 huruf — sekitar 10mm kembali ke kolom nama, di kertas yang memang sedang
  *  kekurangan.
  *
- *  Pgl dan Png memang cuma beda satu huruf, dan itu disebut supaya tidak
- *  dikira terlewat: kolom ini keterangan, bukan kunci. Nilai mengalir lewat
- *  nomor dada, jadi golongan yang salah baca tidak pernah memindahkan angka ke
- *  regu lain — paling jauh membuat petugas melihat dua kali. */
+ *  Singkatannya dipilih panitia: Pgl dan Pgk, keduanya berpola tiga huruf
+ *  konsonan. Versi pertama saya "Png" untuk Penegak, dan itu lebih buruk —
+ *  Png dan Pgl berbeda di dua huruf tengah yang sama-sama tidak menonjol,
+ *  sementara Pgk dan Pgl berbeda di huruf TERAKHIR, tempat mata berhenti.
+ *
+ *  Sekalipun tertukar, akibatnya terbatas: kolom ini keterangan, bukan kunci.
+ *  Nilai mengalir lewat nomor dada, jadi golongan yang salah baca tidak pernah
+ *  memindahkan angka ke regu lain — paling jauh membuat petugas melihat dua
+ *  kali. */
 const GOLONGAN_SINGKAT = {
   penggalang_pa: "Pgl Pa", penggalang_pi: "Pgl Pi",
-  penegak_pa: "Png Pa", penegak_pi: "Png Pi",
+  penegak_pa: "Pgk Pa", penegak_pi: "Pgk Pi",
 };
 let EDISI = null;
 

--- a/web/style.css
+++ b/web/style.css
@@ -689,7 +689,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
      jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
-    width: 12mm; max-width: 14mm;
+    width: 16mm; max-width: 18mm;
   }
   /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
      Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
@@ -713,14 +713,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
      dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
      cek silang. */
-  /* Patokan LEBAR, bukan sempit — ia batas pengaman, bukan target. Kotak
-     isian yang dibatasi ketat (max-width di atas), jadi sisa lebar kertas
-     mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
-     Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
-     sisanya jatuh ke identitas juga. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 76mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 76mm; }
-  /* Golongan disingkat di kertas — "Pgl Pa", bukan "Penggalang PA"
+  /* Identitas DIPADATKAN, dan itu keputusan panitia: lebih baik nama
+     terpotong sedikit daripada kotak nilai yang sempit.
+
+     Diukur pada 10pt huruf besar (~2,3mm per huruf) terhadap nama terpanjang
+     di daftar:
+
+       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 48mm
+       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 58mm
+
+     Keduanya sengaja sedikit di bawah kebutuhan huruf terpanjang, jadi hanya
+     segelintir nama terpanjang yang kehilangan satu-dua huruf di ujung —
+     dan regu tetap dikenali dari nomor dadanya. Yang dibeli: 46mm kembali ke
+     kotak nilai, yang naik dari 14mm ke 18mm.
+
+     Elipsisnya tetap, dan `nowrap` tetap — memotong menjaga tinggi baris
+     seragam, dan keseragaman itu yang membuat mata bisa menyusuri mendatar
+     dari nomor dada ke kotak nilai tanpa kehilangan barisnya. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 48mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 58mm; }
+  /* Golongan disingkat di kertas — "Pgl Pa" / "Pgk Pa", bukan "Penggalang PA"
      (GOLONGAN_SINGKAT di app.js). Enam huruf pada 10pt butuh ~14mm; sisanya
      dikembalikan ke dua kolom nama di sebelahnya, yang memang sedang
      kekurangan dan karena itu dipotong elipsis. */

--- a/web/style.css
+++ b/web/style.css
@@ -718,9 +718,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
      Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
      sisanya jatuh ke identitas juga. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  .lembar-pos .print-table td:nth-child(2) { max-width: 76mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 76mm; }
+  /* Golongan disingkat di kertas — "Pgl Pa", bukan "Penggalang PA"
+     (GOLONGAN_SINGKAT di app.js). Enam huruf pada 10pt butuh ~14mm; sisanya
+     dikembalikan ke dua kolom nama di sebelahnya, yang memang sedang
+     kekurangan dan karena itu dipotong elipsis. */
+  .lembar-pos .print-table td:nth-child(4) { max-width: 16mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }


### PR DESCRIPTION
## What

Dua hal, dan yang kedua menjelaskan beberapa putaran sebelumnya.

**1. Golongan disingkat di kertas** — `Penggalang PA` → `Pgl Pa`. Kolomnya menyusut 26mm → 16mm, dan 10mm itu pindah ke dua kolom nama (70 → 76mm).

**2. Alat pratinjau cetak dibetulkan.** Penyaringnya membuang aturan layar dengan regex:

```
\.(header|isi|notification|overlay)[^{]*\{[^}]*\}
```

`.isi` ikut menangkap **`.isian`** — kelas kotak nilai.

## Why

Akibatnya dua lapis, dan yang kedua lebih buruk:

- Aturan lebar kotak isian hilang → kotak melar, kolom nama tergencet.
- Potongannya berhenti **di tengah selektor**, meninggalkan `.lembar-pos .print-table th` menggantung yang menempel ke aturan berikutnya → **`white-space: nowrap` tidak pernah berlaku**.

Jadi nama membungkus di pratinjau dan tinggi baris jadi tidak seragam, padahal di cetakan sungguhan ia satu baris. Panitia melihatnya dan bertanya kenapa 011 berbeda tinggi dari 012 — dan jawabannya bukan kertasnya.

**Beberapa putaran keputusan bentuk kertas diambil dari pratinjau itu.** Potret dengan elipsis, potret dengan membungkus, melintang 10pt — semuanya dinilai lewat gambar yang salah.

## Notes

Penyaringnya sekarang mencocokkan **satu aturan yang diketahui, apa adanya**, dan berhenti dengan galat kalau tidak ditemukan — lebih baik gagal daripada diam-diam menghapus yang salah. Penjaga kedua memastikan `.isian` masih ada sesudah penyaringan.

Dipindahkan dari skrip sekali pakai ke `tools/pratinjau_cetak.py`, supaya pratinjau berikutnya memakai penyaring yang sudah dibetulkan alih-alih menyalin ulang regex yang salah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)