### PR TITLE
feat: pick one golongan at a time on Live Score with tabs

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1997,3 +1997,40 @@ input.small-input { text-align: center; }
   text-align: center; font-variant-numeric: tabular-nums;
   white-space: nowrap; padding-left: .3rem; padding-right: .3rem;
 }
+
+/* ============================================================================
+   Tab golongan pada Live Score.
+
+   Empat golongan berlomba terpisah, dan yang membuka layar ini hampir selalu
+   sedang menanyakan SATU di antaranya. Tab menaruh keempat pilihannya di satu
+   baris yang terlihat sekaligus — beserta jumlah regunya, supaya golongan
+   yang belum terisi terbaca sebagai "belum ada isinya", bukan sebagai
+   golongan yang tidak ada.
+   ========================================================================== */
+.tab-golongan {
+  display: flex; gap: .4rem; margin-bottom: .9rem;
+  /* Di HP sempit empat pil tidak muat; digeser mendatar, TIDAK dipatahkan ke
+     baris kedua — tab yang berpindah baris berhenti terbaca sebagai satu
+     kelompok pilihan. */
+  overflow-x: auto; padding-bottom: .25rem;
+}
+.tab-gol {
+  flex: 1 0 auto; white-space: nowrap; cursor: pointer; font: inherit;
+  font-weight: 600; min-height: 44px;
+  display: inline-flex; align-items: center; justify-content: center; gap: .4rem;
+  padding: .5rem .85rem; border-radius: 999px;
+  border: 1px solid var(--garis); background: var(--kartu);
+  color: var(--tinta-lembut);
+}
+.tab-gol[aria-selected="true"] {
+  background: var(--utama); border-color: var(--utama); color: #fff;
+}
+.tab-gol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.tab-hitung {
+  font-size: .78rem; font-weight: 700; font-variant-numeric: tabular-nums;
+  background: var(--kertas); color: var(--tinta-lembut);
+  border-radius: 999px; padding: .05rem .45rem;
+}
+.tab-gol[aria-selected="true"] .tab-hitung {
+  background: rgba(255, 255, 255, .24); color: #fff;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4060,11 +4060,7 @@ async function layarLiveScore() {
      berubah bentuk sepanjang hari — Penegak PI muncul belakangan lalu
      menggeser semuanya — dan yang lebih buruk, golongan yang belum satu pun
      regunya masuk terlihat seperti golongan yang tidak ada. */
-  const papan = !klasemen.length
-    ? `<div class="card"><p class="description">Belum ada regu yang bisa
-         diperingkat di golongan mana pun. Klasemen baru terisi setelah ada
-         regu yang kloternya sudah berangkat dan nilainya masuk.</p></div>`
-    : Object.keys(GOLONGAN_LABEL).map(g => {
+  const kartuGolongan = (g) => {
         const baris = klasemen.filter(k => k.golongan === g);
         const juara = baris.filter(k => k.peringkat <= 3);
         if (!baris.length) return `
@@ -4122,7 +4118,40 @@ async function layarLiveScore() {
             </table>
           </div>
         </div>`;
-      }).join("");
+  };
+
+  /* SATU golongan pada satu waktu, dipilih lewat tab.
+     Empat papan bertumpuk berarti detail Penegak PI ada empat layar penuh di
+     bawah — dan yang membuka layar ini hampir selalu sedang menanyakan SATU
+     golongan, bukan membandingkan keempatnya. Keempat tab tetap terlihat
+     sekaligus dengan jumlah regunya, jadi yang hilang cuma gulirannya.
+
+     Semua panel digambar sekali lalu disembunyikan, bukan digambar ulang saat
+     diklik: datanya sudah ada di tangan, dan berpindah tab yang menunggu
+     apa pun terasa rusak. */
+  const GOL = Object.keys(GOLONGAN_LABEL);
+  const jumlahGol = Object.fromEntries(
+    GOL.map(g => [g, klasemen.filter(k => k.golongan === g).length]));
+  // Tab pertama yang sudah ada isinya, supaya layar tidak terbuka pada
+  // golongan kosong ketika golongan lain justru sudah penuh.
+  const golAktif = GOL.find(g => jumlahGol[g] > 0) || GOL[0];
+
+  const tab = !klasemen.length ? "" : `
+    <div class="tab-golongan" role="tablist" aria-label="Golongan">
+      ${GOL.map(g => `
+        <button type="button" role="tab" class="tab-gol" data-gol="${esc(g)}"
+                aria-selected="${g === golAktif ? "true" : "false"}">
+          ${esc(GOLONGAN_LABEL[g])}
+          <span class="tab-hitung">${esc(String(jumlahGol[g]))}</span>
+        </button>`).join("")}
+    </div>`;
+
+  const papan = !klasemen.length
+    ? `<div class="card"><p class="description">Belum ada regu yang bisa
+         diperingkat di golongan mana pun. Klasemen baru terisi setelah ada
+         regu yang kloternya sudah berangkat dan nilainya masuk.</p></div>`
+    : GOL.map(g => `<div class="panel-gol" data-gol="${esc(g)}"${
+        g === golAktif ? "" : " hidden"}>${kartuGolongan(g)}</div>`).join("");
 
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
@@ -4135,7 +4164,22 @@ async function layarLiveScore() {
         diumumkan.</p>
     </div>
     ${kemajuan}
+    ${tab}
     ${papan}`));
+
+  const bilah = LAYAR.querySelector(".tab-golongan");
+  if (bilah) {
+    bilah.addEventListener("click", (e) => {
+      const b = e.target.closest("[data-gol]");
+      if (!b) return;
+      const pilih = b.dataset.gol;
+      bilah.querySelectorAll("[data-gol]").forEach(x =>
+        x.setAttribute("aria-selected", String(x.dataset.gol === pilih)));
+      LAYAR.querySelectorAll(".panel-gol").forEach(pn => {
+        pn.hidden = pn.dataset.gol !== pilih;
+      });
+    });
+  }
 }
 
 /* ============================ RUTE ======================================= */

--- a/web/style.css
+++ b/web/style.css
@@ -1997,3 +1997,40 @@ input.small-input { text-align: center; }
   text-align: center; font-variant-numeric: tabular-nums;
   white-space: nowrap; padding-left: .3rem; padding-right: .3rem;
 }
+
+/* ============================================================================
+   Tab golongan pada Live Score.
+
+   Empat golongan berlomba terpisah, dan yang membuka layar ini hampir selalu
+   sedang menanyakan SATU di antaranya. Tab menaruh keempat pilihannya di satu
+   baris yang terlihat sekaligus — beserta jumlah regunya, supaya golongan
+   yang belum terisi terbaca sebagai "belum ada isinya", bukan sebagai
+   golongan yang tidak ada.
+   ========================================================================== */
+.tab-golongan {
+  display: flex; gap: .4rem; margin-bottom: .9rem;
+  /* Di HP sempit empat pil tidak muat; digeser mendatar, TIDAK dipatahkan ke
+     baris kedua — tab yang berpindah baris berhenti terbaca sebagai satu
+     kelompok pilihan. */
+  overflow-x: auto; padding-bottom: .25rem;
+}
+.tab-gol {
+  flex: 1 0 auto; white-space: nowrap; cursor: pointer; font: inherit;
+  font-weight: 600; min-height: 44px;
+  display: inline-flex; align-items: center; justify-content: center; gap: .4rem;
+  padding: .5rem .85rem; border-radius: 999px;
+  border: 1px solid var(--garis); background: var(--kartu);
+  color: var(--tinta-lembut);
+}
+.tab-gol[aria-selected="true"] {
+  background: var(--utama); border-color: var(--utama); color: #fff;
+}
+.tab-gol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.tab-hitung {
+  font-size: .78rem; font-weight: 700; font-variant-numeric: tabular-nums;
+  background: var(--kertas); color: var(--tinta-lembut);
+  border-radius: 999px; padding: .05rem .45rem;
+}
+.tab-gol[aria-selected="true"] .tab-hitung {
+  background: rgba(255, 255, 255, .24); color: #fff;
+}


### PR DESCRIPTION
## What

Below the progress rings, Live Score now has a tab per golongan. Clicking
**Penegak PA** shows that golongan's three medalists and, below them, its
detail table. One golongan on screen at a time.

Each tab carries its regu count.

## Why

Four boards stacked meant the Penegak PI detail sat four full screens down,
and whoever opens this screen is almost always asking about *one* golongan,
not comparing all four.

All four tabs stay visible at once — a golongan with nobody entered yet reads
as empty rather than absent, which is the same reason all four are drawn in
the first place.

The default tab is the first golongan that already has rows, so the screen
never opens on an empty one while another is full.

**Panels are built once and hidden, not rebuilt on click.** The data is
already in hand, and a tab that waits for anything feels broken.

## Notes

- On narrow phones the tab row scrolls sideways rather than wrapping. Tabs
  that break onto a second line stop reading as one group of choices.
- 44px minimum height on the tabs — they are tapped with a thumb.
- The peserta page keeps its stacked layout for now. It redraws on a timer, so
  a tab there needs the selection held outside the render, the way the search
  box already holds its cursor. Worth its own change rather than smuggled into
  this one — say the word and I will mirror it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)