### PR TITLE
feat: gembok nilai — satu baris dinyatakan selesai dan tidak bisa diubah lagi

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -450,6 +450,17 @@ export async function komponenSemua(edisi) {
     `&order=pos.asc,sort_order.asc`);
 }
 
+/** Gembok: menyatakan nilai satu regu di satu pos sudah selesai (0043).
+ *  Operator pos memakai posnya sendiri; admin dan meja wajib menyebut pos. */
+export const kunciNilaiPos = (nomorDada, pos) =>
+  rpc("kunci_nilai_pos", { p_nomor_dada: nomorDada, p_pos: pos });
+
+/** Membuka gembok. ADMIN SAJA, dan wajib beralasan — bentuk yang sama dengan
+ *  batalkan_tanda_cetak, karena keduanya membatalkan pernyataan "sudah final". */
+export const bukaKunciNilaiPos = (nomorDada, pos, alasan) =>
+  rpc("buka_kunci_nilai_pos",
+      { p_nomor_dada: nomorDada, p_pos: pos, p_alasan: alasan });
+
 /** Riwayat perubahan nilai satu regu di satu pos — siapa mengubah apa, kapan.
  *
  *  Dibaca saat penanda simpan diketuk, bukan ikut dimuat bersama lembarnya:

--- a/live/style.css
+++ b/live/style.css
@@ -1097,6 +1097,23 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Riwayat perubahan nilai: satu baris per perubahan, tanpa kepala tabel.
    Yang dicari cuma lomba apa, dari berapa jadi berapa, dan siapa — tiga hal
    yang muat sebaris, dan mata tidak perlu melewati apa pun sebelum sampai. */
