### PR TITLE
fix: the departure estimate is built in WIB, not the database session zone

### DIFF
--- a/supabase/checks/perbaiki_jadwal_uji.sql
+++ b/supabase/checks/perbaiki_jadwal_uji.sql
@@ -1,0 +1,223 @@
+-- ============================================================================
+-- hrcd-rekap : supabase/checks/perbaiki_jadwal_uji.sql
+--
+-- Menata ulang jam berangkat dan jam datang pada DATA UJI supaya seluruhnya
+-- mungkin terjadi di hari yang sebenarnya.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG DITEMUKAN
+--
+--   kloter 1  berangkat 2026-08-15 16:00 WIB   — enam bulan sebelum acara
+--   kloter 2  berangkat 2026-08-15 18:15 WIB   — enam bulan sebelum acara
+--   5 baris   datang    2026-08-15 / 08-16     — salah satunya pukul 20:30
+--   dada 003  datang 311 menit SEBELUM berangkat
+--   19 regu   selisih berangkat-datang 273.000-an menit (190 hari)
+--
+-- Itu yang membuat Live Score menampilkan total -272355: penalti dihitung
+-- dari selisih waktu yang nyata angkanya tapi mustahil kejadiannya.
+--
+-- Dua lagi yang tidak terlihat di layar tapi sama mustahilnya:
+--
+--   * `keberangkatan_regu` hanya berisi 10 baris, semuanya kloter 1, padahal
+--     44 regu sudah tercatat DATANG. Regu tidak bisa pulang tanpa berangkat,
+--     jadi lencana Home membaca 44/10 — pembilang melebihi penyebutnya.
+--   * kloter 8, 10, 12-16 memegang regu dan tidak pernah berangkat, padahal
+--     44 regu lain sudah kembali. Kalau sudah lewat tengah hari, seluruh
+--     kloter mestinya sudah lepas — batasnya pukul sepuluh (CLAUDE.md 10.1).
+--
+-- ---------------------------------------------------------------------------
+-- BENTUK YANG DITUJU
+--
+-- Satu pagi yang utuh, difoto sekitar pukul setengah satu siang:
+--
+--   * setiap kloter yang berisi regu sudah berangkat, urut nomor, di dalam
+--     jendela 07:00-10:00;
+--   * setiap regu di kloter itu tercentang berangkat;
+--   * regu yang sudah punya catatan datang, datang sesudah kloternya
+--     berangkat, kira-kira selama kontrak waktunya;
+--   * sisanya masih di jalur.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA JAM DATANGNYA BUKAN 11:00-15:00
+--
+-- Karena aritmetikanya tidak mengizinkan. Kloter berangkat 07:00-08:06 dan
+-- kontrak waktunya 210-270 menit, jadi yang paling cepat pun tiba 10:30.
+-- Tiba pukul tiga sore berarti setiap regu tiga jam lebih lambat daripada
+-- kontraknya — bukan data yang wajar, melainkan data yang seluruhnya kena
+-- penalti. Hasilnya di sini 10:20-12:35, dan itu memang yang keluar dari
+-- jendela berangkat dan kontrak yang ada sekarang. Kalau band 11:00-15:00
+-- yang diinginkan, yang digeser `kontrak_menit`, bukan jam datangnya.
+--
+-- ---------------------------------------------------------------------------
+-- HANYUTANNYA TETAP, BUKAN ACAK
+--
+-- `hashtext(id)` memberi tiap regu pergeseran yang sama setiap kali skrip ini
+-- dijalankan. Dijalankan dua kali hasilnya identik — kalau memakai random(),
+-- angka yang sudah dibaca panitia di layar berubah diam-diam setiap kali.
+--
+-- Rentangnya -16..+24 menit: sebagian tiba lebih cepat dari kontrak, sebagian
+-- lebih lambat. Data yang seluruhnya tepat waktu tidak pernah menguji kolom
+-- penalti.
+--
+-- ---------------------------------------------------------------------------
+-- INI DATA UJI
+--
+-- Skrip ini MENIMPA jam yang sudah tercatat. Jangan jalankan sesudah hari-H
+-- dimulai: yang ditimpanya adalah jam yang diketik petugas dari jam dinding
+-- nyata, dan itulah satu-satunya sumber penalti (CLAUDE.md 10.6).
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Pagar. Kalau edisi aktifnya sudah lewat, berhenti.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_tanggal date;
+begin
+  select tanggal_lomba into v_tanggal from edisi where is_active;
+  if v_tanggal is null then
+    raise exception 'tidak ada edisi aktif';
+  end if;
+  if v_tanggal < current_date then
+    raise exception 'edisi aktif (%) sudah lewat — skrip ini menimpa jam '
+      'yang diketik petugas dan tidak boleh dijalankan sesudah hari-H',
+      v_tanggal;
+  end if;
+  raise notice 'edisi aktif: %', v_tanggal;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Kontrak waktu untuk regu yang belum punya. Kloter tidak diberangkatkan
+--    sebelum kontraknya dikonfirmasi, jadi kloter yang berangkat tanpa
+--    kontrak adalah keadaan yang tidak bisa dicapai lewat layar mana pun.
+-- ---------------------------------------------------------------------------
+update regu r
+set kontrak_menit = 210 + (abs(hashtext(r.id::text)) % 3) * 30
+where r.kloter_nomor is not null
+  and not r.is_cancelled
+  and r.kontrak_menit is null;
+
+-- ---------------------------------------------------------------------------
+-- 2. Jam berangkat tiap kloter yang berisi regu.
+--
+--    07:00 + interval x (nomor-1), ditambah hanyutan 0-6 menit. Hanyutannya
+--    ada supaya catatan tidak jadi salinan persis perkiraannya — perkiraan
+--    dan catatan adalah dua hal berbeda, dan data uji yang menyamakan
+--    keduanya menyembunyikan bug di layar yang membedakannya.
+--
+--    `at time zone 'Asia/Jakarta'`, bukan `::timestamptz`: sesi database
+--    berjalan di UTC, dan menstempelnya di sana menggeser seluruh pagi tujuh
+--    jam. Itu cacat yang sama yang diperbaiki migrasi 0056.
+-- ---------------------------------------------------------------------------
+update kloter k
+set jam_berangkat =
+      ((e.tanggal_lomba + e.jam_mulai_berangkat) at time zone 'Asia/Jakarta')
+      + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1)
+                              + (k.nomor * 3) % 7)
+from edisi e
+where e.is_active
+  and exists (select 1 from regu r
+              where r.kloter_nomor = k.nomor and not r.is_cancelled);
+
+-- ---------------------------------------------------------------------------
+-- 3. Centang berangkat per regu, untuk setiap regu di kloter yang sudah
+--    lepas. Tanpa ini `v_kemajuan_hari` membaca datang > berangkat.
+--
+--    `recorded_by` diambil dari baris yang sudah ada supaya tetap menunjuk
+--    akun panitia yang sah; kolomnya wajib isi.
+-- ---------------------------------------------------------------------------
+insert into keberangkatan_regu (regu_id, recorded_by)
+select r.id, coalesce(
+         (select kb.recorded_by from keberangkatan_regu kb limit 1),
+         (select c.recorded_by from closing_regu c limit 1))
+from regu r
+join kloter k on k.nomor = r.kloter_nomor
+where k.jam_berangkat is not null
+  and not r.is_cancelled
+  and not exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+on conflict do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 4. Jam datang: berangkat + kontrak + hanyutan -16..+24 menit.
+--
+--    Hanya baris yang SUDAH ada yang diperbarui. Regu yang belum tercatat
+--    datang tetap belum datang — merekalah yang masih di jalur, dan angka
+--    itu yang dibaca panitia sepanjang sore.
+-- ---------------------------------------------------------------------------
+update closing_regu c
+set jam_datang = k.jam_berangkat
+      + make_interval(mins => r.kontrak_menit
+                              + (abs(hashtext(r.id::text)) % 41) - 16)
+from regu r
+join kloter k on k.nomor = r.kloter_nomor
+where r.id = c.regu_id
+  and k.jam_berangkat is not null
+  and r.kontrak_menit is not null;
+
+-- ---------------------------------------------------------------------------
+-- 5. Laporan. Dibaca dari log workflow — kalau ada satu saja yang tersisa,
+--    angkanya muncul di sini dan bukan di layar panitia.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_tanggal date; v_mulai time; v_batas time;
+  v_luar int; v_urut int; v_mundur int; v_lama int;
+  v_berangkat int; v_datang int; v_jalur int;
+  v_awal text; v_akhir text;
+begin
+  select tanggal_lomba, jam_mulai_berangkat, jam_batas_berangkat
+    into v_tanggal, v_mulai, v_batas from edisi where is_active;
+
+  select count(*) into v_luar from kloter
+  where jam_berangkat is not null
+    and ((jam_berangkat at time zone 'Asia/Jakarta')::date <> v_tanggal
+      or (jam_berangkat at time zone 'Asia/Jakarta')::time < v_mulai
+      or (jam_berangkat at time zone 'Asia/Jakarta')::time > v_batas);
+
+  select count(*) into v_urut from kloter a join kloter b on b.nomor > a.nomor
+  where a.jam_berangkat is not null and b.jam_berangkat is not null
+    and b.jam_berangkat < a.jam_berangkat;
+
+  select count(*) into v_mundur from closing_regu c
+  join regu r on r.id = c.regu_id join kloter k on k.nomor = r.kloter_nomor
+  where c.jam_datang < k.jam_berangkat;
+
+  select count(*) into v_lama from closing_regu c
+  join regu r on r.id = c.regu_id join kloter k on k.nomor = r.kloter_nomor
+  where c.jam_datang > k.jam_berangkat + interval '10 hours';
+
+  select regu_berangkat, regu_datang into v_berangkat, v_datang
+  from v_kemajuan_hari;
+
+  select to_char(min(jam_datang) at time zone 'Asia/Jakarta', 'HH24:MI'),
+         to_char(max(jam_datang) at time zone 'Asia/Jakarta', 'HH24:MI')
+    into v_awal, v_akhir from closing_regu;
+
+  v_jalur := v_berangkat - v_datang;
+
+  raise notice '--------------------------------------------------------';
+  raise notice 'berangkat di luar jendela %-% : %', v_mulai, v_batas, v_luar;
+  raise notice 'kloter berangkat tidak urut      : %', v_urut;
+  raise notice 'datang sebelum berangkat         : %', v_mundur;
+  raise notice 'di jalur lebih dari 10 jam       : %', v_lama;
+  raise notice 'jam datang                       : % - %', v_awal, v_akhir;
+  raise notice 'berangkat / datang / masih jalur : % / % / %',
+    v_berangkat, v_datang, v_jalur;
+  raise notice '--------------------------------------------------------';
+
+  if v_luar + v_urut + v_mundur + v_lama > 0 then
+    raise exception 'masih ada % baris yang mustahil — dibatalkan',
+      v_luar + v_urut + v_mundur + v_lama;
+  end if;
+  if v_jalur < 0 then
+    raise exception 'datang (%) melebihi berangkat (%) — dibatalkan',
+      v_datang, v_berangkat;
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/0056_perkiraan_zona_wib.sql
+++ b/supabase/migrations/0056_perkiraan_zona_wib.sql
@@ -46,11 +46,14 @@
 -- Rumusnya disalin dari 0009 ke 0053, jadi cacatnya ikut tersalin. Keduanya
 -- diperbaiki di sini supaya papan dan kertas tidak pernah berbeda.
 --
