### PR TITLE
fix: "Status", centred, above the progress rings

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2358,3 +2358,9 @@ input.small-input { text-align: center; }
    berwarna tetap dan lebih besar daripada tetangganya, jadi kolom aksi
    terbaca bergerigi. */
 .badge-tombol .ikon { width: 1.15rem; height: 1.15rem; vertical-align: -.2em; }
+
+/* Judul kartu yang rata tengah. Dipakai di atas deretan cincin kemajuan:
+   isinya sendiri sederet lingkaran yang terbagi rata selebar kartu, dan judul
+   rata kiri di atas barisan yang simetris terbaca seperti tersangkut di
+   pojok. */
+.judul-tengah { text-align: center; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4016,7 +4016,7 @@ async function layarLiveScore() {
 
   const kemajuan = `
     <div class="card">
-      <h2>Kemajuan input</h2>
+      <h2 class="judul-tengah">Status</h2>
       <ul class="kemajuan">
         ${pos.map(p => {
           const s = persenPos(p);

--- a/web/style.css
+++ b/web/style.css
@@ -2358,3 +2358,9 @@ input.small-input { text-align: center; }
    berwarna tetap dan lebih besar daripada tetangganya, jadi kolom aksi
    terbaca bergerigi. */
 .badge-tombol .ikon { width: 1.15rem; height: 1.15rem; vertical-align: -.2em; }
+
+/* Judul kartu yang rata tengah. Dipakai di atas deretan cincin kemajuan:
+   isinya sendiri sederet lingkaran yang terbagi rata selebar kartu, dan judul
+   rata kiri di atas barisan yang simetris terbaca seperti tersangkut di
+   pojok. */
+.judul-tengah { text-align: center; }


### PR DESCRIPTION
## What

On Live Score, **Kemajuan input** → **Status**, centred.

## Why

"Kemajuan input" described the mechanism. "Status" is what an admin opens that
card to find out.

Centred because what sits under it is a row of rings spread evenly across the
card — a left-aligned heading over a symmetrical row reads as though it snagged
on the corner.

## Notes

The peserta page keeps `Kemajuan input` and its explanatory line. A pembina
reads that page once, having never seen it before, and "Status" on its own
tells them less than the longer phrase — CLAUDE.md 9.7 weights explanation by
how often a screen is used, and these two screens are not used the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)