### PR TITLE
fix: hover state on the tick and camera, matching the padlock

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1348,6 +1348,19 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      properti itu diabaikan. */
   vertical-align: middle;
 }
+/* Latar menggelap saat disentuh kursor, sama seperti gembok di sebelahnya.
+
+   Tiga tombol sebaris yang hanya satu di antaranya bereaksi membuat dua
+   lainnya terbaca seperti hiasan — dan centang memang PERNAH cuma hiasan
+   sebelum ia jadi pintu riwayat, jadi keraguan itu beralasan.
+
+   Bayangan dalam berjari-jari besar, bukan `background`: centang berlatar
+   hijau muda dan kamera berlatar abu, dan satu aturan yang menimpa `background`
+   akan menghapus salah satunya. Bayangan menggelapkan apa pun yang ada di
+   bawahnya tanpa perlu tahu warnanya — dan ia dilukis DI BAWAH isi, jadi ikon
+   dan hurufnya tetap tajam. */
+.badge-tombol:hover { box-shadow: inset 0 0 0 999px rgba(0, 0, 0, .07); }
+.badge-tombol:active { box-shadow: inset 0 0 0 999px rgba(0, 0, 0, .12); }
 .badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
 
 .table-empty { text-align: center; color: var(--tinta-lembut); padding: 1.4rem .5rem; }

--- a/web/style.css
+++ b/web/style.css
@@ -1348,6 +1348,19 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      properti itu diabaikan. */
   vertical-align: middle;
 }
+/* Latar menggelap saat disentuh kursor, sama seperti gembok di sebelahnya.
+
+   Tiga tombol sebaris yang hanya satu di antaranya bereaksi membuat dua
+   lainnya terbaca seperti hiasan — dan centang memang PERNAH cuma hiasan
+   sebelum ia jadi pintu riwayat, jadi keraguan itu beralasan.
+
+   Bayangan dalam berjari-jari besar, bukan `background`: centang berlatar
+   hijau muda dan kamera berlatar abu, dan satu aturan yang menimpa `background`
+   akan menghapus salah satunya. Bayangan menggelapkan apa pun yang ada di
+   bawahnya tanpa perlu tahu warnanya — dan ia dilukis DI BAWAH isi, jadi ikon
+   dan hurufnya tetap tajam. */
+.badge-tombol:hover { box-shadow: inset 0 0 0 999px rgba(0, 0, 0, .07); }
+.badge-tombol:active { box-shadow: inset 0 0 0 999px rgba(0, 0, 0, .12); }
 .badge-tombol:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
 
 .table-empty { text-align: center; color: var(--tinta-lembut); padding: 1.4rem .5rem; }


### PR DESCRIPTION
## What

`.badge-tombol` — the tick and the camera in each pos-sheet row — gains hover
and active states. The padlock already had one.

## Why

Three buttons in a row where only one reacts to the cursor makes the other two
read as decoration. That doubt is earned: the tick genuinely *was* decoration
before it became the door to the history.

## How

An inset `box-shadow` with a large spread rather than a `background`. The tick
sits on pale green and the camera on grey; one rule overwriting `background`
would erase one of them. A shadow darkens whatever is underneath without
knowing its colour, and is painted below the content so the icon stays crisp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)