### PR TITLE
fix: empat cacat yang merusak data, dari sapuan adversarial 35 PR

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -261,8 +261,23 @@ export function pasangKotakJam(id) {
   const mm = document.getElementById(`${id}-mm`);
   const pendengar = [];
 
-  const gabung = () => `${hh.value.trim()}${mm.value.trim()}`;
-  const nilai = () => jamSah(gabung());
+  /* Kedua kotak DIBACA SEBAGAI DUA, bukan disambung jadi satu teks.
+   *
+   * Versi pertama menyambung isinya lalu menyerahkannya ke jamSah(), yang
+   * membaca "dua angka terakhir adalah menit". Untuk kotak yang terpisah itu
+   * salah, dan salahnya diam-diam: jam 10 menit 5 tersambung jadi "105", lalu
+   * dibaca ulang sebagai 1:05. Petugas melihat 10 dan 5 di layarnya, dan yang
+   * tersimpan pukul satu lewat lima.
+   *
+   * Kotaknya sudah TAHU mana jam dan mana menit. Membuang keterangan itu lalu
+   * menebaknya kembali dari bentuk gabungan adalah kekeliruan yang tidak perlu
+   * ada. Sekarang keduanya dinolkan di depan lebih dulu, jadi "10" dan "5"
+   * menjadi "1005" — satu-satunya bacaan yang mungkin. */
+  const nilai = () => {
+    const h = hh.value.trim(), m = mm.value.trim();
+    if (!h || !m) return null;
+    return jamSah(h.padStart(2, "0") + m.padStart(2, "0"));
+  };
 
   /* ISI DIPILIH SAAT KOTAKNYA DIKETUK, dan tanpa ini kotak yang sudah terisi
      tidak bisa diperbaiki.

--- a/supabase/migrations/0046_gembok_dua_lubang.sql
+++ b/supabase/migrations/0046_gembok_dua_lubang.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- hrcd-rekap : 0046_gembok_dua_lubang.sql
+--
+-- Dua lubang pada gembok, keduanya ditemukan sapuan adversarial dan keduanya
+-- tidak menimbulkan galat apa pun sampai keadaannya tepat.
+--
+-- ---------------------------------------------------------------------------
+-- 1. AKUN TANPA PERAN BISA MEMBUKA GEMBOK
+--
+-- 0045 menulis:  elsif peran() not in ('admin', 'meja') then raise ...
+--
+-- Di PostgreSQL `null not in (...)` bernilai NULL, bukan true. Untuk peran
+-- NULL, cabang pertama (`= 'operator_pos'`) juga NULL, jadi keduanya tidak
+-- diambil dan alirannya jatuh lurus ke delete.
+--
+-- Peran NULL bukan keadaan teoretis: itulah yang terjadi pada akun yang masih
+-- punya sesi Supabase sah tetapi barisnya sudah dicabut dari akun_panitia —
+-- persis akun yang paling tidak boleh membuka gembok.
+--
+-- Diperbaiki dengan memeriksa POSITIF: sebut siapa yang boleh, bukan siapa
+-- yang tidak. `null` gagal memenuhi syarat positif mana pun, jadi ia tertolak
+-- tanpa perlu diingat sebagai kasus tersendiri.
+--
+-- ---------------------------------------------------------------------------
+-- 2. GEMBOK MEMBLOKIR PEMBERSIHAN DATA UJI
+--
+-- nilai_terkunci.regu_id menunjuk regu(id) TANPA on delete cascade, dan
+-- cleanup_data_uji.sql tidak pernah menghapusnya — berkas itu ditulis sebelum
+-- tabel ini ada. Begitu satu gembok terpasang, seluruh pembersihan gagal di
+-- baris `delete from regu`, dan yang menerima pesannya adalah orang yang
+-- sedang menyiapkan lomba dengan data uji yang tidak mau hilang.
+--
+-- Cascade dipilih daripada menambah satu baris di skrip pembersih, karena
+-- gembok memang tidak punya arti tanpa regunya. Baris nilai_mentah dan
+-- closing_regu sengaja TIDAK diberi cascade — keduanya nilai yang hilangnya
+-- harus disengaja. Gembok bukan nilai; ia pernyataan tentang nilai.
+-- ============================================================================
+
+alter table nilai_terkunci
+  drop constraint if exists nilai_terkunci_regu_id_fkey;
+alter table nilai_terkunci
+  add constraint nilai_terkunci_regu_id_fkey
+  foreign key (regu_id) references regu (id) on delete cascade;
+
+create or replace function buka_kunci_nilai_pos(
+  p_nomor_dada integer,
+  p_pos        smallint,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_regu uuid;
+begin
+  -- Siapa pun yang boleh MENGUNCI boleh pula MEMBUKA, dengan pagar pos yang
+  -- sama. Operator pos hanya posnya sendiri.
+  -- Peran diperiksa POSITIF, bukan lewat 'not in'.
+  --
+  -- Versi 0045 memakai `elsif peran() not in ('admin','meja') then raise`, dan
+  -- di PostgreSQL `null not in (...)` bernilai NULL — bukan true. Cabang
+  -- penolakannya karena itu tidak pernah jalan untuk peran NULL, yaitu akun
+  -- yang punya sesi sah tetapi sudah dicabut dari akun_panitia. Ia jatuh
+  -- melewati kedua cabang dan sampai ke delete.
+  if peran() is null or peran() not in ('operator_pos', 'meja', 'admin') then
+    raise exception 'hanya panitia yang boleh membuka gembok';
+  end if;
+  if peran() = 'operator_pos' and p_pos is distinct from pos_saya() then
+    raise exception 'operator pos % tidak boleh membuka gembok pos %',
+      pos_saya(), p_pos;
+  end if;
+
+  -- Alasan tetap WAJIB, dan justru inilah yang menahan seluruh bebannya
+  -- sekarang. Ketika yang mengunci bisa membuka sendiri, tidak ada lagi orang
+  -- kedua yang harus diyakinkan — yang tersisa cuma catatan tentang apa yang
+  -- diyakinkannya kepada dirinya sendiri.
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan membuka gembok wajib diisi';
+  end if;
+
+  select id into v_regu from regu where nomor_dada = p_nomor_dada;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal', p_nomor_dada;
+  end if;
+
+  -- Alasannya dicatat SEBELUM barisnya hilang, kalau tidak ia hilang bersama
+  -- barisnya — dan yang tersisa cuma nilai yang berubah tanpa penjelasan.
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('nilai_terkunci', v_regu::text || ':' || p_pos, v_regu, 'DELETE',
+          jsonb_build_object('alasan_buka_gembok', p_alasan, 'pos', p_pos),
+          auth.uid());
+
+  delete from nilai_terkunci where regu_id = v_regu and pos = p_pos;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -144,6 +144,7 @@ run tests/sql/18_riwayat_nilai.sql
 run supabase/migrations/0043_kunci_nilai.sql
 run supabase/migrations/0044_gembok_di_jalur_tulis.sql
 run supabase/migrations/0045_pos_boleh_buka_gembok.sql
+run supabase/migrations/0046_gembok_dua_lubang.sql
 run tests/sql/19_kunci_nilai.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/19_kunci_nilai.sql
+++ b/tests/sql/19_kunci_nilai.sql
@@ -106,5 +106,53 @@ begin
 end;
 $$;
 
+-- ---------------------------------------------------------------------------
+-- 19.4 Akun TANPA peran ditolak (0046). Bukan kasus teoretis: itulah akun yang
+--      sesinya masih sah tetapi barisnya sudah dicabut dari akun_panitia, dan
+--      `null not in (...)` di PostgreSQL bernilai NULL — bukan true — sehingga
+--      cabang penolakan versi 0045 tidak pernah jalan untuknya.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_dada integer; v_pos smallint; v_tolak boolean := false;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  select r.nomor_dada, w.pos into strict v_dada, v_pos
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  join regu r on r.id = n.regu_id
+  where w.edisi = edisi_aktif() and r.nomor_dada is not null limit 1;
+  perform kunci_nilai_pos(v_dada, v_pos);
+
+  -- uid yang tidak ada di akun_panitia sama sekali -> peran() NULL.
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000ff', false);
+  assert peran() is null, 'akun uji ternyata punya peran';
+  begin
+    perform buka_kunci_nilai_pos(v_dada, v_pos, 'harusnya ditolak');
+    raise exception 'GAGAL: akun tanpa peran bisa membuka gembok';
+  exception when raise_exception then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true;
+  end;
+  assert v_tolak, 'akun tanpa peran tidak ditolak';
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  perform buka_kunci_nilai_pos(v_dada, v_pos, 'uji 19.4 selesai');
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 19.5 Gembok ikut terhapus bersama regunya (0046), supaya pembersihan data
+--      uji tidak gagal di baris `delete from regu`.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_aturan text;
+begin
+  select rc.delete_rule into v_aturan
+  from information_schema.referential_constraints rc
+  where rc.constraint_name = 'nilai_terkunci_regu_id_fkey';
+  assert v_aturan = 'CASCADE',
+    format('nilai_terkunci.regu_id delete_rule = %L, seharusnya CASCADE', v_aturan);
+end;
+$$;
+
 reset role;
 select '19_kunci_nilai OK' as hasil;

--- a/tests/sql/19_kunci_nilai.sql
+++ b/tests/sql/19_kunci_nilai.sql
@@ -144,13 +144,20 @@ $$;
 --      uji tidak gagal di baris `delete from regu`.
 -- ---------------------------------------------------------------------------
 do $$
-declare v_aturan text;
+declare v_aturan "char";
 begin
-  select rc.delete_rule into v_aturan
-  from information_schema.referential_constraints rc
-  where rc.constraint_name = 'nilai_terkunci_regu_id_fkey';
-  assert v_aturan = 'CASCADE',
-    format('nilai_terkunci.regu_id delete_rule = %L, seharusnya CASCADE', v_aturan);
+  -- pg_constraint, BUKAN information_schema. Yang terakhir hanya memperlihatkan
+  -- constraint pada tabel yang penggunanya punya hak — dan tes ini berjalan
+  -- sebagai `authenticated`, jadi kueri-nya mengembalikan nol baris dan
+  -- v_aturan tinggal NULL. Assert-nya lalu gagal dengan alasan yang keliru:
+  -- seolah cascade tidak terpasang, padahal yang tidak ada cuma izin membaca
+  -- katalognya. pg_catalog terbaca siapa pun.
+  select c.confdeltype into v_aturan
+  from pg_constraint c
+  where c.conname = 'nilai_terkunci_regu_id_fkey';
+  assert v_aturan = 'c',
+    format('nilai_terkunci.regu_id confdeltype = %L, seharusnya c (cascade)',
+           v_aturan);
 end;
 $$;
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1970,6 +1970,11 @@ function petunjukKolom(k) {
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
 }
 
+/** Isi kotak yang tidak bisa dibaca sebagai angka/waktu. Sengaja BUKAN null:
+ *  null berarti "kotak kosong", dan jalur simpan menerjemahkan itu jadi
+ *  perintah MENGHAPUS nilai yang sudah tersimpan. */
+const TIDAK_SAH = Symbol("tidak sah");
+
 /** Membaca satu komponen dari barisnya. null = kotaknya kosong, artinya
  *  komponen ini BELUM dinilai — bukan "dinilai nol".
  *
@@ -1984,12 +1989,16 @@ function bacaSel(tr, k) {
   if (k.form === "biner") return { nilai_1: kotak[0].checked ? 1 : 0, nilai_2: null };
 
   if (k.satuan === "detik") {
+    // TIGA keadaan, bukan dua. Kotak kosong dan kotak berisi "1:75" tidak
+    // boleh diperlakukan sama, dan dulu keduanya sama-sama mengembalikan null.
+    //
+    // Akibatnya senyap dan merusak: jalur simpan membaca null sebagai "kotak
+    // dikosongkan", jadi nilai yang SUDAH tersimpan di database ikut DIHAPUS —
+    // lalu barisnya tetap mendapat centang hijau. Petugas salah ketik satu
+    // huruf dan kehilangan angka yang sudah benar, tanpa satu pun tanda.
+    if (!kotak[0].value.trim()) return null;
     const detik = detikSah(kotak[0].value);
-    // null menutupi dua hal yang berbeda: kotak kosong, dan isi yang bukan
-    // waktu. Keduanya sengaja diperlakukan sama — TIDAK DIKIRIM. Menebak
-    // maksud "1:75" berarti mencatat waktu yang tidak pernah terjadi, dan
-    // kotaknya sendiri sudah memerah lewat .input-waktu:invalid.
-    return detik === null ? null : { nilai_1: detik, nilai_2: null };
+    return detik === null ? TIDAK_SAH : { nilai_1: detik, nilai_2: null };
   }
   if (k.form === "benar_kurang_salah") {
     const b = kotak[0].value.trim(), sa = kotak[1].value.trim();
@@ -2817,11 +2826,15 @@ async function layarInputPos() {
     if (tr.dataset.terkunci === "1") return;
     const dada = Number(tr.dataset.dada);
     const lama = asli.get(dada) || {};
-    const baris = [], dihapus = [];
+    const baris = [], dihapus = [], takTerbaca = [];
 
     for (const k of komponenBaris(tr)) {
       const baru = bacaSel(tr, k);
       const ada = lama[k.kode] || null;
+      // Kotak berisi sesuatu yang tidak terbaca: JANGAN disentuh sama sekali.
+      // Bukan dikirim, dan bukan pula dianggap kosong — angka lamanya tetap di
+      // tempatnya sampai petugas membetulkan ketikannya.
+      if (baru === TIDAK_SAH) { takTerbaca.push(k.name); continue; }
       if (baru === null) {
         // Kotak dikosongkan padahal sebelumnya ada isinya = angka itu masuk ke
         // regu yang salah. Dihapus, bukan ditimpa nol.
@@ -2837,6 +2850,24 @@ async function layarInputPos() {
                      nilai_1: baru.nilai_1, nilai_2: baru.nilai_2 });
       }
     }
+    // Ada kotak yang tidak terbaca: barisnya berakhir MERAH, bukan hijau.
+    //
+    // Yang sah tetap dikirim — memaksa petugas mengetik ulang kotak yang sudah
+    // benar karena satu kotak lain salah adalah hukuman yang tidak perlu. Tapi
+    // barisnya tidak boleh terlihat selesai selama masih ada yang salah, dan
+    // merahnya juga yang menahan penyegaran 20 detik agar tidak menghapus
+    // ketikan yang sedang dibetulkan (baris "gagal" termasuk sibuk).
+    const pesanTakTerbaca = takTerbaca.length
+      ? `${takTerbaca.join(", ")}: isinya bukan angka/waktu yang bisa dibaca. `
+        + `Angka lamanya TIDAK diubah.`
+      : null;
+
+    if (pesanTakTerbaca && !baris.length && !dihapus.length) {
+      statusBaris(tr, "gagal", pesanTakTerbaca);
+      notif(`Nomor Dada ${String(dada).padStart(3, "0")}: ${pesanTakTerbaca}`, true);
+      return;
+    }
+
     // Tidak ada yang berubah — misalnya angka diketik ulang sama persis.
     // Barisnya dikembalikan ke keadaan istirahat, BUKAN ditinggalkan dalam
     // keadaan "belum": tanda kuning yang tidak akan pernah hilang sendiri
@@ -2868,7 +2899,12 @@ async function layarInputPos() {
       // dijanjikan cap itu adalah "sudah ada di database", dan yang
       // membuktikannya adalah baris yang barusan dibaca kembali dari sana.
       jamSinkron = new Date();
-      statusBaris(tr, Number(tr.dataset.terisi) > 0 ? "tersimpan" : "");
+      if (pesanTakTerbaca) {
+        statusBaris(tr, "gagal", pesanTakTerbaca);
+        notif(`Nomor Dada ${String(dada).padStart(3, "0")}: ${pesanTakTerbaca}`, true);
+      } else {
+        statusBaris(tr, Number(tr.dataset.terisi) > 0 ? "tersimpan" : "");
+      }
       hitungUlangJumlah();
     } catch (err) {
       statusBaris(tr, "gagal", err.message);

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -261,8 +261,23 @@ export function pasangKotakJam(id) {
   const mm = document.getElementById(`${id}-mm`);
   const pendengar = [];
 
-  const gabung = () => `${hh.value.trim()}${mm.value.trim()}`;
-  const nilai = () => jamSah(gabung());
+  /* Kedua kotak DIBACA SEBAGAI DUA, bukan disambung jadi satu teks.
+   *
+   * Versi pertama menyambung isinya lalu menyerahkannya ke jamSah(), yang
+   * membaca "dua angka terakhir adalah menit". Untuk kotak yang terpisah itu
+   * salah, dan salahnya diam-diam: jam 10 menit 5 tersambung jadi "105", lalu
+   * dibaca ulang sebagai 1:05. Petugas melihat 10 dan 5 di layarnya, dan yang
+   * tersimpan pukul satu lewat lima.
+   *
+   * Kotaknya sudah TAHU mana jam dan mana menit. Membuang keterangan itu lalu
+   * menebaknya kembali dari bentuk gabungan adalah kekeliruan yang tidak perlu
+   * ada. Sekarang keduanya dinolkan di depan lebih dulu, jadi "10" dan "5"
+   * menjadi "1005" — satu-satunya bacaan yang mungkin. */
+  const nilai = () => {
+    const h = hh.value.trim(), m = mm.value.trim();
+    if (!h || !m) return null;
+    return jamSah(h.padStart(2, "0") + m.padStart(2, "0"));
+  };
 
   /* ISI DIPILIH SAAT KOTAKNYA DIKETUK, dan tanpa ini kotak yang sudah terisi
      tidak bisa diperbaiki.


### PR DESCRIPTION
Sapuan lima permukaan atas pekerjaan hari ini, tiap temuan **dibantah dulu** sebelum diakui. **24 cacat bertahan.** PR ini menutup empat yang merusak atau memblokir.

## 1. Jam 10 menit 5 tersimpan sebagai 1:05 — `tinggi`

Kotak jam sepasang menyambung isi kedua kotak jadi satu teks lalu menyerahkannya ke `jamSah()`, yang membaca *"dua angka terakhir adalah menit"*.

```
HH="10"  MM="5"   →  "105"  →  1:05
```

Petugas melihat 10 dan 5 di layarnya, dan yang tersimpan pukul satu lewat lima — **selisih sembilan jam** pada angka yang menentukan penalti seluruh kloter.

## 2. Salah ketik di kotak waktu menghapus nilai yang sudah tersimpan — `tinggi`

`bacaSel` mengembalikan `null` untuk **dua hal yang berbeda**: kotak kosong, dan kotak berisi `1:75`. Jalur simpan membaca `null` sebagai "kotak dikosongkan" → **menghapus nilai yang sudah ada** → lalu barisnya tetap dapat **centang hijau**.

Sekarang tiga keadaan. Isi tak terbaca → `TIDAK_SAH` → komponen itu tidak disentuh; yang sah tetap dikirim, tapi barisnya berakhir **merah** dengan pesan yang menyebut lombanya.

## 3. Akun tanpa peran bisa membuka gembok — `sedang`

```sql
elsif peran() not in ('admin','meja') then raise ...
```

`null not in (...)` bernilai **NULL, bukan true** — kedua cabang tidak diambil, alirannya jatuh lurus ke `delete`. Peran NULL bukan teoretis: itulah akun yang sesinya masih sah tetapi barisnya sudah dicabut dari `akun_panitia`.

Diperbaiki dengan memeriksa **positif**: sebut siapa yang boleh, bukan siapa yang tidak.

## 4. Gembok memblokir pembersihan data uji — `sedang`

`nilai_terkunci.regu_id` tanpa `on delete cascade`, dan `cleanup_data_uji.sql` tidak menghapusnya — berkas itu ditulis sebelum tabelnya ada. **Satu gembok terpasang, seluruh pembersihan gagal.**

Cascade dipilih daripada menambal skrip pembersih: gembok tidak punya arti tanpa regunya. `nilai_mentah` dan `closing_regu` sengaja **tidak** diberi cascade — keduanya nilai yang hilangnya harus disengaja.

## Notes

Sisa 20 cacat didaftar terpisah, tidak dikerjakan di sini. Mengerjakan dua puluh suntingan sekaligus adalah cara membuat cacat kedua puluh satu — dan hari ini sudah **dua kali** suntingan saya hilang di tengah skrip tanpa menimbulkan galat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)