### PR TITLE
fix: popup riwayat tanpa tombol Batal, dan barisnya tidak lagi patah

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -442,7 +442,20 @@ export function notif(pesan, galat = false) {
 /** Dialog sederhana pengganti prompt(): punya judul, kartu identitas,
  *  beberapa isian, dan tombol batal yang jelas (temuan review: prompt()
  *  beruntun membingungkan dan batalnya senyap). */
-export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan" }) {
+/** Dialog. `bacaSaja: true` membuang tombol Batal.
+ *
+ *  "Batal" pada dialog yang tidak mengubah apa pun bukan sekadar mubazir: ia
+ *  menyiratkan ada sesuatu yang sedang berjalan dan bisa diurungkan. Orang yang
+ *  membuka riwayat lalu melihat Batal akan berhenti sejenak memikirkan apa yang
+ *  ia batalkan.
+ *
+ *  Penandanya EKSPLISIT, bukan diterka dari `medan` yang kosong. Lima dari enam
+ *  pemanggil dialog di sistem ini tidak punya medan sama sekali — mereka
+ *  konfirmasi ya/tidak yang justru paling membutuhkan tombol Batal. Menerka
+ *  akan mencabutnya dari kelimanya sekaligus, dan yang tersisa cuma tombol
+ *  "Ya". */
+export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan",
+                         bacaSaja = false }) {
   return new Promise(resolve => {
     const wadah = h(html`<div class="overlay" role="dialog" aria-modal="true"></div>`);
     document.body.appendChild(wadah);
@@ -461,13 +474,14 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
           </div>`).join("")}
         <div class="dialog-error error" hidden></div>
         <div class="option-row">
-          <button class="button button-secondary" data-batal type="button">Batal</button>
+          ${bacaSaja ? "" : `<button class="button button-secondary" data-batal
+            type="button">Batal</button>`}
           <button class="button button-primary" data-ok type="button">${esc(labelAksi)}</button>
         </div>
       </div>`;
 
     const tutup = hasil => { el.remove(); resolve(hasil); };
-    el.querySelector("[data-batal]").addEventListener("click", () => tutup(null));
+    el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });
     el.querySelector("[data-ok]").addEventListener("click", () => {
       const nilai = medan.map((_, i) => el.querySelector(`#dlg-${i}`).value.trim());

--- a/live/style.css
+++ b/live/style.css
@@ -1103,11 +1103,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   padding: .5rem 0; border-bottom: 1px solid var(--garis);
 }
 .riwayat li:last-child { border-bottom: 0; }
-.r-lomba { font-weight: 600; flex: 1 1 8rem; }
+/* Nama lomba yang mengalah, bukan barisnya yang patah. Menaksir bisa bernilai
+   empat digit, dan sebelumnya angka selebar itu mendorong kolom "oleh" turun ke
+   baris kedua — hanya untuk sebagian baris, sehingga daftarnya jadi bergerigi
+   dan justru lebih sulit disapu mata daripada nama yang terpotong. */
+.r-lomba {
+  font-weight: 600; flex: 1 1 6rem; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 .r-nilai { font-variant-numeric: tabular-nums; white-space: nowrap; }
-.r-oleh  { color: var(--tinta-lembut); font-size: .82rem; flex: 1 1 100%; }
-@media (min-width: 480px) {
-  .r-oleh { flex: 0 0 auto; text-align: right; }
+.r-oleh  {
+  color: var(--tinta-lembut); font-size: .82rem;
+  white-space: nowrap; margin-left: auto;
 }
 
 .badge-tombol {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2598,6 +2598,7 @@ async function layarInputPos() {
       judul: `${String(dada).padStart(3, "0")} · ${nama}`,
       kartuHtml: isi,
       labelAksi: "Tutup",
+      bacaSaja: true,
     });
   }
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -442,7 +442,20 @@ export function notif(pesan, galat = false) {
 /** Dialog sederhana pengganti prompt(): punya judul, kartu identitas,
  *  beberapa isian, dan tombol batal yang jelas (temuan review: prompt()
  *  beruntun membingungkan dan batalnya senyap). */
-export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan" }) {
+/** Dialog. `bacaSaja: true` membuang tombol Batal.
+ *
+ *  "Batal" pada dialog yang tidak mengubah apa pun bukan sekadar mubazir: ia
+ *  menyiratkan ada sesuatu yang sedang berjalan dan bisa diurungkan. Orang yang
+ *  membuka riwayat lalu melihat Batal akan berhenti sejenak memikirkan apa yang
+ *  ia batalkan.
+ *
+ *  Penandanya EKSPLISIT, bukan diterka dari `medan` yang kosong. Lima dari enam
+ *  pemanggil dialog di sistem ini tidak punya medan sama sekali — mereka
+ *  konfirmasi ya/tidak yang justru paling membutuhkan tombol Batal. Menerka
+ *  akan mencabutnya dari kelimanya sekaligus, dan yang tersisa cuma tombol
+ *  "Ya". */
+export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan",
+                         bacaSaja = false }) {
   return new Promise(resolve => {
     const wadah = h(html`<div class="overlay" role="dialog" aria-modal="true"></div>`);
     document.body.appendChild(wadah);
@@ -461,13 +474,14 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
           </div>`).join("")}
         <div class="dialog-error error" hidden></div>
         <div class="option-row">
-          <button class="button button-secondary" data-batal type="button">Batal</button>
+          ${bacaSaja ? "" : `<button class="button button-secondary" data-batal
+            type="button">Batal</button>`}
           <button class="button button-primary" data-ok type="button">${esc(labelAksi)}</button>
         </div>
       </div>`;
 
     const tutup = hasil => { el.remove(); resolve(hasil); };
-    el.querySelector("[data-batal]").addEventListener("click", () => tutup(null));
+    el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });
     el.querySelector("[data-ok]").addEventListener("click", () => {
       const nilai = medan.map((_, i) => el.querySelector(`#dlg-${i}`).value.trim());

--- a/web/style.css
+++ b/web/style.css
@@ -1103,11 +1103,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   padding: .5rem 0; border-bottom: 1px solid var(--garis);
 }
 .riwayat li:last-child { border-bottom: 0; }
-.r-lomba { font-weight: 600; flex: 1 1 8rem; }
+/* Nama lomba yang mengalah, bukan barisnya yang patah. Menaksir bisa bernilai
+   empat digit, dan sebelumnya angka selebar itu mendorong kolom "oleh" turun ke
+   baris kedua — hanya untuk sebagian baris, sehingga daftarnya jadi bergerigi
+   dan justru lebih sulit disapu mata daripada nama yang terpotong. */
+.r-lomba {
+  font-weight: 600; flex: 1 1 6rem; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 .r-nilai { font-variant-numeric: tabular-nums; white-space: nowrap; }
-.r-oleh  { color: var(--tinta-lembut); font-size: .82rem; flex: 1 1 100%; }
-@media (min-width: 480px) {
-  .r-oleh { flex: 0 0 auto; text-align: right; }
+.r-oleh  {
+  color: var(--tinta-lembut); font-size: .82rem;
+  white-space: nowrap; margin-left: auto;
 }
 
 .badge-tombol {


### PR DESCRIPTION
## What

Dua kerapian pada popup riwayat, dan yang pertama **nyaris jadi bug**.

## 1. Tombol Batal dibuang — tapi hanya di sini

"Batal" pada dialog yang tidak mengubah apa pun menyiratkan ada sesuatu yang sedang berjalan dan bisa diurungkan.

Percobaan pertama saya menerkanya dari `medan` yang kosong. **Itu salah besar:** lima dari enam pemanggil `dialog()` tidak punya `medan` sama sekali —

| Pemanggil | Butuh Batal? |
|---|---|
| Batalkan verifikasi pembayaran | ya |
| Lunas — cetak kwitansi? | ya |
| Tukar nomor dada rusak | ya |
| Pindah kloter | ya |
| Betulkan jam berangkat | ya |
| **Riwayat nilai** | tidak |

Menerka akan mencabut Batal dari kelimanya sekaligus, dan yang tersisa hanya tombol "Ya" pada lima konfirmasi yang justru paling membutuhkannya.

Penandanya sekarang **eksplisit**: `bacaSaja: true`, dipakai satu pemanggil.

## 2. Baris yang tidak patah

Menaksir bisa bernilai empat digit, dan angka selebar itu mendorong kolom "oleh" turun ke baris kedua — **hanya untuk sebagian baris**, sehingga daftarnya bergerigi dan justru lebih sulit disapu mata daripada nama yang terpotong.

Sekarang nama lomba yang mengalah dengan elipsis; tiap baris tetap satu baris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)