### PR TITLE
fix: Keberangkatan never redraws itself

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -84,6 +84,21 @@ let EDISI = null;
    memakainya jauh di bawah: yang membacanya nanti harus bisa menemukan
    seluruh keadaan yang hidup selama satu sesi di satu tempat. */
 let segarkanDiTempat = null;
+
+/* Layar yang TIDAK BOLEH digambar ulang sendiri, walau tidak punya cara
+   memperbarui diri di tempat.
+
+   Keberangkatan adalah satu-satunya layar yang ditunggui terus-menerus tanpa
+   mengetik apa pun: petugas berdiri di garis start memandanginya, lalu tiba
+   -tiba mencentang hadir atau menekan Berangkatkan. Menggambar ulang saat tab
+   kembali terlihat memindahkan tombol tepat sebelum jempolnya turun, dan
+   mengembalikan chip kloter ke pilihan awal — sementara datanya sendiri hanya
+   berubah lewat perbuatan petugas itu sendiri di layar yang sama.
+
+   Pengaman lain (isian sedang difokus, dialog terbuka, nilai belum tersimpan)
+   tidak menolong di sini justru karena layar ini paling sering sedang TIDAK
+   disentuh saat tab berpindah. */
+let tanpaSegarOtomatis = false;
 const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
 
 /* ---------------- kerangka ---------------- */
@@ -1058,6 +1073,7 @@ async function layarDaftarUlang() {
 /* ============================ KEBERANGKATAN ============================== */
 
 async function layarKeberangkatan() {
+  tanpaSegarOtomatis = true;
   if (!EDISI) { layarButuhEdisi("Keberangkatan"); return; }
   pasangKepala("Keberangkatan", true);
   LAYAR.replaceChildren(h(pemuat()));
@@ -4191,6 +4207,7 @@ const RUTE = {
 
 async function arahkan() {
   segarkanDiTempat = null;
+  tanpaSegarOtomatis = false;
   if (!sesi()) { layarLogin(); return; }
   if (!EDISI) {
     try { EDISI = await infoEdisi(); }
@@ -4249,6 +4266,7 @@ document.addEventListener("visibilitychange", () => {
      kembali dengan angka lama, tanpa memberi tahu siapa pun. */
   if (segarkanDiTempat) { terakhirSegar = Date.now(); segarkanDiTempat(); return; }
 
+  if (tanpaSegarOtomatis) return;
   if (Date.now() - terakhirSegar < 5000) return;
   const fokus = document.activeElement;
   if (fokus && ["INPUT", "SELECT", "TEXTAREA"].includes(fokus.tagName)) return;


### PR DESCRIPTION
## What

A `tanpaSegarOtomatis` flag, set by `layarKeberangkatan` and cleared by
`arahkan()`, makes the `visibilitychange` handler skip that screen.

## Why

Returning to the tab called `arahkan()`, which rebuilds the screen: the button
moves just before a thumb lands on it, and the kloter chips snap back to their
opening selection. That is what "dia loading ulang" was.

Keberangkatan is the only screen watched continuously **without anything being
typed** — an officer stands at the start line looking at it, then suddenly
ticks hadir or presses Berangkatkan. The three existing guards (focused input,
open dialog, unsaved value) all miss that, precisely because the screen is
usually *not* being touched when the tab changes.

Its data only moves through that same officer acting on that same screen, so a
redraw cannot bring them anything they did not just do themselves.

## Notes

Input Pos keeps refreshing, through `segarkanDiTempat` — it updates rows in
place rather than rebuilding, so nothing moves under the hand. That is the
scheme the owner pointed at; Keberangkatan has no in-place path, so it opts out
instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)