### PR TITLE
fix: the dropdown chevron never painted — background shorthand wiped it

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1467,7 +1467,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kali isian disentuh — batas keras di kepala berkas ini, dan sempat
      terlanggar di sini. */
   min-height: 40px; padding: .3rem .5rem; font-size: 1rem;
-  border: 1px solid var(--garis); border-radius: 8px; background: #fff;
+  /* background-COLOR, bukan singkatan `background`. Singkatannya mengatur
+     ulang SELURUH kelompok latar termasuk background-image — dan chevron
+     dropdown di bawah dilukis sebagai background-image. Kelas ini
+     spesifisitasnya lebih tinggi daripada selektor `select`, jadi singkatan di
+     sini menghapus panahnya dan menyisakan kotak tanpa penanda sama sekali,
+     karena appearance: none sudah membuang panah bawaan browser. */
+  border: 1px solid var(--garis); border-radius: 8px; background-color: #fff;
   font-family: inherit;
 }
 
@@ -1505,8 +1511,11 @@ input.small-input { text-align: center; }
 .input-error { border-color: var(--bahaya); background: var(--bahaya-muda); }
 /* Kedip hijau sekejap = "tersimpan", supaya edit langsung di tabel tidak
    terasa seperti tidak terjadi apa-apa. */
+/* background-color di sini juga, alasan yang sama: singkatannya akan
+   menghapus chevron tepat pada satu detik kedipan hijau sesudah tersimpan —
+   panah yang berkedip hilang lalu muncul lagi terbaca seperti kerusakan. */
 .select-small.saved, .small-input.saved {
-  border-color: var(--hijau); background: var(--hijau-muda);
+  border-color: var(--hijau); background-color: var(--hijau-muda);
 }
 .button-mini {
   min-height: 34px; padding: .2rem .55rem; font-size: .8rem; width: auto;

--- a/web/style.css
+++ b/web/style.css
@@ -1467,7 +1467,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kali isian disentuh — batas keras di kepala berkas ini, dan sempat
      terlanggar di sini. */
   min-height: 40px; padding: .3rem .5rem; font-size: 1rem;
-  border: 1px solid var(--garis); border-radius: 8px; background: #fff;
+  /* background-COLOR, bukan singkatan `background`. Singkatannya mengatur
+     ulang SELURUH kelompok latar termasuk background-image — dan chevron
+     dropdown di bawah dilukis sebagai background-image. Kelas ini
+     spesifisitasnya lebih tinggi daripada selektor `select`, jadi singkatan di
+     sini menghapus panahnya dan menyisakan kotak tanpa penanda sama sekali,
+     karena appearance: none sudah membuang panah bawaan browser. */
+  border: 1px solid var(--garis); border-radius: 8px; background-color: #fff;
   font-family: inherit;
 }
 
@@ -1505,8 +1511,11 @@ input.small-input { text-align: center; }
 .input-error { border-color: var(--bahaya); background: var(--bahaya-muda); }
 /* Kedip hijau sekejap = "tersimpan", supaya edit langsung di tabel tidak
    terasa seperti tidak terjadi apa-apa. */
+/* background-color di sini juga, alasan yang sama: singkatannya akan
+   menghapus chevron tepat pada satu detik kedipan hijau sesudah tersimpan —
+   panah yang berkedip hilang lalu muncul lagi terbaca seperti kerusakan. */
 .select-small.saved, .small-input.saved {
-  border-color: var(--hijau); background: var(--hijau-muda);
+  border-color: var(--hijau); background-color: var(--hijau-muda);
 }
 .button-mini {
   min-height: 34px; padding: .2rem .55rem; font-size: .8rem; width: auto;


### PR DESCRIPTION
## What

`.select-small` and `.select-small.saved` use `background-color` instead of the
`background` shorthand.

## Why

A regression from #221. That change set `appearance: none` on `select` and drew
the chevron as a `background-image` — but `.select-small` sets
`background: #fff`, the **shorthand**, which resets the entire background group
including `background-image`. The class outranks the bare `select` selector, so
the custom arrow was erased while the native one had already been removed.

The result is a box with no marker at all. Pos 4 — PBB in the screenshot, but
it was **every** select in the app: Kontrak Waktu and Pindah Kloter at the
start line, Metode at the payments desk.

## Notes

`.select-small.saved` had the same shorthand and would have blinked the arrow
away for the one second of green confirmation after each save — which reads as
a fault, not a confirmation. Fixed in the same pass rather than left to be
found later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)