### PR TITLE
fix: Jam datang and Anggota hadir share a line; time hint says "detik"

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2603,3 +2603,14 @@ input.small-input { text-align: center; }
    Supaya sisanya benar-benar sampai ke kotak cari, baris chip tidak boleh ikut
    melar — lihat .filter-baris. */
 .kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; }
+
+/* Sepasang isian yang TETAP bersebelahan walau layarnya sempit.
+
+   .two-column runtuh jadi satu kolom di bawah 640px, dan itu benar untuk
+   pasangan isian biasa. Tapi "Jam datang" cuma dua kotak HH:MM dan "Anggota
+   hadir" satu digit — keduanya muat bersama bahkan di 360px, dan menumpuknya
+   menurunkan tombol simpan satu baris penuh pada layar yang dipakai berdiri
+   di garis finish. */
+@media (max-width: 640px) {
+  .two-column.pasangan-sempit { grid-template-columns: auto 1fr; }
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1666,7 +1666,7 @@ function layarFinish() {
         <summary style="cursor:pointer;min-height:40px;font-size:.9rem;color:var(--tinta-lembut)">
           Perbaiki jam atau jumlah anggota
         </summary>
-        <div class="two-column" style="margin-top:.5rem">
+        <div class="two-column pasangan-sempit" style="margin-top:.5rem">
           <div class="field" style="margin:0">
             <label for="jam">Jam datang</label>
             <!-- Kotak ketik, alasan sama dengan jam berangkat: pemilih bawaan
@@ -2000,7 +2000,13 @@ function petunjukKolom(k) {
   // menyesatkan; kolom `petunjuk` (0037) ada untuk kasus seperti itu.
   if (k.petunjuk) return k.petunjuk;
   if (k.form === "biner") return "centang bila benar";
-  if (k.satuan === "detik") return "detik, atau m:dd";
+  // "detik" saja. Sebelumnya "detik, atau m:dd" — dan bentuk kedua itu tidak
+  // pernah diminta siapa pun, cuma ditawarkan. Menawarkan dua format untuk
+  // satu angka pada kertas yang diisi tergesa di pos adalah cara sebagian
+  // petugas menulis 1:45 dan sebagian menulis 105 untuk waktu yang sama.
+  // detikSah() memang masih menerima m:dd bagi yang terlanjur hafal; yang
+  // dibuang cuma tawarannya.
+  if (k.satuan === "detik") return "detik";
   if (k.form === "benar_kurang_salah") return "benar / salah";
   if (k.form === "benar_per_total") return `0 – ${angkaRapi(k.total_soal)}`;
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;

--- a/web/style.css
+++ b/web/style.css
@@ -2603,3 +2603,14 @@ input.small-input { text-align: center; }
    Supaya sisanya benar-benar sampai ke kotak cari, baris chip tidak boleh ikut
    melar — lihat .filter-baris. */
 .kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; }
+
+/* Sepasang isian yang TETAP bersebelahan walau layarnya sempit.
+
+   .two-column runtuh jadi satu kolom di bawah 640px, dan itu benar untuk
+   pasangan isian biasa. Tapi "Jam datang" cuma dua kotak HH:MM dan "Anggota
+   hadir" satu digit — keduanya muat bersama bahkan di 360px, dan menumpuknya
+   menurunkan tombol simpan satu baris penuh pada layar yang dipakai berdiri
+   di garis finish. */
+@media (max-width: 640px) {
+  .two-column.pasangan-sempit { grid-template-columns: auto 1fr; }
+}


### PR DESCRIPTION
## What

- On Kedatangan, **Jam datang** and **Anggota hadir** stay side by side at
  every width.
- The hint under time columns reads `detik` instead of `detik, atau m:dd`.

## Why

`.two-column` collapses below 640px, which is right for ordinary pairs. This
pair is two HH:MM boxes and a single digit — they fit together even at 360px,
and stacking them pushes the save button a full line down on a screen used
standing at the finish line.

**The hint offered a second format nobody asked for.** Offering two ways to
write one number, on a sheet filled in a hurry at a pos, is how some officers
write `1:45` and others write `105` for the same time — and the two mean very
different things to the ladder that scores them.

`detikSah()` still accepts `m:dd` for anyone who already learnt it. What goes
is the invitation, not the tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)