### PR TITLE
feat: riwayat nilai bisa disaring per lomba

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1097,6 +1097,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Riwayat perubahan nilai: satu baris per perubahan, tanpa kepala tabel.
    Yang dicari cuma lomba apa, dari berapa jadi berapa, dan siapa — tiga hal
    yang muat sebaris, dan mata tidak perlu melewati apa pun sebelum sampai. */
+.saring-riwayat { margin-bottom: .6rem; flex-wrap: wrap; gap: .35rem; }
 .riwayat { list-style: none; margin: 0; padding: 0; }
 .riwayat li {
   display: flex; flex-wrap: wrap; align-items: baseline; gap: .2rem .8rem;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2585,21 +2585,66 @@ async function layarInputPos() {
        Yang dicari orang saat membukanya cuma tiga hal — lomba apa, dari berapa
        jadi berapa, dan siapa. Kepala tabel dan kalimat penjelas menambah teks
        yang harus dilewati mata sebelum sampai ke jawabannya. */
-    const isi = baris.length
-      ? `<ul class="riwayat">${baris.map(b => html`<li>
-           <span class="r-lomba">${b.nama_lomba}</span>
-           <span class="r-nilai">${b.nilai_lama === null ? "—" : angkaRapi(b.nilai_lama)}
-             → <strong>${b.nilai_baru === null ? "hapus" : angkaRapi(b.nilai_baru)}</strong></span>
-           <span class="r-oleh">${b.oleh} · ${tanggalJam(b.changed_at)}</span>
-         </li>`).join("")}</ul>`
-      : `<p class="description">Belum pernah diubah.</p>`;
+    if (!baris.length) {
+      await dialog({
+        judul: `${String(dada).padStart(3, "0")} · ${nama}`,
+        kartuHtml: `<p class="description">Belum pernah diubah.</p>`,
+        labelAksi: "Tutup", bacaSaja: true,
+      });
+      return;
+    }
 
-    await dialog({
+    /* SARINGAN PER LOMBA, dan hanya muncul kalau memang ada yang disaring.
+       Satu regu di Pos 3 bisa punya tujuh lomba dan puluhan perubahan; yang
+       ditanyakan biasanya satu — "Bidai-nya kenapa berubah dua kali?".
+       Menyaringnya di sini lebih cepat daripada menyusuri daftar.
+
+       Di pos berlomba satu, chip-nya cuma akan berbunyi "Semua" dan nama lomba
+       itu sendiri — dua tombol yang tidak menyaring apa pun. Jadi ia tidak
+       digambar sama sekali. */
+    const lomba = [...new Map(baris.map(b => [b.kode_lomba, b.nama_lomba]))];
+    const chip = lomba.length < 2 ? "" : `
+      <div class="option-row saring-riwayat">
+        <button type="button" class="option option-small" data-lomba=""
+                aria-pressed="true">Semua</button>
+        ${lomba.map(([kode, nama]) => html`
+          <button type="button" class="option option-small" data-lomba="${kode}"
+                  aria-pressed="false">${nama}</button>`).join("")}
+      </div>`;
+
+    const isi = chip + `<ul class="riwayat">${baris.map(b => html`
+      <li data-lomba="${b.kode_lomba}">
+        <span class="r-lomba">${b.nama_lomba}</span>
+        <span class="r-nilai">${b.nilai_lama === null ? "—" : angkaRapi(b.nilai_lama)}
+          → <strong>${b.nilai_baru === null ? "hapus" : angkaRapi(b.nilai_baru)}</strong></span>
+        <span class="r-oleh">${b.oleh} · ${tanggalJam(b.changed_at)}</span>
+      </li>`).join("")}</ul>`;
+
+    // dialog() menempelkan kartunya ke DOM secara SINKRON sebelum janjinya
+    // menunggu, jadi penyaringnya boleh dipasang sebelum di-await. Menunggu
+    // dulu berarti menunggu sampai dialognya ditutup.
+    const janji = dialog({
       judul: `${String(dada).padStart(3, "0")} · ${nama}`,
       kartuHtml: isi,
       labelAksi: "Tutup",
       bacaSaja: true,
     });
+
+    const kartu = document.querySelector(".dialog .saring-riwayat");
+    if (kartu) {
+      kartu.addEventListener("click", (e) => {
+        const b = e.target.closest("[data-lomba]");
+        if (!b) return;
+        const pilih = b.dataset.lomba;
+        kartu.querySelectorAll("[data-lomba]").forEach(x =>
+          x.setAttribute("aria-pressed", String(x.dataset.lomba === pilih)));
+        document.querySelectorAll(".dialog .riwayat li").forEach(li => {
+          li.hidden = !!pilih && li.dataset.lomba !== pilih;
+        });
+      });
+    }
+
+    await janji;
   }
 
   /* ---------- pita keadaan + kirim ulang sendiri ----------

--- a/web/style.css
+++ b/web/style.css
@@ -1097,6 +1097,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Riwayat perubahan nilai: satu baris per perubahan, tanpa kepala tabel.
    Yang dicari cuma lomba apa, dari berapa jadi berapa, dan siapa — tiga hal
    yang muat sebaris, dan mata tidak perlu melewati apa pun sebelum sampai. */
+.saring-riwayat { margin-bottom: .6rem; flex-wrap: wrap; gap: .35rem; }
 .riwayat { list-style: none; margin: 0; padding: 0; }
 .riwayat li {
   display: flex; flex-wrap: wrap; align-items: baseline; gap: .2rem .8rem;


### PR DESCRIPTION
## What

Popup riwayat mendapat chip penyaring per lomba:

```
[ Semua ] [ Semaphore ] [ Tebak Simpul ] [ Menaksir ]

Menaksir    1 → 0      admin.ciradyka · 15 Agu 17:16
Menaksir    3 → 1      admin.ciradyka · 15 Agu 14:36
Menaksir    1000 → 3   admin.ciradyka · 15 Agu 14:36
```

## Why

Satu regu di Pos 3 punya **tujuh lomba**, dan riwayatnya bisa berisi puluhan perubahan. Yang ditanyakan biasanya satu — *"Bidai-nya kenapa berubah dua kali?"* — dan menyusuri seluruh daftar untuk menemukannya mengalahkan gunanya riwayat itu sendiri.

## Notes

**Chip tidak digambar di pos berlomba satu.** Di sana isinya akan "Semua" dan nama lomba itu sendiri: dua tombol yang tidak menyaring apa pun, dan tiap tombol yang tidak melakukan apa-apa mengajari orang berhenti membaca tombol.

**Penyaringnya dipasang sebelum dialognya di-`await`.** `dialog()` menempelkan kartunya ke DOM secara sinkron sebelum janjinya menunggu, jadi elemennya sudah ada — menunggu dulu berarti menunggu sampai dialognya **ditutup**, dan saat itu tidak ada lagi yang bisa dipasangi.

Menyaring hanya menyembunyikan baris, tidak memuat ulang apa pun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)