### PR TITLE
feat: auto-deploy the peserta site on push to live/

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -33,8 +33,37 @@
 
 name: Publish rekap live
 
+# AUTO DEPLOY, dan kenapa ini AMAN padahal Git integration Cloudflare tidak.
+#
+# Keduanya terdengar sama — "deploy tiap push" — tapi yang dilakukan berbeda
+# di satu titik yang menentukan:
+#
+#   Git integration Cloudflare menyajikan folder live/ APA ADANYA dari repo,
+#   termasuk live.json dan rekap.json yang tersimpan di sana sebagai contoh
+#   fase 'pra'. Tiap push akan mengosongkan rekap peserta tanpa ada yang
+#   gagal.
+#
+#   Workflow ini MENIMPA kedua berkas itu dari database lebih dulu, baru
+#   men-deploy. Berkas contoh di repo tidak pernah sampai ke Cloudflare.
+#
+# Jadi larangan di atas tetap berlaku sepenuhnya: project hrcd37 tidak boleh
+# tersambung Git. Yang ditambahkan di sini bukan jalur kedua, melainkan pemicu
+# kedua untuk jalur yang sama.
+#
+# Kenapa perlu: situs peserta memuat FORM PENDAFTARAN dan rekap live, dan
+# keduanya sempat tertinggal berjam-jam karena merge tidak menerbitkan apa
+# pun — larangan angka pada nama sudah merge tapi pembina tetap bisa mengetik
+# angka, karena berkasnya belum naik.
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'live/**'
+      # Query yang menghasilkan isi live.json. Mengubahnya mengubah apa yang
+      # terbit, walau tidak satu berkas pun di live/ ikut berubah.
+      - 'supabase/checks/live_json.sql'
+      - '.github/workflows/publish-live.yml'
   # schedule:
   #   - cron: '*/5 * * * *'   # nyalakan pada minggu lomba
 


### PR DESCRIPTION
## What

`publish-live.yml` gains a `push` trigger on `main`, filtered to `live/**`,
`supabase/checks/live_json.sql` and the workflow itself.

## Why

The peserta site carries the **registration form** and the **live rekap**, and
both sat hours behind `main` because merging publishes nothing there. The
no-digits rule on names had been merged and applied to the database while a
pembina could still type digits into the form — the file had simply never gone
up.

## Why this is safe when Cloudflare's Git integration is not

They sound identical — "deploy on push" — and differ at the one point that
matters:

- **Cloudflare Git integration** serves `live/` verbatim from the repo,
  including the `pra`-phase `live.json` and `rekap.json` committed there. Every
  push would blank the participant rekap with nothing failing.
- **This workflow** overwrites both files from the database first, then
  deploys. The committed examples never reach Cloudflare.

So the standing rule holds in full: `hrcd37` must not be connected to Git. This
adds a second *trigger* for the same path, not a second path — and the header
now says so, because it is exactly the distinction someone would later
"simplify" the wrong way.

## Notes

`live_json.sql` is in the path list because changing that query changes what
gets published even when nothing under `live/` moves.

`concurrency: publish-live` already serialises runs, so a push landing during a
manual run queues instead of racing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)