### PR TITLE
docs: if the term is already clear, do not explain it (9.8-9.9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,3 +220,14 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 7. **Weight explanation by how often a screen is used, not by a fixed budget
    per screen.** The registration form is the exception that proves the rule: a
    pembina fills it once, has had no training, and has nobody to ask.
+8. **A name that already says what the thing is needs no gloss.** "Pendaftaran"
+   does not need "buka form pendaftaran" beneath it, and "Keberangkatan" does
+   not need a list of what happens there. If the term is clear, the interface
+   is finished.
+9. **This applies hardest to domain vocabulary.** Section 5.3 keeps `regu`,
+   `kloter`, `nomor dada`, `Penggalang` and `Penegak` untranslated precisely
+   because panitia and pembina say those words every day. Explaining them back
+   to the people who use them is the same mistake as translating them —
+   glossing "Penggalang PA" as "SMP / MTs — putra" on the registration form was
+   caught and removed for exactly this reason. Explain a term only where the
+   reader genuinely cannot have met it before.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,3 +218,14 @@ Guidance for Claude Code when working in this repository.
 7. **Weight explanation by how often a screen is used, not by a fixed budget
    per screen.** The registration form is the exception that proves the rule: a
    pembina fills it once, has had no training, and has nobody to ask.
+8. **A name that already says what the thing is needs no gloss.** "Pendaftaran"
+   does not need "buka form pendaftaran" beneath it, and "Keberangkatan" does
+   not need a list of what happens there. If the term is clear, the interface
+   is finished.
+9. **This applies hardest to domain vocabulary.** Section 5.3 keeps `regu`,
+   `kloter`, `nomor dada`, `Penggalang` and `Penegak` untranslated precisely
+   because panitia and pembina say those words every day. Explaining them back
+   to the people who use them is the same mistake as translating them —
+   glossing "Penggalang PA" as "SMP / MTs — putra" on the registration form was
+   caught and removed for exactly this reason. Explain a term only where the
+   reader genuinely cannot have met it before.


### PR DESCRIPTION
## What

Two rules added to section 9 of `CLAUDE.md` and `AGENTS.md`.

**9.8** — a name that already says what the thing is needs no gloss.
**9.9** — this applies hardest to domain vocabulary.

## Why

Requested in the owner's own words: *"if the feature is very clear in terms,
don't explain it"* and *"explanation about Pendaftaran — IT'S ALREADY CLEAR
THAT'S REGISTRATION"*.

Rule 9.3 already said to cut what repeats a title. This is narrower and
harder: a self-evident name needs no gloss at all, even one that adds words
the title does not contain.

**Where I had it wrong.** Section 5.3 keeps `regu`, `kloter`, `nomor dada`,
`Penggalang` and `Penegak` untranslated because panitia and pembina say them
daily. I defended glossing "Penggalang PA" as "SMP / MTs — putra" on the
registration form under 9.7's exemption for untrained readers — but a pembina
is not an untrained reader of scouting vocabulary. Explaining those words back
to the people who use them is the same mistake as translating them, and 9.9
now says so with that example named.

9.7 still stands for what a pembina genuinely cannot guess — what to do when
their school is not in the list. That is a way out of a dead end, not a
definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)