### PR TITLE
fix: akun baru lahir tanpa hak, dan dua skrip memakai kolom yang sudah diganti

### DIFF
--- a/scripts/change_password.py
+++ b/scripts/change_password.py
@@ -49,7 +49,7 @@ def headers():
 def find_user_id(username):
     r = requests.get(
         f"{SUPABASE_URL}/rest/v1/akun_panitia",
-        params={"username": f"eq.{username}", "select": "user_id,peran,aktif"},
+        params={"username": f"eq.{username}", "select": "user_id,peran,is_active"},
         headers=headers(), timeout=20,
     )
     r.raise_for_status()
@@ -73,7 +73,7 @@ def main():
     if not akun:
         print(f"x Username '{username}' tidak ditemukan di akun_panitia.")
         sys.exit(1)
-    if not akun["aktif"]:
+    if not akun["is_active"]:
         print(f"! '{username}' berstatus TIDAK AKTIF (edisi lama) — password tetap diganti, "
               "tapi akun ini tidak akan bisa dipakai login sampai diaktifkan lagi.")
 

--- a/scripts/provision_accounts.py
+++ b/scripts/provision_accounts.py
@@ -73,7 +73,7 @@ def link_akun_panitia(user_id, username, peran, pos):
         "username": username,
         "peran": peran,
         "pos": int(pos) if pos else None,
-        "aktif": True,
+        "is_active": True,
     }
     r = requests.post(
         f"{SUPABASE_URL}/rest/v1/akun_panitia",
@@ -81,9 +81,42 @@ def link_akun_panitia(user_id, username, peran, pos):
         json=body,
         timeout=20,
     )
+    if r.status_code not in (200, 201, 204):
+        return f"HTTP {r.status_code}: {r.text[:200]}"
+    return beri_hak_awal(user_id, peran)
+
+
+def beri_hak_awal(user_id, peran):
+    """Centang awal sesuai perannya (migrasi 0057).
+
+    Sejak 0057 yang menentukan hak adalah baris di `akun_hak`, bukan kolom
+    `peran`. Akun yang dibuat tanpa langkah ini lahir dengan peran terisi tapi
+    TANPA satu centang pun — dan begitu policy berpindah ke boleh(), ia tidak
+    bisa membuka apa-apa. Gejalanya paling menyesatkan: akunnya bisa login,
+    perannya terbaca benar di layar, tapi setiap layar kosong.
+
+    Daftar fiturnya TIDAK ditulis ulang di sini. `paket_peran()` hidup di
+    database dan dipakai juga oleh layar Akun; menyalinnya ke Python berarti
+    dua daftar yang suatu hari tidak sepakat.
+    """
+    paket = requests.post(
+        f"{SUPABASE_URL}/rest/v1/rpc/paket_peran",
+        headers=headers(), json={"p_peran": peran}, timeout=20,
+    )
+    if paket.status_code != 200:
+        return f"hak awal gagal baca paket — HTTP {paket.status_code}: {paket.text[:200]}"
+    fitur = paket.json() or []
+    if not fitur:
+        return None
+    r = requests.post(
+        f"{SUPABASE_URL}/rest/v1/akun_hak",
+        headers={**headers(), "Prefer": "resolution=ignore-duplicates,return=minimal"},
+        json=[{"user_id": user_id, "fitur": f} for f in fitur],
+        timeout=20,
+    )
     if r.status_code in (200, 201, 204):
         return None
-    return f"HTTP {r.status_code}: {r.text[:200]}"
+    return f"hak awal gagal — HTTP {r.status_code}: {r.text[:200]}"
 
 
 def main():

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -176,6 +176,23 @@ async function buatAkun(req, env, b) {
       hasil.push({ username, ok: false, pesan: e.message || "Nama akun sudah dipakai." });
       continue;
     }
+    // Centang awal sesuai perannya. Tanpa langkah ini akun baru lahir dengan
+    // peran terisi tapi TANPA satu centang pun — bisa login, perannya terbaca
+    // benar, dan setiap layar kosong. Daftar fiturnya dibaca dari
+    // paket_peran() di database, tidak disalin ke sini: dua daftar suatu hari
+    // tidak sepakat, dan yang di Worker akan jadi yang basi.
+    const paket = await fetch(`${env.SUPABASE_URL}/rest/v1/rpc/paket_peran`, {
+      method: "POST", headers: kepalaLayanan(env),
+      body: JSON.stringify({ p_peran: peran }),
+    });
+    const fitur = paket.ok ? await paket.json() : [];
+    if (fitur.length) {
+      await fetch(`${env.SUPABASE_URL}/rest/v1/akun_hak`, {
+        method: "POST",
+        headers: { ...kepalaLayanan(env), Prefer: "resolution=ignore-duplicates,return=minimal" },
+        body: JSON.stringify(fitur.map((f) => ({ user_id: user.id, fitur: f }))),
+      });
+    }
     hasil.push({ username, ok: true, peran, pos, password });
   }
   return jawab(200, { hasil }, req);


### PR DESCRIPTION
## What

Dua cacat pada jalur pembuatan akun.

1. **Akun baru lahir tanpa satu centang pun.** Sejak `0057` yang menentukan
   hak adalah baris di `akun_hak`, bukan kolom `peran` — tapi rute `/akun` di
   Worker dan `provision_accounts.py` hanya menulis `akun_panitia`. Keduanya
   sekarang membaca `paket_peran()` dari database.
2. **Kolom yang sudah diganti nama.** Migrasi `0014` mengganti
   `akun_panitia.aktif` jadi `is_active` pada 12 Agustus.
   `change_password.py` masih meminta `select=user_id,peran,aktif` dan
   `provision_accounts.py` masih mengirim `"aktif": true`.

## Why

Gejala cacat pertama adalah yang paling menyesatkan yang bisa dibayangkan:
akunnya bisa login, perannya terbaca benar di layar Akun, dan setiap layar
kosong. Tidak ada pesan galat di mana pun.

Cacat kedua berarti **kedua workflow yang dijalankan koordinator dari tab
Actions — ganti password dan provision akun — sudah rusak sejak 12 Agustus**,
ditolak PostgREST dengan "column does not exist". Tidak ada yang memeriksanya
karena keduanya hanya dipakai sesekali menjelang edisi.

Layar Akun kebetulan menggantikan keduanya, tapi memperbaikinya tetap perlu:
provisioning massal dari CSV masih jalur paling masuk akal untuk menyiapkan
dua puluh akun sekaligus.

## Notes

Daftar fiturnya tidak disalin ke Worker maupun ke Python — `paket_peran()`
hidup di database dan dipakai juga oleh layar Akun. Dua daftar suatu hari
tidak sepakat, dan yang di luar database akan jadi yang basi.

Tidak ada migrasi baru. Worker perlu di-deploy ulang setelah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)