### PR TITLE
fix: daftar ulang gagal total setelah kloter dicetak

### DIFF
--- a/supabase/migrations/0040_daftar_ulang_hormati_kloter_tercetak.sql
+++ b/supabase/migrations/0040_daftar_ulang_hormati_kloter_tercetak.sql
@@ -1,0 +1,270 @@
+-- ============================================================================
+-- hrcd-rekap : 0040_daftar_ulang_hormati_kloter_tercetak.sql
+--
+-- MEMBETULKAN REGRESI YANG MEMBUAT DAFTAR ULANG GAGAL TOTAL SETELAH KLOTER
+-- DICETAK.
+--
+-- Gejalanya di lapangan: panitia menekan "Tandai sudah dicetak", lalu sekolah
+-- berikutnya daftar ulang dan SELURUH batch-nya ditolak. Tidak satu regu pun
+-- mendapat nomor dada, dan yang muncul cuma pesan trigger yang tidak
+-- menjelaskan apa-apa bagi petugas meja.
+--
+-- ---------------------------------------------------------------------------
+-- BAGAIMANA IA LAHIR
+--
+-- Migrasi 0008 menambahkan satu syarat ke keempat putaran pemilihan kloter di
+-- `daftar_ulang_batch`: kloter yang kertasnya SUDAH DICETAK tidak boleh dipilih
+-- lagi. Itu satu-satunya isi 0008, karena trigger `jaga_kloter_tercetak` yang
+-- dipasang bersamanya menolak setiap penambahan regu ke kloter tercetak.
+--
+-- Migrasi 0011 menulis ulang fungsi itu untuk nomor dada manual, dan kepalanya
+-- menulis: "algoritmanya disalin apa adanya dari 0004". 0004 mendahului 0008.
+-- Jadi yang tersalin adalah versi SEBELUM syarat itu ada — dan 0014, yang
+-- menyalin ulang 0011 apa adanya untuk keperluan rename, membawanya lebih jauh
+-- lagi ke versi yang berlaku hari ini.
+--
+-- Dua hal ikut mundur. Yang pertama syarat `dicetak_pada is null` tadi. Yang
+-- kedua nama kunci advisory: kembali dari 'hrcd_daftar_ulang' (0007/0008) ke
+-- 'hrcd_kloter_assign' (0004), sementara `pindah_kloter` dan
+-- `tandai_kloter_dicetak` tetap memakai nama lama. Sejak itu ketiganya tidak
+-- lagi saling mengunci walaupun komentar di dalamnya masih mengaku demikian —
+-- dua meja bisa merebut (kloter, urutan) yang sama, dan yang menahannya tinggal
+-- constraint unique yang membatalkan seluruh batch.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TES TIDAK MENANGKAPNYA
+--
+-- Tesnya ADA — tests/sql/04_cetak_kloter.sql bagian 4.4 — dan CI hijau terus.
+-- Ia lolos karena kebetulan: `lompatan_kloter = 2` di supabase/seed.sql membuat
+-- data uji hanya mengisi kloter ganjil, dan kloter genap yang kosong tidak
+-- pernah ditandai tercetak. Putaran pertama mendarat di celah kosong itu, jadi
+-- kloter tercetak tidak pernah terpilih.
+--
+-- Di lapangan celah itu habis begitu kloter 1..30 semuanya berisi minimal satu
+-- regu. Tes itu ikut diperbaiki di commit yang sama supaya tidak bisa lulus
+-- karena keberuntungan.
+--
+-- ---------------------------------------------------------------------------
+-- BADANNYA DISALIN MESIN
+--
+-- `create or replace function` menuntut definisi utuh, dan mengetik ulang 8.000
+-- karakter adalah cara paling mudah menyelundupkan perbedaan yang tidak
+-- disengaja — persis yang terjadi pada 0011. Jadi badan di bawah disalin dari
+-- 0014 oleh skrip, dengan dua tambalan yang dihitung dan diperiksa jumlahnya:
+-- empat sisipan `and k.dicetak_pada is null` (satu per putaran) dan satu
+-- penggantian nama kunci.
+-- ============================================================================
+
+create or replace function daftar_ulang_batch(
+  p_kode  text,
+  -- [{"regu_id": "...", "nomor_dada": 12}, ...] — satu entri per regu yang
+  -- belum bernomor di batch ini, tidak boleh kurang dan tidak boleh lebih.
+  p_nomor jsonb
+)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_berhak     uuid[];
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];      -- kloter yang sudah berisi sekolah ini
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+  v_salah      text;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Regu yang berhak: belum bernomor, tidak batal (rancangan-b.md, temuan 11).
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.is_cancelled and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Pasangan regu -> nomor dari meja. Urutan deterministik (nama regu) supaya
+  -- hasil yang dibacakan meja urut sama dengan kartu di layar.
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+         as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) as t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) as t(g) where not (t.g = any (v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+
+  if exists (select 1 from unnest(v_nomor) as t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct t.nomor) from unnest(v_nomor) as t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  -- Kunci baris stok yang diminta, urut nomor supaya dua meja yang meminta
+  -- himpunan bertumpang tindih tidak saling mengunci silang. Meja kedua
+  -- menunggu sebentar lalu ditolak pemeriksaan "sudah dipakai" di bawah,
+  -- dengan pesan yang bisa dibaca petugas — bukan galat unique mentah.
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any (v_nomor)
+  order by s.nomor
+  for update;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- Serialisasi bagian penempatan kloter (2-3 meja — advisory lock sederhana
+  -- lebih terbaca daripada retry unique-violation; lepas otomatis di akhir tx).
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  -- Sebar N regu: mulai dari kloter termuda yang layak, melompat
+  -- lompatan_kloter (alur 5.6); kloter 31.. dibuka hanya bila 1..30 tidak
+  -- menyediakan slot layak (alur 5.2). "Layak" = belum penuh + belum berisi
+  -- sekolah ini; bila tak terhindarkan, syarat sekolah dilonggarkan (alur 5.4
+  -- "sesedikit mungkin", bukan "tidak boleh").
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam 1..kloter_dasar.
+    if v_mulai is null then
+      v_langkah := 1;  -- pencarian pertama: kloter layak termuda
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and k.jam_berangkat is null
+      and k.dicetak_pada is null
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama tapi abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and k.dicetak_pada is null
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: 1..kloter_dasar masih ada tempat tapi semuanya berisi
+    -- sekolah ini — sekolah sama boleh berkumpul DULU sebelum membuka
+    -- kloter cadangan (alur 5.2: 31-40 hanya bila 1-30 penuh; alur 5.4:
+    -- "sesedikit mungkin", bukan larangan mutlak). Pilih yang paling kosong.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and k.jam_berangkat is null
+        and k.dicetak_pada is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan
+    -- (31..kloter_maks), hindari sekolah sama dulu lalu bebas.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and k.jam_berangkat is null
+        and k.dicetak_pada is null
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),   -- false (bebas sekolah) dulu
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      -- Slot terkecil yang kosong, bukan count+1: lubang bekas koreksi admin
+      -- tidak boleh membuat slot palsu di atas 10 (temuan review).
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -58,6 +58,10 @@ run supabase/seed.sql
 run tests/sql/01_seed_uji.sql
 run tests/sql/02_constraints.sql
 run tests/sql/03_alur.sql
+# 0040 membetulkan regresi daftar_ulang_batch (kloter tercetak tetap dipilih).
+# Dijalankan SEBELUM 04, karena bagian 4.4b menguji perbaikannya.
+# SEMENTARA DIMATIKAN: membuktikan 4.4b menangkap bugnya
+# run supabase/migrations/0040_daftar_ulang_hormati_kloter_tercetak.sql
 run tests/sql/04_cetak_kloter.sql
 run tests/sql/05_pindah_kloter.sql
 run tests/sql/06_koreksi_jam_berangkat.sql

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -60,8 +60,7 @@ run tests/sql/02_constraints.sql
 run tests/sql/03_alur.sql
 # 0040 membetulkan regresi daftar_ulang_batch (kloter tercetak tetap dipilih).
 # Dijalankan SEBELUM 04, karena bagian 4.4b menguji perbaikannya.
-# SEMENTARA DIMATIKAN: membuktikan 4.4b menangkap bugnya
-# run supabase/migrations/0040_daftar_ulang_hormati_kloter_tercetak.sql
+run supabase/migrations/0040_daftar_ulang_hormati_kloter_tercetak.sql
 run tests/sql/04_cetak_kloter.sql
 run tests/sql/05_pindah_kloter.sql
 run tests/sql/06_koreksi_jam_berangkat.sql

--- a/tests/sql/04_cetak_kloter.sql
+++ b/tests/sql/04_cetak_kloter.sql
@@ -185,9 +185,22 @@ begin
   assert (select dicetak_pada from kloter where nomor = v_hasil.kloter) is null,
     format('regu susulan masuk kloter %s yang SUDAH dicetak', v_hasil.kloter);
 
-  -- Dikembalikan persis seperti semula.
+  -- DIKEMBALIKAN PERSIS SEPERTI SEMULA, termasuk sekolah yang dibuat di sini.
+  --
+  -- Bukan kerapian belaka: 4.5 menghitung berapa kloter BARU yang ditandai
+  -- tercetak, dan satu regu yang tertinggal di kloter cadangan membuat
+  -- angkanya 2 alih-alih 1. Tes yang berjejak mengubah arti tes berikutnya,
+  -- dan yang gagal nanti bukan tes ini — jadi jejaknya sulit dilacak.
   reset role;
   update kloter set dicetak_pada = null where nomor = any(v_semula);
+
+  delete from pembayaran p using pendaftaran d
+   where p.pendaftaran_id = d.id and d.kode_pembayaran = v_kode;
+  delete from regu r using pendaftaran d
+   where r.pendaftaran_id = d.id and d.kode_pembayaran = v_kode;
+  delete from pendaftaran where kode_pembayaran = v_kode;
+  delete from sekolah where name = 'SMP Susulan Penuh';
+
   perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
   set role authenticated;
 end;

--- a/tests/sql/04_cetak_kloter.sql
+++ b/tests/sql/04_cetak_kloter.sql
@@ -128,6 +128,71 @@ begin
 end;
 $$;
 
+-- 4.4b SEMUA kloter dasar sudah tercetak — keadaan lapangan yang sebenarnya,
+--      dan justru yang TIDAK diuji 4.4.
+--
+--      4.4 lolos karena keberuntungan: `lompatan_kloter = 2` membuat data uji
+--      hanya mengisi kloter ganjil, dan kloter genap yang kosong tidak pernah
+--      ditandai tercetak. Putaran pertama pemilihan kloter mendarat di celah
+--      kosong itu, jadi kloter tercetak tidak pernah terpilih.
+--
+--      Di lapangan celah itu habis begitu kloter 1..kloter_dasar semuanya
+--      berisi. Bagian ini menirunya dengan menandai SELURUH kloter dasar
+--      tercetak, sehingga putaran 1-3 tidak punya kandidat dan pemilihan harus
+--      jatuh ke kloter cadangan.
+--
+--      Tanpa 0040, putaran pertama tetap memilih kloter dasar yang tercetak,
+--      trigger jaga_kloter_tercetak menolak UPDATE-nya, dan SELURUH batch
+--      gagal — tidak satu regu pun mendapat nomor dada. Itulah bug yang
+--      dilaporkan panitia dari lapangan.
+do $$
+declare
+  v_kode   text;
+  v_hasil  record;
+  v_biaya  integer;
+  v_dasar  smallint;
+  v_semula smallint[];
+begin
+  reset role;
+  select biaya_per_regu, kloter_dasar into v_biaya, v_dasar
+  from edisi where is_active;
+
+  -- Dicatat dulu supaya bisa dikembalikan: 4.5 menghitung berapa kloter BARU
+  -- yang ditandai, dan tanda yang tertinggal di sini akan mengubah angkanya.
+  select array_agg(nomor) into v_semula
+  from kloter where nomor <= v_dasar and dicetak_pada is null;
+
+  update kloter set dicetak_pada = now()
+  where nomor <= v_dasar and dicetak_pada is null;
+
+  set role service_role;
+  v_kode := (submit_pendaftaran('SMP Susulan Penuh', 'Jl. Susulan 2', false,
+    '081200001111',
+    '[{"nama_regu":"Paling Telat","nama_ketua":"Tini","golongan":"penegak_pi"}]',
+    0::smallint, gen_random_uuid())) ->> 'kode_pembayaran';
+  reset role;
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+  set role authenticated;
+  perform verifikasi_pembayaran(v_kode, v_biaya, 'tunai');
+
+  select * into v_hasil from daftar_ulang_batch(v_kode, uji_dada(v_kode)) limit 1;
+  assert v_hasil.nomor_dada is not null,
+    'daftar ulang gagal padahal masih ada kloter cadangan yang belum dicetak';
+  assert v_hasil.kloter > v_dasar,
+    format('regu susulan masuk kloter %s, seharusnya kloter cadangan di atas %s',
+           v_hasil.kloter, v_dasar);
+  assert (select dicetak_pada from kloter where nomor = v_hasil.kloter) is null,
+    format('regu susulan masuk kloter %s yang SUDAH dicetak', v_hasil.kloter);
+
+  -- Dikembalikan persis seperti semula.
+  reset role;
+  update kloter set dicetak_pada = null where nomor = any(v_semula);
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+  set role authenticated;
+end;
+$$;
+
 -- 4.5 Cetak lembar tambahan hanya menandai kloter baru itu.
 do $$
 declare v_baru int;


### PR DESCRIPTION
## Gejala

Panitia menekan **"Tandai sudah dicetak"**, lalu sekolah berikutnya daftar ulang dan **seluruh batch-nya ditolak**. Tidak satu regu pun mendapat nomor dada:

> kloter 6 sudah dicetak — regu baru tidak boleh disisipkan ke sana. Pakai menu "Pindah kloter" bila memang perlu.

## Akarnya: satu kalimat di kepala migrasi 0011

`0008` menambahkan satu syarat ke keempat putaran pemilihan kloter di `daftar_ulang_batch`: **kloter yang kertasnya sudah dicetak tidak boleh dipilih lagi.** Itu satu-satunya isi 0008, karena trigger `jaga_kloter_tercetak` yang dipasang bersamanya menolak setiap penambahan regu ke kloter tercetak.

`0011` menulis ulang fungsi itu untuk nomor dada manual, dan kepalanya menulis:

> "algoritmanya disalin apa adanya dari 0004"

**0004 mendahului 0008.** Yang tersalin adalah versi sebelum syarat itu ada — lalu `0014` menyalin ulang 0011 apa adanya untuk keperluan rename, dan itulah versi yang berlaku hari ini.

Dua hal mundur bersamaan:

| | 0008 | yang berlaku (0014) |
|---|---|---|
| `dicetak_pada is null` di 4 putaran | ada | **hilang** |
| nama kunci advisory | `hrcd_daftar_ulang` | `hrcd_kloter_assign` |

Yang kedua ikut dibetulkan: `pindah_kloter` dan `tandai_kloter_dicetak` tetap memakai nama lama, jadi sejak 0011 ketiganya **tidak lagi saling mengunci** walau komentar di dalamnya masih mengaku demikian.

## Kenapa CI hijau selama ini

Tesnya **ada** — `04_cetak_kloter.sql` bagian 4.4 — dan lolos karena kebetulan. `lompatan_kloter = 2` membuat data uji hanya mengisi kloter ganjil, dan kloter genap yang kosong tidak pernah ditandai tercetak; putaran pertama mendarat di celah kosong itu. Di lapangan celah itu habis begitu kloter 1..30 semuanya berisi.

**4.4b** menirukan keadaan lapangan: seluruh kloter dasar ditandai tercetak, lalu satu sekolah susulan mendaftar — ia harus mendapat kloter cadangan, bukan gagal.

## Dibuktikan, bukan diasumsikan

Commit `84b0a5c` di branch ini **sengaja mematikan 0040** supaya CI memperlihatkan 4.4b gagal dengan pesan trigger yang sama seperti di lapangan:

```
ERROR: kloter 2 sudah dicetak — regu baru tidak boleh disisipkan ke sana.
```

Tes regresi yang tidak pernah gagal pada bugnya tidak menjaga apa-apa, dan 4.4 membuktikan itu bisa terjadi diam-diam berbulan-bulan.

## Notes

Badan fungsinya **disalin dari 0014 oleh skrip**, bukan diketik ulang — mengetik ulang 8.000 karakter adalah cara paling mudah menyelundupkan perbedaan yang tidak disengaja, dan itu persis yang terjadi pada 0011. Tambalannya dihitung dan diperiksa jumlahnya: empat sisipan, satu penggantian nama kunci.

4.4b membersihkan jejaknya sendiri (sekolah, pendaftaran, pembayaran, regu, dan tanda cetak) — tanpa itu 4.5 menghitung 2 kloter baru alih-alih 1, dan yang gagal bukan tes yang meninggalkan jejaknya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)