### PR TITLE
feat: line icons instead of emoji, and Daftar Kloter stops being a printer

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -607,3 +607,58 @@ export function ukuranRapi(bytes) {
   if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
   return `${(n / 1048576).toFixed(1).replace(".", ",")} MB`;
 }
+
+/* ---------- ikon ----------
+
+   Ikon garis dari Lucide (ISC), disalin ke sini sebagai jalur SVG — bukan
+   emoji, dan bukan berkas yang diunduh terpisah.
+
+   Emoji terlihat BERBEDA di tiap alat: satu panitia melihat printer abu-abu,
+   yang lain melihat printer biru mengkilap, dan yang memakai HP lama melihat
+   kotak kosong. Ikon yang digambar sendiri tampil sama di mana pun.
+
+   Digambar dengan `currentColor` dan ukuran `em`, jadi ia mewarisi warna dan
+   ukuran teks di sebelahnya tanpa satu pun aturan tambahan — termasuk saat
+   ubinnya disorot atau saat panitia memperbesar huruf HP-nya.
+
+   Ditempel di dalam berkas, bukan di-fetch: satu permintaan jaringan lagi di
+   lapangan bersinyal buruk lebih mahal daripada beberapa kilobyte di sini,
+   dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
+
+const IKON = {
+  "chart-column":
+    '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
+  "circle-check":
+    '<circle cx="12" cy="12" r="10" /> <path d="m9 12 2 2 4-4" />',
+  "clipboard-list":
+    '<rect width="8" height="4" x="8" y="2" rx="1" ry="1" /> <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /> <path d="M12 11h4" /> <path d="M12 16h4" /> <path d="M8 11h.01" /> <path d="M8 16h.01" />',
+  "credit-card":
+    '<rect width="20" height="14" x="2" y="5" rx="2" /> <line x1="2" x2="22" y1="10" y2="10" />',
+  "flag":
+    '<path d="M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528" />',
+  "house":
+    '<path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /> <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />',
+  "id-card":
+    '<path d="M16 10h2" /> <path d="M16 14h2" /> <path d="M6.17 15a3 3 0 0 1 5.66 0" /> <circle cx="9" cy="11" r="2" /> <rect x="2" y="5" width="20" height="14" rx="2" />',
+  "list-ordered":
+    '<path d="M11 5h10" /> <path d="M11 12h10" /> <path d="M11 19h10" /> <path d="M4 4h1v5" /> <path d="M4 9h2" /> <path d="M6.5 20H3.4c0-1 2.6-1.925 2.6-3.5a1.5 1.5 0 0 0-2.6-1.02" />',
+  "log-out":
+    '<path d="m16 17 5-5-5-5" /> <path d="M21 12H9" /> <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />',
+  "medal":
+    '<path d="M7.21 15 2.66 7.14a2 2 0 0 1 .13-2.2L4.4 2.8A2 2 0 0 1 6 2h12a2 2 0 0 1 1.6.8l1.6 2.14a2 2 0 0 1 .14 2.2L16.79 15" /> <path d="M11 12 5.12 2.2" /> <path d="m13 12 5.88-9.8" /> <path d="M8 7h8" /> <circle cx="12" cy="17" r="5" /> <path d="M12 18v-2h-.5" />',
+  "settings":
+    '<path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" /> <circle cx="12" cy="12" r="3" />',
+  "square-pen":
+    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /> <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />'
+};
+
+/** Satu ikon garis, siap ditempel ke template. Nama yang tidak dikenal
+ *  menghasilkan string kosong — tombolnya tetap punya teks, jadi tidak ada
+ *  yang rusak, hanya kehilangan mukanya. */
+export function ikon(nama, kelas = "ikon") {
+  const d = IKON[nama];
+  if (!d) return "";
+  return `<svg class="${kelas}" viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+    stroke-linejoin="round" aria-hidden="true" focusable="false">${d}</svg>`;
+}

--- a/live/style.css
+++ b/live/style.css
@@ -2125,3 +2125,20 @@ input.small-input { text-align: center; }
    menempel persis di garis itu dan keduanya terbaca sebagai satu kolom. */
 .table-live .rekap-batas + th,
 .table-live .rekap-batas + td { padding-left: .7rem; }
