### PR TITLE
fix: centre the table toolbar row

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -878,7 +878,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* ---------- layar tabel (Pembayaran, Daftar Ulang, Keberangkatan) ---------- */
 
 .table-toolbar {
-  display: flex; flex-wrap: wrap; align-items: flex-end; gap: .6rem;
+  /* Rata TENGAH, bukan rata bawah. flex-end masuk akal waktu kotak cari masih
+     punya label di atasnya — dasar kotak dan dasar chip berbaris rapi. Kedua
+     labelnya sekarang visually-hidden dan tidak memakan tinggi sama sekali,
+     jadi yang tersisa dari flex-end cuma "0 invoice · 0 regu" yang tergantung
+     di bawah, tidak sejajar dengan apa pun. */
+  display: flex; flex-wrap: wrap; align-items: center; gap: .6rem;
   margin-bottom: .8rem;
 }
 .table-toolbar .field { margin-bottom: 0; }

--- a/web/style.css
+++ b/web/style.css
@@ -878,7 +878,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* ---------- layar tabel (Pembayaran, Daftar Ulang, Keberangkatan) ---------- */
 
 .table-toolbar {
-  display: flex; flex-wrap: wrap; align-items: flex-end; gap: .6rem;
+  /* Rata TENGAH, bukan rata bawah. flex-end masuk akal waktu kotak cari masih
+     punya label di atasnya — dasar kotak dan dasar chip berbaris rapi. Kedua
+     labelnya sekarang visually-hidden dan tidak memakan tinggi sama sekali,
+     jadi yang tersisa dari flex-end cuma "0 invoice · 0 regu" yang tergantung
+     di bawah, tidak sejajar dengan apa pun. */
+  display: flex; flex-wrap: wrap; align-items: center; gap: .6rem;
   margin-bottom: .8rem;
 }
 .table-toolbar .field { margin-bottom: 0; }


### PR DESCRIPTION
## What

`.table-toolbar` goes from `align-items: flex-end` to `center`.

## Why

"0 invoice · 0 regu" hung below the filter chips instead of sitting level with
them.

`flex-end` was right when the search box still had a visible label above it —
the bottoms of the field and the chips lined up. Both labels are
`visually-hidden` now and take no height, so all `flex-end` still does is drop
the count to the baseline of a row it is no longer part of.

Affects the Pembayaran, Daftar Ulang and Rekapitulasi toolbars, which share the
class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)