### PR TITLE
fix: drop the explanatory line from the unlock dialog

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2660,11 +2660,11 @@ async function layarInputPos() {
       return;
     }
 
+    // Tanpa kalimat penjelas. Kotak alasan yang wajib diisi sudah mengatakan
+    // seluruhnya — bahwa alasannya dicatat adalah hal yang petugas pelajari
+    // sekali, sedangkan kalimatnya dibaca ulang setiap kali gembok dibuka.
     const jawab = await dialog({
       judul: `Buka gembok ${tiga}?`,
-      kartuHtml: `<p class="description">Alasannya dicatat di riwayat, dan
-        itulah satu-satunya penjelasan yang tersisa kalau nilainya berubah
-        sesudah ini.</p>`,
       medan: [{ label: "Alasan membuka", contoh: "salah ketik Semaphore" }],
       labelAksi: "Buka",
     });


### PR DESCRIPTION
## What

Removed the paragraph "Alasannya dicatat di riwayat, dan itulah satu-satunya
penjelasan yang tersisa kalau nilainya berubah sesudah ini." from the unlock
dialog. Title, mandatory reason field and buttons stay.

## Why

A required field labelled **Alasan membuka** already says all of it. That the
reason is recorded is something an officer learns once; the sentence was
re-read on every unlock, and on a phone it pushed the field it was explaining
further down the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)