+/* Gembok: bawaan TERBUKA, tertutup sesudah dikunci. Ukurannya sengaja sebesar
+   jari — ia satu-satunya tombol di lembar ini yang akibatnya tidak bisa
+   diurungkan sendiri, jadi tidak boleh tertekan karena meleset. */
+.gembok {
+  border: 0; background: none; cursor: pointer; font-size: 1.15rem;
+  line-height: 1; padding: .35rem .4rem; border-radius: 8px;
+}
+.gembok:hover { background: var(--kartu-lembut, rgba(0,0,0,.05)); }
+.gembok:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+
+/* Baris tergembok: kotaknya benar-benar mati, dan terlihat mati. Bukan sekadar
+   pudar — kotak yang masih bisa diketik tapi selalu ditolak adalah jebakan. */
+.baris-terkunci input:disabled {
+  background: var(--kartu-lembut, #f3f4f6);
+  color: var(--tinta-lembut); cursor: not-allowed;
+}
+
 .saring-riwayat { margin-bottom: .6rem; flex-wrap: wrap; gap: .35rem; }
 .riwayat { list-style: none; margin: 0; padding: 0; }
 .riwayat li {

--- a/supabase/migrations/0043_kunci_nilai.sql
+++ b/supabase/migrations/0043_kunci_nilai.sql
@@ -1,0 +1,170 @@
+-- ============================================================================
+-- hrcd-rekap : 0043_kunci_nilai.sql
+--
+-- GEMBOK: satu regu di satu pos dinyatakan selesai, dan nilainya tidak bisa
+-- diubah lagi oleh siapa pun sampai admin membukanya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA ADA
+--
+-- Nilai bisa berubah tanpa ada yang bermaksud mengubahnya: satu ketukan
+-- nyasar di HP, satu baris yang tersimpan ulang, satu angka yang tertimpa.
+-- Riwayat (0042) membuat perubahan itu bisa DITELUSURI sesudahnya, tapi tidak
+-- ada yang MENCEGAHNYA.
+--
+-- Gembok adalah pernyataan petugas: "regu ini sudah saya periksa, angkanya
+-- benar, jangan ada yang menyentuhnya lagi."
+--
+-- ---------------------------------------------------------------------------
+-- SATU BARIS = SATU REGU DI SATU POS
+--
+-- Bukan per regu seluruh lomba, dan bukan per pos seluruh regu. Yang selesai
+-- di lapangan memang satu baris pada satu lembar: regu 005 sudah tuntas di
+-- Pos 1, sementara Pos 3 belum menyentuhnya sama sekali. Mengunci lebih lebar
+-- akan mengunci pekerjaan pos lain yang belum dimulai.
+--
+-- ---------------------------------------------------------------------------
+-- SIAPA MENGUNCI, SIAPA MEMBUKA
+--
+--   mengunci : operator pos (posnya sendiri), meja, admin
+--   membuka  : ADMIN SAJA, dan wajib menyebut alasan
+--
+-- Bentuk yang sama dengan `batalkan_tanda_cetak` (0008), dan alasannya sama:
+-- kalau yang mengunci juga bisa membuka sendiri, gemboknya cuma polisi tidur.
+-- Yang membuatnya berarti justru karena membukanya menuntut orang lain.
+--
+-- Harganya disebut supaya tidak jadi kejutan: petugas yang salah mengunci
+-- harus menghubungi admin. Itu disengaja — mengunci adalah pernyataan
+-- "sudah saya periksa", dan pernyataan yang bisa ditarik sendiri kapan saja
+-- bukan pernyataan.
+--
+-- ---------------------------------------------------------------------------
+-- PENJAGANYA DI SERVER
+--
+-- Layar boleh mengabu-abukan kotaknya, tapi yang menolak tulisan haruslah
+-- database. Lembar pos dibuka di beberapa HP sekaligus, dan HP yang layarnya
+-- dimuat SEBELUM gemboknya dipasang tidak tahu apa-apa tentang gembok itu.
+-- ============================================================================
+
+create table if not exists nilai_terkunci (
+  regu_id      uuid     not null references regu (id),
+  pos          smallint not null,
+  reason       text,
+  locked_by    uuid     not null references auth.users (id),
+  locked_at    timestamptz not null default now(),
+  primary key (regu_id, pos)
+);
+
+alter table nilai_terkunci enable row level security;
+
+-- Dibaca setiap panitia: layar perlu tahu baris mana yang tergembok, dan
+-- menyembunyikan gembok dari orang yang tertolak menulis hanya membuat
+-- penolakannya tidak bisa dijelaskan.
+create policy sel_kunci on nilai_terkunci for select using (peran() is not null);
+-- Menulis HANYA lewat RPC di bawah, yang memeriksa pos dan peran.
+create policy adm_kunci on nilai_terkunci for all using (peran() = 'admin');
+
+grant select on nilai_terkunci to authenticated;
+
+comment on table nilai_terkunci is
+  'Regu yang nilainya dinyatakan selesai di satu pos. Ditulis lewat '
+  'kunci_nilai_pos / buka_kunci_nilai_pos, bukan langsung.';
+
+-- ---------------------------------------------------------------------------
+-- Pemeriksa tunggal, dipakai kedua jalur tulis.
+--
+-- Satu fungsi, bukan dua salinan syarat: `simpan_nilai_massal` dan
+-- `hapus_nilai_pos` sama-sama harus menolak, dan dua salinan adalah cara
+-- mereka mulai berbeda pendapat. Cacat persis itu yang dibetulkan 0040.
+-- ---------------------------------------------------------------------------
+create or replace function nilai_tergembok(p_regu uuid, p_pos smallint)
+returns boolean language sql stable
+set search_path = public
+as $$
+  select exists (
+    select 1 from nilai_terkunci where regu_id = p_regu and pos = p_pos)
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Mengunci. Operator pos hanya boleh posnya sendiri.
+-- ---------------------------------------------------------------------------
+create or replace function kunci_nilai_pos(
+  p_nomor_dada integer,
+  p_pos        smallint default null   -- wajib untuk admin/meja
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_pos smallint; v_regu uuid;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+    if p_pos is not null and p_pos <> v_pos then
+      raise exception 'operator pos % tidak boleh mengunci pos %', v_pos, p_pos;
+    end if;
+  elsif peran() in ('admin', 'meja') then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya panitia yang boleh mengunci';
+  end if;
+
+  select id into v_regu from regu
+  where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal / regu batal',
+      case when p_nomor_dada between 0 and 999
+        then lpad(p_nomor_dada::text, 3, '0') else p_nomor_dada::text end;
+  end if;
+
+  -- Mengunci dua kali bukan galat: dua petugas bisa menekan gembok yang sama
+  -- dari HP berbeda, dan yang kedua tidak melakukan kesalahan apa pun.
+  insert into nilai_terkunci (regu_id, pos, locked_by)
+  values (v_regu, v_pos, auth.uid())
+  on conflict (regu_id, pos) do nothing;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Membuka. ADMIN SAJA, wajib beralasan — bentuk yang sama dengan
+-- batalkan_tanda_cetak, karena keduanya membatalkan pernyataan "sudah final".
+-- ---------------------------------------------------------------------------
+create or replace function buka_kunci_nilai_pos(
+  p_nomor_dada integer,
+  p_pos        smallint,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_regu uuid;
+begin
+  if peran() <> 'admin' then
+    raise exception 'hanya admin yang boleh membuka gembok';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan membuka gembok wajib diisi';
+  end if;
+
+  select id into v_regu from regu where nomor_dada = p_nomor_dada;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+
+  -- Alasannya dicatat SEBELUM barisnya hilang, kalau tidak ia hilang bersama
+  -- barisnya — dan yang tersisa cuma nilai yang berubah tanpa penjelasan.
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('nilai_terkunci', v_regu::text || ':' || p_pos, v_regu, 'DELETE',
+          jsonb_build_object('alasan_buka_gembok', p_alasan, 'pos', p_pos),
+          auth.uid());
+
+  delete from nilai_terkunci where regu_id = v_regu and pos = p_pos;
+end;
+$$;
+
+revoke all on function kunci_nilai_pos(integer, smallint) from public;
+revoke all on function buka_kunci_nilai_pos(integer, smallint, text) from public;
+grant execute on function kunci_nilai_pos(integer, smallint) to authenticated;
+grant execute on function buka_kunci_nilai_pos(integer, smallint, text) to authenticated;

--- a/supabase/migrations/0044_gembok_di_jalur_tulis.sql
+++ b/supabase/migrations/0044_gembok_di_jalur_tulis.sql
@@ -1,0 +1,290 @@
+-- ============================================================================
+-- hrcd-rekap : 0044_gembok_di_jalur_tulis.sql
+--
+-- Memasang gembok (0043) di KEDUA jalur tulis nilai, dan memberitahukan
+-- keadaannya ke layar lewat v_lembar_pos.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DI SERVER, PADAHAL LAYAR SUDAH MENGABUKAN KOTAKNYA
+--
+-- Lembar pos dibuka di beberapa HP sekaligus — itu memang bentuk kerjanya,
+-- dan sejak lembar ini menyegarkan diri tiap 20 detik, HP kedua akan tahu
+-- soal gemboknya dalam waktu paling lama 20 detik.
+--
+-- Paling lama 20 detik masih berarti ada 20 detik. HP yang layarnya dimuat
+-- sebelum gemboknya dipasang akan mengirim angka dengan penuh keyakinan, dan
+-- satu-satunya yang bisa menolaknya adalah database.
+--
+-- ---------------------------------------------------------------------------
+-- SATU PEMERIKSA, DIPAKAI DUA JALUR
+--
+-- `simpan_nilai_massal` dan `hapus_nilai_pos` sama-sama memanggil
+-- `nilai_tergembok()`, bukan menyalin syaratnya masing-masing. Dua salinan
+-- syarat yang sama adalah cara mereka mulai berbeda pendapat — dan itu persis
+-- cacat yang membuat 0040 harus ditulis: 0011 menyalin algoritma dari 0004
+-- lalu kehilangan satu syarat yang ditambahkan 0008 di antaranya.
+--
+-- Badan kedua fungsi disalin dari 0031 dan 0023 oleh skrip, dengan satu
+-- sisipan masing-masing yang diperiksa jumlahnya.
+--
+-- ---------------------------------------------------------------------------
+-- LAYAR PERLU TAHU, TAPI TIDAK MENENTUKAN
+--
+-- v_lembar_pos mendapat kolom `terkunci` supaya lembar bisa menggambar gembok
+-- tertutup dan mematikan kotaknya. Itu untuk KENYAMANAN — supaya petugas tahu
+-- sebelum mengetik, bukan sesudah ditolak. Yang menegakkan aturannya tetap
+-- kedua fungsi di atas.
+-- ============================================================================
+
+create or replace function simpan_nilai_massal(
+  p_baris  jsonb,  -- [{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40,"nilai_2":null}, ...]
+  p_sumber text default 'upload',
+  p_pos    smallint default null  -- wajib untuk admin; operator memakai pos-nya sendiri
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_r      jsonb;
+  v_regu   regu%rowtype;
+  v_wahana wahana%rowtype;
+  v_hasil  jsonb := '[]'::jsonb;
+  v_status text;
+  v_alasan text;
+  v_idx    int := 0;
+  v_pos    smallint;
+  v_kunci  text;
+  v_sudah  text[] := '{}';
+  v_n1     numeric;
+  v_n2     numeric;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+  if p_sumber not in ('manual', 'upload') then
+    raise exception 'sumber tidak dikenal: %', p_sumber;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_baris) loop
+    v_idx := v_idx + 1;
+    v_status := 'tersimpan'; v_alasan := null;
+
+    -- Seluruh pemrosesan baris terlindungi: format angka rusak di baris 7
+    -- tidak boleh menggagalkan 26 baris lain (temuan review).
+    begin
+      v_n1 := (v_r ->> 'nilai_1')::numeric;
+      v_n2 := nullif(v_r ->> 'nilai_2', '')::numeric;
+
+      -- Baris ganda dalam SATU paste = merah (bagian 6.3) — juga di server.
+      v_kunci := (v_r ->> 'nomor_dada') || '|' ||
+                 regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g');
+      if v_kunci = any (v_sudah) then
+        raise exception 'baris ganda dalam paste (nomor dada + komponen sama)';
+      end if;
+      v_sudah := v_sudah || v_kunci;
+
+      -- Regu: harus dikenal, bernomor, tidak batal.
+      select * into v_regu from regu
+      where nomor_dada = (v_r ->> 'nomor_dada')::integer and not is_cancelled;
+      if not found then
+        raise exception 'nomor dada tidak dikenal / regu batal';
+      end if;
+
+      -- Komponen: HANYA pos ini (kode boleh kembar antar pos — temuan
+      -- review); normalisasi dua arah supaya "Lari Zigzag" dari header foto
+      -- cocok dengan kode lari_zigzag.
+      select w.* into v_wahana from wahana w
+      where w.edisi = edisi_aktif()
+        and w.pos = v_pos
+        and regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g')
+            = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+      if not found then
+        raise exception 'kode komponen tidak dikenal di pos % — mungkin ini lembar pos lain?', v_pos;
+      end if;
+
+      -- Baris yang sudah DIGEMBOK: tolak, apa pun isinya.
+      --
+      -- Diperiksa di server, bukan cukup di layar. Lembar pos dibuka di
+      -- beberapa HP sekaligus, dan HP yang layarnya dimuat SEBELUM gemboknya
+      -- dipasang tidak tahu apa-apa tentang gembok itu — ia akan mengirim
+      -- angka dengan penuh keyakinan.
+      if nilai_tergembok(v_regu.id, v_pos) then
+        raise exception 'Nilai regu ini sudah digembok. Buka gemboknya dulu.';
+      end if;
+
+      -- Komponen milik golongan lain: TOLAK.
+      --
+      -- Sejak 0030 satu lomba boleh punya dua baris `wahana`, satu per
+      -- golongan (Tebak Simpul: 5 objek untuk penggalang, 10 untuk penegak).
+      -- Keduanya muncul sebagai kolom di lembar yang sama, jadi tanpa pagar
+      -- ini satu regu bisa terisi DUA-DUANYA — dan totalnya 200 dari
+      -- maksimum 100, tanpa satu pun galat yang memberi tahu siapa pun.
+      if not komponen_berlaku(v_wahana.golongan, v_regu.golongan) then
+        raise exception 'Komponen ini untuk golongan lain.';
+      end if;
+
+      -- Rentang wajar dari konfigurasi (merah di preview = tolak di server).
+      if v_n1 is null
+         or v_n1 not between v_wahana.rentang_mentah_min and v_wahana.rentang_mentah_maks then
+        -- trim_scale membuang nol di belakang koma: rentang_mentah_min
+        -- bertipe numeric(10,2), jadi tanpa ini pesannya berbunyi
+        -- "antara 0.00 - 20.00" — angka yang tidak pernah ditulis siapa pun
+        -- di kertas, dan yang membacanya jadi ragu apakah pecahan diterima.
+        raise exception 'Input harus antara % - %.',
+          trim_scale(v_wahana.rentang_mentah_min),
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+      -- nilai_2 (jumlah salah) ikut divalidasi (temuan review).
+      if v_n2 is not null
+         and v_n2 not between 0 and v_wahana.rentang_mentah_maks then
+        raise exception 'Jumlah salah harus antara 0 - %.',
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+
+      insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+      values (v_regu.id, v_wahana.id, v_n1, v_n2, p_sumber, auth.uid())
+      on conflict (regu_id, wahana_id) do update set
+        nilai_1 = excluded.nilai_1,
+        nilai_2 = excluded.nilai_2,
+        source  = excluded.source,
+        created_by = excluded.created_by,
+        created_at = now()
+      -- Simpan ulang tanpa perubahan = tidak menulis apa pun: kepengarangan
+      -- tidak tergeser, riwayat tidak dibanjiri (temuan review).
+      where nilai_mentah.nilai_1 is distinct from excluded.nilai_1
+         or nilai_mentah.nilai_2 is distinct from excluded.nilai_2;
+
+    exception when others then
+      v_status := 'ditolak';
+      v_alasan := sqlerrm;
+    end;
+
+    v_hasil := v_hasil || jsonb_build_object(
+      'baris', v_idx,
+      'nomor_dada', v_r ->> 'nomor_dada',
+      'kode', v_r ->> 'kode',
+      'status', v_status,
+      'alasan', v_alasan);
+  end loop;
+
+  return v_hasil;
+end;
+$$;
+
+create or replace function hapus_nilai_pos(
+  p_nomor_dada integer,
+  p_kode       text,
+  p_pos        smallint default null   -- wajib untuk admin
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_pos    smallint;
+  v_regu   uuid;
+  v_wahana uuid;
+begin
+  if peran() = 'operator_pos' then
+    v_pos := pos_saya();
+  elsif peran() = 'admin' then
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'admin wajib menyebut pos (p_pos)';
+    end if;
+  else
+    raise exception 'hanya operator pos / admin';
+  end if;
+
+  select id into v_regu from regu
+  where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    -- Tiga digit seperti di kain nomor dadanya (migrasi 0020). Nomor di luar
+    -- 0-999 dicetak apa adanya: lpad MEMOTONG string yang lebih panjang dari
+    -- targetnya, jadi salah ketik "9999" akan dilaporkan sebagai "999" —
+    -- petugas lalu mencari nomor yang tidak pernah diketiknya.
+    raise exception 'nomor dada % tidak dikenal / regu batal',
+      case when p_nomor_dada between 0 and 999
+        then lpad(p_nomor_dada::text, 3, '0')
+        else p_nomor_dada::text end;
+  end if;
+
+  if nilai_tergembok(v_regu, v_pos) then
+    raise exception 'Nilai regu ini sudah digembok. Buka gemboknya dulu.';
+  end if;
+
+  -- Normalisasi kode disamakan dengan simpan_nilai_massal, supaya kolom yang
+  -- bisa DIISI lewat satu pintu selalu bisa DIKOSONGKAN lewat pintu ini.
+  select w.id into v_wahana from wahana w
+  where w.edisi = edisi_aktif()
+    and w.pos = v_pos
+    and regexp_replace(lower(coalesce(p_kode, '')), '[^a-z0-9]', '', 'g')
+        = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+  if not found then
+    raise exception 'kode komponen tidak dikenal di pos %', v_pos;
+  end if;
+
+  delete from nilai_mentah where regu_id = v_regu and wahana_id = v_wahana;
+end;
+$$;
+
+create or replace view v_lembar_pos as
+select
+  p.nomor       as pos,
+  p.name        as nama_pos,
+  p.bayangan,
+  r.id          as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name        as nama_sekolah,
+  r.golongan,
+
+  coalesce((
+    select jsonb_object_agg(w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), '{}'::jsonb) as nilai,
+
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_terisi,
+
+  -- INI yang berubah: hanya komponen yang berlaku untuk golongan regu ini.
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor
+     and komponen_berlaku(w.golongan, r.golongan))::int
+                as jumlah_komponen,
+
+  round(coalesce((
+    select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                           w.raw_terbaik, w.raw_terburuk,
+                           w.poin_benar, w.poin_salah, w.total_soal, w.tingkat))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), 0) * p.bobot, 2) as nilai_pos,
+
+  -- Gembok (0043). Kolom BARU ditaruh paling belakang: `create or replace
+  -- view` menolak daftar kolom yang berubah urutan atau tipenya, dan hanya
+  -- mengizinkan penambahan di ujung.
+  nilai_tergembok(r.id, p.nomor) as terkunci
+
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and peran() is not null
+  and (peran() <> 'operator_pos' or p.nomor = pos_saya());

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -139,5 +139,10 @@ run tests/sql/17_tukar_nomor_tanpa_pensiun.sql
 # 0042 membuka riwayat perubahan NILAI (dan hanya nilai) untuk petugas pos.
 run supabase/migrations/0042_riwayat_nilai.sql
 run tests/sql/18_riwayat_nilai.sql
+# 0043 memasang gembok, 0044 menyalakannya di kedua jalur tulis. Dijalankan
+# di akhir supaya tes 02-18 memakai nilai yang belum tergembok.
+run supabase/migrations/0043_kunci_nilai.sql
+run supabase/migrations/0044_gembok_di_jalur_tulis.sql
+run tests/sql/19_kunci_nilai.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/19_kunci_nilai.sql
+++ b/tests/sql/19_kunci_nilai.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/19_kunci_nilai.sql
+-- Gembok nilai (0043 + 0044).
+--
+-- Yang dijaga: gembok itu PENJAGA, bukan hiasan layar. Kalau penolakannya cuma
+-- ada di JavaScript, HP yang layarnya dimuat sebelum gemboknya dipasang tetap
+-- bisa menulis — dan justru itu keadaan yang paling mungkin terjadi, karena
+-- lembar pos memang dibuka di beberapa HP sekaligus.
+-- ============================================================================
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 19.1 Sesudah dikunci: menyimpan DITOLAK, menghapus DITOLAK.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_dada  integer; v_pos smallint; v_kode text; v_regu uuid;
+  v_hasil jsonb;   v_gagal boolean := false;
+begin
+  select r.nomor_dada, w.pos, w.kode, r.id
+    into strict v_dada, v_pos, v_kode, v_regu
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  join regu r   on r.id = n.regu_id
+  where w.edisi = edisi_aktif() and r.nomor_dada is not null
+  order by n.id limit 1;
+
+  perform kunci_nilai_pos(v_dada, v_pos);
+  assert nilai_tergembok(v_regu, v_pos), 'gembok tidak terpasang';
+
+  -- Menyimpan: ditolak per baris, dengan alasan yang terbaca petugas.
+  v_hasil := simpan_nilai_massal(
+    jsonb_build_array(jsonb_build_object(
+      'nomor_dada', v_dada, 'kode', v_kode, 'nilai_1', 1)), 'manual', v_pos);
+  assert v_hasil -> 0 ->> 'status' = 'ditolak',
+    'nilai masuk padahal barisnya tergembok';
+  assert v_hasil -> 0 ->> 'alasan' like '%digembok%',
+    format('alasan tidak menyebut gembok: %L', v_hasil -> 0 ->> 'alasan');
+
+  -- Menghapus lewat pintu yang lain: harus ditolak juga. Dua jalur tulis, dua
+  -- penolakan — kalau hanya satu yang dijaga, yang lain jadi pintu belakang.
+  begin
+    perform hapus_nilai_pos(v_dada, v_kode, v_pos);
+    raise exception 'GAGAL: hapus lolos padahal barisnya tergembok';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_gagal := true;
+  end;
+  assert v_gagal, 'hapus tidak menolak';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 19.2 v_lembar_pos memberitahu layar — supaya petugas tahu SEBELUM mengetik.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_ada int;
+begin
+  select count(*) into v_ada from v_lembar_pos where terkunci;
+  assert v_ada >= 1, 'v_lembar_pos tidak melaporkan baris yang tergembok';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 19.3 MEMBUKA hanya admin, dan wajib beralasan.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_dada integer; v_pos smallint; v_regu uuid; v_tolak boolean := false;
+begin
+  select r.nomor_dada, k.pos, r.id into strict v_dada, v_pos, v_regu
+  from nilai_terkunci k join regu r on r.id = k.regu_id limit 1;
+
+  -- Alasan kosong ditolak walau yang meminta admin.
+  begin
+    perform buka_kunci_nilai_pos(v_dada, v_pos, '   ');
+    raise exception 'GAGAL: gembok terbuka tanpa alasan';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true;
+  end;
+  assert v_tolak, 'alasan kosong tidak ditolak';
+  assert nilai_tergembok(v_regu, v_pos), 'gembok terlanjur terbuka';
+
+  -- Operator pos ditolak, walaupun posnya sendiri.
+  perform set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
+  v_tolak := false;
+  begin
+    perform buka_kunci_nilai_pos(v_dada, v_pos, 'coba-coba');
+    raise exception 'GAGAL: operator pos bisa membuka gembok';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true;
+  end;
+  assert v_tolak, 'operator pos tidak ditolak';
+
+  -- Admin dengan alasan: berhasil, dan menulis pun kembali bisa.
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  perform buka_kunci_nilai_pos(v_dada, v_pos, 'uji: dibuka kembali');
+  assert not nilai_tergembok(v_regu, v_pos), 'gembok tidak terbuka';
+end;
+$$;
+
+reset role;
+select '19_kunci_nilai OK' as hasil;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -450,6 +450,17 @@ export async function komponenSemua(edisi) {
     `&order=pos.asc,sort_order.asc`);
 }
 
+/** Gembok: menyatakan nilai satu regu di satu pos sudah selesai (0043).
+ *  Operator pos memakai posnya sendiri; admin dan meja wajib menyebut pos. */
+export const kunciNilaiPos = (nomorDada, pos) =>
+  rpc("kunci_nilai_pos", { p_nomor_dada: nomorDada, p_pos: pos });
+
+/** Membuka gembok. ADMIN SAJA, dan wajib beralasan — bentuk yang sama dengan
+ *  batalkan_tanda_cetak, karena keduanya membatalkan pernyataan "sudah final". */
+export const bukaKunciNilaiPos = (nomorDada, pos, alasan) =>
+  rpc("buka_kunci_nilai_pos",
+      { p_nomor_dada: nomorDada, p_pos: pos, p_alasan: alasan });
+
 /** Riwayat perubahan nilai satu regu di satu pos — siapa mengubah apa, kapan.
  *
  *  Dibaca saat penanda simpan diketuk, bukan ikut dimuat bersama lembarnya:

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2478,6 +2478,7 @@ async function layarInputPos() {
                   <span class="kolom-petunjuk">${esc(kol.petunjuk)}</span></th>`).join("")}
               <th class="text-center">Nilai<br>${esc(pos.bayangan ? pos.name : `Pos ${pos.nomor}`)}</th>
               <th class="text-center"><span class="visually-hidden">Status simpan</span></th>
+              <th class="text-center"><span class="visually-hidden">Gembok</span></th>
             </tr>
           </thead>
           <tbody id="isi-tabel"></tbody>
@@ -2508,6 +2509,7 @@ async function layarInputPos() {
       }).join("")}
       <td class="text-center pos-nilai" data-label="Nilai Pos">${esc(angkaRapi(r.nilai_pos))}</td>
       <td class="pos-status" data-label=""></td>
+      <td class="pos-gembok" data-label=""></td>
     </tr>`).join("")));
 
   /* ---------- keadaan simpan per baris ----------
@@ -2561,6 +2563,73 @@ async function layarInputPos() {
     }
     perbaruiRingkasan();
   };
+
+  /** Gembok satu baris: rupanya, dan apa yang ikut mati bersamanya.
+   *
+   *  Terbuka adalah keadaan bawaan — semua baris bisa diisi sampai ada yang
+   *  menyatakan selesai. Sesudah dikunci, kotaknya benar-benar dimatikan, bukan
+   *  sekadar dipudarkan: kotak yang masih bisa diketik tapi selalu ditolak
+   *  adalah jebakan, dan penolakannya baru muncul sesudah petugas mengetik
+   *  angka yang ia kira tersimpan.
+   *
+   *  Yang menegakkan aturannya tetap server (0044). Ini supaya petugas tahu
+   *  SEBELUM mengetik, bukan sesudah ditolak. */
+  const gambarGembok = (tr) => {
+    const kunci = tr.dataset.terkunci === "1";
+    tr.classList.toggle("baris-terkunci", kunci);
+    tr.querySelectorAll("input").forEach(el => { el.disabled = kunci; });
+
+    const sel = tr.querySelector(".pos-gembok");
+    sel.replaceChildren(h(`<button type="button" class="gembok"
+      data-gembok aria-pressed="${kunci}"
+      title="${kunci ? "Terkunci — ketuk untuk membuka (admin)"
+                     : "Ketuk untuk mengunci nilai regu ini"}">${
+      kunci ? "🔒" : "🔓"}</button>`));
+    sel.querySelector("[data-gembok]").addEventListener("click", () => ubahGembok(tr));
+  };
+
+  /** Mengunci, atau meminta admin membukanya. */
+  async function ubahGembok(tr) {
+    const dada = Number(tr.dataset.dada);
+    const kunci = tr.dataset.terkunci === "1";
+    const tiga = String(dada).padStart(3, "0");
+
+    if (!kunci) {
+      const ya = await dialog({
+        judul: `Kunci nilai ${tiga}?`,
+        kartuHtml: `<p class="description">Sesudah dikunci, nilai regu ini
+          tidak bisa diubah siapa pun — termasuk Anda sendiri. Hanya admin yang
+          bisa membukanya lagi, dan wajib menyebut alasan.</p>`,
+        labelAksi: "Kunci",
+      });
+      if (!ya) return;
+      try { await kunciNilaiPos(dada, pos.nomor); }
+      catch (err) { notif(`Gagal mengunci: ${err.message}`, true); return; }
+      tr.dataset.terkunci = "1";
+      gambarGembok(tr);
+      notif(`Nilai ${tiga} dikunci.`);
+      return;
+    }
+
+    if (sesi().peran !== "admin") {
+      notif("Nilai ini terkunci. Hanya admin yang bisa membukanya.", true);
+      return;
+    }
+    const jawab = await dialog({
+      judul: `Buka gembok ${tiga}?`,
+      kartuHtml: `<p class="description">Alasannya dicatat di riwayat, dan
+        itulah satu-satunya penjelasan yang tersisa kalau nilainya berubah
+        sesudah ini.</p>`,
+      medan: [{ label: "Alasan membuka", contoh: "salah ketik Semaphore" }],
+      labelAksi: "Buka",
+    });
+    if (!jawab) return;
+    try { await bukaKunciNilaiPos(dada, pos.nomor, jawab[0]); }
+    catch (err) { notif(`Gagal membuka: ${err.message}`, true); return; }
+    tr.dataset.terkunci = "";
+    gambarGembok(tr);
+    notif(`Gembok ${tiga} dibuka.`);
+  }
 
   /** Riwayat perubahan nilai satu regu di pos ini.
    *
@@ -2727,6 +2796,7 @@ async function layarInputPos() {
   // benar sejak halaman dibuka, bukan hanya untuk yang diketik hari ini.
   [...tbody.children].forEach(tr => {
     if (Number(tr.dataset.terisi) > 0) statusBaris(tr, "tersimpan");
+    gambarGembok(tr);
   });
   perbaruiRingkasan();
 
@@ -2744,6 +2814,9 @@ async function layarInputPos() {
     // seluruh baris, sehingga berapa pun ketukan yang menumpuk cukup
     // diselesaikan satu kali.
     if (tr.dataset.jalan === "1") { tr.dataset.antre = "1"; return; }
+    // Baris tergembok tidak pernah dikirim. Kotaknya memang sudah mati, tapi
+    // simpanBaris juga dipanggil dari antrean dan dari tombol Ulangi.
+    if (tr.dataset.terkunci === "1") return;
     const dada = Number(tr.dataset.dada);
     const lama = asli.get(dada) || {};
     const baris = [], dihapus = [];
@@ -3073,6 +3146,13 @@ async function layarInputPos() {
       if (!r) continue;
 
       asli.set(Number(r.nomor_dada), r.nilai || {});
+      // Gembok yang dipasang dari HP lain menyusul lewat penyegaran ini —
+      // paling lama 20 detik, dan server tetap menolak lebih cepat dari itu.
+      const kunciBaru = r.terkunci ? "1" : "";
+      if (tr.dataset.terkunci !== kunciBaru) {
+        tr.dataset.terkunci = kunciBaru;
+        gambarGembok(tr);
+      }
       if (tr.dataset.terisi !== String(r.jumlah_terisi)) berubah = true;
       tr.dataset.terisi = String(r.jumlah_terisi);
       tr.querySelector(".pos-nilai").textContent = angkaRapi(r.nilai_pos);

--- a/web/style.css
+++ b/web/style.css
@@ -1097,6 +1097,23 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Riwayat perubahan nilai: satu baris per perubahan, tanpa kepala tabel.
    Yang dicari cuma lomba apa, dari berapa jadi berapa, dan siapa — tiga hal
    yang muat sebaris, dan mata tidak perlu melewati apa pun sebelum sampai. */
+/* Gembok: bawaan TERBUKA, tertutup sesudah dikunci. Ukurannya sengaja sebesar
+   jari — ia satu-satunya tombol di lembar ini yang akibatnya tidak bisa
+   diurungkan sendiri, jadi tidak boleh tertekan karena meleset. */
+.gembok {
+  border: 0; background: none; cursor: pointer; font-size: 1.15rem;
+  line-height: 1; padding: .35rem .4rem; border-radius: 8px;
+}
+.gembok:hover { background: var(--kartu-lembut, rgba(0,0,0,.05)); }
+.gembok:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+
+/* Baris tergembok: kotaknya benar-benar mati, dan terlihat mati. Bukan sekadar
+   pudar — kotak yang masih bisa diketik tapi selalu ditolak adalah jebakan. */
+.baris-terkunci input:disabled {
+  background: var(--kartu-lembut, #f3f4f6);
+  color: var(--tinta-lembut); cursor: not-allowed;
+}
+
 .saring-riwayat { margin-bottom: .6rem; flex-wrap: wrap; gap: .35rem; }
 .riwayat { list-style: none; margin: 0; padding: 0; }
 .riwayat li {


### PR DESCRIPTION
## What

Tombol gembok di tiap baris lembar Input Pos. **Terbuka 🔓 adalah bawaan**; sesudah dikunci jadi **🔒** dan kotaknya mati.

| | |
|---|---|
| Satuan | satu regu di **satu pos** |
| Mengunci | operator pos (posnya sendiri), meja, admin |
| Membuka | **admin saja**, wajib beralasan |
| Penjaga | server — kedua jalur tulis |

## Why

Nilai bisa berubah tanpa ada yang bermaksud mengubahnya: satu ketukan nyasar di HP, satu baris tersimpan ulang, satu angka tertimpa. Riwayat (#168) membuat perubahan itu bisa **ditelusuri** sesudahnya — tapi tidak ada yang **mencegahnya**.

## Notes — kenapa admin yang membuka

Bentuk yang sama dengan `batalkan_tanda_cetak`, dan alasannya sama: **kalau yang mengunci juga bisa membuka sendiri, gemboknya cuma polisi tidur.**

Harganya disebut supaya tidak jadi kejutan: petugas yang salah mengunci harus menghubungi admin. Itu disengaja — mengunci adalah pernyataan "sudah saya periksa", dan pernyataan yang bisa ditarik sendiri kapan saja bukan pernyataan.

## Notes — kenapa penjaganya di server

Lembar pos dibuka di beberapa HP sekaligus. Sejak ia menyegarkan diri tiap 20 detik, HP kedua tahu soal gemboknya dalam **paling lama 20 detik** — dan paling lama 20 detik masih berarti ada 20 detik. HP yang layarnya dimuat sebelum gemboknya dipasang akan mengirim angka dengan penuh keyakinan.

**Kedua jalur tulis dijaga.** `simpan_nilai_massal` dan `hapus_nilai_pos` sama-sama memanggil `nilai_tergembok()`, bukan menyalin syaratnya masing-masing — dua salinan syarat yang sama adalah cara mereka mulai berbeda pendapat, persis cacat yang memaksa `0040` ditulis.

Kotaknya **benar-benar dimatikan**, bukan dipudarkan: kotak yang masih bisa diketik tapi selalu ditolak adalah jebakan.

Tes 19 menjaga ketiganya: simpan ditolak, hapus ditolak, dan membuka tanpa alasan atau tanpa admin ditolak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)