### PR TITLE
feat: golongan disingkat Pgl/Pgk di kertas, dan pratinjau cetak yang jujur

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -704,7 +704,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
      jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
-    width: 12mm; max-width: 14mm;
+    width: 16mm; max-width: 18mm;
   }
   /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
      Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
@@ -733,9 +733,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
      Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
      sisanya jatuh ke identitas juga. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Identitas DIPADATKAN, dan itu keputusan panitia: lebih baik nama terpotong
+     sedikit daripada kotak nilai yang sempit. Diukur pada 10pt huruf besar
+     (~2,3mm per huruf) terhadap nama terpanjang di daftar:
+
+       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 48mm
+       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 58mm
+
+     Keduanya sengaja sedikit DI BAWAH kebutuhan nama terpanjang, jadi hanya
+     segelintir yang kehilangan satu-dua huruf di ujung — dan regu tetap
+     dikenali dari nomor dadanya. Yang dibeli: kotak nilai naik 14mm ke 18mm.
+
+     Golongan disingkat "Pgl Pa" / "Pgk Pa" (GOLONGAN_SINGKAT di app.js), jadi
+     16mm cukup dan 10mm sisanya ikut pindah ke kolom nama. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 48mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 58mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 16mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/tools/pratinjau_cetak.py
+++ b/tools/pratinjau_cetak.py
@@ -1,0 +1,63 @@
+r"""Bangkitkan pratinjau cetak dari @media print di web/style.css.
+
+KENAPA BERKAS INI ADA, DAN KENAPA PENYARINGNYA BUKAN REGEX.
+
+Pratinjau ini dipakai memutuskan bentuk kertas — potret atau melintang,
+memotong nama atau membungkusnya — jadi ia HARUS memakai CSS yang sama persis
+dengan yang dicetak. Versi sebelumnya membuang aturan layar dengan regex
+`\.(header|isi|notification|overlay)[^{]*\{[^}]*\}`, dan `.isi` di dalamnya
+ikut menangkap `.isian` — kelas kotak nilai.
+
+Akibatnya dua lapis. Aturan lebar kotak isian hilang, jadi kotaknya melar dan
+menggencet kolom nama. Dan potongannya meninggalkan selektor menggantung
+(`.lembar-pos .print-table th`) yang menempel ke aturan berikutnya, sehingga
+`white-space: nowrap` tidak pernah berlaku — nama membungkus di pratinjau
+padahal di cetakan sungguhan ia satu baris.
+
+Keputusan bentuk kertas diambil beberapa putaran atas dasar pratinjau itu.
+Karena itu penyaringnya sekarang mencocokkan SATU aturan yang diketahui, apa
+adanya, dan berhenti dengan galat kalau aturan itu tidak ditemukan — lebih
+baik gagal daripada diam-diam menghapus yang salah.
+"""
+import re
+from pathlib import Path
+
+AKAR = Path(__file__).resolve().parent.parent
+# Satu-satunya aturan yang memang tidak boleh ikut: penyembunyi layar.
+SEMBUNYI = ".header, .isi, .notification, .overlay { display: none !important; }"
+
+
+def css_cetak() -> str:
+    """Isi blok @media print, siap ditempel ke halaman pratinjau."""
+    css = (AKAR / "web" / "style.css").read_text(encoding="utf-8")
+    i = css.index("@media print {")
+    dalam = 0
+    for j in range(i, len(css)):
+        if css[j] == "{":
+            dalam += 1
+        elif css[j] == "}":
+            dalam -= 1
+            if dalam == 0:
+                break
+    blok = css[i + len("@media print {"):j]
+
+    if SEMBUNYI not in blok:
+        raise SystemExit(
+            "Aturan penyembunyi layar tidak ditemukan apa adanya di @media print.\n"
+            "Jangan tebak — buka web/style.css, cocokkan teksnya, lalu perbarui\n"
+            "SEMBUNYI di berkas ini. Menghapus yang salah membuat pratinjau\n"
+            "berbohong, dan keputusan bentuk kertas diambil dari pratinjau.")
+    blok = blok.replace(SEMBUNYI, "")
+
+    # @page tidak berlaku di layar; dibuang supaya tidak membingungkan, dan
+    # dicocokkan dengan pola yang tidak mungkin mengenai selektor kelas.
+    blok = re.sub(r"@page\s+[\w-]*\s*\{[^}]*\}", "", blok)
+
+    if ".isian" not in blok:
+        raise SystemExit("Aturan .isian ikut terbuang — persis cacat yang "
+                         "membuat berkas ini ditulis. Periksa penyaringnya.")
+    return blok
+
+
+if __name__ == "__main__":
+    print(css_cetak()[:400])

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -32,6 +32,28 @@ const GOLONGAN_LABEL = {
   penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
 };
