### PR TITLE
fix: centre the pos heading and separate the pos groups on Live Score

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2046,3 +2046,22 @@ input.small-input { text-align: center; }
 .tab-gol[aria-selected="true"] .tab-hitung {
   background: rgba(255, 255, 255, .24); color: #fff;
 }
+
+/* ============================================================================
+   Tabel rincian Live Score. Bentuknya meminjam .table-rekap seluruhnya —
+   kolom nomor dada yang menempel saat digeser, garis pemisah antar pos, angka
+   rata tabular — supaya tabel yang panitia sebut "seperti Rekapitulasi" memang
+   benar-benar sama, bukan mirip.
+   ========================================================================== */
+
+/* Judul pos duduk di TENGAH kolom-kolomnya. Rata kiri membuatnya menempel di
+   lomba pertama dan terbaca seolah judul untuk kolom itu saja, bukan untuk
+   kelompoknya — dan pada pos berkolom lima, jaraknya ke kolom terakhir cukup
+   jauh untuk membuat orang mengira kelompoknya berakhir lebih awal. */
+.table-live thead th[colspan] { text-align: center; }
+
+/* Jarak bernapas di kiri tiap kelompok pos. Garis .rekap-batas menutup
+   kelompok di kanan; tanpa lapangnya di kiri, kolom pertama pos berikutnya
+   menempel persis di garis itu dan keduanya terbaca sebagai satu kolom. */
+.table-live .rekap-batas + th,
+.table-live .rekap-batas + td { padding-left: .7rem; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4112,7 +4112,7 @@ async function layarLiveScore() {
               </div>`).join("")}
           </div>
           <div class="table-wrapper table-wrapper-tetap">
-            <table class="table data-table table-tetap">
+            <table class="table data-table table-tetap table-rekap table-live">
               <thead>
                 <tr>
                   <th rowspan="2">#</th>

--- a/web/style.css
+++ b/web/style.css
@@ -2046,3 +2046,22 @@ input.small-input { text-align: center; }
 .tab-gol[aria-selected="true"] .tab-hitung {
   background: rgba(255, 255, 255, .24); color: #fff;
 }
+
+/* ============================================================================
+   Tabel rincian Live Score. Bentuknya meminjam .table-rekap seluruhnya —
+   kolom nomor dada yang menempel saat digeser, garis pemisah antar pos, angka
+   rata tabular — supaya tabel yang panitia sebut "seperti Rekapitulasi" memang
+   benar-benar sama, bukan mirip.
+   ========================================================================== */
+
+/* Judul pos duduk di TENGAH kolom-kolomnya. Rata kiri membuatnya menempel di
+   lomba pertama dan terbaca seolah judul untuk kolom itu saja, bukan untuk
+   kelompoknya — dan pada pos berkolom lima, jaraknya ke kolom terakhir cukup
+   jauh untuk membuat orang mengira kelompoknya berakhir lebih awal. */
+.table-live thead th[colspan] { text-align: center; }
+
+/* Jarak bernapas di kiri tiap kelompok pos. Garis .rekap-batas menutup
+   kelompok di kanan; tanpa lapangnya di kiri, kolom pertama pos berikutnya
+   menempel persis di garis itu dan keduanya terbaca sebagai satu kolom. */
+.table-live .rekap-batas + th,
+.table-live .rekap-batas + td { padding-left: .7rem; }


### PR DESCRIPTION
## What

- The Live Score detail table now carries `.table-rekap`, which brings the
  rule between pos groups, the sticky rank and nomor dada columns, and the
  tabular figures.
- `POS 1 · KEPRAMUKAAN` and the other group headings are centred over their
  columns.
- The first column after each divider gets left padding.

## Why

The table borrowed the *shape* of Rekapitulasi but not its classes, so
`.rekap-batas` — already on the markup — matched nothing, and the pos groups
ran together with no line between them.

A left-aligned group heading sits against its first lomba and reads as a
heading for that column rather than for the group; on a five-column pos it is
far enough from the last column to suggest the group ends early.

Without the left padding the next pos butts straight against the rule, and the
divider stops separating anything.

## Notes

A table panitia describe as "like Rekapitulasi" should be the same table
rather than a lookalike — that is why this takes the whole class instead of
copying two rules out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)