### PR TITLE
fix: kotak jam yang sudah penuh selalu ditimpa, di mana pun kursornya

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -287,6 +287,36 @@ export function pasangKotakJam(id) {
   hh.addEventListener("focus", () => pilihIsi(hh));
   mm.addEventListener("focus", () => pilihIsi(mm));
 
+  /* LAPIS KEDUA: kotak yang sudah PENUH, angka berikutnya memulai dari awal.
+     Berlaku di mana pun kursornya berada.
+
+     Memilih isi saat fokus (di atas) sudah menyelesaikan kasus yang dilaporkan,
+     tapi ia bergantung pada browser menghormati select() — dan Safari iOS
+     punya beberapa keadaan di mana ia tidak. Aturan ini tidak bergantung pada
+     apa pun: kalau kotak sudah memuat dua angka dan yang diketik satu angka
+     lagi, isinya DIGANTI, bukan disisipi. Kursor di awal, di tengah, atau di
+     ujung tidak mengubah hasilnya.
+
+     Ketikan beruntun tidak terganggu. Mengetik 1503 dari kosong tidak pernah
+     memasukkan angka ketiga ke kotak jam — begitu dua angka penuh, fokusnya
+     sudah pindah ke menit. Satu-satunya cara kotak penuh menerima ketikan lagi
+     adalah petugas sengaja kembali ke sana, dan saat itu maksudnya mengganti.
+
+     MENEMPEL dikecualikan: menempel "1503" memang harus meluap ke menit, dan
+     itu jalur yang dipakai saat layar mengisi kotak dari data. */
+  const menimpaBilaPenuh = (el) => el.addEventListener("beforeinput", (e) => {
+    if (e.inputType !== "insertText" || !/^\d$/.test(e.data || "")) return;
+    const penuh = el.value.replace(/\D/g, "").length >= 2;
+    const semuaTerpilih = el.selectionStart === 0
+                       && el.selectionEnd === el.value.length;
+    if (!penuh || semuaTerpilih) return;
+    e.preventDefault();
+    el.value = e.data;
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  menimpaBilaPenuh(hh);
+  menimpaBilaPenuh(mm);
+
   const tandai = () => {
     const kosong = !hh.value.trim() && !mm.value.trim();
     const buruk = !kosong && !nilai();

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -287,6 +287,36 @@ export function pasangKotakJam(id) {
   hh.addEventListener("focus", () => pilihIsi(hh));
   mm.addEventListener("focus", () => pilihIsi(mm));
 
+  /* LAPIS KEDUA: kotak yang sudah PENUH, angka berikutnya memulai dari awal.
+     Berlaku di mana pun kursornya berada.
+
+     Memilih isi saat fokus (di atas) sudah menyelesaikan kasus yang dilaporkan,
+     tapi ia bergantung pada browser menghormati select() — dan Safari iOS
+     punya beberapa keadaan di mana ia tidak. Aturan ini tidak bergantung pada
+     apa pun: kalau kotak sudah memuat dua angka dan yang diketik satu angka
+     lagi, isinya DIGANTI, bukan disisipi. Kursor di awal, di tengah, atau di
+     ujung tidak mengubah hasilnya.
+
+     Ketikan beruntun tidak terganggu. Mengetik 1503 dari kosong tidak pernah
+     memasukkan angka ketiga ke kotak jam — begitu dua angka penuh, fokusnya
+     sudah pindah ke menit. Satu-satunya cara kotak penuh menerima ketikan lagi
+     adalah petugas sengaja kembali ke sana, dan saat itu maksudnya mengganti.
+
+     MENEMPEL dikecualikan: menempel "1503" memang harus meluap ke menit, dan
+     itu jalur yang dipakai saat layar mengisi kotak dari data. */
+  const menimpaBilaPenuh = (el) => el.addEventListener("beforeinput", (e) => {
+    if (e.inputType !== "insertText" || !/^\d$/.test(e.data || "")) return;
+    const penuh = el.value.replace(/\D/g, "").length >= 2;
+    const semuaTerpilih = el.selectionStart === 0
+                       && el.selectionEnd === el.value.length;
+    if (!penuh || semuaTerpilih) return;
+    e.preventDefault();
+    el.value = e.data;
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  menimpaBilaPenuh(hh);
+  menimpaBilaPenuh(mm);
+
   const tandai = () => {
     const kosong = !hh.value.trim() && !mm.value.trim();
     const buruk = !kosong && !nilai();


### PR DESCRIPTION
## What

Kotak jam yang sudah memuat **dua angka**: angka berikutnya yang diketik **mengganti** isinya, bukan disisipkan. Berlaku dengan kursor di awal, di tengah, atau di ujung.

## Why

`select()` saat fokus (#164) sudah menyelesaikan kasus yang dilaporkan, tapi ia **bergantung pada browser menghormatinya** — dan Safari iOS punya beberapa keadaan di mana ia tidak. HP iOS adalah yang dipegang petugas di garis start.

Lapis ini tidak bergantung pada apa pun: ia mencegat `beforeinput`, dan kalau kotaknya penuh, isinya diganti dengan angka yang baru ditekan.

## Notes

**Ketikan beruntun tidak terganggu, dan itu bukan kebetulan.** Mengetik `1503` dari kosong tidak pernah memasukkan angka ketiga ke kotak jam — begitu dua angka penuh, fokusnya sudah pindah ke menit. Satu-satunya cara kotak penuh menerima ketikan lagi adalah petugas **sengaja kembali** ke sana, dan saat itu maksudnya memang mengganti.

**Menempel dikecualikan** lewat `inputType`: menempel `1503` ke kotak jam memang harus meluap ke menit, dan itu jalur yang sama dengan yang dipakai layar saat mengisi kotak dari data.

Dipasang di kedua kotak — menit yang sudah berisi `45` mengalami hal yang sama persis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)