### PR TITLE
feat: peran mengikuti pekerjaan, dan menu mengikuti centang

### DIFF
--- a/.github/workflows/provision-accounts.yml
+++ b/.github/workflows/provision-accounts.yml
@@ -8,7 +8,7 @@
 #   1. Buka repo di app/browser GitHub -> tab Actions -> "Provision akun
 #      panitia" -> Run workflow.
 #   2. Tempel CSV di kotak "csv_akun": username,email,peran,pos (kosongkan
-#      pos untuk admin/meja). JANGAN sertakan password di sini — kotak ini
+#      pos untuk admin/registrasi/gerbang). JANGAN sertakan password di sini — kotak ini
 #      terekam di log Actions, dan password digenerate otomatis di server.
 #   3. Run workflow. Tunggu selesai (~10-20 detik untuk puluhan baris).
 #   4. Buka run yang baru selesai -> bagian "Artifacts" di bawah -> unduh
@@ -31,7 +31,7 @@ on:
       csv_akun:
         description: >-
           CSV: username,email,peran,pos (header wajib). Contoh baris:
-          meja4hrcd37,meja4hrcd37@ciradyka.com,meja,
+          meja4hrcd37,meja4hrcd37@ciradyka.com,registrasi,
         required: true
         type: string
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -75,7 +75,7 @@ penyelesaiannya dicatat di bagian 11.
 | `closing_regu` | Checkout: `jam_datang` **diketik & bisa di-edit**, `anggota_hadir` (0–5) | `PK (regu_id)`; upsert = mekanisme edit yang sah |
 | `ruangan` | Daftar ruang kelas barak + kapasitas orang | — |
 | `penempatan_barak` | Hasil alokasi; satu sekolah **boleh** terpecah ke >1 ruangan bila terpaksa | `UNIQUE (pendaftaran_id, ruangan_id)` |
-| `akun_panitia` | Peta `auth.uid` → peran (`admin/meja/operator_pos`) + nomor pos + aktif | Rotasi tahunan tanpa menyentuh policy |
+| `akun_panitia` | Peta `auth.uid` → peran (`admin/registrasi/gerbang/juri_pos`) + nomor pos + aktif; hak sesungguhnya di `akun_hak` (migrasi 0057-0058) | Rotasi tahunan tanpa menyentuh policy |
 | `riwayat` | Audit otomatis via trigger: siapa, kapan, tabel, nilai lama → baru, + `regu_id` agar bisa dicari per regu | Append-only; tidak bisa dimatikan dari klien |
 | `status_acara` | **Satu baris** saklar hari-H: `daftar_ulang_ditutup`, `fase_live` (`pra/progres/penuh`), `konfigurasi_terkunci` | Trigger menolak edit konfigurasi saat terkunci (kecuali admin) |
 
@@ -103,8 +103,9 @@ penyelesaiannya dicatat di bagian 11.
    | Peran | Contoh akun | Boleh |
    | --- | --- | --- |
    | `admin` | `admin.ciradyka` | Semua tabel, semua layar, konfigurasi |
-   | `operator_pos` | `pos1hrcd37` … `pos5hrcd37` | `nilai_mentah` **hanya** baris `pos = pos_saya()` — ditegakkan RLS, devtools tidak menolong |
-   | `meja` | `meja1hrcd37` … | Semua layar meja (pendaftaran, pembayaran, daftar ulang, garis start, closing) — satu peran untuk semua fungsi meja, jadi **ganti fungsi = pindah layar**, tanpa admin (R14) |
+   | `juri_pos` | `pos1hrcd37` … `pos5hrcd37` | `nilai_mentah` **hanya** baris `pos = pos_saya()` — ditegakkan RLS, devtools tidak menolong |
+   | `registrasi` | `meja1hrcd37` … | Pendaftaran, pembayaran, daftar ulang, daftar kloter |
+   | `gerbang` | `gerbang1hrcd37` … | Keberangkatan dan kedatangan — satu tempat, dua nama menurut arah lari (migrasi 0025) |
 
 2. Dua fungsi helper `peran()` dan `pos_saya()` (membaca `akun_panitia` dari
    `auth.uid()`) dipakai seluruh policy; hanya akun `aktif=true` yang lolos.

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -17,6 +17,16 @@ const BATAS_MS = 20000;   // internet lambat tidak boleh menggantung selamanya
    membuka lagi. localStorage bertahan sampai betul-betul ditekan Keluar,
    dan token di dalamnya tetap kedaluwarsa sendiri via pastikanSesiSegar(). */
 
+/** Apakah akun yang sedang login memegang fitur ini.
+ *
+ *  Cermin `boleh()` di database, dan HANYA untuk menggambar layar. Yang
+ *  menegakkan tetap RLS — menyunting sesi di localStorage cuma memunculkan
+ *  ubin yang begitu diklik menjawab kosong. */
+export function bolehLihat(fitur) {
+  const s = sesi();
+  return !!s && Array.isArray(s.hak) && s.hak.includes(fitur);
+}
+
 export function sesi() {
   const s = localStorage.getItem("hrcd_sesi");
   return s ? JSON.parse(s) : null;
@@ -188,15 +198,24 @@ export async function masuk(username, password) {
       headers: { "Content-Type": "application/json", apikey: K.anonKey },
       body: JSON.stringify({ email, password }),
     });
