### PR TITLE
fix: camera icon rendered as raw SVG in the photo dialog; gradient rings

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -320,9 +320,7 @@ function gambarKelengkapan() {
               <span>${esc(String(persen))}<i>%</i></span>
             </div>
             <div class="c-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</div>
-            <div class="c-angka">${esc(String(p.lengkap))} / ${esc(String(p.regu_total))} regu${
-              Number(p.sebagian) > 0
-                ? `<br>${esc(String(p.sebagian))} baru sebagian` : ""}</div>
+            <div class="c-angka">${esc(String(p.lengkap))} / ${esc(String(p.regu_total))} regu</div>
           </li>`;
         }).join("")}
       </ul>

--- a/live/live.js
+++ b/live/live.js
@@ -285,13 +285,21 @@ function gambarHasil() {
    Satu angka per pos memisahkan keduanya, dan pertanyaan yang tadinya jadi
    antrean di meja panitia terjawab sebelum diajukan.
    ------------------------------------------------------------------------- */
-/* Merah / kuning / hijau, dan hijau sengaja mahal — 90, bukan 80. Pos dengan
-   300 regu yang berhenti di 85% masih kehilangan 45 regu, dan warna hijau di
-   angka itu mengabarkan "selesai" kepada peserta yang regunya justru termasuk
-   45 itu. Angkanya selalu tertulis di dalam cincin, jadi yang tidak bisa
-   membedakan merah dari hijau membaca keadaan yang sama persis. */
-const warnaPersen = (s) => s >= 90 ? "var(--hijau)"
-                         : s >= 50 ? "var(--kuning)" : "var(--bahaya)";
+/** Merah -> kuning -> hijau mengikuti persennya, bukan tiga anak tangga.
+
+ *  Tangga membuat 49% dan 51% terlihat sangat berbeda padahal selisihnya satu
+ *  regu, sementara 51% dan 89% terlihat sama padahal itu dua puluh regu.
+ *  Gradasi menampilkan JARAKNYA, dan jarak itu yang ditanyakan orang saat
+ *  melirik lima cincin sekaligus.
+ *
+ *  Rona 0 di 0%, 50 di 50%, 140 di 100% — merah, kuning, hijau. Angkanya
+ *  tetap tertulis di dalam cincin, jadi warna tidak pernah jadi satu-satunya
+ *  kabar bagi yang sulit membedakan merah dari hijau. */
+const warnaPersen = (s) => {
+  const p = Math.max(0, Math.min(100, Number(s) || 0));
+  const rona = p <= 50 ? p : 50 + (p - 50) * 1.8;
+  return `hsl(${Math.round(rona)}, 72%, 40%)`;
+};
 
 function gambarKelengkapan() {
   const daftar = (META && META.kelengkapan) || [];

--- a/live/style.css
+++ b/live/style.css
@@ -1312,6 +1312,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .badge-tombol {
   border: 0; font: inherit; cursor: pointer;
   padding: .1rem .45rem; line-height: inherit;
+  /* inline-flex supaya ikon di dalamnya benar-benar di tengah. Sebagai inline
+     biasa, SVG duduk di garis dasar teks dan tampak turun sedikit dibanding
+     centang dan gembok di sebelahnya — tiga tombol sebaris yang tidak
+     sejajar. */
+  display: inline-flex; align-items: center; justify-content: center;
 }
 .badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4005,14 +4005,21 @@ async function layarLiveScore() {
   const persenPos = (p) => !p.regu_total
     ? 0 : Math.floor(100 * p.lengkap / p.regu_total);
 
-  /* Merah / kuning / hijau, dan hijau sengaja mahal.
-     90, bukan 80: pos dengan 300 regu yang berhenti di 85% masih kehilangan
-     45 regu — jumlah yang butuh berjam-jam untuk dikejar, dan warna hijau di
-     angka itu memberi tahu panitia bahwa pekerjaannya selesai padahal belum.
-     Angkanya selalu tertulis di dalam cincin, jadi yang tidak bisa
-     membedakan merah dari hijau tetap membaca keadaan yang sama. */
-  const warnaPersen = (s) => s >= 90 ? "var(--hijau)"
-                           : s >= 50 ? "var(--kuning)" : "var(--bahaya)";
+  /** Merah -> kuning -> hijau mengikuti persennya, bukan tiga anak tangga.
+
+   *  Tangga membuat 49% dan 51% terlihat sangat berbeda padahal selisihnya satu
+   *  regu, sementara 51% dan 89% terlihat sama padahal itu dua puluh regu.
+   *  Gradasi menampilkan JARAKNYA, dan jarak itu yang ditanyakan orang saat
+   *  melirik lima cincin sekaligus.
+   *
+   *  Rona 0 di 0%, 50 di 50%, 140 di 100% — merah, kuning, hijau. Angkanya
+   *  tetap tertulis di dalam cincin, jadi warna tidak pernah jadi satu-satunya
+   *  kabar bagi yang sulit membedakan merah dari hijau. */
+  const warnaPersen = (s) => {
+    const p = Math.max(0, Math.min(100, Number(s) || 0));
+    const rona = p <= 50 ? p : 50 + (p - 50) * 1.8;
+    return `hsl(${Math.round(rona)}, 72%, 40%)`;
+  };
 
   const kemajuan = `
     <div class="card">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2785,11 +2785,16 @@ async function layarInputPos() {
 
     const lomba = [...new Map(kolom.map(k => [slugLomba(k.nama), k.nama]))];
 
-    const isi = `<ul class="foto-lomba">${lomba.map(([kode, nama]) => html`
-      <li data-kode="${kode}" data-nama="${nama}">
-        <span class="f-nama">${nama}</span>
+    /* Template BIASA, bukan tag html`` — sama alasannya dengan notif(): tag
+       html`` meng-escape SETIAP sisipan, dan ikon("camera") adalah HTML yang
+       memang harus dirender. Ditulis dengan html``, jalur SVG-nya tampil apa
+       adanya sebagai teks hijau sepanjang tiga baris di dalam tombolnya.
+       Yang datang dari luar tetap lewat esc() satu per satu. */
+    const isi = `<ul class="foto-lomba">${lomba.map(([kode, nama]) => `
+      <li data-kode="${esc(kode)}" data-nama="${esc(nama)}">
+        <span class="f-nama">${esc(nama)}</span>
         <span class="f-jumlah" data-jumlah>${hitung[kode]
-          ? `${hitung[kode]} foto` : "belum ada"}</span>
+          ? `${esc(String(hitung[kode]))} foto` : "belum ada"}</span>
         <button type="button" class="button button-mini" data-lihat
           ${hitung[kode] ? "" : "hidden"}>Lihat</button>
         <label class="button button-mini button-primary">
@@ -4034,9 +4039,7 @@ async function layarLiveScore() {
               <span>${esc(String(s))}<i>%</i></span>
             </div>
             <div class="c-nama">Pos ${esc(String(p.pos))} · ${esc(p.nama_pos)}</div>
-            <div class="c-angka">${esc(String(p.lengkap))} / ${esc(String(p.regu_total))} regu${
-              p.sebagian > 0 ? `<br>${esc(String(p.sebagian))} baru sebagian` : ""}${
-              p.hilang > 0 ? `<br><strong class="c-alarm">${esc(String(p.hilang))} finish tapi belum lengkap</strong>` : ""}</div>
+            <div class="c-angka">${esc(String(p.lengkap))} / ${esc(String(p.regu_total))} regu</div>
           </li>`;
         }).join("")}
       </ul>

--- a/web/style.css
+++ b/web/style.css
@@ -1312,6 +1312,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .badge-tombol {
   border: 0; font: inherit; cursor: pointer;
   padding: .1rem .45rem; line-height: inherit;
+  /* inline-flex supaya ikon di dalamnya benar-benar di tengah. Sebagai inline
+     biasa, SVG duduk di garis dasar teks dan tampak turun sedikit dibanding
+     centang dan gembok di sebelahnya — tiga tombol sebaris yang tidak
+     sejajar. */
+  display: inline-flex; align-items: center; justify-content: center;
 }
 .badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
 


### PR DESCRIPTION
## What

Three things on the same screens:

1. **Bug** — the photo dialog printed the camera icon's SVG path as visible
   text inside each button.
2. The progress rings move from three colour steps to a **red → yellow → green
   gradient** across 0–50–100%.
3. The ring captions drop "N baru sebagian" and "N finish tapi belum lengkap",
   leaving `47 / 53 regu`.

## Why

**The bug.** The dialog built its rows with the `` html`` `` tag, which escapes
every interpolation, so `ikon("camera")` arrived as three lines of path data in
a green button, once per lomba. That trap is already documented at `notif()`:
`` html`` `` exists to escape untrusted values like school names, and HTML that
must render has to use a plain template. Swapped, with `esc()` applied to each
outside value by hand. Only that one call site was affected.

**The gradient.** Steps made 49% and 51% look very different when the gap is
one regu, while 51% and 89% looked identical when the gap is twenty. A gradient
shows the *distance*, which is what someone glancing at five rings is asking.
Hue 0 at 0%, 50 at 50%, 140 at 100%.

**The captions.** Requested. Nothing is lost: `Kelengkapan tiap pos` on
Rekapitulasi still turns a pos card red when regu have finished without a
complete score, which is where the person acting on it is looking.

## Notes

The camera button also gains `inline-flex` so its icon centres — as plain
inline content the SVG sat on the text baseline and hung below the tick and
padlock beside it.

The number stays inside every ring, so colour is still never the only signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)