### PR TITLE
fix: one fraction in the pos counter, not two

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3253,14 +3253,13 @@ async function layarInputPos() {
   function hitungUlangJumlah() {
     const baris = [...tbody.children];
     const tampil = baris.filter(tr => !tr.hidden).length;
-    const sudah = baris.filter(lengkap).length;
-    // DUA pecahan berpenyebut sama, bukan satu angka polos dan satu pecahan.
-    // "6 ditampilkan · 47/53 lengkap" memaksa mata membandingkan 6 dengan 47
-    // — dua angka yang menghitung hal berbeda dan kebetulan bersebelahan.
-    // Dengan penyebut yang sama di keduanya, keduanya langsung terbaca sebagai
-    // bagian dari 53 yang sama.
+    // SATU pecahan. "47/53 lengkap" dibuang karena chip di sebelahnya sudah
+    // menjawabnya: dengan saringan "Belum lengkap" menyala, yang ditampilkan
+    // ITULAH yang belum lengkap — 6/53 dan 47/53 adalah angka yang sama
+    // dibaca dari dua arah. Dua pecahan bersebelahan justru menuntut orang
+    // memeriksa mana yang mana sebelum bisa membacanya.
     document.getElementById("tabel-jumlah").textContent =
-      `${tampil}/${baris.length} ditampilkan · ${sudah}/${baris.length} lengkap`;
+      `${tampil}/${baris.length} ditampilkan`;
   }
 
   /* ---------- cetak lembar kosong ---------- */


### PR DESCRIPTION
## What

`6/53 ditampilkan · 47/53 lengkap` → **`6/53 ditampilkan`**

## Why

The chip beside it already answers the second one. With **Belum lengkap**
selected, what is displayed *is* what is incomplete — `6/53` and `47/53` are
the same number read from opposite ends.

Two fractions side by side make someone check which is which before either can
be read, which is the opposite of what a counter is for.

## Notes

`const sudah` goes with it rather than staying to compute a number nobody sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)