### PR TITLE
feat: show each kloter's estimated departure on the start-line board

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2389,3 +2389,11 @@ input.small-input { text-align: center; }
    inline. Dua kolom juga yang diminta: keduanya disaring mata secara terpisah
    saat mencari satu regu. */
 .table-live .sub-kolom { color: var(--tinta-lembut); }
+
+/* Kloter yang perkiraan berangkatnya sudah melewati batas (bawaan 10:00,
+   edisi.jam_batas_berangkat). Diberi tepi merah, TIDAK dilarang berangkat:
+   jam yang tercatat adalah jam yang benar-benar terjadi, dan sistem yang
+   menolak mencatat kenyataan karena kenyataan itu terlambat kehilangan data
+   yang justru paling perlu dijelaskan sesudahnya. */
+.kloter-chip.lewat-batas { border-color: var(--bahaya); }
+.kloter-chip.lewat-batas .chip-ket { color: var(--bahaya); font-weight: 700; }

--- a/supabase/migrations/0053_perkiraan_berangkat.sql
+++ b/supabase/migrations/0053_perkiraan_berangkat.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- hrcd-rekap : 0053_perkiraan_berangkat.sql
+--
+-- Perkiraan jam berangkat tiap kloter, dan batas pukul 10:00, dibawa ke papan
+-- Keberangkatan.
+--
+-- ---------------------------------------------------------------------------
+-- YANG SUDAH ADA DAN TIDAK PERNAH TERLIHAT
+--
+-- Perkiraannya sudah dihitung sejak migrasi 0009: `edisi.jam_mulai_berangkat`
+-- (bawaan 07:00) ditambah `interval_berangkat_menit` dikali nomor kloter,
+-- dan hasilnya berdiri di `v_daftar_kloter` sebagai `perkiraan_berangkat`.
+--
+-- Tapi view itu hanya dibaca layar CETAK. Papan Keberangkatan — layar yang
+-- ditunggui petugas di garis start sepanjang pagi — membaca `v_keberangkatan`,
+-- dan di sana perkiraannya tidak ada. Petugas yang ditanya "kloter 9 kira-kira
+-- jam berapa?" tidak punya jawaban di layar yang sedang ia pandangi.
+--
+-- Jadi yang ditambahkan di sini bukan perhitungan baru, melainkan kolom yang
+-- sama pada view yang benar. Satu rumus, dua tempat membacanya.
+--
+-- ---------------------------------------------------------------------------
+-- BATAS 10:00
+--
+-- CLAUDE.md bagian 10: tidak ada kloter berangkat sebelum tujuh, dan yang
+-- terakhir sudah lepas pukul sepuluh. Batas atasnya belum pernah jadi data —
+-- hanya angka di kepala panitia.
+--
+-- Ia dijadikan konfigurasi, bukan konstanta, karena alasan yang sama dengan
+-- jam mulainya: panitia tahun depan mengubah jendelanya tanpa menyentuh kode.
+--
+-- Yang dilakukan `lewat_batas` cuma MEMBERI TAHU. Ia tidak menolak
+-- keberangkatan dan tidak boleh: jam yang tercatat adalah jam yang benar-benar
+-- terjadi (alur 12.4), dan sistem yang menolak mencatat kenyataan karena
+-- kenyataan itu terlambat akan kehilangan data yang justru paling perlu
+-- dijelaskan sesudahnya.
+--
+-- ---------------------------------------------------------------------------
+-- PERKIRAAN BUKAN CATATAN
+--
+-- CLAUDE.md 10.6. `perkiraan_berangkat` di sini SELALU perkiraan — ia tidak
+-- pernah jatuh kembali ke `jam_berangkat` seperti di v_daftar_kloter, karena
+-- papan ini sudah menampilkan jam nyata di kolomnya sendiri. Dua kolom
+-- terpisah, dan layar bisa menyebut mana yang mana.
+-- ============================================================================
+
+alter table edisi add column if not exists jam_batas_berangkat time not null
+  default '10:00';
+
+comment on column edisi.jam_batas_berangkat is
+  'Kloter terakhir sudah harus berangkat sebelum jam ini. Dipakai menandai '
+  'perkiraan yang melewatinya — TIDAK menolak keberangkatan.';
+
+-- ---------------------------------------------------------------------------
+-- Badan view disalin dari 0005 apa adanya, dengan SATU perubahan yang
+-- disengaja: `r.batal` jadi `r.is_cancelled`.
+--
+-- Bukan kekeliruan pada 0005 — 0014 mengganti nama kolomnya, dan PostgreSQL
+-- ikut memperbarui definisi view yang menyebutnya. Jadi yang tersimpan di
+-- database sekarang memang `is_cancelled`, dan menulis ulang dengan `batal`
+-- akan gagal.
+--
+-- Dua kolom baru DITARUH DI UJUNG: `create or replace view` mengizinkan
+-- menambah di belakang, tapi menolak kalau urutan atau tipe kolom yang sudah
+-- ada ikut bergeser.
+-- ---------------------------------------------------------------------------
+create or replace view v_keberangkatan with (security_invoker = on) as
+with terakhir as (
+  select coalesce(max(nomor), 0) as n
+  from kloter where jam_berangkat is not null
+)
+select
+  k.nomor,
+  k.jam_berangkat,
+  case
+    when k.jam_berangkat is not null            then 'berangkat'
+    when k.nomor <= t.n + 2                     then 'siap'
+    when k.nomor =  t.n + 3                     then 'konfirmasi_kontrak'
+    else 'menunggu'
+  end as posisi,
+  (select count(*) from regu r
+   where r.kloter_nomor = k.nomor and not r.is_cancelled) as jumlah_regu,
+  (select count(*) from regu r
+   join keberangkatan_regu kb on kb.regu_id = r.id
+   where r.kloter_nomor = k.nomor)               as sudah_ceklis,
+  (select count(*) from regu r
+   where r.kloter_nomor = k.nomor and not r.is_cancelled
+     and r.kontrak_menit is not null)            as sudah_kontrak,
+
+  -- Kolom baru, di ujung.
+  (e.tanggal_lomba + e.jam_mulai_berangkat)::timestamptz
+    + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1))
+                                                 as perkiraan_berangkat,
+  ((e.jam_mulai_berangkat
+    + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1)))
+      > e.jam_batas_berangkat)                   as lewat_batas
+from kloter k
+cross join terakhir t
+cross join edisi e
+where e.aktif
+  and (exists (select 1 from regu r where r.kloter_nomor = k.nomor)
+       or k.jam_berangkat is not null);
+
+comment on view v_keberangkatan is
+  'Papan garis start. `jam_berangkat` yang tercatat dan `perkiraan_berangkat` '
+  'adalah dua hal berbeda dan sengaja dua kolom — perkiraan untuk '
+  'merencanakan pagi, catatan untuk menghitung penalti.';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1108,12 +1108,24 @@ async function layarKeberangkatan() {
          start, melihat kloter mana berangkat pukul berapa, tanpa membuka
          satu-satu. Datanya sudah ikut di v_keberangkatan sejak awal; layar ini
          saja yang membuangnya. */
+      /* Yang BELUM berangkat menampilkan PERKIRAANNYA, bukan kata "menunggu".
+
+         "Menunggu" adalah hal yang sudah terbaca dari warna chip-nya, dan ia
+         menjawab pertanyaan yang tidak ada yang ajukan. Yang ditanyakan
+         sepanjang pagi cuma satu: "kloter 9 kira-kira jam berapa?" — dan
+         jawabannya sudah dihitung sejak migrasi 0009, hanya belum pernah
+         sampai ke layar ini (0053).
+
+         Tandanya "~" supaya tidak pernah tertukar dengan jam yang benar-benar
+         tercatat. Perkiraan bukan catatan — CLAUDE.md 10.6. */
       const label = k.jam_berangkat
         ? jamMenit(k.jam_berangkat)
+        : k.perkiraan_berangkat ? `~${jamMenit(k.perkiraan_berangkat)}`
         : ({ siap: "siap", konfirmasi_kontrak: "kontrak",
              menunggu: "menunggu" }[k.posisi] || "");
       return html`
-        <button type="button" class="kloter-chip ${k.posisi}"
+        <button type="button" class="kloter-chip ${k.posisi}${
+                  k.lewat_batas && !k.jam_berangkat ? " lewat-batas" : ""}"
                 data-kloter="${k.nomor}" aria-pressed="${k.nomor === kloterAktif}">
           <span class="chip-nomor">Kloter ${k.nomor}</span>
           <span class="chip-ket">${k.sudah_ceklis}/${k.jumlah_regu} · ${label}</span>

--- a/web/style.css
+++ b/web/style.css
@@ -2389,3 +2389,11 @@ input.small-input { text-align: center; }
    inline. Dua kolom juga yang diminta: keduanya disaring mata secara terpisah
    saat mencari satu regu. */
 .table-live .sub-kolom { color: var(--tinta-lembut); }
+
+/* Kloter yang perkiraan berangkatnya sudah melewati batas (bawaan 10:00,
+   edisi.jam_batas_berangkat). Diberi tepi merah, TIDAK dilarang berangkat:
+   jam yang tercatat adalah jam yang benar-benar terjadi, dan sistem yang
+   menolak mencatat kenyataan karena kenyataan itu terlambat kehilangan data
+   yang justru paling perlu dijelaskan sesudahnya. */
+.kloter-chip.lewat-batas { border-color: var(--bahaya); }
+.kloter-chip.lewat-batas .chip-ket { color: var(--bahaya); font-weight: 700; }


### PR DESCRIPTION
## What

- `edisi.jam_batas_berangkat` (default `10:00`).
- `v_keberangkatan` gains `perkiraan_berangkat` and `lewat_batas`.
- Chips show `~08:12` instead of `menunggu`, and turn red past the limit.

## Why

**The estimate already existed.** Since `0009`: `jam_mulai_berangkat` (07:00)
plus `interval_berangkat_menit` per kloter. But it lives in `v_daftar_kloter`,
which only the print screen reads. The board an officer watches all morning
reads `v_keberangkatan`, where it was absent — so asked *"kloter 9 kira-kira
jam berapa?"* they had no answer on the screen in front of them.

This adds no new arithmetic. One formula, two readers.

`menunggu` was already legible from the chip's colour and answered a question
nobody asked; the estimate answers the one they do.

**The tilde matters.** An estimate is not a record — CLAUDE.md 10.6 — and here
they are two separate columns so the screen can say which is which.

**`lewat_batas` only tells.** It does not block departure and must not: the
recorded jam berangkat is what actually happened (alur 12.4), and refusing to
record reality because reality ran late loses exactly the data that most needs
explaining afterwards.

## Notes

The view body is copied from `0005` with one deliberate change: `r.batal` →
`r.is_cancelled`. `0014` renamed the column and PostgreSQL rewrote the stored
view definition with it, so what is in the database today says `is_cancelled`
and rewriting it with `batal` would fail. New columns go at the end, since
`create or replace view` refuses to shift existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)