### PR TITLE
fix: one "Pendaftaran", not three

### DIFF
--- a/live/daftar.html
+++ b/live/daftar.html
@@ -10,7 +10,7 @@
   <header class="header">
     <!-- Angka romawi edisinya ditambahkan daftar.js dari data, bukan ditulis
          di sini — supaya tahun depan tidak ada yang lupa menggantinya. -->
-    <span class="title" id="judul-daftar">Pendaftaran Hiking Rally Ciradyka</span>
+    <span class="title" id="judul-daftar">Pendaftaran</span>
     <span class="spacer"></span>
     <span class="user-info" id="label-edisi"></span>
   </header>

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -76,10 +76,6 @@ const labelGolongan = k => GOLONGAN.find(g => g.kode === k).label;
 
 function halaman() {
   LAYAR.replaceChildren(h(`
-    <div class="card card-title" style="border-color:var(--utama)">
-      <h2>Pendaftaran Regu</h2>
-    </div>
-
     <!-- 1. Sekolah -->
     <section class="card" id="bagian-sekolah">
       <h2><span class="section-number">1</span> Asal sekolah</h2>
@@ -605,11 +601,16 @@ async function mulai() {
   // tidak ada, dan membacanya diam-diam menghasilkan undefined.
   document.getElementById("label-edisi").textContent = EDISI.name;
   const romawi = String(EDISI.name || "").replace(/^HRCD\s*/i, "").trim();
-  // Judul di layar DAN judul tab memakai angka romawi yang sama. Sekolah
-  // sering membuka form ini setahun sekali; tanpa nomor edisi, halaman lama
-  // yang masih terbuka di tab lain tidak bisa dibedakan dari yang baru.
-  const judul = `Pendaftaran Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
-  document.getElementById("judul-daftar").textContent = judul;
+  // Judul layar cukup satu kata. Nama acaranya sudah berdiri di kanan kepala
+  // sebagai "HRCD <edisi>", dan sebelum ini tiga label mengatakan hal yang
+  // sama bertumpuk: judul panjang, lencana edisi, dan kartu "Pendaftaran
+  // Regu" — di layar HP ketiganya memakan sepertiga tinggi sebelum kotak
+  // isian pertama muncul.
+  //
+  // Nomor edisi tetap ada di JUDUL TAB. Itulah yang sebenarnya dibutuhkan:
+  // sekolah membuka form ini setahun sekali, dan tab lama yang masih terbuka
+  // harus bisa dibedakan dari yang baru.
+  document.getElementById("judul-daftar").textContent = "Pendaftaran";
   document.title = `Pendaftaran — Hiking Rally Ciradyka${romawi ? ` ${romawi}` : ""}`;
 
   let hasilLama = null, draf = null;


### PR DESCRIPTION
## What

On the peserta registration page:

- header title → **Pendaftaran** (was "Pendaftaran Hiking Rally Ciradyka
  XXXVII")
- the `Pendaftaran Regu` card is removed

The `HRCD XXXVII` badge on the right of the header stays, and so does the
roman numeral in the tab title.

## Why

Three labels said the same thing, stacked, and on a phone they took roughly a
third of the screen before the first input box appeared — visible in the
owner's screenshot.

The edition number was in the header title so that a stale tab could be told
apart from a fresh one. That job belongs to `document.title`, which is
unchanged, and the badge beside the header still names the edition on screen.
CLAUDE.md 9.8: a name that already says what the thing is needs no gloss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)