### PR TITLE
fix: tables become cards below 901px, as the comment already said

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1003,7 +1003,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    memberi tahu 2 apa. Di TABEL judulnya sudah menyebut REGU tepat di atasnya,
    dan mengulangi kata itu di tiap baris memakan lebar kolom yang justru
    dibutuhkan kolom di kanannya. */
-@media (min-width: 561px) {
+/* Kata "regu" hanya dibuang saat tabelnya BENAR-BENAR tabel — dan itu kini
+   mulai 901px, bukan 561px. Di kartu, satuannya wajib: tidak ada judul kolom
+   yang menyebutkannya. */
+@media (min-width: 901px) {
   .satuan-regu { display: none; }
 }
 
@@ -1399,7 +1402,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 
 /* ============================================================================
-   JENDELA SEMPIT TAPI MASIH TABEL (561px - 940px)
+   JENDELA SEMPIT TAPI MASIH TABEL (901px - 940px)
 
    Di sini tabelnya TETAP tabel — bentuk tabel masih terbaca di lebar segini,
    dan menumpuknya jadi kartu justru membuang ruang yang sebenarnya ada.
@@ -1423,7 +1426,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    layar jauh lebih merugikan daripada rincian yang meleset beberapa piksel.
    Di 941px ke atas kesejajarannya kembali utuh.
    ========================================================================= */
-@media (min-width: 561px) and (max-width: 940px) {
+@media (min-width: 901px) and (max-width: 940px) {
   .table-bayar, .table-daftar-ulang,
   .detail-table-bayar, .detail-table-dada {
     table-layout: auto;
@@ -1628,7 +1631,7 @@ input.small-input { text-align: center; }
    Kalau suatu saat kolom ditambah, min-width tabelnya naik — dan ambang ini
    harus ikut naik, kalau tidak tombol yang hilang itu kembali lagi.
    ========================================================================= */
-@media (max-width: 560px) {
+@media (max-width: 900px) {
   /* ---- tabel BERHENTI jadi tabel ----
      Enam kolom tidak akan pernah muat di layar sempit, dan menggeser ke
      samping menyembunyikan justru kolom aksi — panitia tidak tahu ada

--- a/web/style.css
+++ b/web/style.css
@@ -1003,7 +1003,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    memberi tahu 2 apa. Di TABEL judulnya sudah menyebut REGU tepat di atasnya,
    dan mengulangi kata itu di tiap baris memakan lebar kolom yang justru
    dibutuhkan kolom di kanannya. */
-@media (min-width: 561px) {
+/* Kata "regu" hanya dibuang saat tabelnya BENAR-BENAR tabel — dan itu kini
+   mulai 901px, bukan 561px. Di kartu, satuannya wajib: tidak ada judul kolom
+   yang menyebutkannya. */
+@media (min-width: 901px) {
   .satuan-regu { display: none; }
 }
 
@@ -1399,7 +1402,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 
 /* ============================================================================
-   JENDELA SEMPIT TAPI MASIH TABEL (561px - 940px)
+   JENDELA SEMPIT TAPI MASIH TABEL (901px - 940px)
 
    Di sini tabelnya TETAP tabel — bentuk tabel masih terbaca di lebar segini,
    dan menumpuknya jadi kartu justru membuang ruang yang sebenarnya ada.
@@ -1423,7 +1426,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    layar jauh lebih merugikan daripada rincian yang meleset beberapa piksel.
    Di 941px ke atas kesejajarannya kembali utuh.
    ========================================================================= */
-@media (min-width: 561px) and (max-width: 940px) {
+@media (min-width: 901px) and (max-width: 940px) {
   .table-bayar, .table-daftar-ulang,
   .detail-table-bayar, .detail-table-dada {
     table-layout: auto;
@@ -1628,7 +1631,7 @@ input.small-input { text-align: center; }
    Kalau suatu saat kolom ditambah, min-width tabelnya naik — dan ambang ini
    harus ikut naik, kalau tidak tombol yang hilang itu kembali lagi.
    ========================================================================= */
-@media (max-width: 560px) {
+@media (max-width: 900px) {
   /* ---- tabel BERHENTI jadi tabel ----
      Enam kolom tidak akan pernah muat di layar sempit, dan menggeser ke
      samping menyembunyikan justru kolom aksi — panitia tidak tahu ada


### PR DESCRIPTION
## What

The table→card media query moves from `max-width: 560px` to `max-width: 900px`.
The squeezed-table band follows to `901–940px`, and `.satuan-regu` hides only
from 901px.

## Why

**The comment above that query has said 901px all along**, and named the exact
failure:

> Persis itu yang terjadi di jendela ~720px

The button column gets pushed off the right edge and an officer sees a table
with no visible **Batalkan**. The query underneath said 560px. The decision was
written down and never implemented.

At ~610px the payment table squeezed a school name onto four lines, wrapped
`Rp 250.000`, and cut Batalkan in half — the documented failure, in a
screenshot.

## Two thresholds, two reasons

The chrome threshold stays at **560px**, and the block that governs it already
explains why: *"Tetap di ambang 560px, bukan 900px: yang menggantikannya adalah
menu bawah, dan menu bawah hanya muncul di HP."*

Table shape follows the table's contents; chrome follows the size of a thumb.
They are not the same measurement and were never meant to share a number.

## Notes

Everything inside the moved block is `.data-table` / `.table-bayar` /
`.table-daftar-ulang` / `.table-wrapper` — table shape only, nothing else rides
along.

`.table-tetap` is excluded by the selector, so the pos sheet and Live Score stay
tables at every width. That is deliberate and documented: one regu at Pos 1
would be a card eleven lines tall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)