### PR TITLE
fix: backup sheet — fixed identity widths, the rest to the scoring columns

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -826,9 +826,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mengisi sisa lebar. Tanpa max-width, di Pos 1 yang cuma punya tiga kotak,
      seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
      jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
+  /* LEBAR KOLOM DIPATOK, sisanya milik kolom penilaian.
+
+     Dengan table-layout auto, kolom identitas tumbuh mengikuti nama terpanjang
+     dan kolom penilaian menerima apa pun yang tersisa — pada Pos 5 itu
+     menyisakan 16mm untuk judul "KREATIVITAS", yang tumpah keluar kertas.
+
+     Nama regu 44mm karena 0051 membatasinya 20 karakter, dan 20 kapital 10pt
+     memang selebar itu. Organisasi diberi lebar yang sama dan dipotong
+     elipsis di situ: nama sekolah bisa sepanjang apa pun, dan lembar ini
+     dibaca untuk MENCOCOKKAN baris, bukan untuk membaca nama sekolah utuh —
+     nomor dada di kolom pertama yang jadi kuncinya.
+
+     Sisanya dibagi rata antar kolom penilaian oleh table-layout: fixed. */
+  .lembar-pos .print-table { table-layout: fixed; }
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
-    width: 16mm; max-width: 18mm;
+    width: auto; max-width: none;
   }
+  /* Judul kolom penilaian boleh membungkus dua baris — ia cuma dicetak SEKALI
+     di kepala tabel, jadi tingginya tidak dikalikan 30 baris seperti sel isi. */
+  .lembar-pos .print-table th.isian { white-space: normal; line-height: 1.1; }
   /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
      Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
      tingginya berbeda dari tetangganya, dan tabel yang barisnya tidak rata
@@ -869,9 +886,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
      Golongan disingkat "Pgl Pa" / "Pgk Pa" (GOLONGAN_SINGKAT di app.js), jadi
      16mm cukup dan 10mm sisanya ikut pindah ke kolom nama. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 48mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 58mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 16mm; }
