### PR TITLE
chore: repair the dummy departure and arrival times

### DIFF
--- a/supabase/checks/perbaiki_jadwal_uji.sql
+++ b/supabase/checks/perbaiki_jadwal_uji.sql
@@ -67,9 +67,11 @@
 -- nyata, dan itulah satu-satunya sumber penalti (CLAUDE.md 10.6).
 -- ============================================================================
 
-\set ON_ERROR_STOP on
-
-begin;
+-- Tanpa `begin;`/`commit;` sendiri: apply-migration.yml sudah menjalankan
+-- psql dengan --single-transaction dan ON_ERROR_STOP=1, jadi `raise exception`
+-- di blok laporan paling bawah membatalkan SELURUH perubahan di atasnya.
+-- Membuka transaksi kedua di sini justru menutupnya lebih awal dan melepaskan
+-- jaring itu.
 
 -- ---------------------------------------------------------------------------
 -- 0. Pagar. Kalau edisi aktifnya sudah lewat, berhenti.
@@ -219,5 +221,3 @@ begin
   end if;
 end;
 $$;
-
-commit;


### PR DESCRIPTION
## What

`supabase/checks/perbaiki_jadwal_uji.sql` — a one-shot repair of the seeded
schedule.

## Why

The dummy data contained times that cannot have happened:

```
kloter 1  departed 2026-08-15 16:00 WIB   — six months before the event
kloter 2  departed 2026-08-15 18:15 WIB   — six months before the event
5 rows    arrived  2026-08-15 / 08-16     — one of them at 20:30
dada 003  arrived 311 minutes BEFORE departing
19 regu   elapsed ~273,000 minutes (190 days)
```

That is where Live Score's `-272355` came from: a penalty computed from an
elapsed time that is real as arithmetic and impossible as an event.

Two more that never reached the screen:

- `keberangkatan_regu` held **10 rows, all kloter 1**, while **44 regu** were
  recorded as arrived. A regu cannot come back without leaving, so the Home
  badge read `44/10` — numerator above its own denominator.
- kloter 8, 10, 12–16 hold regu and never departed, while 44 others had
  already returned. Past midday every kloter must be away; the deadline is ten
  (CLAUDE.md 10.1).

## What it produces

One coherent morning, photographed around half past twelve: every kloter
holding regu has left, in order, inside 07:00–10:00; every regu in those
kloter is ticked off; those with an arrival arrived after their kloter left,
roughly one kontrak later; the rest are still out there.

## Notes

**Arrivals land 10:20–12:35, not the 11:00–15:00 that was asked for**, because
the arithmetic does not allow it. Departures run 07:00–08:06 and `kontrak_menit`
is 210–270, so even the longest contract puts the last regu in before one.
Arriving at three would mean every single regu is three hours over contract —
not plausible data, just data that is uniformly penalised. The lever for a
later band is `kontrak_menit`, not `jam_datang`.

Drift is `hashtext(id)`, not `random()`: running it twice gives the same
result. With `random()` the numbers a panitia already read off the screen
would change quietly on every run.

The script refuses to run if the active edition is in the past — after the
event those columns hold times typed from a real clock, and they are the only
source of penalties (CLAUDE.md 10.6).

No `begin;`/`commit;` of its own: `apply-migration.yml` runs psql with
`--single-transaction`, so the `raise exception` in the report block at the
bottom rolls back everything above it. Opening a second transaction would
close that net early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)