### PR TITLE
fix: "Daftarkan regu lain", on the green button

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -627,7 +627,7 @@ async function mulai() {
         <div class="giant-number" style="margin:.6rem 0">${hasilLama.kode_pembayaran}</div>
         <p class="description">${hasilLama.jumlah_regu} regu · ${rupiah(hasilLama.total_tagihan)}</p>
       </div>
-      <button class="button button-secondary" id="baru" type="button">Daftarkan sekolah lain</button>`));
+      <button class="button button-primary" id="baru" type="button">Daftarkan regu lain</button>`));
     document.getElementById("baru").addEventListener("click", () => {
       try { localStorage.removeItem(KUNCI_HASIL); } catch {}
       sessionStorage.removeItem("hrcd_selesai");


### PR DESCRIPTION
## What

On the peserta registration page, after a submission: **Daftarkan sekolah
lain** → **Daftarkan regu lain**, and the button becomes primary (green)
instead of secondary (white).

## Why

One school registers several regu, and the regu is what the form counts and
what the payment is priced by. "Sekolah lain" told a pembina who still had two
regu left to enter that this button was not for them.

Green because it is the only thing to do on that screen. A white secondary
button standing next to nothing else reads as the cautious choice, and there
is no other choice to be cautious about.

## Notes

`live/js/daftar.js` is peserta-only and not one of the files mirrored into
`web/`, so nothing needs copying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)