### PR TITLE
fix: tukar nomor dada tidak lagi selalu memensiunkan nomor lama

### DIFF
--- a/supabase/migrations/0041_tukar_nomor_tanpa_pensiun.sql
+++ b/supabase/migrations/0041_tukar_nomor_tanpa_pensiun.sql
@@ -1,0 +1,127 @@
+-- ============================================================================
+-- hrcd-rekap : 0041_tukar_nomor_tanpa_pensiun.sql
+--
+-- Menukar nomor dada tidak lagi selalu memensiunkan nomor lama.
+--
+-- ---------------------------------------------------------------------------
+-- YANG SALAH
+--
+-- `tukar_nomor_dada` SELALU memasukkan nomor lama ke `nomor_dada_pensiun`,
+-- dan nomor pensiun ditolak selamanya oleh `daftar_ulang_batch` maupun oleh
+-- fungsi ini sendiri. Alasannya masuk akal untuk satu keadaan: lembar yang
+-- sudah tercetak masih menuliskan nomor lama, jadi nomor itu tidak boleh
+-- terbit ulang ke regu lain.
+--
+-- Tapi ia berlaku untuk SEMUA keadaan, termasuk yang paling sering: petugas
+-- meja salah ketik satu digit. Kain nomor lama masih utuh di kardus, belum
+-- pernah dipakai siapa pun, belum tercetak di lembar mana pun — dan ia mati
+-- permanen. Regu yang benar-benar memegang kain itu nanti ditolak sistem, dan
+-- tidak ada satu pun layar yang bisa menghidupkannya kembali.
+--
+-- Itu menjadikan satu-satunya tombol pembetulan di layar Daftar Ulang lebih
+-- merugikan daripada kesalahan yang diperbaikinya.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DIPERTAHANKAN, DAN KENAPA
+--
+-- Pemensiunan tetap berjalan bila kertas kloternya SUDAH DICETAK atau kloternya
+-- sudah berangkat — patokan yang sama persis dengan yang sudah dipakai fungsi
+-- ini untuk memutuskan siapa boleh menukar.
+--
+-- Alasannya menguat sejak form per lomba dipakai: slip yang ditulis petugas di
+-- wahana hanya memuat NOMOR DADA, tanpa nama regu. Kalau 001 terbit ulang ke
+-- regu lain, slip bertuliskan 001 tidak bisa lagi dipastikan milik siapa —
+-- lembar lama menyebut satu nama, kenyataan menyebut nama lain, dan tidak ada
+-- apa pun di kertas yang membedakannya.
+--
+-- ---------------------------------------------------------------------------
+-- SATU PATOKAN, BUKAN DUA
+--
+-- "Apakah kertas sudah beredar" kini dihitung sekali ke dalam v_beredar dan
+-- dipakai oleh izin maupun pemensiunan. Dua salinan syarat yang sama adalah
+-- cara mereka mulai berbeda pendapat — dan itu persis cacat yang dibetulkan
+-- 0019, ketika izin memakai jam_berangkat sementara komentarnya bicara soal
+-- kertas dicetak.
+--
+-- Badan fungsinya disalin dari 0019 oleh skrip, dengan tiga tambalan yang
+-- diperiksa jumlahnya.
+-- ============================================================================
+
+create or replace function tukar_nomor_dada(
+  p_regu       uuid,
+  p_nomor_baru integer,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu    regu%rowtype;
+  v_beredar boolean;
+begin
+  if peran() not in ('admin', 'meja') then
+    raise exception 'hanya meja/admin';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan tukar wajib diisi';
+  end if;
+
+  select * into v_regu from regu where id = p_regu for update;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_regu.is_cancelled then
+    raise exception 'regu berstatus batal';
+  end if;
+  if v_regu.nomor_dada is null then
+    raise exception 'regu belum punya nomor dada';
+  end if;
+  -- Begitu kertasnya DICETAK, lembar yang beredar memakai nomor lama —
+  -- penukaran hanya boleh oleh admin yang paham konsekuensinya. Keberangkatan
+  -- ikut dihitung karena kloter yang sudah jalan pasti kertasnya beredar,
+  -- walau tanda cetaknya sempat dibatalkan (batalkan_tanda_cetak tidak
+  -- memeriksa keberangkatan sama sekali).
+  v_beredar := exists (
+    select 1 from kloter where nomor = v_regu.kloter_nomor
+      and (dicetak_pada is not null or jam_berangkat is not null));
+
+  if peran() <> 'admin' and v_beredar then
+    raise exception 'kertas kloter ini sudah beredar — tukar nomor hanya lewat admin';
+  end if;
+  if not exists (select 1 from nomor_dada_stok where nomor = p_nomor_baru) then
+    raise exception 'nomor % tidak ada di stok', p_nomor_baru;
+  end if;
+  if exists (select 1 from regu where nomor_dada = p_nomor_baru)
+     or exists (select 1 from nomor_dada_pensiun where nomor = p_nomor_baru) then
+    raise exception 'nomor % sudah terpakai / pensiun', p_nomor_baru;
+  end if;
+
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('regu', p_regu::text, p_regu, 'UPDATE',
+          jsonb_build_object('alasan_tukar_nomor', p_alasan,
+                             'nomor_lama', v_regu.nomor_dada,
+                             'nomor_baru', p_nomor_baru), auth.uid());
+
+  -- Nomor lama dipensiunkan HANYA bila kertasnya sudah beredar.
+  --
+  -- Dulu selalu, dan itu menghukum kasus yang paling sering: petugas meja
+  -- salah ketik satu digit, lalu kain nomor lama yang masih utuh di kardus
+  -- ikut mati — regu yang benar-benar memegangnya nanti ditolak permanen.
+  --
+  -- Sesudah kertas beredar ceritanya lain, dan justru makin genting sejak
+  -- form per lomba dipakai: slip yang ditulis petugas hanya memuat NOMOR DADA.
+  -- Kalau 001 terbit ulang ke regu lain, slip bertuliskan 001 tidak bisa lagi
+  -- dipastikan milik siapa — lembar lama menyebut Melati, kenyataan menyebut
+  -- orang lain, dan tidak ada apa pun di kertas yang membedakannya.
+  --
+  -- Patokannya SATU variabel dengan yang mengatur izin di atas. Dua patokan
+  -- terpisah untuk pertanyaan yang sama ("apakah kertas sudah beredar") adalah
+  -- cara mereka mulai berbeda pendapat — persis yang dibetulkan 0019.
+  if v_beredar then
+    insert into nomor_dada_pensiun (nomor, reason)
+    values (v_regu.nomor_dada, p_alasan);
+  end if;
+
+  update regu set nomor_dada = p_nomor_baru where id = p_regu;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -130,4 +130,11 @@ run supabase/migrations/0038_petunjuk_menaksir.sql
 # database uji `menaksir` tidak ada, jadi UPDATE-nya melapor dilewati.
 run supabase/migrations/0039_judul_isian.sql
 
+# 0041 mengubah kapan nomor lama dipensiunkan. Dijalankan di akhir supaya tes
+# 04 dan 05 masih memakai perilaku lama saat mereka berjalan — keduanya tidak
+# menyentuh tukar_nomor_dada, tapi urutan yang jelas lebih murah daripada
+# menelusuri kenapa satu tes berubah arti.
+run supabase/migrations/0041_tukar_nomor_tanpa_pensiun.sql
+run tests/sql/17_tukar_nomor_tanpa_pensiun.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/sql/17_tukar_nomor_tanpa_pensiun.sql
+++ b/tests/sql/17_tukar_nomor_tanpa_pensiun.sql
@@ -1,0 +1,99 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/17_tukar_nomor_tanpa_pensiun.sql
+-- Menukar nomor dada (0041): kapan nomor lama boleh dipakai lagi.
+--
+-- Dua keadaan yang berlawanan, dan keduanya harus tetap berlawanan:
+--
+--   kertas BELUM beredar  -> nomor lama KEMBALI ke stok, boleh dipakai lagi
+--   kertas SUDAH beredar  -> nomor lama PENSIUN, tidak pernah terbit ulang
+--
+-- Yang pertama adalah kasus paling sering: petugas meja salah ketik satu
+-- digit. Dulu nomor itu mati permanen walau kainnya masih utuh di kardus.
+--
+-- Yang kedua bukan kehati-hatian berlebih. Slip form per lomba hanya memuat
+-- NOMOR DADA tanpa nama regu; kalau 001 terbit ulang, slip bertuliskan 001
+-- tidak bisa lagi dipastikan milik siapa.
+-- ============================================================================
+
+select set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', false);
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 17.1 Kertas BELUM beredar: nomor lama kembali ke peredaran.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_regu  uuid;
+  v_lama  integer;
+  v_baru  integer;
+begin
+  -- Regu yang kloternya belum dicetak dan belum berangkat.
+  select r.id, r.nomor_dada into v_regu, v_lama
+  from regu r join kloter k on k.nomor = r.kloter_nomor
+  where r.nomor_dada is not null and not r.is_cancelled
+    and k.dicetak_pada is null and k.jam_berangkat is null
+  order by r.nomor_dada limit 1;
+  assert v_regu is not null, 'tidak ada regu di kloter yang belum beredar';
+
+  select s.nomor into v_baru from nomor_dada_stok s
+  where not exists (select 1 from regu where nomor_dada = s.nomor)
+    and not exists (select 1 from nomor_dada_pensiun where nomor = s.nomor)
+  order by s.nomor desc limit 1;
+
+  perform tukar_nomor_dada(v_regu, v_baru, 'uji: salah ketik di meja');
+
+  assert (select nomor_dada from regu where id = v_regu) = v_baru,
+    'nomor baru tidak terpasang';
+  assert not exists (select 1 from nomor_dada_pensiun where nomor = v_lama),
+    format('nomor %s dipensiunkan padahal kertasnya belum beredar', v_lama);
+
+  -- Dan benar-benar bisa dipakai lagi, bukan sekadar tidak tercatat pensiun.
+  perform tukar_nomor_dada(v_regu, v_lama, 'uji: dikembalikan');
+  assert (select nomor_dada from regu where id = v_regu) = v_lama,
+    'nomor lama tidak bisa dipakai lagi padahal tidak pensiun';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 17.2 Kertas SUDAH beredar: nomor lama pensiun, dan penukaran hanya oleh
+--      admin. Dijalankan sebagai admin karena meja memang ditolak di sini.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+
+do $$
+declare
+  v_regu uuid;
+  v_lama integer;
+  v_baru integer;
+begin
+  select r.id, r.nomor_dada into v_regu, v_lama
+  from regu r join kloter k on k.nomor = r.kloter_nomor
+  where r.nomor_dada is not null and not r.is_cancelled
+    and k.dicetak_pada is not null
+  order by r.nomor_dada limit 1;
+  assert v_regu is not null, 'tidak ada regu di kloter yang sudah dicetak';
+
+  select s.nomor into v_baru from nomor_dada_stok s
+  where not exists (select 1 from regu where nomor_dada = s.nomor)
+    and not exists (select 1 from nomor_dada_pensiun where nomor = s.nomor)
+  order by s.nomor desc limit 1;
+
+  perform tukar_nomor_dada(v_regu, v_baru, 'uji: kain robek di lapangan');
+
+  assert (select nomor_dada from regu where id = v_regu) = v_baru,
+    'nomor baru tidak terpasang';
+  assert exists (select 1 from nomor_dada_pensiun where nomor = v_lama),
+    format('nomor %s TIDAK dipensiunkan padahal kertasnya sudah beredar', v_lama);
+
+  -- Dan penolakannya nyata, bukan sekadar tercatat di tabel pensiun.
+  begin
+    perform tukar_nomor_dada(v_regu, v_lama, 'uji: seharusnya ditolak');
+    raise exception 'GAGAL: nomor pensiun masih bisa dipakai lagi';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+  end;
+end;
+$$;
+
+reset role;
+select '17_tukar_nomor_tanpa_pensiun OK' as hasil;


### PR DESCRIPTION
## What

| Keadaan | Sebelum | Sekarang |
|---|---|---|
| Kertas **belum** beredar (salah ketik di meja) | nomor lama **pensiun permanen** | **kembali ke stok** |
| Kertas **sudah** dicetak / kloter berangkat | nomor lama pensiun | pensiun (tetap) |

## Why

`tukar_nomor_dada` selalu memensiunkan nomor lama, dan nomor pensiun ditolak selamanya. Alasannya masuk akal untuk satu keadaan — lembar tercetak masih menuliskan nomor lama.

Tapi ia berlaku untuk **semua** keadaan, termasuk yang paling sering: petugas meja salah ketik satu digit. Kain nomor lama **masih utuh di kardus**, belum dipakai siapa pun, belum tercetak di lembar mana pun — dan mati permanen. Regu yang benar-benar memegangnya nanti ditolak sistem, dan tidak ada layar yang bisa menghidupkannya kembali.

Satu-satunya tombol pembetulan di layar Daftar Ulang jadi **lebih merugikan daripada kesalahan yang diperbaikinya.**

## Notes — kenapa carve-out-nya tetap ada

Alasannya **menguat** sejak form per lomba dipakai: slip yang ditulis petugas di wahana hanya memuat **nomor dada**, tanpa nama regu. Kalau `001` terbit ulang ke regu lain, slip bertuliskan `001` tidak bisa lagi dipastikan milik siapa — lembar lama menyebut satu nama, kenyataan menyebut nama lain, dan tidak ada apa pun di kertas yang membedakannya.

Patokannya **sama persis** dengan yang sudah dipakai fungsi ini untuk memutuskan siapa boleh menukar, dan kini dihitung sekali ke `v_beredar`. Dua salinan syarat yang sama adalah cara mereka mulai berbeda pendapat — persis cacat yang dibetulkan `0019`.

Tes 17 menjaga keduanya tetap berlawanan, dan **tidak berhenti pada tabel pensiun**: yang belum beredar dibuktikan bisa dipakai lagi, yang sudah beredar dibuktikan ditolak saat dicoba.

Badan fungsinya disalin dari `0019` oleh skrip dengan tiga tambalan yang diperiksa jumlahnya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)