### PR TITLE
fix: search fills the toolbar, and the password card drops the account name

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2527,9 +2527,13 @@ input.small-input { text-align: center; }
    baris berbeda dan angkanya menggantung sendirian di baris ketiga, rata
    kanan, tidak sejajar dengan apa pun. Dibungkus begini, angkanya selalu
    duduk setinggi chip yang dihitungnya. */
+/* `flex: 0 1 auto` dan rata kiri, BUKAN `1 1 auto` + space-between. Kalau ia
+   ikut melar, sisa lebar berhenti di sini sebagai pita kosong antara chip
+   terakhir dan hitungan barisnya — dan yang seharusnya menerimanya kotak
+   cari. Seukuran isinya, hitungan barisnya duduk tepat sesudah chip. */
 .filter-baris {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .6rem; flex: 1 1 auto; min-width: 0; flex-wrap: wrap;
+  display: flex; align-items: center; justify-content: flex-start;
+  gap: .6rem; flex: 0 1 auto; min-width: 0; flex-wrap: wrap;
 }
 
 /* Tombol kamera di lembar pos: ikon polos setinggi gembok di sebelahnya, dan
@@ -2586,15 +2590,16 @@ input.small-input { text-align: center; }
   border: 1px solid var(--garis);
 }
 
-/* Kotak cari: melar sampai batas, lalu berhenti.
+/* Kotak cari mengambil SELURUH sisa lebar. Sempat dibatasi 24rem, dan
+   batasnya justru membuat lubang: sisanya jatuh ke dalam baris chip yang
+   memakai `space-between`, jadi yang muncul bukan tata letak lebih rapat
+   melainkan pita kosong selebar telapak tangan antara chip terakhir dan
+   hitungan barisnya.
 
-   Dulu `flex:1` tanpa batas atas, jadi ia menyerap SELURUH sisa lebar — pada
-   1200px itu kotak teks selebar setengah layar untuk mengetik "UJI-022" atau
-   sepotong nama sekolah. Kotak yang jauh lebih panjang daripada isinya
-   terbaca seperti kolom tulisan, bukan kotak cari, dan matanya harus berjalan
-   melewatinya untuk sampai ke chip saringan di sebelah.
+   Ruang kosong di tengah toolbar lebih buruk daripada kotak cari yang lapang:
+   yang satu tidak melakukan apa-apa, yang lain setidaknya menampung nama
+   sekolah panjang tanpa menggulir mendatar.
 
-   24rem menampung nama sekolah terpanjang di data ini dengan sisa; lebihnya
-   diserahkan ke baris chip, yang memang mendorong hitungan invoice ke tepi
-   kanan. */
-.kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; max-width: 24rem; }
+   Supaya sisanya benar-benar sampai ke kotak cari, baris chip tidak boleh ikut
+   melar — lihat .filter-baris. */
+.kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -320,8 +320,6 @@ function layarGantiPassword() {
   LAYAR.replaceChildren(h(`
     <div class="card" style="max-width:480px;margin:0 auto">
       <h2>Ganti Password Akun Sendiri</h2>
-      <p class="description">
-         <strong>${esc(sesi().username)}</strong>.</p>
       <div class="field">
         <label for="gp-baru">Password baru</label>
         <input type="password" id="gp-baru" autocomplete="new-password">

--- a/web/style.css
+++ b/web/style.css
@@ -2527,9 +2527,13 @@ input.small-input { text-align: center; }
    baris berbeda dan angkanya menggantung sendirian di baris ketiga, rata
    kanan, tidak sejajar dengan apa pun. Dibungkus begini, angkanya selalu
    duduk setinggi chip yang dihitungnya. */
+/* `flex: 0 1 auto` dan rata kiri, BUKAN `1 1 auto` + space-between. Kalau ia
+   ikut melar, sisa lebar berhenti di sini sebagai pita kosong antara chip
+   terakhir dan hitungan barisnya — dan yang seharusnya menerimanya kotak
+   cari. Seukuran isinya, hitungan barisnya duduk tepat sesudah chip. */
 .filter-baris {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .6rem; flex: 1 1 auto; min-width: 0; flex-wrap: wrap;
+  display: flex; align-items: center; justify-content: flex-start;
+  gap: .6rem; flex: 0 1 auto; min-width: 0; flex-wrap: wrap;
 }
 
 /* Tombol kamera di lembar pos: ikon polos setinggi gembok di sebelahnya, dan
@@ -2586,15 +2590,16 @@ input.small-input { text-align: center; }
   border: 1px solid var(--garis);
 }
 
-/* Kotak cari: melar sampai batas, lalu berhenti.
+/* Kotak cari mengambil SELURUH sisa lebar. Sempat dibatasi 24rem, dan
+   batasnya justru membuat lubang: sisanya jatuh ke dalam baris chip yang
+   memakai `space-between`, jadi yang muncul bukan tata letak lebih rapat
+   melainkan pita kosong selebar telapak tangan antara chip terakhir dan
+   hitungan barisnya.
 
-   Dulu `flex:1` tanpa batas atas, jadi ia menyerap SELURUH sisa lebar — pada
-   1200px itu kotak teks selebar setengah layar untuk mengetik "UJI-022" atau
-   sepotong nama sekolah. Kotak yang jauh lebih panjang daripada isinya
-   terbaca seperti kolom tulisan, bukan kotak cari, dan matanya harus berjalan
-   melewatinya untuk sampai ke chip saringan di sebelah.
+   Ruang kosong di tengah toolbar lebih buruk daripada kotak cari yang lapang:
+   yang satu tidak melakukan apa-apa, yang lain setidaknya menampung nama
+   sekolah panjang tanpa menggulir mendatar.
 
-   24rem menampung nama sekolah terpanjang di data ini dengan sisa; lebihnya
-   diserahkan ke baris chip, yang memang mendorong hitungan invoice ke tepi
-   kanan. */
-.kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; max-width: 24rem; }
+   Supaya sisanya benar-benar sampai ke kotak cari, baris chip tidak boleh ikut
+   melar — lihat .filter-baris. */
+.kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; }


### PR DESCRIPTION
## What

- The search box loses its 24rem cap, and `.filter-baris` stops growing so the
  spare width actually reaches it.
- The Ganti Password card no longer prints the account name.

## Why

**The cap did not tighten anything.** It moved the slack into the chip row,
which uses `space-between` — so a palm-wide empty band opened between the last
chip and the row count, visible in the owner's screenshot of Meja Daftar Ulang.

Empty space in the middle of a toolbar is worse than a roomy search box: one
does nothing, the other at least holds a long school name without scrolling
sideways.

Both halves are needed. Removing the cap alone would not help while
`.filter-baris` still grows — the gap would simply reappear inside it.

**The account name** was above "Password baru" while the header carries it two
lines up, and being logged in is not news to the person who just logged in.
The sentence around it went in the text sweep; this takes the rest.

## Notes

This reverses #255, which I shipped an hour ago on the reasonable-sounding
argument that a half-screen search field reads as prose. That was true and
still made the screen worse — the alternative was not a tighter toolbar but a
hole in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)