### PR TITLE
fix: a progress badge over 100% is an alarm, not a number

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -242,10 +242,19 @@ async function layarHome() {
    *  sama akan mewarnai hijau tepat pada keadaan yang paling belum selesai.
    *
    *  Jadi netral sepanjang jalan, dan hijau HANYA saat penuh. */
-  const kemajuan = (sudah, dari) => {
+  const kemajuan = (sudah, dari, judulMustahil) => {
     if (sudah === null || dari === null) return "";
-    const penuh = dari > 0 && sudah >= dari;
-    return `<span class="badge ${penuh ? "badge-green" : "badge-kemajuan"}"
+    /* Pembilang MELEBIHI penyebut berarti data rusak, bukan kemajuan.
+       Regu tidak bisa datang tanpa berangkat, jadi 44/10 hanya mungkin kalau
+       ada baris closing tanpa baris keberangkatan yang cocok — dan itu
+       menghilangkan regu-regu itu dari klasemen, karena v_klasemen menuntut
+       keduanya. Dimerahkan, bukan dibulatkan: angka yang dirapikan menyembunyikan
+       persoalan yang justru paling perlu dilihat. */
+    const mustahil = sudah > dari;
+    const penuh = !mustahil && dari > 0 && sudah >= dari;
+    const kelas = mustahil ? "badge-red" : penuh ? "badge-green" : "badge-kemajuan";
+    return `<span class="badge ${kelas}"${mustahil && judulMustahil
+      ? ` title="${esc(judulMustahil)}"` : ""}
       >${esc(String(sudah))}/${esc(String(dari))}</span>`;
   };
 
@@ -275,7 +284,9 @@ async function layarHome() {
       </a>
       <a href="#/finish">
         <div class="function-name">${ikonKotak("circle-check", "zamrud")} Kedatangan ${
-          kemajuan(r ? r.regu_datang : null, r ? r.regu_berangkat : null)}</div>
+          kemajuan(r ? r.regu_datang : null, r ? r.regu_berangkat : null,
+            "Ada regu tercatat datang tapi tidak tercatat berangkat. "
+            + "Regu itu TIDAK masuk klasemen — periksa layar Keberangkatan.")}</div>
       </a>
       ${peran === "admin" ? `
       <a href="#/pos">


### PR DESCRIPTION
## What

When a progress badge's numerator exceeds its denominator it turns red and
carries a title saying what to check.

## Why

Kedatangan showed **44/10** on the first load after #237.

A regu cannot arrive without departing, so a numerator above the denominator
only happens when `closing_regu` rows exist without matching
`keberangkatan_regu` rows — which is what the seed data has.

**It matters beyond looking wrong.** `v_klasemen` requires *both*, so every one
of those regu is absent from the ranking entirely while their scores sit intact
in the database. This badge is currently the only place in the app that reveals
it — and it is the same failure mode as a kloter whose `jam_berangkat` was
never typed.

Red rather than clamped: a tidied number hides exactly the thing worth seeing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)