### PR TITLE
fix: the search box stops growing at 24rem

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2585,3 +2585,16 @@ input.small-input { text-align: center; }
   background: var(--kertas); color: var(--tinta-lembut);
   border: 1px solid var(--garis);
 }
+
+/* Kotak cari: melar sampai batas, lalu berhenti.
+
+   Dulu `flex:1` tanpa batas atas, jadi ia menyerap SELURUH sisa lebar — pada
+   1200px itu kotak teks selebar setengah layar untuk mengetik "UJI-022" atau
+   sepotong nama sekolah. Kotak yang jauh lebih panjang daripada isinya
+   terbaca seperti kolom tulisan, bukan kotak cari, dan matanya harus berjalan
+   melewatinya untuk sampai ke chip saringan di sebelah.
+
+   24rem menampung nama sekolah terpanjang di data ini dengan sisa; lebihnya
+   diserahkan ke baris chip, yang memang mendorong hitungan invoice ke tepi
+   kanan. */
+.kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; max-width: 24rem; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -375,7 +375,7 @@ function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "", kanan
   return `
     <div class="table-toolbar">
       ${kiri}
-      <div class="field" style="margin:0;flex:1;min-width:220px">
+      <div class="field kotak-cari">
         <label for="cari-tabel" class="visually-hidden">Cari</label>
         <input type="text" id="cari-tabel" autocomplete="off"
                placeholder="${esc(cariContoh || "Cari kode, sekolah, atau nama regu…")}">
@@ -3833,7 +3833,7 @@ async function layarRekap() {
       <div id="rekap-panel"></div>
       <div class="card">
         <div class="table-toolbar">
-          <div class="field" style="margin:0;flex:1;min-width:220px">
+          <div class="field kotak-cari">
             <label for="rekap-cari" class="visually-hidden">Cari</label>
             <input type="text" id="rekap-cari" autocomplete="off"
                    placeholder="Cari sekolah, regu, atau nomor dada…">

--- a/web/style.css
+++ b/web/style.css
@@ -2585,3 +2585,16 @@ input.small-input { text-align: center; }
   background: var(--kertas); color: var(--tinta-lembut);
   border: 1px solid var(--garis);
 }
+
+/* Kotak cari: melar sampai batas, lalu berhenti.
+
+   Dulu `flex:1` tanpa batas atas, jadi ia menyerap SELURUH sisa lebar — pada
+   1200px itu kotak teks selebar setengah layar untuk mengetik "UJI-022" atau
+   sepotong nama sekolah. Kotak yang jauh lebih panjang daripada isinya
+   terbaca seperti kolom tulisan, bukan kotak cari, dan matanya harus berjalan
+   melewatinya untuk sampai ke chip saringan di sebelah.
+
+   24rem menampung nama sekolah terpanjang di data ini dengan sisa; lebihnya
+   diserahkan ke baris chip, yang memang mendorong hitungan invoice ke tepi
+   kanan. */
+.kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; max-width: 24rem; }


### PR DESCRIPTION
## What

The search field on Pembayaran, Daftar Ulang and Rekapitulasi caps at `24rem`
instead of absorbing all spare width. The inline style becomes a `.kotak-cari`
class.

## Why

`flex: 1` with no ceiling meant it swallowed every spare pixel — at 1200px, a
text input half the screen wide for typing `UJI-022` or part of a school name.

A box far longer than anything typed into it reads as a column of prose rather
than a search field, and the eye has to walk its whole length to reach the
filter chips beside it.

24rem holds the longest school name in this data with room to spare. What is
left goes to the chip row, which already pushes the invoice count to the right
edge.

## Notes

The inline style moves to a class because it was three declarations repeated on
two screens, and the `max-width` would have had to be repeated as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)