### PR TITLE
feat: colour the menu icons, one tint per function

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -662,3 +662,18 @@ export function ikon(nama, kelas = "ikon") {
     stroke="currentColor" stroke-width="2" stroke-linecap="round"
     stroke-linejoin="round" aria-hidden="true" focusable="false">${d}</svg>`;
 }
+
+/** Ikon di dalam kotak bertint — satu warna per fungsi.
+ *
+ *  Ikon garis satu warna membuat papan menu jadi rata: sepuluh ubin yang
+ *  bentuknya sama dan warnanya sama harus dibaca kata demi kata. Warna
+ *  memberi tiap ubin penanda yang dikenali sebelum tulisannya sempat dibaca,
+ *  dan sesudah beberapa kali pakai panitia menuju "yang jingga" tanpa
+ *  mengeja "Keberangkatan".
+ *
+ *  Warna TIDAK PERNAH jadi satu-satunya pembeda — namanya selalu tertulis di
+ *  sebelahnya. Sekitar satu dari dua belas laki-laki sulit membedakan merah
+ *  dari hijau, dan bagi mereka papan ini harus tetap terbaca persis sama. */
+export function ikonKotak(nama, warna) {
+  return `<span class="ikon-kotak i-${warna}">${ikon(nama)}</span>`;
+}

--- a/live/style.css
+++ b/live/style.css
@@ -2148,6 +2148,49 @@ input.small-input { text-align: center; }
 /* Di ubin menu ikonnya sedikit lebih besar dan berwarna hijau HRCD: satu
    aksen warna pada papan yang selebihnya netral, persis peran yang dipegang
    warna di papan rujukan. */
-.function-name .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
+/* Di dalam kotak bertint, ukuran dan warnanya diatur .ikon-kotak. */
+.function-name > .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
 .icon-button .ikon { width: 1.4em; height: 1.4em; }
 .bottom-nav-icon .ikon { width: 1.5em; height: 1.5em; }
+
+/* ============================================================================
+   Kotak ikon bertint — satu warna per fungsi.
+
+   Sepuluh ubin sebentuk dan sewarna harus dibaca kata demi kata. Warna
+   memberi tiap ubin penanda yang dikenali sebelum tulisannya sempat dibaca,
+   dan sesudah beberapa hari panitia menuju "yang jingga" tanpa mengeja
+   "Keberangkatan".
+
+   Warnanya TIDAK PERNAH jadi satu-satunya pembeda: namanya selalu tertulis di
+   sebelahnya, dan bentuk ikonnya sendiri sudah berbeda. Sekitar satu dari dua
+   belas laki-laki sulit membedakan merah dari hijau, dan papan ini harus
+   terbaca sama persis bagi mereka.
+
+   Latarnya tint pucat dengan ikon versi pekat dari warna yang sama —
+   pasangan itu yang membuat kotaknya terbaca sebagai satu benda, bukan
+   sebagai kotak warna dengan gambar di atasnya.
+   ========================================================================== */
+.ikon-kotak {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 2.25rem; height: 2.25rem;
+  border-radius: 11px;
+  flex: 0 0 auto;
+}
+.ikon-kotak .ikon { width: 1.2rem; height: 1.2rem; }
+
+.i-biru   { background: #e7f0fd; color: #1a56db; }
+.i-hijau  { background: #e4f6ec; color: #067647; }
+.i-ungu   { background: #f0eafe; color: #6941c6; }
+.i-toska  { background: #dff2f0; color: #00695c; }
+.i-jingga { background: #fdefe0; color: #b54708; }
+.i-zamrud { background: #e2f7f0; color: #047857; }
+.i-emas   { background: #fdf3dc; color: #a16207; }
+.i-nila   { background: #e9ecfc; color: #3538cd; }
+.i-mawar  { background: #fce9ee; color: #c01048; }
+
+/* Di kertas semua tint hilang — CLAUDE.md 8.4 melarang abu dan raster, dan
+   latar berwarna yang difotokopi jadi kotoran. Ikonnya sendiri tidak dicetak
+   di blangko mana pun, tapi aturan ini menjaga kalau suatu hari ikut. */
+@media print {
+  .ikon-kotak { background: none !important; color: #000 !important; }
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,7 +27,7 @@ import {
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
-         kotakJamHtml, kecilkanFoto, ukuranRapi, ikon } from "./util.js";
+         kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -220,7 +220,7 @@ async function layarHome() {
     LAYAR.replaceChildren(h(html`
       <div class="function-menu">
         <a href="#/pos">
-          <div class="function-name">${ikon("square-pen")} Input Nilai Pos ${sesi().pos}</div>
+          <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos ${sesi().pos}</div>
         </a>
       </div>
 `));
@@ -242,33 +242,33 @@ async function layarHome() {
            asal, tautannya mutlak dan diambil dari config.js. -->
       <a href="${esc((window.HRCD && window.HRCD.pesertaUrl) || "")}/daftar.html"
          target="_blank" rel="noopener">
-        <div class="function-name">${ikon("clipboard-list")} Pendaftaran</div>
+        <div class="function-name">${ikonKotak("clipboard-list", "biru")} Pendaftaran</div>
       </a>
       <a href="#/pembayaran">
-        <div class="function-name">${ikon("credit-card")} Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
+        <div class="function-name">${ikonKotak("credit-card", "hijau")} Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
       </a>
       <a href="#/daftar-ulang">
-        <div class="function-name">${ikon("id-card")} Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
+        <div class="function-name">${ikonKotak("id-card", "ungu")} Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
       </a>
       <a href="#/cetak-kloter">
-        <div class="function-name">${ikon("list-ordered")} Daftar Kloter</div>
+        <div class="function-name">${ikonKotak("list-ordered", "toska")} Daftar Kloter</div>
       </a>
       <a href="#/keberangkatan">
-        <div class="function-name">${ikon("flag")} Keberangkatan</div>
+        <div class="function-name">${ikonKotak("flag", "jingga")} Keberangkatan</div>
       </a>
       <a href="#/finish">
-        <div class="function-name">${ikon("circle-check")} Kedatangan</div>
+        <div class="function-name">${ikonKotak("circle-check", "zamrud")} Kedatangan</div>
       </a>
       ${peran === "admin" ? `
       <a href="#/pos">
-        <div class="function-name">${ikon("square-pen")} Input Nilai Pos</div>
+        <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos</div>
       </a>` : ""}
       ${peran === "admin" ? `
       <a href="#/live-score">
-        <div class="function-name">${ikon("medal")} Live Score</div>
+        <div class="function-name">${ikonKotak("medal", "emas")} Live Score</div>
       </a>` : ""}
       <a href="#/rekap">
-        <div class="function-name">${ikon("chart-column")} Rekapitulasi</div>
+        <div class="function-name">${ikonKotak("chart-column", "mawar")} Rekapitulasi</div>
       </a>
     </div>
   `));

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -662,3 +662,18 @@ export function ikon(nama, kelas = "ikon") {
     stroke="currentColor" stroke-width="2" stroke-linecap="round"
     stroke-linejoin="round" aria-hidden="true" focusable="false">${d}</svg>`;
 }
+
+/** Ikon di dalam kotak bertint — satu warna per fungsi.
+ *
+ *  Ikon garis satu warna membuat papan menu jadi rata: sepuluh ubin yang
+ *  bentuknya sama dan warnanya sama harus dibaca kata demi kata. Warna
+ *  memberi tiap ubin penanda yang dikenali sebelum tulisannya sempat dibaca,
+ *  dan sesudah beberapa kali pakai panitia menuju "yang jingga" tanpa
+ *  mengeja "Keberangkatan".
+ *
+ *  Warna TIDAK PERNAH jadi satu-satunya pembeda — namanya selalu tertulis di
+ *  sebelahnya. Sekitar satu dari dua belas laki-laki sulit membedakan merah
+ *  dari hijau, dan bagi mereka papan ini harus tetap terbaca persis sama. */
+export function ikonKotak(nama, warna) {
+  return `<span class="ikon-kotak i-${warna}">${ikon(nama)}</span>`;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -2148,6 +2148,49 @@ input.small-input { text-align: center; }
 /* Di ubin menu ikonnya sedikit lebih besar dan berwarna hijau HRCD: satu
    aksen warna pada papan yang selebihnya netral, persis peran yang dipegang
    warna di papan rujukan. */
-.function-name .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
+/* Di dalam kotak bertint, ukuran dan warnanya diatur .ikon-kotak. */
+.function-name > .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
 .icon-button .ikon { width: 1.4em; height: 1.4em; }
 .bottom-nav-icon .ikon { width: 1.5em; height: 1.5em; }
+
+/* ============================================================================
+   Kotak ikon bertint — satu warna per fungsi.
+
+   Sepuluh ubin sebentuk dan sewarna harus dibaca kata demi kata. Warna
+   memberi tiap ubin penanda yang dikenali sebelum tulisannya sempat dibaca,
+   dan sesudah beberapa hari panitia menuju "yang jingga" tanpa mengeja
+   "Keberangkatan".
+
+   Warnanya TIDAK PERNAH jadi satu-satunya pembeda: namanya selalu tertulis di
+   sebelahnya, dan bentuk ikonnya sendiri sudah berbeda. Sekitar satu dari dua
+   belas laki-laki sulit membedakan merah dari hijau, dan papan ini harus
+   terbaca sama persis bagi mereka.
+
+   Latarnya tint pucat dengan ikon versi pekat dari warna yang sama —
+   pasangan itu yang membuat kotaknya terbaca sebagai satu benda, bukan
+   sebagai kotak warna dengan gambar di atasnya.
+   ========================================================================== */
+.ikon-kotak {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 2.25rem; height: 2.25rem;
+  border-radius: 11px;
+  flex: 0 0 auto;
+}
+.ikon-kotak .ikon { width: 1.2rem; height: 1.2rem; }
+
+.i-biru   { background: #e7f0fd; color: #1a56db; }
+.i-hijau  { background: #e4f6ec; color: #067647; }
+.i-ungu   { background: #f0eafe; color: #6941c6; }
+.i-toska  { background: #dff2f0; color: #00695c; }
+.i-jingga { background: #fdefe0; color: #b54708; }
+.i-zamrud { background: #e2f7f0; color: #047857; }
+.i-emas   { background: #fdf3dc; color: #a16207; }
+.i-nila   { background: #e9ecfc; color: #3538cd; }
+.i-mawar  { background: #fce9ee; color: #c01048; }
+
+/* Di kertas semua tint hilang — CLAUDE.md 8.4 melarang abu dan raster, dan
+   latar berwarna yang difotokopi jadi kotoran. Ikonnya sendiri tidak dicetak
+   di blangko mana pun, tapi aturan ini menjaga kalau suatu hari ikut. */
+@media print {
+  .ikon-kotak { background: none !important; color: #000 !important; }
+}


### PR DESCRIPTION
## What

Each Home tile's icon moves into a soft tinted rounded square, one hue per
function.

| | tint |
|---|---|
| Pendaftaran | blue |
| Pembayaran | green |
| Daftar Ulang | violet |
| Daftar Kloter | teal |
| Keberangkatan | orange |
| Kedatangan | emerald |
| Input Nilai Pos | indigo |
| Live Score | gold |
| Rekapitulasi | rose |

## Why

Monochrome line icons made the board flat — ten tiles of the same shape in the
same green have to be read word by word. A colour gives each tile a mark
recognised before the writing is; after a few days panitia go to *the orange
one* without spelling out Keberangkatan.

The pale background with a deeper shade of the same hue for the stroke is what
makes each box read as one object rather than a coloured square with a picture
sitting on it.

## Notes

**Colour is never the only difference.** The name is always beside it and the
icon shapes already differ. Roughly one man in twelve cannot separate red from
green; for them this board reads exactly as it did before, which is the test
that matters.

Tints are stripped inside `@media print`. CLAUDE.md 8.4 bans grey and tints
because a copier renders them as dirt. No blangko carries these icons today —
the rule should not depend on that staying true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)