### PR TITLE
feat: ketuk centang untuk melihat riwayat nilai, terbuka juga bagi petugas pos

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -450,6 +450,22 @@ export async function komponenSemua(edisi) {
     `&order=pos.asc,sort_order.asc`);
 }
 
+/** Riwayat perubahan nilai satu regu di satu pos — siapa mengubah apa, kapan.
+ *
+ *  Dibaca saat penanda simpan diketuk, bukan ikut dimuat bersama lembarnya:
+ *  lembar pos memuat ratusan baris dan hampir semuanya tidak pernah ditanya
+ *  riwayatnya. */
+export async function riwayatNilai(pos, nomorDada) {
+  if (K.mode === "dev") {
+    return baca(`/riwayat-nilai?pos=${encodeURIComponent(pos)}` +
+                `&dada=${encodeURIComponent(nomorDada)}`);
+  }
+  return baca(null,
+    `v_riwayat_nilai?pos=eq.${encodeURIComponent(pos)}` +
+    `&nomor_dada=eq.${encodeURIComponent(nomorDada)}` +
+    `&select=*&order=changed_at.desc`);
+}
+
 /** Kelengkapan input per pos — satu baris per pos, bukan per regu.
  *
  *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5

--- a/live/style.css
+++ b/live/style.css
@@ -1091,6 +1091,31 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    di depan. */
 .data-table td[data-label="Metode"] { text-transform: capitalize; }
 .data-table td[data-label="Metode"] .badge { text-transform: none; }
