### PR TITLE
fix: impor kunciNilaiPos yang hilang, dan pemeriksa supaya tidak terulang

### DIFF
--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -68,3 +68,10 @@ jobs:
             exit 1
           fi
           echo "Seluruh salinan sama dengan acuannya."
+
+      # Nama yang dipakai tanpa diimpor tidak menggagalkan apa pun sampai baris
+      # itu dijalankan: `node --check` lulus, halaman terbuka normal, dan
+      # galatnya baru muncul saat petugas menekan tombolnya di lapangan.
+      # `kunciNilaiPos` pernah lolos sampai produksi persis begitu.
+      - name: Setiap fungsi api.js yang dipanggil app.js benar-benar diimpor
+        run: python tools/periksa_impor.py

--- a/tools/periksa_impor.py
+++ b/tools/periksa_impor.py
@@ -1,0 +1,71 @@
+r"""Pastikan setiap fungsi api.js yang DIPANGGIL app.js benar-benar diimpor.
+
+KENAPA BERKAS INI ADA
+
+Sebuah nama yang dipakai tanpa diimpor tidak menggagalkan apa pun sampai baris
+itu benar-benar dijalankan. `node --check` lulus, CI hijau, halaman terbuka
+normal — dan galatnya baru muncul saat petugas menekan tombolnya di lapangan.
+
+Itu bukan kemungkinan teoretis: `kunciNilaiPos` dan `bukaKunciNilaiPos` pernah
+lolos sampai produksi persis begitu. Suntingan yang menambahkan importnya ada
+di skrip yang gagal di tengah jalan, jadi berkasnya tidak pernah ditulis,
+sementara suntingan berikutnya menambahkan pemanggilnya dari arah lain. Yang
+menemukannya akhirnya adalah mengetuk tombolnya di browser sungguhan.
+
+Pemeriksa ini menutup celah itu di CI, di tempat yang tidak menuntut siapa pun
+membuka layar.
+"""
+import re
+import sys
+from pathlib import Path
+
+AKAR = Path(__file__).resolve().parent.parent
+
+
+def periksa(app_path: Path, api_path: Path) -> list[str]:
+    app = app_path.read_text(encoding="utf-8")
+    api = api_path.read_text(encoding="utf-8")
+
+    ekspor = set(re.findall(
+        r"export\s+(?:async\s+function|function|const)\s+(\w+)", api))
+    m = re.search(r'import\s*\{([^}]*)\}\s*from\s*"\./api\.js"', app, re.S)
+    if not m:
+        raise SystemExit(f"{app_path}: pernyataan import api.js tidak ditemukan")
+    diimpor = {x.strip() for x in m.group(1).replace("\n", " ").split(",") if x.strip()}
+
+    # Hanya badan SESUDAH importnya — kalau tidak, daftar impor itu sendiri
+    # terbaca sebagai pemakaian.
+    badan = tanpa_komentar(app[m.end():])
+    return sorted(
+        n for n in ekspor
+        # (?<![\w.]) supaya `obj.namaSama(...)` tidak terhitung.
+        if re.search(r"(?<![\w.])" + n + r"\s*\(", badan) and n not in diimpor)
+
+
+def tanpa_komentar(kode: str) -> str:
+    """Buang komentar supaya nama yang cuma DISEBUT tidak terhitung dipanggil.
+
+    Versi pertama pemeriksa ini melaporkan `pesanRamah` hilang, padahal ia
+    hanya disebut di dalam satu komentar yang menjelaskan bahwa api.js sudah
+    memanggilnya. Lapor palsu adalah cara tercepat membuat orang berhenti
+    mempercayai pemeriksa, dan pemeriksa yang tidak dipercaya sama saja
+    dengan tidak ada.
+
+    Batasnya diakui: baris berisi "https://" di dalam string akan dianggap
+    berkomentar mulai dari situ. Yang hilang karenanya paling jauh satu
+    pemeriksaan — lapor KURANG, bukan lapor PALSU — dan itu arah kesalahan
+    yang benar untuk alat seperti ini.
+    """
+    kode = re.sub(r"/\*.*?\*/", " ", kode, flags=re.S)
+    baris = [b.split("//")[0] for b in kode.split(chr(10))]
+    return chr(10).join(baris)
+
+
+if __name__ == "__main__":
+    kurang = periksa(AKAR / "web" / "js" / "app.js", AKAR / "web" / "js" / "api.js")
+    if kurang:
+        print("Dipanggil app.js tapi TIDAK diimpor dari api.js:")
+        for n in kurang:
+            print(f"  {n}")
+        sys.exit(1)
+    print("Semua fungsi api.js yang dipanggil app.js sudah diimpor.")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -20,6 +20,7 @@ import {
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
   batasNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
+  kunciNilaiPos, bukaKunciNilaiPos,
   statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,


### PR DESCRIPTION
## What

Gembok tidak pernah bisa dipasang — `kunciNilaiPos is not defined`. Importnya ada di skrip sunting yang **gagal di tengah jalan**, sama dengan `data-terkunci` yang baru dibetulkan di #172. Satu skrip gagal, tiga suntingan hilang, **dua di antaranya lolos sampai produksi**.

## Kenapa tidak ada yang menangkapnya

Nama yang dipakai tanpa diimpor **tidak menggagalkan apa pun sampai baris itu dijalankan**:

| | |
|---|---|
| `node --check` | lulus — sintaksnya sah |
| CI | hijau |
| Halaman dibuka | normal, seluruh layar jalan |
| Tombolnya ditekan | **ReferenceError** |

Dan di lembar pos, tombol itu ditekan pertama kali oleh petugas di lapangan. Yang akhirnya menemukannya adalah mengetuk gemboknya di browser sungguhan.

## Penutupnya

`tools/periksa_impor.py` — tiap fungsi yang diekspor `api.js` dan **dipanggil** `app.js` wajib ada di daftar impornya. Dijalankan di workflow **Shared files**, yang memang sudah menjaga hal sejenis.

**Pemeriksanya sendiri sempat melapor palsu.** Versi pertama menyebut `pesanRamah` hilang, padahal ia cuma disebut di dalam komentar. Lapor palsu adalah cara tercepat membuat orang berhenti mempercayai pemeriksa, jadi ia sekarang membuang komentar lebih dulu — dan batasnya diakui di dalam kodenya: baris berisi `https://` dianggap berkomentar mulai dari situ, yang membuatnya lapor **kurang** alih-alih lapor **palsu**. Itu arah kesalahan yang benar untuk alat seperti ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)