+    const kepala = { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` };
     const akun = await kirim(
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,
-      { headers: { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` } });
+      { headers: kepala });
     if (!akun.length || !akun[0].is_active)
       throw new ErrorApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
+    // Hak dibawa ke dalam sesi supaya papan Home bisa memilih ubinnya tanpa
+    // satu permintaan lagi tiap kali dibuka. Ini HANYA untuk menggambar —
+    // yang menegakkan tetap RLS, dan sesi yang diutak-atik di devtools tidak
+    // mendapat satu baris pun lebih banyak.
+    const hak = await kirim(
+      `${K.supabaseUrl}/rest/v1/akun_hak?user_id=eq.${j.user.id}&select=fitur`,
+      { headers: kepala }).catch(() => []);
     s = {
       uid: j.user.id, token: j.access_token, refresh: j.refresh_token,
       kedaluwarsa: Date.now() + (j.expires_in || 3600) * 1000,
       ...akun[0],
+      hak: (hak || []).map(x => x.fitur),
     };
   }
   simpanSesi(s);
@@ -736,11 +755,11 @@ export async function daftarAkun() {
 }
 
 /** Ganti peran dan/atau pos. Keduanya dikirim bersama karena database
- *  menuntutnya konsisten: operator_pos wajib punya pos, peran lain wajib
+ *  menuntutnya konsisten: juri_pos wajib punya pos, peran lain wajib
  *  tidak (check di 0001_schema.sql). Mengirim peran saja akan ditolak
  *  constraint itu, dan pesannya tidak akan terbaca sebagai "posnya lupa". */
 export async function ubahPeranAkun(userId, peran, pos) {
-  const badan = { peran, pos: peran === "operator_pos" ? pos : null };
+  const badan = { peran, pos: peran === "juri_pos" ? pos : null };
   if (K.mode === "dev")
     return kirim(`${K.devUrl}/akun/ubah`, {
       method: "POST",

--- a/scripts/provision_accounts.py
+++ b/scripts/provision_accounts.py
@@ -24,7 +24,7 @@
 # Format CSV masukan (header wajib persis ini; kolom password boleh kosong):
 #   username,email,peran,pos,password
 #   admin.ciradyka,admin.ciradyka@ciradyka.com,admin,,
-#   pos1hrcd37,pos1hrcd37@ciradyka.com,operator_pos,1,
+#   pos1hrcd37,pos1hrcd37@ciradyka.com,juri_pos,1,
 # ============================================================================
 import csv
 import os

--- a/supabase/migrations/0058_peran_per_pekerjaan.sql
+++ b/supabase/migrations/0058_peran_per_pekerjaan.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- hrcd-rekap : 0058_peran_per_pekerjaan.sql
+-- Peran mengikuti pekerjaan yang benar-benar ada di lapangan.
+--
+-- KENAPA
+--
+-- Tiga peran lama dinamai menurut TEMPAT DUDUK, bukan pekerjaan: `meja`
+-- adalah semua yang duduk di meja, dan itu menyatukan empat pekerjaan yang di
+-- lapangan dipegang orang berbeda — yang menerima pendaftaran, yang
+-- memverifikasi pembayaran, yang memberi nomor dada, dan yang memberangkatkan
+-- kloter. Koordinator yang ingin satu orang hanya memegang pembayaran tetap
+-- harus memberinya seluruh paket.
+--
+-- Peran baru dinamai menurut pekerjaannya:
+--
+--   registrasi  pendaftaran, pembayaran, daftar ulang, daftar kloter
+--   gerbang     keberangkatan, kedatangan
+--   juri_pos    satu pos, ditentukan kolom `pos` (1-5 di edisi 37)
+--   admin       semuanya
+--
+-- `gerbang` menamai TEMPATNYA, dan itu disengaja: Pos 0 dan Pos 5 adalah
+-- garis start dan garis finish (migrasi 0025) — satu tempat yang sama,
+-- disebut dua nama menurut arah lari. Orang yang berjaga di sana memegang
+-- keduanya.
+--
+-- SEMUA PERAN MEMEGANG LIVE SCORE. Papan itu versi panitia (v_klasemen_live
+-- _score, cuma peran admin di database sampai 0057) dan tidak membocorkan apa
+-- pun ke peserta — fase live yang menentukan itu. Yang berjaga di pos ingin
+-- tahu klasemen sama seperti yang di meja.
+--
+-- APA YANG BERUBAH UNTUK AKUN YANG SUDAH ADA
+--
+-- Ini BUKAN migrasi yang netral seperti 0057. Peran lama dipindah:
+--
+--   meja          -> registrasi   KEHILANGAN keberangkatan + kedatangan
+--   operator_pos  -> juri_pos     tidak berubah, kecuali dapat live score
+--
+-- Yang kehilangan itu disengaja — pekerjaan gerbang sekarang punya perannya
+-- sendiri. Kalau ada orang yang memang memegang keduanya, koordinator
+-- mencentangnya kembali di layar Akun; centang selalu menang atas peran
+-- (0057), dan itulah gunanya.
+--
+-- Migrasi ini MENULIS ULANG hak tiap akun sesuai paket perannya. Centang yang
+-- pernah disesuaikan tangan akan hilang. Itu bisa diterima sekarang karena
+-- layar Akun baru dipasang hari ini dan belum ada yang menyesuaikannya; kalau
+-- suatu hari perlu diulang, jangan lakukan ini begitu saja.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Nilai peran yang diizinkan.
+--
+--    Dua check constraint sekaligus: yang mendaftar nilainya, dan yang
+--    memasangkan peran dengan kolom `pos`. Yang kedua sempat terlewat waktu
+--    ditulis pertama kali dan baru ketahuan karena juri_pos jadi tidak wajib
+--    punya pos sama sekali.
+-- ---------------------------------------------------------------------------
+-- IF EXISTS: berkas ini dijalankan ulang di tests/dev_database.sh sesudah
+-- seed, dan di sana constraint-nya sudah dilepas lebih dulu supaya seed yang
+-- memakai nama peran lama bisa masuk.
+alter table akun_panitia drop constraint if exists akun_panitia_peran_check;
+alter table akun_panitia drop constraint if exists akun_panitia_check;
+
+update akun_panitia set peran = 'registrasi' where peran = 'meja';
+update akun_panitia set peran = 'juri_pos'   where peran = 'operator_pos';
+
+alter table akun_panitia add constraint akun_panitia_peran_check
+  check (peran in ('admin', 'registrasi', 'gerbang', 'juri_pos'));
+-- juri_pos wajib punya pos; peran lain wajib tidak.
+alter table akun_panitia add constraint akun_panitia_check
+  check ((peran = 'juri_pos') = (pos is not null));
+
+-- ---------------------------------------------------------------------------
+-- 2. Paket tiap peran. Satu tempat — dipakai migrasi ini, layar Akun waktu
+--    membuat akun, Worker gateway, dan provision_accounts.py.
+--
+--    `live_score` ada di SEMUA paket. Kalau suatu hari ada peran yang tidak
+--    boleh melihat klasemen, keluarkan dari paketnya di sini, bukan dengan
+--    mencabut centangnya satu per satu.
+-- ---------------------------------------------------------------------------
+create or replace function paket_peran(p_peran text)
+returns text[]
+language sql immutable
+as $$
+  select case p_peran
+    when 'admin' then array[
+      'pendaftaran','pembayaran','daftar_ulang','cetak_kloter',
+      'keberangkatan','kedatangan','pos','live_score','rekap','akun',
+      'pengaturan']
+    when 'registrasi' then array[
+      'pendaftaran','pembayaran','daftar_ulang','cetak_kloter','live_score']
+    when 'gerbang' then array[
+      'keberangkatan','kedatangan','live_score']
+    -- Posnya sendiri yang membatasi barisnya — pos_saya(), tidak disentuh.
+    when 'juri_pos' then array['pos','live_score']
+    else array[]::text[]
+  end
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Tulis ulang hak tiap akun sesuai paket perannya. Lihat catatan di kepala
+--    berkas: ini menghapus centang yang pernah disesuaikan tangan.
+-- ---------------------------------------------------------------------------
+delete from akun_hak;
+insert into akun_hak (user_id, fitur)
+select a.user_id, f
+from akun_panitia a, unnest(paket_peran(a.peran)) as f
+on conflict do nothing;
+
+do $$
+declare r record;
+begin
+  for r in
+    select a.peran, count(distinct a.user_id) akun, count(h.fitur) / greatest(count(distinct a.user_id), 1) fitur
+      from akun_panitia a left join akun_hak h on h.user_id = a.user_id
+     group by a.peran order by a.peran
+  loop
+    raise notice '0058: peran % — % akun, % fitur masing-masing', r.peran, r.akun, r.fitur;
+  end loop;
+end $$;
+
+comment on function paket_peran(text) is
+  'Centang awal tiap peran. Dipakai migrasi, layar Akun, Worker, dan provision_accounts.py — satu daftar, bukan empat.';

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -30,16 +30,37 @@ run supabase/seed.sql
 # Konfigurasi pos butuh edisinya sudah ada — lihat catatan panjang yang sama
 # di tests/run.sh.
 run supabase/migrations/0024_komponen_pos.sql
+# Konfigurasi pos edisi 37 (0032-0039) DIJALANKAN ULANG di sini, dan itu
+# perlu. Di glob di atas mereka berjalan sebelum seed.sql sempat membuat
+# edisi 37, jadi tidak menemukan apa-apa dan diam-diam tidak melakukan apa
+# pun — dev lalu memakai konfigurasi pos edisi LAMA (Games, Kostum) sementara
+# produksi memakai yang baru (Halang Rintang, PBB, Yel-yel). Perbedaan itu
+# tidak menggagalkan apa pun; ia cuma membuat layar yang dicoba di dev
+# berbicara tentang pos yang tidak ada di produksi.
+#
+# 0033 melewati dirinya sendiri kalau edisinya sudah memuat nilai, jadi ini
+# harus di ATAS 01_seed_uji.sql maupun pengisi nilai mana pun.
+for m in 0032_konfigurasi_xxxvii 0033_nama_pos_xxxvii 0034_nama_pos_final          0035_tangga_menaksir 0036_kriteria_bidai 0037_petunjuk_kolom          0038_petunjuk_menaksir 0039_judul_isian; do
+  run "supabase/migrations/$m.sql"
+done
+# Constraint peran dilonggarkan SEBENTAR. Seed akun uji sengaja memakai nama
+# peran lama (meja, operator_pos), karena di tests/run.sh ia berjalan lebih
+# dulu lalu 0058 memindahkannya — itulah yang menguji migrasinya terhadap
+# database yang sudah berisi. Di sini 0058 sudah lewat di glob, jadi
+# constraint barunya menolak nama lama; dipasang kembali oleh 0058 yang
+# dijalankan ulang tepat di bawah.
+"$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q -c   "alter table akun_panitia drop constraint akun_panitia_peran_check;
+   alter table akun_panitia drop constraint akun_panitia_check;"
 run tests/sql/01_seed_uji.sql
 
-# Akun uji lahir SESUDAH 0057 dijalankan di atas, jadi INSERT pengisi hak
-# di dalam migrasi itu tidak kebagian satu baris pun — di tests/run.sh
-# urutannya kebalikannya dan tidak kelihatan. Diisi di sini dengan
-# paket_peran() yang SAMA, supaya dev dan produksi tidak pernah memakai
-# dua daftar hak yang berbeda.
-"$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q -c "
-  insert into akun_hak (user_id, fitur)
-  select a.user_id, f from akun_panitia a, unnest(paket_peran(a.peran)) f
-  on conflict do nothing;"
+# 0058 DIJALANKAN ULANG, dan seed akun di atas sengaja masih memakai nama
+# peran LAMA (meja, operator_pos). Alasannya: di tests/run.sh seed berjalan
+# lebih dulu lalu 0058 memindahkannya — itu yang menguji migrasinya terhadap
+# database yang sudah berisi. Kalau seed diganti memakai nama baru, jalur itu
+# hilang dan yang teruji tinggal database kosong.
+#
+# 0058 sekaligus menulis ulang akun_hak dari paket_peran(), jadi tidak perlu
+# langkah pengisi terpisah di sini.
+run supabase/migrations/0058_peran_per_pekerjaan.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -279,9 +279,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
         try:
             if u.path == "/login":
                 b = self._badan()
+                # Hak ikut dibawa, sama seperti jalur Supabase — kalau tidak,
+                # papan Home di dev memilih ubin dengan daftar kosong dan
+                # tampak seolah semua peran kehilangan aksesnya.
                 akun = q(
-                    "select user_id::text as uid, username, peran, pos "
-                    "from akun_panitia where username = %s and is_active",
+                    "select a.user_id::text as uid, a.username, a.peran, a.pos,"
+                    "       coalesce(array_agg(h.fitur) filter (where h.fitur is not null),"
+                    "                '{}') as hak "
+                    "from akun_panitia a left join akun_hak h on h.user_id = a.user_id "
+                    "where a.username = %s and a.is_active "
+                    "group by a.user_id, a.username, a.peran, a.pos",
                     (b.get("username", ""),), role="service_role", fetch="one")
                 # Dev server: password apa pun diterima — auth sungguhan milik
                 # Supabase; yang diuji di sini adalah alur & RLS.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -183,5 +183,10 @@ run tests/sql/23_perkiraan_zona_wib.sql
 # syarat migrasi ini boleh dipasang di tengah edisi.
 run supabase/migrations/0057_hak_akses.sql
 run tests/sql/24_hak_akses.sql
+# 0058 mengganti nama peran dan MENULIS ULANG hak tiap akun. Tesnya menjaga
+# yang paling mahal kalau bocor: nilai peran lama harus benar-benar ditolak
+# database, bukan sekadar tidak dipakai lagi.
+run supabase/migrations/0058_peran_per_pekerjaan.sql
+run tests/sql/25_peran_per_pekerjaan.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/25_peran_per_pekerjaan.sql
+++ b/tests/sql/25_peran_per_pekerjaan.sql
@@ -1,0 +1,101 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/25_peran_per_pekerjaan.sql
+-- Peran per pekerjaan (migrasi 0058).
+--
+-- Yang dijaga paling keras: peran lama benar-benar HILANG. Selama `meja` atau
+-- `operator_pos` masih bisa ditulis, akun baru bisa lahir dengan peran yang
+-- paket_peran() jawab array kosong — akunnya bisa login, perannya terbaca,
+-- dan setiap layar kosong tanpa satu pun pesan galat.
+-- ============================================================================
+
+do $$
+declare
+  v_admin uuid := '00000000-0000-0000-0000-00000000000a';
+  v_meja  uuid := '00000000-0000-0000-0000-0000000000b1';
+  v_pos   uuid := '00000000-0000-0000-0000-000000000001';
+  v_n     int;
+  v_peran text;
+begin
+  -- ------------------------------------------------------------------ 1
+  -- Akun lama sudah pindah, dan tidak ada yang tertinggal.
+  select count(*) into v_n from akun_panitia where peran in ('meja', 'operator_pos');
+  assert v_n = 0, format('masih ada %s akun berperan lama', v_n);
+
+  select peran into v_peran from akun_panitia where user_id = v_meja;
+  assert v_peran = 'registrasi', format('meja harus jadi registrasi, jadi %s', v_peran);
+  select peran into v_peran from akun_panitia where user_id = v_pos;
+  assert v_peran = 'juri_pos', format('operator_pos harus jadi juri_pos, jadi %s', v_peran);
+
+  -- ------------------------------------------------------------------ 2
+  -- Nilai peran lama ditolak database, bukan sekadar tidak dipakai.
+  begin
+    update akun_panitia set peran = 'meja' where user_id = v_meja;
+    assert false, 'peran "meja" seharusnya sudah ditolak check constraint';
+  exception when check_violation then null;
+  end;
+
+  -- ------------------------------------------------------------------ 3
+  -- Isi paket tiap peran, persis seperti yang diminta.
+  assert paket_peran('registrasi') @> array['pendaftaran','pembayaran','daftar_ulang','cetak_kloter'],
+         'registrasi kurang salah satu dari empat pekerjaannya';
+  assert not (paket_peran('registrasi') @> array['keberangkatan']),
+         'registrasi TIDAK memegang keberangkatan — itu pekerjaan gerbang';
+  assert paket_peran('gerbang') @> array['keberangkatan','kedatangan'],
+         'gerbang harus memegang keberangkatan dan kedatangan';
+  assert paket_peran('juri_pos') @> array['pos'],
+         'juri_pos harus memegang pos';
+
+  -- Semua peran memegang live score. Ditulis sebagai perulangan supaya peran
+  -- yang ditambah tahun depan ikut terjaga tanpa menambah baris di sini.
+  for v_peran in select unnest(array['admin','registrasi','gerbang','juri_pos'])
+  loop
+    assert paket_peran(v_peran) @> array['live_score'],
+           format('peran %s harus memegang live_score', v_peran);
+  end loop;
+
+  -- Yang TIDAK boleh: hanya admin yang mengelola akun dan pengaturan.
+  for v_peran in select unnest(array['registrasi','gerbang','juri_pos'])
+  loop
+    assert not (paket_peran(v_peran) @> array['akun']),
+           format('peran %s tidak boleh mengelola akun', v_peran);
+    assert not (paket_peran(v_peran) @> array['pengaturan']),
+           format('peran %s tidak boleh mengubah pengaturan', v_peran);
+  end loop;
+
+  -- ------------------------------------------------------------------ 4
+  -- juri_pos wajib punya pos; peran lain wajib tidak.
+  begin
+    update akun_panitia set peran = 'juri_pos', pos = null where user_id = v_meja;
+    assert false, 'juri_pos tanpa pos seharusnya ditolak';
+  exception when check_violation then null;
+  end;
+  begin
+    update akun_panitia set peran = 'registrasi', pos = 3 where user_id = v_meja;
+    assert false, 'registrasi dengan pos seharusnya ditolak';
+  exception when check_violation then null;
+  end;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Hak nyatanya, dilihat dari kursi masing-masing.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  set local role authenticated;
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', true);
+  assert boleh('pembayaran'),      'registrasi harus boleh pembayaran';
+  assert boleh('live_score'),      'registrasi harus boleh live score';
+  assert not boleh('keberangkatan'), 'registrasi TIDAK boleh keberangkatan';
+  assert not boleh('akun'),        'registrasi TIDAK boleh akun';
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-000000000001', true);
+  assert boleh('pos'),             'juri_pos harus boleh pos';
+  assert boleh('live_score'),      'juri_pos harus boleh live score';
+  assert not boleh('pembayaran'),  'juri_pos TIDAK boleh pembayaran';
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  assert boleh('akun') and boleh('pengaturan'), 'admin harus boleh akun dan pengaturan';
+end $$;
+
+\echo '25 peran per pekerjaan: LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -17,6 +17,16 @@ const BATAS_MS = 20000;   // internet lambat tidak boleh menggantung selamanya
    membuka lagi. localStorage bertahan sampai betul-betul ditekan Keluar,
    dan token di dalamnya tetap kedaluwarsa sendiri via pastikanSesiSegar(). */
 
+/** Apakah akun yang sedang login memegang fitur ini.
+ *
+ *  Cermin `boleh()` di database, dan HANYA untuk menggambar layar. Yang
+ *  menegakkan tetap RLS — menyunting sesi di localStorage cuma memunculkan
+ *  ubin yang begitu diklik menjawab kosong. */
+export function bolehLihat(fitur) {
+  const s = sesi();
+  return !!s && Array.isArray(s.hak) && s.hak.includes(fitur);
+}
+
 export function sesi() {
   const s = localStorage.getItem("hrcd_sesi");
   return s ? JSON.parse(s) : null;
@@ -188,15 +198,24 @@ export async function masuk(username, password) {
       headers: { "Content-Type": "application/json", apikey: K.anonKey },
       body: JSON.stringify({ email, password }),
     });
+    const kepala = { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` };
     const akun = await kirim(
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,
-      { headers: { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` } });
+      { headers: kepala });
     if (!akun.length || !akun[0].is_active)
       throw new ErrorApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
