### PR TITLE
fix: always order golongan Penegak PA, PI, Penggalang PA, PI

### DIFF
--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -75,3 +75,10 @@ jobs:
       # `kunciNilaiPos` pernah lolos sampai produksi persis begitu.
       - name: Setiap fungsi api.js yang dipanggil app.js benar-benar diimpor
         run: python tools/periksa_impor.py
+
+      # URUT_GOLONGAN ada dua kali dengan sengaja — app.js dan live.js
+      # di-deploy sebagai Worker terpisah. Layar Live Score menjanjikan
+      # tampilan yang identik dengan halaman peserta, dan urutan yang
+      # menyimpang membatalkan janji itu tanpa menggagalkan apa pun.
+      - name: Urutan golongan sama di layar panitia dan halaman peserta
+        run: python tools/periksa_urutan_golongan.py

--- a/tools/periksa_urutan_golongan.py
+++ b/tools/periksa_urutan_golongan.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Pastikan URUT_GOLONGAN sama persis di layar panitia dan halaman peserta.
+
+KENAPA PERLU DIPERIKSA MESIN
+
+Konstanta ini ada DUA KALI dengan sengaja: `web/js/app.js` melayani situs
+panitia, `live/live.js` melayani situs peserta, dan keduanya di-deploy sebagai
+Worker terpisah tanpa satu pun berkas bersama. Tidak ada cara satu konstanta
+hidup di dua akar tanpa disalin (lihat kepala shared-files.yml) — dan
+`live.js` bukan salah satu berkas yang disalin utuh, karena isinya memang
+berbeda; hanya baris inilah yang harus sama.
+
+Layar Live Score menjanjikan satu hal: "ini persis yang akan dilihat peserta".
+Kalau urutan golongannya berbeda, janji itu bohong dengan cara yang tidak
+menggagalkan apa pun — tidak ada galat, tidak ada tes merah, cuma admin yang
+menghafal urutan salah lalu membacakan juara dengan urutan itu di depan
+lapangan.
+
+Repo ini sudah pernah kehilangan 21 baris karena sepasang berkas yang
+"seharusnya sama" tidak ada yang memeriksanya (CLAUDE.md 7.5). Komentar yang
+menyuruh dua tempat tetap sama bukan penjaga; skrip ini yang jadi penjaganya.
+"""
+
+import pathlib
+import re
+import sys
+
+POLA = re.compile(r"const URUT_GOLONGAN\s*=\s*\[(.*?)\]", re.S)
+BERKAS = ["web/js/app.js", "live/live.js"]
+
+akar = pathlib.Path(__file__).resolve().parent.parent
+temuan = {}
+gagal = False
+
+for nama in BERKAS:
+    berkas = akar / nama
+    if not berkas.exists():
+        print(f"GAGAL: {nama} tidak ada.")
+        gagal = True
+        continue
+    cocok = POLA.search(berkas.read_text(encoding="utf-8"))
+    if not cocok:
+        print(f"GAGAL: {nama} tidak memuat `const URUT_GOLONGAN = [...]`.")
+        gagal = True
+        continue
+    temuan[nama] = re.findall(r'"([^"]+)"', cocok.group(1))
+
+if gagal:
+    sys.exit(1)
+
+urutan = list(temuan.values())
+if urutan[0] != urutan[1]:
+    print("GAGAL: urutan golongan berbeda antara kedua berkas.")
+    for nama, isi in temuan.items():
+        print(f"  {nama:<16} {isi}")
+    print("\nSamakan keduanya — layar Live Score menjanjikan tampilan yang")
+    print("identik dengan halaman peserta.")
+    sys.exit(1)
+
+# Keempatnya harus ada. Daftar yang kebetulan sama tapi kehilangan satu
+# golongan lolos perbandingan di atas, dan golongan yang hilang tidak pernah
+# digambar sama sekali.
+WAJIB = {"penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"}
+kurang = WAJIB - set(urutan[0])
+if kurang:
+    print(f"GAGAL: golongan hilang dari URUT_GOLONGAN: {sorted(kurang)}")
+    sys.exit(1)
+
+print(f"Urutan golongan sama di kedua berkas: {urutan[0]}")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -31,9 +31,26 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
-  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
+  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
 };
+
+/** URUTAN BAKU golongan, di mana pun keempatnya dijejer.
+ *
+ *  Penegak lebih dulu, lalu Penggalang; PA sebelum PI. Ini urutan yang dipakai
+ *  panitia saat mengumumkan juara, dan layar yang berbeda urutan dari corong
+ *  memaksa pembaca acara mencocokkan sendiri di depan lapangan.
+ *
+ *  Ditulis eksplisit, bukan disandarkan pada urutan kunci GOLONGAN_LABEL:
+ *  urutan kunci objek memang terjaga di JavaScript, tapi ia tidak terlihat
+ *  sebagai keputusan — orang berikutnya yang merapikan daftar label itu secara
+ *  alfabetis akan mengubah urutan tampil tanpa pernah tahu ia melakukannya.
+ *
+ *  Kembarannya ada di live/live.js sebagai URUT_GOLONGAN dengan isi yang sama
+ *  persis. Halaman peserta berdiri sendiri (Worker terpisah, tanpa berkas
+ *  bersama), jadi salinannya disengaja — dan keduanya harus tetap sama, karena
+ *  layar Live Score memang menjanjikan tampilan yang identik. */
+const URUT_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
 
 /** Golongan versi pendek, HANYA untuk kertas. Di layar tetap panjang — di sana
  *  lebar tidak diperebutkan siapa pun, dan dua nama untuk satu hal cuma
@@ -53,8 +70,8 @@ const GOLONGAN_LABEL = {
  *  Nilai mengalir lewat nomor dada, jadi golongan yang salah baca tidak pernah
  *  memindahkan angka ke regu lain. */
 const GOLONGAN_SINGKAT = {
-  penggalang_pa: "Pgl Pa", penggalang_pi: "Pgl Pi",
   penegak_pa: "Pgk Pa", penegak_pi: "Pgk Pi",
+  penggalang_pa: "Pgl Pa", penggalang_pi: "Pgl Pi",
 };
 let EDISI = null;
 
@@ -4129,7 +4146,7 @@ async function layarLiveScore() {
      Semua panel digambar sekali lalu disembunyikan, bukan digambar ulang saat
      diklik: datanya sudah ada di tangan, dan berpindah tab yang menunggu
      apa pun terasa rusak. */
-  const GOL = Object.keys(GOLONGAN_LABEL);
+  const GOL = URUT_GOLONGAN;
   const jumlahGol = Object.fromEntries(
     GOL.map(g => [g, klasemen.filter(k => k.golongan === g).length]));
   // Tab pertama yang sudah ada isinya, supaya layar tidak terbuka pada


### PR DESCRIPTION
## What

Golongan are now always listed **Penegak PA → Penegak PI → Penggalang PA →
Penggalang PI**, everywhere the four are enumerated.

- `URUT_GOLONGAN` added to `web/js/app.js`, matching the one already in
  `live/live.js`; the Live Score tabs use it.
- `GOLONGAN_LABEL` and `GOLONGAN_SINGKAT` keys reordered to match, so a future
  `Object.keys` over either is right by default.
- `tools/periksa_urutan_golongan.py` + a CI step, so the two copies cannot
  drift.

## Why

This is the order panitia read the winners in. A screen that differs from the
microphone makes the announcer reconcile the two in front of the field.

**Explicit constant, not key order.** Object key order is stable in
JavaScript, but it does not *read* as a decision. The next person to
alphabetise the label list would change what the screen shows without knowing
they had.

**Why the check.** The constant is duplicated on purpose — the two sites
deploy as separate Workers with no shared file, and `live.js` is not copied
wholesale because the rest of it genuinely differs. Only this line has to
match. CLAUDE.md 7.5 records a pair that "should be the same" drifting by 21
lines with nobody watching; a comment saying "keep these equal" is not a
guard.

The checker also fails if any of the four golongan goes missing — a list that
matches but has lost one would otherwise pass, and the missing golongan would
simply never be drawn.

## Notes

Verified negatively: with the two lists deliberately shuffled apart, the check
exits 1 and prints both lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)