### PR TITLE
docs: peserta mengonfirmasi datanya sebelum kertas dicetak

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -138,8 +138,25 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 7. **Kloternya tetap ditentukan sistem** (bagian 5.3). Yang manual hanya
    nomor dadanya; penyebaran kloter justru tidak boleh diserahkan ke petugas
    karena bertumpu pada keadaan seluruh sekolah, bukan satu meja saja.
-8. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
-   petugas lapangan (bagian 8.6).
+8. **Peserta wajib mengonfirmasi datanya sendiri, termasuk nomor dada,
+   sebelum kertas dicetak.** Yang dikonfirmasi: nama regu, asal sekolah,
+   golongan, dan nomor dada tiap regu.
+
+   Ini bukan formalitas, melainkan pintu terakhir yang masih murah. Sesudah
+   lembar kloter dicetak, isinya dibekukan: menambah regu ke kloter tercetak
+   ditolak sistem, dan menukar nomor dada hanya boleh lewat admin — nomor
+   lamanya pun dipensiunkan permanen, karena kertas yang sudah beredar masih
+   menuliskannya (bagian 8.8).
+
+   Harganya naik lagi sesudah lomba mulai. Slip penilaian per lomba hanya
+   memuat NOMOR DADA tanpa nama regu, jadi nomor dada yang salah bukan
+   sekadar salah tulis — ia memindahkan seluruh nilai satu regu ke regu lain,
+   dan tidak ada apa pun di kertas yang memperlihatkannya.
+
+   Sebelum dicetak, pembetulan hanya perlu satu ketukan di meja: nomor lama
+   kembali ke stok dan bisa langsung dipakai regu yang benar.
+9. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
+   petugas lapangan (bagian 8.8).
 
 ## 5. Kloter dan kontrak waktu
 

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -155,6 +155,17 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
    Sebelum dicetak, pembetulan hanya perlu satu ketukan di meja: nomor lama
    kembali ke stok dan bisa langsung dipakai regu yang benar.
+
+   **Bentuknya lisan: panitia membacakan, peserta mengiyakan.** Tidak ada
+   lembar tanda tangan dan tidak ada centang di sistem. Itu keputusan sadar —
+   tiap langkah tambahan di meja daftar ulang berlipat lebih dari seratus
+   sekolah, dan antrean di meja adalah biaya yang dibayar semua orang.
+
+   Yang ikut hilang disebutkan supaya tidak jadi kejutan: **tidak ada catatan
+   siapa mengonfirmasi apa dan kapan**. Kalau nanti ada sekolah yang membantah
+   nomor dadanya, tidak ada yang bisa ditunjukkan selain riwayat perubahan di
+   `history`, dan riwayat itu mencatat panitia yang mengetik — bukan peserta
+   yang mengiyakan.
 9. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
    petugas lapangan (bagian 8.8).
 


### PR DESCRIPTION
## What

Bagian 4 (Daftar ulang) butir 8 yang baru: **peserta wajib mengonfirmasi datanya sendiri — nama regu, asal sekolah, golongan, dan nomor dada — sebelum kertas dicetak.**

## Why

Yang dicatat bukan cuma aturannya, melainkan kenapa ia diletakkan **sebelum** cetak: di situlah pembetulan masih murah.

| Kapan | Biaya membetulkan nomor dada |
|---|---|
| Sebelum cetak | satu ketukan di meja; nomor lama kembali ke stok |
| Sesudah cetak | hanya lewat admin, dan nomor lama **pensiun permanen** |
| Sesudah lomba mulai | nilai satu regu pindah ke regu lain, tanpa jejak di kertas |

Baris terakhir itu alasan yang **baru muncul bulan ini**: slip penilaian per lomba hanya memuat **nomor dada** tanpa nama regu. Nomor dada yang salah bukan sekadar salah tulis — dan tidak ada apa pun di kertas yang memperlihatkannya.

## Notes

Rujukan `8.6` di butir berikutnya ikut dibetulkan jadi `8.8`; penomorannya bergeser sejak bagian 8 ditulis ulang untuk alur kotak penilaian.

Dokumen saja. Belum ada kertas yang bisa dikonfirmasi peserta — kwitansi terbit **sebelum** nomor dada ada, dan lembar kloter dicetak untuk petugas staging, bukan untuk sekolah. Artefaknya menyusul terpisah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)