### PR TITLE
fix: "HARUS SAMA" in bold, and stop the note hugging the card edge

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1258,7 +1258,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    nomor dada, tempat mata dan kursor berada setelah mengetik angka
    terakhir. Tombol di kiri memaksa perjalanan balik melintasi tabel. */
 .action-row-simpan { justify-content: space-between; }
-.action-row-simpan .sub { flex: 1; min-width: 12rem; }
+/* Sejajar dengan teks di dalam tabel di atasnya, bukan dengan tepi kartu.
+   Sel tabel punya padding sendiri, jadi keterangan yang tidak punya padding
+   apa pun mulai lebih kiri daripada seluruh kolom di atasnya dan terbaca
+   seperti jatuh keluar dari tabelnya. Hanya KIRI yang diberi jarak: tombol
+   Simpan di kanan sengaja berbaris dengan kolom Nomor Dada, dan padding
+   kanan akan menggesernya keluar dari barisan itu. */
+.action-row-simpan .sub { flex: 1; min-width: 12rem; padding-left: .5rem; }
 /* Tombol Simpan selebar kolom Nomor Dada (28%) supaya titik tengahnya jatuh
    segaris dengan kotak-kotak isian di atasnya — satu pita lurus dari tombol
    "Isi N Nomor Dada", turun ke kotak isian, turun ke tombol Simpan. Dulu

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -889,8 +889,8 @@ async function layarDaftarUlang() {
               </tbody>
             </table>
             <div class="action-row action-row-simpan" style="margin-top:.6rem">
-              <span class="sub">Nomor dada yang diinput harus SAMA dengan
-                yang diberikan ke regunya.</span>
+              <span class="sub">Nomor dada yang diinput <strong>HARUS SAMA</strong>
+                dengan yang diberikan ke regunya.</span>
               <button class="button button-primary button-small" type="button"
                       data-simpan-dada="${kode}">Simpan ${menunggu.length} Nomor Dada</button>
             </div>

--- a/web/style.css
+++ b/web/style.css
@@ -1258,7 +1258,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    nomor dada, tempat mata dan kursor berada setelah mengetik angka
    terakhir. Tombol di kiri memaksa perjalanan balik melintasi tabel. */
 .action-row-simpan { justify-content: space-between; }
-.action-row-simpan .sub { flex: 1; min-width: 12rem; }
+/* Sejajar dengan teks di dalam tabel di atasnya, bukan dengan tepi kartu.
+   Sel tabel punya padding sendiri, jadi keterangan yang tidak punya padding
+   apa pun mulai lebih kiri daripada seluruh kolom di atasnya dan terbaca
+   seperti jatuh keluar dari tabelnya. Hanya KIRI yang diberi jarak: tombol
+   Simpan di kanan sengaja berbaris dengan kolom Nomor Dada, dan padding
+   kanan akan menggesernya keluar dari barisan itu. */
+.action-row-simpan .sub { flex: 1; min-width: 12rem; padding-left: .5rem; }
 /* Tombol Simpan selebar kolom Nomor Dada (28%) supaya titik tengahnya jatuh
    segaris dengan kotak-kotak isian di atasnya — satu pita lurus dari tombol
    "Isi N Nomor Dada", turun ke kotak isian, turun ke tombol Simpan. Dulu


### PR DESCRIPTION
## What

On Daftar Ulang, the footer note under the nomor dada table:

- **HARUS SAMA** is now bold
- the note gets `padding-left: .5rem` so it lines up with the table above it

## Why

The nomor dada is typed by panitia from the physical cloth, not issued by the
system (migration `0011`). A number that drifts from the cloth corrupts that
regu's data for the rest of the day — so the words carrying the warning are
the words that should be heavy.

The note started further left than every column above it because table cells
carry their own padding and it carried none. It read as though it had fallen
out of the table.

## Notes

Only the left side is padded. The Simpan button on the right is deliberately
sized to 28% so its centre lands under the Nomor Dada column — padding on the
right would push it out of that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)