### PR TITLE
feat: progress badges on Keberangkatan and Kedatangan

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -294,15 +294,20 @@ export async function ringkasanMeja() {
   if (K.mode === "dev") return baca("/ringkasan");
   // Dihitung dari sisi regu supaya angkanya benar-benar "batch lunas yang
   // masih punya regu tanpa nomor dada" (temuan review: query lama salah).
-  const [menunggu, tanpaNomor] = await Promise.all([
+  const [menunggu, tanpaNomor, kemajuan] = await Promise.all([
     baca(null, "pendaftaran?status=eq.menunggu_pembayaran&select=id"),
     baca(null, "regu?nomor_dada=is.null&is_cancelled=is.false" +
                "&select=pendaftaran_id,pendaftaran!inner(status)" +
                "&pendaftaran.status=eq.lunas"),
+    baca(null, "v_kemajuan_hari?select=*"),
   ]);
+  const k = (Array.isArray(kemajuan) ? kemajuan[0] : kemajuan) || {};
   return {
     menunggu_pembayaran: menunggu.length,
     lunas_belum_nomor: new Set(tanpaNomor.map(r => r.pendaftaran_id)).size,
+    regu_siap: k.regu_siap ?? null,
+    regu_berangkat: k.regu_berangkat ?? null,
+    regu_datang: k.regu_datang ?? null,
   };
 }
 

--- a/live/style.css
+++ b/live/style.css
@@ -2442,3 +2442,15 @@ input.small-input { text-align: center; }
    yang justru paling perlu dijelaskan sesudahnya. */
 .kloter-chip.lewat-batas { border-color: var(--bahaya); }
 .kloter-chip.lewat-batas .chip-ket { color: var(--bahaya); font-weight: 700; }
+
+/* Lencana KEMAJUAN (18/53), bukan antrean. Netral sepanjang jalan.
+
+   badge-yellow/green yang dipakai Pembayaran dan Daftar Ulang berarti "masih
+   ada N yang menunggu dikerjakan" — hijau saat habis. Kemajuan berlawanan
+   arah, jadi mewarnainya dengan aturan yang sama akan menyalakan hijau tepat
+   pada pagi yang belum dimulai. Warnanya baru berubah hijau saat benar-benar
+   penuh, dan itu ditentukan JavaScript, bukan kelas ini. */
+.badge-kemajuan {
+  background: var(--kertas); color: var(--tinta-lembut);
+  border: 1px solid var(--garis);
+}

--- a/supabase/migrations/0055_kemajuan_hari.sql
+++ b/supabase/migrations/0055_kemajuan_hari.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- hrcd-rekap : 0055_kemajuan_hari.sql
+--
+-- Tiga angka kemajuan hari-H, satu baris, untuk lencana di layar Home.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA SATU VIEW, BUKAN TIGA QUERY DARI KLIEN
+--
+-- Home dibuka tiap kali panitia kembali dari layar lain — puluhan kali sehari,
+-- oleh belasan orang. `ringkasanMeja()` sudah menembakkan dua permintaan;
+-- menambah tiga lagi menjadikannya lima, untuk tiga angka yang database bisa
+-- hitung sekaligus dalam satu kali jalan.
+--
+-- ---------------------------------------------------------------------------
+-- PENYEBUTNYA BERANTAI, DAN ITU DISENGAJA
+--
+--   berangkat / siap      — dari yang sudah bernomor dada, berapa yang jalan
+--   datang    / berangkat — dari yang jalan, berapa yang sudah pulang
+--
+-- Pembilang yang satu jadi penyebut berikutnya. Regu tidak bisa datang tanpa
+-- berangkat, jadi menghitung kedatangan terhadap SELURUH regu akan
+-- menampilkan angka yang tidak mungkin penuh sampai kloter terakhir lepas —
+-- dan angka yang tidak pernah bisa penuh berhenti dibaca.
+--
+-- ---------------------------------------------------------------------------
+-- YANG SEBENARNYA DIJAWAB ANGKA KEDUA
+--
+-- Selisihnya: berangkat dikurangi datang = REGU YANG MASIH DI JALUR. Itu bukan
+-- statistik, itu hitungan kepala. Angka itu harus nol sebelum ada panitia yang
+-- pulang, dan sepanjang sore ia satu-satunya yang menjawab "masih ada berapa
+-- di luar sana".
+--
+-- ---------------------------------------------------------------------------
+-- TERBUKA UNTUK SELURUH PANITIA
+--
+-- Tidak ada nilai, tidak ada peringkat, tidak ada PII — cuma tiga hitungan.
+-- Operator pos pun boleh melihatnya; ia berdiri di jalur dan pertanyaan
+-- "masih ada berapa" juga miliknya.
+-- ============================================================================
+
+create or replace view v_kemajuan_hari as
+with siap as (
+  select r.id
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+)
+select
+  (select count(*) from siap)::int                                as regu_siap,
+  (select count(*) from siap s
+   join keberangkatan_regu kb on kb.regu_id = s.id)::int          as regu_berangkat,
+  (select count(*) from siap s
+   join closing_regu c on c.regu_id = s.id)::int                  as regu_datang;
+
+comment on view v_kemajuan_hari is
+  'Tiga hitungan untuk lencana Home: siap (bernomor dada), berangkat, datang. '
+  'berangkat - datang = regu yang masih di jalur, dan itu harus nol sebelum '
+  'panitia pulang.';
+
+grant select on v_kemajuan_hari to authenticated;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -175,5 +175,6 @@ run supabase/migrations/0052_nama_tanpa_angka.sql
 run tests/sql/22_nama_tanpa_angka.sql
 run supabase/migrations/0053_perkiraan_berangkat.sql
 run supabase/migrations/0054_kolom_lomba.sql
+run supabase/migrations/0055_kemajuan_hari.sql
 
 echo "SEMUA TES LULUS"

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -294,15 +294,20 @@ export async function ringkasanMeja() {
   if (K.mode === "dev") return baca("/ringkasan");
   // Dihitung dari sisi regu supaya angkanya benar-benar "batch lunas yang
   // masih punya regu tanpa nomor dada" (temuan review: query lama salah).
-  const [menunggu, tanpaNomor] = await Promise.all([
+  const [menunggu, tanpaNomor, kemajuan] = await Promise.all([
     baca(null, "pendaftaran?status=eq.menunggu_pembayaran&select=id"),
     baca(null, "regu?nomor_dada=is.null&is_cancelled=is.false" +
                "&select=pendaftaran_id,pendaftaran!inner(status)" +
                "&pendaftaran.status=eq.lunas"),
+    baca(null, "v_kemajuan_hari?select=*"),
   ]);
+  const k = (Array.isArray(kemajuan) ? kemajuan[0] : kemajuan) || {};
   return {
     menunggu_pembayaran: menunggu.length,
     lunas_belum_nomor: new Set(tanpaNomor.map(r => r.pendaftaran_id)).size,
+    regu_siap: k.regu_siap ?? null,
+    regu_berangkat: k.regu_berangkat ?? null,
+    regu_datang: k.regu_datang ?? null,
   };
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -234,6 +234,21 @@ async function layarHome() {
     ? `<span class="badge badge-gray" title="jumlah antrean tidak terbaca">?</span>`
     : `<span class="badge ${n > 0 ? "badge-yellow" : "badge-green"}">${n}</span>`;
 
+  /* KEMAJUAN, bukan antrean — dan karena itu lencananya BERBEDA.
+   *
+   *  lencana() di atas berarti "masih ada N yang menunggu dikerjakan": kuning
+   *  saat ada, hijau saat habis. Kemajuan berlawanan arah — 0/53 adalah pagi
+   *  yang belum mulai, 53/53 adalah pekerjaan selesai. Memakai lencana yang
+   *  sama akan mewarnai hijau tepat pada keadaan yang paling belum selesai.
+   *
+   *  Jadi netral sepanjang jalan, dan hijau HANYA saat penuh. */
+  const kemajuan = (sudah, dari) => {
+    if (sudah === null || dari === null) return "";
+    const penuh = dari > 0 && sudah >= dari;
+    return `<span class="badge ${penuh ? "badge-green" : "badge-kemajuan"}"
+      >${esc(String(sudah))}/${esc(String(dari))}</span>`;
+  };
+
   LAYAR.replaceChildren(h(`
     ${galat ? kartuGalat(`Jumlah antrean tidak bisa dibaca: ${galat}`) : ""}
     <div class="function-menu">
@@ -255,10 +270,12 @@ async function layarHome() {
         <div class="function-name">${ikonKotak("list-ordered", "toska")} Daftar Kloter</div>
       </a>
       <a href="#/keberangkatan">
-        <div class="function-name">${ikonKotak("flag", "jingga")} Keberangkatan</div>
+        <div class="function-name">${ikonKotak("flag", "jingga")} Keberangkatan ${
+          kemajuan(r ? r.regu_berangkat : null, r ? r.regu_siap : null)}</div>
       </a>
       <a href="#/finish">
-        <div class="function-name">${ikonKotak("circle-check", "zamrud")} Kedatangan</div>
+        <div class="function-name">${ikonKotak("circle-check", "zamrud")} Kedatangan ${
+          kemajuan(r ? r.regu_datang : null, r ? r.regu_berangkat : null)}</div>
       </a>
       ${peran === "admin" ? `
       <a href="#/pos">

--- a/web/style.css
+++ b/web/style.css
@@ -2442,3 +2442,15 @@ input.small-input { text-align: center; }
    yang justru paling perlu dijelaskan sesudahnya. */
 .kloter-chip.lewat-batas { border-color: var(--bahaya); }
 .kloter-chip.lewat-batas .chip-ket { color: var(--bahaya); font-weight: 700; }
+
+/* Lencana KEMAJUAN (18/53), bukan antrean. Netral sepanjang jalan.
+
+   badge-yellow/green yang dipakai Pembayaran dan Daftar Ulang berarti "masih
+   ada N yang menunggu dikerjakan" — hijau saat habis. Kemajuan berlawanan
+   arah, jadi mewarnainya dengan aturan yang sama akan menyalakan hijau tepat
+   pada pagi yang belum dimulai. Warnanya baru berubah hijau saat benar-benar
+   penuh, dan itu ditentukan JavaScript, bukan kelas ini. */
+.badge-kemajuan {
+  background: var(--kertas); color: var(--tinta-lembut);
+  border: 1px solid var(--garis);
+}


### PR DESCRIPTION
## What

Two badges on Home:

- **Keberangkatan** `18/53` — regu departed / regu holding a nomor dada
- **Kedatangan** `6/18` — regu arrived / regu departed

`0055_kemajuan_hari.sql` supplies all three counts in one view.

## Why the denominators chain

The first badge's numerator is the second's denominator. A regu cannot arrive
without leaving, so counting arrivals against *every* regu shows a number that
cannot be full until the last kloter departs — and a number that can never be
full stops being read.

## Assessment, since you asked

**Kedatangan is the more valuable of the two, for a reason the fraction
hides.** Its complement — `berangkat − datang` — is how many regu are still out
on the course. That is not a statistic, it is a headcount, and it has to reach
zero before anyone goes home. The migration header says so, because the next
person will otherwise read it as decoration.

**Keberangkatan is useful to the admin, not to the officer.** Whoever is at the
start line lives on that screen and does not need Home to tell them. But
"are we on schedule?" is the question of the morning against the 07:00–10:00
window in section 10, and Home is where it gets glanced at.

## The trap this avoids

They do **not** reuse the existing badge. `badge-yellow`/`badge-green` means
"N still waiting to be done" and turns green when the queue empties. Progress
runs the other way — `0/53` is a morning that has not started. The same
colouring would paint green on exactly the least-finished state. Progress stays
neutral and turns green only when full.

## Notes

One view rather than three more client queries: Home is opened dozens of times
a day by a dozen people, and `ringkasanMeja` already fires two.

`v_kemajuan_hari` is open to every panitia — no scores, no ranking, no PII,
just three counts. An operator standing on the course has as much right to ask
how many are still out as anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)