### PR TITLE
feat: show live input progress and medals on the peserta page

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -78,7 +78,7 @@ jobs:
 
           d = json.load(open('/tmp/rekap-utuh.json'))
           for k in ('dibuat_pada', 'fase', 'edisi', 'ringkas', 'pos',
-                    'progres', 'klasemen'):
+                    'kelengkapan', 'progres', 'klasemen'):
               if k not in d:
                   sys.exit(f'kunci {k} hilang dari keluaran live_json.sql')
 
@@ -90,6 +90,8 @@ jobs:
           # Kalau suatu hari ia tidak lagi begitu, berhenti di sini.
           if d['fase'] == 'pra' and d['progres']:
               sys.exit('BOCOR: baris regu ikut tertulis padahal fase masih pra')
+          if d['fase'] == 'pra' and d['kelengkapan']:
+              sys.exit('BOCOR: kelengkapan pos tertulis padahal fase masih pra')
 
           rekap = {'progres': d['progres'], 'klasemen': d['klasemen']}
           sidik = hashlib.sha256(json.dumps(
@@ -104,6 +106,11 @@ jobs:
               'edisi':       d['edisi'],
               'ringkas':     d['ringkas'],
               'pos':         d['pos'],
+              # Kemajuan input per pos (0048). Ditaruh di live.json dan bukan
+              # di rekap.json justru karena ia berubah terus: rekap.json
+              # dialamati `?v=<versi>` dan sengaja mengendap di cache, jadi
+              # angka yang harus selalu segar tidak boleh menumpang di sana.
+              'kelengkapan': d['kelengkapan'],
               'jumlah_regu': len(d['progres']),
           }
 

--- a/live/live.css
+++ b/live/live.css
@@ -149,3 +149,60 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
   min-height: 48px; line-height: 34px;
 }
 .tombol:hover { background: #004d43; }
+
+/* ============================================================================
+   Kemajuan input per pos (0048).
+
+   Batang, bukan angka saja: yang dicari mata di sini perbandingan antar pos —
+   "pos mana yang tertinggal" — dan itu terbaca dari panjang dalam sekali
+   lihat, sedangkan lima angka persen harus dibaca satu per satu lalu
+   dibandingkan di kepala.
+   ========================================================================== */
+.kemajuan { list-style: none; }
+.kemajuan li { margin-bottom: .85rem; }
+.kemajuan li:last-child { margin-bottom: 0; }
+.k-kepala {
+  display: flex; align-items: baseline; gap: .5rem; margin-bottom: .3rem;
+}
+.k-nama {
+  font-weight: 600; flex: 1 1 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.k-persen {
+  font-weight: 800; font-variant-numeric: tabular-nums;
+  color: var(--utama); white-space: nowrap;
+}
+/* Tinggi 10px, bukan 4px: dibaca sambil berdiri di bawah matahari, dan garis
+   tipis yang elegan di monitor hilang sama sekali di layar HP yang silau. */
+.k-batang {
+  height: 10px; border-radius: 999px; background: var(--kertas);
+  border: 1px solid var(--garis); overflow: hidden;
+}
+.k-batang span {
+  display: block; height: 100%; background: var(--utama);
+  border-radius: 999px; transition: width .4s ease;
+}
+.k-angka { font-size: .82rem; color: var(--tinta-lembut); margin-top: .25rem; }
+
+/* ---------------------------------------------------------------------------
+   Medali. Ia MENGGANTIKAN angka besar di podium, tapi angka peringkatnya
+   tetap tertulis di bawahnya — sebagian HP lama tidak punya emoji medali dan
+   akan menggambar kotak kosong, dan podium tanpa penanda juara sama sekali
+   lebih buruk daripada podium tanpa medali.
+   ------------------------------------------------------------------------- */
+.medali { font-size: 2.2rem; line-height: 1; }
+.juara .peringkat {
+  font-size: .78rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--tinta-lembut); margin-top: .15rem;
+}
+.dada-juara {
+  font-variant-numeric: tabular-nums; font-weight: 700;
+  color: var(--utama); font-size: .9rem;
+}
+
+/* Kolom poin per pos di tabel rincian. Sempit dan rata tengah supaya lima
+   kolom angka tetap muat sebelum tabelnya perlu digeser. */
+.pos-kol {
+  text-align: center; font-variant-numeric: tabular-nums;
+  white-space: nowrap; padding-left: .3rem; padding-right: .3rem;
+}

--- a/live/live.js
+++ b/live/live.js
@@ -279,9 +279,61 @@ function gambarHasil() {
    Fase 'penuh' — klasemen per golongan, juara di atas. Tampil tanpa perlu
    mencari apa pun: inilah pengumumannya.
    ------------------------------------------------------------------------- */
+/* ---------------------------------------------------------------------------
+   Kemajuan input per pos.
+
+   Sepanjang hari peserta menanyakan satu hal: "nilai regu saya sudah masuk
+   belum?" Centang per pos di bawah sudah menjawabnya, tapi centang KOSONG
+   punya dua arti yang jauh berbeda — "regu kamu terlewat" atau "pos itu
+   memang baru mulai diinput" — dan dari kursi peserta keduanya terlihat sama
+   persis.
+
+   Satu angka per pos memisahkan keduanya, dan pertanyaan yang tadinya jadi
+   antrean di meja panitia terjawab sebelum diajukan.
+   ------------------------------------------------------------------------- */
+function gambarKelengkapan() {
+  const daftar = (META && META.kelengkapan) || [];
+  if (!daftar.length) return "";
+
+  return `
+    <div class="kartu">
+      <h2>Kemajuan input</h2>
+      <p class="keterangan">Berapa banyak regu yang nilainya sudah masuk di tiap
+        pos. Angka ini bukan nilai — nilai baru terbit saat hasil diumumkan.</p>
+      <ul class="kemajuan">
+        ${daftar.map(p => {
+          const persen = Number(p.persen) || 0;
+          return `
+          <li>
+            <div class="k-kepala">
+              <span class="k-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</span>
+              <span class="k-persen">${esc(String(persen))}%</span>
+            </div>
+            <div class="k-batang" role="img"
+                 aria-label="Pos ${esc(String(p.pos))} ${esc(String(persen))} persen selesai">
+              <span style="width:${persen}%"></span>
+            </div>
+            <div class="k-angka">${esc(String(p.lengkap))} dari
+              ${esc(String(p.regu_total))} regu${Number(p.sebagian) > 0
+                ? ` · ${esc(String(p.sebagian))} baru sebagian` : ""}</div>
+          </li>`;
+        }).join("")}
+      </ul>
+    </div>`;
+}
+
+/* Emas, perak, perunggu. Angka peringkat tetap ada di bawahnya untuk yang
+   tidak menampilkan emoji — medali di sini menggantikan angka besar, bukan
+   satu-satunya penanda juara. */
+const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
+
 function gambarKlasemen() {
   const semua = (REKAP && REKAP.klasemen) || [];
   if (!semua.length) return "";
+  // Kolom rincian dibentuk dari daftar pos yang terbit di live.json, bukan
+  // ditulis di sini: jumlah pos berubah tiap edisi, dan halaman peserta tidak
+  // boleh jadi tempat kedua yang harus ikut disunting saat itu terjadi.
+  const POS = (META && META.pos) || [];
 
   return URUT_GOLONGAN.map(g => {
     const baris = semua.filter(k => k.golongan === g);
@@ -293,7 +345,9 @@ function gambarKlasemen() {
         <div class="podium">
           ${juara.map(k => `
             <div class="juara j${esc(String(k.peringkat))}">
-              <div class="peringkat">${esc(String(k.peringkat))}</div>
+              <div class="medali" aria-hidden="true">${MEDALI[k.peringkat] || ""}</div>
+              <div class="peringkat">Juara ${esc(String(k.peringkat))}</div>
+              <div class="dada-juara">${esc(dada(k.nomor_dada))}</div>
               <div class="nama">${esc(k.nama_regu)}</div>
               <div class="sekolah">${esc(k.nama_sekolah)}</div>
               <div class="total">${esc(String(k.total))}</div>
@@ -303,19 +357,32 @@ function gambarKlasemen() {
           <table class="tabel">
             <thead>
               <tr><th>#</th><th>No<br>Dada</th><th>Regu</th>
+                  ${POS.map(p => `<th class="pos-kol" title="${esc(p.name)}"
+                    >P${esc(String(p.nomor))}</th>`).join("")}
                   <th>Nilai Pos</th><th>Penalti</th><th>Total</th></tr>
             </thead>
             <tbody>
-              ${baris.map(k => `
+              ${baris.map(k => {
+                const perPos = k.poin_per_pos || {};
+                return `
                 <tr class="${k.peringkat <= 3 ? "atas" : ""}">
-                  <td class="dada">${esc(String(k.peringkat))}</td>
+                  <td class="dada">${MEDALI[k.peringkat] || ""}${esc(String(k.peringkat))}</td>
                   <td class="dada">${esc(dada(k.nomor_dada))}</td>
                   <td class="regu">${esc(k.nama_regu)}<span class="sekolah">${esc(k.nama_sekolah)}</span></td>
+                  ${POS.map(p => {
+                    const v = perPos[String(p.nomor)];
+                    // Garis pendek, bukan nol. Pos yang belum menyetor nilai
+                    // dan pos yang benar-benar memberi nol adalah dua hal
+                    // berbeda, dan angka 0 menyamakan keduanya.
+                    return `<td class="pos-kol">${v === undefined || v === null
+                      ? "–" : esc(String(v))}</td>`;
+                  }).join("")}
                   <td>${esc(String(k.total_pos))}</td>
                   <td>${esc(String(
                        Number(k.penalti_waktu) + Number(k.penalti_checkout) + Number(k.penalti_anggota)))}</td>
                   <td class="total">${esc(String(k.total))}</td>
-                </tr>`).join("")}
+                </tr>`;
+              }).join("")}
             </tbody>
           </table>
         </div>
@@ -338,7 +405,8 @@ function gambar() {
 
   isi.innerHTML = !mulai()
     ? gambarPra()
-    : (fase() === "penuh" ? gambarKlasemen() : "") + gambarCari() + gambarHasil();
+    : (fase() === "penuh" ? gambarKlasemen() : "")
+      + gambarKelengkapan() + gambarCari() + gambarHasil();
 
   const kotak = document.getElementById("cari");
   if (kotak) {

--- a/live/live.json
+++ b/live/live.json
@@ -9,5 +9,6 @@
     "per_golongan": null
   },
   "pos": [],
+  "kelengkapan": [],
   "jumlah_regu": 0
 }

--- a/supabase/checks/live_json.sql
+++ b/supabase/checks/live_json.sql
@@ -36,6 +36,13 @@ select jsonb_pretty(jsonb_build_object(
                  order by nomor), '[]'::jsonb)
           from v_pos where jumlah_komponen > 0),
 
+  -- Kemajuan input per pos (0048). Ikut ke live.json — berkas kecil yang
+  -- memang di-poll — bukan ke rekap.json, karena inilah angka yang berubah
+  -- terus sepanjang hari dan justru itu yang datang dilihat peserta.
+  'kelengkapan', (select coalesce(jsonb_agg(to_jsonb(kl) order by kl.pos),
+                         '[]'::jsonb)
+                  from v_kelengkapan_publik kl),
+
   'progres', (select coalesce(jsonb_agg(to_jsonb(p) order by p.nomor_dada),
                      '[]'::jsonb)
               from v_progres_publik p),

--- a/supabase/migrations/0048_live_skor_peserta.sql
+++ b/supabase/migrations/0048_live_skor_peserta.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- hrcd-rekap : 0048_live_skor_peserta.sql
+--
+-- Dua tambahan untuk halaman rekap peserta:
+--   1. kemajuan input per pos, dalam persen — terlihat SELAMA lomba
+--   2. rincian poin per pos di klasemen — terlihat setelah hasil diumumkan
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA PERSENTASE INPUT DITERBITKAN KE PESERTA
+--
+-- Sepanjang hari peserta menanyakan satu hal ke panitia mana pun yang lewat:
+-- "nilai regu saya sudah masuk belum?" Halaman rekap sudah menjawabnya per
+-- regu lewat centang pos, tapi centang yang masih kosong punya DUA arti yang
+-- sangat berbeda — "regu kamu terlewat" atau "pos itu memang baru mulai
+-- diinput" — dan peserta tidak punya cara membedakannya.
+--
+-- Satu angka per pos menutup selisih itu. "Pos 3: 42%" mengubah centang kosong
+-- dari kabar buruk jadi kabar biasa, dan pertanyaan yang tadinya jadi antrean
+-- di meja panitia terjawab sebelum diajukan.
+--
+-- Angkanya juga bukan rahasia: ia menghitung BERAPA BANYAK yang sudah diinput,
+-- bukan berapa nilainya. Tidak ada satu pun angka nilai yang bocor lewat sini.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA `lengkap`, BUKAN `sebagian`, YANG JADI PENYEBUT PERSEN
+--
+-- Satu regu dihitung sudah masuk hanya kalau SELURUH komponen pos itu terisi.
+-- Pos 3 punya tujuh kolom; regu yang baru terisi dua kolomnya belum bisa
+-- dinilai, dan menghitungnya sebagai "sudah" membuat angka persennya
+-- menanjak cepat lalu berhenti lama di 90-an — bentuk grafik yang membuat
+-- orang mengira pekerjaannya hampir selesai padahal justru sedang tersendat.
+--
+-- `sebagian` tetap diterbitkan terpisah, karena transkripsi yang terpotong
+-- adalah hal yang memang perlu terlihat.
+--
+-- ---------------------------------------------------------------------------
+-- PAGARNYA TETAP `fase_live`, SAMA SEPERTI SEMUA VIEW PUBLIK
+--
+-- Di fase 'pra' view ini mengembalikan NOL BARIS, persis seperti
+-- v_progres_publik (0026) dan v_klasemen_publik (0005). Jadi persentase tidak
+-- pernah ikut tertulis ke berkas statis sebelum lomba mulai — bukan dikirim
+-- lalu disembunyikan CSS, yang bisa dibuka siapa pun lewat devtools.
+--
+-- Halaman peserta TIDAK membaca database sama sekali; publish-live.yml yang
+-- membacanya dengan service role lalu menulis live.json. Karena itu tidak ada
+-- grant ke `anon` di berkas ini — menambahkannya justru akan membuka jalur
+-- yang sengaja tidak pernah dibuka.
+-- ============================================================================
+
+create or replace view v_kelengkapan_publik as
+with regu_ikut as (
+  -- Sama seperti v_kelengkapan_pos (0028): sebelum daftar ulang tidak ada yang
+  -- bisa dinilai, jadi tidak ada yang bisa hilang.
+  select r.id
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor                                                    as pos,
+  p.name                                                     as nama_pos,
+  p.jumlah_komponen,
+  count(ri.id)::int                                          as regu_total,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) = p.jumlah_komponen)::int    as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0) < p.jumlah_komponen)::int    as sebagian,
+  -- Dibulatkan ke bawah, bukan ke terdekat: 99,6% yang tampil sebagai "100%"
+  -- padahal masih ada dua regu tertinggal adalah persis kekeliruan yang
+  -- membuat orang berhenti mencari.
+  case when count(ri.id) = 0 then 0 else
+    floor(100.0 * count(ri.id) filter (
+      where coalesce(t.jumlah, 0) = p.jumlah_komponen) / count(ri.id))::int
+  end                                                        as persen
+from v_pos p
+left join regu_ikut ri on true
+left join terisi t     on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and (select fase_live from status_acara) in ('progres', 'penuh')
+group by p.nomor, p.name, p.jumlah_komponen;
+
+comment on view v_kelengkapan_publik is
+  'Kemajuan input per pos untuk halaman peserta — hitungan saja, tidak satu '
+  'pun angka nilai. Nol baris selama fase_live masih `pra`.';
+
+-- ---------------------------------------------------------------------------
+-- Rincian poin per pos di klasemen.
+--
+-- Kolom baru DITARUH DI UJUNG. `create or replace view` mengizinkan menambah
+-- kolom di belakang, tapi menolak kalau urutan atau tipe kolom yang sudah ada
+-- ikut bergeser — dan v_klasemen_publik sudah dibaca live_json.sql apa adanya
+-- lewat to_jsonb().
+--
+-- Kenapa jsonb dan bukan satu kolom per pos: jumlah pos berubah tiap edisi
+-- (rancangan-b: aturan adalah data). Satu kolom per pos berarti view ini harus
+-- ditulis ulang setiap kali panitia menambah pos, dan halaman peserta ikut
+-- ditulis ulang bersamanya.
+-- ---------------------------------------------------------------------------
+create or replace view v_klasemen_publik as
+select
+  k.peringkat, k.nomor_dada, k.nama_regu, k.nama_sekolah, k.golongan,
+  k.total_pos, k.penalti_waktu, k.penalti_checkout, k.penalti_anggota, k.total,
+  (select jsonb_object_agg(pp.pos::text, pp.poin_pos)
+   from v_poin_pos pp where pp.regu_id = k.regu_id)          as poin_per_pos,
+  -- Selisih menit terhadap kontrak. Inilah tie-break yang sudah dipakai
+  -- ORDER BY v_klasemen — menerbitkannya membuat dua regu bernilai sama yang
+  -- berbeda peringkat bisa dijelaskan tanpa bertanya ke panitia.
+  k.selisih_menit
+from v_klasemen k
+where (select fase_live from status_acara) = 'penuh';
+
+comment on view v_klasemen_publik is
+  'Klasemen untuk halaman peserta, per golongan. Nol baris sampai fase_live '
+  'jadi `penuh`. `poin_per_pos` berisi {"<nomor pos>": poin}.';


### PR DESCRIPTION
## What

- `0048_live_skor_peserta.sql` — `v_kelengkapan_publik` (input progress per
  pos) and `poin_per_pos` + `selisih_menit` added to the end of
  `v_klasemen_publik`.
- `live_json.sql` + `publish-live.yml` — publish `kelengkapan` into
  `live.json`, the small polled file, with a leak guard matching the existing
  ones.
- `live/live.js` + `live.css` — progress bars per pos, 🥇🥈🥉 on the podium,
  and one column per pos in the detail table.

## Why

**Progress per pos.** Peserta ask one question all day: has my regu's score
been entered? The page already answers it per regu with a checkmark, but an
empty checkmark means two very different things — "your regu was missed" or
"that pos has barely started" — and from a participant's seat they look
identical. `Pos 3: 42%` separates them, and it leaks nothing: it counts how
many rows are in, never what they say.

`lengkap` is the numerator, not `sebagian`. Pos 3 has seven columns; a regu
with two of them filled cannot be scored, and counting it as done makes the
bar climb fast then sit in the nineties — the shape that makes people think
work is nearly finished exactly when it has stalled.

**Medals.** The podium showed a bare rank digit. The rank stays underneath the
medal because older phones render an empty box for the emoji.

**Per-pos points.** Built from `META.pos`, so adding a pos next edition does
not require editing the peserta page. Missing values print `–` rather than
`0` — a pos that has not reported and a pos that scored zero are not the same
thing.

## Notes

- No new `anon` grants. The peserta page reads static JSON published by
  service role; granting anon here would open a path that is deliberately
  closed.
- `fase_live` still gates everything. `v_kelengkapan_publik` returns zero rows
  in `pra`, and the workflow now fails loudly if progress rows appear before
  the phase moves.
- Percentages floor rather than round: 99.6% shown as 100% while two regu are
  still missing is exactly what makes people stop looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)