### PR TITLE
feat: chip kloter menampilkan jam berangkatnya, bukan kata "berangkat"

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1083,8 +1083,22 @@ async function layarKeberangkatan() {
 
   const gambarPita = () => {
     document.getElementById("pita-kloter").replaceChildren(h(papan.map(k => {
-      const label = { berangkat: "berangkat", siap: "siap",
-                      konfirmasi_kontrak: "kontrak", menunggu: "menunggu" }[k.posisi] || "";
+      /* Kloter yang SUDAH berangkat menampilkan JAMNYA, bukan kata
+         "berangkat".
+
+         Kata itu tidak menambah apa pun — chip-nya sudah berwarna hijau
+         "berangkat", dan angka ceklis di sebelahnya sudah penuh. Sementara
+         jamnya adalah hal yang justru dicari, dan sebelumnya hanya bisa
+         dilihat dengan MENGETUK kloternya satu per satu lalu membaca pitanya.
+
+         Panitia memeriksa jadwal keberangkatan dari luar — berdiri di garis
+         start, melihat kloter mana berangkat pukul berapa, tanpa membuka
+         satu-satu. Datanya sudah ikut di v_keberangkatan sejak awal; layar ini
+         saja yang membuangnya. */
+      const label = k.jam_berangkat
+        ? jamMenit(k.jam_berangkat)
+        : ({ siap: "siap", konfirmasi_kontrak: "kontrak",
+             menunggu: "menunggu" }[k.posisi] || "");
       return html`
         <button type="button" class="kloter-chip ${k.posisi}"
                 data-kloter="${k.nomor}" aria-pressed="${k.nomor === kloterAktif}">


### PR DESCRIPTION
## What

```
sebelum : Kloter 1 · 10/10 · berangkat
sesudah : Kloter 1 · 10/10 · 11:00
```

## Why

Panitia memeriksa jadwal keberangkatan **dari luar** — berdiri di garis start, melihat kloter mana berangkat pukul berapa. Sebelumnya itu menuntut **mengetuk tiap kloter satu per satu** lalu membaca pita di dalamnya.

Kata "berangkat" di chip tidak menambah apa pun: chip-nya sudah berwarna berangkat, dan angka ceklis di sebelahnya sudah penuh. Jamnya yang justru dicari — dan ia **sudah ikut di `v_keberangkatan` sejak awal**; layar ini saja yang membuangnya.

## Notes

Kloter yang belum berangkat tidak berubah: `siap`, `kontrak`, `menunggu` tetap kata, karena untuk mereka memang belum ada jam yang bisa disebut.

Tidak ada perubahan data, view, atau permintaan tambahan — satu ekspresi di pembangun chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)