### PR TITLE
fix: keep the wide Live Score table inside its own scroller

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4114,7 +4114,7 @@ async function layarLiveScore() {
                 <div class="total">${esc(angkaRapi(k.total))}</div>
               </div>`).join("")}
           </div>
-          <div class="table-wrap">
+          <div class="table-wrapper table-wrapper-tetap">
             <table class="table data-table table-tetap">
               <thead>
                 <tr>


### PR DESCRIPTION
## What

One class name. `table-wrap` → `table-wrapper table-wrapper-tetap` on the
Live Score detail table.

## Why

The detail table carries a column per lomba, so it is wider than a phone by
design and has to scroll sideways inside itself. It was wrapped in
`table-wrap`, which has no rule anywhere in `style.css` — so it got no
`overflow-x`, and the table pushed the entire page sideways. The podium above
it was scrolled half off the left edge, which is what the screenshot showed.

`table-wrapper` carries `overflow-x: auto`. `table-wrapper-tetap` is the
companion that keeps a table a table on a phone instead of collapsing it into
stacked cards — correct here, because this table is read across, rank against
rank.

## Notes

Swept the rest of `app.js` for the same mistake: seven class names appear in
markup without a matching CSS rule, and all seven are JS-only hooks
(`pos-foto`, `pos-gembok`, `panel-gol`, `nomor-dada`, `invoice-row`,
`bl-catat`, `input-waktu`). `table-wrap` was the only one that actually needed
styling.

That sweep is a seven-line script with a seven-name allowlist and it would
have caught this before it shipped. Worth adding to CI as its own change if
you want it — three invented identifiers have reached review this session
(`judul()`, `simpanSebagian()`, `table-wrap`), and only the first two were
caught by the checks that already exist.

The peserta page was never affected: its table sits in `.gulir`, which does
have `overflow-x: auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)