### PR TITLE
feat: lift the cards — softer shadows, rounder corners, more room

### DIFF
--- a/live/live.css
+++ b/live/live.css
@@ -11,9 +11,9 @@
 :root {
   --tinta:        #1a1a1a;
   --tinta-lembut: #5c5c5c;
-  --kertas:       #f7f6f3;
+  --kertas:       #f0f1f4;
   --kartu:        #ffffff;
-  --garis:        #dcdcd7;
+  --garis:        #e7e8ec;
   --utama:        #00695c;   /* hijau tua HRCD */
   --hijau:        #2e7d32;
   --hijau-muda:   #e8f5e9;
@@ -21,7 +21,9 @@
   --bahaya:       #c62828;
   --kuning-muda:  #fff3e0;
   --emas:         #b8860b;
-  --radius:       14px;
+  --radius:       18px;
+  /* Sama persis dengan style.css layar panitia: dua situs, satu tampilan. */
+  --bayang:       0 1px 2px rgba(16,24,40,.04), 0 6px 20px rgba(16,24,40,.07);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -51,7 +53,8 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 
 .kartu {
   background: var(--kartu); border: 1px solid var(--garis);
-  border-radius: var(--radius); padding: .9rem; margin-bottom: 1rem;
+  border-radius: var(--radius); padding: 1.15rem; margin-bottom: 1rem;
+  box-shadow: var(--bayang);
 }
 .kartu h2 { font-size: 1.05rem; margin-bottom: .35rem; }
 .kartu .keterangan { color: var(--tinta-lembut); font-size: .88rem; margin-bottom: .7rem; }

--- a/live/style.css
+++ b/live/style.css
@@ -21,9 +21,9 @@
 :root {
   --tinta:        #1a1a1a;
   --tinta-lembut: #5c5c5c;
-  --kertas:       #f7f6f3;
+  --kertas:       #f0f1f4;
   --kartu:        #ffffff;
-  --garis:        #dcdcd7;
+  --garis:        #e7e8ec;
   --utama:        #00695c;   /* hijau tua HRCD */
   --utama-gelap:  #004d43;
   --utama-muda:   #e0f2f1;
@@ -33,8 +33,14 @@
   --kuning-muda:  #fff3e0;
   --hijau:        #2e7d32;
   --hijau-muda:   #e8f5e9;
-  --radius:       14px;
-  --bayang:       0 1px 3px rgba(0,0,0,.08), 0 4px 14px rgba(0,0,0,.06);
+  --radius:       18px;
+  --radius-kecil: 12px;
+  /* Dua lapis: satu tipis dan rapat untuk memberi tepi tanpa garis, satu
+     lebar dan sangat pucat untuk mengangkat kartu dari kertasnya. Garis keras
+     membagi; bayangan menumpuk — dan yang membuat papan seperti ini terbaca
+     cepat adalah kartu yang terlihat sebagai benda, bukan kotak. */
+  --bayang:       0 1px 2px rgba(16,24,40,.04), 0 6px 20px rgba(16,24,40,.07);
+  --bayang-naik:  0 2px 4px rgba(16,24,40,.05), 0 14px 30px rgba(16,24,40,.11);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -84,13 +90,13 @@ body {
 
 .card {
   background: var(--kartu);
-  border: 1.5px solid var(--garis);
+  border: 1px solid var(--garis);
   border-radius: var(--radius);
   box-shadow: var(--bayang);
-  padding: .9rem;
-  margin-bottom: .8rem;
+  padding: 1.15rem;
+  margin-bottom: 1rem;
 }
-.card h2 { font-size: 1.1rem; margin-bottom: .45rem; }
+.card h2 { font-size: 1.1rem; margin-bottom: .5rem; letter-spacing: -.01em; }
 .card .description { color: var(--tinta-lembut); font-size: .9rem; }
 
 /* Kartu identitas hasil lookup (echo-confirm) — HARUS terbaca dari jauh */
@@ -114,9 +120,10 @@ button { font: inherit; cursor: pointer; }
   padding: .55rem 1.1rem;
   font-size: 1rem;
   font-weight: 700;
-  border-radius: var(--radius);
+  border-radius: var(--radius-kecil);
   border: 2px solid transparent;
   width: 100%;
+  transition: background .15s ease, box-shadow .15s ease;
 }
 .button-primary {
   background: var(--utama);
@@ -273,10 +280,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   display: inline-flex;
   align-items: center;
   gap: .4rem;
-  padding: .2rem .6rem;
+  padding: .25rem .65rem;
   border-radius: 999px;
   font-weight: 700;
   font-size: .85rem;
+  font-variant-numeric: tabular-nums;
 }
 .badge-green  { background: var(--hijau-muda);  color: var(--hijau); }
 .badge-yellow { background: var(--kuning-muda); color: var(--kuning); }
@@ -430,12 +438,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   text-decoration: none;
   color: inherit;
   background: var(--kartu);
-  border: 2px solid var(--garis);
+  border: 1px solid var(--garis);
   border-radius: var(--radius);
+  box-shadow: var(--bayang);
+  transition: box-shadow .18s ease, transform .18s ease, border-color .18s ease;
   padding: 1rem;
   box-shadow: var(--bayang);
 }
-.function-menu a:hover { border-color: var(--utama); }
+/* Terangkat sedikit saat disentuh — isyarat "ini bisa ditekan" yang tidak
+   memakan satu piksel pun ruang. Dimatikan untuk yang meminta gerak minimal. */
+.function-menu a:hover {
+  border-color: var(--utama);
+  box-shadow: var(--bayang-naik);
+  transform: translateY(-2px);
+}
+.function-menu a:active { transform: translateY(0); }
+@media (prefers-reduced-motion: reduce) {
+  .function-menu a { transition: none; }
+  .function-menu a:hover { transform: none; }
+}
 .function-menu .function-name { font-size: 1.15rem; font-weight: 800; display: flex; justify-content: space-between; align-items: center; }
 .function-menu .description { color: var(--tinta-lembut); margin-top: .3rem; }
 

--- a/web/style.css
+++ b/web/style.css
@@ -21,9 +21,9 @@
 :root {
   --tinta:        #1a1a1a;
   --tinta-lembut: #5c5c5c;
-  --kertas:       #f7f6f3;
+  --kertas:       #f0f1f4;
   --kartu:        #ffffff;
-  --garis:        #dcdcd7;
+  --garis:        #e7e8ec;
   --utama:        #00695c;   /* hijau tua HRCD */
   --utama-gelap:  #004d43;
   --utama-muda:   #e0f2f1;
@@ -33,8 +33,14 @@
   --kuning-muda:  #fff3e0;
   --hijau:        #2e7d32;
   --hijau-muda:   #e8f5e9;
-  --radius:       14px;
-  --bayang:       0 1px 3px rgba(0,0,0,.08), 0 4px 14px rgba(0,0,0,.06);
+  --radius:       18px;
+  --radius-kecil: 12px;
+  /* Dua lapis: satu tipis dan rapat untuk memberi tepi tanpa garis, satu
+     lebar dan sangat pucat untuk mengangkat kartu dari kertasnya. Garis keras
+     membagi; bayangan menumpuk — dan yang membuat papan seperti ini terbaca
+     cepat adalah kartu yang terlihat sebagai benda, bukan kotak. */
+  --bayang:       0 1px 2px rgba(16,24,40,.04), 0 6px 20px rgba(16,24,40,.07);
+  --bayang-naik:  0 2px 4px rgba(16,24,40,.05), 0 14px 30px rgba(16,24,40,.11);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -84,13 +90,13 @@ body {
 
 .card {
   background: var(--kartu);
-  border: 1.5px solid var(--garis);
+  border: 1px solid var(--garis);
   border-radius: var(--radius);
   box-shadow: var(--bayang);
-  padding: .9rem;
-  margin-bottom: .8rem;
+  padding: 1.15rem;
+  margin-bottom: 1rem;
 }
-.card h2 { font-size: 1.1rem; margin-bottom: .45rem; }
+.card h2 { font-size: 1.1rem; margin-bottom: .5rem; letter-spacing: -.01em; }
 .card .description { color: var(--tinta-lembut); font-size: .9rem; }
 
 /* Kartu identitas hasil lookup (echo-confirm) — HARUS terbaca dari jauh */
@@ -114,9 +120,10 @@ button { font: inherit; cursor: pointer; }
   padding: .55rem 1.1rem;
   font-size: 1rem;
   font-weight: 700;
-  border-radius: var(--radius);
+  border-radius: var(--radius-kecil);
   border: 2px solid transparent;
   width: 100%;
+  transition: background .15s ease, box-shadow .15s ease;
 }
 .button-primary {
   background: var(--utama);
@@ -273,10 +280,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   display: inline-flex;
   align-items: center;
   gap: .4rem;
-  padding: .2rem .6rem;
+  padding: .25rem .65rem;
   border-radius: 999px;
   font-weight: 700;
   font-size: .85rem;
+  font-variant-numeric: tabular-nums;
 }
 .badge-green  { background: var(--hijau-muda);  color: var(--hijau); }
 .badge-yellow { background: var(--kuning-muda); color: var(--kuning); }
@@ -430,12 +438,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   text-decoration: none;
   color: inherit;
   background: var(--kartu);
-  border: 2px solid var(--garis);
+  border: 1px solid var(--garis);
   border-radius: var(--radius);
+  box-shadow: var(--bayang);
+  transition: box-shadow .18s ease, transform .18s ease, border-color .18s ease;
   padding: 1rem;
   box-shadow: var(--bayang);
 }
-.function-menu a:hover { border-color: var(--utama); }
+/* Terangkat sedikit saat disentuh — isyarat "ini bisa ditekan" yang tidak
+   memakan satu piksel pun ruang. Dimatikan untuk yang meminta gerak minimal. */
+.function-menu a:hover {
+  border-color: var(--utama);
+  box-shadow: var(--bayang-naik);
+  transform: translateY(-2px);
+}
+.function-menu a:active { transform: translateY(0); }
+@media (prefers-reduced-motion: reduce) {
+  .function-menu a { transition: none; }
+  .function-menu a:hover { transform: none; }
+}
 .function-menu .function-name { font-size: 1.15rem; font-weight: 800; display: flex; justify-content: space-between; align-items: center; }
 .function-menu .description { color: var(--tinta-lembut); margin-top: .3rem; }
 


### PR DESCRIPTION
## What

A visual refresh of both stylesheets, tokens first:

| | before | after |
|---|---|---|
| page | `#f7f6f3` warm | `#f0f1f4` cool grey |
| card edge | `1.5px #dcdcd7` | `1px #e7e8ec` + layered shadow |
| corners | 14px | 18px (`--radius-kecil: 12px` for buttons) |
| card padding | .9rem | 1.15rem |

Home tiles gain a shadow, a 2px hover lift and a press state. Badges get
tabular figures so counts stop shifting width.

## Why

The reference the owner shared reads as modern for four reasons, none of them
colour: shadows instead of borders, rounder corners, more room inside each
card, and a firm split between figure and label. This does the first three at
token level, so every screen inherits them without markup changes.

Lines divide; shadows stack. A board of nine tiles reads faster when each one
looks like an object sitting on the page.

The border stays at 1px rather than going to zero because several cards set
`border-color` inline as an accent — the Live Score banner, the peserta
success card. At zero width those would go silent.

## Notes

**Nothing about legibility moved.** Body stays 16px, inputs 17px, tap targets
46px. The header of `style.css` records that those were recalibrated on real
phones after a first version made the registration form four screens long;
that is not worth re-opening for appearance.

The hover lift is the only animation and it is disabled under
`prefers-reduced-motion`.

Print CSS is untouched and `tools/pratinjau_cetak.py` still passes — the
copier rules in CLAUDE.md 8 are unaffected by any of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)