### PR TITLE
fix: receipt buttons back to the left on the phone card

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1756,13 +1756,14 @@ input.small-input { text-align: center; }
     min-width: 5rem; width: 100%; max-width: 10rem;
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
-  /* Cetak Kwitansi + Batalkan DITENGAHKAN di kartu HP. Keduanya melintangi
-     seluruh lebar kartu di barisnya sendiri, dan sepasang tombol rata kiri di
-     bawah blok yang selebihnya simetris terbaca seperti tersangkut di pojok —
-     alasan yang sama dengan judul kartu di Live Score. Tampilan tabel lebar
-     sudah ditengahkan sejak awal (lihat .table-bayar td:nth-child(6)). */
+  /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
+     dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya
+     rata kiri, dan sepasang tombol yang menyendiri di tengah memutus garis
+     baca tegak yang dipakai mata menyusuri kartu demi kartu. Tampilan tabel
+     lebar tetap tengah (lihat .table-bayar td:nth-child(6)): di sana tombolnya
+     mengisi satu KOLOM, bukan satu baris. */
   .table-bayar tbody tr[data-baris] > td:last-child .action-row {
-    justify-content: center;
+    justify-content: flex-start;
   }
 
   /* ---- Kartu HP meja daftar ulang ----

--- a/web/style.css
+++ b/web/style.css
@@ -1756,13 +1756,14 @@ input.small-input { text-align: center; }
     min-width: 5rem; width: 100%; max-width: 10rem;
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
-  /* Cetak Kwitansi + Batalkan DITENGAHKAN di kartu HP. Keduanya melintangi
-     seluruh lebar kartu di barisnya sendiri, dan sepasang tombol rata kiri di
-     bawah blok yang selebihnya simetris terbaca seperti tersangkut di pojok —
-     alasan yang sama dengan judul kartu di Live Score. Tampilan tabel lebar
-     sudah ditengahkan sejak awal (lihat .table-bayar td:nth-child(6)). */
+  /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
+     dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya
+     rata kiri, dan sepasang tombol yang menyendiri di tengah memutus garis
+     baca tegak yang dipakai mata menyusuri kartu demi kartu. Tampilan tabel
+     lebar tetap tengah (lihat .table-bayar td:nth-child(6)): di sana tombolnya
+     mengisi satu KOLOM, bukan satu baris. */
   .table-bayar tbody tr[data-baris] > td:last-child .action-row {
-    justify-content: center;
+    justify-content: flex-start;
   }
 
   /* ---- Kartu HP meja daftar ulang ----


### PR DESCRIPTION
## What

`Cetak Kwitansi` and `Batalkan` are left-aligned again on the phone card.

## Why

I centred them in #239; the owner tried it on a real phone and left reads
better.

Everything else in the card is left-aligned, and a pair of buttons alone in the
middle breaks the vertical reading line an eye follows down a stack of cards.

The wide table keeps them centred, and that stays right — there they fill a
**column**, not a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)