### PR TITLE
feat: one blangko per lomba, not per criterion

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -467,7 +467,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }
@@ -481,7 +481,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
-    `golongan,petunjuk,judul_isian,` +
+    `golongan,petunjuk,judul_isian,lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/live/style.css
+++ b/live/style.css
@@ -766,6 +766,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .bl-nilai-contoh { display: block; font-size: 9pt; margin-top: .8mm; }
   .bl-nilai-kotak { height: 30mm; }
 
+  /* LOMBA BERKRITERIA BANYAK: satu kotak per kriteria, berjajar.
+
+     Pembidaian dinilai lima hal di satu meja oleh satu juri, jadi kelimanya
+     ada di kertas yang sama — selembar per kriteria menyerahkan lima kertas
+     kepada regu yang sama di satu tempat (CLAUDE.md 11.5).
+
+     Kotaknya menyusut mengikuti jumlahnya, dan itu tidak apa-apa: yang ditulis
+     di dalamnya paling banyak dua digit. Yang TIDAK boleh menyusut adalah
+     nomor dada dan identitasnya di atas — itu yang dibaca saat menyortir
+     tumpukan. */
+  .bl-nilai-banyak { display: flex; gap: 2.5mm; align-items: stretch; }
+  .bl-nilai-banyak .bl-nilai-sel { flex: 1 1 0; min-width: 0; }
+  .bl-nilai-banyak .bl-nilai-judul { font-size: 9pt; }
+  .bl-nilai-banyak .bl-nilai-kotak { min-height: 14mm; }
+  /* Judul kriteria boleh dua baris — "Diagnosis dan Penanganan Awal" tidak
+     muat satu baris pada seperlima lebar A5, dan memotongnya menghilangkan
+     kata yang membedakannya dari kriteria sebelahnya. */
+  .bl-nilai-banyak .bl-nilai-kepala { min-height: 9mm; }
+
   .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
   .bl-ttd { margin: auto 0 0; text-align: center; font-size: 8pt; }
   .bl-garis { margin: 7mm auto 0; width: 70mm; border-bottom: .75pt solid #000; }

--- a/supabase/migrations/0054_kolom_lomba.sql
+++ b/supabase/migrations/0054_kolom_lomba.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- hrcd-rekap : 0054_kolom_lomba.sql
+--
+-- Tingkat LOMBA jadi data, bukan kebiasaan penamaan.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- CLAUDE.md bagian 11: satu pos berisi beberapa lomba, satu lomba berisi satu
+-- atau lebih penilaian. Sistem ini hanya pernah memodelkan dua tingkat — `pos`
+-- dan `wahana` — jadi tiap kriteria berdiri sendiri seolah ia satu lomba.
+--
+-- Akibatnya paling terlihat di blangko: pencetaknya menghasilkan satu master
+-- per KRITERIA, jadi Pos 3 keluar tujuh lembar padahal dua, dan Pos 4 empat
+-- padahal satu. Satu regu dinilai SEKALI di satu lomba dan jurinya menulis
+-- semua kriteria di kertas yang ada di depannya — selembar per kriteria
+-- menyerahkan lima kertas kepada regu yang sama di satu tempat.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TIDAK MEMBELAH AWALAN KODE SAJA
+--
+-- Karena `bidai_`, `kim_`, `pbb_`, `yel_` adalah kebiasaan menamai, bukan
+-- sesuatu yang dijaga database (bagian 11.7). Ia bekerja sampai ada edisi yang
+-- menamai dua komponen tidak berhubungan dengan kata pertama yang sama —
+-- `pbb_dasar` dan `pbb_gerakan` kebetulan satu lomba, tapi tidak ada yang
+-- menjamin `kim_cium` dan `kimia_dasar` tidak muncul bersamaan suatu hari.
+--
+-- Jadi kolomnya eksplisit, dan pengisian awalnya menyebut nama lombanya satu
+-- per satu untuk edisi yang ada sekarang. Edisi berikutnya mengisinya sendiri
+-- saat admin menyusun komponen.
+--
+-- ---------------------------------------------------------------------------
+-- BAWAAN: SATU KOMPONEN = SATU LOMBA
+--
+-- Kolomnya boleh NULL, dan NULL berarti "komponen ini lomba tersendiri".
+-- Itu keadaan yang benar untuk sebagian besar baris — Semaphore, Menaksir,
+-- Bakiak — dan membuat kolom ini hanya perlu diisi pada yang memang
+-- berkelompok. Layar membaca `coalesce(lomba, name)`.
+-- ============================================================================
+
+alter table wahana add column if not exists lomba text;
+
+comment on column wahana.lomba is
+  'Nama LOMBA yang menaungi komponen ini. NULL = komponen ini lomba '
+  'tersendiri. Satu blangko dicetak per lomba, bukan per komponen.';
+
+-- ---------------------------------------------------------------------------
+-- Pengisian awal untuk edisi aktif. Disebut satu per satu, bukan dibelah dari
+-- awalan kode — lihat kepala berkas.
+--
+-- Dipagari `where lomba is null` supaya menjalankannya dua kali tidak menimpa
+-- perubahan yang sudah dilakukan admin sesudahnya.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  peta jsonb := jsonb_build_object(
+    'bidai', 'Pembidaian',
+    'kim',   'KIM',
+    'pbb',   'PBB',
+    'yel',   'Yel-Yel'
+  );
+  awalan text;
+  v_baris int;
+  v_total int := 0;
+begin
+  for awalan in select jsonb_object_keys(peta) loop
+    update wahana
+    set lomba = peta ->> awalan
+    where edisi = edisi_aktif()
+      and lomba is null
+      and kode like awalan || '\_%';
+    get diagnostics v_baris = row_count;
+    v_total := v_total + v_baris;
+    if v_baris > 0 then
+      raise notice '0054: % komponen jadi lomba "%".', v_baris, peta ->> awalan;
+    end if;
+  end loop;
+
+  if v_total = 0 then
+    raise notice '0054: tidak ada komponen berkelompok di edisi aktif — '
+      'setiap komponen berdiri sebagai lombanya sendiri.';
+  end if;
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -174,5 +174,6 @@ run supabase/checks/hapus_angka_nama_uji.sql
 run supabase/migrations/0052_nama_tanpa_angka.sql
 run tests/sql/22_nama_tanpa_angka.sql
 run supabase/migrations/0053_perkiraan_berangkat.sql
+run supabase/migrations/0054_kolom_lomba.sql
 
 echo "SEMUA TES LULUS"

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -467,7 +467,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }
@@ -481,7 +481,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
-    `golongan,petunjuk,judul_isian,` +
+    `golongan,petunjuk,judul_isian,lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2056,6 +2056,28 @@ function kolomPos(komponen) {
  *  null = kolom ini memang bukan untuk golongannya. Itu keadaan sah, bukan
  *  konfigurasi rusak: Tebak Simpul Penegak tidak ada urusannya dengan regu
  *  Penggalang. */
+/** Kolom layar dikelompokkan jadi LOMBA — tingkat ketiga yang tidak dimiliki
+ *  `wahana` sampai migrasi 0054 (CLAUDE.md bagian 11).
+ *
+ *  Kolom di layar tetap satu per PENILAIAN: Pembidaian lima kolom. Blangko
+ *  tetap satu per LOMBA: Pembidaian selembar dengan lima kotak. Keduanya
+ *  benar, dan yang satu tidak boleh "diperbaiki" mengikuti yang lain — 11.6.
+ *
+ *  `lomba` kosong berarti komponen itu lomba tersendiri, keadaan yang benar
+ *  untuk sebagian besar baris. */
+function kelompokLomba(kolom) {
+  const urut = [], peta = new Map();
+  for (const kol of kolom) {
+    const nama = kol.varian[0].lomba || kol.nama;
+    if (!peta.has(nama)) {
+      peta.set(nama, { nama, kolom: [] });
+      urut.push(peta.get(nama));
+    }
+    peta.get(nama).kolom.push(kol);
+  }
+  return urut;
+}
+
 const varianUntuk = (kol, golongan) =>
   kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
 
@@ -2274,16 +2296,16 @@ function siapkanCetakBlangko(pos, kolomLayar) {
 
   const judulPos = pos.bayangan ? pos.name : `Pos ${pos.nomor} · ${pos.name}`;
 
-  const satuBlangko = (kol) => {
+  const satuBlangko = (lomba) => {
+    const kols = lomba.kolom;
     // Varian mana pun boleh dipakai untuk menurunkan bentuknya: yang berbeda
     // antar golongan hanya skalanya, dan skala tidak dicetak di blangko —
     // justru itu gunanya. Petugas menulis jumlah benar apa adanya, dan sistem
     // yang tahu 5 simpul untuk Penggalang, 10 untuk Penegak.
-    const k = kol.varian[0];
     return `
     <article class="blangko">
       <p class="bl-pos">${esc(judulPos)}</p>
-      <h2 class="bl-lomba">${esc(kol.nama)}</h2>
+      <h2 class="bl-lomba">${esc(lomba.nama)}</h2>
       <p class="bl-acara">${esc(EDISI ? EDISI.name : "")} · Petugas: ____________</p>
 
       <table class="bl-identitas"><tbody>
@@ -2293,17 +2315,21 @@ function siapkanCetakBlangko(pos, kolomLayar) {
         </tr>
       </tbody></table>
 
-      <div class="bl-nilai">
-        <div class="bl-nilai-kepala">
-          <span class="bl-nilai-judul">${esc(judulIsian(k))}</span>
-          <span class="bl-nilai-contoh">${esc(contohIsian(kol))}</span>
-        </div>
-        <div class="bl-nilai-kotak"></div>
+      <div class="bl-nilai${kols.length > 1 ? " bl-nilai-banyak" : ""}">
+        ${kols.map(kol => `
+        <div class="bl-nilai-sel">
+          <div class="bl-nilai-kepala">
+            <span class="bl-nilai-judul">${esc(kols.length > 1
+              ? kol.nama : judulIsian(kol.varian[0]))}</span>
+            <span class="bl-nilai-contoh">${esc(contohIsian(kol))}</span>
+          </div>
+          <div class="bl-nilai-kotak"></div>
+        </div>`).join("")}
       </div>
 
       <p class="bl-catatan"><strong>Tulis angkanya saja — jangan menghitung
          poin.</strong></p>
-      <p class="bl-ttd">Petugas ${esc(kol.nama)}</p>
+      <p class="bl-ttd">Petugas ${esc(lomba.nama)}</p>
       <p class="bl-garis"></p>
     </article>`;
   };
@@ -2319,11 +2345,12 @@ function siapkanCetakBlangko(pos, kolomLayar) {
   // Jadi keluarannya tiga halaman untuk Pos 1: Semaphore, Tebak Simpul,
   // Menaksir. Panitia menggandakan tiap halaman sebanyak yang dibutuhkan, dan
   // tiap tumpukan otomatis berisi satu lomba saja.
-  const cetakan = kolomLayar.map(kol => `
-    <section class="print-page blangko-halaman">${satuBlangko(kol)}</section>`).join("");
+  const daftarLomba = kelompokLomba(kolomLayar);
+  const cetakan = daftarLomba.map(l => `
+    <section class="print-page blangko-halaman">${satuBlangko(l)}</section>`).join("");
 
   document.body.appendChild(h(`<div id="cetakan" class="printout">${cetakan}</div>`));
-  return kolomLayar.length;
+  return daftarLomba.length;
 }
 
 /** Layar Input Pos — lembar kertas yang dipindah ke layar.

--- a/web/style.css
+++ b/web/style.css
@@ -766,6 +766,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .bl-nilai-contoh { display: block; font-size: 9pt; margin-top: .8mm; }
   .bl-nilai-kotak { height: 30mm; }
 
+  /* LOMBA BERKRITERIA BANYAK: satu kotak per kriteria, berjajar.
+
+     Pembidaian dinilai lima hal di satu meja oleh satu juri, jadi kelimanya
+     ada di kertas yang sama — selembar per kriteria menyerahkan lima kertas
+     kepada regu yang sama di satu tempat (CLAUDE.md 11.5).
+
+     Kotaknya menyusut mengikuti jumlahnya, dan itu tidak apa-apa: yang ditulis
+     di dalamnya paling banyak dua digit. Yang TIDAK boleh menyusut adalah
+     nomor dada dan identitasnya di atas — itu yang dibaca saat menyortir
+     tumpukan. */
+  .bl-nilai-banyak { display: flex; gap: 2.5mm; align-items: stretch; }
+  .bl-nilai-banyak .bl-nilai-sel { flex: 1 1 0; min-width: 0; }
+  .bl-nilai-banyak .bl-nilai-judul { font-size: 9pt; }
+  .bl-nilai-banyak .bl-nilai-kotak { min-height: 14mm; }
+  /* Judul kriteria boleh dua baris — "Diagnosis dan Penanganan Awal" tidak
+     muat satu baris pada seperlima lebar A5, dan memotongnya menghilangkan
+     kata yang membedakannya dari kriteria sebelahnya. */
+  .bl-nilai-banyak .bl-nilai-kepala { min-height: 9mm; }
+
   .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
   .bl-ttd { margin: auto 0 0; text-align: center; font-size: 8pt; }
   .bl-garis { margin: 7mm auto 0; width: 70mm; border-bottom: .75pt solid #000; }


### PR DESCRIPTION
## What

- `0054_kolom_lomba.sql` — `wahana.lomba`, backfilled for the active edition.
- `kelompokLomba()` in `app.js`; the blangko generator groups by it.
- A multi-criterion sheet lays its boxes side by side.

| pos | masters before | after |
|---|---|---|
| Pos 3 | 7 | **2** (Pembidaian, KIM) |
| Pos 4 | 4 | **1** (PBB) |
| Pos 5 | 4 | **1** (Yel-Yel) |

## Why

A regu is judged **once** at a lomba, and the judge fills every criterion on
the sheet in front of them. A sheet per criterion hands the same regu five
pieces of paper at one station.

## Why a column and not a prefix split

`bidai_`, `kim_`, `pbb_`, `yel_` are a naming habit that nothing in the
database enforces — CLAUDE.md 11.7. Splitting on them works right up until an
edition names two unrelated components with the same first word. The backfill
therefore names each lomba explicitly, scoped to the active edition, and next
year's admin fills the column as they build the components.

`NULL` means *this component is its own lomba*, the correct state for most rows
— Semaphore, Menaksir, Bakiak — so only grouped components need a value.

## Notes

**The screen does not change, deliberately.** One column per penilaian there,
one sheet per lomba on paper. Both are correct and neither should be made to
match the other — 11.6.

Boxes shrink as criteria multiply, which is fine: at most two digits go in
them. What does not shrink is the nomor dada and the identity line above,
which is what gets read when sorting the stack.

`0054` is in `tests/run.sh` from the start, unlike the seven that #232 had to
rescue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)