### PR TITLE
fix: "Daftar Kloter", not "Cetak Daftar Kloter"

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -156,7 +156,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/home` | Home | menu + dua lencana angka: menunggu pembayaran, lunas belum bernomor |
 | `#/pembayaran` | Meja Pembayaran | tabel semua invoice, tandai lunas, cetak kwitansi |
 | `#/daftar-ulang` | Meja Daftar Ulang | isi nomor dada per regu, tukar nomor rusak |
-| `#/cetak-kloter` | Cetak Daftar Kloter | lembar per kloter untuk petugas start |
+| `#/cetak-kloter` | Daftar Kloter | lembar per kloter untuk petugas start |
 | `#/keberangkatan` | Keberangkatan | ceklis hadir, kontrak waktu, pindah kloter, berangkatkan |
 | `#/finish` | Kedatangan | catat jam datang + anggota hadir |
 | `#/pos` | Input Nilai Pos | lembar penilaian satu pos, satu baris per regu |

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -246,7 +246,7 @@ async function layarHome() {
         <div class="function-name">🎽 Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
       </a>
       <a href="#/cetak-kloter">
-        <div class="function-name">🖨️ Cetak Daftar Kloter</div>
+        <div class="function-name">🖨️ Daftar Kloter</div>
       </a>
       <a href="#/keberangkatan">
         <div class="function-name">🚩 Keberangkatan</div>
@@ -1423,7 +1423,7 @@ async function layarKeberangkatan() {
 /* ============================ CETAK DAFTAR KLOTER ======================== */
 
 async function layarCetakKloter() {
-  pasangKepala("Cetak Daftar Kloter");
+  pasangKepala("Daftar Kloter");
   LAYAR.replaceChildren(h(pemuat()));
 
   let baris;


### PR DESCRIPTION
## What

Menu entry and screen header: **Cetak Daftar Kloter** → **Daftar Kloter**. The
row in `docs/final-architecture.md` follows.

## Why

The printer belongs to the button, not the name. Opening the menu prints
nothing; the button inside it does. The screen is a daftar kloter whether or
not anyone ever prints it — carrying the verb in the title described one thing
you can do there rather than what it is.

## Notes

The route stays `#/cetak-kloter`. It is technical rather than domain text, and
renaming it breaks whatever panitia have bookmarked in exchange for nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)