+/* Lencana yang SEKALIGUS tombol. Rupanya tetap lencana — yang berubah cuma
+   kursornya dan cincin fokus, supaya jelas ia bisa diketuk tanpa menjadikannya
+   tombol besar yang menuntut lebar kolom sendiri. */
+/* Riwayat perubahan nilai: satu baris per perubahan, tanpa kepala tabel.
+   Yang dicari cuma lomba apa, dari berapa jadi berapa, dan siapa — tiga hal
+   yang muat sebaris, dan mata tidak perlu melewati apa pun sebelum sampai. */
+.riwayat { list-style: none; margin: 0; padding: 0; }
+.riwayat li {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: .2rem .8rem;
+  padding: .5rem 0; border-bottom: 1px solid var(--garis);
+}
+.riwayat li:last-child { border-bottom: 0; }
+.r-lomba { font-weight: 600; flex: 1 1 8rem; }
+.r-nilai { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.r-oleh  { color: var(--tinta-lembut); font-size: .82rem; flex: 1 1 100%; }
+@media (min-width: 480px) {
+  .r-oleh { flex: 0 0 auto; text-align: right; }
+}
+
+.badge-tombol {
+  border: 0; font: inherit; cursor: pointer;
+  padding: .1rem .45rem; line-height: inherit;
+}
+.badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+
 .table-empty { text-align: center; color: var(--tinta-lembut); padding: 1.4rem .5rem; }
 
 /* Kontrol di dalam sel: cukup besar untuk jari, cukup ringkas untuk tabel. */

--- a/supabase/migrations/0042_riwayat_nilai.sql
+++ b/supabase/migrations/0042_riwayat_nilai.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- hrcd-rekap : 0042_riwayat_nilai.sql
+--
+-- Riwayat perubahan NILAI, dan hanya nilai, terbuka bagi panitia yang berhak.
+--
+-- ---------------------------------------------------------------------------
+-- YANG SUDAH ADA DAN TIDAK PERNAH TERPAKAI
+--
+-- Setiap perubahan `nilai_mentah` sudah tercatat sejak migrasi 0002: trigger
+-- `audit_nilai_mentah` menyimpan baris lama, baris baru, siapa, dan kapan.
+-- Datanya utuh, tapi tidak pernah bisa dilihat — RLS tabel `history` hanya
+-- mengizinkan `peran() = 'admin'` (0003), dan tidak ada satu layar pun yang
+-- membacanya.
+--
+-- Jadi kalau satu nilai berubah tanpa ada yang tahu, jawabannya SUDAH tersimpan
+-- di database sejak awal. Yang tidak ada cuma jalan untuk bertanya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA VIEW SEMPIT, BUKAN MELEBARKAN RLS `history`
+--
+-- Melonggarkan tabelnya akan membuka jauh lebih banyak daripada yang diminta:
+-- `history` mencatat SELURUH tabel, termasuk `pendaftaran` — dan baris
+-- pendaftaran memuat nomor WhatsApp. Membuka audit nilai kepada operator pos
+-- tidak boleh berarti membuka nomor telepon sekolah kepada mereka.
+--
+-- View ini karena itu menyaring `table_name = 'nilai_mentah'` lebih dulu, lalu
+-- hanya mengeluarkan kolom yang memang perlu dibaca manusia: nomor dada, nama
+-- lomba, angka lama, angka baru, siapa, kapan.
+--
+-- ---------------------------------------------------------------------------
+-- SIAPA BOLEH MELIHAT APA
+--
+-- Pagarnya sama persis dengan pagar menulis nilai (policy sel_nilai, 0003):
+-- admin dan meja melihat seluruh pos, operator pos hanya posnya sendiri. Kalau
+-- keduanya berbeda, akan ada operator yang bisa MENGUBAH satu nilai tetapi
+-- tidak bisa melihat bahwa ia mengubahnya — atau sebaliknya.
+--
+-- Dibuat `security_invoker = off` dengan pagar di dalam view, sebab `history`
+-- sendiri tertutup untuk selain admin dan tidak bisa dilonggarkan tanpa ikut
+-- membuka isi tabel lain. Pola yang sama dipakai `v_lembar_pos` (0023) dan
+-- `v_rekap_penuh` (0027).
+-- ============================================================================
+
+create or replace view v_riwayat_nilai as
+select
+  h.id,
+  r.nomor_dada,
+  w.pos,
+  w.name                        as nama_lomba,
+  w.kode                        as kode_lomba,
+  (h.old_value ->> 'nilai_1')::numeric as nilai_lama,
+  (h.new_value ->> 'nilai_1')::numeric as nilai_baru,
+  h.action,
+  coalesce(a.username, '(tidak dikenal)') as oleh,
+  h.changed_at
+from history h
+join regu r   on r.id = h.regu_id
+-- Baris nilai_mentah menyimpan wahana_id di kedua sisi; DELETE hanya punya
+-- yang lama, INSERT hanya yang baru.
+join wahana w on w.id = coalesce((h.new_value ->> 'wahana_id')::uuid,
+                                 (h.old_value ->> 'wahana_id')::uuid)
+left join akun_panitia a on a.user_id = h.changed_by
+where h.table_name = 'nilai_mentah'
+  and w.edisi = edisi_aktif()
+  and (
+    peran() in ('admin', 'meja')
+    or (peran() = 'operator_pos' and w.pos = pos_saya())
+  );
+
+comment on view v_riwayat_nilai is
+  'Riwayat perubahan nilai per regu — hanya nilai_mentah, tidak menyentuh '
+  'riwayat tabel lain. Pagarnya menyalin policy sel_nilai: admin/meja seluruh '
+  'pos, operator pos hanya posnya sendiri.';
+
+grant select on v_riwayat_nilai to authenticated;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -156,6 +156,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "
                     "order by pos, sort_order", uid=p.get("uid")))
