### PR TITLE
fix: payment card on a phone — method and LUNAS on one line, buttons centred

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1258,6 +1258,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    di depan. */
 .data-table td[data-label="Metode"] { text-transform: capitalize; }
 .data-table td[data-label="Metode"] .badge { text-transform: none; }
+/* "Transfer LUNAS" pada SATU baris selama ruangnya cukup, dan menumpuk
+   sendiri kalau tidak. Di kartu HP kolomnya lapang jadi keduanya sebaris; di
+   tabel lebar kolom Metode cuma 15% jadi ia membungkus jadi dua baris seperti
+   sebelumnya. Satu aturan, dua tampilan — tanpa media query yang harus
+   ditebak batasnya. */
+.metode-lunas {
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-wrap: wrap; gap: .35rem;
+}
 /* Lencana yang SEKALIGUS tombol. Rupanya tetap lencana — yang berubah cuma
    kursornya dan cincin fokus, supaya jelas ia bisa diketuk tanpa menjadikannya
    tombol besar yang menuntut lebar kolom sendiri. */
@@ -1718,6 +1727,14 @@ input.small-input { text-align: center; }
     min-width: 5rem; width: 100%; max-width: 10rem;
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
+  /* Cetak Kwitansi + Batalkan DITENGAHKAN di kartu HP. Keduanya melintangi
+     seluruh lebar kartu di barisnya sendiri, dan sepasang tombol rata kiri di
+     bawah blok yang selebihnya simetris terbaca seperti tersangkut di pojok —
+     alasan yang sama dengan judul kartu di Live Score. Tampilan tabel lebar
+     sudah ditengahkan sejak awal (lihat .table-bayar td:nth-child(6)). */
+  .table-bayar tbody tr[data-baris] > td:last-child .action-row {
+    justify-content: center;
+  }
 
   /* ---- Kartu HP meja daftar ulang ----
          HRCD37-7808B6   SMPN 1 HAHAHA

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -517,8 +517,14 @@ async function layarPembayaran() {
         // Nomor kwitansi TIDAK ditampilkan di tabel: panjang, tidak pernah
         // dicari lewat layar ini, dan sudah tercetak di kwitansinya sendiri
         // — di situlah ia berguna saat menyusun berkas.
-        ? html`<div>${b.pembayaran ? b.pembayaran.method : "—"}</div>
-               <span class="badge badge-green">LUNAS</span>`
+        // Cara bayar dan LUNAS SEBARIS, dibungkus satu pembungkus lentur.
+        // Sebelumnya cara bayarnya di dalam <div> — elemen blok — jadi LUNAS
+        // selalu jatuh ke baris berikutnya, bahkan di kartu HP yang kolomnya
+        // lapang. Dengan flex-wrap ia tetap menumpuk sendiri di kolom tabel
+        // lebar yang cuma 15%, jadi satu aturan melayani kedua tampilan.
+        ? html`<span class="metode-lunas"
+               ><span>${b.pembayaran ? b.pembayaran.method : "—"}</span
+               ><span class="badge badge-green">LUNAS</span></span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`
           : `<select class="select-small" data-metode="${esc(b.kode_pembayaran)}">

--- a/web/style.css
+++ b/web/style.css
@@ -1258,6 +1258,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    di depan. */
 .data-table td[data-label="Metode"] { text-transform: capitalize; }
 .data-table td[data-label="Metode"] .badge { text-transform: none; }
+/* "Transfer LUNAS" pada SATU baris selama ruangnya cukup, dan menumpuk
+   sendiri kalau tidak. Di kartu HP kolomnya lapang jadi keduanya sebaris; di
+   tabel lebar kolom Metode cuma 15% jadi ia membungkus jadi dua baris seperti
+   sebelumnya. Satu aturan, dua tampilan — tanpa media query yang harus
+   ditebak batasnya. */
+.metode-lunas {
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-wrap: wrap; gap: .35rem;
+}
 /* Lencana yang SEKALIGUS tombol. Rupanya tetap lencana — yang berubah cuma
    kursornya dan cincin fokus, supaya jelas ia bisa diketuk tanpa menjadikannya
    tombol besar yang menuntut lebar kolom sendiri. */
@@ -1718,6 +1727,14 @@ input.small-input { text-align: center; }
     min-width: 5rem; width: 100%; max-width: 10rem;
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
+  /* Cetak Kwitansi + Batalkan DITENGAHKAN di kartu HP. Keduanya melintangi
+     seluruh lebar kartu di barisnya sendiri, dan sepasang tombol rata kiri di
+     bawah blok yang selebihnya simetris terbaca seperti tersangkut di pojok —
+     alasan yang sama dengan judul kartu di Live Score. Tampilan tabel lebar
+     sudah ditengahkan sejak awal (lihat .table-bayar td:nth-child(6)). */
+  .table-bayar tbody tr[data-baris] > td:last-child .action-row {
+    justify-content: center;
+  }
 
   /* ---- Kartu HP meja daftar ulang ----
          HRCD37-7808B6   SMPN 1 HAHAHA


### PR DESCRIPTION
## What

On the Pembayaran card at phone width:

- `Transfer` and `LUNAS` sit on one line
- **Cetak Kwitansi** and **Batalkan** are centred

## Why

The method was inside a `<div>` — a block element — so `LUNAS` always dropped
to the next line, even on the phone card where that column is wide open. It is
now an inline-flex wrapper that wraps only when it must, so the 15% Metode
column in the wide table still stacks to two lines exactly as before. One rule
serves both layouts with no breakpoint to guess.

The buttons span the full width of the card on a row of their own, and a
left-aligned pair under an otherwise symmetrical block reads as though it
snagged on the corner. The wide table had centred them since the beginning; the
card had not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)