### PR TITLE
feat: show input progress as red/yellow/green rings instead of bars

### DIFF
--- a/live/live.css
+++ b/live/live.css
@@ -18,6 +18,7 @@
   --hijau:        #2e7d32;
   --hijau-muda:   #e8f5e9;
   --kuning:       #b26a00;
+  --bahaya:       #c62828;
   --kuning-muda:  #fff3e0;
   --emas:         #b8860b;
   --radius:       14px;
@@ -158,31 +159,46 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
    lihat, sedangkan lima angka persen harus dibaca satu per satu lalu
    dibandingkan di kepala.
    ========================================================================== */
-.kemajuan { list-style: none; }
-.kemajuan li { margin-bottom: .85rem; }
-.kemajuan li:last-child { margin-bottom: 0; }
-.k-kepala {
-  display: flex; align-items: baseline; gap: .5rem; margin-bottom: .3rem;
+.kemajuan {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-wrap: wrap; gap: 1rem .6rem;
 }
-.k-nama {
-  font-weight: 600; flex: 1 1 auto; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+.kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
+
+/* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
+   properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti
+   satu angka (ukuran ::before). Merah/kuning/hijau ditentukan JavaScript dan
+   masuk lewat --warna, supaya ambangnya tertulis SEKALI di satu tempat. */
+.cincin {
+  width: 84px; height: 84px; margin: 0 auto .4rem;
+  border-radius: 50%;
+  background: conic-gradient(var(--warna) calc(var(--persen) * 3.6deg),
+                             var(--garis) 0);
+  display: grid; place-items: center;
 }
-.k-persen {
-  font-weight: 800; font-variant-numeric: tabular-nums;
-  color: var(--utama); white-space: nowrap;
+.cincin::before {
+  content: ""; grid-area: 1 / 1;
+  width: 64px; height: 64px; border-radius: 50%; background: var(--kartu);
 }
-/* Tinggi 10px, bukan 4px: dibaca sambil berdiri di bawah matahari, dan garis
-   tipis yang elegan di monitor hilang sama sekali di layar HP yang silau. */
-.k-batang {
-  height: 10px; border-radius: 999px; background: var(--kertas);
-  border: 1px solid var(--garis); overflow: hidden;
+/* Angkanya di TENGAH cincin, selalu. Warna sendirian tidak boleh jadi
+   satu-satunya kabar: sekitar satu dari dua belas laki-laki sulit
+   membedakan merah dari hijau, dan bagi mereka lima cincin tanpa angka
+   adalah lima lingkaran yang sama. */
+.cincin > span {
+  grid-area: 1 / 1;
+  font-weight: 800; font-size: 1.2rem; line-height: 1;
+  font-variant-numeric: tabular-nums; color: var(--warna);
 }
-.k-batang span {
-  display: block; height: 100%; background: var(--utama);
-  border-radius: 999px; transition: width .4s ease;
+.cincin i { font-style: normal; font-size: .62em; }
+.c-nama {
+  font-weight: 600; font-size: .84rem; line-height: 1.25;
+  overflow-wrap: anywhere;
 }
-.k-angka { font-size: .82rem; color: var(--tinta-lembut); margin-top: .25rem; }
+.c-angka {
+  font-size: .78rem; color: var(--tinta-lembut); line-height: 1.35;
+  margin-top: .15rem;
+}
+.c-alarm { color: var(--bahaya); }
 
 /* ---------------------------------------------------------------------------
    Medali. Ia MENGGANTIKAN angka besar di podium, tapi angka peringkatnya

--- a/live/live.js
+++ b/live/live.js
@@ -291,6 +291,14 @@ function gambarHasil() {
    Satu angka per pos memisahkan keduanya, dan pertanyaan yang tadinya jadi
    antrean di meja panitia terjawab sebelum diajukan.
    ------------------------------------------------------------------------- */
+/* Merah / kuning / hijau, dan hijau sengaja mahal — 90, bukan 80. Pos dengan
+   300 regu yang berhenti di 85% masih kehilangan 45 regu, dan warna hijau di
+   angka itu mengabarkan "selesai" kepada peserta yang regunya justru termasuk
+   45 itu. Angkanya selalu tertulis di dalam cincin, jadi yang tidak bisa
+   membedakan merah dari hijau membaca keadaan yang sama persis. */
+const warnaPersen = (s) => s >= 90 ? "var(--hijau)"
+                         : s >= 50 ? "var(--kuning)" : "var(--bahaya)";
+
 function gambarKelengkapan() {
   const daftar = (META && META.kelengkapan) || [];
   if (!daftar.length) return "";
@@ -305,17 +313,15 @@ function gambarKelengkapan() {
           const persen = Number(p.persen) || 0;
           return `
           <li>
-            <div class="k-kepala">
-              <span class="k-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</span>
-              <span class="k-persen">${esc(String(persen))}%</span>
-            </div>
-            <div class="k-batang" role="img"
+            <div class="cincin" style="--persen:${persen};--warna:${warnaPersen(persen)}"
+                 role="img"
                  aria-label="Pos ${esc(String(p.pos))} ${esc(String(persen))} persen selesai">
-              <span style="width:${persen}%"></span>
+              <span>${esc(String(persen))}<i>%</i></span>
             </div>
-            <div class="k-angka">${esc(String(p.lengkap))} dari
-              ${esc(String(p.regu_total))} regu${Number(p.sebagian) > 0
-                ? ` · ${esc(String(p.sebagian))} baru sebagian` : ""}</div>
+            <div class="c-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</div>
+            <div class="c-angka">${esc(String(p.lengkap))} / ${esc(String(p.regu_total))} regu${
+              Number(p.sebagian) > 0
+                ? `<br>${esc(String(p.sebagian))} baru sebagian` : ""}</div>
           </li>`;
         }).join("")}
       </ul>

--- a/live/style.css
+++ b/live/style.css
@@ -1925,27 +1925,46 @@ input.small-input { text-align: center; }
    benar untuk peserta", dan pratinjau yang tampil berbeda dari aslinya tidak
    menjawab pertanyaan itu.
    ========================================================================== */
-.kemajuan { list-style: none; margin: 0; padding: 0; }
-.kemajuan li { margin-bottom: .85rem; }
-.kemajuan li:last-child { margin-bottom: 0; }
-.k-kepala { display: flex; align-items: baseline; gap: .5rem; margin-bottom: .3rem; }
-.k-nama {
-  font-weight: 600; flex: 1 1 auto; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+.kemajuan {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-wrap: wrap; gap: 1rem .6rem;
 }
-.k-persen {
-  font-weight: 800; font-variant-numeric: tabular-nums;
-  color: var(--utama); white-space: nowrap;
+.kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
+
+/* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
+   properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti
+   satu angka (ukuran ::before). Merah/kuning/hijau ditentukan JavaScript dan
+   masuk lewat --warna, supaya ambangnya tertulis SEKALI di satu tempat. */
+.cincin {
+  width: 84px; height: 84px; margin: 0 auto .4rem;
+  border-radius: 50%;
+  background: conic-gradient(var(--warna) calc(var(--persen) * 3.6deg),
+                             var(--garis) 0);
+  display: grid; place-items: center;
 }
-.k-batang {
-  height: 10px; border-radius: 999px; background: var(--kertas, #f4f4f2);
-  border: 1px solid var(--garis); overflow: hidden;
+.cincin::before {
+  content: ""; grid-area: 1 / 1;
+  width: 64px; height: 64px; border-radius: 50%; background: var(--kartu);
 }
-.k-batang span {
-  display: block; height: 100%; background: var(--utama);
-  border-radius: 999px; transition: width .4s ease;
+/* Angkanya di TENGAH cincin, selalu. Warna sendirian tidak boleh jadi
+   satu-satunya kabar: sekitar satu dari dua belas laki-laki sulit
+   membedakan merah dari hijau, dan bagi mereka lima cincin tanpa angka
+   adalah lima lingkaran yang sama. */
+.cincin > span {
+  grid-area: 1 / 1;
+  font-weight: 800; font-size: 1.2rem; line-height: 1;
+  font-variant-numeric: tabular-nums; color: var(--warna);
 }
-.k-angka { font-size: .82rem; color: var(--tinta-lembut); margin-top: .25rem; }
+.cincin i { font-style: normal; font-size: .62em; }
+.c-nama {
+  font-weight: 600; font-size: .84rem; line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+.c-angka {
+  font-size: .78rem; color: var(--tinta-lembut); line-height: 1.35;
+  margin-top: .15rem;
+}
+.c-alarm { color: var(--bahaya); }
 
 /* Podium. flex-wrap, bukan grid tiga kolom: di HP sempit tiga kartu juara
    berdesakan sampai nama regu terpotong, dan nama juara adalah satu-satunya

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4021,6 +4021,15 @@ async function layarLiveScore() {
   const persenPos = (p) => !p.regu_total
     ? 0 : Math.floor(100 * p.lengkap / p.regu_total);
 
+  /* Merah / kuning / hijau, dan hijau sengaja mahal.
+     90, bukan 80: pos dengan 300 regu yang berhenti di 85% masih kehilangan
+     45 regu — jumlah yang butuh berjam-jam untuk dikejar, dan warna hijau di
+     angka itu memberi tahu panitia bahwa pekerjaannya selesai padahal belum.
+     Angkanya selalu tertulis di dalam cincin, jadi yang tidak bisa
+     membedakan merah dari hijau tetap membaca keadaan yang sama. */
+  const warnaPersen = (s) => s >= 90 ? "var(--hijau)"
+                           : s >= 50 ? "var(--kuning)" : "var(--bahaya)";
+
   const kemajuan = `
     <div class="card">
       <h2>Kemajuan input</h2>
@@ -4029,15 +4038,14 @@ async function layarLiveScore() {
           const s = persenPos(p);
           return `
           <li>
-            <div class="k-kepala">
-              <span class="k-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</span>
-              <span class="k-persen">${esc(String(s))}%</span>
+            <div class="cincin" style="--persen:${s};--warna:${warnaPersen(s)}"
+                 role="img" aria-label="Pos ${esc(String(p.pos))} ${esc(String(s))} persen selesai">
+              <span>${esc(String(s))}<i>%</i></span>
             </div>
-            <div class="k-batang"><span style="width:${s}%"></span></div>
-            <div class="k-angka">${esc(String(p.lengkap))} dari
-              ${esc(String(p.regu_total))} regu${p.sebagian > 0
-                ? ` · ${esc(String(p.sebagian))} baru sebagian` : ""}${p.hilang > 0
-                ? ` · <strong>${esc(String(p.hilang))} sudah finish tapi belum lengkap</strong>` : ""}</div>
+            <div class="c-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</div>
+            <div class="c-angka">${esc(String(p.lengkap))} / ${esc(String(p.regu_total))} regu${
+              p.sebagian > 0 ? `<br>${esc(String(p.sebagian))} baru sebagian` : ""}${
+              p.hilang > 0 ? `<br><strong class="c-alarm">${esc(String(p.hilang))} finish tapi belum lengkap</strong>` : ""}</div>
           </li>`;
         }).join("")}
       </ul>

--- a/web/style.css
+++ b/web/style.css
@@ -1925,27 +1925,46 @@ input.small-input { text-align: center; }
    benar untuk peserta", dan pratinjau yang tampil berbeda dari aslinya tidak
    menjawab pertanyaan itu.
    ========================================================================== */
-.kemajuan { list-style: none; margin: 0; padding: 0; }
-.kemajuan li { margin-bottom: .85rem; }
-.kemajuan li:last-child { margin-bottom: 0; }
-.k-kepala { display: flex; align-items: baseline; gap: .5rem; margin-bottom: .3rem; }
-.k-nama {
-  font-weight: 600; flex: 1 1 auto; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+.kemajuan {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-wrap: wrap; gap: 1rem .6rem;
 }
-.k-persen {
-  font-weight: 800; font-variant-numeric: tabular-nums;
-  color: var(--utama); white-space: nowrap;
+.kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
+
+/* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
+   properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti
+   satu angka (ukuran ::before). Merah/kuning/hijau ditentukan JavaScript dan
+   masuk lewat --warna, supaya ambangnya tertulis SEKALI di satu tempat. */
+.cincin {
+  width: 84px; height: 84px; margin: 0 auto .4rem;
+  border-radius: 50%;
+  background: conic-gradient(var(--warna) calc(var(--persen) * 3.6deg),
+                             var(--garis) 0);
+  display: grid; place-items: center;
 }
-.k-batang {
-  height: 10px; border-radius: 999px; background: var(--kertas, #f4f4f2);
-  border: 1px solid var(--garis); overflow: hidden;
+.cincin::before {
+  content: ""; grid-area: 1 / 1;
+  width: 64px; height: 64px; border-radius: 50%; background: var(--kartu);
 }
-.k-batang span {
-  display: block; height: 100%; background: var(--utama);
-  border-radius: 999px; transition: width .4s ease;
+/* Angkanya di TENGAH cincin, selalu. Warna sendirian tidak boleh jadi
+   satu-satunya kabar: sekitar satu dari dua belas laki-laki sulit
+   membedakan merah dari hijau, dan bagi mereka lima cincin tanpa angka
+   adalah lima lingkaran yang sama. */
+.cincin > span {
+  grid-area: 1 / 1;
+  font-weight: 800; font-size: 1.2rem; line-height: 1;
+  font-variant-numeric: tabular-nums; color: var(--warna);
 }
-.k-angka { font-size: .82rem; color: var(--tinta-lembut); margin-top: .25rem; }
+.cincin i { font-style: normal; font-size: .62em; }
+.c-nama {
+  font-weight: 600; font-size: .84rem; line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+.c-angka {
+  font-size: .78rem; color: var(--tinta-lembut); line-height: 1.35;
+  margin-top: .15rem;
+}
+.c-alarm { color: var(--bahaya); }
 
 /* Podium. flex-wrap, bukan grid tiga kolom: di HP sempit tiga kartu juara
    berdesakan sampai nama regu terpotong, dan nama juara adalah satu-satunya


### PR DESCRIPTION
## What

The **Kemajuan input** panel on Live Score (and on the peserta rekap page)
now draws one circular ring per pos instead of a stacked bar, coloured red /
yellow / green by completion, with the percentage inside the ring.

| Percentage | Colour |
|---|---|
| below 50 | red |
| 50 – 89 | yellow |
| 90 and above | green |

## Why

Five bars stacked vertically are read one at a time and compared in the head.
Five rings side by side answer the only question anyone asks of this panel —
*which pos is behind* — in one glance, because colour and arc both carry it.

**Green starts at 90.** A pos with 300 regu sitting at 85% is still missing 45
of them, which is hours of work; a green ring there reports the job as done
when it is not.

**The number is always inside the ring.** Roughly one man in twelve cannot
separate red from green, and for them five colour-only rings are five
identical circles. Colour is the fast path, never the only one.

**conic-gradient, not SVG or a library.** One CSS property, no extra files,
and the ring thickness changes by editing the size of `::before`. CLAUDE.md 6
asks for patterns a student can navigate.

## Notes

- Both pages change together. The admin screen's whole justification is that
  it shows exactly what peserta will see; a preview that renders differently
  previews nothing. If bars are wanted on the peserta side, that is a one-file
  revert.
- `--bahaya` was missing from `live.css` and has been added to its token
  block, matching `style.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)