+            elif u.path == "/riwayat-nilai":
+                self._kirim(200, q(
+                    "select * from v_riwayat_nilai where pos = %s "
+                    "and nomor_dada = %s order by changed_at desc",
+                    (p.get("pos") or 0, p.get("dada") or 0), uid=p.get("uid")))
             elif u.path == "/batas-nomor-dada":
                 self._kirim(200, q(
                     "select nomor from nomor_dada_stok order by nomor desc limit 1",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -136,5 +136,8 @@ run supabase/migrations/0039_judul_isian.sql
 # menelusuri kenapa satu tes berubah arti.
 run supabase/migrations/0041_tukar_nomor_tanpa_pensiun.sql
 run tests/sql/17_tukar_nomor_tanpa_pensiun.sql
+# 0042 membuka riwayat perubahan NILAI (dan hanya nilai) untuk petugas pos.
+run supabase/migrations/0042_riwayat_nilai.sql
+run tests/sql/18_riwayat_nilai.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/18_riwayat_nilai.sql
+++ b/tests/sql/18_riwayat_nilai.sql
@@ -1,0 +1,86 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/18_riwayat_nilai.sql
+-- Riwayat perubahan nilai (0042).
+--
+-- Yang dijaga di sini PAGARNYA, bukan isinya. Tabel `history` mencatat SELURUH
+-- tabel — termasuk `pendaftaran`, yang memuat nomor WhatsApp sekolah. Membuka
+-- riwayat nilai kepada operator pos tidak boleh berarti membuka nomor telepon
+-- kepada mereka, dan satu-satunya yang memisahkan keduanya adalah saringan
+-- `table_name = 'nilai_mentah'` di dalam view.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 18.1 Operator pos melihat riwayat POSNYA SENDIRI, dan hanya itu.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+set role authenticated;
+
+do $$
+declare v_pos smallint; v_asing int;
+begin
+  select pos_saya() into v_pos;
+  assert v_pos is not null, 'akun uji bukan operator pos';
+
+  select count(*) into v_asing from v_riwayat_nilai where pos <> v_pos;
+  assert v_asing = 0,
+    format('operator pos %s melihat %s baris riwayat pos lain', v_pos, v_asing);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 18.2 Riwayat tabel LAIN tidak pernah bocor lewat view ini — terutama
+--      pendaftaran, yang memuat nomor WhatsApp.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_bocor int;
+begin
+  select count(*) into v_bocor
+  from history h
+  where h.table_name <> 'nilai_mentah'
+    and exists (select 1 from v_riwayat_nilai v where v.id = h.id);
+  assert v_bocor = 0,
+    format('%s baris riwayat tabel lain ikut terlihat di v_riwayat_nilai', v_bocor);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 18.3 Perubahan nilai BENAR-BENAR tercatat dan terbaca: angka lama, angka
+--      baru, dan siapa. Diubah lalu dikembalikan.
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+
+do $$
+declare
+  v_regu   uuid; v_wahana uuid; v_pos smallint;
+  v_lama   numeric; v_baru numeric;
+  v_dada   integer; v_catat record;
+begin
+  select n.regu_id, n.wahana_id, w.pos, n.nilai_1, r.nomor_dada
+    into strict v_regu, v_wahana, v_pos, v_lama, v_dada
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  join regu r   on r.id = n.regu_id
+  where w.edisi = edisi_aktif() and r.nomor_dada is not null
+  order by n.id limit 1;
+
+  v_baru := case when v_lama = 0 then 1 else 0 end;
+  update nilai_mentah set nilai_1 = v_baru
+  where regu_id = v_regu and wahana_id = v_wahana;
+
+  select * into v_catat from v_riwayat_nilai
+  where nomor_dada = v_dada and pos = v_pos
+  order by changed_at desc, id desc limit 1;
+
+  assert v_catat.nilai_lama = v_lama,
+    format('angka lama tercatat %s, seharusnya %s', v_catat.nilai_lama, v_lama);
+  assert v_catat.nilai_baru = v_baru,
+    format('angka baru tercatat %s, seharusnya %s', v_catat.nilai_baru, v_baru);
+  assert v_catat.oleh is not null, 'penginput tidak tercatat';
+
+  update nilai_mentah set nilai_1 = v_lama
+  where regu_id = v_regu and wahana_id = v_wahana;
+end;
+$$;
+
+reset role;
+select '18_riwayat_nilai OK' as hasil;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -450,6 +450,22 @@ export async function komponenSemua(edisi) {
     `&order=pos.asc,sort_order.asc`);
 }
 
+/** Riwayat perubahan nilai satu regu di satu pos — siapa mengubah apa, kapan.
+ *
+ *  Dibaca saat penanda simpan diketuk, bukan ikut dimuat bersama lembarnya:
+ *  lembar pos memuat ratusan baris dan hampir semuanya tidak pernah ditanya
+ *  riwayatnya. */
+export async function riwayatNilai(pos, nomorDada) {
+  if (K.mode === "dev") {
+    return baca(`/riwayat-nilai?pos=${encodeURIComponent(pos)}` +
+                `&dada=${encodeURIComponent(nomorDada)}`);
+  }
+  return baca(null,
+    `v_riwayat_nilai?pos=eq.${encodeURIComponent(pos)}` +
+    `&nomor_dada=eq.${encodeURIComponent(nomorDada)}` +
+    `&select=*&order=changed_at.desc`);
+}
+
 /** Kelengkapan input per pos — satu baris per pos, bukan per regu.
  *
  *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -19,7 +19,7 @@ import {
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
   batasNomorDada,
-  komponenSemua, rekapPenuh, kelengkapanPos,
+  komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
@@ -2540,7 +2540,18 @@ async function layarInputPos() {
     } else if (keadaan === "menyimpan") {
       sel.replaceChildren(h(`<span class="badge badge-gray">…</span>`));
     } else if (keadaan === "tersimpan") {
-      sel.replaceChildren(h(`<span class="badge badge-green" title="Sudah masuk database">✓</span>`));
+      // Centangnya SEKALIGUS pintu riwayat. Bukan tombol tambahan di kolom
+      // terpisah: lembar ini sudah selebar layar dua kali, dan satu kolom lagi
+      // dibayar setiap baris walau riwayatnya hampir tidak pernah ditanya.
+      //
+      // Yang ditanyakan orang saat menatap centang hijau memang persis ini —
+      // "angka ini sudah masuk, tapi siapa yang menaruhnya, dan apakah ia
+      // mengganti angka lain?" Jadi jawabannya ditaruh di tempat pertanyaannya
+      // muncul.
+      sel.replaceChildren(h(`<button class="badge badge-green badge-tombol"
+        type="button" data-riwayat title="Sudah masuk database — ketuk untuk melihat riwayat">✓</button>`));
+      sel.querySelector("[data-riwayat]")
+         .addEventListener("click", () => bukaRiwayat(tr));
     } else if (keadaan === "gagal") {
       sel.replaceChildren(h(html`<button class="button button-danger button-mini"
         type="button" data-ulang title="${pesan}">Ulangi</button>`));
@@ -2550,6 +2561,45 @@ async function layarInputPos() {
     }
     perbaruiRingkasan();
   };
+
+  /** Riwayat perubahan nilai satu regu di pos ini.
+   *
+   *  Dibaca saat DIKETUK, bukan ikut dimuat bersama lembarnya: lembar pos
+   *  memuat ratusan baris dan hampir semuanya tidak pernah ditanya riwayatnya.
+   *
+   *  Yang ditampilkan sengaja apa adanya — angka lama, angka baru, siapa,
+   *  kapan — tanpa menyimpulkan mana yang "mencurigakan". Yang tahu apakah
+   *  suatu perubahan wajar adalah orang yang berdiri di pos itu, bukan layar. */
+  async function bukaRiwayat(tr) {
+    const dada = Number(tr.dataset.dada);
+    const nama = tr.children[1].textContent.trim();
+    let baris;
+    try {
+      baris = await riwayatNilai(pos.nomor, dada);
+    } catch (err) {
+      notif(`Riwayat tidak bisa dibaca: ${err.message}`, true);
+      return;
+    }
+
+    /* Sengaja RINGKAS: satu baris per perubahan, tanpa kepala tabel.
+       Yang dicari orang saat membukanya cuma tiga hal — lomba apa, dari berapa
+       jadi berapa, dan siapa. Kepala tabel dan kalimat penjelas menambah teks
+       yang harus dilewati mata sebelum sampai ke jawabannya. */
+    const isi = baris.length
+      ? `<ul class="riwayat">${baris.map(b => html`<li>
+           <span class="r-lomba">${b.nama_lomba}</span>
+           <span class="r-nilai">${b.nilai_lama === null ? "—" : angkaRapi(b.nilai_lama)}
+             → <strong>${b.nilai_baru === null ? "hapus" : angkaRapi(b.nilai_baru)}</strong></span>
+           <span class="r-oleh">${b.oleh} · ${tanggalJam(b.changed_at)}</span>
+         </li>`).join("")}</ul>`
+      : `<p class="description">Belum pernah diubah.</p>`;
+
+    await dialog({
+      judul: `${String(dada).padStart(3, "0")} · ${nama}`,
+      kartuHtml: isi,
+      labelAksi: "Tutup",
+    });
+  }
 
   /* ---------- pita keadaan + kirim ulang sendiri ----------
 

--- a/web/style.css
+++ b/web/style.css
@@ -1091,6 +1091,31 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    di depan. */
 .data-table td[data-label="Metode"] { text-transform: capitalize; }
 .data-table td[data-label="Metode"] .badge { text-transform: none; }
+/* Lencana yang SEKALIGUS tombol. Rupanya tetap lencana — yang berubah cuma
+   kursornya dan cincin fokus, supaya jelas ia bisa diketuk tanpa menjadikannya
+   tombol besar yang menuntut lebar kolom sendiri. */
+/* Riwayat perubahan nilai: satu baris per perubahan, tanpa kepala tabel.
+   Yang dicari cuma lomba apa, dari berapa jadi berapa, dan siapa — tiga hal
+   yang muat sebaris, dan mata tidak perlu melewati apa pun sebelum sampai. */
+.riwayat { list-style: none; margin: 0; padding: 0; }
+.riwayat li {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: .2rem .8rem;
+  padding: .5rem 0; border-bottom: 1px solid var(--garis);
+}
+.riwayat li:last-child { border-bottom: 0; }
+.r-lomba { font-weight: 600; flex: 1 1 8rem; }
+.r-nilai { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.r-oleh  { color: var(--tinta-lembut); font-size: .82rem; flex: 1 1 100%; }
+@media (min-width: 480px) {
+  .r-oleh { flex: 0 0 auto; text-align: right; }
+}
+
+.badge-tombol {
+  border: 0; font: inherit; cursor: pointer;
+  padding: .1rem .45rem; line-height: inherit;
+}
+.badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+
 .table-empty { text-align: center; color: var(--tinta-lembut); padding: 1.4rem .5rem; }
 
 /* Kontrol di dalam sel: cukup besar untuk jari, cukup ringkas untuk tabel. */


### PR DESCRIPTION
## What

Mengetuk **centang hijau** di lembar Input Pos membuka riwayat perubahan nilai regu itu:

```
Semaphore        3 → 4      pos1hrcd37 · 21 Feb 2027 14:22
Tebak Simpul     — → 7      pos1hrcd37 · 21 Feb 2027 14:20
Menaksir         2 → hapus  admin.ciradyka · 21 Feb 2027 14:31
```

Satu baris per perubahan, tanpa kepala tabel.

## Why

Setiap perubahan `nilai_mentah` **sudah tercatat sejak migrasi 0002** — trigger audit menyimpan baris lama, baris baru, siapa, kapan. Datanya utuh dan tidak pernah bisa dilihat: RLS `history` hanya mengizinkan admin, dan tidak ada layar yang membacanya.

Kalau satu nilai berubah tanpa ada yang tahu, **jawabannya sudah ada di database sejak awal**. Yang tidak ada cuma jalan untuk bertanya.

## Notes — kenapa view sempit, bukan melebarkan RLS

`history` mencatat **seluruh tabel**, termasuk `pendaftaran` — dan baris pendaftaran memuat **nomor WhatsApp**. Membuka audit nilai kepada operator pos tidak boleh berarti membuka nomor telepon sekolah kepada mereka.

`v_riwayat_nilai` menyaring `table_name = 'nilai_mentah'` lebih dulu. Pagarnya **menyalin persis** policy `sel_nilai`: admin dan meja seluruh pos, operator pos hanya posnya sendiri. Kalau keduanya berbeda, akan ada operator yang bisa **mengubah** satu nilai tetapi tidak bisa melihat bahwa ia mengubahnya.

## Notes — kenapa centangnya, bukan tombol baru

Lembar ini sudah selebar layar dua kali; satu kolom lagi dibayar setiap baris walau riwayatnya hampir tidak pernah ditanya. Dan yang ditanyakan orang saat menatap centang hijau memang persis ini — *"angka ini sudah masuk, tapi siapa yang menaruhnya?"*

Dibaca saat diketuk, bukan ikut dimuat bersama lembarnya.

Tes 18 menjaga **pagarnya**, bukan isinya: operator pos tidak melihat pos lain, dan riwayat tabel lain tidak pernah bocor lewat view ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)