### PR TITLE
fix: drop the golongan heading, the tab already says it

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4093,14 +4093,11 @@ async function layarLiveScore() {
         const juara = baris.filter(k => k.peringkat <= 3);
         if (!baris.length) return `
         <div class="card">
-          <h2>${esc(GOLONGAN_LABEL[g])}</h2>
           <p class="description">Belum ada regu golongan ini yang bisa
             diperingkat.</p>
         </div>`;
         return `
         <div class="card">
-          <h2>${esc(GOLONGAN_LABEL[g])}
-            <span class="sub">${esc(String(baris.length))} regu diperingkat</span></h2>
           <div class="podium">
             ${juara.map(k => `
               <div class="juara j${esc(String(k.peringkat))}">


### PR DESCRIPTION
## What

Removed `<h2>Penegak PA · 3 regu diperingkat</h2>` from the Live Score
golongan panel, and the bare heading from the empty-golongan card.

## Why

That heading sat directly beneath a tab reading **Penegak PA 3**, selected.
Two labels for the same fact, one right below the other, pushing the medals a
line further down for nothing.

The empty card reads fine without it: "Belum ada regu golongan ini yang bisa
diperingkat" already names what it is about.

## Notes

The peserta page keeps its headings. It has no tabs — all four golongan are
stacked there — so the heading is the only thing separating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)