### PR TITLE
fix: lock without asking, keep the question for unlocking

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2642,15 +2642,16 @@ async function layarInputPos() {
     const kunci = tr.dataset.terkunci === "1";
     const tiga = String(dada).padStart(3, "0");
 
+    // MENGUNCI tidak bertanya. Petugas menekan gembok ratusan kali dalam satu
+    // shift, dan setiap kali harus menjawab "yakin?" untuk perbuatan yang bisa
+    // ia batalkan sendiri (0045) — ongkos itu dibayar di tiap baris, sementara
+    // yang dicegahnya cuma satu ketukan nyasar yang tinggal diketuk lagi.
+    //
+    // MEMBUKA bertanya, dan itu bukan sekadar konfirmasi: alasannya wajib, dan
+    // alasan itulah satu-satunya penjelasan yang tersisa kalau nilainya
+    // berubah sesudah gemboknya terbuka. Yang mahal memang arah itu, bukan
+    // arah sebaliknya.
     if (!kunci) {
-      const ya = await dialog({
-        judul: `Kunci nilai ${tiga}?`,
-        kartuHtml: `<p class="description">Sesudah dikunci, nilai regu ini
-          tidak bisa diubah sampai gemboknya dibuka lagi — dan membukanya
-          wajib menyebut alasan, yang tercatat di riwayat.</p>`,
-        labelAksi: "Kunci",
-      });
-      if (!ya) return;
       try { await kunciNilaiPos(dada, pos.nomor); }
       catch (err) { notif(`Gagal mengunci: ${err.message}`, true); return; }
       tr.dataset.terkunci = "1";


### PR DESCRIPTION
## What

Tapping the padlock now locks the row immediately. The confirmation dialog is
gone from that direction; unlocking still opens its dialog and still requires a
reason.

## Why

The padlock is tapped once per regu — hundreds of times across a shift — and
every tap asked "yakin?" for an action the same person can undo, since pos
officers gained the right to unlock their own pos in `0045`. That cost is paid
on every row, and what it prevents is one stray tap that can simply be tapped
again.

Unlocking keeps its dialog, and it was never really a confirmation: the reason
is mandatory and it is the only explanation left if the value changes after the
padlock opens. That is the direction worth slowing down.

## Notes

Nothing changes on the server. `kunci_nilai_pos` was always idempotent —
`on conflict do nothing` — precisely because two officers can press the same
padlock from different phones and neither has made a mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)