### PR TITLE
feat: back up every scoring slip as a photo on the server

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -550,3 +550,101 @@ export const simpanNilaiPos = (baris, pos) =>
  *  sel kosong berarti "belum dinilai", bukan "hapus". */
 export const hapusNilaiPos = (nomorDada, kode, pos) =>
   rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });
+
+/* ============================ FOTO LEMBAR =============================== */
+
+/* Salinan slip penilaian di server (migrasi 0047). Kertas hilang; foto tidak.
+   Difoto petugas IT dengan HP sambil mengetik, jadi fotonya tertaut sendiri ke
+   nomor dada dan lomba yang tepat.
+
+   Gambar TIDAK lewat rpc/baca di atas: keduanya mengirim dan menerima JSON,
+   sedangkan ini mengunggah biner ke Storage — endpoint, header, dan bentuk
+   jawabannya semuanya berbeda. Dibuat jalur sendiri, bukan dengan menambah
+   cabang ke pembungkus yang sudah ada. */
+
+const BUCKET = "lembar";
+
+/** Nama objek di bucket. Prefiks pertama WAJIB `pos<n>` — itulah yang dipagari
+ *  policy storage.objects, dan RPC catat_foto_lembar menolak path yang tidak
+ *  cocok dengan posnya. */
+export function namaObjekFoto(pos, kodeLomba, nomorDada) {
+  const acak = Math.random().toString(36).slice(2, 8);
+  return `pos${pos}/${kodeLomba}/` +
+         `${String(nomorDada).padStart(3, "0")}-${Date.now()}-${acak}.jpg`;
+}
+
+/** Unggah satu gambar, lalu catat barisnya.
+ *
+ *  Urutannya disengaja: gambar dulu, baris sesudahnya. Baris tanpa gambar
+ *  adalah kebohongan — layar bilang "sudah difoto" padahal tidak ada apa-apa.
+ *  Gambar tanpa baris cuma berkas yatim yang masih bisa ditemukan lewat
+ *  path-nya, dan tidak merugikan siapa pun. */
+export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blob) {
+  const path = namaObjekFoto(pos, kodeLomba, nomorDada);
+
+  if (K.mode === "dev") {
+    // Dev server tidak punya Storage. Barisnya tetap dicatat supaya alur
+    // layarnya bisa dicoba tanpa Supabase.
+    await rpc("catat_foto_lembar", {
+      p_nomor_dada: nomorDada, p_pos: pos, p_kode_lomba: kodeLomba,
+      p_nama_lomba: namaLomba, p_path: path, p_ukuran: blob.size,
+    });
+    return { path, ukuran: blob.size };
+  }
+
+  await pastikanSesiSegar();
+  const s = sesi();
+  await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET}/${path}`, {
+    method: "POST",
+    headers: {
+      apikey: K.anonKey,
+      Authorization: `Bearer ${s && s.token ? s.token : K.anonKey}`,
+      "Content-Type": "image/jpeg",
+      "x-upsert": "false",
+    },
+    body: blob,
+  });
+
+  await rpc("catat_foto_lembar", {
+    p_nomor_dada: nomorDada, p_pos: pos, p_kode_lomba: kodeLomba,
+    p_nama_lomba: namaLomba, p_path: path, p_ukuran: blob.size,
+  });
+  return { path, ukuran: blob.size };
+}
+
+/** Foto satu regu di satu pos, terbaru dulu. */
+export async function daftarFotoLembar(pos, nomorDada) {
+  if (K.mode === "dev") {
+    return baca(`/foto-lembar?pos=${encodeURIComponent(pos)}` +
+                `&dada=${encodeURIComponent(nomorDada)}`);
+  }
+  return baca(null,
+    `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}` +
+    `&nomor_dada=eq.${encodeURIComponent(nomorDada)}` +
+    `&select=*&order=diunggah_pada.desc`);
+}
+
+/** Link sementara untuk melihat satu foto. Bucket-nya privat, jadi tidak ada
+ *  URL tetap — dan itu memang yang diinginkan: link yang tidak kedaluwarsa
+ *  akan beredar di WhatsApp selamanya. Satu jam cukup untuk melihatnya. */
+export async function tautanFoto(path) {
+  if (K.mode === "dev") return null;
+  await pastikanSesiSegar();
+  const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}/${path}`, {
+    method: "POST",
+    headers: kepalaSupabase(),
+    body: JSON.stringify({ expiresIn: 3600 }),
+  });
+  return `${K.supabaseUrl}/storage/v1${j.signedURL || j.signedUrl}`;
+}
+
+/** Pemakaian kuota. Dibaca layar supaya kehabisan ruang tidak jadi kejutan di
+ *  tengah acara — dan supaya rata-rata yang membengkak (tanda pengecilan
+ *  gambar gagal di sebagian HP) terlihat sebagai angka, bukan sebagai
+ *  unggahan yang tiba-tiba ditolak semua. */
+export async function kuotaFoto() {
+  const d = K.mode === "dev"
+    ? await baca("/kuota-foto")
+    : await baca(null, "v_kuota_foto?select=*");
+  return Array.isArray(d) ? d[0] : d;
+}

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -533,3 +533,77 @@ export function kartuGagalMuat(pesan, saatCobaLagi) {
   frag.querySelector("[data-ulang]").addEventListener("click", saatCobaLagi);
   return frag;
 }