+
+/* ============================================================================
+   Ikon garis (Lucide, ISC). Digambar dengan currentColor dan berukuran `em`,
+   jadi ia mewarisi warna dan ukuran teks di sebelahnya — termasuk saat panitia
+   memperbesar huruf HP-nya, yang membuat emoji dan teks berpisah ukuran.
+   ========================================================================== */
+.ikon {
+  width: 1.15em; height: 1.15em;
+  flex: 0 0 auto;
+  vertical-align: -.18em;
+}
+/* Di ubin menu ikonnya sedikit lebih besar dan berwarna hijau HRCD: satu
+   aksen warna pada papan yang selebihnya netral, persis peran yang dipegang
+   warna di papan rujukan. */
+.function-name .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
+.icon-button .ikon { width: 1.4em; height: 1.4em; }
+.bottom-nav-icon .ikon { width: 1.5em; height: 1.5em; }

--- a/web/index.html
+++ b/web/index.html
@@ -13,11 +13,11 @@
 </head>
 <body>
   <header class="header" id="kepala" hidden>
-    <button class="icon-button" id="btn-home" type="button" aria-label="Home" title="Home">🏠</button>
+    <button class="icon-button" id="btn-home" type="button" aria-label="Home" title="Home"><svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /> <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /></svg></button>
     <span class="title" id="judul-layar">Sistem Panitia</span>
     <span class="spacer"></span>
     <span class="user-info" id="siapa"></span>
-    <button class="icon-button" id="ganti-password" type="button" aria-label="Ganti Password" title="Ganti Password">⚙️</button>
+    <button class="icon-button" id="ganti-password" type="button" aria-label="Ganti Password" title="Ganti Password"><svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" /> <circle cx="12" cy="12" r="3" /></svg></button>
     <button class="button button-small button-secondary" id="btn-keluar" type="button">Keluar</button>
   </header>
 
@@ -31,13 +31,13 @@
        karena header sudah cukup. -->
   <nav class="bottom-nav" id="bottom-nav" hidden aria-label="Menu utama">
     <button class="bottom-nav-item" id="nav-home" type="button">
-      <span class="bottom-nav-icon">🏠</span><span>Home</span>
+      <span class="bottom-nav-icon"><svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /> <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /></svg></span><span>Home</span>
     </button>
     <button class="bottom-nav-item" id="nav-setting" type="button">
-      <span class="bottom-nav-icon">⚙️</span><span>Setelan</span>
+      <span class="bottom-nav-icon"><svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" /> <circle cx="12" cy="12" r="3" /></svg></span><span>Setelan</span>
     </button>
     <button class="bottom-nav-item" id="nav-keluar" type="button">
