### PR TITLE
fix: the header stays one line and shortens instead of wrapping

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -101,11 +101,30 @@ body {
   display: flex;
   align-items: center;
   gap: .7rem;
-  flex-wrap: wrap;
+  /* TIDAK membungkus. Dulu `wrap`, dan pada ~570px tombol Keluar jatuh ke
+     baris kedua — kepala setinggi dua baris yang memakan isi layar, tepat di
+     lebar yang paling sering dipakai tablet meja.
+     Yang benar bukan membungkus melainkan MENGALAH: judul dan identitas akun
+     dipotong elipsis, tombolnya tidak pernah bergeser. */
+  flex-wrap: nowrap;
 }
-.header .title  { font-weight: 700; font-size: 1rem; }
-.header .spacer { flex: 1; }
-.header .user-info  { font-size: .85rem; opacity: .9; }
+/* min-width: 0 wajib — anak flex bawaannya tidak boleh menyusut di bawah
+   lebar isinya, dan tanpa ini elipsisnya tidak pernah aktif. */
+.header .title {
+  font-weight: 700; font-size: 1rem;
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.header .spacer { flex: 1 1 auto; min-width: 0; }
+/* Menyusut TIGA KALI lebih cepat daripada judul. Kalau ruangnya kurang, yang
+   pertama mengalah nama akun — ia terpotong dari kanan, jadi yang hilang duluan
+   nomor edisinya ("· HRCD XXXVII") dan yang bertahan justru nama akunnya.
+   Judul layar dipertahankan lebih lama: ia yang memberi tahu petugas ia sedang
+   di layar mana. */
+.header .user-info {
+  font-size: .85rem; opacity: .9;
+  flex: 0 3 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 .isi {
   max-width: 760px;

--- a/web/style.css
+++ b/web/style.css
@@ -101,11 +101,30 @@ body {
   display: flex;
   align-items: center;
   gap: .7rem;
-  flex-wrap: wrap;
+  /* TIDAK membungkus. Dulu `wrap`, dan pada ~570px tombol Keluar jatuh ke
+     baris kedua — kepala setinggi dua baris yang memakan isi layar, tepat di
+     lebar yang paling sering dipakai tablet meja.
+     Yang benar bukan membungkus melainkan MENGALAH: judul dan identitas akun
+     dipotong elipsis, tombolnya tidak pernah bergeser. */
+  flex-wrap: nowrap;
 }
-.header .title  { font-weight: 700; font-size: 1rem; }
-.header .spacer { flex: 1; }
-.header .user-info  { font-size: .85rem; opacity: .9; }
+/* min-width: 0 wajib — anak flex bawaannya tidak boleh menyusut di bawah
+   lebar isinya, dan tanpa ini elipsisnya tidak pernah aktif. */
+.header .title {
+  font-weight: 700; font-size: 1rem;
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.header .spacer { flex: 1 1 auto; min-width: 0; }
+/* Menyusut TIGA KALI lebih cepat daripada judul. Kalau ruangnya kurang, yang
+   pertama mengalah nama akun — ia terpotong dari kanan, jadi yang hilang duluan
+   nomor edisinya ("· HRCD XXXVII") dan yang bertahan justru nama akunnya.
+   Judul layar dipertahankan lebih lama: ia yang memberi tahu petugas ia sedang
+   di layar mana. */
+.header .user-info {
+  font-size: .85rem; opacity: .9;
+  flex: 0 3 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 .isi {
   max-width: 760px;


### PR DESCRIPTION
## What

`.header` goes from `flex-wrap: wrap` to `nowrap`. The title and the account
name ellipsise instead.

## Why

At ~570px the **Keluar** button dropped onto a second row — a two-line header
eating screen at exactly the width a desk tablet uses.

Wrapping was the wrong answer. Yielding is the right one: buttons never move,
and the two pieces of text give way.

## Which text yields first

The account name shrinks **three times faster** than the title. It truncates
from the right, so the edition suffix goes first and `admin.ciradyka` survives.
The title holds on longer, because it is what tells an officer which screen
they are on.

## Notes

`min-width: 0` is not decoration here — a flex child refuses to shrink below
its content width by default, so without it the ellipsis never engages and the
row overflows anyway.

Below 560px the gear and Keluar are already hidden and the bottom nav takes
over, so this band is 561px upward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)