### PR TITLE
fix: #, No Dada and Regu scroll together in the score table

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2148,18 +2148,28 @@ input.small-input { text-align: center; }
    jauh di kanan, terpisah dari Penalti yang seharusnya dibacanya bersama. */
 .table-rekap th:last-child, .table-rekap td:last-child { width: auto; }
 
-/* Rank dipatok lebih dulu, lalu Nomor Dada menempel tepat di belakangnya.
-   Lebar kolom pertama HARUS pasti, kalau tidak `left` kolom kedua meleset —
-   isinya cuma satu sampai tiga digit, jadi mematoknya tidak merugikan. */
-.table-rekap th:first-child, .table-rekap td:first-child {
-  width: 56px; min-width: 56px;
-}
+/* TIDAK ADA KOLOM YANG DIPATOK KE TEPI KIRI DI SINI. # / No Dada / Regu
+   tergeser bersama-sama, seperti kolom lainnya.
+
+   Sebelumnya Nomor Dada dipatok, dan itu tidak pernah bekerja: kolom di
+   SEBELAH KANANNYA adalah Nama Regu, jadi yang dipatok tidak berdiri di
+   pinggir tabel melainkan MELAYANG DI ATAS nama regu yang menggeser di
+   bawahnya. Setengah nama tertutup, dan yang tersisa terbaca sebagai satu
+   kata rusak — "SATYA ... RAN". Patokan itu dipasang supaya baris tetap
+   dikenali saat digeser jauh; yang sebenarnya terjadi adalah ia menutupi
+   satu-satunya kolom yang mengenali baris.
+
+   Bisa saja tiga kolomnya dipatok sekalian supaya tidak saling menutupi,
+   tapi bertiga mereka memakan ±330px — di HP itu hampir seluruh layar, dan
+   yang tersisa untuk angka yang sedang dicari tinggal sejengkal.
+
+   `left: auto`, bukan `position: static`: kepala tabel menempel ke ATAS
+   lewat `.data-table thead th { top: 0 }`, dan mematikan position di sini
+   akan ikut melepaskannya. Yang dilepas cuma patokan sampingnya. */
+.table-rekap th:first-child, .table-rekap td:first-child,
 .table-rekap th:nth-child(2), .table-rekap td:nth-child(2) {
-  position: sticky; left: 56px; z-index: 2;
-  background: var(--kartu); box-shadow: 1px 0 0 var(--garis);
+  left: auto; box-shadow: none;
 }
-.table-rekap thead th:nth-child(2) { z-index: 3; background: var(--kertas); }
-.table-rekap tbody tr:hover td:nth-child(2) { background: var(--utama-muda); }
 
 /* Batas kanan tiap kelompok pos, dan sebelum Nilai Total. */
 .table-rekap .rekap-batas { border-right: 2px solid var(--garis); }

--- a/web/style.css
+++ b/web/style.css
@@ -2148,18 +2148,28 @@ input.small-input { text-align: center; }
    jauh di kanan, terpisah dari Penalti yang seharusnya dibacanya bersama. */
 .table-rekap th:last-child, .table-rekap td:last-child { width: auto; }
 
-/* Rank dipatok lebih dulu, lalu Nomor Dada menempel tepat di belakangnya.
-   Lebar kolom pertama HARUS pasti, kalau tidak `left` kolom kedua meleset —
-   isinya cuma satu sampai tiga digit, jadi mematoknya tidak merugikan. */
-.table-rekap th:first-child, .table-rekap td:first-child {
-  width: 56px; min-width: 56px;
-}
+/* TIDAK ADA KOLOM YANG DIPATOK KE TEPI KIRI DI SINI. # / No Dada / Regu
+   tergeser bersama-sama, seperti kolom lainnya.
+
+   Sebelumnya Nomor Dada dipatok, dan itu tidak pernah bekerja: kolom di
+   SEBELAH KANANNYA adalah Nama Regu, jadi yang dipatok tidak berdiri di
+   pinggir tabel melainkan MELAYANG DI ATAS nama regu yang menggeser di
+   bawahnya. Setengah nama tertutup, dan yang tersisa terbaca sebagai satu
+   kata rusak — "SATYA ... RAN". Patokan itu dipasang supaya baris tetap
+   dikenali saat digeser jauh; yang sebenarnya terjadi adalah ia menutupi
+   satu-satunya kolom yang mengenali baris.
+
+   Bisa saja tiga kolomnya dipatok sekalian supaya tidak saling menutupi,
+   tapi bertiga mereka memakan ±330px — di HP itu hampir seluruh layar, dan
+   yang tersisa untuk angka yang sedang dicari tinggal sejengkal.
+
+   `left: auto`, bukan `position: static`: kepala tabel menempel ke ATAS
+   lewat `.data-table thead th { top: 0 }`, dan mematikan position di sini
+   akan ikut melepaskannya. Yang dilepas cuma patokan sampingnya. */
+.table-rekap th:first-child, .table-rekap td:first-child,
 .table-rekap th:nth-child(2), .table-rekap td:nth-child(2) {
-  position: sticky; left: 56px; z-index: 2;
-  background: var(--kartu); box-shadow: 1px 0 0 var(--garis);
+  left: auto; box-shadow: none;
 }
-.table-rekap thead th:nth-child(2) { z-index: 3; background: var(--kertas); }
-.table-rekap tbody tr:hover td:nth-child(2) { background: var(--utama-muda); }
 
 /* Batas kanan tiap kelompok pos, dan sebelum Nilai Total. */
 .table-rekap .rekap-batas { border-right: 2px solid var(--garis); }


### PR DESCRIPTION
## What

Nothing is pinned to the left edge of the Rekapitulasi / Live Score table any
more. `#`, `No Dada` and `Regu` scroll with everything else.

## Why

Nomor Dada was pinned, and **it never worked**: the column to its right is
Nama Regu, so the pinned cell did not sit at the edge of the table — it
floated *over* the regu name sliding underneath. Half the name was covered and
what remained read as one broken word, `SATYA ... RAN`. Scrolled further it
climbed over the Pos 1 scores and the header read `P( NO EPRAMUKAAN`.

The pin existed so a row stays identifiable when scrolled far right. What it
actually did was cover the only column that identifies the row.

Live Score was worse than Rekapitulasi by accident. Rekapitulasi carries both
`.table-pos` and `.table-rekap`, so its rank column was pinned at `left: 0`
and Nomor Dada landed flush behind it at `left: 56px`. Live Score has
`.table-rekap` only — the rank column scrolled away and left the pinned cell
hanging in open space, which is what the screenshot shows.

Pinning all three instead would cost ~330px — nearly a whole phone screen,
leaving a sliver for the numbers being looked up.

## Notes

`left: auto`, not `position: static`: the table head sticks to the **top** via
`.data-table thead th { top: 0 }`, and killing `position` here would let go of
that too. Only the sideways pin goes.

Verified on the deployed site at 1920px, scrolled to 500px, on both
`#/live-score` and `#/rekap`: columns measure `-55..1`, `1..54`, `54..197` —
contiguous, no overlap. Row height unchanged at 38px.

Input Pos keeps its pinned first column. There the pinned cell is Nomor Dada
and the row is being *typed into*, so knowing whose row it is outweighs the
same overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)