### PR TITLE
feat: kotak jam jadi sepasang [HH] : [MM], luapan otomatis dipertahankan

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -208,67 +208,134 @@ export function detikTeks(total) {
  *  isinya bukan jam. Membetulkan saat blur, BUKAN saat tiap ketukan — menata
  *  ulang teks di tengah orang mengetik memindahkan kursornya dan membuat
  *  angka berikutnya mendarat di tempat yang salah. */
-/** Titik dua disisipkan SETELAH DUA ANGKA: mengetik 15 langsung jadi "15:",
- *  lalu 03 mengisi menitnya. Dua angka pertama SELALU jam, dua berikutnya
- *  SELALU menit — angka yang sudah diketik tidak pernah berubah arti oleh
- *  angka sesudahnya.
+/** DUA KOTAK JAM: [HH] : [MM], tapi mengetik "1503" beruntun tetap jalan.
  *
- *  SATU PENGECUALIAN, DAN IA MENYELAMATKAN CARA MENGETIK YANG PALING SERING.
+ *  Dua kotak supaya bagian menit bisa diklik dan diperbaiki sendiri tanpa
+ *  mengetik ulang jamnya. Satu kotak tidak bisa memberi itu: mengklik di tengah
+ *  lalu mengetik membuat kursor melompat ke ujung.
  *
- *  Jam tertinggi 23, jadi angka pertama 3-9 MUSTAHIL menjadi awal jam dua
- *  angka. Kalau yang diketik 7, satu-satunya bacaan yang mungkin adalah jam
- *  07 — jadi nolnya dipasangkan saat itu juga, dan "745" jadi "07:45".
+ *  Yang tidak boleh hilang karena pemisahan itu adalah mengetik beruntun.
+ *  Petugas keberangkatan mengetik empat angka tanpa melihat layar, dan memaksa
+ *  mereka berpindah kotak di tengah akan lebih lambat daripada sebelumnya. Jadi
+ *  HH MELUAP sendiri ke MM begitu ia penuh.
  *
- *  Tanpa pengecualian itu "745" akan jadi "74:5" dan ditolak, padahal itulah
- *  bentuk yang paling sering diketik petugas untuk jam pagi — dan lomba ini
- *  berangkat pukul tujuh.
+ *  KAPAN HH DIANGGAP PENUH — dan di sinilah satu aturan menyelamatkan bentuk
+ *  ketikan yang paling sering:
+ *
+ *    dua angka           -> penuh. "15" lalu lompat.
+ *    satu angka 3-9      -> penuh JUGA, dan dijadikan "07".
+ *
+ *  Jam tertinggi 23, jadi angka pertama 3-9 mustahil menjadi awal jam dua
+ *  angka: kalau yang diketik 7, satu-satunya bacaan yang mungkin adalah 07.
+ *  Karena itu "745" jadi 07:45 — bentuk yang paling sering diketik untuk jam
+ *  pagi, dan lomba ini berangkat pukul tujuh.
  *
  *  Yang dikorbankan: "250" tidak lagi terbaca 2:50, karena angka pertama 2
  *  memang bisa menjadi awal jam 20-23. Jam dua pagi tidak pernah terjadi di
  *  lomba yang berangkat pukul 07.00 dan selesai sore.
- *
- *  Dibatasi empat angka. Jam mana pun muat, dan angka kelima yang diterima
- *  diam-diam cuma akan ditolak saat kotaknya ditinggalkan. */
-export function maskJam(teks) {
-  let angka = String(teks ?? "").replace(/\D/g, "");
-  if (angka.length && Number(angka[0]) > 2) angka = "0" + angka;
-  angka = angka.slice(0, 4);
-  if (angka.length < 2) return angka;
-  return `${angka.slice(0, 2)}:${angka.slice(2)}`;
+ */
+
+/** Markup sepasang kotak jam. `id` jadi patokan: `<id>-hh` dan `<id>-mm`. */
+export function kotakJamHtml(id, nilai = "") {
+  const [hh = "", mm = ""] = String(nilai || "").split(":");
+  return `<span class="jam-pasang" id="${id}">
+    <input type="text" class="jam-ketik jam-hh" id="${id}-hh" value="${hh}"
+           inputmode="numeric" maxlength="2" autocomplete="off"
+           spellcheck="false" placeholder="HH" aria-label="Jam">
+    <span class="jam-titik" aria-hidden="true">:</span>
+    <input type="text" class="jam-ketik jam-mm" id="${id}-mm" value="${mm}"
+           inputmode="numeric" maxlength="2" autocomplete="off"
+           spellcheck="false" placeholder="MM" aria-label="Menit">
+  </span>`;
 }
 
-
-/** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:
- *  menyisipkan titik dua sambil diketik, membetulkan bentuknya saat kotak
- *  ditinggalkan, dan menandainya merah kalau isinya bukan jam.
+/** Menyalakan sepasang kotak jam dan mengembalikan kendalinya.
  *
- *  MENGHAPUS TIDAK IKUT DIRAPIKAN, dan itu bukan kelalaian. Kalau setiap
- *  ketukan dirapikan termasuk backspace, menghapus satu huruf dari "15:03"
- *  menyisakan "15:0" yang lalu dibaca ulang jadi "1:50" — angka berubah
- *  sendiri di bawah jari orang yang sedang membetulkannya. Jadi saat
- *  menghapus, isinya dibiarkan apa adanya sampai kotaknya ditinggalkan. */
-export function pasangKotakJam(el) {
-  if (!el) return;
-  const nilai = () => jamSah(el.value);
-  el.addEventListener("blur", () => {
-    if (!el.value.trim()) { el.classList.remove("jam-salah"); return; }
-    const v = nilai();
-    if (v) { el.value = v; el.classList.remove("jam-salah"); }
-    else el.classList.add("jam-salah");
-  });
-  el.addEventListener("input", (e) => {
-    if (!String(e.inputType || "").startsWith("delete")) {
-      const rapi = maskJam(el.value);
-      if (rapi !== el.value) {
-        el.value = rapi;
-        // Kursor ke ujung. Kotak selebar lima huruf tidak dipakai menyunting
-        // di tengah, dan kursor yang melompat ke tempat tak terduga lebih
-        // membingungkan daripada mengetik ulang empat angka.
-        try { el.setSelectionRange(rapi.length, rapi.length); } catch { /* input tanpa seleksi */ }
-      }
+ *  Sengaja BUKAN objek yang menyamar jadi <input>. Layar memanggil nilai() dan
+ *  setNilai() dengan nama itu, jadi terbaca bahwa yang dipegang adalah sepasang
+ *  kotak — bukan satu kotak yang kebetulan punya titik dua. */
+export function pasangKotakJam(id) {
+  const wadah = document.getElementById(id);
+  if (!wadah) return null;
+  const hh = document.getElementById(`${id}-hh`);
+  const mm = document.getElementById(`${id}-mm`);
+  const pendengar = [];
+
+  const gabung = () => `${hh.value.trim()}${mm.value.trim()}`;
+  const nilai = () => jamSah(gabung());
+
+  const tandai = () => {
+    const kosong = !hh.value.trim() && !mm.value.trim();
+    const buruk = !kosong && !nilai();
+    // Merah dipasang di WADAH, bukan di salah satu kotak: yang salah adalah
+    // jamnya sebagai satu kesatuan, dan menyalahkan kotak menit untuk jam 25
+    // menyuruh petugas membetulkan tempat yang benar.
+    wadah.classList.toggle("jam-salah", buruk);
+    return !buruk;
+  };
+
+  const beri = (fn) => { pendengar.forEach(fn); };
+
+  hh.addEventListener("input", () => {
+    const angka = hh.value.replace(/\D/g, "");
+    // Ketikan beruntun / tempel: sisanya dijatuhkan ke menit, bukan dibuang.
+    if (angka.length > 2) {
+      hh.value = angka.slice(0, 2);
+      mm.value = angka.slice(2, 4);
+      mm.focus(); mm.setSelectionRange(mm.value.length, mm.value.length);
+    } else if (angka.length === 2) {
+      hh.value = angka; mm.focus(); mm.select();
+    } else if (angka.length === 1 && Number(angka) > 2) {
+      hh.value = `0${angka}`; mm.focus(); mm.select();
+    } else {
+      hh.value = angka;
     }
-    if (nilai() || !el.value.trim()) el.classList.remove("jam-salah");
+    tandai(); beri(f => f());
   });
+
+  mm.addEventListener("input", () => {
+    mm.value = mm.value.replace(/\D/g, "").slice(0, 2);
+    tandai(); beri(f => f());
+  });
+
+  // Backspace di menit yang sudah kosong melompat balik ke jam. Tanpa itu
+  // petugas harus mengangkat tangan dari papan angka untuk mengetuk kotak
+  // sebelahnya — satu-satunya gerakan yang tidak bisa dilakukan sambil menatap
+  // regu di depan meja.
+  mm.addEventListener("keydown", (e) => {
+    if (e.key === "Backspace" && mm.value === "") {
+      hh.focus(); hh.setSelectionRange(hh.value.length, hh.value.length);
+    }
+  });
+
+  // Dirapikan saat SEPASANG kotak ini ditinggalkan, bukan saat pindah antar
+  // keduanya: "7" di jam belum tentu salah, ia mungkin sedang menuju "07".
+  const rapikan = () => {
+    setTimeout(() => {
+      if (document.activeElement === hh || document.activeElement === mm) return;
+      const v = nilai();
+      if (v) { [hh.value, mm.value] = v.split(":"); }
+      tandai();
+    }, 0);
+  };
+  hh.addEventListener("blur", rapikan);
+  mm.addEventListener("blur", rapikan);
+
+  return {
+    nilai,
+    setNilai(v) {
+      const [a = "", b = ""] = String(v || "").split(":");
+      hh.value = a; mm.value = b; tandai();
+    },
+    kosong: () => !hh.value.trim() && !mm.value.trim(),
+    salah(ya) { wadah.classList.toggle("jam-salah", !!ya); },
+    fokus() { hh.focus(); hh.select(); },
+    dengar(fn) { pendengar.push(fn); },
+    // Peristiwa DOM dipasang ke KEDUA kotak. Enter di kotak menit harus
+    // menyimpan sama seperti Enter di kotak jam — petugas tidak boleh perlu
+    // tahu kotak mana yang sedang aktif.
+    pada(nama, fn) { hh.addEventListener(nama, fn); mm.addEventListener(nama, fn); },
+  };
 }
 
 /** Notifikasi bawah layar.

--- a/live/style.css
+++ b/live/style.css
@@ -203,14 +203,29 @@ input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min
    kotak selebar layar mengundang orang mengetik kalimat ke dalamnya. Angka
    tabular supaya "11:11" dan "07:45" sama lebarnya dan kolomnya tidak
    bergoyang saat diketik. */
+/* SEPASANG kotak jam: [HH] : [MM]. Dipisah supaya bagian menit bisa diklik
+   dan diperbaiki sendiri; mengetik beruntun tetap jalan karena HH meluap ke MM
+   (pasangKotakJam di util.js). */
+.jam-pasang {
+  display: inline-flex; align-items: center; gap: .3rem;
+}
+.jam-titik {
+  font-size: 1.25rem; font-weight: 700; line-height: 1;
+  /* Sedikit terangkat: titik dua duduk di garis dasar huruf, sementara yang
+     harus disejajarkan adalah TENGAH kotak di kiri-kanannya. */
+  transform: translateY(-.06em);
+}
 input.jam-ketik {
-  width: 7.5em;
+  width: 3.2em;
   max-width: 100%;
   font-variant-numeric: tabular-nums;
   letter-spacing: .08em;
   text-align: center;
 }
-input.jam-ketik.jam-salah {
+/* Merah dipasang di WADAH, bukan salah satu kotak: yang salah adalah jamnya
+   sebagai satu kesatuan. Menyalahkan kotak menit untuk "jam 25" menyuruh
+   petugas membetulkan tempat yang keliru. */
+.jam-pasang.jam-salah input.jam-ketik {
   border-color: var(--bahaya);
   background: var(--bahaya-muda);
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -24,7 +24,8 @@ import {
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
-         berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks } from "./util.js";
+         berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
+         kotakJamHtml } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -1165,11 +1166,7 @@ async function layarKeberangkatan() {
                    browser merender AM/PM kalau locale browsernya Inggris, dan
                    tidak ada atribut yang bisa memaksanya 24 jam. Lihat
                    jamSah() di util.js. -->
-              <input type="text" id="jam-berangkat" class="jam-ketik"
-                     inputmode="numeric" maxlength="5" autocomplete="off"
-                     spellcheck="false" placeholder="HH:MM"
-                     aria-describedby="hint-jam-berangkat"
-                     value="${jamMenit(new Date())}">
+              ${kotakJamHtml("jam-berangkat", jamMenit(new Date()))}
               <div class="hint" id="hint-jam-berangkat">24 jam · 00:00–23:59</div>
             </div>
             <button class="button button-primary" id="aksi-berangkat" type="button">
@@ -1345,24 +1342,25 @@ async function layarKeberangkatan() {
       gambarKloter();
     });
 
-    const kotakJamBerangkat = document.getElementById("jam-berangkat");
-    pasangKotakJam(kotakJamBerangkat);
+    const kotakJamBerangkat = pasangKotakJam("jam-berangkat");
 
     const tombol = document.getElementById("aksi-berangkat");
     if (tombol) tombol.addEventListener("click", async () => {
       if (tombol.dataset.jalan === "1") return;
-      const mentah = kotakJamBerangkat.value.trim();
-      if (!mentah) { notif("Jam berangkat wajib diisi.", true); return; }
+      if (kotakJamBerangkat.kosong()) {
+        notif("Jam berangkat wajib diisi.", true); return;
+      }
       // Ditolak, bukan ditebak. Jam berangkat menentukan penalti seluruh
-      // kloter — menebak maksud "1975" akan menghukum sepuluh regu sekaligus.
-      const hhmm = jamSah(mentah);
+      // kloter — menebak maksud "19:75" akan menghukum sepuluh regu sekaligus.
+      const hhmm = kotakJamBerangkat.nilai();
       if (!hhmm) {
-        kotakJamBerangkat.classList.add("jam-salah");
-        kotakJamBerangkat.focus();
-        notif(`"${mentah}" bukan jam yang sah. Pakai 00:00–23:59, misalnya 07:15.`, true);
+        kotakJamBerangkat.salah(true);
+        kotakJamBerangkat.fokus();
+        notif("Jam berangkat belum lengkap atau di luar 00:00–23:59. "
+              + "Contoh: 07:15.", true);
         return;
       }
-      kotakJamBerangkat.value = hhmm;
+      kotakJamBerangkat.setNilai(hhmm);
       tombol.dataset.jalan = "1"; tombol.disabled = true; tombol.textContent = "Menyimpan…";
       try {
         await berangkatkanKloter(kloterAktif, jamHariIni(hhmm).toISOString());
@@ -1592,9 +1590,7 @@ function layarFinish() {
             <label for="jam">Jam datang</label>
             <!-- Kotak ketik, alasan sama dengan jam berangkat: pemilih bawaan
                  browser bisa muncul sebagai AM/PM. Lihat jamSah() di util.js. -->
-            <input type="text" id="jam" class="jam-ketik" inputmode="numeric"
-                   maxlength="5" autocomplete="off" spellcheck="false"
-                   placeholder="HH:MM">
+            ${kotakJamHtml("jam")}
             <div class="hint">24 jam · kosong = jam saat tombol ditekan.</div>
           </div>
           <div class="field" style="margin:0">
@@ -1616,7 +1612,7 @@ function layarFinish() {
   const inp = document.getElementById("dada");
   const kotak = document.getElementById("kartu-regu");
   const tombol = document.getElementById("sampai");
-  const inpJam = document.getElementById("jam");
+  const inpJam = pasangKotakJam("jam");
   const inpHadir = document.getElementById("hadir");
   let regu = null;
   let jeda = null;
@@ -1624,9 +1620,11 @@ function layarFinish() {
   inp.focus();
   gambarRiwayat();
 
-  [inpJam, inpHadir].forEach(el => el.addEventListener("keydown", e => {
+  const enter = (e) => {
     if (e.key === "Enter" && !tombol.disabled) { e.preventDefault(); tombol.click(); }
-  }));
+  };
+  inpJam.pada("keydown", enter);
+  inpHadir.addEventListener("keydown", enter);
 
   // Angka penalti dipakai untuk menjawab pertanyaan yang sebenarnya saat
   // membandingkan catatan kertas dengan jam tombol: bukan "beda berapa menit",
@@ -1653,7 +1651,7 @@ function layarFinish() {
     // Setengah jam yang sedang diketik ("07" menuju "07:15") bukan jam, dan
     // menghitung dampak dari angka setengah jadi membuat lencananya
     // berkedip-kedip menampilkan penalti yang tidak pernah berlaku.
-    const isi = jamSah(inpJam.value);
+    const isi = inpJam.nilai();
     const jamIsi = isi ? jamHariIni(isi) : dasar;
     const pDasar = hitungPenalti(dasar, regu.target_datang);
     const pIsi = hitungPenalti(jamIsi, regu.target_datang);
@@ -1673,12 +1671,11 @@ function layarFinish() {
       ? html`<span class="badge badge-green">${arah} — penalti tetap ${tulis(pIsi)}</span>`
       : html`<span class="badge badge-yellow">${arah} — penalti berubah ${tulis(pDasar)} → ${tulis(pIsi)}</span>`;
   };
-  inpJam.addEventListener("input", perbaruiDampak);
-  pasangKotakJam(inpJam);
+  inpJam.dengar(perbaruiDampak);
   // Bentuknya dirapikan saat kotak ditinggalkan, jadi lencana dampaknya ikut
   // dihitung ulang sesudah itu — tanpa ini "745" yang jadi "07:45" saat blur
   // meninggalkan lencana menampilkan hitungan dari teks yang sudah tidak ada.
-  inpJam.addEventListener("blur", perbaruiDampak);
+
 
   const bersihkan = () => {
     regu = null;
@@ -1746,7 +1743,7 @@ function layarFinish() {
     // Regu yang sudah tercatat: tampilkan jam lamanya di kolom perbaikan,
     // supaya verifikasi terhadap kertas tinggal membandingkan lalu mengubah.
     if (r.sudah_finish && r.jam_datang) {
-      inpJam.value = jamMenit(r.jam_datang);
+      inpJam.setNilai(jamMenit(r.jam_datang));
       inpHadir.value = r.anggota_hadir ?? 5;
     }
     perbaruiDampak();
@@ -1765,12 +1762,12 @@ function layarFinish() {
     // bukan diam-diam dilewati: petugas mengetiknya justru karena jam tombol
     // salah, dan menyimpan jam tombol setelah ia mengetik yang lain adalah
     // membuang koreksi yang sedang dia kerjakan.
-    const jamKetikan = inpJam.value.trim();
-    const jamIsi = jamKetikan ? jamSah(jamKetikan) : null;
-    if (jamKetikan && !jamIsi) {
-      inpJam.classList.add("jam-salah");
-      inpJam.focus();
-      notif(`"${jamKetikan}" bukan jam yang sah. Pakai 00:00–23:59, atau kosongkan.`, true);
+    const jamIsi = inpJam.kosong() ? null : inpJam.nilai();
+    if (!inpJam.kosong() && !jamIsi) {
+      inpJam.salah(true);
+      inpJam.fokus();
+      notif("Jam datang belum lengkap atau di luar 00:00–23:59. "
+            + "Kosongkan untuk memakai jam saat tombol ditekan.", true);
       return;
     }
     tombol.dataset.jalan = "1"; tombol.disabled = true;
@@ -1791,7 +1788,7 @@ function layarFinish() {
     catatTerakhir("finish", String(dada).padStart(3, "0"),
       `${nama} — ${jamMenit(jam)}${hadir < 5 ? ` · ${hadir} anggota` : ""}`);
     tombol.dataset.jalan = "";
-    inp.value = ""; inpJam.value = ""; inpHadir.value = "5";
+    inp.value = ""; inpJam.setNilai(""); inpHadir.value = "5";
     bersihkan(); inp.focus();
     gambarRiwayat();
     notif(`${String(dada).padStart(3, "0")} tercatat ${jamMenit(jam)}.`);

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -208,67 +208,134 @@ export function detikTeks(total) {
  *  isinya bukan jam. Membetulkan saat blur, BUKAN saat tiap ketukan — menata
  *  ulang teks di tengah orang mengetik memindahkan kursornya dan membuat
  *  angka berikutnya mendarat di tempat yang salah. */
-/** Titik dua disisipkan SETELAH DUA ANGKA: mengetik 15 langsung jadi "15:",
- *  lalu 03 mengisi menitnya. Dua angka pertama SELALU jam, dua berikutnya
- *  SELALU menit — angka yang sudah diketik tidak pernah berubah arti oleh
- *  angka sesudahnya.
+/** DUA KOTAK JAM: [HH] : [MM], tapi mengetik "1503" beruntun tetap jalan.
  *
- *  SATU PENGECUALIAN, DAN IA MENYELAMATKAN CARA MENGETIK YANG PALING SERING.
+ *  Dua kotak supaya bagian menit bisa diklik dan diperbaiki sendiri tanpa
+ *  mengetik ulang jamnya. Satu kotak tidak bisa memberi itu: mengklik di tengah
+ *  lalu mengetik membuat kursor melompat ke ujung.
  *
- *  Jam tertinggi 23, jadi angka pertama 3-9 MUSTAHIL menjadi awal jam dua
- *  angka. Kalau yang diketik 7, satu-satunya bacaan yang mungkin adalah jam
- *  07 — jadi nolnya dipasangkan saat itu juga, dan "745" jadi "07:45".
+ *  Yang tidak boleh hilang karena pemisahan itu adalah mengetik beruntun.
+ *  Petugas keberangkatan mengetik empat angka tanpa melihat layar, dan memaksa
+ *  mereka berpindah kotak di tengah akan lebih lambat daripada sebelumnya. Jadi
+ *  HH MELUAP sendiri ke MM begitu ia penuh.
  *
- *  Tanpa pengecualian itu "745" akan jadi "74:5" dan ditolak, padahal itulah
- *  bentuk yang paling sering diketik petugas untuk jam pagi — dan lomba ini
- *  berangkat pukul tujuh.
+ *  KAPAN HH DIANGGAP PENUH — dan di sinilah satu aturan menyelamatkan bentuk
+ *  ketikan yang paling sering:
+ *
+ *    dua angka           -> penuh. "15" lalu lompat.
+ *    satu angka 3-9      -> penuh JUGA, dan dijadikan "07".
+ *
+ *  Jam tertinggi 23, jadi angka pertama 3-9 mustahil menjadi awal jam dua
+ *  angka: kalau yang diketik 7, satu-satunya bacaan yang mungkin adalah 07.
+ *  Karena itu "745" jadi 07:45 — bentuk yang paling sering diketik untuk jam
+ *  pagi, dan lomba ini berangkat pukul tujuh.
  *
  *  Yang dikorbankan: "250" tidak lagi terbaca 2:50, karena angka pertama 2
  *  memang bisa menjadi awal jam 20-23. Jam dua pagi tidak pernah terjadi di
  *  lomba yang berangkat pukul 07.00 dan selesai sore.
- *
- *  Dibatasi empat angka. Jam mana pun muat, dan angka kelima yang diterima
- *  diam-diam cuma akan ditolak saat kotaknya ditinggalkan. */
-export function maskJam(teks) {
-  let angka = String(teks ?? "").replace(/\D/g, "");
-  if (angka.length && Number(angka[0]) > 2) angka = "0" + angka;
-  angka = angka.slice(0, 4);
-  if (angka.length < 2) return angka;
-  return `${angka.slice(0, 2)}:${angka.slice(2)}`;
+ */
+
+/** Markup sepasang kotak jam. `id` jadi patokan: `<id>-hh` dan `<id>-mm`. */
+export function kotakJamHtml(id, nilai = "") {
+  const [hh = "", mm = ""] = String(nilai || "").split(":");
+  return `<span class="jam-pasang" id="${id}">
+    <input type="text" class="jam-ketik jam-hh" id="${id}-hh" value="${hh}"
+           inputmode="numeric" maxlength="2" autocomplete="off"
+           spellcheck="false" placeholder="HH" aria-label="Jam">
+    <span class="jam-titik" aria-hidden="true">:</span>
+    <input type="text" class="jam-ketik jam-mm" id="${id}-mm" value="${mm}"
+           inputmode="numeric" maxlength="2" autocomplete="off"
+           spellcheck="false" placeholder="MM" aria-label="Menit">
+  </span>`;
 }
 
-
-/** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:
- *  menyisipkan titik dua sambil diketik, membetulkan bentuknya saat kotak
- *  ditinggalkan, dan menandainya merah kalau isinya bukan jam.
+/** Menyalakan sepasang kotak jam dan mengembalikan kendalinya.
  *
- *  MENGHAPUS TIDAK IKUT DIRAPIKAN, dan itu bukan kelalaian. Kalau setiap
- *  ketukan dirapikan termasuk backspace, menghapus satu huruf dari "15:03"
- *  menyisakan "15:0" yang lalu dibaca ulang jadi "1:50" — angka berubah
- *  sendiri di bawah jari orang yang sedang membetulkannya. Jadi saat
- *  menghapus, isinya dibiarkan apa adanya sampai kotaknya ditinggalkan. */
-export function pasangKotakJam(el) {
-  if (!el) return;
-  const nilai = () => jamSah(el.value);
-  el.addEventListener("blur", () => {
-    if (!el.value.trim()) { el.classList.remove("jam-salah"); return; }
-    const v = nilai();
-    if (v) { el.value = v; el.classList.remove("jam-salah"); }
-    else el.classList.add("jam-salah");
-  });
-  el.addEventListener("input", (e) => {
-    if (!String(e.inputType || "").startsWith("delete")) {
-      const rapi = maskJam(el.value);
-      if (rapi !== el.value) {
-        el.value = rapi;
-        // Kursor ke ujung. Kotak selebar lima huruf tidak dipakai menyunting
-        // di tengah, dan kursor yang melompat ke tempat tak terduga lebih
-        // membingungkan daripada mengetik ulang empat angka.
-        try { el.setSelectionRange(rapi.length, rapi.length); } catch { /* input tanpa seleksi */ }
-      }
+ *  Sengaja BUKAN objek yang menyamar jadi <input>. Layar memanggil nilai() dan
+ *  setNilai() dengan nama itu, jadi terbaca bahwa yang dipegang adalah sepasang
+ *  kotak — bukan satu kotak yang kebetulan punya titik dua. */
+export function pasangKotakJam(id) {
+  const wadah = document.getElementById(id);
+  if (!wadah) return null;
+  const hh = document.getElementById(`${id}-hh`);
+  const mm = document.getElementById(`${id}-mm`);
+  const pendengar = [];
+
+  const gabung = () => `${hh.value.trim()}${mm.value.trim()}`;
+  const nilai = () => jamSah(gabung());
+
+  const tandai = () => {
+    const kosong = !hh.value.trim() && !mm.value.trim();
+    const buruk = !kosong && !nilai();
+    // Merah dipasang di WADAH, bukan di salah satu kotak: yang salah adalah
+    // jamnya sebagai satu kesatuan, dan menyalahkan kotak menit untuk jam 25
+    // menyuruh petugas membetulkan tempat yang benar.
+    wadah.classList.toggle("jam-salah", buruk);
+    return !buruk;
+  };
+
+  const beri = (fn) => { pendengar.forEach(fn); };
+
+  hh.addEventListener("input", () => {
+    const angka = hh.value.replace(/\D/g, "");
+    // Ketikan beruntun / tempel: sisanya dijatuhkan ke menit, bukan dibuang.
+    if (angka.length > 2) {
+      hh.value = angka.slice(0, 2);
+      mm.value = angka.slice(2, 4);
+      mm.focus(); mm.setSelectionRange(mm.value.length, mm.value.length);
+    } else if (angka.length === 2) {
+      hh.value = angka; mm.focus(); mm.select();
+    } else if (angka.length === 1 && Number(angka) > 2) {
+      hh.value = `0${angka}`; mm.focus(); mm.select();
+    } else {
+      hh.value = angka;
     }
-    if (nilai() || !el.value.trim()) el.classList.remove("jam-salah");
+    tandai(); beri(f => f());
   });
+
+  mm.addEventListener("input", () => {
+    mm.value = mm.value.replace(/\D/g, "").slice(0, 2);
+    tandai(); beri(f => f());
+  });
+
+  // Backspace di menit yang sudah kosong melompat balik ke jam. Tanpa itu
+  // petugas harus mengangkat tangan dari papan angka untuk mengetuk kotak
+  // sebelahnya — satu-satunya gerakan yang tidak bisa dilakukan sambil menatap
+  // regu di depan meja.
+  mm.addEventListener("keydown", (e) => {
+    if (e.key === "Backspace" && mm.value === "") {
+      hh.focus(); hh.setSelectionRange(hh.value.length, hh.value.length);
+    }
+  });
+
+  // Dirapikan saat SEPASANG kotak ini ditinggalkan, bukan saat pindah antar
+  // keduanya: "7" di jam belum tentu salah, ia mungkin sedang menuju "07".
+  const rapikan = () => {
+    setTimeout(() => {
+      if (document.activeElement === hh || document.activeElement === mm) return;
+      const v = nilai();
+      if (v) { [hh.value, mm.value] = v.split(":"); }
+      tandai();
+    }, 0);
+  };
+  hh.addEventListener("blur", rapikan);
+  mm.addEventListener("blur", rapikan);
+
+  return {
+    nilai,
+    setNilai(v) {
+      const [a = "", b = ""] = String(v || "").split(":");
+      hh.value = a; mm.value = b; tandai();
+    },
+    kosong: () => !hh.value.trim() && !mm.value.trim(),
+    salah(ya) { wadah.classList.toggle("jam-salah", !!ya); },
+    fokus() { hh.focus(); hh.select(); },
+    dengar(fn) { pendengar.push(fn); },
+    // Peristiwa DOM dipasang ke KEDUA kotak. Enter di kotak menit harus
+    // menyimpan sama seperti Enter di kotak jam — petugas tidak boleh perlu
+    // tahu kotak mana yang sedang aktif.
+    pada(nama, fn) { hh.addEventListener(nama, fn); mm.addEventListener(nama, fn); },
+  };
 }
 
 /** Notifikasi bawah layar.

--- a/web/style.css
+++ b/web/style.css
@@ -203,14 +203,29 @@ input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min
    kotak selebar layar mengundang orang mengetik kalimat ke dalamnya. Angka
    tabular supaya "11:11" dan "07:45" sama lebarnya dan kolomnya tidak
    bergoyang saat diketik. */
+/* SEPASANG kotak jam: [HH] : [MM]. Dipisah supaya bagian menit bisa diklik
+   dan diperbaiki sendiri; mengetik beruntun tetap jalan karena HH meluap ke MM
+   (pasangKotakJam di util.js). */
+.jam-pasang {
+  display: inline-flex; align-items: center; gap: .3rem;
+}
+.jam-titik {
+  font-size: 1.25rem; font-weight: 700; line-height: 1;
+  /* Sedikit terangkat: titik dua duduk di garis dasar huruf, sementara yang
+     harus disejajarkan adalah TENGAH kotak di kiri-kanannya. */
+  transform: translateY(-.06em);
+}
 input.jam-ketik {
-  width: 7.5em;
+  width: 3.2em;
   max-width: 100%;
   font-variant-numeric: tabular-nums;
   letter-spacing: .08em;
   text-align: center;
 }
-input.jam-ketik.jam-salah {
+/* Merah dipasang di WADAH, bukan salah satu kotak: yang salah adalah jamnya
+   sebagai satu kesatuan. Menyalahkan kotak menit untuk "jam 25" menyuruh
+   petugas membetulkan tempat yang keliru. */
+.jam-pasang.jam-salah input.jam-ketik {
   border-color: var(--bahaya);
   background: var(--bahaya-muda);
 }


### PR DESCRIPTION
## What

Kotak jam kini sepasang: `[HH]` `:` `[MM]` — bagian menit bisa diklik dan diperbaiki sendiri.

**Mengetik beruntun tetap jalan.** HH meluap ke MM begitu penuh:

| Diketik | Hasil | Berpindah kotak dengan tangan? |
|---|---|---|
| `1503` | `15:03` | tidak |
| `745` | `07:45` | tidak |
| `15` lalu klik MM lalu `30` | `15:30` | ya, sengaja |

## Why

Satu kotak teks tidak bisa memberi yang diminta: mengklik di bagian menit lalu mengetik membuat kursor melompat ke ujung, jadi memperbaiki menit berarti mengetik ulang jamnya.

Yang tidak boleh hilang karena pemisahan itu adalah **mengetik beruntun** — petugas keberangkatan mengetik empat angka tanpa melihat layar.

## Notes

**Kapan HH dianggap penuh:**

```
dua angka       -> penuh, lompat.  "15" lalu ke menit.
satu angka 3-9  -> penuh JUGA, dan dijadikan "07".
```

Jam tertinggi 23, jadi angka pertama 3–9 mustahil menjadi awal jam dua angka. Karena itu `745` jadi `07:45` — bentuk yang paling sering diketik untuk jam pagi, dan lomba ini berangkat pukul tujuh.

**Backspace di menit yang sudah kosong melompat balik ke jam.** Tanpa itu petugas harus mengangkat tangan dari papan angka untuk mengetuk kotak sebelahnya.

**Merah dipasang di wadah,** bukan salah satu kotak: yang salah adalah jamnya sebagai satu kesatuan. Menyalahkan kotak menit untuk "jam 25" menyuruh petugas membetulkan tempat yang keliru.

`pasangKotakJam` mengembalikan **kendali bernama** — `nilai()`, `setNilai()`, `kosong()`, `salah()`, `fokus()`, `dengar()`, `pada()` — bukan objek yang menyamar jadi `<input>`. Kedua pemanggilnya ikut dirapikan: dulu memvalidasi ulang dengan `jamSah(el.value.trim())` padahal kendali ini sudah menjawabnya.

**Belum diuji di browser sungguhan** — perilaku fokus dan kursor tidak bisa saya buktikan dari sini, dan menebaknya adalah persis kekeliruan yang membuat pratinjau cetak kemarin berbohong. Mohon dicoba di layar Keberangkatan dan Kedatangan sebelum dianggap selesai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)