### PR TITLE
fix: baris lembar pos membawa keadaan gemboknya

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2493,7 +2493,8 @@ async function layarInputPos() {
   const tbody = document.getElementById("isi-tabel");
   tbody.replaceChildren(h(lembar.map(r => `
     <tr data-dada="${esc(r.nomor_dada)}" data-terisi="${esc(r.jumlah_terisi)}"
-        data-golongan="${esc(r.golongan)}" data-komponen="${esc(r.jumlah_komponen)}">
+        data-golongan="${esc(r.golongan)}" data-komponen="${esc(r.jumlah_komponen)}"
+        data-terkunci="${r.terkunci ? "1" : ""}">
       <td class="angka text-center" data-label="Nomor Dada">${esc(String(r.nomor_dada).padStart(3, "0"))}</td>
       <td data-label="Nama Regu"><strong>${esc(r.nama_regu)}</strong></td>
       <td data-label="Organisasi">${esc(r.nama_sekolah)}</td>


### PR DESCRIPTION
## What

Atribut `data-terkunci` pada `<tr>` tidak pernah ikut terpasang, jadi gembok **tidak pernah tahu keadaannya sendiri**: tiap baris tergambar terbuka 🔓 walau gemboknya sudah terpasang di database, dan kotaknya tidak pernah mati.

Server tetap menolak tulisannya — penjaga yang sebenarnya memang di sana — tapi petugas baru mengetahuinya **sesudah** mengetik.

## Why hilang

Ia ada di skrip sunting yang **gagal di tengah jalan**: berkasnya tidak pernah ditulis, dan dua suntingan lain di skrip yang sama ikut hilang. Yang tersisa lolos hanya karena suntingan berikutnya menambahkannya dari arah lain.

## Notes

Ditemukan dengan **membuka layarnya sungguhan dan mengetuk gemboknya**, bukan dengan membaca kode. Yang membuatnya kelihatan: atribut yang dicari mengembalikan `null`, bukan string kosong — dan `null` berarti tidak pernah digambar sama sekali.

🤖 Generated with [Claude Code](https://claude.com/claude-code)