### PR TITLE
feat: let admin preview the live rekap before peserta see it

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -551,6 +551,17 @@ export const simpanNilaiPos = (baris, pos) =>
 export const hapusNilaiPos = (nomorDada, kode, pos) =>
   rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });
 
+/** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin (0049).
+ *
+ *  Bukan `v_klasemen_publik`: view itu dipagari `fase_live = 'penuh'` dan
+ *  pagar itu yang menahan hasil lomba supaya tidak bocor sebelum diumumkan.
+ *  Yang ini dipagari peran, dan hanya admin yang mendapat baris. */
+export async function klasemenPratinjau() {
+  if (K.mode === "dev") return baca("/klasemen-pratinjau");
+  return baca(null,
+    "v_klasemen_pratinjau?select=*&order=golongan.asc,peringkat.asc");
+}
+
 /* ============================ FOTO LEMBAR =============================== */
 
 /* Salinan slip penilaian di server (migrasi 0047). Kertas hilang; foto tidak.

--- a/live/style.css
+++ b/live/style.css
@@ -1916,3 +1916,65 @@ input.small-input { text-align: center; }
   display: flex; align-items: center; gap: .5rem;
   margin-left: auto; flex-wrap: nowrap;
 }
+
+/* ============================================================================
+   Pratinjau Rekap Live (0049) — kemajuan input dan podium bermedali.
+
+   Gayanya sengaja mengikuti live.css halaman peserta, bukan sisa layar
+   panitia: yang dinilai admin di layar ini justru "apakah tampilannya sudah
+   benar untuk peserta", dan pratinjau yang tampil berbeda dari aslinya tidak
+   menjawab pertanyaan itu.
+   ========================================================================== */
+.kemajuan { list-style: none; margin: 0; padding: 0; }
+.kemajuan li { margin-bottom: .85rem; }
+.kemajuan li:last-child { margin-bottom: 0; }
+.k-kepala { display: flex; align-items: baseline; gap: .5rem; margin-bottom: .3rem; }
+.k-nama {
+  font-weight: 600; flex: 1 1 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.k-persen {
+  font-weight: 800; font-variant-numeric: tabular-nums;
+  color: var(--utama); white-space: nowrap;
+}
+.k-batang {
+  height: 10px; border-radius: 999px; background: var(--kertas, #f4f4f2);
+  border: 1px solid var(--garis); overflow: hidden;
+}
+.k-batang span {
+  display: block; height: 100%; background: var(--utama);
+  border-radius: 999px; transition: width .4s ease;
+}
+.k-angka { font-size: .82rem; color: var(--tinta-lembut); margin-top: .25rem; }
+
+/* Podium. flex-wrap, bukan grid tiga kolom: di HP sempit tiga kartu juara
+   berdesakan sampai nama regu terpotong, dan nama juara adalah satu-satunya
+   hal di kartu itu yang benar-benar dicari orang. */
+.podium {
+  display: flex; flex-wrap: wrap; gap: .6rem; margin: .6rem 0 1rem;
+}
+.juara {
+  flex: 1 1 8.5rem; text-align: center; padding: .7rem .5rem;
+  border: 1px solid var(--garis); border-radius: 12px; min-width: 0;
+}
+.juara.j1 { border-color: #b8860b; border-width: 2px; }
+.medali { font-size: 2.2rem; line-height: 1; }
+.juara .peringkat {
+  font-size: .72rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--tinta-lembut); margin-top: .15rem;
+}
+.dada-juara {
+  font-variant-numeric: tabular-nums; font-weight: 700; color: var(--utama);
+  font-size: .9rem;
+}
+.juara .nama { font-weight: 700; margin-top: .2rem; overflow-wrap: anywhere; }
+.juara .sekolah { font-size: .78rem; color: var(--tinta-lembut); overflow-wrap: anywhere; }
+.juara .total {
+  font-size: 1.5rem; font-weight: 800; color: var(--utama); margin-top: .3rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.pos-kol {
+  text-align: center; font-variant-numeric: tabular-nums;
+  white-space: nowrap; padding-left: .3rem; padding-right: .3rem;
+}

--- a/supabase/migrations/0049_pratinjau_live_admin.sql
+++ b/supabase/migrations/0049_pratinjau_live_admin.sql
@@ -1,0 +1,61 @@
+-- ============================================================================
+-- hrcd-rekap : 0049_pratinjau_live_admin.sql
+--
+-- Klasemen live untuk ADMIN SAJA — persis yang akan dilihat peserta, tapi
+-- sebelum peserta melihatnya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA VIEW KEDUA, BUKAN MELONGGARKAN v_klasemen_publik
+--
+-- `v_klasemen_publik` dipagari `fase_live = 'penuh'`, dan pagar itu bukan
+-- kenyamanan — ia yang menahan hasil lomba supaya tidak bocor sebelum
+-- diumumkan (0005, 0026). Melonggarkannya "sedikit saja untuk admin" berarti
+-- syaratnya jadi `fase = 'penuh' or peran() = 'admin'`, dan sejak saat itu
+-- satu view mengerjakan dua tugas yang berlawanan: menyembunyikan dari publik
+-- dan menampilkan ke admin.
+--
+-- Yang lebih buruk: view itu dibaca `publish-live.yml` dengan service role
+-- untuk menulis berkas STATIS yang disajikan ke ribuan HP. Kalau suatu hari
+-- peran service role terbaca sebagai admin oleh `peran()`, seluruh klasemen
+-- tertulis ke berkas publik tanpa satu pun galat muncul.
+--
+-- Jadi dua view, dua tugas, dan yang publik tidak pernah disentuh:
+--
+--   v_klasemen_publik     fase_live = 'penuh'   -> berkas statis peserta
+--   v_klasemen_pratinjau  peran() = 'admin'     -> layar panitia, login
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA ADMIN SAJA, BUKAN ADMIN DAN MEJA
+--
+-- Meja boleh melihat seluruh nilai lewat layar Rekapitulasi — itu pekerjaan
+-- mereka. Yang dibatasi di sini bukan angkanya, melainkan PERINGKATNYA:
+-- klasemen yang sudah terurut adalah hasil lomba, dan hasil lomba yang
+-- beredar di grup panitia sebelum pengumuman sudah pernah merusak acara
+-- di mana pun hal itu terjadi. Satu orang yang memutuskan kapan angka itu
+-- keluar, dan orang itu admin.
+--
+-- ---------------------------------------------------------------------------
+-- KEMAJUAN INPUT TIDAK PERLU VIEW BARU
+--
+-- `v_kelengkapan_pos` (0028) sudah memberi lengkap / sebagian / regu_total per
+-- pos kepada panitia, dan persennya satu pembagian di layar. Menambah view
+-- ketiga yang menghitung hal yang sama adalah tempat kedua yang harus ikut
+-- benar setiap kali definisi "lengkap" berubah.
+-- ============================================================================
+
+create or replace view v_klasemen_pratinjau with (security_invoker = on) as
+select
+  k.peringkat, k.nomor_dada, k.nama_regu, k.nama_sekolah, k.golongan,
+  k.total_pos, k.penalti_waktu, k.penalti_checkout, k.penalti_anggota, k.total,
+  (select jsonb_object_agg(pp.pos::text, pp.poin_pos)
+   from v_poin_pos pp where pp.regu_id = k.regu_id)          as poin_per_pos,
+  k.selisih_menit
+from v_klasemen k
+where peran() = 'admin';
+
+comment on view v_klasemen_pratinjau is
+  'Klasemen yang akan dilihat peserta, dibuka lebih awal untuk ADMIN SAJA. '
+  'Bentuk kolomnya sengaja sama persis dengan v_klasemen_publik supaya layar '
+  'pratinjau dan halaman peserta tidak pernah berbeda diam-diam.';
+
+grant select on v_klasemen_pratinjau to authenticated;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -551,6 +551,17 @@ export const simpanNilaiPos = (baris, pos) =>
 export const hapusNilaiPos = (nomorDada, kode, pos) =>
   rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });
 
+/** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin (0049).
+ *
+ *  Bukan `v_klasemen_publik`: view itu dipagari `fase_live = 'penuh'` dan
+ *  pagar itu yang menahan hasil lomba supaya tidak bocor sebelum diumumkan.
+ *  Yang ini dipagari peran, dan hanya admin yang mendapat baris. */
+export async function klasemenPratinjau() {
+  if (K.mode === "dev") return baca("/klasemen-pratinjau");
+  return baca(null,
+    "v_klasemen_pratinjau?select=*&order=golongan.asc,peringkat.asc");
+}
+
 /* ============================ FOTO LEMBAR =============================== */
 
 /* Salinan slip penilaian di server (migrasi 0047). Kertas hilang; foto tidak.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -21,7 +21,7 @@ import {
   batasNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
-  unggahFotoLembar, daftarFotoLembar, tautanFoto,
+  unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenPratinjau,
   statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
@@ -252,6 +252,11 @@ async function layarHome() {
       <a href="#/pos">
         <div class="function-name">📋 Input Nilai Pos</div>
         <div class="description">Lembar penilaian tiap pos — admin boleh membuka pos mana pun</div>
+      </a>` : ""}
+      ${peran === "admin" ? `
+      <a href="#/pratinjau">
+        <div class="function-name">🥇 Pratinjau Rekap Live</div>
+        <div class="description">Persis yang akan dilihat peserta — kemajuan input dan klasemen bermedali, sebelum diumumkan</div>
       </a>` : ""}
       <a href="#/rekap">
         <div class="function-name">📊 Rekapitulasi</div>
@@ -3973,6 +3978,145 @@ async function layarRekap() {
   mulaiDenyut();
 }
 
+/* ==================== PRATINJAU REKAP LIVE (ADMIN) ======================= */
+
+/** Persis yang akan dilihat peserta, dibuka lebih awal untuk admin saja.
+ *
+ *  KENAPA LAYAR TERSENDIRI, BUKAN MENYALAKAN HALAMAN PESERTA LEBIH AWAL.
+ *  Halaman peserta membaca berkas statis yang diterbitkan publish-live.yml,
+ *  dan menyalakannya lebih awal berarti menerbitkan hasil lomba ke alamat
+ *  yang sudah beredar ke ratusan orang. Tidak ada tombol "hanya untuk saya"
+ *  di berkas statis — begitu terbit, ia terbit untuk semua.
+ *
+ *  Jadi pratinjaunya tinggal di situs panitia, di balik login yang sudah ada,
+ *  membaca database langsung. Yang dilihat admin sama persis, yang dilihat
+ *  peserta belum berubah sama sekali. */
+async function layarPratinjauLive() {
+  pasangKepala("Pratinjau Rekap Live", true);
+  LAYAR.replaceChildren(h(pemuat()));
+  const layarIni = location.hash;
+
+  let pos, klasemen, status;
+  try {
+    [pos, klasemen, status] = await Promise.all([
+      kelengkapanPos(), klasemenPratinjau(), statusAcara(),
+    ]);
+  } catch (e) {
+    LAYAR.replaceChildren(kartuGagalMuat(e.message, layarPratinjauLive));
+    return;
+  }
+  if (location.hash !== layarIni) return;
+
+  const fase = (status && status.fase_live) || "pra";
+  const FASE_KATA = {
+    pra: "peserta belum melihat apa pun",
+    progres: "peserta melihat kemajuan input, belum melihat nilai",
+    penuh: "peserta sudah melihat klasemen ini",
+  };
+
+  // Persen dihitung di sini, bukan di view. `v_kelengkapan_pos` sudah membawa
+  // `lengkap` dan `regu_total`, dan menambah view yang menghitung pembagian
+  // itu adalah tempat kedua yang harus ikut benar setiap kali definisi
+  // "lengkap" berubah.
+  const persenPos = (p) => !p.regu_total
+    ? 0 : Math.floor(100 * p.lengkap / p.regu_total);
+
+  const kemajuan = `
+    <div class="card">
+      <h2>Kemajuan input</h2>
+      <ul class="kemajuan">
+        ${pos.map(p => {
+          const s = persenPos(p);
+          return `
+          <li>
+            <div class="k-kepala">
+              <span class="k-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</span>
+              <span class="k-persen">${esc(String(s))}%</span>
+            </div>
+            <div class="k-batang"><span style="width:${s}%"></span></div>
+            <div class="k-angka">${esc(String(p.lengkap))} dari
+              ${esc(String(p.regu_total))} regu${p.sebagian > 0
+                ? ` · ${esc(String(p.sebagian))} baru sebagian` : ""}${p.hilang > 0
+                ? ` · <strong>${esc(String(p.hilang))} sudah finish tapi belum lengkap</strong>` : ""}</div>
+          </li>`;
+        }).join("")}
+      </ul>
+    </div>`;
+
+  const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
+  const golongan = [...new Set(klasemen.map(k => k.golongan))];
+
+  const papan = !klasemen.length
+    ? `<div class="card"><p class="description">Belum ada regu yang bisa
+         diperingkat. Klasemen baru terisi setelah ada regu yang kloternya
+         sudah berangkat dan nilainya masuk.</p></div>`
+    : golongan.map(g => {
+        const baris = klasemen.filter(k => k.golongan === g);
+        const juara = baris.filter(k => k.peringkat <= 3);
+        return `
+        <div class="card">
+          <h2>${esc(GOLONGAN_LABEL[g] || g)}</h2>
+          <div class="podium">
+            ${juara.map(k => `
+              <div class="juara j${esc(String(k.peringkat))}">
+                <div class="medali" aria-hidden="true">${MEDALI[k.peringkat] || ""}</div>
+                <div class="peringkat">Juara ${esc(String(k.peringkat))}</div>
+                <div class="dada-juara">${esc(String(k.nomor_dada).padStart(3, "0"))}</div>
+                <div class="nama">${esc(k.nama_regu)}</div>
+                <div class="sekolah">${esc(k.nama_sekolah)}</div>
+                <div class="total">${esc(angkaRapi(k.total))}</div>
+              </div>`).join("")}
+          </div>
+          <div class="table-wrap">
+            <table class="table data-table">
+              <thead>
+                <tr><th>#</th><th>No<br>Dada</th><th>Regu</th>
+                  ${pos.map(p => `<th class="pos-kol" title="${esc(p.nama_pos)}"
+                    >P${esc(String(p.pos))}</th>`).join("")}
+                  <th>Nilai Pos</th><th>Penalti</th><th>Total</th></tr>
+              </thead>
+              <tbody>
+                ${baris.map(k => {
+                  const perPos = k.poin_per_pos || {};
+                  return `
+                  <tr>
+                    <td class="angka">${MEDALI[k.peringkat] || ""}${esc(String(k.peringkat))}</td>
+                    <td class="angka">${esc(String(k.nomor_dada).padStart(3, "0"))}</td>
+                    <td>${esc(k.nama_regu)}<span class="sub">${esc(k.nama_sekolah)}</span></td>
+                    ${pos.map(p => {
+                      const v = perPos[String(p.pos)];
+                      // Garis pendek, bukan nol: pos yang belum menyetor dan
+                      // pos yang memang memberi nol bukan hal yang sama.
+                      return `<td class="pos-kol">${v === undefined || v === null
+                        ? "–" : esc(angkaRapi(v))}</td>`;
+                    }).join("")}
+                    <td class="text-center">${esc(angkaRapi(k.total_pos))}</td>
+                    <td class="text-center">${esc(angkaRapi(
+                      Number(k.penalti_waktu) + Number(k.penalti_checkout)
+                      + Number(k.penalti_anggota)))}</td>
+                    <td class="text-center"><strong>${esc(angkaRapi(k.total))}</strong></td>
+                  </tr>`;
+                }).join("")}
+              </tbody>
+            </table>
+          </div>
+        </div>`;
+      }).join("");
+
+  LAYAR.replaceChildren(h(`
+    <div class="card" style="border-color:var(--utama)">
+      <h2>Pratinjau — hanya admin</h2>
+      <p class="description">Ini yang <strong>akan</strong> dilihat peserta.
+        Halaman peserta sendiri belum berubah: fase sekarang
+        <strong>${esc(fase)}</strong> — ${esc(FASE_KATA[fase] || "")}.</p>
+      <p class="description">Peringkat di sini hidup mengikuti input dan masih
+        bisa berubah sampai seluruh pos selesai. Jangan dibagikan sebelum
+        diumumkan.</p>
+    </div>
+    ${kemajuan}
+    ${papan}`));
+}
+
 /* ============================ RUTE ======================================= */
 
 const RUTE = {
@@ -3984,6 +4128,7 @@ const RUTE = {
   "#/finish": layarFinish,
   "#/pos": layarInputPos,
   "#/rekap": layarRekap,
+  "#/pratinjau": layarPratinjauLive,
   "#/ganti-password": layarGantiPassword,
 };
 

--- a/web/style.css
+++ b/web/style.css
@@ -1916,3 +1916,65 @@ input.small-input { text-align: center; }
   display: flex; align-items: center; gap: .5rem;
   margin-left: auto; flex-wrap: nowrap;
 }
+
+/* ============================================================================
+   Pratinjau Rekap Live (0049) — kemajuan input dan podium bermedali.
+
+   Gayanya sengaja mengikuti live.css halaman peserta, bukan sisa layar
+   panitia: yang dinilai admin di layar ini justru "apakah tampilannya sudah
+   benar untuk peserta", dan pratinjau yang tampil berbeda dari aslinya tidak
+   menjawab pertanyaan itu.
+   ========================================================================== */
+.kemajuan { list-style: none; margin: 0; padding: 0; }
+.kemajuan li { margin-bottom: .85rem; }
+.kemajuan li:last-child { margin-bottom: 0; }
+.k-kepala { display: flex; align-items: baseline; gap: .5rem; margin-bottom: .3rem; }
+.k-nama {
+  font-weight: 600; flex: 1 1 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.k-persen {
+  font-weight: 800; font-variant-numeric: tabular-nums;
+  color: var(--utama); white-space: nowrap;
+}
+.k-batang {
+  height: 10px; border-radius: 999px; background: var(--kertas, #f4f4f2);
+  border: 1px solid var(--garis); overflow: hidden;
+}
+.k-batang span {
+  display: block; height: 100%; background: var(--utama);
+  border-radius: 999px; transition: width .4s ease;
+}
+.k-angka { font-size: .82rem; color: var(--tinta-lembut); margin-top: .25rem; }
+
+/* Podium. flex-wrap, bukan grid tiga kolom: di HP sempit tiga kartu juara
+   berdesakan sampai nama regu terpotong, dan nama juara adalah satu-satunya
+   hal di kartu itu yang benar-benar dicari orang. */
+.podium {
+  display: flex; flex-wrap: wrap; gap: .6rem; margin: .6rem 0 1rem;
+}
+.juara {
+  flex: 1 1 8.5rem; text-align: center; padding: .7rem .5rem;
+  border: 1px solid var(--garis); border-radius: 12px; min-width: 0;
+}
+.juara.j1 { border-color: #b8860b; border-width: 2px; }
+.medali { font-size: 2.2rem; line-height: 1; }
+.juara .peringkat {
+  font-size: .72rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--tinta-lembut); margin-top: .15rem;
+}
+.dada-juara {
+  font-variant-numeric: tabular-nums; font-weight: 700; color: var(--utama);
+  font-size: .9rem;
+}
+.juara .nama { font-weight: 700; margin-top: .2rem; overflow-wrap: anywhere; }
+.juara .sekolah { font-size: .78rem; color: var(--tinta-lembut); overflow-wrap: anywhere; }
+.juara .total {
+  font-size: 1.5rem; font-weight: 800; color: var(--utama); margin-top: .3rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.pos-kol {
+  text-align: center; font-variant-numeric: tabular-nums;
+  white-space: nowrap; padding-left: .3rem; padding-right: .3rem;
+}


### PR DESCRIPTION
## What

A new admin-only screen on the panitia site, `#/pratinjau`, showing exactly
what the peserta page will show: input progress bars per pos, 🥇🥈🥉 podium
per golongan, and the detail table with one column per pos.

- `0049_pratinjau_live_admin.sql` — `v_klasemen_pratinjau`, same columns as
  `v_klasemen_publik` but fenced on `peran() = 'admin'` instead of
  `fase_live`.
- `klasemenPratinjau()` in `api.js`, the screen in `app.js`, styles in
  `style.css` (copied to `live/`).

## Why

Admin has to check the medals, the bars and the ranking before anyone else,
and the peserta page cannot serve that. It reads a static file published to an
address already circulated to hundreds of people — there is no "only for me"
switch on a static file.

**A second view, not a loosened one.** `v_klasemen_publik` is fenced on
`fase_live` and that fence is what holds results back until they are
announced. Widening it to `fase = 'penuh' or peran() = 'admin'` makes one view
do two opposing jobs — and that view is read by `publish-live.yml` with the
service role to write the file 3.000 phones fetch. If `peran()` ever reads as
admin for the service role, the whole klasemen lands in a public file with no
error raised.

**Admin only, not admin and meja.** What is restricted is not the numbers —
meja already read every score on Rekapitulasi — but the *ordering*. A sorted
klasemen is the result of the event.

**No third view for progress.** `v_kelengkapan_pos` already gives
`lengkap` / `sebagian` / `regu_total` to panitia; the percentage is one
division on screen. A view computing the same thing is a second place that has
to stay correct whenever "lengkap" changes meaning.

## Notes

- The screen states the current `fase_live` and what peserta can see right
  now, so preview is never mistaken for published.
- Reachable only from the admin menu; a non-admin who types the hash gets an
  empty klasemen because the view returns no rows. The fence is in the
  database, not the menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)