### PR TITLE
fix: history chips in scoring order, and a full-width single button

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -282,6 +282,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* Pilihan besar (pengganti dropdown): kartu yang bisa diketuk */
 .option-row { display: grid; gap: .55rem; grid-template-columns: 1fr 1fr; }
+/* Tombol tunggal memakai kedua kolom. Tanpa ini ia duduk di sel kiri dan
+   tampil separuh lebar, rata kiri — dialog baca-saja seperti riwayat hanya
+   punya satu tombol Tutup, dan tombol separuh lebar di bawah kartu selebar
+   penuh terbaca seperti tata letak yang belum selesai. */
+.option-row > :only-child { grid-column: 1 / -1; }
 .option {
   border: 2px solid var(--garis);
   border-radius: var(--radius);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2677,7 +2677,17 @@ async function layarInputPos() {
        Di pos berlomba satu, chip-nya cuma akan berbunyi "Semua" dan nama lomba
        itu sendiri — dua tombol yang tidak menyaring apa pun. Jadi ia tidak
        digambar sama sekali. */
-    const lomba = [...new Map(baris.map(b => [b.kode_lomba, b.nama_lomba]))];
+    /* Chip diurutkan seperti URUTAN PENILAIAN, bukan seperti urutan perubahan.
+       Daftar riwayat di bawahnya urut waktu-terbaru-dulu, dan chip yang ikut
+       urutan itu berpindah tempat setiap kali ada nilai baru masuk — tombol
+       yang berpindah antar kunjungan harus dibaca ulang tiap kali.
+       kolom[] datang dari kolomPos() yang sudah urut sort_order, jadi
+       chip-nya berbaris sama dengan kolom di lembar: Semaphore, Tebak Simpul,
+       Menaksir. Lomba yang tidak dikenali kolom (mis. komponen yang sudah
+       dihapus admin tapi masih punya riwayat) jatuh ke belakang. */
+    const urutLomba = new Map(kolom.map((k, i) => [k.nama, i]));
+    const lomba = [...new Map(baris.map(b => [b.kode_lomba, b.nama_lomba]))]
+      .sort((a, b) => (urutLomba.get(a[1]) ?? 1e9) - (urutLomba.get(b[1]) ?? 1e9));
     const chip = lomba.length < 2 ? "" : `
       <div class="option-row saring-riwayat">
         <button type="button" class="option option-small" data-lomba=""

--- a/web/style.css
+++ b/web/style.css
@@ -282,6 +282,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 /* Pilihan besar (pengganti dropdown): kartu yang bisa diketuk */
 .option-row { display: grid; gap: .55rem; grid-template-columns: 1fr 1fr; }
+/* Tombol tunggal memakai kedua kolom. Tanpa ini ia duduk di sel kiri dan
+   tampil separuh lebar, rata kiri — dialog baca-saja seperti riwayat hanya
+   punya satu tombol Tutup, dan tombol separuh lebar di bawah kartu selebar
+   penuh terbaca seperti tata letak yang belum selesai. */
+.option-row > :only-child { grid-column: 1 / -1; }
 .option {
   border: 2px solid var(--garis);
   border-radius: var(--radius);


### PR DESCRIPTION
## What

- The lomba chips in the history dialog are ordered by `kolomPos()` — the same
  order as the columns on the sheet — instead of by when changes happened.
- `.option-row > :only-child` spans both columns, so a lone **Tutup** is full
  width and centred.

## Why

The chips followed the order of the history rows, which is newest-first. That
means they **move every time a new value lands** — a row of buttons that has
to be re-read on every visit instead of being reached for from memory. Pos 1
now always reads Semaphore, Tebak Simpul, Menaksir.

A lone button in `.option-row` sat in the left cell of a two-column grid at
half width. Read-only dialogs have exactly one button, and half a button under
a full-width card reads as a layout that did not finish.

## Notes

Components the columns no longer know about — a wahana an admin deleted that
still has history — sort to the end rather than disappearing.

The single-child rule fixes every read-only dialog at once, not just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)