+
+/** Golongan versi pendek, HANYA untuk kertas. Di layar tetap panjang — di sana
+ *  lebar tidak diperebutkan siapa pun, dan dua nama untuk satu hal cuma
+ *  sepadan kalau ada yang dibeli dengannya.
+ *
+ *  Di lembar cadangan ia diperebutkan, dan yang kalah selama ini nama regu dan
+ *  sekolah: keduanya dipotong elipsis supaya tinggi baris tetap seragam.
+ *  "Penggalang PA" 13 huruf jadi "Pgl Pa" 6 huruf — sekitar 10mm kembali ke
+ *  kolom nama, di kertas yang memang sedang kekurangan.
+ *
+ *  Singkatannya dipilih panitia: Pgl dan Pgk. Versi pertama saya "Png" untuk
+ *  Penegak, dan itu lebih buruk — Png dan Pgl berbeda di dua huruf TENGAH yang
+ *  sama-sama tidak menonjol, sementara Pgk dan Pgl berbeda di huruf TERAKHIR,
+ *  tempat mata berhenti.
+ *
+ *  Sekalipun tertukar, akibatnya terbatas: kolom ini keterangan, bukan kunci.
+ *  Nilai mengalir lewat nomor dada, jadi golongan yang salah baca tidak pernah
+ *  memindahkan angka ke regu lain. */
+const GOLONGAN_SINGKAT = {
+  penggalang_pa: "Pgl Pa", penggalang_pi: "Pgl Pi",
+  penegak_pa: "Pgk Pa", penegak_pi: "Pgk Pi",
+};
 let EDISI = null;
 
 /* Layar yang sanggup memperbarui dirinya SENDIRI tanpa digambar ulang
@@ -2097,7 +2119,7 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
       ${html`<td class="dada">${String(r.nomor_dada).padStart(3, "0")}</td>
       <td>${r.nama_regu}</td>
       <td>${r.nama_sekolah}</td>
-      <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>`}
+      <td>${GOLONGAN_SINGKAT[r.golongan] || r.golongan}</td>`}
       ${kolom.map(() => `<td class="isian"></td>`).join("")}
     </tr>`;
 

--- a/web/style.css
+++ b/web/style.css
@@ -704,7 +704,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
      jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
-    width: 12mm; max-width: 14mm;
+    width: 16mm; max-width: 18mm;
   }
   /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
      Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
@@ -733,9 +733,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
      Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
      sisanya jatuh ke identitas juga. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 70mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 26mm; }
+  /* Identitas DIPADATKAN, dan itu keputusan panitia: lebih baik nama terpotong
+     sedikit daripada kotak nilai yang sempit. Diukur pada 10pt huruf besar
+     (~2,3mm per huruf) terhadap nama terpanjang di daftar:
+
+       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 48mm
+       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 58mm
+
+     Keduanya sengaja sedikit DI BAWAH kebutuhan nama terpanjang, jadi hanya
+     segelintir yang kehilangan satu-dua huruf di ujung — dan regu tetap
+     dikenali dari nomor dadanya. Yang dibeli: kotak nilai naik 14mm ke 18mm.
+
+     Golongan disingkat "Pgl Pa" / "Pgk Pa" (GOLONGAN_SINGKAT di app.js), jadi
+     16mm cukup dan 10mm sisanya ikut pindah ke kolom nama. */
+  .lembar-pos .print-table td:nth-child(2) { max-width: 48mm; }
+  .lembar-pos .print-table td:nth-child(3) { max-width: 58mm; }
+  .lembar-pos .print-table td:nth-child(4) { max-width: 16mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }


### PR DESCRIPTION
Menerapkan ulang #156 di atas `main` yang sekarang — branch lamanya tertinggal **15 commit** dan menyentuh aturan CSS yang sama dengan pekerjaan melintang/10pt yang mendarat sesudahnya.

## Golongan disingkat, hanya di kertas

| Layar | Kertas |
|---|---|
| Penggalang PA / PI | `Pgl Pa` · `Pgl Pi` |
| Penegak PA / PI | `Pgk Pa` · `Pgk Pi` |

Singkatannya dipilih panitia, dan pilihannya lebih baik daripada punya saya: `Png` berbeda dari `Pgl` di dua huruf **tengah** yang sama-sama tidak menonjol; `Pgk` berbeda di huruf **terakhir**, tempat mata berhenti.

## Identitas dipadatkan, lebarnya pindah

| | Sebelum | Sekarang |
|---|---|---|
| Nama regu | 70mm | **48mm** |
| Organisasi | 70mm | **58mm** |
| Golongan | 26mm | **16mm** |
| **Kotak nilai** | 14mm | **18mm** |

Patokannya sengaja sedikit **di bawah** kebutuhan nama terpanjang — persis pilihan panitia: lebih baik nama terpotong sedikit daripada kotak nilai yang sempit. `nowrap` dan elipsis tetap, jadi tinggi baris tetap seragam.

## Alat pratinjau yang tidak berbohong

Yang paling penting walau tidak terlihat di layar mana pun. Skrip pratinjau membuang aturan layar dengan regex `\.(header|isi|…)`, dan **`.isi` ikut menangkap `.isian`** — kelas kotak nilai. Aturan lebarnya hilang, dan potongannya berhenti **di tengah selektor** sehingga `white-space: nowrap` tidak pernah berlaku.

Akibatnya nama membungkus dan tinggi baris tidak seragam **di pratinjau**, padahal di cetakan sungguhan satu baris. Beberapa putaran keputusan bentuk kertas dinilai lewat gambar yang salah.

Penyaringnya sekarang mencocokkan satu aturan yang diketahui **apa adanya**, dan **berhenti dengan galat** kalau tidak ditemukan. Penjaga kedua memastikan `.isian` masih ada sesudah penyaringan.

Menggantikan #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)