### PR TITLE
fix: icon and name side by side on the menu tiles

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -491,7 +491,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .function-menu a { transition: none; }
   .function-menu a:hover { transform: none; }
 }
-.function-menu .function-name { font-size: 1.15rem; font-weight: 800; display: flex; justify-content: space-between; align-items: center; }
+/* Ikon dan nama berdampingan di kiri, lencana didorong ke kanan.
+   Sebelumnya baris ini memakai space-between untuk sepasang anak — nama dan
+   lencana. Begitu ikon jadi anak ketiga, space-between membagi ruang di ANTARA
+   ketiganya dan namanya terlempar ke tengah-kanan, menjauh dari ikon yang
+   seharusnya jadi pasangannya. */
+.function-menu .function-name {
+  font-size: 1.15rem; font-weight: 800;
+  display: flex; align-items: center; gap: .6rem;
+}
+.function-menu .function-name .badge { margin-left: auto; }
 .function-menu .description { color: var(--tinta-lembut); margin-top: .3rem; }
 
 /* ---------- dialog (pengganti prompt) ---------- */

--- a/web/style.css
+++ b/web/style.css
@@ -491,7 +491,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .function-menu a { transition: none; }
   .function-menu a:hover { transform: none; }
 }
-.function-menu .function-name { font-size: 1.15rem; font-weight: 800; display: flex; justify-content: space-between; align-items: center; }
+/* Ikon dan nama berdampingan di kiri, lencana didorong ke kanan.
+   Sebelumnya baris ini memakai space-between untuk sepasang anak — nama dan
+   lencana. Begitu ikon jadi anak ketiga, space-between membagi ruang di ANTARA
+   ketiganya dan namanya terlempar ke tengah-kanan, menjauh dari ikon yang
+   seharusnya jadi pasangannya. */
+.function-menu .function-name {
+  font-size: 1.15rem; font-weight: 800;
+  display: flex; align-items: center; gap: .6rem;
+}
+.function-menu .function-name .badge { margin-left: auto; }
 .function-menu .description { color: var(--tinta-lembut); margin-top: .3rem; }
 
 /* ---------- dialog (pengganti prompt) ---------- */


### PR DESCRIPTION
## What

`.function-name` becomes a plain flex row with a gap; only `.badge` is pushed
right with `margin-left: auto`.

## Why

A regression from #200. That rule used `justify-content: space-between` for a
pair — name on the left, count badge on the right. Adding the icon made it
three children, so the space was divided *between all three* and the name was
thrown out to the right edge, away from the icon it belongs with.

Icon and name are one unit and now sit together; the badge keeps its right
edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)