### PR TITLE
feat: give Home the full width so the menu reads as one board

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -202,7 +202,12 @@ function layarLogin(pesan) {
 /* ============================ BERANDA MEJA (home) ========================= */
 
 async function layarHome() {
-  pasangKepala("Home");
+  // Lebar penuh: pada 760px hanya muat dua kolom, dan menu sepuluh tombol
+  // jadi kolom sempit dengan lapangan kosong di kanannya. 1080px muat tiga,
+  // sehingga seluruh menu terlihat sekaligus tanpa menggulir. Di HP grid-nya
+  // tetap runtuh jadi satu kolom — minmax(280px, 1fr) yang memutuskan, bukan
+  // lebar wadahnya.
+  pasangKepala("Home", true);
   const peran = sesi().peran;
   LAYAR.replaceChildren(h(pemuat()));
 


### PR DESCRIPTION
## What

`pasangKepala("Home")` → `pasangKepala("Home", true)`, which swaps the 760px
container for the existing 1080px one.

## Why

At 760px the ten tiles fit two columns and leave a field of empty page beside
them — the menu becomes a narrow strip scanned downward rather than a board
taken in at a glance, which is the shape the owner's reference has.

1080px fits three columns of 280px with room for the gaps.

## Notes

The phone view is unchanged. `minmax(280px, 1fr)` is what collapses the grid to
a single column, not the container width, so a narrower screen behaves exactly
as before.

`.isi.wide` already exists and is used by the meja screens; nothing new was
introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)