### PR TITLE
fix: split Organisasi into its own column, right-align the rank

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2364,3 +2364,23 @@ input.small-input { text-align: center; }
    rata kiri di atas barisan yang simetris terbaca seperti tersangkut di
    pojok. */
 .judul-tengah { text-align: center; }
+/* ---------------------------------------------------------------------------
+   Tabel rincian Live Score: kolom peringkat, dan pemisah sebelum pos pertama.
+   ------------------------------------------------------------------------- */
+
+/* Peringkat rata KANAN. Tiga baris teratas membawa medali di depan angkanya
+   dan sisanya tidak, jadi rata kiri menaruh "1" pada posisi yang berbeda dari
+   "4" — kolom angka yang tidak berbaris adalah kolom yang harus dibaca satu
+   per satu, bukan disapu. */
+.table-live .rekap-rank {
+  text-align: right; white-space: nowrap;
+  font-variant-numeric: tabular-nums; font-weight: 700;
+}
+.table-live .rekap-rank .rank-angka { margin-left: .15rem; }
+
+/* Nama sekolah kolomnya sendiri, bukan menumpang di bawah nama regu.
+   Sebagai <span> inline ia menempel di ujung nama regu — "SATYA
+   PAJAJARANSMKN 3 TASIKMALAYA" — karena margin-top tidak berlaku pada elemen
+   inline. Dua kolom juga yang diminta: keduanya disaring mata secara terpisah
+   saat mencari satu regu. */
+.table-live .sub-kolom { color: var(--tinta-lembut); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4084,6 +4084,7 @@ async function layarLiveScore() {
                   <th rowspan="2">#</th>
                   <th rowspan="2">No<br>Dada</th>
                   <th rowspan="2">Regu</th>
+                  <th rowspan="2" class="rekap-batas">Organisasi</th>
                   ${posKolom.map(p => `<th colspan="${p.kolom.length + 1}"
                     class="rekap-batas">Pos ${esc(String(p.nomor))} · ${esc(p.name)}</th>`).join("")}
                   <th rowspan="2">Penalti</th>
@@ -4102,9 +4103,10 @@ async function layarLiveScore() {
                   const poin = k.poin_per_pos || {};
                   return `
                   <tr>
-                    <td class="angka">${MEDALI[k.peringkat] || ""}${esc(String(k.peringkat))}</td>
+                    <td class="rekap-rank">${MEDALI[k.peringkat] || ""}<span class="rank-angka">${esc(String(k.peringkat))}</span></td>
                     <td class="angka">${esc(dada3(k.nomor_dada))}</td>
-                    <td>${esc(k.nama_regu)}<span class="sub">${esc(k.nama_sekolah)}</span></td>
+                    <td>${esc(k.nama_regu)}</td>
+                    <td class="rekap-batas sub-kolom">${esc(k.nama_sekolah)}</td>
                     ${posKolom.map(p => p.kolom.map(kol => {
                         // Satu lomba bisa punya baris wahana berbeda per
                         // golongan; yang berlaku untuk regu INI yang dibaca.

--- a/web/style.css
+++ b/web/style.css
@@ -2364,3 +2364,23 @@ input.small-input { text-align: center; }
    rata kiri di atas barisan yang simetris terbaca seperti tersangkut di
    pojok. */
 .judul-tengah { text-align: center; }
+/* ---------------------------------------------------------------------------
+   Tabel rincian Live Score: kolom peringkat, dan pemisah sebelum pos pertama.
+   ------------------------------------------------------------------------- */
+
+/* Peringkat rata KANAN. Tiga baris teratas membawa medali di depan angkanya
+   dan sisanya tidak, jadi rata kiri menaruh "1" pada posisi yang berbeda dari
+   "4" — kolom angka yang tidak berbaris adalah kolom yang harus dibaca satu
+   per satu, bukan disapu. */
+.table-live .rekap-rank {
+  text-align: right; white-space: nowrap;
+  font-variant-numeric: tabular-nums; font-weight: 700;
+}
+.table-live .rekap-rank .rank-angka { margin-left: .15rem; }
+
+/* Nama sekolah kolomnya sendiri, bukan menumpang di bawah nama regu.
+   Sebagai <span> inline ia menempel di ujung nama regu — "SATYA
+   PAJAJARANSMKN 3 TASIKMALAYA" — karena margin-top tidak berlaku pada elemen
+   inline. Dua kolom juga yang diminta: keduanya disaring mata secara terpisah
+   saat mencari satu regu. */
+.table-live .sub-kolom { color: var(--tinta-lembut); }


### PR DESCRIPTION
## What

In the Live Score detail table:

- **Organisasi** becomes its own column instead of a `<span>` inside the regu
  cell
- the rank column is right-aligned
- the divider now also falls between the identity columns and Pos 1

## Why

`SATYA PAJAJARANSMKN 3 TASIKMALAYA`. The school was a `<span class="sub">` and
`.data-table .sub` positions it with `margin-top`, which does nothing to an
inline element — so it sat flush against the end of the regu name.

Two columns is also what reading that table actually does: an eye scans regu
names and school names separately when hunting for one row.

The top three ranks carry a medal before the digit and the rest do not, so
left-aligned put `1` in a different place from `4`. A column of numbers that
does not line up has to be read one at a time instead of swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)