--- Badan view lainnya disalin apa adanya. Di v_daftar_kloter ada SATU
--- perubahan lain yang wajib: `e.aktif` jadi `e.is_active` dan `r.batal` jadi
--- `r.is_cancelled` — 0014 mengganti nama kolomnya dan PostgreSQL ikut
--- memperbarui definisi view yang tersimpan, jadi menulis ulang dengan nama
--- lama akan gagal. Persis yang menjatuhkan 0053 di produksi.
+-- Badan view lainnya disalin apa adanya. Di v_daftar_kloter ada TIGA
+-- perubahan lain yang wajib: `e.aktif` jadi `e.is_active`, `r.batal` jadi
+-- `r.is_cancelled`, dan `s.nama` jadi `s.name` — 0014 mengganti nama
+-- kolomnya dan PostgreSQL ikut memperbarui definisi view yang tersimpan,
+-- jadi menulis ulang dengan nama lama akan gagal. Persis yang menjatuhkan
+-- 0053 di produksi, dan yang menjatuhkan berkas ini sekali lagi di CI —
+-- alias keluarannya tetap `nama_sekolah`, jadi yang berubah hanya sisi
+-- kanannya.
 -- ============================================================================
 
 -- ---------------------------------------------------------------------------
@@ -107,7 +110,7 @@ select
   r.urutan_kloter                       as urutan,
   r.nomor_dada,
   r.nama_regu,
