### PR TITLE
fix: read every clock in WIB, and 24-hour boxes in the correction dialog

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -60,17 +60,43 @@ const BULAN = ["Januari", "Februari", "Maret", "April", "Mei", "Juni",
 const dua = (n) => String(n).padStart(2, "0");
 
 /** "15:30" — 24 jam. Kosong jadi "—", bukan "NaN:NaN". */
+/* SEMUA jam di layar dibaca dalam WIB, apa pun zona waktu alatnya.
+
+   Sebelumnya getHours() dipakai apa adanya, yang berarti jam yang tampil
+   adalah jam ALAT. Laptop meja IT yang zonanya UTC menampilkan 01:53 untuk
+   pukul 08:53 WIB — dan kotak "Jam berangkat" terisi angka itu sebagai
+   tebakan awal, lalu ditekan panitia yang sedang terburu-buru.
+
+   Jam berangkat menentukan penalti seluruh regu di kloter itu. Tujuh jam
+   meleset bukan salah tampilan; itu seluruh kloter dihitung salah.
+
+   Asia/Jakarta ditulis eksplisit, bukan diserahkan ke locale: satu alat yang
+   zonanya keliru cukup untuk merusak satu kloter, dan tidak ada seorang pun
+   yang akan memeriksa setelan zona waktu laptop pinjaman pada pukul enam
+   pagi. */
+const ZONA = "Asia/Jakarta";
+const FMT_JAM = new Intl.DateTimeFormat("en-GB", {
+  timeZone: ZONA, hour: "2-digit", minute: "2-digit", hour12: false,
+});
+const FMT_TANGGAL = new Intl.DateTimeFormat("en-GB", {
+  timeZone: ZONA, day: "numeric", month: "numeric", year: "numeric",
+});
+
 export function jamMenit(t) {
   if (!t) return "—";
-  const d = new Date(t);
-  return `${dua(d.getHours())}:${dua(d.getMinutes())}`;
+  return FMT_JAM.format(new Date(t));
 }
 
 /** "17 Agustus 2026" */
 export function tanggalPanjang(t) {
   if (!t) return "—";
-  const d = new Date(t);
-  return `${d.getDate()} ${BULAN[d.getMonth()]} ${d.getFullYear()}`;
+  // Tanggalnya WIB juga, bukan cuma jamnya. tanggalJam() menggabung keduanya,
+  // dan menjelang tengah malam tanggal alat dan jam WIB bisa menunjuk hari
+  // yang berbeda — riwayat yang berbunyi "16 Agustus 06:10" untuk kejadian
+  // tanggal 17 lebih buruk daripada tidak ada tanggal sama sekali.
+  const bagian = {};
+  for (const b of FMT_TANGGAL.formatToParts(new Date(t))) bagian[b.type] = b.value;
+  return `${Number(bagian.day)} ${BULAN[Number(bagian.month) - 1]} ${bagian.year}`;
 }
 
 /** "17 Agustus 2026 15:30" */
@@ -483,10 +509,12 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
         ${kartuHtml}
         ${medan.map((m, i) => `
           <div class="field">
-            <label for="dlg-${i}">${esc(m.label)}</label>
-            <input id="dlg-${i}" type="${m.tipe || "text"}"
+            <label for="dlg-${i}${m.tipe === "jam" ? "-hh" : ""}">${esc(m.label)}</label>
+            ${m.tipe === "jam"
+              ? kotakJamHtml(`dlg-${i}`, m.nilai ?? "")
+              : `<input id="dlg-${i}" type="${m.tipe || "text"}"
                    inputmode="${m.tipe === "number" ? "numeric" : "text"}"
-                   value="${esc(m.nilai ?? "")}" placeholder="${esc(m.contoh ?? "")}">
+                   value="${esc(m.nilai ?? "")}" placeholder="${esc(m.contoh ?? "")}">`}
             ${m.bantuan ? `<div class="hint">${esc(m.bantuan)}</div>` : ""}
           </div>`).join("")}
         <div class="dialog-error error" hidden></div>
@@ -497,17 +525,45 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
         </div>
       </div>`;
 
+    /* tipe "jam" memakai kotak HH:MM buatan sendiri, BUKAN <input type="time">.
+       Pemilih bawaan browser mengikuti locale alatnya, jadi HP berbahasa
+       Inggris menampilkan "07:00 AM" — dan panitia mencatat jam berangkat
+       dalam format 24 jam di kertas. Dua format untuk satu angka adalah cara
+       07:00 dan 19:00 tertukar. */
+    const jamPasang = {};
+    medan.forEach((m, i) => {
+      if (m.tipe === "jam") jamPasang[i] = pasangKotakJam(`dlg-${i}`);
+    });
+
     const tutup = hasil => { el.remove(); resolve(hasil); };
     el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });
     el.querySelector("[data-ok]").addEventListener("click", () => {
-      const nilai = medan.map((_, i) => el.querySelector(`#dlg-${i}`).value.trim());
+      const nilai = medan.map((m, i) => m.tipe === "jam"
+        ? (jamPasang[i]?.nilai() ?? "")
+        : el.querySelector(`#dlg-${i}`).value.trim());
+
+      // Jam yang TERISI TAPI TIDAK MASUK AKAL harus ditolak dengan kalimatnya
+      // sendiri. Tanpa ini "99:99" jatuh ke cabang "wajib diisi" — nilai()
+      // mengembalikan null untuk jam ngawur maupun kotak kosong, dan pesan
+      // "wajib diisi" di atas kotak yang jelas-jelas terisi membingungkan.
+      const jamNgawur = medan.findIndex((m, i) => m.tipe === "jam"
+        && !nilai[i] && !jamPasang[i]?.kosong());
+      if (jamNgawur >= 0) {
+        const g = el.querySelector(".dialog-error");
+        g.textContent = `${medan[jamNgawur].label} di luar 00:00–23:59.`;
+        g.hidden = false;
+        jamPasang[jamNgawur].fokus();
+        return;
+      }
+
       const kosong = medan.findIndex((m, i) => m.wajib !== false && !nilai[i]);
       if (kosong >= 0) {
         const g = el.querySelector(".dialog-error");
         g.textContent = `${medan[kosong].label} wajib diisi.`;
         g.hidden = false;
-        el.querySelector(`#dlg-${kosong}`).focus();
+        if (medan[kosong].tipe === "jam") jamPasang[kosong].fokus();
+        else el.querySelector(`#dlg-${kosong}`).focus();
         return;
       }
       tutup(nilai);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1371,9 +1371,9 @@ async function layarKeberangkatan() {
             seluruh regu di Kloter ${kloterAktif}.${tetangga ? ` ${tetangga}.` : ""}</div>
         </div>`,
         medan: [
-          { label: "Jam berangkat yang benar", tipe: "time",
+          { label: "Jam berangkat yang benar", tipe: "jam",
             nilai: jamMenit(info.jam_berangkat) },
-          { label: "Alasan koreksi" },
+          { label: "Alasan koreksi", contoh: "salah input" },
         ],
         labelAksi: "Simpan Koreksi",
       });

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -60,17 +60,43 @@ const BULAN = ["Januari", "Februari", "Maret", "April", "Mei", "Juni",
 const dua = (n) => String(n).padStart(2, "0");
 
 /** "15:30" — 24 jam. Kosong jadi "—", bukan "NaN:NaN". */
+/* SEMUA jam di layar dibaca dalam WIB, apa pun zona waktu alatnya.
+
+   Sebelumnya getHours() dipakai apa adanya, yang berarti jam yang tampil
+   adalah jam ALAT. Laptop meja IT yang zonanya UTC menampilkan 01:53 untuk
+   pukul 08:53 WIB — dan kotak "Jam berangkat" terisi angka itu sebagai
+   tebakan awal, lalu ditekan panitia yang sedang terburu-buru.
+
+   Jam berangkat menentukan penalti seluruh regu di kloter itu. Tujuh jam
+   meleset bukan salah tampilan; itu seluruh kloter dihitung salah.
+
+   Asia/Jakarta ditulis eksplisit, bukan diserahkan ke locale: satu alat yang
+   zonanya keliru cukup untuk merusak satu kloter, dan tidak ada seorang pun
+   yang akan memeriksa setelan zona waktu laptop pinjaman pada pukul enam
+   pagi. */
+const ZONA = "Asia/Jakarta";
+const FMT_JAM = new Intl.DateTimeFormat("en-GB", {
+  timeZone: ZONA, hour: "2-digit", minute: "2-digit", hour12: false,
+});
+const FMT_TANGGAL = new Intl.DateTimeFormat("en-GB", {
+  timeZone: ZONA, day: "numeric", month: "numeric", year: "numeric",
+});
+
 export function jamMenit(t) {
   if (!t) return "—";
-  const d = new Date(t);
-  return `${dua(d.getHours())}:${dua(d.getMinutes())}`;
+  return FMT_JAM.format(new Date(t));
 }
 
 /** "17 Agustus 2026" */
 export function tanggalPanjang(t) {
   if (!t) return "—";
-  const d = new Date(t);
-  return `${d.getDate()} ${BULAN[d.getMonth()]} ${d.getFullYear()}`;
+  // Tanggalnya WIB juga, bukan cuma jamnya. tanggalJam() menggabung keduanya,
+  // dan menjelang tengah malam tanggal alat dan jam WIB bisa menunjuk hari
+  // yang berbeda — riwayat yang berbunyi "16 Agustus 06:10" untuk kejadian
+  // tanggal 17 lebih buruk daripada tidak ada tanggal sama sekali.
+  const bagian = {};
+  for (const b of FMT_TANGGAL.formatToParts(new Date(t))) bagian[b.type] = b.value;
+  return `${Number(bagian.day)} ${BULAN[Number(bagian.month) - 1]} ${bagian.year}`;
 }
 
 /** "17 Agustus 2026 15:30" */
@@ -483,10 +509,12 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
         ${kartuHtml}
         ${medan.map((m, i) => `
           <div class="field">
-            <label for="dlg-${i}">${esc(m.label)}</label>
-            <input id="dlg-${i}" type="${m.tipe || "text"}"
+            <label for="dlg-${i}${m.tipe === "jam" ? "-hh" : ""}">${esc(m.label)}</label>
+            ${m.tipe === "jam"
+              ? kotakJamHtml(`dlg-${i}`, m.nilai ?? "")
+              : `<input id="dlg-${i}" type="${m.tipe || "text"}"
                    inputmode="${m.tipe === "number" ? "numeric" : "text"}"
-                   value="${esc(m.nilai ?? "")}" placeholder="${esc(m.contoh ?? "")}">
+                   value="${esc(m.nilai ?? "")}" placeholder="${esc(m.contoh ?? "")}">`}
             ${m.bantuan ? `<div class="hint">${esc(m.bantuan)}</div>` : ""}
           </div>`).join("")}
         <div class="dialog-error error" hidden></div>
@@ -497,17 +525,45 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
         </div>
       </div>`;
 
+    /* tipe "jam" memakai kotak HH:MM buatan sendiri, BUKAN <input type="time">.
+       Pemilih bawaan browser mengikuti locale alatnya, jadi HP berbahasa
+       Inggris menampilkan "07:00 AM" — dan panitia mencatat jam berangkat
+       dalam format 24 jam di kertas. Dua format untuk satu angka adalah cara
+       07:00 dan 19:00 tertukar. */
+    const jamPasang = {};
+    medan.forEach((m, i) => {
+      if (m.tipe === "jam") jamPasang[i] = pasangKotakJam(`dlg-${i}`);
+    });
+
     const tutup = hasil => { el.remove(); resolve(hasil); };
     el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });
     el.querySelector("[data-ok]").addEventListener("click", () => {
-      const nilai = medan.map((_, i) => el.querySelector(`#dlg-${i}`).value.trim());
+      const nilai = medan.map((m, i) => m.tipe === "jam"
+        ? (jamPasang[i]?.nilai() ?? "")
+        : el.querySelector(`#dlg-${i}`).value.trim());
+
+      // Jam yang TERISI TAPI TIDAK MASUK AKAL harus ditolak dengan kalimatnya
+      // sendiri. Tanpa ini "99:99" jatuh ke cabang "wajib diisi" — nilai()
+      // mengembalikan null untuk jam ngawur maupun kotak kosong, dan pesan
+      // "wajib diisi" di atas kotak yang jelas-jelas terisi membingungkan.
+      const jamNgawur = medan.findIndex((m, i) => m.tipe === "jam"
+        && !nilai[i] && !jamPasang[i]?.kosong());
+      if (jamNgawur >= 0) {
+        const g = el.querySelector(".dialog-error");
+        g.textContent = `${medan[jamNgawur].label} di luar 00:00–23:59.`;
+        g.hidden = false;
+        jamPasang[jamNgawur].fokus();
+        return;
+      }
+
       const kosong = medan.findIndex((m, i) => m.wajib !== false && !nilai[i]);
       if (kosong >= 0) {
         const g = el.querySelector(".dialog-error");
         g.textContent = `${medan[kosong].label} wajib diisi.`;
         g.hidden = false;
-        el.querySelector(`#dlg-${kosong}`).focus();
+        if (medan[kosong].tipe === "jam") jamPasang[kosong].fokus();
+        else el.querySelector(`#dlg-${kosong}`).focus();
         return;
       }
       tutup(nilai);


### PR DESCRIPTION
## What

- `jamMenit()` and `tanggalPanjang()` format in **Asia/Jakarta** instead of the
  device's timezone.
- `dialog()` learns a `tipe: "jam"` field that renders the app's own HH:MM
  boxes; the jam-berangkat correction dialog uses it instead of
  `<input type="time">`.
- That dialog's reason field gets `salah input` back as a placeholder.

## Why

`jamMenit()` used `getHours()`, which is the **device's** timezone. A laptop
set to UTC showed `01:53` for 08:53 WIB — and that number was pre-filled into
the *Jam berangkat* box as the opening guess, for a panitia in a hurry. Visible
in the owner's screenshot.

Jam berangkat decides the time penalty for every regu in that kloter. Seven
hours out is not a display bug; it is a whole kloter scored wrong.

`Asia/Jakarta` is written explicitly rather than left to the locale. One
mis-set device is enough to ruin a kloter, and nobody checks the timezone of a
borrowed laptop at six in the morning.

`tanggalPanjang` follows because `tanggalJam` joins the two, and near midnight
the device's date and the WIB hour point at different days.

**The correction dialog** used `<input type="time">`, whose native picker
follows the device locale and rendered `07:00 AM`. `dialog()` now knows a `jam`
type using the same boxes as everywhere else, so future dialogs get 24-hour
without anyone remembering to ask.

## Notes

This fixes the **timezone**, which is what produced 01:53. If a device's clock
itself is wrong the displayed time is still wrong — reading true server time
would mean taking the `Date` header off a response and carrying an offset.
Worth doing separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)