### PR TITLE
fix: lift the toast above the bottom bar and let it fill the width

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -464,6 +464,24 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .notification { transition: opacity .35s ease; }
 .notification.pudar { opacity: 0; }
 
+/* Di HP, pesan ini muncul TEPAT DI ATAS bar bawah, hampir selebar layar.
+
+   Sebelumnya ia pil sempit di `bottom: 1.2rem` — yaitu DI BELAKANG bar Home /
+   Setelan / Keluar, yang tingginya 56px dan menempel di dasar layar. Pesan
+   terpenting di aplikasi ini ("nomor dada sudah dipakai regu lain") separuh
+   tertutup tombol Keluar.
+   
+   Selebar layar bukan soal selera: pesannya menyebut DAFTAR nomor, dan pil
+   yang menyempit ke lebar isinya memecah daftar itu jadi dua baris pendek di
+   tengah layar yang kosong di kiri-kanannya. */
+@media (max-width: 560px) {
+  .notification {
+    left: .75rem; right: .75rem; transform: none; max-width: none;
+    bottom: calc(56px + env(safe-area-inset-bottom) + .75rem);
+  }
+  .notification-close { margin-left: auto; }
+}
+
 /* ---------- menu beranda meja ---------- */
 
 .function-menu { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }

--- a/web/style.css
+++ b/web/style.css
@@ -464,6 +464,24 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .notification { transition: opacity .35s ease; }
 .notification.pudar { opacity: 0; }
 
+/* Di HP, pesan ini muncul TEPAT DI ATAS bar bawah, hampir selebar layar.
+
+   Sebelumnya ia pil sempit di `bottom: 1.2rem` — yaitu DI BELAKANG bar Home /
+   Setelan / Keluar, yang tingginya 56px dan menempel di dasar layar. Pesan
+   terpenting di aplikasi ini ("nomor dada sudah dipakai regu lain") separuh
+   tertutup tombol Keluar.
+   
+   Selebar layar bukan soal selera: pesannya menyebut DAFTAR nomor, dan pil
+   yang menyempit ke lebar isinya memecah daftar itu jadi dua baris pendek di
+   tengah layar yang kosong di kiri-kanannya. */
+@media (max-width: 560px) {
+  .notification {
+    left: .75rem; right: .75rem; transform: none; max-width: none;
+    bottom: calc(56px + env(safe-area-inset-bottom) + .75rem);
+  }
+  .notification-close { margin-left: auto; }
+}
+
 /* ---------- menu beranda meja ---------- */
 
 .function-menu { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }


### PR DESCRIPTION
## What

On screens ≤560px the notification toast moves to
`bottom: calc(56px + env(safe-area-inset-bottom) + .75rem)` and spans
`left/right: .75rem` instead of being a centred pill.

## Why

It sat at `bottom: 1.2rem` — **behind** the Home / Setelan / Keluar bar, which
is 56px tall and pinned to the floor. The most important message this app
produces, `Nomor dada sudah dipakai regu lain: 1, 2`, was half covered by the
Keluar button. Visible in the owner's screenshot.

Full width is not taste either: that message carries a *list* of numbers, and a
pill that shrinks to its content broke the list across two short lines floating
in the middle of an otherwise empty row.

## Notes

Desktop is unchanged — there is no bottom bar there and nothing to clear, so
the centred pill still reads as a toast rather than a banner.

`env(safe-area-inset-bottom)` is included because the bar already reserves it;
without it the toast would sit right on the gesture area on newer phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)