+    // Hak dibawa ke dalam sesi supaya papan Home bisa memilih ubinnya tanpa
+    // satu permintaan lagi tiap kali dibuka. Ini HANYA untuk menggambar —
+    // yang menegakkan tetap RLS, dan sesi yang diutak-atik di devtools tidak
+    // mendapat satu baris pun lebih banyak.
+    const hak = await kirim(
+      `${K.supabaseUrl}/rest/v1/akun_hak?user_id=eq.${j.user.id}&select=fitur`,
+      { headers: kepala }).catch(() => []);
     s = {
       uid: j.user.id, token: j.access_token, refresh: j.refresh_token,
       kedaluwarsa: Date.now() + (j.expires_in || 3600) * 1000,
       ...akun[0],
+      hak: (hak || []).map(x => x.fitur),
     };
   }
   simpanSesi(s);
@@ -736,11 +755,11 @@ export async function daftarAkun() {
 }
 
 /** Ganti peran dan/atau pos. Keduanya dikirim bersama karena database
- *  menuntutnya konsisten: operator_pos wajib punya pos, peran lain wajib
+ *  menuntutnya konsisten: juri_pos wajib punya pos, peran lain wajib
  *  tidak (check di 0001_schema.sql). Mengirim peran saja akan ditolak
  *  constraint itu, dan pesannya tidak akan terbaca sebagai "posnya lupa". */
 export async function ubahPeranAkun(userId, peran, pos) {
-  const badan = { peran, pos: peran === "operator_pos" ? pos : null };
+  const badan = { peran, pos: peran === "juri_pos" ? pos : null };
   if (K.mode === "dev")
     return kirim(`${K.devUrl}/akun/ubah`, {
       method: "POST",

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -22,7 +22,7 @@ import {
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenLiveScore,
-  statusAcara,
+  statusAcara, bolehLihat,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak,
 } from "./api.js";
@@ -132,7 +132,9 @@ function pasangKepala(judul, lebar = false) {
   // Akun hanya untuk admin. Disembunyikan, BUKAN dinonaktifkan: tombol mati di
   // pojok header tidak memberi tahu apa pun selain bahwa ada sesuatu yang
   // tidak boleh disentuh.
-  const adminSaja = !!s && s.peran === "admin";
+  // Ikut CENTANG, bukan peran: admin yang centang Akun-nya dicabut tidak
+  // boleh tetap melihat tombolnya (0057).
+  const adminSaja = !!s && bolehLihat("akun");
   document.getElementById("btn-akun").hidden = !adminSaja;
   document.getElementById("nav-akun").hidden = !adminSaja;
   document.getElementById("judul-layar").textContent = judul;
@@ -228,7 +230,9 @@ async function layarHome() {
   // Tapi ia punya satu layar sendiri, dan Home-nya harus menunjukkan layar
   // itu: sebelumnya halaman ini buntu, dan akun pos tidak punya jalan ke
   // mana pun kecuali mengetik alamatnya sendiri.
-  if (peran === "operator_pos") {
+  // Yang hanya memegang pos tidak punya layar meja sama sekali; papan penuh
+  // untuknya adalah papan berisi ubin yang semuanya menjawab kosong.
+  if (bolehLihat("pos") && !bolehLihat("pembayaran") && !bolehLihat("keberangkatan")) {
     LAYAR.replaceChildren(h(html`
       <div class="function-menu">
         <a href="#/pos">
@@ -279,41 +283,48 @@ async function layarHome() {
            situs PESERTA bersama rekap live, supaya alamat yang beredar ke
            ratusan orang bukan alamat yang ada kotak loginnya. Karena beda
            asal, tautannya mutlak dan diambil dari config.js. -->
+      ${bolehLihat("pendaftaran") ? `
       <a href="${esc((window.HRCD && window.HRCD.pesertaUrl) || "")}/daftar.html"
          target="_blank" rel="noopener">
         <div class="function-name">${ikonKotak("clipboard-list", "biru")} Pendaftaran</div>
-      </a>
+      </a>` : ""}
+      ${bolehLihat("pembayaran") ? `
       <a href="#/pembayaran">
         <div class="function-name">${ikonKotak("credit-card", "hijau")} Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
-      </a>
+      </a>` : ""}
+      ${bolehLihat("daftar_ulang") ? `
       <a href="#/daftar-ulang">
         <div class="function-name">${ikonKotak("id-card", "ungu")} Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
-      </a>
+      </a>` : ""}
+      ${bolehLihat("cetak_kloter") ? `
       <a href="#/cetak-kloter">
         <div class="function-name">${ikonKotak("list-ordered", "toska")} Daftar Kloter</div>
-      </a>
+      </a>` : ""}
+      ${bolehLihat("keberangkatan") ? `
       <a href="#/keberangkatan">
         <div class="function-name">${ikonKotak("flag", "jingga")} Keberangkatan ${
           kemajuan(r ? r.regu_berangkat : null, r ? r.regu_siap : null)}</div>
-      </a>
+      </a>` : ""}
+      ${bolehLihat("kedatangan") ? `
       <a href="#/finish">
         <div class="function-name">${ikonKotak("circle-check", "zamrud")} Kedatangan ${
           kemajuan(r ? r.regu_datang : null, r ? r.regu_berangkat : null,
             "Ada regu tercatat datang tapi tidak tercatat berangkat. "
             + "Regu itu TIDAK masuk klasemen — periksa layar Keberangkatan.")}</div>
-      </a>
-      ${peran === "admin" ? `
+      </a>` : ""}
+      ${bolehLihat("pos") ? `
       <a href="#/pos">
         <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos</div>
       </a>` : ""}
-      ${peran === "admin" ? `
+      ${bolehLihat("live_score") ? `
       <a href="#/live-score">
         <div class="function-name">${ikonKotak("medal", "emas")} Live Score</div>
       </a>` : ""}
 
+      ${bolehLihat("rekap") ? `
       <a href="#/rekap">
         <div class="function-name">${ikonKotak("chart-column", "mawar")} Rekapitulasi</div>
-      </a>
+      </a>` : ""}
     </div>
   `));
 }
@@ -2436,7 +2447,7 @@ function siapkanCetakBlangko(pos, kolomLayar) {
  */
 async function layarInputPos() {
   const s = sesi();
-  if (s.peran === "meja") {
+  if (!bolehLihat("pos")) {
     pasangKepala("Input Nilai Pos");
     LAYAR.replaceChildren(h(html`
       <div class="card">
@@ -2464,7 +2475,7 @@ async function layarInputPos() {
 
   // Operator pos tidak memilih apa pun — posnya sudah melekat di akunnya, dan
   // RLS akan menolak pos lain seandainya layar ini mencoba.
-  const nomorPos = s.peran === "operator_pos"
+  const nomorPos = s.peran === "juri_pos"
     ? Number(s.pos)
     : (posDipilih.nomor
        ?? (posDinilai.length ? posDinilai[0].nomor
@@ -3631,7 +3642,7 @@ const angka = (n) => n === null || n === undefined ? "—"
 
 async function layarRekap() {
   const s = sesi();
-  if (s.peran === "operator_pos") {
+  if (!bolehLihat("rekap")) {
     pasangKepala("Rekapitulasi");
     LAYAR.replaceChildren(h(html`
       <div class="card">
@@ -4297,7 +4308,8 @@ async function layarLiveScore() {
 
 /* ============================ AKUN ======================================= */
 
-const PERAN_LABEL = { admin: "Admin", meja: "Meja", operator_pos: "Operator Pos" };
+const PERAN_LABEL = { admin: "Admin", registrasi: "Registrasi",
+                      gerbang: "Gerbang", juri_pos: "Juri Pos" };
 
 /** Kartu password. Ditampilkan SEKALI — tidak disimpan di mana pun dan tidak
  *  bisa dibaca lagi setelah dialognya ditutup, persis seperti CSV hasil
@@ -4327,7 +4339,7 @@ async function layarAkun() {
 
   // RLS yang sebenarnya menahan — ini supaya layarnya tidak tampak kosong dan
   // membingungkan kalau alamatnya diketik langsung.
-  if (sesi().peran !== "admin") {
+  if (!bolehLihat("akun")) {
     LAYAR.replaceChildren(h(kartuGalat("Hanya admin yang bisa mengelola akun.")));
     return;
   }
@@ -4359,7 +4371,7 @@ async function layarAkun() {
       <div class="table-toolbar" style="align-items:flex-end">
         <div class="field"><label for="ak-nama">Nama akun</label>
           <input id="ak-nama" type="text" class="small-input" autocomplete="off"
-            placeholder="pos6hrcd37" style="width:14rem"></div>
+            placeholder="pos1hrcd37" style="width:14rem"></div>
         <div class="field"><label for="ak-peran">Peran</label>
           <select id="ak-peran" class="select-small">${opsiPeran("meja")}</select></div>
         <div class="field"><label for="ak-pos">Pos</label>
@@ -4372,7 +4384,7 @@ async function layarAkun() {
         <div class="field">
           <label for="ak-tempel">Satu akun per baris: nama akun, peran, pos</label>
           <textarea id="ak-tempel" rows="4"
-            placeholder="pos6hrcd37, operator_pos, 6&#10;meja3hrcd37, meja"></textarea>
+            placeholder="pos1hrcd37, juri_pos, 1&#10;meja1hrcd37, registrasi"></textarea>
         </div>
         <button class="button button-primary" id="ak-buat-massal" type="button">Buat Semua</button>
       </details>
@@ -4409,7 +4421,7 @@ async function layarAkun() {
                 a.is_active ? "" : ' <span class="badge badge-gray">nonaktif</span>'}</td>
               <td><select class="select-small" data-peran>${opsiPeran(a.peran)}</select></td>
               <td><input type="number" class="small-input" data-pos min="1" max="20" style="width:4.5rem"
-                    value="${a.pos ?? ""}" ${a.peran === "operator_pos" ? "" : "disabled"}></td>
+                    value="${a.pos ?? ""}" ${a.peran === "juri_pos" ? "" : "disabled"}></td>
               ${fitur.map(f => `
                 <td class="text-center"><input type="checkbox" class="checkbox"
                   data-fitur="${esc(f.kode)}"
@@ -4427,10 +4439,10 @@ async function layarAkun() {
   const peranBaru = document.getElementById("ak-peran");
   const posBaru = document.getElementById("ak-pos");
 
-  // Pos hanya milik operator_pos — itu check constraint di database, bukan
+  // Pos hanya milik juri_pos — itu check constraint di database, bukan
   // selera. Kotaknya dimatikan supaya bentroknya ketahuan sebelum dikirim.
   peranBaru.addEventListener("change", () => {
-    posBaru.disabled = peranBaru.value !== "operator_pos";
+    posBaru.disabled = peranBaru.value !== "juri_pos";
     if (posBaru.disabled) posBaru.value = "";
   });
 
@@ -4453,7 +4465,7 @@ async function layarAkun() {
     const nama = document.getElementById("ak-nama").value.trim();
     if (!nama) { lapor("Nama akun wajib diisi."); return; }
     kirimBuat([{ username: nama, peran: peranBaru.value,
-      pos: peranBaru.value === "operator_pos" ? Number(posBaru.value) || null : null }],
+      pos: peranBaru.value === "juri_pos" ? Number(posBaru.value) || null : null }],
       ev.currentTarget);
   });
 
@@ -4507,12 +4519,12 @@ async function layarAkun() {
     const peran = tr.querySelector("[data-peran]").value;
     const kotakPos = tr.querySelector("[data-pos]");
     if (ev.target.matches("[data-peran]")) {
-      kotakPos.disabled = peran !== "operator_pos";
+      kotakPos.disabled = peran !== "juri_pos";
       if (kotakPos.disabled) kotakPos.value = "";
       else if (!kotakPos.value) { kotakPos.focus(); return; }
     }
-    const pos = peran === "operator_pos" ? Number(kotakPos.value) || null : null;
-    if (peran === "operator_pos" && !pos) { kotakPos.focus(); return; }
+    const pos = peran === "juri_pos" ? Number(kotakPos.value) || null : null;
+    if (peran === "juri_pos" && !pos) { kotakPos.focus(); return; }
     try {
       await ubahPeranAkun(tr.dataset.uid, peran, pos);
       notif(`${tr.dataset.nama} sekarang ${PERAN_LABEL[peran]}${pos ? ` pos ${pos}` : ""}.`);

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -135,12 +135,14 @@ async function buatAkun(req, env, b) {
       hasil.push({ username, ok: false, pesan: "Nama akun hanya huruf kecil, angka, titik, dan strip (3–40)." });
       continue;
     }
-    if (!["admin", "meja", "operator_pos"].includes(peran)) {
-      hasil.push({ username, ok: false, pesan: "Peran harus admin, meja, atau operator_pos." });
+    if (!["admin", "registrasi", "gerbang", "juri_pos"].includes(peran)) {
+      hasil.push({ username, ok: false,
+        pesan: "Peran harus admin, registrasi, gerbang, atau juri_pos." });
       continue;
     }
-    if ((peran === "operator_pos") !== (pos !== null)) {
-      hasil.push({ username, ok: false, pesan: "operator_pos wajib punya pos; peran lain wajib tanpa pos." });
+    if ((peran === "juri_pos") !== (pos !== null)) {
+      hasil.push({ username, ok: false,
+        pesan: "juri_pos wajib punya pos; peran lain wajib tanpa pos." });
       continue;
     }
     if (pos !== null && !(Number.isInteger(pos) && pos >= 1 && pos <= 20)) {


### PR DESCRIPTION
## What

Empat peran menggantikan tiga yang lama:

| peran | hak |
| --- | --- |
| `registrasi` | pendaftaran, pembayaran, daftar ulang, daftar kloter |
| `gerbang` | keberangkatan, kedatangan |
| `juri_pos` | satu pos (kolom `pos`) |
| `admin` | semuanya |

**Semuanya memegang Live Score versi panitia.** Papan Home sekarang memilih
ubin menurut **centang**, bukan peran.

Migrasi `0058` **sudah diterapkan ke produksi**
([run](https://github.com/ciradyka/hrcd-rekap/actions/runs/31966123315)):
1 admin, 5 juri_pos, 4 registrasi.

## Why

Peran lama dinamai menurut **tempat duduk**, bukan pekerjaan. `meja` adalah
semua yang duduk di meja, dan itu menyatukan empat pekerjaan yang di lapangan
dipegang orang berbeda.

`gerbang` menamai tempatnya, dan itu disengaja: Pos 0 dan Pos 5 adalah garis
start dan garis finish (migrasi 0025) — satu tempat, dua nama menurut arah
lari. Yang berjaga di sana memegang keduanya.

Papan Home harus ikut centang, kalau tidak peran baru tidak berarti apa-apa di
layar: akun `gerbang` akan tetap melihat ubin Pembayaran, mengkliknya, dan
mendapat tabel kosong yang terbaca seperti "belum ada yang bayar" alih-alih
"ini bukan pekerjaanmu". RLS sudah menahan datanya; yang kurang cuma papannya
ikut jujur.

## Notes

- **Migrasi ini TIDAK netral.** Akun `meja` kehilangan keberangkatan dan
  kedatangan. Kalau ada yang memang memegang keduanya, koordinator
  mencentangnya kembali di layar Akun — centang selalu menang atas peran.
- Hak dibawa ke sesi saat login supaya papan tidak perlu satu permintaan lagi.
  Itu **hanya untuk menggambar**; menyunting sesi di devtools cuma memunculkan
  ubin yang begitu diklik menjawab kosong.
- **Dev memakai konfigurasi pos edisi LAMA tanpa ada yang tahu.** 0033
  melewati dirinya sendiri kalau edisinya sudah memuat nilai, dan di
  `dev_database.sh` ia berjalan sebelum `seed.sql` sempat membuat edisi 37 —
  dev menampilkan Games dan Kostum, produksi memakai Halang Rintang, PBB, dan
  Yel-yel. Ikut diperbaiki.
- Worker perlu di-deploy ulang setelah merge (daftar peran yang divalidasi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)