### PR TITLE
fix: Kedatangan measures against the event day, not today

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -87,6 +87,33 @@ export function jamMenit(t) {
   return FMT_JAM.format(new Date(t));
 }
 
+/** "11:26" + hari acuan -> Date pada jam itu, di hari WIB yang sama dengan
+ *  acuan.
+ *
+ *  Bukan "hari ini". Petugas mengetik jam dinding — "11:26" — dan jam dinding
+ *  tidak membawa tanggal; tanggalnya harus datang dari peristiwa yang sedang
+ *  dicatat, bukan dari kalender alat yang dipakai mencatat. Keduanya sama
+ *  pada hari-H dan berbeda pada setiap hari lainnya, termasuk setiap kali
+ *  layar ini dibuka untuk dicoba sebelum acara.
+ *
+ *  Dirakit lewat teks ISO dengan offset +07:00, bukan lewat setHours: yang
+ *  terakhir memakai zona alat, dan satu laptop pinjaman yang zonanya keliru
+ *  cukup untuk menggeser jam yang tercatat (alasan yang sama dengan ZONA di
+ *  atas).
+ */
+export function jamPadaHari(hhmm, acuan) {
+  const [j, m] = hhmm.split(":").map(Number);
+  const bagian = {};
+  // `new Date(null)` adalah 1 Januari 1970, bukan galat — jadi acuan kosong
+  // harus ditangkap di sini, bukan dibiarkan lewat.
+  for (const b of FMT_TANGGAL.formatToParts(new Date(acuan || Date.now()))) bagian[b.type] = b.value;
+  const dd = String(bagian.day).padStart(2, "0");
+  const mm = String(bagian.month).padStart(2, "0");
+  const HH = String(j).padStart(2, "0");
+  const MM = String(m).padStart(2, "0");
+  return new Date(`${bagian.year}-${mm}-${dd}T${HH}:${MM}:00+07:00`);
+}
+
 /** "17 Agustus 2026" */
 export function tanggalPanjang(t) {
   if (!t) return "—";

--- a/live/style.css
+++ b/live/style.css
@@ -2637,6 +2637,14 @@ input.small-input { text-align: center; }
    hadir" satu digit — keduanya muat bersama bahkan di 360px, dan menumpuknya
    menurunkan tombol simpan satu baris penuh pada layar yang dipakai berdiri
    di garis finish. */
+/* Jaraknya lebih lebar daripada .two-column biasa. Dua isian yang saling
+   bersinggungan di kolom sempit terbaca sebagai satu kelompok: kotak menit
+   berakhir 10px sebelum kotak "Anggota hadir" dimulai, dan labelnya berdiri
+   berdempetan di atasnya sehingga tidak jelas label mana milik kotak mana.
+   1,25rem sudah cukup memisahkan keduanya tanpa mendorong apa pun ke bawah. */
 @media (max-width: 640px) {
-  .two-column.pasangan-sempit { grid-template-columns: auto 1fr; }
+  .two-column.pasangan-sempit {
+    grid-template-columns: auto 1fr;
+    column-gap: 1.25rem;
+  }
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,7 +27,8 @@ import {
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
-         kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3 } from "./util.js";
+         kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
+         jamPadaHari } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN_LABEL = {
@@ -1097,6 +1098,17 @@ async function layarKeberangkatan() {
 
   const layarIni = location.hash;
   let papan, opsi;
+
+  /* Tanggalnya diambil dari perkiraan berangkat, yang selalu jatuh di tanggal
+     lomba — BUKAN dari kalender alat pencatat. Petugas mengetik jam dinding,
+     dan jam dinding tidak membawa tanggal.
+
+     Ini bukan kehati-hatian teoretis: mencoba layar ini sebelum hari-H adalah
+     persis yang menaruh "kloter 1 berangkat 2026-08-15 16:00" di database,
+     enam bulan sebelum acaranya, dan membuat penalti seluruh kloter itu
+     terhitung 190 hari. */
+  const hariLomba = () =>
+    papan.find(k => k.perkiraan_berangkat)?.perkiraan_berangkat || Date.now();
   try { [papan, opsi] = await Promise.all([papanKeberangkatan(), kontrakOpsi()]); }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarKeberangkatan)); return; }
   // Daftar sisipan pindah ke sini bersama layar Pindah Kloter yang dihapus.