+
+/* ---------- gambar ----------
+
+   Foto slip penilaian TIDAK PERNAH diunggah apa adanya. Satu acara berisi
+   ~5.500 slip; kalau tiap foto 4 MB seperti keluaran kamera HP, seluruhnya
+   22 GB — dua puluh dua kali kuota yang ada.
+
+   Yang dibuang tidak membawa informasi apa pun:
+
+     warna       slip adalah tinta hitam di kertas putih
+     resolusi    12 MP untuk membaca angka setinggi satu sentimeter
+     mutu JPEG   detail yang hilang di mutu 0,6 adalah tekstur kertas
+
+   Sisanya ~50-90 KB per foto, dan angkanya tetap terbaca jelas: pada 1400 px
+   melintang selembar A5 (210 mm), satu digit setinggi 10 mm masih 67 piksel.
+
+   Kalau hasilnya masih di atas 150 KB — foto ruangan gelap penuh derau, yang
+   tidak bisa dimampatkan JPEG — dicoba sekali lagi dengan mutu lebih rendah.
+   Sekali, bukan sampai muat: gelung yang mengejar ukuran akan menurunkan mutu
+   tanpa batas demi angka, dan foto yang tidak terbaca bukan backup.          */
+
+const SISI_MAKS = 1400;
+const MUTU_AWAL = 0.6;
+const MUTU_ULANG = 0.45;
+const TARGET_BYTES = 150 * 1024;
+
+/** Kecilkan + abu-abukan satu foto jadi Blob JPEG siap unggah.
+ *  Melempar Error kalau berkasnya bukan gambar yang bisa dibaca browser. */
+export async function kecilkanFoto(file) {
+  let gambar;
+  try {
+    gambar = await createImageBitmap(file);
+  } catch {
+    throw new Error("Berkas ini tidak bisa dibaca sebagai gambar. Coba foto ulang.");
+  }
+
+  const skala = Math.min(1, SISI_MAKS / Math.max(gambar.width, gambar.height));
+  const lebar = Math.max(1, Math.round(gambar.width * skala));
+  const tinggi = Math.max(1, Math.round(gambar.height * skala));
+
+  const kanvas = document.createElement("canvas");
+  kanvas.width = lebar;
+  kanvas.height = tinggi;
+  const ktx = kanvas.getContext("2d");
+  // Latar putih lebih dulu: PNG/HEIC dengan alpha akan jadi hitam pekat di
+  // JPEG kalau kanvasnya dibiarkan transparan, dan slip hitam total tidak
+  // bisa dibaca siapa pun.
+  ktx.fillStyle = "#fff";
+  ktx.fillRect(0, 0, lebar, tinggi);
+  ktx.filter = "grayscale(1)";
+  ktx.drawImage(gambar, 0, 0, lebar, tinggi);
+  if (gambar.close) gambar.close();
+
+  const jadikan = (mutu) => new Promise((selesai, gagal) => {
+    kanvas.toBlob(b => b ? selesai(b) : gagal(new Error("Gagal memproses gambar.")),
+                  "image/jpeg", mutu);
+  });
+
+  let blob = await jadikan(MUTU_AWAL);
+  if (blob.size > TARGET_BYTES) {
+    const lagi = await jadikan(MUTU_ULANG);
+    if (lagi.size < blob.size) blob = lagi;
+  }
+  return blob;
+}
+
+/** "83 KB", "1,4 MB" — dipakai layar foto supaya pemakaian kuota terbaca
+ *  tanpa menghitung apa pun di kepala. */
+export function ukuranRapi(bytes) {
+  const n = Number(bytes) || 0;
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${(n / 1048576).toFixed(1).replace(".", ",")} MB`;
+}

--- a/live/style.css
+++ b/live/style.css
@@ -1135,6 +1135,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   white-space: nowrap; margin-left: auto;
 }
 
+/* Foto slip per lomba (0047). Bentuknya sengaja sama dengan .riwayat — dua
+   dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua
+   aplikasi berbeda. */
+.foto-lomba { list-style: none; margin: 0; padding: 0; }
+.foto-lomba li {
+  display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem;
+  padding: .55rem 0; border-bottom: 1px solid var(--garis);
+}
+.foto-lomba li:last-child { border-bottom: 0; }
+.f-nama {
+  font-weight: 600; flex: 1 1 6rem; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Keadaan unggahan menumpang di tempat jumlah foto: "belum ada" ->
+   "mengecilkan…" -> "mengirim 71 KB…" -> "1 foto · 71 KB". Satu tempat, satu
+   kalimat — petugas tidak perlu mencari di mana kabarnya muncul. */
+.f-jumlah {
+  color: var(--tinta-lembut); font-size: .82rem;
+  flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere;
+}
+/* Tombol didorong ke kanan supaya kolomnya lurus walau nama lombanya pendek. */
+.foto-lomba li > :nth-last-child(2) { margin-left: auto; }
+/* <label> yang membungkus <input type=file> tersembunyi. Tanpa ini ia
+   ditampilkan sebagai teks biasa, bukan sebagai tombol. */
+.foto-lomba label.button { display: inline-flex; align-items: center; cursor: pointer; }
+
 .badge-tombol {
   border: 0; font: inherit; cursor: pointer;
   padding: .1rem .45rem; line-height: inherit;

--- a/supabase/migrations/0047_foto_lembar.sql
+++ b/supabase/migrations/0047_foto_lembar.sql
@@ -1,0 +1,285 @@
+-- ============================================================================
+-- hrcd-rekap : 0047_foto_lembar.sql
+--
+-- FOTO LEMBAR: setiap slip penilaian punya salinan di server, satu foto per
+-- lomba per regu, difoto petugas IT dengan HP sambil mengetik nilainya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA ADA
+--
+-- Nilai satu acara ada di ~5.500 lembar kertas A5 yang berpindah tangan dari
+-- pos ke kotak ke meja IT. Kertas hilang, basah, tertukar, atau tertinggal —
+-- dan begitu hilang, tidak ada apa pun yang bisa memulihkan angkanya. Yang
+-- tersimpan di database cuma hasil ketikan; kalau ketikan itu dipertanyakan,
+-- tidak ada yang bisa diadu dengannya.
+--
+-- Foto adalah catatannya. Ia tidak perlu dibaca mesin, tidak perlu akurat,
+-- tidak perlu rapi. Ia cuma perlu ADA.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DIFOTO DI MEJA IT, BUKAN DI POS
+--
+-- Karena di meja IT fotonya tertaut sendiri ke nomor dada dan lomba yang
+-- tepat — petugas baru saja mengetiknya. Foto borongan di pos harus dicari
+-- satu per satu nanti di antara ribuan gambar, dan backup yang tidak bisa
+-- ditemukan kembali bukan backup.
+--
+-- Harganya disebut supaya tidak jadi kejutan: slip yang HILANG DI JALAN antara
+-- pos dan meja IT tidak pernah difoto sama sekali. Jendela itu memang tidak
+-- terlindungi oleh migrasi ini.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA BOLEH LEBIH DARI SATU FOTO
+--
+-- Foto pertama buram, tangan bergoyang, kertasnya terlipat. Memaksa satu foto
+-- per lomba berarti petugas harus MENGHAPUS yang buram sebelum memotret ulang,
+-- dan tombol hapus pada backup adalah cara backup itu hilang. Jadi: banyak
+-- foto boleh, tidak ada yang pernah dihapus, yang terbaru yang ditampilkan.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KODE LOMBA, BUKAN wahana_id
+--
+-- Satu slip = satu LOMBA, dan satu lomba bisa berisi beberapa baris wahana:
+-- Bidai punya lima kriteria di satu kertas, Tebak Simpul punya satu baris per
+-- golongan. Menaut foto ke wahana_id akan memaksa lima baris untuk satu
+-- selembar kertas, dan kelimanya menunjuk gambar yang sama.
+--
+-- Jadi tautannya ke nama lomba yang sudah dipakai layar untuk mengelompokkan
+-- kolom, disimpan sebagai slug supaya aman jadi bagian nama berkas.
+--
+-- ---------------------------------------------------------------------------
+-- ANGGARAN PENYIMPANAN — DIHITUNG, BUKAN DIHARAP
+--
+-- 500 regu x 11 lomba = ~5.500 foto. Kuota Supabase tier gratis 1 GB, jadi
+-- angka yang boleh dipakai per foto adalah 1 GB / 5.500 = ~190 KB, dan itu
+-- SEBELUM ruang untuk foto ulang yang buram.
+--
+-- Karena itu klien tidak pernah mengunggah foto apa adanya. Slip adalah
+-- dokumen hitam-putih berisi tulisan tangan besar: warna tidak membawa
+-- informasi apa pun, dan resolusi kamera 12 MP membawa 40x lebih banyak piksel
+-- daripada yang dibutuhkan untuk membaca angka setinggi satu sentimeter.
+-- Setiap gambar diubah jadi abu-abu, dikecilkan ke sisi terpanjang 1400 px,
+-- dan dikodekan JPEG mutu 0,6 -> biasanya 50-90 KB. Seluruh acara ~350 MB.
+--
+-- `file_size_limit` bucket di bawah adalah pagar KEDUA, bukan yang pertama.
+-- Ia sengaja dipasang 1 MB: sepuluh kali lipat ukuran wajar, jadi ia tidak
+-- pernah menolak foto yang benar — tapi ia menolak foto mentah 4 MB dari
+-- kamera kalau pengecilan di klien suatu hari gagal diam-diam. Tanpa pagar
+-- kedua, kegagalan itu baru ketahuan saat kuota habis di tengah acara.
+-- ============================================================================
+
+create table if not exists foto_lembar (
+  id             uuid primary key default gen_random_uuid(),
+  regu_id        uuid     not null references regu (id) on delete cascade,
+  pos            smallint not null,
+  kode_lomba     text     not null,
+  nama_lomba     text     not null,
+  -- Nama objek di bucket `lembar`. Unik: dua baris yang menunjuk satu gambar
+  -- berarti satu di antaranya berbohong tentang siapa yang mengunggahnya.
+  path           text     not null unique,
+  ukuran_bytes   integer,
+  diunggah_oleh  uuid     not null references auth.users (id),
+  diunggah_pada  timestamptz not null default now(),
+
+  constraint foto_lembar_kode_slug check (kode_lomba ~ '^[a-z0-9-]+$')
+);
+
+create index if not exists foto_lembar_regu_pos_idx
+  on foto_lembar (regu_id, pos, kode_lomba);
+
+alter table foto_lembar enable row level security;
+
+-- Pagarnya menyalin sel_nilai (0003) dan v_riwayat_nilai (0042): admin dan meja
+-- seluruh pos, operator pos hanya posnya sendiri. Kalau berbeda, akan ada
+-- petugas yang bisa MENGUNGGAH foto tapi tidak bisa melihat bahwa ia sudah
+-- mengunggahnya — lalu ia mengunggahnya lagi, dan lagi.
+create policy sel_foto on foto_lembar for select using (
+  peran() in ('admin', 'meja')
+  or (peran() = 'operator_pos' and pos = pos_saya())
+);
+
+-- Menulis HANYA lewat catat_foto_lembar di bawah. Tidak ada policy delete
+-- untuk siapa pun kecuali admin: backup yang bisa dihapus dari layar bukan
+-- backup.
+create policy adm_foto on foto_lembar for all using (peran() = 'admin');
+
+grant select on foto_lembar to authenticated;
+
+comment on table foto_lembar is
+  'Foto slip penilaian, satu baris per foto. Ditulis lewat catat_foto_lembar, '
+  'tidak pernah dihapus dari layar. Gambarnya sendiri di bucket privat `lembar`.';
+
+-- ---------------------------------------------------------------------------
+-- Bucket privat.
+--
+-- Dibungkus exception handler karena hak atas skema `storage` berbeda antar
+-- proyek Supabase: di sebagian proyek peran migrasi boleh menulis
+-- storage.buckets, di sebagian lain hanya supabase_storage_admin. Gagal di
+-- sini TIDAK BOLEH menggagalkan seluruh migrasi — tabel dan RPC di atas sudah
+-- benar, dan buckets bisa dibuat dari dashboard dalam sepuluh detik.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  values ('lembar', 'lembar', false, 1048576, array['image/jpeg'])
+  on conflict (id) do update
+    set public = false,
+        file_size_limit = 1048576,
+        allowed_mime_types = array['image/jpeg'];
+  raise notice '0047: bucket `lembar` siap (privat, maks 1 MB, hanya JPEG).';
+exception
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0047: TIDAK BISA membuat bucket dari SQL. Buat manual di '
+      'Dashboard > Storage: nama `lembar`, PRIVAT, batas 1 MB (1048576), '
+      'allowed MIME image/jpeg.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Pagar bucket. Prefiks pertama nama objek adalah posnya: `pos1/...`.
+--
+-- Dipagari sendiri, tidak mengandalkan tabel foto_lembar: gambar diunggah
+-- LEBIH DULU, barisnya ditulis sesudahnya. Kalau pagarnya bergantung pada
+-- baris yang belum ada, tidak ada unggahan yang pernah berhasil.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  execute $p$
+    create policy foto_lembar_baca on storage.objects for select
+    using (
+      bucket_id = 'lembar' and (
+        peran() in ('admin', 'meja')
+        or (peran() = 'operator_pos'
+            and split_part(name, '/', 1) = 'pos' || pos_saya()::text)
+      )
+    )
+  $p$;
+  execute $p$
+    create policy foto_lembar_tulis on storage.objects for insert
+    with check (
+      bucket_id = 'lembar' and (
+        peran() in ('admin', 'meja')
+        or (peran() = 'operator_pos'
+            and split_part(name, '/', 1) = 'pos' || pos_saya()::text)
+      )
+    )
+  $p$;
+  raise notice '0047: policy storage.objects untuk bucket `lembar` terpasang.';
+exception
+  when duplicate_object then
+    raise notice '0047: policy storage.objects sudah ada — dilewati.';
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0047: TIDAK BISA memasang policy storage.objects dari SQL. '
+      'Pasang manual di Dashboard > Storage > lembar > Policies, '
+      'salin syarat dari kepala migrasi ini.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Mencatat foto yang SUDAH terunggah.
+--
+-- Dipanggil sesudah gambarnya mendarat di bucket, bukan sebelumnya. Urutan itu
+-- disengaja: baris tanpa gambar adalah kebohongan (layar bilang "sudah difoto"
+-- padahal tidak ada apa-apa), sedangkan gambar tanpa baris cuma berkas yatim
+-- yang tidak merugikan siapa pun dan masih bisa ditemukan lewat path-nya.
+-- ---------------------------------------------------------------------------
+create or replace function catat_foto_lembar(
+  p_nomor_dada integer,
+  p_pos        smallint,
+  p_kode_lomba text,
+  p_nama_lomba text,
+  p_path       text,
+  p_ukuran     integer default null
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_regu uuid;
+begin
+  if peran() = 'operator_pos' then
+    if p_pos is distinct from pos_saya() then
+      raise exception 'operator pos % tidak boleh mengunggah foto pos %',
+        pos_saya(), p_pos;
+    end if;
+  elsif peran() not in ('admin', 'meja') then
+    raise exception 'hanya panitia yang boleh mengunggah foto lembar';
+  end if;
+
+  if coalesce(trim(p_kode_lomba), '') = '' or coalesce(trim(p_path), '') = '' then
+    raise exception 'kode lomba dan path wajib diisi';
+  end if;
+
+  -- Path harus berada di dalam folder posnya. Tanpa ini seorang operator bisa
+  -- mencatat baris pos-nya sendiri yang menunjuk gambar milik pos lain.
+  if split_part(p_path, '/', 1) <> 'pos' || p_pos::text then
+    raise exception 'path % tidak berada di folder pos %', p_path, p_pos;
+  end if;
+
+  select id into v_regu from regu
+  where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal / regu batal',
+      case when p_nomor_dada between 0 and 999
+        then lpad(p_nomor_dada::text, 3, '0') else p_nomor_dada::text end;
+  end if;
+
+  insert into foto_lembar
+    (regu_id, pos, kode_lomba, nama_lomba, path, ukuran_bytes, diunggah_oleh)
+  values
+    (v_regu, p_pos, p_kode_lomba, p_nama_lomba, p_path, p_ukuran, auth.uid())
+  -- Mengirim ulang berkas yang sama bukan galat: jaringan lapangan memutus
+  -- jawaban, bukan permintaan, dan petugas yang menekan "kirim ulang" tidak
+  -- melakukan kesalahan apa pun.
+  on conflict (path) do nothing;
+end;
+$$;
+
+revoke all on function catat_foto_lembar(integer, smallint, text, text, text, integer) from public;
+grant execute on function catat_foto_lembar(integer, smallint, text, text, text, integer) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Berapa foto sudah masuk, per regu per lomba. Dibaca layar untuk menampilkan
+-- angka di samping tiap lomba tanpa menarik seluruh daftar.
+-- ---------------------------------------------------------------------------
+create or replace view v_foto_lembar as
+select
+  f.id, r.nomor_dada, f.pos, f.kode_lomba, f.nama_lomba, f.path,
+  f.ukuran_bytes,
+  coalesce(a.username, '(tidak dikenal)') as oleh,
+  f.diunggah_pada
+from foto_lembar f
+join regu r on r.id = f.regu_id
+left join akun_panitia a on a.user_id = f.diunggah_oleh
+where peran() in ('admin', 'meja')
+   or (peran() = 'operator_pos' and f.pos = pos_saya());
+
+comment on view v_foto_lembar is
+  'Foto lembar dengan nomor dada dan nama pengunggah. Pagarnya sama dengan '
+  'tabelnya: admin/meja seluruh pos, operator pos hanya posnya sendiri.';
+
+grant select on v_foto_lembar to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Kuota terpakai, dibaca langsung oleh layar.
+--
+-- Angka ini ada supaya kehabisan kuota tidak pernah jadi kejutan di tengah
+-- acara. Kalau rata-rata per foto mulai menanjak jauh di atas ~90 KB, artinya
+-- pengecilan di klien gagal pada sebagian HP — dan itu ketahuan dari satu
+-- angka di layar, bukan dari unggahan yang tiba-tiba ditolak semua.
+--
+-- Agregat tanpa pagar peran: tidak ada data siapa pun di dalamnya, cuma
+-- hitungan dan jumlah byte.
+-- ---------------------------------------------------------------------------
+create or replace view v_kuota_foto as
+select
+  count(*)                                        as jumlah_foto,
+  coalesce(sum(ukuran_bytes), 0)                  as total_bytes,
+  coalesce(round(avg(ukuran_bytes))::bigint, 0)   as rata_bytes,
+  coalesce(max(ukuran_bytes), 0)                  as terbesar_bytes
+from foto_lembar;
+
+comment on view v_kuota_foto is
+  'Ringkasan pemakaian bucket `lembar`. Rata-rata jauh di atas 90 KB berarti '
+  'pengecilan gambar di klien tidak jalan pada sebagian HP.';
+
+grant select on v_kuota_foto to authenticated;

--- a/tests/sql/20_foto_lembar.sql
+++ b/tests/sql/20_foto_lembar.sql
@@ -1,0 +1,144 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/20_foto_lembar.sql
+-- Foto slip penilaian (0047).
+--
+-- Yang dijaga: pagarnya ada di SERVER, bukan di layar. Gambar diunggah langsung
+-- dari browser ke Storage, jadi path-nya datang dari JavaScript — dan apa pun
+-- yang datang dari JavaScript bisa dikarang. Yang harus menolak path karangan
+-- adalah database.
+--
+-- Yang TIDAK diuji di sini: policy storage.objects itu sendiri, karena
+-- storage.objects tidak ada di Postgres lokal. Pagarnya karena itu dipasang
+-- dua kali — sekali di bucket, sekali di catat_foto_lembar — dan yang kedua
+-- inilah yang bisa diuji.
+-- ============================================================================
+
+-- Dicari SEBELUM `set role`, selagi masih boleh membaca akun_panitia utuh.
+create temp table t_op as
+select user_id as uid, pos from akun_panitia
+where peran = 'operator_pos' and is_active and pos is not null
+order by pos limit 1;
+
+create temp table t_regu as
+select id, nomor_dada from regu
+where nomor_dada is not null and not is_cancelled
+order by nomor_dada limit 1;
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 20.1  Admin mencatat foto, barisnya mendarat di regu yang benar.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_dada integer; v_regu uuid; v_ada integer;
+begin
+  select nomor_dada, id into v_dada, v_regu from t_regu;
+
+  perform catat_foto_lembar(v_dada, 1::smallint, 'uji-lomba', 'Uji Lomba',
+                            'pos1/uji-lomba/uji-a.jpg', 71234);
+
+  select count(*) into v_ada from foto_lembar
+  where path = 'pos1/uji-lomba/uji-a.jpg' and regu_id = v_regu;
+  assert v_ada = 1, 'foto tidak tercatat / regu salah';
+
+  raise notice '20.1 OK — foto tercatat.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 20.2  Path di luar folder posnya DITOLAK.
+--
+-- Ini kebocoran yang paling mudah terjadi dan paling sulit dilihat: baris
+-- tercatat sebagai milik Pos 1, gambarnya sebenarnya di folder Pos 3. Yang
+-- membaca daftar foto Pos 1 kemudian melihat kertas pos lain, dan mengira
+-- itulah slip regu tersebut.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_dada integer; v_tolak boolean := false;
+begin
+  select nomor_dada into v_dada from t_regu;
+  begin
+    perform catat_foto_lembar(v_dada, 1::smallint, 'uji-lomba', 'Uji Lomba',
+                              'pos3/uji-lomba/nyasar.jpg', 1000);
+    raise exception 'GAGAL: path pos3 diterima sebagai foto pos 1';
+  exception
+    when others then
+      if sqlerrm like 'GAGAL:%' then raise; end if;
+      v_tolak := true;
+  end;
+  assert v_tolak, 'path lintas pos tidak ditolak';
+  raise notice '20.2 OK — path lintas pos ditolak.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 20.3  Mengirim ulang path yang sama BUKAN galat, dan tidak menggandakan.
+--
+-- Jaringan lapangan memutus JAWABAN, bukan permintaan. Petugas yang menekan
+-- "kirim ulang" setelah unggahan yang sebenarnya berhasil tidak melakukan
+-- kesalahan apa pun, dan tidak boleh melihat pesan merah.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_dada integer; v_ada integer;
+begin
+  select nomor_dada into v_dada from t_regu;
+  perform catat_foto_lembar(v_dada, 1::smallint, 'uji-lomba', 'Uji Lomba',
+                            'pos1/uji-lomba/uji-a.jpg', 71234);
+  select count(*) into v_ada from foto_lembar
+  where path = 'pos1/uji-lomba/uji-a.jpg';
+  assert v_ada = 1, 'kiriman ulang menggandakan barisnya';
+  raise notice '20.3 OK — kiriman ulang tidak menggandakan.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 20.4  Operator pos tidak boleh mencatat foto pos lain, dan tidak boleh
+--       MELIHAT foto pos lain.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_dada integer; v_uid uuid; v_pos smallint;
+  v_lain smallint; v_tolak boolean := false; v_lihat integer;
+begin
+  select nomor_dada into v_dada from t_regu;
+  select uid, pos into v_uid, v_pos from t_op;
+  if v_uid is null then
+    raise notice '20.4 DILEWATI — tidak ada akun operator_pos aktif.';
+    return;
+  end if;
+  v_lain := case when v_pos = 1 then 2 else 1 end;
+
+  perform set_config('app.uid', v_uid::text, false);
+
+  begin
+    perform catat_foto_lembar(v_dada, v_lain, 'uji-lomba', 'Uji Lomba',
+                              'pos' || v_lain::text || '/uji-lomba/curi.jpg', 1000);
+    raise exception 'GAGAL: operator pos % mencatat foto pos %', v_pos, v_lain;
+  exception
+    when others then
+      if sqlerrm like 'GAGAL:%' then raise; end if;
+      v_tolak := true;
+  end;
+  assert v_tolak, 'operator pos lain tidak ditolak';
+
+  -- Foto 20.1 ada di Pos 1. Operator pos selain 1 tidak boleh melihatnya.
+  if v_pos <> 1 then
+    select count(*) into v_lihat from foto_lembar
+    where path = 'pos1/uji-lomba/uji-a.jpg';
+    assert v_lihat = 0, 'operator pos ' || v_pos || ' bisa melihat foto pos 1';
+  end if;
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  raise notice '20.4 OK — operator pos terkurung di posnya.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Bersih-bersih. Barisnya dibuang dari akar ke daun seperti tes lain — tanpa
+-- ini hitungan tes berikutnya ikut bergeser.
+-- ---------------------------------------------------------------------------
+reset role;
+delete from foto_lembar where kode_lomba = 'uji-lomba';
+drop table if exists t_op;
+drop table if exists t_regu;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -550,3 +550,101 @@ export const simpanNilaiPos = (baris, pos) =>
  *  sel kosong berarti "belum dinilai", bukan "hapus". */
 export const hapusNilaiPos = (nomorDada, kode, pos) =>
   rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });
+
+/* ============================ FOTO LEMBAR =============================== */
+
+/* Salinan slip penilaian di server (migrasi 0047). Kertas hilang; foto tidak.
+   Difoto petugas IT dengan HP sambil mengetik, jadi fotonya tertaut sendiri ke
+   nomor dada dan lomba yang tepat.
+
+   Gambar TIDAK lewat rpc/baca di atas: keduanya mengirim dan menerima JSON,
+   sedangkan ini mengunggah biner ke Storage — endpoint, header, dan bentuk
+   jawabannya semuanya berbeda. Dibuat jalur sendiri, bukan dengan menambah
+   cabang ke pembungkus yang sudah ada. */
+
+const BUCKET = "lembar";
+
+/** Nama objek di bucket. Prefiks pertama WAJIB `pos<n>` — itulah yang dipagari
+ *  policy storage.objects, dan RPC catat_foto_lembar menolak path yang tidak
+ *  cocok dengan posnya. */
+export function namaObjekFoto(pos, kodeLomba, nomorDada) {
+  const acak = Math.random().toString(36).slice(2, 8);
+  return `pos${pos}/${kodeLomba}/` +
+         `${String(nomorDada).padStart(3, "0")}-${Date.now()}-${acak}.jpg`;
+}
+
+/** Unggah satu gambar, lalu catat barisnya.
+ *
+ *  Urutannya disengaja: gambar dulu, baris sesudahnya. Baris tanpa gambar
+ *  adalah kebohongan — layar bilang "sudah difoto" padahal tidak ada apa-apa.
+ *  Gambar tanpa baris cuma berkas yatim yang masih bisa ditemukan lewat
+ *  path-nya, dan tidak merugikan siapa pun. */
+export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blob) {
+  const path = namaObjekFoto(pos, kodeLomba, nomorDada);
+
+  if (K.mode === "dev") {
+    // Dev server tidak punya Storage. Barisnya tetap dicatat supaya alur
+    // layarnya bisa dicoba tanpa Supabase.
+    await rpc("catat_foto_lembar", {
+      p_nomor_dada: nomorDada, p_pos: pos, p_kode_lomba: kodeLomba,
+      p_nama_lomba: namaLomba, p_path: path, p_ukuran: blob.size,
+    });
+    return { path, ukuran: blob.size };
+  }
+
+  await pastikanSesiSegar();
+  const s = sesi();
+  await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET}/${path}`, {
+    method: "POST",
+    headers: {
+      apikey: K.anonKey,
+      Authorization: `Bearer ${s && s.token ? s.token : K.anonKey}`,
+      "Content-Type": "image/jpeg",
+      "x-upsert": "false",
+    },
+    body: blob,
+  });
+
+  await rpc("catat_foto_lembar", {
+    p_nomor_dada: nomorDada, p_pos: pos, p_kode_lomba: kodeLomba,
+    p_nama_lomba: namaLomba, p_path: path, p_ukuran: blob.size,
+  });
+  return { path, ukuran: blob.size };
+}
+
+/** Foto satu regu di satu pos, terbaru dulu. */
+export async function daftarFotoLembar(pos, nomorDada) {
+  if (K.mode === "dev") {
+    return baca(`/foto-lembar?pos=${encodeURIComponent(pos)}` +
+                `&dada=${encodeURIComponent(nomorDada)}`);
+  }
+  return baca(null,
+    `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}` +
+    `&nomor_dada=eq.${encodeURIComponent(nomorDada)}` +
+    `&select=*&order=diunggah_pada.desc`);
+}
+
+/** Link sementara untuk melihat satu foto. Bucket-nya privat, jadi tidak ada
+ *  URL tetap — dan itu memang yang diinginkan: link yang tidak kedaluwarsa
+ *  akan beredar di WhatsApp selamanya. Satu jam cukup untuk melihatnya. */
+export async function tautanFoto(path) {
+  if (K.mode === "dev") return null;
+  await pastikanSesiSegar();
+  const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}/${path}`, {
+    method: "POST",
+    headers: kepalaSupabase(),
+    body: JSON.stringify({ expiresIn: 3600 }),
+  });
+  return `${K.supabaseUrl}/storage/v1${j.signedURL || j.signedUrl}`;
+}
+
+/** Pemakaian kuota. Dibaca layar supaya kehabisan ruang tidak jadi kejutan di
+ *  tengah acara — dan supaya rata-rata yang membengkak (tanda pengecilan
+ *  gambar gagal di sebagian HP) terlihat sebagai angka, bukan sebagai
+ *  unggahan yang tiba-tiba ditolak semua. */
+export async function kuotaFoto() {
+  const d = K.mode === "dev"
+    ? await baca("/kuota-foto")
+    : await baca(null, "v_kuota_foto?select=*");
+  return Array.isArray(d) ? d[0] : d;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -21,12 +21,13 @@ import {
   batasNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
+  unggahFotoLembar, daftarFotoLembar, tautanFoto,
   statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
-         kotakJamHtml } from "./util.js";
+         kotakJamHtml, kecilkanFoto, ukuranRapi } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -2488,6 +2489,7 @@ async function layarInputPos() {
                   <span class="kolom-petunjuk">${esc(kol.petunjuk)}</span></th>`).join("")}
               <th class="text-center">Nilai<br>${esc(pos.bayangan ? pos.name : `Pos ${pos.nomor}`)}</th>
               <th class="text-center"><span class="visually-hidden">Status simpan</span></th>
