### PR TITLE
feat: names may not contain digits

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -77,6 +77,12 @@ export function pesanRamah(m) {
     return "Nama regu itu sudah dipakai regu lain. Pilih nama yang berbeda.";
   if (/regu_nama_panjang/i.test(t))
     return "Nama regu paling panjang 20 karakter.";
+  if (/nama_regu_tanpa_angka/i.test(t))
+    return "Nama regu tidak boleh memakai angka.";
+  if (/nama_ketua_tanpa_angka/i.test(t))
+    return "Nama ketua tidak boleh memakai angka.";
+  if (/nama_kontak_tanpa_angka/i.test(t))
+    return "Nama contact person tidak boleh memakai angka.";
   if (/permission denied|insufficient/i.test(t))
     return "Akun ini tidak berhak melakukan itu. Pakai akun yang sesuai.";
   if (/password.*(should be different|new password should be different)/i.test(t))

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -86,6 +86,16 @@ const labelGolongan = k => GOLONGAN.find(g => g.kode === k).label;
    dilewati dengan menekan Caps Lock bukan pembatas.                        */
 
 const NAMA_MAKS = 20;
+
+/* Angka di kolom nama selalu berarti salah satu dari dua hal: kolomnya
+   tertukar (nomor WA diketik di kotak Nama), atau regunya dinomori sendiri
+   ("REGU 1") — dan nomor regu sudah ada, namanya nomor dada.
+
+   Yang ditolak HANYA digit. Nama sungguhan memuat spasi, titik, apostrof,
+   dan tanda hubung — "Nur Aisyah binti H. Abdul", "Ma'ruf", "Siti Nur-Aini"
+   — dan menolak semuanya demi menolak angka akan menolak lebih banyak nama
+   asli daripada kesalahan yang dicegahnya. */
+const ADA_ANGKA = /[0-9]/;
 const normalNama = (t) => String(t || "").trim().toLowerCase().replace(/\s+/g, " ");
 
 /* Jawaban server, diingat per nama supaya satu nama tidak ditanyakan berkali
@@ -166,7 +176,13 @@ function halaman() {
   document.getElementById("nama-kontak").value = jawab.nama_kontak;
   document.getElementById("nama-kontak").addEventListener("input", e => {
     jawab.nama_kontak = e.target.value; simpanDraf();
-    document.getElementById("g-nama-kontak").hidden = !!e.target.value.trim();
+    const salahKontak = !e.target.value.trim()
+      ? "Nama contact person wajib diisi."
+      : ADA_ANGKA.test(e.target.value)
+        ? "Nama contact person tidak boleh memakai angka." : null;
+    const gk = document.getElementById("g-nama-kontak");
+    gk.textContent = salahKontak || "";
+    gk.hidden = !salahKontak;
     if (sudahDiperiksa) periksa(false);
   });
   document.getElementById("wa").value = jawab.kontak_wa;
@@ -412,6 +428,7 @@ function gambarRegu() {
   const masalahNama = (i) => {
     const n = normalNama(jawab.regu[i].nama_regu);
     if (!n) return "Nama regu wajib diisi.";
+    if (ADA_ANGKA.test(n)) return "Nama regu tidak boleh memakai angka.";
     if (jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n))
       return "Nama ini sudah dipakai regu lain di form ini.";
     if (namaTerpakai.get(n))
@@ -424,13 +441,18 @@ function gambarRegu() {
     const inpKetua = document.getElementById(`r-ketua-${i}`);
     if (!inpNama || !inpKetua) return;
     const salahNama = masalahNama(i);
-    const ketuaKosong = !inpKetua.value.trim();
+    const salahKetua = !inpKetua.value.trim()
+      ? "Nama ketua wajib diisi."
+      : ADA_ANGKA.test(inpKetua.value) ? "Nama ketua tidak boleh memakai angka." : null;
+    const ketuaKosong = !!salahKetua;
     inpNama.setAttribute("aria-invalid", String(!!salahNama));
     inpKetua.setAttribute("aria-invalid", String(ketuaKosong));
     const kotakGalat = document.getElementById(`r-nama-galat-${i}`);
     kotakGalat.textContent = salahNama || "";
     kotakGalat.hidden = !salahNama;
-    document.getElementById(`r-ketua-galat-${i}`).hidden = !ketuaKosong;
+    const kotakKetua = document.getElementById(`r-ketua-galat-${i}`);
+    kotakKetua.textContent = salahKetua || "";
+    kotakKetua.hidden = !salahKetua;
     document.getElementById(`regu-${i}`).classList.toggle("regu-card-error", !!salahNama || ketuaKosong);
   };
 
@@ -509,7 +531,7 @@ function periksa(gulir = true) {
     const namaSalah = !n
       || jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n)
       || namaTerpakai.get(n) === true;
-    const kurang = namaSalah || !r.nama_ketua;
+    const kurang = namaSalah || !r.nama_ketua || ADA_ANGKA.test(r.nama_ketua);
     const el = document.getElementById(`regu-${i}`);
     if (el) el.classList.toggle("regu-card-error", kurang);
     if (kurang) {
@@ -518,9 +540,12 @@ function periksa(gulir = true) {
     }
   });
 
-  const namaKontakKosong = !jawab.nama_kontak.trim();
+  const namaKontakKosong = !jawab.nama_kontak.trim()
+    || ADA_ANGKA.test(jawab.nama_kontak);
   if (namaKontakKosong)
-    galat.push({ ke: "bagian-kontak", teks: "Nama contact person belum diisi" });
+    galat.push({ ke: "bagian-kontak", teks: !jawab.nama_kontak.trim()
+      ? "Nama contact person belum diisi"
+      : "Nama contact person tidak boleh memakai angka" });
   tandai("g-nama-kontak", namaKontakKosong);
 
   const digitWa = jawab.kontak_wa.replace(/\D/g, "");

--- a/supabase/migrations/0052_nama_tanpa_angka.sql
+++ b/supabase/migrations/0052_nama_tanpa_angka.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- hrcd-rekap : 0052_nama_tanpa_angka.sql
+--
+-- Nama orang dan nama regu tidak boleh memuat angka.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Angka di kolom nama selalu berarti salah satu dari dua hal, dan keduanya
+-- merusak:
+--
+--   1. Kolomnya tertukar. Nomor WhatsApp diketik di kotak Nama, atau nomor
+--      dada diketik di kotak Nama Ketua. Pembina mengisi form ini sekali,
+--      dari HP, sambil mengurus hal lain — dan kotak yang bersebelahan memang
+--      tertukar.
+--   2. Nama regu dipakai sebagai penomoran: "REGU 1", "REGU 2". Nomor regu
+--      SUDAH ada dan namanya nomor dada; nama yang juga berisi angka membuat
+--      dua penomoran bersaing di lembar yang sama, dan panitia harus menebak
+--      mana yang dimaksud saat memanggil.
+--
+-- Keduanya baru ketahuan di meja daftar ulang, saat pembinanya sudah pulang.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DILARANG HANYA DIGIT
+--
+-- Bukan "hanya huruf". Nama sungguhan memuat spasi, titik, apostrof, dan
+-- tanda hubung — "Nur Aisyah binti H. Abdul", "Ma'ruf", "Siti Nur-Aini".
+-- Menolak semuanya demi menolak angka akan menolak lebih banyak nama asli
+-- daripada kesalahan yang dicegahnya.
+--
+-- Jadi syaratnya sesempit mungkin: tidak boleh ada satu pun 0-9. Itu menutup
+-- kedua kekeliruan di atas dan tidak menyentuh apa pun yang lain.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DI DATABASE, BUKAN CUKUP DI FORM
+--
+-- Form pendaftaran juga menolaknya sambil diketik — itu yang membuatnya
+-- terasa wajar. Tapi form bisa dilewati: RPC-nya terbuka, dan panitia sendiri
+-- bisa menulis nama lewat layar meja. Yang menegakkan aturan harus yang
+-- paling akhir menyentuh datanya.
+-- ============================================================================
+
+do $$
+declare v_regu text; v_ketua text; v_kontak text;
+begin
+  select string_agg(nama_regu, ', ') into v_regu
+  from regu where not is_cancelled and nama_regu ~ '[0-9]';
+  select string_agg(nama_ketua, ', ') into v_ketua
+  from regu where not is_cancelled and nama_ketua ~ '[0-9]';
+  select string_agg(nama_kontak, ', ') into v_kontak
+  from pendaftaran where nama_kontak ~ '[0-9]';
+
+  if coalesce(v_regu, v_ketua, v_kontak) is not null then
+    raise exception '0052: masih ada nama berangka — perbaiki dulu. regu: % | ketua: % | kontak: %',
+      coalesce(v_regu, '-'), coalesce(v_ketua, '-'), coalesce(v_kontak, '-');
+  end if;
+  raise notice '0052: data yang ada lolos — tidak ada nama berangka.';
+end;
+$$;
+
+alter table regu drop constraint if exists regu_nama_regu_tanpa_angka;
+alter table regu add constraint regu_nama_regu_tanpa_angka
+  check (nama_regu !~ '[0-9]');
+
+alter table regu drop constraint if exists regu_nama_ketua_tanpa_angka;
+alter table regu add constraint regu_nama_ketua_tanpa_angka
+  check (nama_ketua !~ '[0-9]');
+
+-- nama_kontak boleh NULL (ditambahkan 0013 pada data yang sudah ada), dan
+-- `null !~ ...` bernilai NULL yang diterima check constraint — jadi baris lama
+-- tanpa nama kontak tidak ikut ditolak, sesuai maksudnya.
+alter table pendaftaran drop constraint if exists pendaftaran_nama_kontak_tanpa_angka;
+alter table pendaftaran add constraint pendaftaran_nama_kontak_tanpa_angka
+  check (nama_kontak !~ '[0-9]');
+
+comment on constraint regu_nama_regu_tanpa_angka on regu is
+  'Angka di kolom nama selalu berarti kolom tertukar atau regu dinomori '
+  'sendiri — dua penomoran yang bersaing dengan nomor dada.';

--- a/tests/sql/22_nama_tanpa_angka.sql
+++ b/tests/sql/22_nama_tanpa_angka.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/22_nama_tanpa_angka.sql
+-- Nama regu, nama ketua, dan nama contact person tanpa angka (0052).
+--
+-- Yang dijaga: yang ditolak HANYA digit. Aturan yang ikut menolak titik atau
+-- apostrof akan menolak lebih banyak nama asli daripada kekeliruan yang
+-- dicegahnya, dan itu ditemukan di meja pendaftaran saat antrean mengular.
+-- ============================================================================
+
+create temp table t_daftar as select id from pendaftaran limit 1;
+
+do $$
+declare v_d uuid; v_tolak boolean;
+begin
+  select id into v_d from t_daftar;
+
+  -- Nama regu berangka ditolak.
+  v_tolak := false;
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    values (v_d, 'Uji Regu 1', 'Uji Angka', 'penegak_pa');
+    raise exception 'GAGAL: nama regu berangka diterima';
+  exception when others then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true;
+  end;
+  assert v_tolak, 'nama regu berangka tidak ditolak';
+
+  -- Nama ketua berangka ditolak.
+  v_tolak := false;
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    values (v_d, 'Uji Regu Bebas', '08123456789', 'penegak_pa');
+    raise exception 'GAGAL: nama ketua berangka diterima';
+  exception when others then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true;
+  end;
+  assert v_tolak, 'nama ketua berangka tidak ditolak';
+
+  raise notice '22.1 OK — nama berangka ditolak.';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 22.2  Tanda baca dalam nama asli TETAP diterima. Inilah bagian yang mudah
+--       dirusak kalau suatu hari aturannya diperketat jadi "hanya huruf".
+-- ---------------------------------------------------------------------------
+do $$
+declare v_d uuid; v_ada integer;
+begin
+  select id into v_d from t_daftar;
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_d, 'Uji Ma''ruf-Aini', 'Nur Aisyah binti H. Abdul', 'penegak_pi');
+
+  select count(*) into v_ada from regu where nama_regu = 'Uji Ma''ruf-Aini';
+  assert v_ada = 1, 'nama dengan apostrof/titik/tanda hubung ikut ditolak';
+  raise notice '22.2 OK — titik, apostrof, dan tanda hubung tetap boleh.';
+end;
+$$;
+
+delete from regu where nama_regu like 'Uji %';
+drop table if exists t_daftar;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -77,6 +77,12 @@ export function pesanRamah(m) {
     return "Nama regu itu sudah dipakai regu lain. Pilih nama yang berbeda.";
   if (/regu_nama_panjang/i.test(t))
     return "Nama regu paling panjang 20 karakter.";
+  if (/nama_regu_tanpa_angka/i.test(t))
+    return "Nama regu tidak boleh memakai angka.";
+  if (/nama_ketua_tanpa_angka/i.test(t))
+    return "Nama ketua tidak boleh memakai angka.";
+  if (/nama_kontak_tanpa_angka/i.test(t))
+    return "Nama contact person tidak boleh memakai angka.";
   if (/permission denied|insufficient/i.test(t))
     return "Akun ini tidak berhak melakukan itu. Pakai akun yang sesuai.";
   if (/password.*(should be different|new password should be different)/i.test(t))


### PR DESCRIPTION
## What

Nama Regu, Nama Ketua and Nama Contact Person reject digits — in the form as
they are typed, and in the database.

- `0052_nama_tanpa_angka.sql` — three check constraints, with a pre-flight that
  names every offending row rather than failing on one.
- `daftar.js` — inline errors on all three fields, and Kirim held back.
- `pesanRamah` — three translations so a constraint violation never reaches a
  pembina raw.
- `tests/sql/22_nama_tanpa_angka.sql`.

## Why

A digit in a name always means one of two things:

**The columns got swapped** — a WhatsApp number in Nama, a nomor dada in Nama
Ketua. A pembina fills this once, from a phone, while doing something else.

**Or the regu numbered itself** — "REGU 1", "REGU 2". Regu already have numbers
and they are called nomor dada; a name carrying its own number puts two
numbering schemes on one sheet and panitia have to guess which is being called.

Either way it surfaces at the daftar ulang desk, after the pembina has gone
home.

## Only digits

Not "letters only". Real names carry spaces, full stops, apostrophes and
hyphens — `Nur Aisyah binti H. Abdul`, `Ma'ruf`, `Siti Nur-Aini`. A rule strict
enough to catch those rejects more real names than mistakes, at a desk with a
queue behind it. Test 22.2 exists to stop that being tightened later.

## Notes

`nama_kontak` is nullable from `0013`, and `null !~ '[0-9]'` is NULL, which a
check constraint accepts — so old rows without a contact name are not caught by
this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)