### PR TITLE
fix: isi kotak jam dipilih saat diketuk, supaya bisa diganti

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -264,6 +264,29 @@ export function pasangKotakJam(id) {
   const gabung = () => `${hh.value.trim()}${mm.value.trim()}`;
   const nilai = () => jamSah(gabung());
 
+  /* ISI DIPILIH SAAT KOTAKNYA DIKETUK, dan tanpa ini kotak yang sudah terisi
+     tidak bisa diperbaiki.
+
+     Kotak HH berisi "10". Petugas mengetuknya untuk mengubah jam, menekan 1,
+     dan yang terjadi bukan "1" melainkan "110" — angka baru DISISIPKAN di
+     sebelah yang lama. Tiga angka lalu terbaca sebagai ketikan beruntun, jadi
+     luapannya menendang satu angka ke kotak menit. Petugas menekan satu tombol
+     dan kursornya sudah pindah kotak.
+
+     Memilih seluruh isi saat fokus membuat ketukan pertama MENGGANTI, bukan
+     menyisipkan — perilaku yang sama dengan kotak jam di aplikasi mana pun.
+     Mengetuk kedua kali tetap menaruh kursor seperti biasa, jadi menyunting
+     satu angka masih mungkin bagi yang menginginkannya.
+
+     Lewat setTimeout karena Safari iOS membatalkan select() yang dipanggil di
+     dalam penanganan focus itu sendiri — dan HP iOS adalah yang dipegang
+     petugas di garis start. */
+  const pilihIsi = (el) => setTimeout(() => {
+    if (document.activeElement === el) { try { el.select(); } catch { /* abaikan */ } }
+  }, 0);
+  hh.addEventListener("focus", () => pilihIsi(hh));
+  mm.addEventListener("focus", () => pilihIsi(mm));
+
   const tandai = () => {
     const kosong = !hh.value.trim() && !mm.value.trim();
     const buruk = !kosong && !nilai();

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -264,6 +264,29 @@ export function pasangKotakJam(id) {
   const gabung = () => `${hh.value.trim()}${mm.value.trim()}`;
   const nilai = () => jamSah(gabung());
 
+  /* ISI DIPILIH SAAT KOTAKNYA DIKETUK, dan tanpa ini kotak yang sudah terisi
+     tidak bisa diperbaiki.
+
+     Kotak HH berisi "10". Petugas mengetuknya untuk mengubah jam, menekan 1,
+     dan yang terjadi bukan "1" melainkan "110" — angka baru DISISIPKAN di
+     sebelah yang lama. Tiga angka lalu terbaca sebagai ketikan beruntun, jadi
+     luapannya menendang satu angka ke kotak menit. Petugas menekan satu tombol
+     dan kursornya sudah pindah kotak.
+
+     Memilih seluruh isi saat fokus membuat ketukan pertama MENGGANTI, bukan
+     menyisipkan — perilaku yang sama dengan kotak jam di aplikasi mana pun.
+     Mengetuk kedua kali tetap menaruh kursor seperti biasa, jadi menyunting
+     satu angka masih mungkin bagi yang menginginkannya.
+
+     Lewat setTimeout karena Safari iOS membatalkan select() yang dipanggil di
+     dalam penanganan focus itu sendiri — dan HP iOS adalah yang dipegang
+     petugas di garis start. */
+  const pilihIsi = (el) => setTimeout(() => {
+    if (document.activeElement === el) { try { el.select(); } catch { /* abaikan */ } }
+  }, 0);
+  hh.addEventListener("focus", () => pilihIsi(hh));
+  mm.addEventListener("focus", () => pilihIsi(mm));
+
   const tandai = () => {
     const kosong = !hh.value.trim() && !mm.value.trim();
     const buruk = !kosong && !nilai();


### PR DESCRIPTION
## Gejala

Kotak sudah berisi `10:00`. Petugas mengetuk kotak jam untuk menggantinya jadi `10:45`, menekan `1` — dan kursornya **langsung lompat ke kotak menit**.

## Sebabnya

Mengetuk kotak tidak memilih isinya, jadi angka baru **disisipkan** di sebelah yang lama:

```
"10"  + ketuk + ketik "1"  ->  "110"   (tiga angka)
                           ->  luapan menganggap ini ketikan beruntun
                           ->  HH="11", MM="0", fokus pindah
```

Aturan luapan itu benar untuk mengetik `1503` dari kosong. Ia salah untuk **mengganti** isi yang sudah ada — dan tidak ada cara membedakannya selama isi kotak tidak pernah terpilih.

## Perbaikan

Isi dipilih saat kotaknya diketuk, jadi ketukan pertama **mengganti** alih-alih menyisipkan — perilaku yang sama dengan kotak jam di aplikasi mana pun. Mengetuk kedua kali tetap menaruh kursor seperti biasa, jadi menyunting satu angka masih mungkin bagi yang menginginkannya.

Lewat `setTimeout` karena **Safari iOS membatalkan `select()`** yang dipanggil di dalam penanganan `focus` itu sendiri — dan HP iOS adalah yang dipegang petugas di garis start. Dijaga dengan memeriksa `activeElement` supaya tidak memilih kotak yang fokusnya sudah berpindah lagi sebelum timeout jalan.

Sesudah ini: ketuk HH, ketik `1045` → `10:45`. Ketuk HH, ketik `1` → tetap di HH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)