### PR TITLE
feat: wide payment cards fit on a single line, buttons included

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1765,20 +1765,32 @@ input.small-input { text-align: center; }
      memaksa dua baris membuang satu baris penuh per kartu: pada layar 880px
      yang memuat belasan invoice, itu belasan baris kosong yang harus digulir.
 
-     Tombolnya tetap turun sendiri. Ia satu-satunya isi kartu yang DIKETUK, dan
-     mencampurnya ke barisan keterangan membuat jempol harus membidik di antara
-     teks. */
+     TOMBOLNYA IKUT SEBARIS di sini, dan itu kebalikan dari yang berlaku di
+     kartu HP. Alasannya berubah bersama alatnya: di bawah 640px kartunya
+     dipegang dan diketuk jempol, jadi tombol yang bercampur barisan keterangan
+     memaksa membidik di antara teks. Dari 640px ke atas yang memegangnya
+     kursor — bidikannya setajam satu piksel — dan yang mahal justru barisnya:
+     satu baris terbuang per invoice, belasan kali per layar.
+
+     Labelnya ikut memendek jadi "Kwitansi" dan "Lunas" lewat .teks-lebar yang
+     memang sudah ada. Kata keduanya sudah membedakan aksinya, dan ~50px yang
+     dihemat tiap tombol itu yang menentukan muat atau tidak. */
   @media (min-width: 640px) {
     .table-bayar tbody tr[data-baris] {
       grid-template-columns:
-        max-content minmax(0, 1fr) max-content max-content max-content;
+        max-content minmax(0, 1fr) max-content max-content max-content max-content;
     }
+    .table-bayar tbody tr[data-baris] .teks-lebar { display: none; }
+    /* Tombol seukuran isinya, bukan selebar petaknya — di kartu HP ia sengaja
+       melebar penuh (baris 1701), dan di sini itu akan meregangkan kolom
+       terakhir sampai menghimpit nama sekolah. */
+    .table-bayar tbody tr[data-baris] .button-small { width: auto; }
     .table-bayar tbody tr[data-baris] > td[data-label="Kode Bayar"] { grid-area: 1 / 1; }
     .table-bayar tbody tr[data-baris] > td[data-label="Sekolah"]    { grid-area: 1 / 2; }
     .table-bayar tbody tr[data-baris] > td[data-label="Regu"]       { grid-area: 1 / 3; }
     .table-bayar tbody tr[data-baris] > td[data-label="Tagihan"]    { grid-area: 1 / 4; }
     .table-bayar tbody tr[data-baris] > td[data-label="Metode"]     { grid-area: 1 / 5; }
-    .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 2 / 1 / auto / 6; }
+    .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 1 / 6; }
   }
   /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
      dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya

--- a/web/style.css
+++ b/web/style.css
@@ -1765,20 +1765,32 @@ input.small-input { text-align: center; }
      memaksa dua baris membuang satu baris penuh per kartu: pada layar 880px
      yang memuat belasan invoice, itu belasan baris kosong yang harus digulir.
 
-     Tombolnya tetap turun sendiri. Ia satu-satunya isi kartu yang DIKETUK, dan
-     mencampurnya ke barisan keterangan membuat jempol harus membidik di antara
-     teks. */
+     TOMBOLNYA IKUT SEBARIS di sini, dan itu kebalikan dari yang berlaku di
+     kartu HP. Alasannya berubah bersama alatnya: di bawah 640px kartunya
+     dipegang dan diketuk jempol, jadi tombol yang bercampur barisan keterangan
+     memaksa membidik di antara teks. Dari 640px ke atas yang memegangnya
+     kursor — bidikannya setajam satu piksel — dan yang mahal justru barisnya:
+     satu baris terbuang per invoice, belasan kali per layar.
+
+     Labelnya ikut memendek jadi "Kwitansi" dan "Lunas" lewat .teks-lebar yang
+     memang sudah ada. Kata keduanya sudah membedakan aksinya, dan ~50px yang
+     dihemat tiap tombol itu yang menentukan muat atau tidak. */
   @media (min-width: 640px) {
     .table-bayar tbody tr[data-baris] {
       grid-template-columns:
-        max-content minmax(0, 1fr) max-content max-content max-content;
+        max-content minmax(0, 1fr) max-content max-content max-content max-content;
     }
+    .table-bayar tbody tr[data-baris] .teks-lebar { display: none; }
+    /* Tombol seukuran isinya, bukan selebar petaknya — di kartu HP ia sengaja
+       melebar penuh (baris 1701), dan di sini itu akan meregangkan kolom
+       terakhir sampai menghimpit nama sekolah. */
+    .table-bayar tbody tr[data-baris] .button-small { width: auto; }
     .table-bayar tbody tr[data-baris] > td[data-label="Kode Bayar"] { grid-area: 1 / 1; }
     .table-bayar tbody tr[data-baris] > td[data-label="Sekolah"]    { grid-area: 1 / 2; }
     .table-bayar tbody tr[data-baris] > td[data-label="Regu"]       { grid-area: 1 / 3; }
     .table-bayar tbody tr[data-baris] > td[data-label="Tagihan"]    { grid-area: 1 / 4; }
     .table-bayar tbody tr[data-baris] > td[data-label="Metode"]     { grid-area: 1 / 5; }
-    .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 2 / 1 / auto / 6; }
+    .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 1 / 6; }
   }
   /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
      dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya


### PR DESCRIPTION
## What

From 640px up the whole invoice is one row — kode, sekolah, regu, tagihan,
metode **and** the buttons — with labels shortened to `Kwitansi` and `Lunas`.

## Why

This reverses what #250 said one commit ago, and the reason changes with the
input device.

Below 640 the card is held and tapped with a **thumb**, so buttons mixed into
the line of facts force someone to aim between words. From 640 up it is a
**cursor**, accurate to a pixel — and what actually costs something there is
the line: one wasted row per invoice, a dozen per screen.

## Notes

The short labels come from `.teks-lebar`, which already existed for exactly
this — "Cetak Kwitansi" → "Kwitansi", "Tandai Lunas" → "Lunas". #240 narrowed
the squeezed-table band to 901–940 and left that span stranded in a 40px
window; it does real work again.

Buttons revert to `width: auto` in this band. Cards give them `width: 100%` on
purpose, and at this width that would stretch the last column until it crowded
the school name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)