### PR TITLE
fix: camera button uses the line icon like everything beside it

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -684,6 +684,8 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "camera":
+    '<path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" /> <circle cx="12" cy="13" r="3" />',
   "lock":
     '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 10 0v4" />',
   "lock-open":

--- a/live/style.css
+++ b/live/style.css
@@ -2332,3 +2332,9 @@ input.small-input { text-align: center; }
   display: flex; align-items: center; justify-content: space-between;
   gap: .6rem; flex: 1 1 auto; min-width: 0; flex-wrap: wrap;
 }
+
+/* Tombol kamera di lembar pos: ikon polos setinggi gembok di sebelahnya, dan
+   warnanya ikut keadaan barisnya lewat currentColor — emoji dulu tampil
+   berwarna tetap dan lebih besar daripada tetangganya, jadi kolom aksi
+   terbaca bergerigi. */
+.badge-tombol .ikon { width: 1.15rem; height: 1.15rem; vertical-align: -.2em; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2523,7 +2523,7 @@ async function layarInputPos() {
       <td class="pos-status" data-label=""></td>
       <td class="pos-foto text-center" data-label="">
         <button type="button" class="badge badge-tombol" data-foto
-          title="Foto slip penilaian regu ini">📷</button></td>
+          title="Foto slip penilaian regu ini">${ikon("camera")}</button></td>
       <td class="pos-gembok" data-label=""></td>
     </tr>`).join("")));
 
@@ -2796,7 +2796,7 @@ async function layarInputPos() {
         <button type="button" class="button button-mini" data-lihat
           ${hitung[kode] ? "" : "hidden"}>Lihat</button>
         <label class="button button-mini button-primary">
-          <input type="file" accept="image/*" multiple hidden data-ambil>📷 Foto
+          <input type="file" accept="image/*" multiple hidden data-ambil>${ikon("camera")} Foto
         </label>
       </li>`).join("")}</ul>
 `;

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -684,6 +684,8 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  "camera":
+    '<path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" /> <circle cx="12" cy="13" r="3" />',
   "lock":
     '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 10 0v4" />',
   "lock-open":

--- a/web/style.css
+++ b/web/style.css
@@ -2332,3 +2332,9 @@ input.small-input { text-align: center; }
   display: flex; align-items: center; justify-content: space-between;
   gap: .6rem; flex: 1 1 auto; min-width: 0; flex-wrap: wrap;
 }
+
+/* Tombol kamera di lembar pos: ikon polos setinggi gembok di sebelahnya, dan
+   warnanya ikut keadaan barisnya lewat currentColor — emoji dulu tampil
+   berwarna tetap dan lebih besar daripada tetangganya, jadi kolom aksi
+   terbaca bergerigi. */
+.badge-tombol .ikon { width: 1.15rem; height: 1.15rem; vertical-align: -.2em; }


### PR DESCRIPTION
## What

📷 becomes the Lucide `camera` icon, in the pos sheet row and in the photo
dialog's file button.

## Why

The emoji sat next to a drawn padlock and a drawn tick, in its own fixed
colours and its own size. The action column read as ragged — and on an older
phone the emoji is an empty box while its neighbours render fine.

Drawn, it inherits the size and colour of the row it is in, including the
muted grey of a locked row, which the emoji ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)