### PR TITLE
fix: seven migrations and three tests were never run by CI

### DIFF
--- a/supabase/checks/hapus_angka_nama_uji.sql
+++ b/supabase/checks/hapus_angka_nama_uji.sql
@@ -40,6 +40,14 @@ declare
   romawi text[] := array['I','II','III','IV','V','VI','VII','VIII','IX'];
   n int;
 begin
+  -- Nol tidak punya angka Romawi. Diganti huruf O, yang bentuknya memang
+  -- asalnya: fixture tes memakai "Regu A01", dan tanpa baris ini nol-nya
+  -- tertinggal lalu 0052 tetap menolak.
+  update regu set nama_regu = replace(nama_regu, '0', 'O') where nama_regu ~ '0';
+  update regu set nama_ketua = replace(nama_ketua, '0', 'O') where nama_ketua ~ '0';
+  update pendaftaran set nama_kontak = replace(nama_kontak, '0', 'O')
+  where nama_kontak ~ '0';
+
   for n in 1..9 loop
     update regu
     set nama_regu = regexp_replace(nama_regu, n::text, romawi[n], 'g')

--- a/supabase/migrations/0053_perkiraan_berangkat.sql
+++ b/supabase/migrations/0053_perkiraan_berangkat.sql
@@ -53,7 +53,7 @@ comment on column edisi.jam_batas_berangkat is
 
 -- ---------------------------------------------------------------------------
 -- Badan view disalin dari 0005 apa adanya, dengan SATU perubahan yang
--- disengaja: `r.batal` jadi `r.is_cancelled`.
+-- disengaja: `r.batal` jadi `r.is_cancelled`, dan `e.aktif` jadi `e.is_active`.
 --
 -- Bukan kekeliruan pada 0005 — 0014 mengganti nama kolomnya, dan PostgreSQL
 -- ikut memperbarui definisi view yang menyebutnya. Jadi yang tersimpan di
@@ -97,7 +97,7 @@ select
 from kloter k
 cross join terakhir t
 cross join edisi e
-where e.aktif
+where e.is_active
   and (exists (select 1 from regu r where r.kloter_nomor = k.nomor)
        or k.jam_berangkat is not null);
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -167,6 +167,10 @@ run supabase/migrations/0050_rename_live_score.sql
 # masih bebas memakai nama apa pun.
 run supabase/migrations/0051_nama_regu_unik.sql
 run tests/sql/21_nama_regu_unik.sql
+# Fixture tes memakai nama berangka ("Regu A01", "Ketua A1"), jadi 0052 akan
+# menolaknya. Dibersihkan dengan skrip yang SAMA PERSIS dengan yang dipakai
+# produksi — sekalian membuktikan skrip itu sendiri bekerja.
+run supabase/checks/hapus_angka_nama_uji.sql
 run supabase/migrations/0052_nama_tanpa_angka.sql
 run tests/sql/22_nama_tanpa_angka.sql
 run supabase/migrations/0053_perkiraan_berangkat.sql

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -147,4 +147,28 @@ run supabase/migrations/0045_pos_boleh_buka_gembok.sql
 run supabase/migrations/0046_gembok_dua_lubang.sql
 run tests/sql/19_kunci_nilai.sql
 
+# --------------------------------------------------------------------------
+# 0047-0053. Ketujuhnya SEMPAT TIDAK ADA di berkas ini, dan itu berarti CI
+# hijau selama berhari-hari tanpa pernah menjalankan satu pun di antaranya —
+# termasuk tes 20, 21, dan 22 yang ditulis bersamanya. Yang menemukannya
+# akhirnya bukan CI, melainkan produksi: 0053 gagal di sana dengan "column
+# e.aktif does not exist", galat yang seharusnya muncul di sini lebih dulu.
+#
+# Daftar ini ditulis tangan, jadi migrasi baru TIDAK otomatis teruji. Setiap
+# berkas baru di supabase/migrations/ harus ditambahkan di sini pada commit
+# yang sama.
+# --------------------------------------------------------------------------
+run supabase/migrations/0047_foto_lembar.sql
+run tests/sql/20_foto_lembar.sql
+run supabase/migrations/0048_live_skor_peserta.sql
+run supabase/migrations/0049_pratinjau_live_admin.sql
+run supabase/migrations/0050_rename_live_score.sql
+# 0051 melarang nama regu kembar; dijalankan sesudah tes lain supaya mereka
+# masih bebas memakai nama apa pun.
+run supabase/migrations/0051_nama_regu_unik.sql
+run tests/sql/21_nama_regu_unik.sql
+run supabase/migrations/0052_nama_tanpa_angka.sql
+run tests/sql/22_nama_tanpa_angka.sql
+run supabase/migrations/0053_perkiraan_berangkat.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/sql/20_foto_lembar.sql
+++ b/tests/sql/20_foto_lembar.sql
@@ -24,6 +24,12 @@ select id, nomor_dada from regu
 where nomor_dada is not null and not is_cancelled
 order by nomor_dada limit 1;
 
+-- Tabel sementara di atas dibuat SEBAGAI PEMILIK, lalu dibaca sebagai
+-- `authenticated` di bawah — dan tabel temp tidak mewarisi hak apa pun.
+-- Tanpa grant ini seluruh berkas berhenti di "permission denied for table
+-- t_regu", galat yang tidak ada hubungannya dengan apa yang sedang diuji.
+grant select on t_op, t_regu to public;
+
 select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
 set role authenticated;
 


### PR DESCRIPTION
## What

`tests/run.sh` gains `0047`–`0053` and tests `20`, `21`, `22`. `0053` gets
`e.aktif` → `e.is_active`.

## Why

`tests/run.sh` lists every migration **by hand**, and nothing added since
`0046` was ever on the list. CI has been green for days without executing one
of them — and tests 20, 21 and 22, written alongside them, have never run at
all. I reported them as passing; what passed was the older suite.

**Production found it, not CI.** `0053` failed on apply with
`column e.aktif does not exist`. `0014` renamed `edisi.aktif` to `is_active`,
and I caught that same rename for `regu.batal` in the copied view body while
missing this one. The error should have surfaced here first.

## Notes

The list stays hand-written, so this can recur. A comment now says so at the
point someone adding a migration will be reading.

This PR is where CI first exercises everything since `0046`. If anything else
in those seven is wrong, it should fail here — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)