+              <th class="text-center"><span class="visually-hidden">Foto</span></th>
               <th class="text-center"><span class="visually-hidden">Gembok</span></th>
             </tr>
           </thead>
@@ -2520,8 +2522,21 @@ async function layarInputPos() {
       }).join("")}
       <td class="text-center pos-nilai" data-label="Nilai Pos">${esc(angkaRapi(r.nilai_pos))}</td>
       <td class="pos-status" data-label=""></td>
+      <td class="pos-foto text-center" data-label="">
+        <button type="button" class="badge badge-tombol" data-foto
+          title="Foto slip penilaian regu ini">📷</button></td>
       <td class="pos-gembok" data-label=""></td>
     </tr>`).join("")));
+
+  /* Kamera dipasang lewat satu pendengar di tbody, bukan satu per baris.
+     Tombolnya digambar sekali di template dan tidak pernah digambar ulang —
+     berbeda dengan gembok dan penanda simpan, yang berganti rupa mengikuti
+     keadaan barisnya. Menempelkan ~300 pendengar untuk tombol yang tidak
+     pernah berubah adalah ongkos yang tidak dibayar apa-apa. */
+  tbody.addEventListener("click", (e) => {
+    const b = e.target.closest("[data-foto]");
+    if (b) bukaFoto(b.closest("tr"));
+  });
 
   /* ---------- keadaan simpan per baris ----------
 
@@ -2717,6 +2732,134 @@ async function layarInputPos() {
         document.querySelectorAll(".dialog .riwayat li").forEach(li => {
           li.hidden = !!pilih && li.dataset.lomba !== pilih;
         });
+      });
+    }
+
+    await janji;
+  }
+
+  /** Slug lomba dari NAMANYA, bukan dari kode wahana.
+   *
+   *  Satu slip = satu lomba, tapi satu lomba bisa punya beberapa baris wahana:
+   *  Bidai lima kriteria di satu kertas, Tebak Simpul satu baris per golongan.
+   *  Kode wahana karena itu bukan penanda selembar kertas — namanya yang
+   *  justru satu, dan itulah yang sudah dipakai kolomPos() mengelompokkan. */
+  const slugLomba = (nama) => String(nama).toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
+
+  /** Foto slip penilaian satu regu — satu foto per lomba (migrasi 0047).
+   *
+   *  Kertas berpindah tangan dari pos ke kotak ke meja IT, dan begitu hilang
+   *  tidak ada apa pun yang bisa memulihkan angkanya. Difoto di sini, di meja
+   *  IT, karena di sinilah fotonya tertaut sendiri ke nomor dada dan lomba
+   *  yang tepat — petugas baru saja mengetiknya.
+   *
+   *  Gembok TIDAK mematikan tombol ini. Mengunci berarti angkanya final;
+   *  fotonya justru bukti untuk angka final itu, dan menolak bukti setelah
+   *  putusan adalah urutan yang terbalik. */
+  async function bukaFoto(tr) {
+    const dada = Number(tr.dataset.dada);
+    const namaRegu = tr.children[1].textContent.trim();
+    const tiga = String(dada).padStart(3, "0");
+
+    let sudah = [];
+    try {
+      sudah = await daftarFotoLembar(pos.nomor, dada);
+    } catch (err) {
+      notif(`Daftar foto tidak bisa dibaca: ${err.message}`, true);
+    }
+
+    const hitung = {};
+    const terbaru = {};
+    sudah.forEach(f => {
+      hitung[f.kode_lomba] = (hitung[f.kode_lomba] || 0) + 1;
+      if (!terbaru[f.kode_lomba]) terbaru[f.kode_lomba] = f.path;   // sudah urut terbaru dulu
+    });
+
+    const lomba = [...new Map(kolom.map(k => [slugLomba(k.nama), k.nama]))];
+
+    const isi = `<ul class="foto-lomba">${lomba.map(([kode, nama]) => html`
+      <li data-kode="${kode}" data-nama="${nama}">
+        <span class="f-nama">${nama}</span>
+        <span class="f-jumlah" data-jumlah>${hitung[kode]
+          ? `${hitung[kode]} foto` : "belum ada"}</span>
+        <button type="button" class="button button-mini" data-lihat
+          ${hitung[kode] ? "" : "hidden"}>Lihat</button>
+        <label class="button button-mini button-primary">
+          <input type="file" accept="image/*" multiple hidden data-ambil>📷 Foto
+        </label>
+      </li>`).join("")}</ul>
+      <p class="description" style="margin-top:.6rem">Gambar dikecilkan otomatis
+        (abu-abu, ±70 KB) sebelum dikirim. Foto lama tidak pernah tertimpa —
+        memotret ulang menambah, bukan mengganti.</p>`;
+
+    // Sama seperti bukaRiwayat: dialog() menempelkan kartunya secara SINKRON,
+    // jadi pendengarnya boleh dipasang sebelum janjinya ditunggu.
+    const janji = dialog({
+      judul: `Foto slip · ${tiga} · ${namaRegu}`,
+      kartuHtml: isi,
+      labelAksi: "Tutup",
+      bacaSaja: true,
+    });
+
+    const kartu = document.querySelector(".dialog .foto-lomba");
+    if (kartu) {
+      kartu.addEventListener("click", async (e) => {
+        const b = e.target.closest("[data-lihat]");
+        if (!b) return;
+        const kode = b.closest("li").dataset.kode;
+        if (!terbaru[kode]) return;
+        // Jendelanya dibuka SEBELUM await. Dibuka sesudahnya, browser HP
+        // menganggapnya popup yang tidak diminta pengguna dan memblokirnya.
+        const jendela = window.open("", "_blank");
+        try {
+          const url = await tautanFoto(terbaru[kode]);
+          if (jendela && url) jendela.location = url;
+          else if (jendela) jendela.close();
+        } catch (err) {
+          if (jendela) jendela.close();
+          notif(`Foto tidak bisa dibuka: ${err.message}`, true);
+        }
+      });
+
+      kartu.addEventListener("change", async (e) => {
+        const inp = e.target.closest("[data-ambil]");
+        if (!inp || !inp.files || !inp.files.length) return;
+        const li = inp.closest("li");
+        const kode = li.dataset.kode;
+        const status = li.querySelector("[data-jumlah]");
+        const berkas = [...inp.files];
+        // Dikosongkan supaya memilih BERKAS YANG SAMA lagi tetap memicu change
+        // — persis yang dilakukan orang setelah unggahan pertama gagal.
+        inp.value = "";
+
+        for (const f of berkas) {
+          let blob;
+          try {
+            status.textContent = "mengecilkan…";
+            blob = await kecilkanFoto(f);
+          } catch (err) {
+            status.textContent = err.message;
+            continue;
+          }
+          try {
+            status.textContent = `mengirim ${ukuranRapi(blob.size)}…`;
+            const hasil = await unggahFotoLembar(
+              pos.nomor, kode, li.dataset.nama, dada, blob);
+            hitung[kode] = (hitung[kode] || 0) + 1;
+            terbaru[kode] = hasil.path;
+            status.textContent = `${hitung[kode]} foto · ${ukuranRapi(blob.size)}`;
+            const lihat = li.querySelector("[data-lihat]");
+            if (lihat) lihat.hidden = false;
+          } catch (err) {
+            // Blob-nya sudah tidak dipegang, tapi berkas aslinya masih di
+            // galeri HP — dan itulah antreannya. Petugas memilih ulang berkas
+            // yang sama, dan input di atas sengaja sudah dikosongkan supaya
+            // pilihan itu terbaca.
+            status.textContent = `gagal — ${err.message}`;
+            notif(`Foto ${tiga} ${li.dataset.nama} gagal terkirim: ${err.message}`, true);
+          }
+        }
       });
     }
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -533,3 +533,77 @@ export function kartuGagalMuat(pesan, saatCobaLagi) {
   frag.querySelector("[data-ulang]").addEventListener("click", saatCobaLagi);
   return frag;
 }
+
+/* ---------- gambar ----------
+
+   Foto slip penilaian TIDAK PERNAH diunggah apa adanya. Satu acara berisi
+   ~5.500 slip; kalau tiap foto 4 MB seperti keluaran kamera HP, seluruhnya
+   22 GB — dua puluh dua kali kuota yang ada.
+
+   Yang dibuang tidak membawa informasi apa pun:
+
+     warna       slip adalah tinta hitam di kertas putih
+     resolusi    12 MP untuk membaca angka setinggi satu sentimeter
+     mutu JPEG   detail yang hilang di mutu 0,6 adalah tekstur kertas
+
+   Sisanya ~50-90 KB per foto, dan angkanya tetap terbaca jelas: pada 1400 px
+   melintang selembar A5 (210 mm), satu digit setinggi 10 mm masih 67 piksel.
+
+   Kalau hasilnya masih di atas 150 KB — foto ruangan gelap penuh derau, yang
+   tidak bisa dimampatkan JPEG — dicoba sekali lagi dengan mutu lebih rendah.
+   Sekali, bukan sampai muat: gelung yang mengejar ukuran akan menurunkan mutu
+   tanpa batas demi angka, dan foto yang tidak terbaca bukan backup.          */
+
+const SISI_MAKS = 1400;
+const MUTU_AWAL = 0.6;
+const MUTU_ULANG = 0.45;
+const TARGET_BYTES = 150 * 1024;
+
+/** Kecilkan + abu-abukan satu foto jadi Blob JPEG siap unggah.
+ *  Melempar Error kalau berkasnya bukan gambar yang bisa dibaca browser. */
+export async function kecilkanFoto(file) {
+  let gambar;
+  try {
+    gambar = await createImageBitmap(file);
+  } catch {
+    throw new Error("Berkas ini tidak bisa dibaca sebagai gambar. Coba foto ulang.");
+  }
+
+  const skala = Math.min(1, SISI_MAKS / Math.max(gambar.width, gambar.height));
+  const lebar = Math.max(1, Math.round(gambar.width * skala));
+  const tinggi = Math.max(1, Math.round(gambar.height * skala));
+
+  const kanvas = document.createElement("canvas");
+  kanvas.width = lebar;
+  kanvas.height = tinggi;
+  const ktx = kanvas.getContext("2d");
+  // Latar putih lebih dulu: PNG/HEIC dengan alpha akan jadi hitam pekat di
+  // JPEG kalau kanvasnya dibiarkan transparan, dan slip hitam total tidak
+  // bisa dibaca siapa pun.
+  ktx.fillStyle = "#fff";
+  ktx.fillRect(0, 0, lebar, tinggi);
+  ktx.filter = "grayscale(1)";
+  ktx.drawImage(gambar, 0, 0, lebar, tinggi);
+  if (gambar.close) gambar.close();
+
+  const jadikan = (mutu) => new Promise((selesai, gagal) => {
+    kanvas.toBlob(b => b ? selesai(b) : gagal(new Error("Gagal memproses gambar.")),
+                  "image/jpeg", mutu);
+  });
+
+  let blob = await jadikan(MUTU_AWAL);
+  if (blob.size > TARGET_BYTES) {
+    const lagi = await jadikan(MUTU_ULANG);
+    if (lagi.size < blob.size) blob = lagi;
+  }
+  return blob;
+}
+
+/** "83 KB", "1,4 MB" — dipakai layar foto supaya pemakaian kuota terbaca
+ *  tanpa menghitung apa pun di kepala. */
+export function ukuranRapi(bytes) {
+  const n = Number(bytes) || 0;
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${(n / 1048576).toFixed(1).replace(".", ",")} MB`;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1135,6 +1135,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   white-space: nowrap; margin-left: auto;
 }
 