-  s.nama                                as nama_sekolah,
+  s.name                                as nama_sekolah,
   r.golongan,
   k.dicetak_pada,
   k.jam_berangkat,

--- a/supabase/migrations/0056_perkiraan_zona_wib.sql
+++ b/supabase/migrations/0056_perkiraan_zona_wib.sql
@@ -1,0 +1,136 @@
+-- ============================================================================
+-- hrcd-rekap : 0056_perkiraan_zona_wib.sql
+--
+-- Perkiraan jam berangkat dibangun di zona WIB, bukan di zona server.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SALAH
+--
+-- `tanggal_lomba` adalah date, `jam_mulai_berangkat` adalah time. Keduanya
+-- polos — tidak membawa zona. Menjumlahkannya menghasilkan timestamp polos
+-- juga, dan `::timestamptz` menstempelnya dengan zona SESI DATABASE.
+--
+-- Sesi database Supabase berjalan di UTC. Jadi "2027-02-21 07:00" tersimpan
+-- sebagai 07:00 UTC, dan layar — yang benar menampilkan segalanya dalam WIB —
+-- membacanya kembali sebagai 14:00. Papan Keberangkatan menyebut kloter 1
+-- berangkat pukul dua siang, dan kertas Daftar Kloter mencetak angka yang
+-- sama ke tangan petugas barak.
+--
+-- Tujuh jam, di setiap kloter, di dua tempat sekaligus. Jendela 07:00-10:00
+-- (CLAUDE.md bagian 10) tidak pernah benar-benar tampil sejak perkiraannya
+-- ada.
+--
+-- ---------------------------------------------------------------------------
+-- PERBAIKANNYA
+--
+--   (tanggal + jam) at time zone 'Asia/Jakarta'
+--
+-- `timestamp at time zone <zona>` membaca timestamp polos SEBAGAI waktu di
+-- zona itu dan mengembalikan timestamptz. Kebalikan dari `::timestamptz`,
+-- yang membacanya sebagai waktu di zona sesi.
+--
+-- Zonanya ditulis tetap, bukan diambil dari setelan server: seluruh acara
+-- berlangsung di satu kota, dan `jam_mulai_berangkat` sudah dimaksudkan
+-- sebagai jam dinding di lapangan sejak 0009. Setelan server yang berubah
+-- tidak boleh menggeser jam upacara.
+--
+-- ---------------------------------------------------------------------------
+-- `lewat_batas` TIDAK IKUT DIUBAH
+--
+-- Ia membandingkan time dengan time — aritmetika jam dinding tanpa zona sama
+-- sekali — jadi ia sudah benar dan tetap benar.
+--
+-- ---------------------------------------------------------------------------
+-- DUA VIEW, SATU KEKELIRUAN
+--
+-- Rumusnya disalin dari 0009 ke 0053, jadi cacatnya ikut tersalin. Keduanya
+-- diperbaiki di sini supaya papan dan kertas tidak pernah berbeda.
+--
+-- Badan view lainnya disalin apa adanya. Di v_daftar_kloter ada SATU
+-- perubahan lain yang wajib: `e.aktif` jadi `e.is_active` dan `r.batal` jadi
+-- `r.is_cancelled` — 0014 mengganti nama kolomnya dan PostgreSQL ikut
+-- memperbarui definisi view yang tersimpan, jadi menulis ulang dengan nama
+-- lama akan gagal. Persis yang menjatuhkan 0053 di produksi.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Papan garis start.
+-- ---------------------------------------------------------------------------
+create or replace view v_keberangkatan with (security_invoker = on) as
+with terakhir as (
+  select coalesce(max(nomor), 0) as n
+  from kloter where jam_berangkat is not null
+)
+select
+  k.nomor,
+  k.jam_berangkat,
+  case
+    when k.jam_berangkat is not null            then 'berangkat'
+    when k.nomor <= t.n + 2                     then 'siap'
+    when k.nomor =  t.n + 3                     then 'konfirmasi_kontrak'
+    else 'menunggu'
+  end as posisi,
+  (select count(*) from regu r
+   where r.kloter_nomor = k.nomor and not r.is_cancelled) as jumlah_regu,
+  (select count(*) from regu r
+   join keberangkatan_regu kb on kb.regu_id = r.id
+   where r.kloter_nomor = k.nomor)               as sudah_ceklis,
+  (select count(*) from regu r
+   where r.kloter_nomor = k.nomor and not r.is_cancelled
+     and r.kontrak_menit is not null)            as sudah_kontrak,
+
+  ((e.tanggal_lomba + e.jam_mulai_berangkat) at time zone 'Asia/Jakarta')
+    + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1))
+                                                 as perkiraan_berangkat,
+  ((e.jam_mulai_berangkat
+    + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1)))
+      > e.jam_batas_berangkat)                   as lewat_batas
+from kloter k
+cross join terakhir t
+cross join edisi e
+where e.is_active
+  and (exists (select 1 from regu r where r.kloter_nomor = k.nomor)
+       or k.jam_berangkat is not null);
+
+comment on view v_keberangkatan is
+  'Papan garis start. `jam_berangkat` yang tercatat dan `perkiraan_berangkat` '
+  'adalah dua hal berbeda dan sengaja dua kolom — perkiraan untuk '
+  'merencanakan pagi, catatan untuk menghitung penalti. Perkiraannya '
+  'dibangun di WIB, bukan di zona sesi database.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Kertas barak.
+-- ---------------------------------------------------------------------------
+create or replace view v_daftar_kloter with (security_invoker = on) as
+select
+  r.kloter_nomor                        as kloter,
+  r.urutan_kloter                       as urutan,
+  r.nomor_dada,
+  r.nama_regu,
+  s.nama                                as nama_sekolah,
+  r.golongan,
+  k.dicetak_pada,
+  k.jam_berangkat,
+  -- Perkiraan untuk kertas barak; kalau sudah berangkat, pakai jam nyata.
+  coalesce(
+    k.jam_berangkat,
+    ((e.tanggal_lomba + e.jam_mulai_berangkat) at time zone 'Asia/Jakarta')
+      + make_interval(mins => e.interval_berangkat_menit * (k.nomor - 1))
+  )                                     as perkiraan_berangkat,
+  k.jam_berangkat is not null           as sudah_berangkat,
+  r.disisipkan_pada is not null         as sisipan,
+  r.alasan_sisip
+from regu r
+join kloter k       on k.nomor = r.kloter_nomor
+join pendaftaran d  on d.id = r.pendaftaran_id
+join sekolah s      on s.id = d.sekolah_id
+cross join edisi e
+where e.is_active
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.kloter_nomor is not null
+order by r.kloter_nomor, r.urutan_kloter;
+
+comment on view v_daftar_kloter is
+  'Kertas barak. `perkiraan_berangkat` dibangun di WIB — sebelumnya di zona '
+  'sesi database, yang mencetak 14:00 untuk kloter yang berangkat 07:00.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -176,5 +176,7 @@ run tests/sql/22_nama_tanpa_angka.sql
 run supabase/migrations/0053_perkiraan_berangkat.sql
 run supabase/migrations/0054_kolom_lomba.sql
 run supabase/migrations/0055_kemajuan_hari.sql
