### PR TITLE
refactor: rename pratinjau to Live Score, and always draw all four golongan

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -551,15 +551,16 @@ export const simpanNilaiPos = (baris, pos) =>
 export const hapusNilaiPos = (nomorDada, kode, pos) =>
   rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });
 
-/** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin (0049).
+/** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin
+ *  (0049, dinamai ulang 0050).
  *
  *  Bukan `v_klasemen_publik`: view itu dipagari `fase_live = 'penuh'` dan
  *  pagar itu yang menahan hasil lomba supaya tidak bocor sebelum diumumkan.
  *  Yang ini dipagari peran, dan hanya admin yang mendapat baris. */
-export async function klasemenPratinjau() {
-  if (K.mode === "dev") return baca("/klasemen-pratinjau");
+export async function klasemenLiveScore() {
+  if (K.mode === "dev") return baca("/klasemen-live-score");
   return baca(null,
-    "v_klasemen_pratinjau?select=*&order=golongan.asc,peringkat.asc");
+    "v_klasemen_live_score?select=*&order=golongan.asc,peringkat.asc");
 }
 
 /* ============================ FOTO LEMBAR =============================== */

--- a/supabase/migrations/0050_rename_live_score.sql
+++ b/supabase/migrations/0050_rename_live_score.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- hrcd-rekap : 0050_rename_live_score.sql
+--
+-- `v_klasemen_pratinjau` (0049) jadi `v_klasemen_live_score`.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DIGANTI
+--
+-- Layarnya disebut "Live Score" oleh panitia, dan itu memang kata yang mereka
+-- pakai — CLAUDE.md pasal 5 ayat 7: pakai kata yang orang benar-benar
+-- ucapkan, termasuk kalau itu serapan Inggris. "Pratinjau" bukan salah, cuma
+-- tidak pernah terucap.
+--
+-- Nama di database ikut berganti, bukan cuma nama di layar. Satu hal dengan
+-- dua nama — "Live Score" di menu, `pratinjau` di kode — memaksa setiap
+-- percakapan berikutnya membayar ongkos penerjemahan, dan pemelihara
+-- berikutnya adalah siswa SMA yang tidak ikut percakapan ini.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA `alter view ... rename`, BUKAN drop + create
+--
+-- Rename memindahkan view yang sama beserta hak aksesnya; drop + create
+-- MENGHAPUS grant-nya, dan `grant select ... to authenticated` yang lupa
+-- ditulis ulang menghasilkan layar yang kosong tanpa galat apa pun — persis
+-- kegagalan yang paling sulit dilihat.
+--
+-- Dibungkus supaya menjalankannya dua kali tidak apa-apa: kalau nama barunya
+-- sudah ada, tidak ada yang perlu dikerjakan.
+-- ============================================================================
+
+do $$
+begin
+  if exists (select 1 from pg_views
+             where schemaname = 'public' and viewname = 'v_klasemen_live_score') then
+    raise notice '0050: v_klasemen_live_score sudah ada — dilewati.';
+  elsif exists (select 1 from pg_views
+                where schemaname = 'public' and viewname = 'v_klasemen_pratinjau') then
+    alter view v_klasemen_pratinjau rename to v_klasemen_live_score;
+    raise notice '0050: v_klasemen_pratinjau -> v_klasemen_live_score.';
+  else
+    raise exception '0050: v_klasemen_pratinjau tidak ada. Jalankan 0049 dulu.';
+  end if;
+end;
+$$;
+
+comment on view v_klasemen_live_score is
+  'Klasemen yang akan dilihat peserta, dibuka lebih awal untuk ADMIN SAJA. '
+  'Bentuk kolomnya sengaja sama persis dengan v_klasemen_publik supaya layar '
+  'Live Score dan halaman peserta tidak pernah berbeda diam-diam.';

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -551,15 +551,16 @@ export const simpanNilaiPos = (baris, pos) =>
 export const hapusNilaiPos = (nomorDada, kode, pos) =>
   rpc("hapus_nilai_pos", { p_nomor_dada: nomorDada, p_kode: kode, p_pos: pos });
 
