### PR TITLE
fix: card thresholds measured from real content, not estimated

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1803,8 +1803,20 @@ input.small-input { text-align: center; }
      menempel di sisinya. Enam kolom butuh ~820px, bukan 640.
 
      Jadi dua tahap, dan kolom sekolah diberi lantai supaya ia tidak pernah
-     lagi jadi yang dikorbankan diam-diam. */
-  @media (min-width: 640px) {
+     lagi jadi yang dikorbankan diam-diam.
+
+     ANGKANYA DIUKUR, BUKAN DITEBAK. Diambil dari isi terpanjang di seluruh 25
+     invoice yang ada, lewat max-content tiap sel di browser:
+
+       kode 139 · lantai sekolah 144/176 · regu 58 · tagihan 104 · metode 130
+       tombol 197 (label panjang) / 157 (label pendek)
+
+     Ditambah jarak antar kolom dan padding: lima kolom butuh 672px, enam
+     kolom 872px. Percobaan pertama memakai 640 dan 820 — keduanya di bawah
+     kebutuhannya, jadi masing-masing rusak di seluruh rentang 640-671 dan
+     820-871. Kalau kolom ditambah lagi, ukur ulang; jangan menaikkan
+     angkanya dengan perasaan. */
+  @media (min-width: 680px) {
     .table-bayar tbody tr[data-baris] {
       grid-template-columns:
         max-content minmax(9rem, 1fr) max-content max-content max-content;
@@ -1816,7 +1828,7 @@ input.small-input { text-align: center; }
     .table-bayar tbody tr[data-baris] > td[data-label="Metode"]     { grid-area: 1 / 5; }
     .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 2 / 1 / auto / 6; }
   }
-  @media (min-width: 820px) {
+  @media (min-width: 880px) {
     .table-bayar tbody tr[data-baris] {
       grid-template-columns:
         max-content minmax(11rem, 1fr) max-content max-content max-content max-content;

--- a/web/style.css
+++ b/web/style.css
@@ -1803,8 +1803,20 @@ input.small-input { text-align: center; }
      menempel di sisinya. Enam kolom butuh ~820px, bukan 640.
 
      Jadi dua tahap, dan kolom sekolah diberi lantai supaya ia tidak pernah
-     lagi jadi yang dikorbankan diam-diam. */
-  @media (min-width: 640px) {
+     lagi jadi yang dikorbankan diam-diam.
+
+     ANGKANYA DIUKUR, BUKAN DITEBAK. Diambil dari isi terpanjang di seluruh 25
+     invoice yang ada, lewat max-content tiap sel di browser:
+
+       kode 139 · lantai sekolah 144/176 · regu 58 · tagihan 104 · metode 130
+       tombol 197 (label panjang) / 157 (label pendek)
+
+     Ditambah jarak antar kolom dan padding: lima kolom butuh 672px, enam
+     kolom 872px. Percobaan pertama memakai 640 dan 820 — keduanya di bawah
+     kebutuhannya, jadi masing-masing rusak di seluruh rentang 640-671 dan
+     820-871. Kalau kolom ditambah lagi, ukur ulang; jangan menaikkan
+     angkanya dengan perasaan. */
+  @media (min-width: 680px) {
     .table-bayar tbody tr[data-baris] {
       grid-template-columns:
         max-content minmax(9rem, 1fr) max-content max-content max-content;
@@ -1816,7 +1828,7 @@ input.small-input { text-align: center; }
     .table-bayar tbody tr[data-baris] > td[data-label="Metode"]     { grid-area: 1 / 5; }
     .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 2 / 1 / auto / 6; }
   }
-  @media (min-width: 820px) {
+  @media (min-width: 880px) {
     .table-bayar tbody tr[data-baris] {
       grid-template-columns:
         max-content minmax(11rem, 1fr) max-content max-content max-content max-content;


### PR DESCRIPTION
## What

| band | was | now | measured need |
|---|---|---|---|
| description on one line | 640 | **680** | 672px |
| everything on one line | 820 | **880** | 872px |

## Why

I estimated both, twice, and both were too low — each broken across the entire
range between its threshold and its real requirement.

Measured in the browser from the longest content across all 25 invoices, using
`max-content` per cell:

```
kode 139 · school floor 144/176 · regu 58 · tagihan 104
metode 130 · buttons 197 (long labels) / 157 (short)
```

With gaps and padding: five columns need **672px**, six need **872px**. The
thresholds said 640 and 820, so five columns were crushed from 640–671 and six
from 820–871 — exactly the band the owner was dragging through when the school
name broke onto four lines.

## Notes

The comment now carries the measurements and says to re-measure if a column is
added, rather than nudging the number by feel. Feel has been wrong twice.

Verified separately at 556px with real geometry: no overlap, no overflow, no
clipped text, and the header does not wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)