### PR TITLE
docs: do not over-educate on screen (section 9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,3 +191,32 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
     1.500. Printing the stack from a browser spends a whole office toner on
     work a copier finishes in minutes — and the count is decided at the copier
     anyway, since the forms are blank.
+
+## 9. Screen text
+
+1. **Do not over-educate. People are smart.** A small feature with a clear
+   title needs no paragraph explaining itself. Panitia read these screens
+   hundreds of times in a shift, and a sentence that teaches something learned
+   once is re-read on every one of them.
+2. **A title, a labelled field, and a button name are usually the whole
+   interface.** "Buka gembok 001?" above a required field labelled "Alasan
+   membuka" already says everything the paragraph "Alasannya dicatat di
+   riwayat, dan itulah satu-satunya penjelasan yang tersisa…" said — in a
+   quarter of the height, on a phone where the field it explained had been
+   pushed down the screen to make room for it.
+3. **Cut anything that repeats the title, the field label, or the button next
+   to it.** Two labels for one fact do not reinforce each other.
+4. **Keep text that carries a fact the reader cannot get from the screen
+   itself**: the figure currently in force, the state of the data right now, a
+   consequence that cannot be undone, a warning that something is already
+   printed or has already departed.
+5. **The test when unsure** — if this sentence disappeared, could the officer
+   make a mistake that costs something? If not, cut it. "They might not know
+   how it works" is not a cost; they will after the first time.
+6. **Explain in code comments and migration headers, not on screen.** Those are
+   read by whoever maintains the thing, which is exactly the audience an
+   explanation is for. Section 6.3 asks for generous documentation — it means
+   there, not in the interface.
+7. **Weight explanation by how often a screen is used, not by a fixed budget
+   per screen.** The registration form is the exception that proves the rule: a
+   pembina fills it once, has had no training, and has nobody to ask.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,3 +189,32 @@ Guidance for Claude Code when working in this repository.
     1.500. Printing the stack from a browser spends a whole office toner on
     work a copier finishes in minutes — and the count is decided at the copier
     anyway, since the forms are blank.
+
+## 9. Screen text
+
+1. **Do not over-educate. People are smart.** A small feature with a clear
+   title needs no paragraph explaining itself. Panitia read these screens
+   hundreds of times in a shift, and a sentence that teaches something learned
+   once is re-read on every one of them.
+2. **A title, a labelled field, and a button name are usually the whole
+   interface.** "Buka gembok 001?" above a required field labelled "Alasan
+   membuka" already says everything the paragraph "Alasannya dicatat di
+   riwayat, dan itulah satu-satunya penjelasan yang tersisa…" said — in a
+   quarter of the height, on a phone where the field it explained had been
+   pushed down the screen to make room for it.
+3. **Cut anything that repeats the title, the field label, or the button next
+   to it.** Two labels for one fact do not reinforce each other.
+4. **Keep text that carries a fact the reader cannot get from the screen
+   itself**: the figure currently in force, the state of the data right now, a
+   consequence that cannot be undone, a warning that something is already
+   printed or has already departed.
+5. **The test when unsure** — if this sentence disappeared, could the officer
+   make a mistake that costs something? If not, cut it. "They might not know
+   how it works" is not a cost; they will after the first time.
+6. **Explain in code comments and migration headers, not on screen.** Those are
+   read by whoever maintains the thing, which is exactly the audience an
+   explanation is for. Section 6.3 asks for generous documentation — it means
+   there, not in the interface.
+7. **Weight explanation by how often a screen is used, not by a fixed budget
+   per screen.** The registration form is the exception that proves the rule: a
+   pembina fills it once, has had no training, and has nobody to ask.


### PR DESCRIPTION
## What

New section 9 in `CLAUDE.md` and `AGENTS.md`: **Screen text**. Seven rules on
how much explanation an interface should carry.

Line endings in both files were normalised in the same commit — `CLAUDE.md`
had drifted to a mix of CRLF and LF, which made the two files compare as
different even where the text was identical.

## Why

Requested verbatim: *"not overeducate, small feature but to the point title is
clear"*.

Panitia read the same screen hundreds of times in a shift, so a sentence that
teaches something learned once is paid for on every reading after the first.
On a phone it also pushes the control it explains further down the page — the
unlock dialog that triggered this had a paragraph about the history sitting
above the required field labelled "Alasan membuka", which already said it.

The section is not "write less". It draws a line:

- **cut** what repeats the title, the field label or the button beside it, and
  what teaches how a feature works;
- **keep** what carries a fact the reader cannot get from the screen — the
  figure in force, the state of the data now, something already printed or
  already departed, a consequence that cannot be undone;
- **the test**: if the sentence disappeared, could the officer make a mistake
  that costs something? "They might not know how it works" is not a cost.

Long explanations still get written — in code comments and migration headers,
where the maintainer reads them. Section 6.3 asks for generous documentation
and this does not walk that back; it says where it belongs.

Rule 7 keeps the registration form exempt: a pembina fills it once, untrained,
with nobody to ask.

## Notes

A sweep of the existing screens against this rule is running separately; this
PR is the rule itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)