### PR TITLE
feat: petugas pos boleh membuka gemboknya sendiri

### DIFF
--- a/supabase/migrations/0045_pos_boleh_buka_gembok.sql
+++ b/supabase/migrations/0045_pos_boleh_buka_gembok.sql
@@ -1,0 +1,82 @@
+-- ============================================================================
+-- hrcd-rekap : 0045_pos_boleh_buka_gembok.sql
+--
+-- Petugas pos boleh membuka gemboknya sendiri, tidak lagi harus lewat admin.
+--
+-- ---------------------------------------------------------------------------
+-- YANG BERUBAH, DAN KENAPA SAYA SEMULA MEMILIH SEBALIKNYA
+--
+-- 0043 mengunci pembukaan hanya untuk admin, meniru `batalkan_tanda_cetak`.
+-- Alasannya: kalau yang mengunci bisa membuka sendiri, gemboknya cuma polisi
+-- tidur.
+--
+-- Panitia memutuskan lain, dan alasannya lebih berat daripada alasan saya.
+-- Kedua hal itu tidak sebanding. Tanda cetak menyangkut kertas yang sudah
+-- BEREDAR — sesudahnya ada lembar di tangan orang lain yang tidak bisa
+-- ditarik kembali. Gembok nilai tidak meninggalkan apa pun di luar sistem;
+-- yang salah kunci cuma menghalangi dirinya sendiri.
+--
+-- Dan harganya ditanggung di tempat yang paling buruk: pos di tengah lomba,
+-- sinyal seadanya, satu regu menunggu sementara petugas mencari admin untuk
+-- membuka gembok yang ia pasang sendiri semenit lalu.
+--
+-- ---------------------------------------------------------------------------
+-- YANG TIDAK BERUBAH: ALASAN TETAP WAJIB
+--
+-- Justru inilah yang sekarang menahan seluruh bebannya. Ketika yang mengunci
+-- bisa membuka sendiri, tidak ada lagi orang kedua yang harus diyakinkan —
+-- yang tersisa cuma catatan tentang apa yang ia yakinkan kepada dirinya
+-- sendiri. Alasannya masuk `history` sebelum barisnya dihapus, jadi ia tetap
+-- ada walau gemboknya sudah tidak.
+--
+-- Pagar posnya juga tetap: operator pos hanya bisa membuka posnya sendiri,
+-- sama persis dengan aturan menguncinya.
+--
+-- Badan fungsinya disalin dari 0043 oleh skrip, dengan satu blok izin yang
+-- ditukar.
+-- ============================================================================
+
+create or replace function buka_kunci_nilai_pos(
+  p_nomor_dada integer,
+  p_pos        smallint,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_regu uuid;
+begin
+  -- Siapa pun yang boleh MENGUNCI boleh pula MEMBUKA, dengan pagar pos yang
+  -- sama. Operator pos hanya posnya sendiri.
+  if peran() = 'operator_pos' then
+    if p_pos is distinct from pos_saya() then
+      raise exception 'operator pos % tidak boleh membuka gembok pos %',
+        pos_saya(), p_pos;
+    end if;
+  elsif peran() not in ('admin', 'meja') then
+    raise exception 'hanya panitia yang boleh membuka gembok';
+  end if;
+
+  -- Alasan tetap WAJIB, dan justru inilah yang menahan seluruh bebannya
+  -- sekarang. Ketika yang mengunci bisa membuka sendiri, tidak ada lagi orang
+  -- kedua yang harus diyakinkan — yang tersisa cuma catatan tentang apa yang
+  -- diyakinkannya kepada dirinya sendiri.
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan membuka gembok wajib diisi';
+  end if;
+
+  select id into v_regu from regu where nomor_dada = p_nomor_dada;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+
+  -- Alasannya dicatat SEBELUM barisnya hilang, kalau tidak ia hilang bersama
+  -- barisnya — dan yang tersisa cuma nilai yang berubah tanpa penjelasan.
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('nilai_terkunci', v_regu::text || ':' || p_pos, v_regu, 'DELETE',
+          jsonb_build_object('alasan_buka_gembok', p_alasan, 'pos', p_pos),
+          auth.uid());
+
+  delete from nilai_terkunci where regu_id = v_regu and pos = p_pos;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -143,6 +143,7 @@ run tests/sql/18_riwayat_nilai.sql
 # di akhir supaya tes 02-18 memakai nilai yang belum tergembok.
 run supabase/migrations/0043_kunci_nilai.sql
 run supabase/migrations/0044_gembok_di_jalur_tulis.sql
+run supabase/migrations/0045_pos_boleh_buka_gembok.sql
 run tests/sql/19_kunci_nilai.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/19_kunci_nilai.sql
+++ b/tests/sql/19_kunci_nilai.sql
@@ -84,19 +84,22 @@ begin
   assert v_tolak, 'alasan kosong tidak ditolak';
   assert nilai_tergembok(v_regu, v_pos), 'gembok terlanjur terbuka';
 
-  -- Operator pos ditolak, walaupun posnya sendiri.
+  -- Operator pos ditolak untuk pos ORANG LAIN (0045). Pagar posnya sama
+  -- persis dengan aturan menguncinya.
   perform set_config('app.uid', '00000000-0000-0000-0000-000000000001', false);
-  v_tolak := false;
-  begin
-    perform buka_kunci_nilai_pos(v_dada, v_pos, 'coba-coba');
-    raise exception 'GAGAL: operator pos bisa membuka gembok';
-  exception when raise_exception then
-    if sqlerrm like 'GAGAL:%' then raise; end if;
-    v_tolak := true;
-  end;
-  assert v_tolak, 'operator pos tidak ditolak';
+  if v_pos <> pos_saya() then
+    v_tolak := false;
+    begin
+      perform buka_kunci_nilai_pos(v_dada, v_pos, 'coba-coba');
+      raise exception 'GAGAL: operator pos membuka gembok pos lain';
+    exception when raise_exception then
+      if sqlerrm like 'GAGAL:%' then raise; end if;
+      v_tolak := true;
+    end;
+    assert v_tolak, 'operator pos pos lain tidak ditolak';
+  end if;
 
-  -- Admin dengan alasan: berhasil, dan menulis pun kembali bisa.
+  -- Dengan alasan: berhasil.
   perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
   perform buka_kunci_nilai_pos(v_dada, v_pos, 'uji: dibuka kembali');
   assert not nilai_tergembok(v_regu, v_pos), 'gembok tidak terbuka';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2600,8 +2600,8 @@ async function layarInputPos() {
       const ya = await dialog({
         judul: `Kunci nilai ${tiga}?`,
         kartuHtml: `<p class="description">Sesudah dikunci, nilai regu ini
-          tidak bisa diubah siapa pun — termasuk Anda sendiri. Hanya admin yang
-          bisa membukanya lagi, dan wajib menyebut alasan.</p>`,
+          tidak bisa diubah sampai gemboknya dibuka lagi — dan membukanya
+          wajib menyebut alasan, yang tercatat di riwayat.</p>`,
         labelAksi: "Kunci",
       });
       if (!ya) return;
@@ -2613,10 +2613,6 @@ async function layarInputPos() {
       return;
     }
 
-    if (sesi().peran !== "admin") {
-      notif("Nilai ini terkunci. Hanya admin yang bisa membukanya.", true);
-      return;
-    }
     const jawab = await dialog({
       judul: `Buka gembok ${tiga}?`,
       kartuHtml: `<p class="description">Alasannya dicatat di riwayat, dan


### PR DESCRIPTION
## What

| | 0043 | sekarang |
|---|---|---|
| Mengunci | operator pos, meja, admin | sama |
| **Membuka** | **admin saja** | **operator pos (posnya sendiri), meja, admin** |
| Alasan wajib | ya | **ya — tetap** |

## Why

`0043` meniru `batalkan_tanda_cetak`, dengan alasan: kalau yang mengunci bisa membuka sendiri, gemboknya cuma polisi tidur.

**Kedua hal itu tidak sebanding.** Tanda cetak menyangkut kertas yang sudah **beredar** — sesudahnya ada lembar di tangan orang lain yang tidak bisa ditarik kembali. Gembok nilai tidak meninggalkan apa pun di luar sistem; yang salah kunci cuma menghalangi dirinya sendiri.

Dan harganya ditanggung di tempat yang paling buruk: pos di tengah lomba, sinyal seadanya, satu regu menunggu sementara petugas mencari admin untuk membuka gembok yang ia pasang sendiri semenit lalu.

## Notes

**Alasan tetap wajib, dan justru inilah yang sekarang menahan seluruh bebannya.** Ketika yang mengunci bisa membuka sendiri, tidak ada lagi orang kedua yang harus diyakinkan — yang tersisa cuma catatan tentang apa yang ia yakinkan kepada dirinya sendiri. Alasannya masuk `history` **sebelum** barisnya dihapus, jadi ia tetap ada walau gemboknya sudah tidak.

**Pagar posnya tetap:** operator pos hanya bisa membuka posnya sendiri.

Kalimat konfirmasi saat mengunci ikut dibetulkan — ia masih menjanjikan *"hanya admin yang bisa membukanya"*, dan janji yang tidak lagi benar lebih buruk daripada tidak ada janji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)