+/* Foto slip per lomba (0047). Bentuknya sengaja sama dengan .riwayat — dua
+   dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua
+   aplikasi berbeda. */
+.foto-lomba { list-style: none; margin: 0; padding: 0; }
+.foto-lomba li {
+  display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem;
+  padding: .55rem 0; border-bottom: 1px solid var(--garis);
+}
+.foto-lomba li:last-child { border-bottom: 0; }
+.f-nama {
+  font-weight: 600; flex: 1 1 6rem; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Keadaan unggahan menumpang di tempat jumlah foto: "belum ada" ->
+   "mengecilkan…" -> "mengirim 71 KB…" -> "1 foto · 71 KB". Satu tempat, satu
+   kalimat — petugas tidak perlu mencari di mana kabarnya muncul. */
+.f-jumlah {
+  color: var(--tinta-lembut); font-size: .82rem;
+  flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere;
+}
+/* Tombol didorong ke kanan supaya kolomnya lurus walau nama lombanya pendek. */
+.foto-lomba li > :nth-last-child(2) { margin-left: auto; }
+/* <label> yang membungkus <input type=file> tersembunyi. Tanpa ini ia
+   ditampilkan sebagai teks biasa, bukan sebagai tombol. */
+.foto-lomba label.button { display: inline-flex; align-items: center; cursor: pointer; }
+
 .badge-tombol {
   border: 0; font: inherit; cursor: pointer;
   padding: .1rem .45rem; line-height: inherit;


### PR DESCRIPTION
## What

The IT desk can now photograph each scoring slip while typing its value. One
photo per lomba per regu, taken on a phone, stored in a private Supabase
Storage bucket.

- `0047_foto_lembar.sql` — private bucket `lembar`, table `foto_lembar`, RPC
  `catat_foto_lembar`, views `v_foto_lembar` and `v_kuota_foto`.
- `kecilkanFoto()` in `util.js` — grayscale, 1400 px cap, JPEG 0.6.
- A camera button per row on the pos sheet, next to the padlock.
- `tests/sql/20_foto_lembar.sql` — four cases, including a forged path.

## Why

Paper holds the only original of ~5.500 slips and it travels from pos to box
to the IT desk. Once a slip is gone there is nothing left to check a typed
number against. Photographing at the desk — rather than at the pos — means the
image binds itself to the right nomor dada and lomba, because the operator has
just typed them; a bulk photo taken at a pos would have to be hunted for later
among thousands of images.

Storage is budgeted rather than hoped for. 5.500 photos against a 1 GB free
quota allows ~190 KB each. Slips are black ink on white paper, so colour
carries nothing and 12 MP carries ~40x more pixels than reading a 1 cm digit
needs. Grayscale + 1400 px + JPEG 0.6 lands at 50-90 KB, about 350 MB for the
whole event. `v_kuota_foto` puts the running average on screen, so shrinking
that silently fails on some phones shows up as a number rather than as uploads
that suddenly all get rejected.

## Notes

- The pos → box → IT desk leg is still unprotected: a slip that never arrives
  is never photographed. Bulk photos at the pos would cover that, and are not
  part of this PR.
- The bucket and its `storage.objects` policies are created inside exception
  handlers. Local Postgres has no `storage` schema, and Supabase projects
  differ on whether the migration role may write there — if the migration logs
  a warning instead of a notice, create the bucket from the dashboard and copy
  the policy predicates from the migration header. `catat_foto_lembar` fences
  the same rule a second time, and that fence is what the test covers.
- Photos are never deleted from any screen, and re-sending the same path is a
  no-op rather than an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)