-/** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin (0049).
+/** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin
+ *  (0049, dinamai ulang 0050).
  *
  *  Bukan `v_klasemen_publik`: view itu dipagari `fase_live = 'penuh'` dan
  *  pagar itu yang menahan hasil lomba supaya tidak bocor sebelum diumumkan.
  *  Yang ini dipagari peran, dan hanya admin yang mendapat baris. */
-export async function klasemenPratinjau() {
-  if (K.mode === "dev") return baca("/klasemen-pratinjau");
+export async function klasemenLiveScore() {
+  if (K.mode === "dev") return baca("/klasemen-live-score");
   return baca(null,
-    "v_klasemen_pratinjau?select=*&order=golongan.asc,peringkat.asc");
+    "v_klasemen_live_score?select=*&order=golongan.asc,peringkat.asc");
 }
 
 /* ============================ FOTO LEMBAR =============================== */

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -21,7 +21,7 @@ import {
   batasNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
-  unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenPratinjau,
+  unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenLiveScore,
   statusAcara,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
@@ -254,8 +254,8 @@ async function layarHome() {
         <div class="description">Lembar penilaian tiap pos — admin boleh membuka pos mana pun</div>
       </a>` : ""}
       ${peran === "admin" ? `
-      <a href="#/pratinjau">
-        <div class="function-name">🥇 Pratinjau Rekap Live</div>
+      <a href="#/live-score">
+        <div class="function-name">🥇 Live Score</div>
         <div class="description">Persis yang akan dilihat peserta — kemajuan input dan klasemen bermedali, sebelum diumumkan</div>
       </a>` : ""}
       <a href="#/rekap">
@@ -3978,7 +3978,7 @@ async function layarRekap() {
   mulaiDenyut();
 }
 
-/* ==================== PRATINJAU REKAP LIVE (ADMIN) ======================= */
+/* ======================= LIVE SCORE (ADMIN) ============================== */
 
 /** Persis yang akan dilihat peserta, dibuka lebih awal untuk admin saja.
  *
@@ -3988,21 +3988,21 @@ async function layarRekap() {
  *  yang sudah beredar ke ratusan orang. Tidak ada tombol "hanya untuk saya"
  *  di berkas statis — begitu terbit, ia terbit untuk semua.
  *
- *  Jadi pratinjaunya tinggal di situs panitia, di balik login yang sudah ada,
+ *  Jadi Live Score tinggal di situs panitia, di balik login yang sudah ada,
  *  membaca database langsung. Yang dilihat admin sama persis, yang dilihat
  *  peserta belum berubah sama sekali. */
-async function layarPratinjauLive() {
-  pasangKepala("Pratinjau Rekap Live", true);
+async function layarLiveScore() {
+  pasangKepala("Live Score", true);
   LAYAR.replaceChildren(h(pemuat()));
   const layarIni = location.hash;
 
   let pos, klasemen, status;
   try {
     [pos, klasemen, status] = await Promise.all([
-      kelengkapanPos(), klasemenPratinjau(), statusAcara(),
+      kelengkapanPos(), klasemenLiveScore(), statusAcara(),
     ]);
   } catch (e) {
-    LAYAR.replaceChildren(kartuGagalMuat(e.message, layarPratinjauLive));
+    LAYAR.replaceChildren(kartuGagalMuat(e.message, layarLiveScore));
     return;
   }
   if (location.hash !== layarIni) return;
@@ -4044,18 +4044,31 @@ async function layarPratinjauLive() {
     </div>`;
 
   const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
-  const golongan = [...new Set(klasemen.map(k => k.golongan))];
-
+  /* KEEMPAT golongan selalu digambar, dengan urutan tetap — bukan hanya yang
+     kebetulan sudah punya baris.
+     Empat golongan berlomba TERPISAH: masing-masing punya juara sendiri, dan
+     tidak ada satu pun peringkat yang membandingkan Penggalang dengan
+     Penegak. Menggambar hanya golongan yang sudah terisi membuat papannya
+     berubah bentuk sepanjang hari — Penegak PI muncul belakangan lalu
+     menggeser semuanya — dan yang lebih buruk, golongan yang belum satu pun
+     regunya masuk terlihat seperti golongan yang tidak ada. */
   const papan = !klasemen.length
     ? `<div class="card"><p class="description">Belum ada regu yang bisa
-         diperingkat. Klasemen baru terisi setelah ada regu yang kloternya
-         sudah berangkat dan nilainya masuk.</p></div>`
-    : golongan.map(g => {
+         diperingkat di golongan mana pun. Klasemen baru terisi setelah ada
+         regu yang kloternya sudah berangkat dan nilainya masuk.</p></div>`
+    : Object.keys(GOLONGAN_LABEL).map(g => {
         const baris = klasemen.filter(k => k.golongan === g);
         const juara = baris.filter(k => k.peringkat <= 3);
+        if (!baris.length) return `
+        <div class="card">
+          <h2>${esc(GOLONGAN_LABEL[g])}</h2>
+          <p class="description">Belum ada regu golongan ini yang bisa
+            diperingkat.</p>
+        </div>`;
         return `
         <div class="card">
-          <h2>${esc(GOLONGAN_LABEL[g] || g)}</h2>
+          <h2>${esc(GOLONGAN_LABEL[g])}
+            <span class="sub">${esc(String(baris.length))} regu diperingkat</span></h2>
           <div class="podium">
             ${juara.map(k => `
               <div class="juara j${esc(String(k.peringkat))}">
@@ -4105,7 +4118,7 @@ async function layarPratinjauLive() {
 
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
-      <h2>Pratinjau — hanya admin</h2>
+      <h2>Live Score — hanya admin</h2>
       <p class="description">Ini yang <strong>akan</strong> dilihat peserta.
         Halaman peserta sendiri belum berubah: fase sekarang
         <strong>${esc(fase)}</strong> — ${esc(FASE_KATA[fase] || "")}.</p>
@@ -4128,7 +4141,7 @@ const RUTE = {
   "#/finish": layarFinish,
   "#/pos": layarInputPos,
   "#/rekap": layarRekap,
-  "#/pratinjau": layarPratinjauLive,
+  "#/live-score": layarLiveScore,
   "#/ganti-password": layarGantiPassword,
 };
 


### PR DESCRIPTION
## What

- `#/pratinjau` → `#/live-score`; menu reads **🥇 Live Score**; header and
  banner follow.
- `v_klasemen_pratinjau` → `v_klasemen_live_score` (`0050`), and
  `klasemenPratinjau()` → `klasemenLiveScore()`.
- All four golongan are always rendered, in the order of `GOLONGAN_LABEL`,
  each with its own podium, its own table, and a count in the heading. An
  empty golongan gets one line instead of an empty table.

## Why

**The name.** Panitia call it Live Score. CLAUDE.md 5.7 says use the word
people actually say, loanword or not. The view is renamed as well as the
label — one thing under two names makes every later conversation pay a
translation tax, and section 6 says the next maintainer is a student who did
not attend this one.

**All four.** The golongan compete separately; each has its own winners and no
rank compares Penggalang with Penegak. Drawing only the golongan that happen
to have rows means the board changes shape through the day as one appears and
pushes the others down — and a golongan nobody has entered yet reads as a
golongan that does not exist.

## Notes

- `alter view ... rename`, not drop + create. Rename carries the grants;
  a recreate that forgets `grant select to authenticated` produces a blank
  screen with no error, which is the hardest failure to see.
- `0050` is guarded both ways: it skips if the new name already exists, and
  raises if neither name does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)