### PR TITLE
fix: the MM box was too narrow for its own placeholder

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -257,7 +257,14 @@ input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min
   transform: translateY(-.06em);
 }
 input.jam-ketik {
-  width: 3.2em;
+  /* 4em, bukan 3.2em, dan padding sampingnya dipangkas. Ukuran lama dihitung
+     untuk ANGKA — dua digit tabular selalu muat. Yang tidak muat placeholder
+     "MM": huruf M jauh lebih lebar daripada H, ditambah letter-spacing di
+     bawah, dan kotak yang pas untuk "HH" memotong "MM" jadi "MN".
+     Kotak jam yang placeholder-nya terpotong terbaca seperti kotak rusak,
+     tepat pada layar yang dipakai sambil terburu-buru di garis finish. */
+  width: 4em;
+  padding-left: .4rem; padding-right: .4rem;
   max-width: 100%;
   font-variant-numeric: tabular-nums;
   letter-spacing: .08em;

--- a/web/style.css
+++ b/web/style.css
@@ -257,7 +257,14 @@ input.besar { font-size: 1.45rem; letter-spacing: .05em; text-align: center; min
   transform: translateY(-.06em);
 }
 input.jam-ketik {
-  width: 3.2em;
+  /* 4em, bukan 3.2em, dan padding sampingnya dipangkas. Ukuran lama dihitung
+     untuk ANGKA — dua digit tabular selalu muat. Yang tidak muat placeholder
+     "MM": huruf M jauh lebih lebar daripada H, ditambah letter-spacing di
+     bawah, dan kotak yang pas untuk "HH" memotong "MM" jadi "MN".
+     Kotak jam yang placeholder-nya terpotong terbaca seperti kotak rusak,
+     tepat pada layar yang dipakai sambil terburu-buru di garis finish. */
+  width: 4em;
+  padding-left: .4rem; padding-right: .4rem;
   max-width: 100%;
   font-variant-numeric: tabular-nums;
   letter-spacing: .08em;


### PR DESCRIPTION
## What

`input.jam-ketik` goes from `3.2em` to `4em`, with the side padding trimmed to
`.4rem`.

## Why

3.2em was sized for **digits** — two tabular figures always fit. The
placeholder does not: `M` is far wider than `H`, plus the `.08em`
letter-spacing, so a box that fits `HH` clips `MM` to `MN`.

A clock box whose own placeholder is cut off reads as a broken box — on the
screen someone uses in a hurry at the finish line, where the value being typed
decides the time penalty.

## Notes

The padding trim keeps the box from looking oversized for two digits; the text
is centred, so the padding was doing nothing but taking room from the
placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)