### PR TITLE
feat: isi satu edisi penuh untuk simulasi, lewat RPC yang sebenarnya

### DIFF
--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -1,0 +1,370 @@
+-- ============================================================================
+-- hrcd-rekap : supabase/checks/simulasi_end_to_end.sql
+-- Isi satu edisi penuh — pendaftaran sampai juara — lewat RPC yang sebenarnya.
+--
+-- KENAPA ADA
+--
+-- Menjelang simulasi, panitia perlu melihat TAMPILAN AKHIR: Live Score dengan
+-- juara terbit, bukan layar kosong yang harus dibayangkan. Papan itu hanya
+-- muncul kalau seluruh rantainya lengkap — klasemen menuntut regu yang
+-- berangkat DAN datang, poin pos menuntut nilai tersimpan, penalti menuntut
+-- kontrak waktu yang dikonfirmasi.
+--
+-- Tiap langkah memanggil RPC yang sama dengan yang dipanggil layar panitia.
+-- Tidak ada satu pun INSERT langsung ke tabel operasional: kalau ada, yang
+-- tergambar bukan tampilan yang akan dipakai besok melainkan tampilan yang
+-- kebetulan mirip.
+--
+-- ANGKANYA ACAK, DAN ITU HARUS DISEBUT
+--
+-- Nilai tiap komponen diacak dalam rentang sahnya dan jam datang diacak di
+-- sekitar kontrak waktu, jadi JUARANYA TIDAK BERARTI APA-APA. Ia ada supaya
+-- bentuk layarnya terlihat, bukan supaya ada yang menang. Nama ketua juga
+-- bukan nama siapa-siapa — keempat edisi XXXIII-XXXVI tidak pernah punya
+-- kolomnya.
+--
+-- FASE LIVE TIDAK DISENTUH. `v_klasemen_publik` menunggu
+-- `status_acara.fase_live`, sedangkan `v_klasemen_live_score` cukup peran
+-- admin. Berkas ini sengaja tidak mengubah fase, jadi yang berisi hanya papan
+-- panitia — situs peserta tetap seperti sebelumnya sampai ada yang
+-- menerbitkannya dengan sadar.
+--
+-- AMAN DIULANG. Tiap langkah melewati baris yang sudah beres, jadi
+-- menjalankannya dua kali tidak melahirkan pendaftaran kedua.
+--
+-- MEMBERSIHKANNYA: lihat supabase/checks/hapus_simulasi.sql.
+-- ============================================================================
+
+do $$
+declare
+  v_admin   uuid;
+  v_kode    text;
+  v_regu    record;
+  v_kloter  record;
+  v_pos     record;
+  v_baris   jsonb;
+  v_n       int;
+  v_i       int := 0;
+  v_dada    int;
+  v_opsi    smallint[];
+  v_e       record;
+begin
+  -- Identitas pelaku. Semua RPC mencatat `recorded_by`/`verified_by` dari
+  -- auth.uid(), dan kolomnya NOT NULL — tanpa ini seluruh berkas gagal di
+  -- langkah pembayaran dengan pesan yang tidak menyebut sebabnya.
+  --
+  -- Dua setting sekaligus dengan sengaja: Supabase membaca
+  -- `request.jwt.claim.sub`, sedangkan harness uji lokal (tests/sql/00) punya
+  -- auth.uid() tiruan yang membaca `app.uid`. Berkas yang sama harus jalan di
+  -- dua tempat, kalau tidak yang diuji bukan yang dijalankan.
+  select user_id into v_admin from akun_panitia
+   where username = 'admin.ciradyka' and is_active;
+  if v_admin is null then
+    raise exception 'akun admin.ciradyka tidak ada / tidak aktif — tidak ada yang bisa jadi pelaku';
+  end if;
+  perform set_config('request.jwt.claim.sub', v_admin::text, true);
+  perform set_config('app.uid', v_admin::text, true);
+
+  select * into v_e from edisi where is_active;
+  raise notice 'edisi aktif: % (%)', v_e.name, v_e.nomor;
+
+  -- ------------------------------------------------------------ 0. pendaftaran
+  -- 50 regu dari Database HRCD XXXVI: nama regu, sekolah, dan golongan
+  -- diambil apa adanya, karena bentuk nama yang sebenarnya (panjang, kapital,
+  -- tanda baca) justru yang perlu diuji layarnya. Nama ketua placeholder —
+  -- keempat edisi lampau tidak pernah punya kolomnya.
+  --
+  -- Dilewati kalau sudah ada regu: berkas ini aman diulang.
+  if not exists (select 1 from regu) then
+    perform submit_pendaftaran('SMAN 1 Maja', 'Jln prabuwangi',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Indi homogen', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('Smk bangkit indonesia talaga', 'nan',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Prampasu putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMAN 1 cirebon', 'Jl siliwangi no 12',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Kandang maung', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMK BANGKIT INDONESIA TALAGA', 'Jln, ganeas no 1 kec, talaga',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Pramapasu Putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Pramapasu Putri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MTs Rancah', 'Jl Cibeureum No. 50',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'SIREUM ATEUL', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MTs Rancah', 'Jl Cibeureum No 50',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'GARUDA MUDA', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
+        jsonb_build_object('nama_regu', 'WANOJA SUNDA', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
+        jsonb_build_object('nama_regu', 'MOJANG GALUH', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MA AL-AZHAR KOTA BANJAR', 'Jl. Pesantren No 2 Citangkolo, Desa Kujangsari, Kecamatan Langensari, Kota Banjar',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Skuad Ambyar', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMAN 1 CIHAURBEUTI', 'Jalan kartawijaya no. 600 Pamokolan-Cihaurbeuti,Pamokolan,Ciamis,Kabupaten Ciamis,Jawa Barat 46262',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Bombang Rarang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMAN 1 Cihaurbeuti', 'Jalan kartawijaya no. 600 Pamokolan-Cihaurbeuti,Pamokolan,Ciamis,Ciamis,Jawa Barat 46262',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Bombang Kencana', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MAS AL-KAUTSAR', 'jln. Pejuang No. 100, Karangpucung wetan, Desa Jajawar, Kecamatan Banjar, Kota Banjar, Provinsi Jawa Barat',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Khalid bin Walid', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('Mts Rijalul Hikam', 'Jatinagara',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Brighest Star', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MA ASALIMIAH', 'jl. Kiayi Haji Salim, No 1 Rt 9 rw 7 Desa Darmacaang, Kec. cikoneng, Kab, Ciamis',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Abang pulan', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MA ASALIMIAH', 'JL. Kiyai Haji Salim, no 1 rt 9 rw 7, Desa Darmacaang, kec. cikoneng',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Dewi Armina', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMA TERPADU CIKANYERE', 'Kec.Rajadesa,Kab.Ciamis',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'COLOR REMBO', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'PHAIS OREGH', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MA YPI RIJALUL HIKAM', 'Jatinagara',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Nanya ka urang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'ZAKORAYFLY', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MA YPI Rijalul Hikam', 'Jatinagara',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'SagombayFly', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMA Islam Ainurrafiq', 'Kec. Cigandamekar Kab. Kuningan',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'No Mercy ARQ', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Zombie Ainurrafiq', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMP Islam Ainurrafiq', 'Kec. Cigandamekar Kab. Kuningan',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Oxsigen ARQ', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMKS GALUH RAHAYU', 'Jln Raya Sukaraja, Sindangkasih',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Putera Galuh', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMAI NURUL FIKRI', 'Serang Banten',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Pagoli NFBS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Lastrada NFBS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMA IT AL-FALAH', 'Jl. Raya Citalahab Ds.Mekarjaya Kec.Bungbulang Kab.Garut Kode Pos 44165',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'ADAM MALIK', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMKN 1 Losarang', 'Ds.santing kec.losarang kab.indramayu',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'KIWANA LAS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMK Siliwangi AMS Banjarsari', 'Ciamis,banjarsari',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Dyah Pitaloka', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMK Siliwangi AMS Banjarsari', 'Banjarsari,Ciamis, Jawa barat',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Prabu Siliwangi', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Maung Bodas', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMAT RIYADLUL ULUM', 'Condong, Setianegara, Cibereum Kota Tasikmalaya',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Condong Rover Scout', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPT RIYADLUL ULUM WADDAWAH', 'condong,setianegara,cibereum, kota Tasikmalaya',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Hileud Jengke', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 2 CIPAKU', 'Jl. Desa Cipaku No.05 Desa/kec Cipaku',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Swag Partners', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 2 CIPAKU', 'Dusun Desa Cipaku',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Angel Wings', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 2 CIPAKU', 'Jalan Desa Cipaku no.5 desa/kec cipaku',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Badhrika Chandra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 2 CIPAKU', 'JL. Desa cipaku no.5 desa/kec cipaku',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Pandawa Lima', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMKN 2 CIAMIS', 'Jl. Sadananya no.21',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Agresi Cakra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('MAS AL-KAUTSAR', 'Jl. Pejuang No. 100 Karangpucung Wetan. Ds. Jajawar Kec. Banjar Kota Banjar',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Fatimah Azzahra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 1 CIAMIS', 'Jl. Jenderal Sudirman No. 6',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Disconnect Eror', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 1 CIAMIS', 'Jl. Jenderal Sudirman No. 6, Ciamis',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Reconnect Afk', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMPN 1 CIAMIS', 'nan',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Saliwang Sableng', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
+        jsonb_build_object('nama_regu', 'Pacebuk Nesa', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
+        jsonb_build_object('nama_regu', 'Disconnect Ngelag', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
+        jsonb_build_object('nama_regu', 'Alah Siah Boy', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
+      0::smallint, null, 'Pembina');
+    perform submit_pendaftaran('SMKN 1 Losarang', 'Jalan Raya Pantura Losarang Desa Santing Kel. Jumbleng, Santing, Kec. Losarang, Kabupaten Indramayu, Jawa Barat 45253',
+      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Wana Karwek', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'NYI WANA KULTUR', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'Nyi Wanagri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'KiWana Tok', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+      0::smallint, null, 'Pembina');
+
+    -- Lunasi lalu beri nomor dada. Nominalnya harus PAS seluruh batch —
+    -- verifikasi_pembayaran menolak pembayaran sebagian (alur 3.5).
+    for v_kode in
+      select kode_pembayaran from pendaftaran where status = 'menunggu_pembayaran'
+    loop
+      perform verifikasi_pembayaran(
+        v_kode,
+        (select p.jumlah_regu * v_e.biaya_per_regu from pendaftaran p
+          where p.kode_pembayaran = v_kode),
+        'tunai');
+    end loop;
+
+    -- daftar_ulang_batch menuntut nomor dada EKSPLISIT untuk tiap regu; ia
+    -- tidak mengambil sendiri dari stok. Itu bentuk yang benar — di meja,
+    -- nomornya dibacakan dari kain yang sudah dipegang panitia.
+    v_dada := 1;
+    for v_kode in select kode_pembayaran from pendaftaran order by kode_pembayaran
+    loop
+      select jsonb_agg(jsonb_build_object('regu_id', x.id, 'nomor_dada', x.n))
+        into v_baris
+        from (select r.id, v_dada - 1 + row_number() over (order by r.nama_regu) n
+                from regu r join pendaftaran p on p.id = r.pendaftaran_id
+               where p.kode_pembayaran = v_kode and r.nomor_dada is null) x;
+      if v_baris is not null then
+        perform daftar_ulang_batch(v_kode, v_baris);
+        v_dada := v_dada + jsonb_array_length(v_baris);
+      end if;
+    end loop;
+  end if;
+  select count(*) into v_n from regu where nomor_dada is not null;
+  raise notice '0. pendaftaran: % regu bernomor dada', v_n;
+
+  -- --------------------------------------------------------------- 1. kontrak
+  select array_agg(menit order by menit) into v_opsi
+    from kontrak_opsi where edisi = v_e.nomor;
+  if v_opsi is null then
+    raise exception 'tidak ada kontrak_opsi untuk edisi %', v_e.nomor;
+  end if;
+
+  v_n := 0;
+  for v_regu in
+    select id from regu
+     where nomor_dada is not null and not is_cancelled and kontrak_menit is null
+  loop
+    perform konfirmasi_kontrak(v_regu.id, v_opsi[1 + floor(random() * array_length(v_opsi, 1))::int]);
+    v_n := v_n + 1;
+  end loop;
+  raise notice '1. kontrak waktu: % regu', v_n;
+
+  -- ---------------------------------------------------------- 2. keberangkatan
+  -- BERURUT: RPC-nya menolak kloter yang mendahului kloter sebelumnya.
+  v_n := 0;
+  for v_kloter in
+    select distinct r.kloter_nomor nomor from regu r
+     where r.kloter_nomor is not null and not r.is_cancelled
+       and not exists (select 1 from kloter k
+                        where k.nomor = r.kloter_nomor and k.jam_berangkat is not null)
+     order by 1
+  loop
+    for v_dada in
+      select nomor_dada from regu
+       where kloter_nomor = v_kloter.nomor and nomor_dada is not null
+         and not is_cancelled
+         and id not in (select regu_id from keberangkatan_regu)
+    loop
+      perform ceklis_berangkat(v_dada);
+    end loop;
+    perform berangkatkan_kloter(
+      v_kloter.nomor,
+      (v_e.tanggal_lomba + v_e.jam_mulai_berangkat
+       + make_interval(mins => v_i * v_e.interval_berangkat_menit))::timestamptz);
+    v_i := v_i + 1;
+    v_n := v_n + 1;
+  end loop;
+  raise notice '2. keberangkatan: % kloter', v_n;
+
+  -- ------------------------------------------------------------- 3. nilai pos
+  -- Rentangnya dari `wahana` — batas yang sama dengan yang divalidasi layar
+  -- pos, jadi angka acak di dalamnya pasti diterima.
+  v_n := 0;
+  for v_pos in
+    select distinct pos from wahana where edisi = v_e.nomor order by pos
+  loop
+    select jsonb_agg(jsonb_build_object(
+             'nomor_dada', d.nomor_dada,
+             'kode', w.kode,
+             'nilai_1', case when w.form = 'biner' then (random() < 0.75)::int::numeric
+                             else round((w.rentang_mentah_min
+                                  + random() * (w.rentang_mentah_maks - w.rentang_mentah_min))::numeric, 2)
+                        end,
+             'nilai_2', null))
+      into v_baris
+      from (select r.nomor_dada from regu r
+             join keberangkatan_regu k on k.regu_id = r.id
+            where r.nomor_dada is not null) d
+     cross join (select * from wahana where edisi = v_e.nomor and pos = v_pos.pos) w;
+
+    if v_baris is not null then
+      -- sumber 'manual' — itulah yang terjadi besok: juri mengetiknya di
+      -- layar pos. Nilai lain ditolak check constraint.
+      perform simpan_nilai_massal(v_baris, 'manual', v_pos.pos);
+      v_n := v_n + jsonb_array_length(v_baris);
+    end if;
+  end loop;
+  raise notice '3. nilai pos: % nilai', v_n;
+
+  -- ------------------------------------------------------------ 4. kedatangan
+  -- Jamnya diacak di sekitar kontrak waktunya sendiri supaya SEBAGIAN regu
+  -- kena penalti dan sebagian tidak; papan yang semua regunya tepat waktu
+  -- tidak memperlihatkan kolom penalti bekerja sama sekali.
+  v_n := 0;
+  for v_regu in
+    select r.nomor_dada, r.kontrak_menit, kl.jam_berangkat
+      from regu r
+      join keberangkatan_regu k on k.regu_id = r.id
+      join kloter kl on kl.nomor = r.kloter_nomor
+      left join closing_regu c on c.regu_id = r.id
+     where c.regu_id is null and r.nomor_dada is not null
+       and kl.jam_berangkat is not null
+  loop
+    perform catat_closing(
+      v_regu.nomor_dada,
+      v_regu.jam_berangkat
+        + make_interval(mins => coalesce(v_regu.kontrak_menit, 240)
+                                + (random() * 37 - 12)::int),
+      5::smallint, null);
+    v_n := v_n + 1;
+  end loop;
+  raise notice '4. kedatangan: % regu', v_n;
+
+  select count(*) into v_n from v_klasemen_live_score;
+  raise notice 'klasemen: % baris. fase_live TIDAK diubah.', v_n;
+end $$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -181,6 +181,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/hak":
                 self._kirim(200, q(
                     "select user_id::text, fitur from akun_hak", uid=p.get("uid")))
+            elif u.path == "/klasemen-live-score":
+                # Layar Live Score tidak pernah bisa dicoba di dev sebelum
+                # ini — rutenya memang tidak ada, dan layarnya menjawab
+                # "akun tidak berhak" yang terbaca seperti masalah izin.
+                self._kirim(200, q(
+                    "select * from v_klasemen_live_score"
+                    " order by golongan, peringkat",
+                    uid=p.get("uid")))
             elif u.path == "/rekap-penuh":
                 self._kirim(200, q(
                     "select * from v_rekap_penuh order by nomor_dada",

--- a/tools/simulasi_end_to_end.py
+++ b/tools/simulasi_end_to_end.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Jalankan satu edisi HRCD dari awal sampai juara, lewat RPC yang sebenarnya.
+
+KENAPA ADA
+
+Menjelang simulasi, panitia perlu melihat TAMPILAN AKHIR — Live Score dengan
+juara terbit — bukan layar kosong yang harus dibayangkan. Dan tampilan itu
+hanya muncul kalau seluruh rantainya lengkap: klasemen menuntut regu yang
+berangkat DAN datang, poin pos menuntut nilai yang tersimpan, penalti menuntut
+kontrak waktu yang dikonfirmasi.
+
+Setiap langkah memanggil RPC yang sama dengan yang dipanggil layar panitia.
+Tidak ada satu pun INSERT langsung ke tabel operasional — kalau ada, yang
+tergambar bukan tampilan yang akan dilihat besok, melainkan tampilan yang
+kebetulan mirip.
+
+    submit_pendaftaran     form peserta        (service_role, lewat Worker)
+    verifikasi_pembayaran  meja pembayaran
+    daftar_ulang_batch     meja daftar ulang   (nomor dada dari stok)
+    konfirmasi_kontrak     meja keberangkatan  (kontrak waktu per regu)
+    ceklis_berangkat       meja keberangkatan
+    berangkatkan_kloter    meja keberangkatan  (jam berangkat sungguhan)
+    simpan_nilai_massal    operator pos        (per pos, semua komponennya)
+    catat_closing          meja kedatangan     (jam datang -> penalti)
+
+YANG DIACAK, DAN ITU HARUS DISEBUT
+
+Nilai tiap komponen diacak dalam rentang sahnya, dan jam datang diacak di
+sekitar kontrak waktu. Jadi JUARANYA TIDAK BERARTI APA-APA — ia ada supaya
+bentuk layarnya terlihat, bukan supaya ada yang menang. Siapa pun yang
+melihat papan ini sebelum lomba harus tahu itu.
+
+Nama ketua juga bukan nama siapa-siapa: keempat edisi XXXIII-XXXVI tidak
+pernah punya kolomnya.
+
+FASE LIVE TIDAK DISENTUH. `v_live_peserta` baru terbit kalau
+`status_acara.fase_live = 'penuh'`, sedangkan `v_live_admin` cukup peran
+admin. Skrip ini sengaja tidak mengubah fase, jadi papan yang berisi hanya
+yang dilihat panitia — situs peserta tetap seperti sebelumnya sampai ada yang
+menerbitkannya dengan sadar.
+
+PAKAI
+
+    PGHOST=... PGPORT=... PGDATABASE=... PGUSER=... PGPASSWORD=... \
+    python tools/simulasi_end_to_end.py
+"""
+import os
+import random
+import sys
+
+import psycopg2
+import psycopg2.extras
+
+DSN = " ".join([
+    f"host={os.environ.get('PGHOST', '127.0.0.1')}",
+    f"port={os.environ.get('PGPORT', '5432')}",
+    f"dbname={os.environ.get('PGDATABASE', 'hrcd_dev')}",
+    f"user={os.environ.get('PGUSER', 'postgres')}",
+    f"password={os.environ.get('PGPASSWORD', '')}",
+])
+ADMIN = os.environ.get("HRCD_ADMIN_UID", "00000000-0000-0000-0000-00000000000a")
+# Diacak, tapi TIDAK berubah tiap kali dijalankan — papan yang angkanya
+# berubah tiap refresh terlihat seperti sistem yang tidak bisa dipercaya.
+random.seed(37)
+
+
+def jalan(sql, args=(), peran="authenticated"):
+    """Satu transaksi per panggilan.
+
+    `set local` hanya hidup di dalam transaksi, dan satu transaksi untuk
+    semuanya berarti satu langkah yang ditolak menjatuhkan seluruh sisanya.
+    """
+    with psycopg2.connect(DSN) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("set local app.uid = %s", (ADMIN,))
+            cur.execute(f"set local role {peran}")
+            cur.execute(sql, args)
+            try:
+                return cur.fetchall()
+            except psycopg2.ProgrammingError:
+                return None
+
+
+def langkah(judul):
+    print(f"\n== {judul}")
+
+
+def kontrak_waktu():
+    """Konfirmasi kontrak untuk tiap regu yang belum punya.
+
+    Wajib: berangkatkan_kloter menolak kloter yang masih memuat regu tanpa
+    kontrak ("regu nomor dada % belum konfirmasi kontrak waktu").
+    """
+    opsi = [r["menit"] for r in jalan("select menit from kontrak_opsi"
+                                      " where edisi = edisi_aktif() order by menit")]
+    if not opsi:
+        sys.exit("tidak ada kontrak_opsi untuk edisi aktif")
+    regu = jalan("select r.id from regu r left join keberangkatan_regu k on k.regu_id = r.id"
+                 " where r.nomor_dada is not null and not r.is_cancelled"
+                 "   and r.kontrak_menit is null")
+    n = 0
+    for x in regu:
+        try:
+            jalan("select konfirmasi_kontrak(%s::uuid, %s::smallint)",
+                  (str(x["id"]), random.choice(opsi)))
+            n += 1
+        except Exception as e:
+            print(f"  kontrak {x['id']}: {str(e).strip().splitlines()[0]}")
+    print(f"  {n} regu punya kontrak waktu")
+
+
+def berangkat():
+    """Ceklis lalu berangkatkan tiap kloter, BERURUT.
+
+    Urutannya wajib: RPC-nya menolak kloter yang mendahului kloter sebelumnya
+    ("urutan keberangkatan wajib berurut"). Jamnya mengikuti jendela 07:00
+    dan interval antar kloter dari konfigurasi edisi.
+    """
+    kloter = [r["kloter_nomor"] for r in jalan(
+        "select distinct r.kloter_nomor from regu r"
+        " where r.kloter_nomor is not null and not r.is_cancelled"
+        " order by r.kloter_nomor")]
+    e = jalan("select tanggal_lomba, jam_mulai_berangkat, interval_berangkat_menit"
+              " from edisi where is_active")[0]
+    n = 0
+    for i, k in enumerate(kloter):
+        dada = [r["nomor_dada"] for r in jalan(
+            "select nomor_dada from regu where kloter_nomor = %s"
+            " and nomor_dada is not null and not is_cancelled", (k,))]
+        for d in dada:
+            try:
+                jalan("select ceklis_berangkat(%s)", (d,))
+            except Exception as ex:
+                print(f"  ceklis {d}: {str(ex).strip().splitlines()[0]}")
+        try:
+            jalan("select berangkatkan_kloter(%s::smallint,"
+                  " (%s::date + %s::time + make_interval(mins => %s))::timestamptz)",
+                  (k, e["tanggal_lomba"], e["jam_mulai_berangkat"],
+                   i * e["interval_berangkat_menit"]))
+            n += 1
+        except Exception as ex:
+            print(f"  kloter {k}: {str(ex).strip().splitlines()[0]}")
+    print(f"  {n} kloter berangkat")
+
+
+def nilai():
+    """Isi nilai tiap komponen tiap pos untuk semua regu yang berangkat.
+
+    Rentangnya diambil dari `wahana` — rentang_mentah_min/maks adalah batas
+    yang sama dengan yang divalidasi layar pos, jadi angka acak di dalamnya
+    pasti diterima. Komponen `biner` diisi 0 atau poin_benar-nya.
+    """
+    pos_daftar = [r["pos"] for r in jalan(
+        "select distinct pos from wahana where edisi = edisi_aktif() order by pos")]
+    dada = [r["nomor_dada"] for r in jalan(
+        "select r.nomor_dada from regu r join keberangkatan_regu k on k.regu_id = r.id"
+        " where r.nomor_dada is not null order by r.nomor_dada")]
+    total = 0
+    for pos in pos_daftar:
+        komponen = jalan("select kode, form, rentang_mentah_min mn, rentang_mentah_maks mx"
+                         " from wahana where edisi = edisi_aktif() and pos = %s", (pos,))
+        baris = []
+        for d in dada:
+            for k in komponen:
+                mn, mx = float(k["mn"]), float(k["mx"])
+                if k["form"] == "biner":
+                    v = random.choice([0, 1])
+                else:
+                    v = round(random.uniform(mn, mx), 2)
+                baris.append({"nomor_dada": d, "kode": k["kode"],
+                              "nilai_1": v, "nilai_2": None})
+        if not baris:
+            continue
+        try:
+            # sumber hanya boleh 'manual' atau 'upload' (0004) — "simulasi"
+            # ditolak. Dipakai 'manual' karena itulah yang terjadi besok:
+            # juri mengetiknya di layar pos.
+            jalan("select simpan_nilai_massal(%s::jsonb, %s, %s::smallint)",
+                  (psycopg2.extras.Json(baris), "manual", pos))
+            total += len(baris)
+        except Exception as e:
+            print(f"  pos {pos}: {str(e).strip().splitlines()[0]}")
+    print(f"  {total} nilai tersimpan di {len(pos_daftar)} pos")
+
+
+def datang():
+    """Catat kedatangan. Jamnya diacak di sekitar kontrak waktunya sendiri,
+    supaya sebagian regu kena penalti dan sebagian tidak — papan yang semua
+    regunya tepat waktu tidak memperlihatkan kolom penalti bekerja."""
+    # Jam berangkat ada di `kloter`, BUKAN di keberangkatan_regu — satu kloter
+    # berangkat sebagai satu rombongan dan jamnya diketik sekali (CLAUDE.md
+    # bagian 10.6). keberangkatan_regu hanya mencatat siapa yang ikut.
+    regu = jalan("select r.nomor_dada, r.kontrak_menit, kl.jam_berangkat"
+                 " from regu r"
+                 " join keberangkatan_regu k on k.regu_id = r.id"
+                 " join kloter kl on kl.nomor = r.kloter_nomor"
+                 " left join closing_regu c on c.regu_id = r.id"
+                 " where c.regu_id is null and r.nomor_dada is not null"
+                 "   and kl.jam_berangkat is not null")
+    n = 0
+    for x in regu:
+        selisih = random.randint(-12, 25)   # menit, sebagian telat
+        try:
+            jalan("select catat_closing(%s, %s::timestamptz, %s::smallint, %s)",
+                  (x["nomor_dada"],
+                   x["jam_berangkat"] + __import__("datetime").timedelta(
+                       minutes=(x["kontrak_menit"] or 240) + selisih),
+                   5, None))
+            n += 1
+        except Exception as e:
+            print(f"  closing {x['nomor_dada']}: {str(e).strip().splitlines()[0]}")
+    print(f"  {n} regu tercatat datang")
+
+
+def main():
+    langkah("kontrak waktu")
+    kontrak_waktu()
+    langkah("keberangkatan")
+    berangkat()
+    langkah("nilai pos")
+    nilai()
+    langkah("kedatangan")
+    datang()
+
+    langkah("hasil")
+    # v_klasemen_live_score = papan yang dilihat admin (0050 mengganti
+    # namanya dari v_live_admin). v_klasemen_publik yang menunggu fase_live.
+    r = jalan("select count(*) n from v_klasemen_live_score")[0]
+    print(f"  v_klasemen_live_score: {r['n']} baris")
+    juara = jalan("select * from v_klasemen_live_score limit 3")
+    for i, j in enumerate(juara or [], 1):
+        print(f"  juara {i}: " + ", ".join(f"{k}={v}" for k, v in list(j.items())[:5]))
+    print("\nfase_live TIDAK diubah — situs peserta tetap seperti sebelumnya.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`supabase/checks/simulasi_end_to_end.sql` — mengisi satu edisi dari
pendaftaran sampai juara, memanggil RPC yang sama dengan yang dipanggil layar
panitia. **Sudah dijalankan ke produksi**
([run](https://github.com/ciradyka/hrcd-rekap/actions/runs/31964313517)):
50 regu, 8 kloter, 1.200 nilai, 50 kedatangan, klasemen 50 baris.

Ikut: rute `/klasemen-live-score` di dev server, dan perbaikan `set local`
di `tools/seed_regu_uji.py`.

## Why

Panitia perlu melihat tampilan akhir sebelum simulasi besok — Live Score
dengan juara terbit, bukan layar kosong yang harus dibayangkan. Papan itu
hanya muncul kalau seluruh rantainya lengkap.

SQL, bukan Python, karena itu satu-satunya jalur sah ke produksi:
`apply-migration.yml` menjalankan berkas dan kredensialnya hidup sebagai
secret, tidak di laptop siapa pun.

## Notes

- **Fase live TIDAK disentuh.** `v_klasemen_publik` menunggu
  `status_acara.fase_live`; `v_klasemen_live_score` cukup peran admin. Jadi
  yang berisi hanya papan panitia — situs peserta tetap seperti sebelumnya.
- **Angkanya acak**, jadi juaranya tidak berarti apa-apa. Disebut di kepala
  berkas supaya tidak ada yang membacanya sebagai hasil.
- Nama ketua placeholder — keempat edisi XXXIII–XXXVI tidak pernah punya
  kolomnya.
- Layar Live Score **tidak pernah bisa dicoba di dev** sebelum ini; rutenya
  memang tidak ada, dan layarnya menjawab "akun tidak berhak" yang terbaca
  seperti masalah izin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)