### PR TITLE
feat: wide payment cards put everything on one line but the buttons

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1756,6 +1756,30 @@ input.small-input { text-align: center; }
     min-width: 5rem; width: 100%; max-width: 10rem;
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
+
+  /* KARTU LEBAR (640px ke atas, tapi masih kartu): semuanya SATU BARIS, dan
+     hanya tombolnya turun.
+
+     Di bawah 640px kartunya butuh dua baris — kode, sekolah, jumlah regu,
+     tagihan, dan cara bayar tidak muat bersama. Di atas itu ruangnya ada, dan
+     memaksa dua baris membuang satu baris penuh per kartu: pada layar 880px
+     yang memuat belasan invoice, itu belasan baris kosong yang harus digulir.
+
+     Tombolnya tetap turun sendiri. Ia satu-satunya isi kartu yang DIKETUK, dan
+     mencampurnya ke barisan keterangan membuat jempol harus membidik di antara
+     teks. */
+  @media (min-width: 640px) {
+    .table-bayar tbody tr[data-baris] {
+      grid-template-columns:
+        max-content minmax(0, 1fr) max-content max-content max-content;
+    }
+    .table-bayar tbody tr[data-baris] > td[data-label="Kode Bayar"] { grid-area: 1 / 1; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Sekolah"]    { grid-area: 1 / 2; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Regu"]       { grid-area: 1 / 3; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Tagihan"]    { grid-area: 1 / 4; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Metode"]     { grid-area: 1 / 5; }
+    .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 2 / 1 / auto / 6; }
+  }
   /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
      dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya
      rata kiri, dan sepasang tombol yang menyendiri di tengah memutus garis

--- a/web/style.css
+++ b/web/style.css
@@ -1756,6 +1756,30 @@ input.small-input { text-align: center; }
     min-width: 5rem; width: 100%; max-width: 10rem;
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
+
+  /* KARTU LEBAR (640px ke atas, tapi masih kartu): semuanya SATU BARIS, dan
+     hanya tombolnya turun.
+
+     Di bawah 640px kartunya butuh dua baris — kode, sekolah, jumlah regu,
+     tagihan, dan cara bayar tidak muat bersama. Di atas itu ruangnya ada, dan
+     memaksa dua baris membuang satu baris penuh per kartu: pada layar 880px
+     yang memuat belasan invoice, itu belasan baris kosong yang harus digulir.
+
+     Tombolnya tetap turun sendiri. Ia satu-satunya isi kartu yang DIKETUK, dan
+     mencampurnya ke barisan keterangan membuat jempol harus membidik di antara
+     teks. */
+  @media (min-width: 640px) {
+    .table-bayar tbody tr[data-baris] {
+      grid-template-columns:
+        max-content minmax(0, 1fr) max-content max-content max-content;
+    }
+    .table-bayar tbody tr[data-baris] > td[data-label="Kode Bayar"] { grid-area: 1 / 1; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Sekolah"]    { grid-area: 1 / 2; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Regu"]       { grid-area: 1 / 3; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Tagihan"]    { grid-area: 1 / 4; }
+    .table-bayar tbody tr[data-baris] > td[data-label="Metode"]     { grid-area: 1 / 5; }
+    .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 2 / 1 / auto / 6; }
+  }
   /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
      dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya
      rata kiri, dan sepasang tombol yang menyendiri di tengah memutus garis


### PR DESCRIPTION
## What

From 640px up (still inside the card range, which now ends at 900px) the
payment card lays kode, sekolah, regu, tagihan and metode on **one line**, with
the buttons alone on a second.

## Why

At 880px the card was still using two description rows while the room for one
was plainly there. On a window showing a dozen invoices that is a dozen wasted
lines to scroll past.

Below 640 it stays two rows — those five cells do not fit together, and forcing
them squeezes the school name to nothing.

**The buttons keep their own row at every width.** They are the only part of the
card that gets *tapped*, and mixing them into the line of facts makes a thumb
aim between words.

## Notes

Builds on #240, which moved the card/table boundary to 900px. This fills in the
band that change opened up: 640–900 is card-shaped but not phone-shaped, and it
now looks like neither by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)