### PR TITLE
feat: colour the bottom nav, one hue per destination

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1422,8 +1422,28 @@ input.small-input { text-align: center; }
     color: var(--tinta-lembut); font-size: .72rem; font-weight: 600;
     cursor: pointer;
   }
-  .bottom-nav-icon { font-size: 1.3rem; line-height: 1; }
-  .bottom-nav-item[aria-current="page"] { color: var(--utama); }
+  .bottom-nav-icon {
+    font-size: 1.3rem; line-height: 1;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 2.6rem; height: 1.9rem; border-radius: 999px;
+  }
+
+  /* Satu warna per tujuan. Tiga ikon abu-abu sebaris menuntut label dibaca
+     tiap kali; warna membuat jempol menemukan tujuannya tanpa membaca.
+
+     Keluar merah bukan hiasan — ia satu-satunya tombol di bar ini yang
+     mengakhiri sesi, dan warna yang menahan sedetak sebelum diketuk memang
+     yang diinginkan di sana. */
+  #nav-home    .ikon { color: var(--utama); }
+  #nav-setting .ikon { color: #6941c6; }
+  #nav-keluar  .ikon { color: var(--bahaya); }
+
+  /* Halaman yang sedang dibuka ditandai LATAR, bukan warna ikon — kalau
+     penandanya ikut warna, ia bertabrakan dengan warna tetap di atas dan
+     tidak ada lagi yang menunjukkan posisi. */
+  .bottom-nav-item[aria-current="page"] { color: var(--tinta); font-weight: 700; }
+  #nav-home[aria-current="page"]    .bottom-nav-icon { background: var(--utama-muda); }
+  #nav-setting[aria-current="page"] .bottom-nav-icon { background: #f0eafe; }
 
   /* Ruang supaya baris terakhir isi halaman tidak tertutup bar. */
   .isi { padding-bottom: 6rem; }

--- a/web/style.css
+++ b/web/style.css
@@ -1422,8 +1422,28 @@ input.small-input { text-align: center; }
     color: var(--tinta-lembut); font-size: .72rem; font-weight: 600;
     cursor: pointer;
   }
-  .bottom-nav-icon { font-size: 1.3rem; line-height: 1; }
-  .bottom-nav-item[aria-current="page"] { color: var(--utama); }
+  .bottom-nav-icon {
+    font-size: 1.3rem; line-height: 1;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 2.6rem; height: 1.9rem; border-radius: 999px;
+  }
+
+  /* Satu warna per tujuan. Tiga ikon abu-abu sebaris menuntut label dibaca
+     tiap kali; warna membuat jempol menemukan tujuannya tanpa membaca.
+
+     Keluar merah bukan hiasan — ia satu-satunya tombol di bar ini yang
+     mengakhiri sesi, dan warna yang menahan sedetak sebelum diketuk memang
+     yang diinginkan di sana. */
+  #nav-home    .ikon { color: var(--utama); }
+  #nav-setting .ikon { color: #6941c6; }
+  #nav-keluar  .ikon { color: var(--bahaya); }
+
+  /* Halaman yang sedang dibuka ditandai LATAR, bukan warna ikon — kalau
+     penandanya ikut warna, ia bertabrakan dengan warna tetap di atas dan
+     tidak ada lagi yang menunjukkan posisi. */
+  .bottom-nav-item[aria-current="page"] { color: var(--tinta); font-weight: 700; }
+  #nav-home[aria-current="page"]    .bottom-nav-icon { background: var(--utama-muda); }
+  #nav-setting[aria-current="page"] .bottom-nav-icon { background: #f0eafe; }
 
   /* Ruang supaya baris terakhir isi halaman tidak tertutup bar. */
   .isi { padding-bottom: 6rem; }


### PR DESCRIPTION
## What

The phone bottom bar: **Home** green, **Setelan** violet, **Keluar** red. The
active page is marked by a tinted pill behind its icon instead of by the icon
colour.

## Why

Three grey icons in a row make the label be read every time. A colour lets the
thumb find its target without reading — the same reason the menu tiles got
tints in #202.

**Keluar is red on purpose.** It is the only button on that bar that ends the
session, and a colour that holds you for a beat before you tap it is what
belongs there.

**The active marker had to move.** It used to be "colour the current item
green". With fixed colours per item that signal collides with them and nothing
shows where you are, so it becomes a pale pill behind the icon — the pattern
phones already use.

## Notes

Colour is not the only difference: every item keeps its written label, and the
active one is also set in a heavier weight and darker ink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)