### PR TITLE
fix: the search box stops reserving 173px of empty height on phones

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2614,6 +2614,22 @@ input.small-input { text-align: center; }
    melar — lihat .filter-baris. */
 .kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; }
 
+/* Di HP toolbar-nya BERDIRI (flex-direction: column, lihat @560px), dan begitu
+   arahnya berubah `flex: 1 1 220px` di atas berhenti berarti "lebar 220px"
+   lalu berarti "TINGGI 220px" — sumbu utamanya ikut memutar. Kotak carinya
+   setinggi 47px, jadi 173px sisanya berdiri kosong antara kotak cari dan baris
+   chip. Itulah lubang selebar setengah layar di Meja Daftar Ulang.
+
+   `0 0 auto`: tingginya kembali seukuran isinya, dan lebarnya tetap penuh
+   karena toolbar-nya `align-items: stretch`.
+
+   Ditaruh SESUDAH aturan di atas, bukan di dalam blok @560px yang jauh di
+   atas sana. Kekhususan keduanya sama (0,1,0), jadi yang menang adalah yang
+   belakangan — media query saja tidak menambah bobot apa pun. */
+@media (max-width: 560px) {
+  .kotak-cari { flex: 0 0 auto; min-width: 0; }
+}
+
 /* Sepasang isian yang TETAP bersebelahan walau layarnya sempit.
 
    .two-column runtuh jadi satu kolom di bawah 640px, dan itu benar untuk

--- a/web/style.css
+++ b/web/style.css
@@ -2614,6 +2614,22 @@ input.small-input { text-align: center; }
    melar — lihat .filter-baris. */
 .kotak-cari { margin: 0; flex: 1 1 220px; min-width: 220px; }
 
+/* Di HP toolbar-nya BERDIRI (flex-direction: column, lihat @560px), dan begitu
+   arahnya berubah `flex: 1 1 220px` di atas berhenti berarti "lebar 220px"
+   lalu berarti "TINGGI 220px" — sumbu utamanya ikut memutar. Kotak carinya
+   setinggi 47px, jadi 173px sisanya berdiri kosong antara kotak cari dan baris
+   chip. Itulah lubang selebar setengah layar di Meja Daftar Ulang.
+
+   `0 0 auto`: tingginya kembali seukuran isinya, dan lebarnya tetap penuh
+   karena toolbar-nya `align-items: stretch`.
+
+   Ditaruh SESUDAH aturan di atas, bukan di dalam blok @560px yang jauh di
+   atas sana. Kekhususan keduanya sama (0,1,0), jadi yang menang adalah yang
+   belakangan — media query saja tidak menambah bobot apa pun. */
+@media (max-width: 560px) {
+  .kotak-cari { flex: 0 0 auto; min-width: 0; }
+}
+
 /* Sepasang isian yang TETAP bersebelahan walau layarnya sempit.
 
    .two-column runtuh jadi satu kolom di bawah 640px, dan itu benar untuk


### PR DESCRIPTION
## What

`.kotak-cari` gets `flex: 0 0 auto` once the toolbar switches to a column.

## Why

On phones `.table-toolbar` is `flex-direction: column` (the 560px query). The
moment the direction turns, `flex: 1 1 220px` stops meaning *220px wide* and
starts meaning **220px tall** — the flex basis follows the main axis.

The search input is 47px. The other **173px stood empty** between it and the
filter chips. That is the half-screen hole in the screenshot of Meja Daftar
Ulang.

## Notes

The override sits directly after the base rule, not inside the `560px` block
further up the file. Both selectors are specificity `(0,1,0)`, so the later
one wins — wrapping a rule in a media query adds no weight of its own. Put in
the earlier block it would have been silently overridden.

Measured in an iframe at 360 / 420 / 494 / 560 / 561 / 700 / 1000 px: the box
is 47px tall at every width, the toolbar drops from 270px to 97px at 494, the
gap to the chips is a steady 10px, and nothing jumps across the 560/561
boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)