### PR TITLE
fix: shorter filter names on Daftar Ulang, and keep the count on the chip row

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2231,3 +2231,15 @@ input.small-input { text-align: center; }
 @media print {
   .ikon-kotak { background: none !important; color: #000 !important; }
 }
+
+/* Chip saringan dan hitungan barisnya adalah SATU baris, dan tetap satu baris
+   waktu toolbar-nya patah di layar sempit.
+
+   Sebelumnya keduanya anak langsung .table-toolbar, jadi di HP mereka jatuh ke
+   baris berbeda dan angkanya menggantung sendirian di baris ketiga, rata
+   kanan, tidak sejajar dengan apa pun. Dibungkus begini, angkanya selalu
+   duduk setinggi chip yang dihitungnya. */
+.filter-baris {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .6rem; flex: 1 1 auto; min-width: 0; flex-wrap: wrap;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -351,12 +351,14 @@ function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "", kanan
         <input type="text" id="cari-tabel" autocomplete="off"
                placeholder="${esc(cariContoh || "Cari kode, sekolah, atau nama regu…")}">
       </div>
-      <div class="filter-row">
-        ${saringan.map(s => `
-          <button type="button" class="option option-small" data-saring="${esc(s.kode)}"
-                  aria-pressed="${s.kode === saringAktif}">${esc(s.label)}</button>`).join("")}
+      <div class="filter-baris">
+        <div class="filter-row">
+          ${saringan.map(s => `
+            <button type="button" class="option option-small" data-saring="${esc(s.kode)}"
+                    aria-pressed="${s.kode === saringAktif}">${esc(s.label)}</button>`).join("")}
+        </div>
+        <span class="table-count" id="tabel-jumlah">${jumlah} baris</span>
       </div>
-      <span class="table-count" id="tabel-jumlah">${jumlah} baris</span>
       ${kanan}
     </div>`;
 }
@@ -783,9 +785,9 @@ async function layarDaftarUlang() {
     <div class="card">
       ${alatTabel({
         saringan: [
-          { kode: "belum", label: "Belum dapat nomor" },
-          { kode: "sudah", label: "Sudah" },
-          { kode: "semua", label: "Semua yang lunas" },
+          { kode: "belum", label: "Perlu Nomor Dada" },
+          { kode: "sudah", label: "Selesai" },
+          { kode: "semua", label: "Semua" },
         ],
         saringAktif: "belum",
         jumlah: semua.length,

--- a/web/style.css
+++ b/web/style.css
@@ -2231,3 +2231,15 @@ input.small-input { text-align: center; }
 @media print {
   .ikon-kotak { background: none !important; color: #000 !important; }
 }
+
+/* Chip saringan dan hitungan barisnya adalah SATU baris, dan tetap satu baris
+   waktu toolbar-nya patah di layar sempit.
+
+   Sebelumnya keduanya anak langsung .table-toolbar, jadi di HP mereka jatuh ke
+   baris berbeda dan angkanya menggantung sendirian di baris ketiga, rata
+   kanan, tidak sejajar dengan apa pun. Dibungkus begini, angkanya selalu
+   duduk setinggi chip yang dihitungnya. */
+.filter-baris {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .6rem; flex: 1 1 auto; min-width: 0; flex-wrap: wrap;
+}


### PR DESCRIPTION
## What

| was | now |
|---|---|
| Belum dapat nomor | **Perlu Nomor Dada** |
| Sudah | **Selesai** |
| Semua yang lunas | **Semua** |

The `N baris` count now sits inside a wrapper with the chips instead of being a
sibling of the whole toolbar.

## Why

The old labels named a *state*; the new ones name the *work*. At that desk the
choice is "which pile am I working through", and "Perlu Nomor Dada" answers it
in the words the job is described in.

On a phone the count was falling to a third line of its own, right-aligned and
level with nothing — visible in the owner's screenshot. Wrapped with the chips
it counts, it stays beside them at every width.

`align-items: center` on the toolbar (#208) fixed the desktop case; this fixes
the wrapped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)