-      <span class="bottom-nav-icon">🚪</span><span>Keluar</span>
+      <span class="bottom-nav-icon"><svg class="ikon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m16 17 5-5-5-5" /> <path d="M21 12H9" /> <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /></svg></span><span>Keluar</span>
     </button>
   </nav>
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,7 +27,7 @@ import {
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
-         kotakJamHtml, kecilkanFoto, ukuranRapi } from "./util.js";
+         kotakJamHtml, kecilkanFoto, ukuranRapi, ikon } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -220,7 +220,7 @@ async function layarHome() {
     LAYAR.replaceChildren(h(html`
       <div class="function-menu">
         <a href="#/pos">
-          <div class="function-name">📋 Input Nilai Pos ${sesi().pos}</div>
+          <div class="function-name">${ikon("square-pen")} Input Nilai Pos ${sesi().pos}</div>
         </a>
       </div>
 `));
@@ -242,33 +242,33 @@ async function layarHome() {
            asal, tautannya mutlak dan diambil dari config.js. -->
       <a href="${esc((window.HRCD && window.HRCD.pesertaUrl) || "")}/daftar.html"
          target="_blank" rel="noopener">
-        <div class="function-name">📝 Pendaftaran</div>
+        <div class="function-name">${ikon("clipboard-list")} Pendaftaran</div>
       </a>
       <a href="#/pembayaran">
-        <div class="function-name">💳 Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
+        <div class="function-name">${ikon("credit-card")} Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
       </a>
       <a href="#/daftar-ulang">
-        <div class="function-name">🎽 Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
+        <div class="function-name">${ikon("id-card")} Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
       </a>
       <a href="#/cetak-kloter">
-        <div class="function-name">🖨️ Daftar Kloter</div>
+        <div class="function-name">${ikon("list-ordered")} Daftar Kloter</div>
       </a>
       <a href="#/keberangkatan">
-        <div class="function-name">🚩 Keberangkatan</div>
+        <div class="function-name">${ikon("flag")} Keberangkatan</div>
       </a>
       <a href="#/finish">
-        <div class="function-name">🏁 Kedatangan</div>
+        <div class="function-name">${ikon("circle-check")} Kedatangan</div>
       </a>
       ${peran === "admin" ? `
       <a href="#/pos">
-        <div class="function-name">📋 Input Nilai Pos</div>
+        <div class="function-name">${ikon("square-pen")} Input Nilai Pos</div>
       </a>` : ""}
       ${peran === "admin" ? `
       <a href="#/live-score">
-        <div class="function-name">🥇 Live Score</div>
+        <div class="function-name">${ikon("medal")} Live Score</div>
       </a>` : ""}
       <a href="#/rekap">
-        <div class="function-name">📊 Rekapitulasi</div>
+        <div class="function-name">${ikon("chart-column")} Rekapitulasi</div>
       </a>
     </div>
   `));

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -607,3 +607,58 @@ export function ukuranRapi(bytes) {
   if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
   return `${(n / 1048576).toFixed(1).replace(".", ",")} MB`;
 }
+
+/* ---------- ikon ----------
+
+   Ikon garis dari Lucide (ISC), disalin ke sini sebagai jalur SVG — bukan
+   emoji, dan bukan berkas yang diunduh terpisah.
+
+   Emoji terlihat BERBEDA di tiap alat: satu panitia melihat printer abu-abu,
+   yang lain melihat printer biru mengkilap, dan yang memakai HP lama melihat
+   kotak kosong. Ikon yang digambar sendiri tampil sama di mana pun.
+
+   Digambar dengan `currentColor` dan ukuran `em`, jadi ia mewarisi warna dan
+   ukuran teks di sebelahnya tanpa satu pun aturan tambahan — termasuk saat
+   ubinnya disorot atau saat panitia memperbesar huruf HP-nya.
+
+   Ditempel di dalam berkas, bukan di-fetch: satu permintaan jaringan lagi di
+   lapangan bersinyal buruk lebih mahal daripada beberapa kilobyte di sini,
+   dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
+
+const IKON = {
+  "chart-column":
+    '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
+  "circle-check":
+    '<circle cx="12" cy="12" r="10" /> <path d="m9 12 2 2 4-4" />',
+  "clipboard-list":
+    '<rect width="8" height="4" x="8" y="2" rx="1" ry="1" /> <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /> <path d="M12 11h4" /> <path d="M12 16h4" /> <path d="M8 11h.01" /> <path d="M8 16h.01" />',
+  "credit-card":
+    '<rect width="20" height="14" x="2" y="5" rx="2" /> <line x1="2" x2="22" y1="10" y2="10" />',
+  "flag":
+    '<path d="M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528" />',
+  "house":
+    '<path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /> <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />',
+  "id-card":
+    '<path d="M16 10h2" /> <path d="M16 14h2" /> <path d="M6.17 15a3 3 0 0 1 5.66 0" /> <circle cx="9" cy="11" r="2" /> <rect x="2" y="5" width="20" height="14" rx="2" />',
+  "list-ordered":
+    '<path d="M11 5h10" /> <path d="M11 12h10" /> <path d="M11 19h10" /> <path d="M4 4h1v5" /> <path d="M4 9h2" /> <path d="M6.5 20H3.4c0-1 2.6-1.925 2.6-3.5a1.5 1.5 0 0 0-2.6-1.02" />',
+  "log-out":
+    '<path d="m16 17 5-5-5-5" /> <path d="M21 12H9" /> <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />',
+  "medal":
+    '<path d="M7.21 15 2.66 7.14a2 2 0 0 1 .13-2.2L4.4 2.8A2 2 0 0 1 6 2h12a2 2 0 0 1 1.6.8l1.6 2.14a2 2 0 0 1 .14 2.2L16.79 15" /> <path d="M11 12 5.12 2.2" /> <path d="m13 12 5.88-9.8" /> <path d="M8 7h8" /> <circle cx="12" cy="17" r="5" /> <path d="M12 18v-2h-.5" />',
+  "settings":
+    '<path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" /> <circle cx="12" cy="12" r="3" />',
+  "square-pen":
+    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /> <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />'
+};
+
+/** Satu ikon garis, siap ditempel ke template. Nama yang tidak dikenal
+ *  menghasilkan string kosong — tombolnya tetap punya teks, jadi tidak ada
+ *  yang rusak, hanya kehilangan mukanya. */
+export function ikon(nama, kelas = "ikon") {
+  const d = IKON[nama];
+  if (!d) return "";
+  return `<svg class="${kelas}" viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+    stroke-linejoin="round" aria-hidden="true" focusable="false">${d}</svg>`;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -2125,3 +2125,20 @@ input.small-input { text-align: center; }
    menempel persis di garis itu dan keduanya terbaca sebagai satu kolom. */
 .table-live .rekap-batas + th,
 .table-live .rekap-batas + td { padding-left: .7rem; }
+
+/* ============================================================================
+   Ikon garis (Lucide, ISC). Digambar dengan currentColor dan berukuran `em`,
+   jadi ia mewarisi warna dan ukuran teks di sebelahnya — termasuk saat panitia
+   memperbesar huruf HP-nya, yang membuat emoji dan teks berpisah ukuran.
+   ========================================================================== */
+.ikon {
+  width: 1.15em; height: 1.15em;
+  flex: 0 0 auto;
+  vertical-align: -.18em;
+}
+/* Di ubin menu ikonnya sedikit lebih besar dan berwarna hijau HRCD: satu
+   aksen warna pada papan yang selebihnya netral, persis peran yang dipegang
+   warna di papan rujukan. */
+.function-name .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
+.icon-button .ikon { width: 1.4em; height: 1.4em; }
+.bottom-nav-icon .ikon { width: 1.5em; height: 1.5em; }


### PR DESCRIPTION
## What

The menu tiles, the header buttons and the bottom nav move from emoji to
Lucide line icons, inlined as SVG paths in `util.js` with an `ikon(nama)`
helper.

| screen | was | now |
|---|---|---|
| Pendaftaran | 📝 | clipboard-list |
| Pembayaran | 💳 | credit-card |
| Daftar Ulang | 🎽 | id-card |
| **Daftar Kloter** | **🖨️** | **list-ordered** |
| Keberangkatan | 🚩 | flag |
| Kedatangan | 🏁 | circle-check |
| Input Nilai Pos | 📋 | square-pen |
| Live Score | 🥇 | medal |
| Rekapitulasi | 📊 | chart-column |

## Why

**The printer was wrong** the moment the screen stopped being called "Cetak"
(#196). Opening that menu prints nothing — the button inside it does. What is
on the page is a numbered list.

**Emoji look different on every device.** One panitia sees a grey printer,
another a glossy blue one, and an older phone draws an empty box. Drawn icons
look the same everywhere, which is most of what makes the reference board feel
tidy.

**Pasted, not fetched.** One more network request in a field with bad signal
costs more than a few kilobytes in the file, and an icon that fails to load
leaves a button with no face.

They draw in `currentColor` at `em` sizes, so they inherit the colour and size
of the text beside them — including when a panitia enlarges their phone's
font, which is exactly where emoji and text drift apart. On the tiles they
take the HRCD green: one accent on an otherwise neutral board.

## Notes

Medals 🥇🥈🥉 on the podium stay as emoji — those are literally medals and the
colour is the point. The padlock and camera in the pos sheet are untouched.

Lucide is ISC-licensed; attribution is in the comment above the icon set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)