@@ -1425,7 +1437,8 @@ async function layarKeberangkatan() {
       if (!jawab) return;
       const [hhmm, alasan] = jawab;
       try {
-        await koreksiJamBerangkat(kloterAktif, jamHariIni(hhmm).toISOString(), alasan);
+        await koreksiJamBerangkat(kloterAktif,
+          jamPadaHari(hhmm, hariLomba()).toISOString(), alasan);
       } catch (err) { notif(err.message, true); return; }
       notif(`Jam berangkat Kloter ${kloterAktif} dibetulkan jadi ${hhmm}.`);
       papan = await papanKeberangkatan();
@@ -1454,7 +1467,8 @@ async function layarKeberangkatan() {
       kotakJamBerangkat.setNilai(hhmm);
       tombol.dataset.jalan = "1"; tombol.disabled = true; tombol.textContent = "Menyimpan…";
       try {
-        await berangkatkanKloter(kloterAktif, jamHariIni(hhmm).toISOString());
+        await berangkatkanKloter(kloterAktif,
+          jamPadaHari(hhmm, hariLomba()).toISOString());
       } catch (err) {
         notif(err.message, true);
         tombol.dataset.jalan = ""; tombol.disabled = false;
@@ -1727,7 +1741,7 @@ function layarFinish() {
     // menghitung dampak dari angka setengah jadi membuat lencananya
     // berkedip-kedip menampilkan penalti yang tidak pernah berlaku.
     const isi = inpJam.nilai();
-    const jamIsi = isi ? jamHariIni(isi) : dasar;
+    const jamIsi = isi ? jamPadaHari(isi, regu.target_datang) : dasar;
     const pDasar = hitungPenalti(dasar, regu.target_datang);
     const pIsi = hitungPenalti(jamIsi, regu.target_datang);
     const tulis = (n) => n === 0 ? "0" : `−${n}`;
@@ -1848,7 +1862,7 @@ function layarFinish() {
 
     // Jam dikunci DI SINI — saat tombol ditekan, dari jam laptop panitia.
     // Kolom jam hanya dipakai bila memang diisi (koreksi hasil verifikasi).
-    const jam = jamIsi ? jamHariIni(jamIsi) : new Date();
+    const jam = jamIsi ? jamPadaHari(jamIsi, regu.target_datang) : new Date();
     const hadir = Math.max(0, Math.min(5, Number(inpHadir.value) || 0));
     const dada = regu.nomor_dada;
     const nama = regu.nama_regu;
@@ -1882,17 +1896,19 @@ function layarFinish() {
   }
 }
 
-/** "14:35" -> Date hari ini pada jam itu (untuk pencatatan susulan). */
-function jamHariIni(hhmm) {
-  const [j, m] = hhmm.split(":").map(Number);
-  const d = new Date();
-  d.setHours(j, m, 0, 0);
-  return d;
-}
-
 function kartuReguFinish(r) {
+  /* Regu yang SUDAH tercatat diukur dari jam datangnya, bukan dari jam
+     sekarang. Angka pada regu yang sudah pulang tidak boleh bergerak lagi —
+     versi sebelumnya membandingkan Date.now() dengan target, jadi lencana
+     yang sama menampilkan angka berbeda setiap kali layarnya dibuka, dan
+     enam bulan sebelum acara ia berbunyi "−271874 menit dari target".
+
+     Untuk regu yang belum pulang, jam sekarang memang pembandingnya: yang
+     ditanya petugas adalah "sudah lewat berapa menit dari targetnya". */
+  const acuan = r.sudah_finish && r.jam_datang
+    ? new Date(r.jam_datang).getTime() : Date.now();
   const selisih = r.target_datang
-    ? Math.round((Date.now() - new Date(r.target_datang).getTime()) / 60000)
+    ? Math.round((acuan - new Date(r.target_datang).getTime()) / 60000)
     : null;
   const tandaWaktu = selisih === null ? ""
     : `<span class="badge ${Math.abs(selisih) < 10 ? "badge-green" : "badge-yellow"}">

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -87,6 +87,33 @@ export function jamMenit(t) {
   return FMT_JAM.format(new Date(t));
 }
 
+/** "11:26" + hari acuan -> Date pada jam itu, di hari WIB yang sama dengan
+ *  acuan.
+ *
+ *  Bukan "hari ini". Petugas mengetik jam dinding — "11:26" — dan jam dinding
+ *  tidak membawa tanggal; tanggalnya harus datang dari peristiwa yang sedang
+ *  dicatat, bukan dari kalender alat yang dipakai mencatat. Keduanya sama
+ *  pada hari-H dan berbeda pada setiap hari lainnya, termasuk setiap kali
+ *  layar ini dibuka untuk dicoba sebelum acara.
+ *
+ *  Dirakit lewat teks ISO dengan offset +07:00, bukan lewat setHours: yang
+ *  terakhir memakai zona alat, dan satu laptop pinjaman yang zonanya keliru
+ *  cukup untuk menggeser jam yang tercatat (alasan yang sama dengan ZONA di
+ *  atas).
+ */
+export function jamPadaHari(hhmm, acuan) {
+  const [j, m] = hhmm.split(":").map(Number);
+  const bagian = {};
+  // `new Date(null)` adalah 1 Januari 1970, bukan galat — jadi acuan kosong
+  // harus ditangkap di sini, bukan dibiarkan lewat.
+  for (const b of FMT_TANGGAL.formatToParts(new Date(acuan || Date.now()))) bagian[b.type] = b.value;
+  const dd = String(bagian.day).padStart(2, "0");
+  const mm = String(bagian.month).padStart(2, "0");
+  const HH = String(j).padStart(2, "0");
+  const MM = String(m).padStart(2, "0");
+  return new Date(`${bagian.year}-${mm}-${dd}T${HH}:${MM}:00+07:00`);
+}
+
 /** "17 Agustus 2026" */
 export function tanggalPanjang(t) {
   if (!t) return "—";

--- a/web/style.css
+++ b/web/style.css
@@ -2637,6 +2637,14 @@ input.small-input { text-align: center; }
    hadir" satu digit — keduanya muat bersama bahkan di 360px, dan menumpuknya
    menurunkan tombol simpan satu baris penuh pada layar yang dipakai berdiri
    di garis finish. */
+/* Jaraknya lebih lebar daripada .two-column biasa. Dua isian yang saling
+   bersinggungan di kolom sempit terbaca sebagai satu kelompok: kotak menit
+   berakhir 10px sebelum kotak "Anggota hadir" dimulai, dan labelnya berdiri
+   berdempetan di atasnya sehingga tidak jelas label mana milik kotak mana.
+   1,25rem sudah cukup memisahkan keduanya tanpa mendorong apa pun ke bawah. */
 @media (max-width: 640px) {
-  .two-column.pasangan-sempit { grid-template-columns: auto 1fr; }
+  .two-column.pasangan-sempit {
+    grid-template-columns: auto 1fr;
+    column-gap: 1.25rem;
+  }
 }


### PR DESCRIPTION
## What

Every typed clock reading on Kedatangan and Keberangkatan is now anchored to
the **event day** instead of the device calendar, and the arrival badge is
measured from the recorded arrival instead of the current time. Plus a
spacing fix on the correction row.

## Why

A typed clock reading — `11:26` — carries no date. The date was being taken
from whatever day the recorder happened to be looking at the screen.

Three numbers came out of that:

- **The card badge** compared `Date.now()` to the target *even for a regu
  already recorded as arrived*. That number must never move again once the
  regu is back, yet it changed every time the screen was opened. Six months
  before the event it read `-271874 menit dari target`.
  An arrived regu is now measured from its own `jam_datang`. A regu still out
  is still measured from now — *how many minutes past target* is exactly what
  the officer is asking about that one.
- **The penalty preview** turned `11:26` into *today* at 11:26 and compared it
  to a target on the event day: `272160 menit lebih awal — penalti berubah
  −20 → −272130`.
- **Saving** an arrival, and both writes on Keberangkatan, stamped today's
  date onto the typed time.

That last one is not theoretical. **Trying the Keberangkatan screen before the
day is exactly what put `kloter 1 berangkat 2026-08-15 16:00` into the
database** — six months before the event — and made that kloter's penalty 190
days. `perbaiki_jadwal_uji.sql` (#261) cleaned it up; this stops it coming
back on the next test.

## Notes

`jamPadaHari()` assembles the timestamp from an ISO string with a `+07:00`
offset rather than `setHours`, which uses the device zone — the same reason
`ZONA` is written down explicitly in `util.js`. It falls back to now when the
anchor is missing, because `new Date(null)` is 1 January 1970, not an error.

The anchor is the regu's own `target_datang` on Kedatangan and the kloter
`perkiraan_berangkat` on Keberangkatan; both sit on the event day by
construction — the second one only since #260 fixed its timezone.

Second commit: the minute box ended 10px before the "Anggota hadir" box began,
so the two labels stood shoulder to shoulder above them and it was not obvious
which label belonged to which box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)