### PR TITLE
feat: notifications as a card with a coloured icon badge

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -437,8 +437,10 @@ export function notif(pesan, galat = false) {
   // tanpa perlu menyentuh belasan `raise exception` di migrasi.
   const kalimat = String(pesan).charAt(0).toUpperCase() + String(pesan).slice(1);
   const n = h(`<div class="notification ${galat ? "error" : ""}" role="alert">
-      <span>${esc(kalimat)}</span>
-      ${galat ? '<button class="notification-close" type="button" aria-label="tutup">✕</button>' : ""}
+      <span class="notif-ikon">${ikon(galat ? "circle-alert" : "circle-check-big")}</span>
+      <span class="notif-teks">${esc(kalimat)}</span>
+      ${galat ? `<button class="notification-close" type="button" aria-label="tutup">${
+        ikon("x")}</button>` : ""}
     </div>`);
   document.body.appendChild(n);
   const el = document.body.lastElementChild;
@@ -626,6 +628,12 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "circle-alert":
+    '<circle cx="12" cy="12" r="10" /> <line x1="12" x2="12" y1="8" y2="12" /> <line x1="12" x2="12.01" y1="16" y2="16" />',
+  "circle-check-big":
+    '<path d="M21.801 10A10 10 0 1 1 17 3.335" /> <path d="m9 11 3 3L22 4" />',
+  "x":
+    '<path d="M18 6 6 18" /> <path d="m6 6 12 12" />',
   "chart-column":
     '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
   "circle-check":

--- a/live/style.css
+++ b/live/style.css
@@ -443,20 +443,42 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* ---------- notifikasi ---------- */
 
+/* Kartu putih dengan lencana ikon berwarna, bukan blok merah pekat.
+
+   Bukan sekadar selera: pesan ini dibaca sambil berdiri di bawah matahari,
+   dan tulisan putih di atas merah jenuh justru paling cepat hilang di layar
+   yang silau. Tinta gelap di atas putih terbaca jauh lebih lama.
+
+   Yang menandai galat tetap merah — lingkaran seru dan tepi kartunya — jadi
+   sifatnya dikenali sebelum satu kata pun dibaca, sementara kata-katanya
+   sendiri tetap terbaca. Warna menandai, tulisan menjelaskan; keduanya tidak
+   perlu memperebutkan permukaan yang sama. */
 .notification {
   position: fixed;
   left: 50%; bottom: 1.2rem;
   transform: translateX(-50%);
-  background: var(--tinta);
-  color: #fff;
-  padding: .8rem 1.4rem;
-  border-radius: var(--radius);
+  background: var(--kartu);
+  color: var(--tinta);
+  border: 1px solid var(--garis);
+  padding: .75rem .9rem;
+  border-radius: var(--radius-kecil);
   font-weight: 600;
-  box-shadow: var(--bayang);
+  /* Lebih pekat daripada bayangan kartu biasa: benda ini melayang DI ATAS
+     halaman, dan bayangan yang sama dengan kartu di bawahnya membuatnya
+     terbaca seperti bagian dari halaman itu. */
+  box-shadow: 0 4px 10px rgba(16,24,40,.07), 0 18px 40px rgba(16,24,40,.16);
   z-index: 50;
   max-width: 92vw;
 }
-.notification.error { background: var(--bahaya); }
+.notif-ikon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 2rem; height: 2rem; border-radius: 9px; flex: 0 0 auto;
+  background: var(--utama-muda); color: var(--utama);
+}
+.notif-ikon .ikon { width: 1.15rem; height: 1.15rem; }
+.notif-teks { flex: 1 1 auto; min-width: 0; }
+.notification.error { border-color: #f3c6c6; }
+.notification.error .notif-ikon { background: var(--bahaya-muda); color: var(--bahaya); }
 /* Memudar sebelum dibuang (lihat notif() di util.js). Transisinya dipatok di
    sini, bukan di JavaScript, supaya aturan prefers-reduced-motion di bawah
    berkas ini ikut mematikannya — di sana `transition: none` membuat pesannya
@@ -544,12 +566,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   box-shadow: 0 10px 40px rgba(0,0,0,.3);
 }
 .dialog h2 { margin-bottom: .8rem; }
-.notification { display: flex; align-items: center; gap: .8rem; }
+.notification { display: flex; align-items: center; gap: .7rem; }
 .notification-close {
-  background: rgba(255,255,255,.25); color: #fff;
-  border: 0; border-radius: 8px;
-  min-width: 36px; min-height: 36px; font-size: 1rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: none; color: var(--tinta-lembut);
+  border: 0; border-radius: 8px; cursor: pointer;
+  min-width: 36px; min-height: 36px; flex: 0 0 auto;
 }
+.notification-close:hover { background: var(--kertas); color: var(--tinta); }
+.notification-close .ikon { width: 1.05rem; height: 1.05rem; }
 
 /* ---------- cetak: hanya kwitansi yang ikut tercetak ---------- */
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -437,8 +437,10 @@ export function notif(pesan, galat = false) {
   // tanpa perlu menyentuh belasan `raise exception` di migrasi.
   const kalimat = String(pesan).charAt(0).toUpperCase() + String(pesan).slice(1);
   const n = h(`<div class="notification ${galat ? "error" : ""}" role="alert">
-      <span>${esc(kalimat)}</span>
-      ${galat ? '<button class="notification-close" type="button" aria-label="tutup">✕</button>' : ""}
+      <span class="notif-ikon">${ikon(galat ? "circle-alert" : "circle-check-big")}</span>
+      <span class="notif-teks">${esc(kalimat)}</span>
+      ${galat ? `<button class="notification-close" type="button" aria-label="tutup">${
+        ikon("x")}</button>` : ""}
     </div>`);
   document.body.appendChild(n);
   const el = document.body.lastElementChild;
@@ -626,6 +628,12 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "circle-alert":
+    '<circle cx="12" cy="12" r="10" /> <line x1="12" x2="12" y1="8" y2="12" /> <line x1="12" x2="12.01" y1="16" y2="16" />',
+  "circle-check-big":
+    '<path d="M21.801 10A10 10 0 1 1 17 3.335" /> <path d="m9 11 3 3L22 4" />',
+  "x":
+    '<path d="M18 6 6 18" /> <path d="m6 6 12 12" />',
   "chart-column":
     '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
   "circle-check":

--- a/web/style.css
+++ b/web/style.css
@@ -443,20 +443,42 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* ---------- notifikasi ---------- */
 
+/* Kartu putih dengan lencana ikon berwarna, bukan blok merah pekat.
+
+   Bukan sekadar selera: pesan ini dibaca sambil berdiri di bawah matahari,
+   dan tulisan putih di atas merah jenuh justru paling cepat hilang di layar
+   yang silau. Tinta gelap di atas putih terbaca jauh lebih lama.
+
+   Yang menandai galat tetap merah — lingkaran seru dan tepi kartunya — jadi
+   sifatnya dikenali sebelum satu kata pun dibaca, sementara kata-katanya
+   sendiri tetap terbaca. Warna menandai, tulisan menjelaskan; keduanya tidak
+   perlu memperebutkan permukaan yang sama. */
 .notification {
   position: fixed;
   left: 50%; bottom: 1.2rem;
   transform: translateX(-50%);
-  background: var(--tinta);
-  color: #fff;
-  padding: .8rem 1.4rem;
-  border-radius: var(--radius);
+  background: var(--kartu);
+  color: var(--tinta);
+  border: 1px solid var(--garis);
+  padding: .75rem .9rem;
+  border-radius: var(--radius-kecil);
   font-weight: 600;
-  box-shadow: var(--bayang);
+  /* Lebih pekat daripada bayangan kartu biasa: benda ini melayang DI ATAS
+     halaman, dan bayangan yang sama dengan kartu di bawahnya membuatnya
+     terbaca seperti bagian dari halaman itu. */
+  box-shadow: 0 4px 10px rgba(16,24,40,.07), 0 18px 40px rgba(16,24,40,.16);
   z-index: 50;
   max-width: 92vw;
 }
-.notification.error { background: var(--bahaya); }
+.notif-ikon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 2rem; height: 2rem; border-radius: 9px; flex: 0 0 auto;
+  background: var(--utama-muda); color: var(--utama);
+}
+.notif-ikon .ikon { width: 1.15rem; height: 1.15rem; }
+.notif-teks { flex: 1 1 auto; min-width: 0; }
+.notification.error { border-color: #f3c6c6; }
+.notification.error .notif-ikon { background: var(--bahaya-muda); color: var(--bahaya); }
 /* Memudar sebelum dibuang (lihat notif() di util.js). Transisinya dipatok di
    sini, bukan di JavaScript, supaya aturan prefers-reduced-motion di bawah
    berkas ini ikut mematikannya — di sana `transition: none` membuat pesannya
@@ -544,12 +566,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   box-shadow: 0 10px 40px rgba(0,0,0,.3);
 }
 .dialog h2 { margin-bottom: .8rem; }
-.notification { display: flex; align-items: center; gap: .8rem; }
+.notification { display: flex; align-items: center; gap: .7rem; }
 .notification-close {
-  background: rgba(255,255,255,.25); color: #fff;
-  border: 0; border-radius: 8px;
-  min-width: 36px; min-height: 36px; font-size: 1rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: none; color: var(--tinta-lembut);
+  border: 0; border-radius: 8px; cursor: pointer;
+  min-width: 36px; min-height: 36px; flex: 0 0 auto;
 }
+.notification-close:hover { background: var(--kertas); color: var(--tinta); }
+.notification-close .ikon { width: 1.05rem; height: 1.05rem; }
 
 /* ---------- cetak: hanya kwitansi yang ikut tercetak ---------- */
 


### PR DESCRIPTION
## What

The toast becomes a white card: a tinted icon badge on the left, dark text, a
quiet outline ✕, and a heavier shadow. Errors take a red alert circle and a
red-tinted edge; confirmations take a green check.

## Why

A saturated red block with white text is the first thing to disappear on a
phone screen in direct sun — and these are read standing outdoors, at a pos.
Dark ink on white survives that.

What marks it as an error stays red: the alert circle and the card edge. The
nature of the message is recognised before a word is read, while the words
themselves stay legible. Colour marks, text explains — they do not have to
fight over the same surface.

## Notes

The close button loses its white slab and becomes an outline ✕ that only
shades on hover, so it stops competing with the icon for attention.

The shadow is deliberately heavier than a card's. This floats above the page,
and wearing the same shadow as the cards underneath made it read as part of
them.

Builds on #212, which lifted the toast clear of the phone bottom bar and let
it fill the width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)