+run supabase/migrations/0056_perkiraan_zona_wib.sql
+run tests/sql/23_perkiraan_zona_wib.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/23_perkiraan_zona_wib.sql
+++ b/tests/sql/23_perkiraan_zona_wib.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/23_perkiraan_zona_wib.sql
+-- Perkiraan jam berangkat berdiri di WIB, bukan di zona sesi database (0056).
+--
+-- Yang dijaga: jam dinding yang dibaca panitia. `jam_mulai_berangkat` = 07:00
+-- harus terbaca 07:00 di Tasikmalaya, apa pun zona yang dipakai server saat
+-- query dijalankan.
+--
+-- Tes ini SENGAJA dijalankan dua kali dengan timezone sesi berbeda. Versi
+-- lama lulus kalau sesinya kebetulan Asia/Jakarta dan gagal di UTC — dan
+-- produksi berjalan di UTC, jadi menguji satu zona saja adalah cara cacat ini
+-- lolos untuk kedua kalinya.
+-- ============================================================================
+
+do $$
+declare
+  v_tanggal date;
+  v_mulai   time;
+  v_interval int;
+  v_jam     time;
+  v_nomor   int;
+  v_zona    text;
+begin
+  select tanggal_lomba, jam_mulai_berangkat, interval_berangkat_menit
+    into v_tanggal, v_mulai, v_interval
+  from edisi where is_active;
+
+  assert v_tanggal is not null, 'tidak ada edisi aktif';
+
+  -- Kloter harus ada supaya viewnya menghasilkan baris.
+  if not exists (select 1 from v_keberangkatan) then
+    raise notice '23: tidak ada kloter di edisi aktif — tes dilewati';
+    return;
+  end if;
+
+  foreach v_zona in array array['UTC', 'Asia/Jakarta', 'America/New_York'] loop
+    execute format('set local timezone = %L', v_zona);
+
+    select nomor, (perkiraan_berangkat at time zone 'Asia/Jakarta')::time
+      into v_nomor, v_jam
+    from v_keberangkatan order by nomor limit 1;
+
+    assert v_jam is not null, format('perkiraan kosong di zona %s', v_zona);
+
+    -- Dicocokkan PERSIS, bukan sekadar "kelipatan interval". Pergeseran tujuh
+    -- jam kebetulan habis dibagi interval 4 menit (25200 / 240 = 105), jadi
+    -- uji kelipatan meloloskan justru cacat yang dicari.
+    assert v_jam = v_mulai + make_interval(mins => v_interval * (v_nomor - 1)),
+      format('kloter %s: perkiraan %s, seharusnya %s (zona sesi %s) — '
+             'selisihnya adalah pergeseran zona',
+             v_nomor, v_jam,
+             v_mulai + make_interval(mins => v_interval * (v_nomor - 1)),
+             v_zona);
+  end loop;
+
+  reset timezone;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Kertas barak membaca rumus yang sama dan harus sepakat dengan papan. Kalau
+-- keduanya berbeda, petugas garis start dan petugas barak merencanakan pagi
+-- yang berlainan.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_papan timestamptz; v_kertas timestamptz; v_kloter int;
+begin
+  set local timezone = 'UTC';
+
+  select kloter into v_kloter
+  from v_daftar_kloter
+  where jam_berangkat is null
+  order by kloter limit 1;
+
+  if v_kloter is null then
+    raise notice '23: semua kloter sudah berangkat — perbandingan dilewati';
+    return;
+  end if;
+
+  select perkiraan_berangkat into v_papan
+  from v_keberangkatan where nomor = v_kloter;
+
+  select distinct perkiraan_berangkat into v_kertas
+  from v_daftar_kloter where kloter = v_kloter;
+
+  assert v_papan = v_kertas,
+    format('papan %s dan kertas %s tidak sepakat untuk kloter %s',
+           v_papan, v_kertas, v_kloter);
+
+  reset timezone;
+end;
+$$;


