### PR TITLE
fix: Daftar Kloter card down to two totals

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -628,6 +628,8 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "printer":
+    '<path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /> <path d="M6 9V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v6" /> <rect x="6" y="14" width="12" height="8" rx="1" />',
   "circle-alert":
     '<circle cx="12" cy="12" r="10" /> <line x1="12" x2="12" y1="8" y2="12" /> <line x1="12" x2="12.01" y1="16" y2="16" />',
   "circle-check-big":

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1456,24 +1456,19 @@ async function layarCetakKloter() {
   };
 
   let perKloter = kelompokkan(baris);
-  const belum = [...perKloter.entries()].filter(([, v]) => !v.dicetak).length;
 
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
-      <h2>Daftar kloter untuk garis start</h2>
-      <p class="description">Setelah dicetak, isi kloter <strong>dibekukan</strong>. Sekolah yang daftar ulang setelah ini masuk
-         kloter cadangan dan dicetak sebagai lembar tambahan.</p>
-      <table class="table" style="margin-top:.6rem">
-        <tr><td>Kloter berisi regu</td><td class="angka">${perKloter.size}</td></tr>
-        <tr><td>Belum pernah dicetak</td><td class="angka">${belum}</td></tr>
-        <tr><td>Total regu</td><td class="angka">${baris.length}</td></tr>
+      <table class="table">
+        <tr><td>Total Kloter</td><td class="angka">${perKloter.size}</td></tr>
+        <tr><td>Total Regu</td><td class="angka">${baris.length}</td></tr>
       </table>
       <div class="option-row" style="margin-top:.9rem">
         <button class="button button-primary" id="cetak-petugas" type="button">
-          🖨️ Cetak Kloter untuk Petugas
+          ${ikon("printer")} Cetak Kloter untuk Petugas
         </button>
         <button class="button button-primary" id="cetak-peserta" type="button">
-          🖨️ Cetak Kloter untuk Peserta
+          ${ikon("printer")} Cetak Kloter untuk Peserta
         </button>
       </div>
     </div>

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -628,6 +628,8 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "printer":
+    '<path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /> <path d="M6 9V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v6" /> <rect x="6" y="14" width="12" height="8" rx="1" />',
   "circle-alert":
     '<circle cx="12" cy="12" r="10" /> <line x1="12" x2="12" y1="8" y2="12" /> <line x1="12" x2="12.01" y1="16" y2="16" />',
   "circle-check-big":


### PR DESCRIPTION
## What

The summary card on Daftar Kloter loses its heading and its paragraph, and
reports two numbers instead of three:

```
Total Kloter   12
Total Regu     53
```

The two print buttons take the printer line icon instead of 🖨️.

## Why

The heading repeated the screen title one line above it — CLAUDE.md 9.8.

The freeze paragraph goes on the owner's own ground: **the sheets are printed
H-1**, when the roster has already settled. A caution about schools
registering afterwards landing in the reserve describes something that does
not happen in practice. The behaviour is unchanged and still documented in the
migration header; it just stops being read aloud to someone who has printed
this sheet every year.

I had kept that sentence during the text sweep, arguing it was an irreversible
consequence rather than instruction. That was right about the rule and wrong
about the event — which is the sort of thing only the person running it knows.

**"Belum pernah dicetak" goes with it.** It only mattered as a companion to
that warning. Each kloter already carries its own `sudah dicetak` badge in the
list below, which is where the person deciding what to print is looking.

## Notes

The `belum` variable that fed that row is removed rather than left computing a
number nobody reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)