### PR TITLE
fix: make locked rows visible, and the padlock a line icon

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -684,6 +684,10 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "lock":
+    '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 10 0v4" />',
+  "lock-open":
+    '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 9.9-1" />',
   "printer":
     '<path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /> <path d="M6 9V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v6" /> <rect x="6" y="14" width="12" height="8" rx="1" />',
   "circle-alert":

--- a/live/style.css
+++ b/live/style.css
@@ -1233,7 +1233,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Baris tergembok: kotaknya benar-benar mati, dan terlihat mati. Bukan sekadar
    pudar — kotak yang masih bisa diketik tapi selalu ditolak adalah jebakan. */
 .baris-terkunci input:disabled {
-  background: var(--kartu-lembut, #f3f4f6);
+  background: #dfe3e9; border-color: #cfd5de;
   color: var(--tinta-lembut); cursor: not-allowed;
 }
 
@@ -1853,11 +1853,30 @@ input.small-input { text-align: center; }
    toh terjadi — gembok terpasang dari HP lain tepat saat baris ini sedang
    diketik — yang menang gembok, karena itulah keadaan yang sebenarnya di
    server. */
+/* Baris tergembok harus terlihat DARI JAUH, bukan ditebak.
+
+   #f3f4f6 sebelumnya nyaris tidak terbaca sebagai apa pun — dan sejak
+   kertasnya jadi #f0f1f4 ia lebih pucat daripada halaman di belakangnya.
+   Lembar pos berisi ratusan baris; kalau yang terkunci tidak menonjol,
+   petugas mencoba mengetik dulu lalu menemukan kotaknya mati.
+
+   Dua penanda, bukan satu: latar yang benar-benar lebih gelap, DAN pita hijau
+   di tepi kiri. Pita itu yang terbaca saat mata menyusuri kolom nomor dada
+   dari atas ke bawah, dan ia tetap ada bagi yang sulit membedakan naungan
+   abu-abu. */
 .table-pos tbody tr.baris-terkunci td,
 .table-pos tbody tr.baris-terkunci td:first-child {
-  background: var(--kartu-lembut, #f3f4f6);
+  background: #e4e7ec;
   color: var(--tinta-lembut);
 }
+.table-pos tbody tr.baris-terkunci td:first-child {
+  box-shadow: inset 3px 0 0 var(--utama);
+}
+/* Hijau, bukan abu: gembok tertutup berarti "sudah diperiksa dan benar",
+   sekelas dengan centang hijau di baris yang sama — bukan berarti mati. */
+.table-pos tbody tr.baris-terkunci .gembok { color: var(--utama); }
+.gembok { color: var(--tinta-lembut); background: none; border: 0; cursor: pointer; }
+.gembok .ikon { width: 1.15rem; height: 1.15rem; }
 /* Nomor dada tetap pekat: ia satu-satunya yang masih perlu dibaca cepat di
    baris yang sudah tidak bisa disentuh. */
 .table-pos tbody tr.baris-terkunci td.angka { color: var(--tinta); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2593,7 +2593,7 @@ async function layarInputPos() {
       data-gembok aria-pressed="${kunci}"
       title="${kunci ? "Terkunci — buka gembok (admin)"
                      : "Kunci nilai"}">${
-      kunci ? "🔒" : "🔓"}</button>`));
+      ikon(kunci ? "lock" : "lock-open")}</button>`));
     sel.querySelector("[data-gembok]").addEventListener("click", () => ubahGembok(tr));
   };
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -684,6 +684,10 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "lock":
+    '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 10 0v4" />',
+  "lock-open":
+    '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 9.9-1" />',
   "printer":
     '<path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /> <path d="M6 9V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v6" /> <rect x="6" y="14" width="12" height="8" rx="1" />',
   "circle-alert":

--- a/web/style.css
+++ b/web/style.css
@@ -1233,7 +1233,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Baris tergembok: kotaknya benar-benar mati, dan terlihat mati. Bukan sekadar
    pudar — kotak yang masih bisa diketik tapi selalu ditolak adalah jebakan. */
 .baris-terkunci input:disabled {
-  background: var(--kartu-lembut, #f3f4f6);
+  background: #dfe3e9; border-color: #cfd5de;
   color: var(--tinta-lembut); cursor: not-allowed;
 }
 
@@ -1853,11 +1853,30 @@ input.small-input { text-align: center; }
    toh terjadi — gembok terpasang dari HP lain tepat saat baris ini sedang
    diketik — yang menang gembok, karena itulah keadaan yang sebenarnya di
    server. */
+/* Baris tergembok harus terlihat DARI JAUH, bukan ditebak.
+
+   #f3f4f6 sebelumnya nyaris tidak terbaca sebagai apa pun — dan sejak
+   kertasnya jadi #f0f1f4 ia lebih pucat daripada halaman di belakangnya.
+   Lembar pos berisi ratusan baris; kalau yang terkunci tidak menonjol,
+   petugas mencoba mengetik dulu lalu menemukan kotaknya mati.
+
+   Dua penanda, bukan satu: latar yang benar-benar lebih gelap, DAN pita hijau
+   di tepi kiri. Pita itu yang terbaca saat mata menyusuri kolom nomor dada
+   dari atas ke bawah, dan ia tetap ada bagi yang sulit membedakan naungan
+   abu-abu. */
 .table-pos tbody tr.baris-terkunci td,
 .table-pos tbody tr.baris-terkunci td:first-child {
-  background: var(--kartu-lembut, #f3f4f6);
+  background: #e4e7ec;
   color: var(--tinta-lembut);
 }
+.table-pos tbody tr.baris-terkunci td:first-child {
+  box-shadow: inset 3px 0 0 var(--utama);
+}
+/* Hijau, bukan abu: gembok tertutup berarti "sudah diperiksa dan benar",
+   sekelas dengan centang hijau di baris yang sama — bukan berarti mati. */
+.table-pos tbody tr.baris-terkunci .gembok { color: var(--utama); }
+.gembok { color: var(--tinta-lembut); background: none; border: 0; cursor: pointer; }
+.gembok .ikon { width: 1.15rem; height: 1.15rem; }
 /* Nomor dada tetap pekat: ia satu-satunya yang masih perlu dibaca cepat di
    baris yang sudah tidak bisa disentuh. */
 .table-pos tbody tr.baris-terkunci td.angka { color: var(--tinta); }


### PR DESCRIPTION
## What

- Locked rows go from `#f3f4f6` to `#e4e7ec` and gain a green bar down the
  left edge.
- Disabled inputs in those rows darken to match.
- 🔒 / 🔓 become the Lucide `lock` / `lock-open` icons, green when closed.

## Why

`#f3f4f6` was barely readable as anything, and once the page background moved
to `#f0f1f4` in #197 the locked row was **paler than the page behind it**.

A pos sheet runs to hundreds of rows. If the frozen ones do not stand out, an
officer types first and finds the box dead second.

**Two markers, not one.** The bar is what reads while an eye runs down the
nomor dada column, and it still reads for anyone who cannot separate two shades
of grey — the tint alone would not.

The padlock is green when closed because closed means *checked and correct* —
the same thing the green tick on that row says. Grey would read as broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)