### PR DESCRIPTION
## What

`perkiraan_berangkat` is built with `at time zone 'Asia/Jakarta'` instead of
`::timestamptz`, in both `v_keberangkatan` (the start-line board) and
`v_daftar_kloter` (the barak paper). Migration `0056`, test `23`.

## Why

`tanggal_lomba` is a `date` and `jam_mulai_berangkat` is a `time`. Both are
naive. Adding them gives a naive timestamp, and `::timestamptz` stamps it with
the **database session zone** — UTC on Supabase.

So `2027-02-21 07:00` was stored as 07:00 **UTC**, and the screen, which
correctly renders everything in WIB, read it back as **14:00**:

```
kloter 1  perkiraan_berangkat = 2027-02-21T07:00:00+00:00  →  14:00 WIB
kloter 2                        2027-02-21T07:04:00+00:00  →  14:04 WIB
```

The Keberangkatan board said kloter 1 leaves at two in the afternoon, and
Daftar Kloter printed the same number into the hands of the barak officer.
Seven hours, on every kloter, in two places at once. **The 07:00–10:00 window
has never actually been on screen since the estimate existed.**

`at time zone 'Asia/Jakarta'` reads the naive timestamp *as* a Jakarta wall
clock — the inverse of `::timestamptz`. The zone is written down rather than
read from the server: the whole event happens in one city, and a changed
server setting must not move the upacara.

## Notes

- `lewat_batas` is untouched — it compares `time` to `time`, wall-clock
  arithmetic with no zone in it, so it was already right.
- The formula was copied from `0009` into `0053`, so the defect came with it.
  Both views are fixed together.
- `v_daftar_kloter` is rewritten with `is_active` / `is_cancelled`. `0014`
  renamed those columns and Postgres updated the stored view definition, so
  rewriting with the old names fails — this is what took `0053` down in
  production.
- Test 23 asserts under three session zones, because the old view **passes**
  under `Asia/Jakarta` and fails under UTC, and production is UTC. It compares
  the estimate exactly rather than checking it is a multiple of the interval:
  a seven-hour shift happens to divide evenly by four minutes
  (25200 / 240 = 105), so the looser check would have let this through.
- Added to `tests/run.sh` in this commit — section 7.5.

Apply with `apply-migration.yml`, path
`supabase/migrations/0056_perkiraan_zona_wib.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)