### PR TITLE
fix: menu labels at 700, not 800

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -497,7 +497,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    ketiganya dan namanya terlempar ke tengah-kanan, menjauh dari ikon yang
    seharusnya jadi pasangannya. */
 .function-menu .function-name {
-  font-size: 1.15rem; font-weight: 800;
+  font-size: 1.1rem;
+  /* 700, bukan 800. Angka itu dipilih waktu fontnya masih Segoe UI, yang
+     menggambar 800 jauh lebih ringan daripada Inter — Inter punya bobot
+     sungguhan, jadi nilai yang sama mendadak berteriak.
+     Penekanannya juga sudah pindah: ikon berwarna di sebelah kirilah yang
+     sekarang menandai tiap ubin, jadi tulisannya boleh mengendur. */
+  font-weight: 700;
   display: flex; align-items: center; gap: .6rem;
 }
 .function-menu .function-name .badge { margin-left: auto; }

--- a/web/style.css
+++ b/web/style.css
@@ -497,7 +497,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    ketiganya dan namanya terlempar ke tengah-kanan, menjauh dari ikon yang
    seharusnya jadi pasangannya. */
 .function-menu .function-name {
-  font-size: 1.15rem; font-weight: 800;
+  font-size: 1.1rem;
+  /* 700, bukan 800. Angka itu dipilih waktu fontnya masih Segoe UI, yang
+     menggambar 800 jauh lebih ringan daripada Inter — Inter punya bobot
+     sungguhan, jadi nilai yang sama mendadak berteriak.
+     Penekanannya juga sudah pindah: ikon berwarna di sebelah kirilah yang
+     sekarang menandai tiap ubin, jadi tulisannya boleh mengendur. */
+  font-weight: 700;
   display: flex; align-items: center; gap: .6rem;
 }
 .function-menu .function-name .badge { margin-left: auto; }


### PR DESCRIPTION
## What

`.function-name` drops from `font-weight: 800` to `700`, and from `1.15rem` to
`1.1rem`.

## Why

800 was chosen while the font was Segoe UI, which draws that weight far
lighter than Inter does. Inter has real weights, so after #199 the same number
started shouting.

The emphasis has moved anyway. The coloured icon beside each label is what
marks the tile now, so the text can relax — the reference sets its card titles
semibold and saves heavy weights for figures.

## Notes

If it still reads heavy, 600 is one number away and Inter is variable, so
there is nothing to download either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)