+  .lembar-pos .print-table td:nth-child(2),
+  .lembar-pos .print-table th:nth-child(2) { width: 44mm; max-width: 44mm; }
+  .lembar-pos .print-table td:nth-child(3),
+  .lembar-pos .print-table th:nth-child(3) { width: 44mm; max-width: 44mm; }
+  .lembar-pos .print-table td:nth-child(4),
+  .lembar-pos .print-table th:nth-child(4) { width: 14mm; max-width: 14mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2114,7 +2114,7 @@ const kolomCetakPos = (kolom) => kolom.flatMap(kol => {
  *  Sisa ruang setelah semuanya: 10-21mm per halaman, tergantung pos. */
 const REGU_PER_LEMBAR = 30;
 
-function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
+function siapkanCetakLembarPos(pos, kolomLayar, baris) {
   document.getElementById("cetakan")?.remove();
   const set = [{ judul: null, kolom: kolomCetakPos(kolomLayar) }];
   const judul = pos.bayangan ? `POS BAYANGAN — ${pos.name}`
@@ -2168,9 +2168,6 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris, daftarUlangDitutup) {
       <p class="lembar-kepala">${esc(EDISI ? EDISI.name : "")} · ${esc(tanggal)} ·
          dada ${esc(dada3(grup[0].nomor_dada))}–${esc(dada3(grup[grup.length - 1].nomor_dada))}
          · Petugas: ______________ · Diperiksa: ______________</p>
-      ${daftarUlangDitutup ? "" : `<p class="insert-note">DAFTAR ULANG BELUM DITUTUP
-        — regu yang menyusul BARISNYA SUDAH ADA di sini, hanya namanya yang
-        belum tercetak. Tulis nama regu dan sekolahnya di baris kosong.</p>`}
       <table class="print-table">
         <thead>
           <tr>
@@ -3258,7 +3255,7 @@ async function layarInputPos() {
       const n = siapkanCetakBlangko(pos, kolom);
       notif(`${n} master A5 melintang, satu per lomba.`);
     } else {
-      siapkanCetakLembarPos(pos, kolom, semua, ditutup);
+      siapkanCetakLembarPos(pos, kolom, semua);
     }
     window.print();
   };

--- a/web/style.css
+++ b/web/style.css
@@ -826,9 +826,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      mengisi sisa lebar. Tanpa max-width, di Pos 1 yang cuma punya tiga kotak,
      seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
      jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
+  /* LEBAR KOLOM DIPATOK, sisanya milik kolom penilaian.
+
+     Dengan table-layout auto, kolom identitas tumbuh mengikuti nama terpanjang
+     dan kolom penilaian menerima apa pun yang tersisa — pada Pos 5 itu
+     menyisakan 16mm untuk judul "KREATIVITAS", yang tumpah keluar kertas.
+
+     Nama regu 44mm karena 0051 membatasinya 20 karakter, dan 20 kapital 10pt
+     memang selebar itu. Organisasi diberi lebar yang sama dan dipotong
+     elipsis di situ: nama sekolah bisa sepanjang apa pun, dan lembar ini
+     dibaca untuk MENCOCOKKAN baris, bukan untuk membaca nama sekolah utuh —
+     nomor dada di kolom pertama yang jadi kuncinya.
+
+     Sisanya dibagi rata antar kolom penilaian oleh table-layout: fixed. */
+  .lembar-pos .print-table { table-layout: fixed; }
   .lembar-pos .print-table th.isian, .lembar-pos .print-table td.isian {
-    width: 16mm; max-width: 18mm;
+    width: auto; max-width: none;
   }
+  /* Judul kolom penilaian boleh membungkus dua baris — ia cuma dicetak SEKALI
+     di kepala tabel, jadi tingginya tidak dikalikan 30 baris seperti sel isi. */
+  .lembar-pos .print-table th.isian { white-space: normal; line-height: 1.1; }
   /* Identitas SATU BARIS, dan 10pt supaya muat tanpa dipotong.
      Bukan sekadar hemat lebar: satu nama yang pecah dua baris membuat
      tingginya berbeda dari tetangganya, dan tabel yang barisnya tidak rata
@@ -869,9 +886,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
      Golongan disingkat "Pgl Pa" / "Pgk Pa" (GOLONGAN_SINGKAT di app.js), jadi
      16mm cukup dan 10mm sisanya ikut pindah ke kolom nama. */
-  .lembar-pos .print-table td:nth-child(2) { max-width: 48mm; }
-  .lembar-pos .print-table td:nth-child(3) { max-width: 58mm; }
-  .lembar-pos .print-table td:nth-child(4) { max-width: 16mm; }
+  .lembar-pos .print-table td:nth-child(2),
+  .lembar-pos .print-table th:nth-child(2) { width: 44mm; max-width: 44mm; }
+  .lembar-pos .print-table td:nth-child(3),
+  .lembar-pos .print-table th:nth-child(3) { width: 44mm; max-width: 44mm; }
+  .lembar-pos .print-table td:nth-child(4),
+  .lembar-pos .print-table th:nth-child(4) { width: 14mm; max-width: 14mm; }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }


### PR DESCRIPTION
## What

- `table-layout: fixed` on the backup sheet.
- Nama Regu **44mm**, Organisasi **44mm**, Golongan **14mm**; scoring columns
  share everything left.
- Scoring headings may wrap.
- The `DAFTAR ULANG BELUM DITUTUP` banner is removed.

## Why

With `table-layout: auto` the identity columns grew to the longest name and
the scoring columns took the remainder. On Pos 5 that left 16mm for a heading
reading **KREATIVITAS** — which spilled off the edge of the paper, visible in
the owner's screenshot.

44mm is not a guess: `0051` caps nama regu at 20 characters, and 20 capitals at
10pt is 44mm. Organisasi gets the same and ellipsises there. A school name can
be any length, and this sheet is read to *match a row*, not to read a school
name in full — the nomor dada in the first column is the key.

Headings may wrap because they are printed once in the table head; their height
is not multiplied by thirty rows the way a body cell is.

## Notes

Freed width per sheet: Pos 5 goes from 16mm to roughly 40mm per scoring column,
Pos 3 (seven criteria) from 16mm to about 23mm.

`siapkanCetakLembarPos` loses the `daftarUlangDitutup` parameter along with the
banner rather than leaving it computed and unread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)