### PR TITLE
fix: centre the camera button in its row

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1336,6 +1336,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      centang dan gembok di sebelahnya — tiga tombol sebaris yang tidak
      sejajar. */
   display: inline-flex; align-items: center; justify-content: center;
+  /* Dan `vertical-align: middle` pada TOMBOLNYA, bukan pada ikonnya.
+
+     Kotak inline-flex mengambil garis dasarnya dari garis dasar anak
+     pertamanya, dan garis dasar sebuah SVG adalah tepi BAWAHnya. Jadi seluruh
+     pil terdorong naik sampai dasar gambarnya duduk di garis dasar teks
+     sebelahnya — ikonnya sendiri sudah di tengah tombol, tombolnya yang tidak
+     di tengah baris.
+
+     `vertical-align` pada anaknya tidak menolong sama sekali: pada flex item
+     properti itu diabaikan. */
+  vertical-align: middle;
 }
 .badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
 
@@ -2381,7 +2392,9 @@ input.small-input { text-align: center; }
    warnanya ikut keadaan barisnya lewat currentColor — emoji dulu tampil
    berwarna tetap dan lebih besar daripada tetangganya, jadi kolom aksi
    terbaca bergerigi. */
-.badge-tombol .ikon { width: 1.15rem; height: 1.15rem; vertical-align: -.2em; }
+/* Tanpa vertical-align: ikon ini flex item, dan di sana properti itu tidak
+   berlaku — yang mengatur letaknya align-items pada tombolnya. */
+.badge-tombol .ikon { width: 1.15rem; height: 1.15rem; }
 
 /* Judul kartu yang rata tengah. Dipakai di atas deretan cincin kemajuan:
    isinya sendiri sederet lingkaran yang terbagi rata selebar kartu, dan judul

--- a/web/style.css
+++ b/web/style.css
@@ -1336,6 +1336,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      centang dan gembok di sebelahnya — tiga tombol sebaris yang tidak
      sejajar. */
   display: inline-flex; align-items: center; justify-content: center;
+  /* Dan `vertical-align: middle` pada TOMBOLNYA, bukan pada ikonnya.
+
+     Kotak inline-flex mengambil garis dasarnya dari garis dasar anak
+     pertamanya, dan garis dasar sebuah SVG adalah tepi BAWAHnya. Jadi seluruh
+     pil terdorong naik sampai dasar gambarnya duduk di garis dasar teks
+     sebelahnya — ikonnya sendiri sudah di tengah tombol, tombolnya yang tidak
+     di tengah baris.
+
+     `vertical-align` pada anaknya tidak menolong sama sekali: pada flex item
+     properti itu diabaikan. */
+  vertical-align: middle;
 }
 .badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
 
@@ -2381,7 +2392,9 @@ input.small-input { text-align: center; }
    warnanya ikut keadaan barisnya lewat currentColor — emoji dulu tampil
    berwarna tetap dan lebih besar daripada tetangganya, jadi kolom aksi
    terbaca bergerigi. */
-.badge-tombol .ikon { width: 1.15rem; height: 1.15rem; vertical-align: -.2em; }
+/* Tanpa vertical-align: ikon ini flex item, dan di sana properti itu tidak
+   berlaku — yang mengatur letaknya align-items pada tombolnya. */
+.badge-tombol .ikon { width: 1.15rem; height: 1.15rem; }
 
 /* Judul kartu yang rata tengah. Dipakai di atas deretan cincin kemajuan:
    isinya sendiri sederet lingkaran yang terbagi rata selebar kartu, dan judul


### PR DESCRIPTION
## What

`vertical-align: middle` on `.badge-tombol`, and the inert `vertical-align` on
the icon inside it removed.

## Why

The icon was already centred **inside** the button. The button was not centred
in the row.

An inline-flex box takes its baseline from its first flex item, and an SVG's
baseline is its bottom edge — so the whole pill was pushed up until the picture
sat on the neighbouring text baseline, leaving it high against the tick and
padlock.

The `vertical-align: -.2em` I had put on the icon never did anything: on a flex
item that property is ignored. It is gone rather than left looking like it
works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)