### PR TITLE
feat: nilai mentah tidak punya koma

### DIFF
--- a/supabase/migrations/0059_nilai_mentah_bulat.sql
+++ b/supabase/migrations/0059_nilai_mentah_bulat.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- hrcd-rekap : 0059_nilai_mentah_bulat.sql
+-- Nilai mentah tidak punya koma.
+--
+-- KENAPA
+--
+-- Tidak ada satu pun komponen di edisi ini yang nilai mentahnya pecahan.
+-- Semuanya salah satu dari tiga hal, dan ketiganya bulat menurut sifatnya:
+--
+--   hitungan  — berapa huruf semaphore benar, berapa simpul benar (0-5, 0-10)
+--   skor juri — angka yang dilingkari juri di blangko (0-20, 0-30)
+--   detik     — dicatat dari stopwatch dan diketik sebagai MM:SS
+--
+-- `menaksir` pun bulat: selisih taksir dihitung per meter, dan tangganya
+-- (migrasi 0035) turun 20 poin tiap meter penuh — 2,5 m tidak pernah punya
+-- tempat di tangga itu.
+--
+-- Sampai sekarang tidak ada yang menahannya. Kolomnya `numeric`, kotak
+-- isiannya `step="any"` dengan `inputmode="decimal"` — dua-duanya MENGUNDANG
+-- koma. Juri yang mengetik 4,85 untuk Semaphore diterima tanpa sepatah kata,
+-- dan angka itu lalu ikut dihitung ke klasemen sebagai kalau-kalau ia berarti.
+--
+-- YANG DIJAGA CONSTRAINT INI, DAN YANG TIDAK
+--
+-- Ia menjaga bentuk angkanya, bukan besarnya. Rentang tetap dijaga
+-- `rentang_mentah_min/maks` seperti sebelumnya — 99.999.999 tetap sah untuk
+-- menaksir, karena rentang itu memang sengaja longgar supaya isian sah apa pun
+-- diterima dan yang menghukum kelewatan adalah tangganya, bukan penolakan.
+--
+-- KALAU SUATU HARI ADA KOMPONEN YANG MEMANG PECAHAN
+--
+-- Jangan melonggarkan constraint ini diam-diam. Yang benar: simpan angkanya
+-- dalam satuan terkecil yang bulat — sentimeter alih-alih meter, atau
+-- persepuluh detik — persis seperti `detik` yang sudah disimpan sebagai detik
+-- bulat, bukan menit pecahan. Pecahan yang masuk ke satu kolom akan menyebar
+-- ke setiap tempat yang membacanya.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Laporkan dulu kalau ada yang tidak lolos. Constraint yang gagal hanya
+--    menyebut nama constraint-nya; yang dibutuhkan orang yang menjalankannya
+--    adalah baris MANA yang salah.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_n int; r record;
+begin
+  select count(*) into v_n from nilai_mentah
+   where nilai_1 <> round(nilai_1)
+      or (nilai_2 is not null and nilai_2 <> round(nilai_2));
+  if v_n > 0 then
+    for r in
+      select n.regu_id, w.kode, n.nilai_1, n.nilai_2
+        from nilai_mentah n join wahana w on w.id = n.wahana_id
+       where n.nilai_1 <> round(n.nilai_1)
+          or (n.nilai_2 is not null and n.nilai_2 <> round(n.nilai_2))
+       limit 20
+    loop
+      raise notice '0059: pecahan — regu % komponen % : % / %',
+        r.regu_id, r.kode, r.nilai_1, r.nilai_2;
+    end loop;
+    raise exception '0059: % nilai mentah masih pecahan (20 pertama di atas). '
+      'Bulatkan dulu, atau periksa apakah komponennya memang perlu pecahan.', v_n;
+  end if;
+  raise notice '0059: semua nilai mentah sudah bulat.';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Pagarnya.
+-- ---------------------------------------------------------------------------
+alter table nilai_mentah add constraint nilai_mentah_bulat
+  check (nilai_1 = round(nilai_1)
+         and (nilai_2 is null or nilai_2 = round(nilai_2)));
+
+comment on constraint nilai_mentah_bulat on nilai_mentah is
+  'Nilai mentah selalu bulat: hitungan, skor juri, atau detik. Komponen pecahan disimpan dalam satuan terkecilnya, bukan dengan melonggarkan ini.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -188,5 +188,10 @@ run tests/sql/24_hak_akses.sql
 # database, bukan sekadar tidak dipakai lagi.
 run supabase/migrations/0058_peran_per_pekerjaan.sql
 run tests/sql/25_peran_per_pekerjaan.sql
+# 0059 menolak nilai mentah pecahan. Tesnya membuktikan penolakannya datang
+# dari DATABASE, bukan dari kotak isian — import massal dan tempel dari
+# spreadsheet tidak lewat kotak itu sama sekali.
+run supabase/migrations/0059_nilai_mentah_bulat.sql
+run tests/sql/26_nilai_mentah_bulat.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/08_lembar_pos.sql
+++ b/tests/sql/08_lembar_pos.sql
@@ -90,10 +90,19 @@ select simpan_nilai_massal('[
   {"nomor_dada": 13, "kode": "tebak_simpul",          "nilai_1": 1}
 ]'::jsonb, 'manual', 1::smallint);
 
--- Pos 3, baris 004 RIMBA KUYY: 4 / 4,5 / 8 / 40 / 2 -> 285
+-- Pos 3, baris 004 RIMBA KUYY: 4 / 5 / 8 / 40 / 2
+--
+-- Lembar aslinya menulis 4,5 untuk Merayap — nilai setengah dari juri. Sejak
+-- migrasi 0059 nilai mentah wajib bulat, jadi angka itu tidak bisa lagi
+-- dimasukkan dan fixture ini memakai 5. Totalnya ikut berubah; yang dijaga
+-- tes ini rumus penilaiannya, bukan angka lembar itu sendiri.
+--
+-- Merayap tidak ada lagi di konfigurasi edisi 37 (0033), jadi setengah nilai
+-- itu tidak menghalangi siapa pun hari ini. Kalau suatu edisi memang perlu
+-- setengah, simpan dalam satuan terkecilnya — lihat kepala 0059.
 select simpan_nilai_massal('[
   {"nomor_dada": 13, "kode": "logika",       "nilai_1": 4},
-  {"nomor_dada": 13, "kode": "merayap",      "nilai_1": 4.5},
+  {"nomor_dada": 13, "kode": "merayap",      "nilai_1": 5},
   {"nomor_dada": 13, "kode": "balap_karung", "nilai_1": 8},
   {"nomor_dada": 13, "kode": "lempar_pisau", "nilai_1": 40},
   {"nomor_dada": 13, "kode": "poros_bumi",   "nilai_1": 2}
@@ -129,7 +138,10 @@ begin
   assert l.nilai -> 'tidak_ada_kolom_ini' is null, 'kolom asing muncul di nilai';
 
   select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 3;
-  assert l.nilai_pos = 285, 'Pos 3 dada 13 = ' || l.nilai_pos || ', sheet bilang 285';
+  -- 293,33 bukan 285: Merayap naik dari 4,5 ke 5 (lihat catatan di atas),
+  -- dan 0,5 dari 6 bernilai 8,33 poin. Rumusnya tidak berubah.
+  assert round(l.nilai_pos, 2) = 293.33,
+    'Pos 3 dada 13 = ' || l.nilai_pos || ', harusnya 293,33';
 
   select * into strict l from v_lembar_pos where nomor_dada = 13 and pos = 4;
   assert l.nilai_pos = 125, 'Pos 4 dada 13 = ' || l.nilai_pos || ', sheet bilang 125';
@@ -150,8 +162,8 @@ do $$
 declare v_total numeric;
 begin
   select total_pos into v_total from v_total_skor where nomor_dada = 13;
-  assert v_total = 705,
-    'total pos dada 13 = ' || v_total || ', harusnya 230+285+125+65 = 705';
+  assert round(v_total, 2) = 713.33,
+    'total pos dada 13 = ' || v_total || ', harusnya 230+293,33+125+65 = 713,33';
 end;
 $$;
 

--- a/tests/sql/26_nilai_mentah_bulat.sql
+++ b/tests/sql/26_nilai_mentah_bulat.sql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/26_nilai_mentah_bulat.sql
+-- Nilai mentah tidak punya koma (migrasi 0059).
+--
+-- Yang dijaga: penolakannya datang dari DATABASE, bukan dari kotak isian.
+-- `step="1"` di layar hanya membuat koma sulit diketik — ia tidak menahan
+-- import massal, tidak menahan tempel dari spreadsheet, dan tidak menahan
+-- siapa pun yang membuka devtools. Kalau tes ini lulus hanya karena layarnya
+-- rapi, ia tidak menjaga apa-apa.
+-- ============================================================================
+
+do $$
+declare
+  v_wahana uuid;
+  v_regu   uuid;
+begin
+  -- Pasangan diambil dari nilai_mentah ITU SENDIRI. Mengambil wahana dan regu
+  -- terpisah bisa menghasilkan pasangan yang tidak punya baris, dan UPDATE
+  -- yang tidak mengenai apa pun tidak melanggar constraint apa pun — tesnya
+  -- lalu lulus tanpa menguji sesuatu. Itu yang terjadi waktu ini ditulis
+  -- pertama kali.
+  select regu_id, wahana_id into v_regu, v_wahana from nilai_mentah limit 1;
+  if v_wahana is null or v_regu is null then
+    raise notice '26: belum ada wahana/nilai di edisi aktif — tes dilewati';
+    return;
+  end if;
+
+  -- Bulat: diterima.
+  update nilai_mentah set nilai_1 = 4
+   where regu_id = v_regu and wahana_id = v_wahana;
+
+  -- Pecahan: ditolak, dan ditolak oleh constraint — bukan oleh trigger lain
+  -- yang kebetulan ikut menggagalkannya.
+  begin
+    update nilai_mentah set nilai_1 = 4.85
+     where regu_id = v_regu and wahana_id = v_wahana;
+    assert false, 'nilai 4,85 seharusnya ditolak constraint nilai_mentah_bulat';
+  exception when check_violation then
+    null;
+  end;
+
+  -- nilai_2 juga, dan null tetap boleh.
+  begin
+    update nilai_mentah set nilai_2 = 1.5
+     where regu_id = v_regu and wahana_id = v_wahana;
+    assert false, 'nilai_2 1,5 seharusnya ditolak';
+  exception when check_violation then
+    null;
+  end;
+  update nilai_mentah set nilai_2 = null
+   where regu_id = v_regu and wahana_id = v_wahana;
+
+  -- Angka besar tetap boleh: yang dijaga BENTUKNYA, bukan besarnya. Rentang
+  -- tetap urusan rentang_mentah_min/maks.
+  update nilai_mentah set nilai_1 = 1000
+   where regu_id = v_regu and wahana_id = v_wahana;
+end $$;
+
+-- Seluruh isi tabel lolos — kalau tidak, migrasinya tidak akan terpasang di
+-- produksi dan yang menemukannya adalah apply-migration yang gagal.
+do $$
+declare v_n int;
+begin
+  select count(*) into v_n from nilai_mentah
+   where nilai_1 <> round(nilai_1)
+      or (nilai_2 is not null and nilai_2 <> round(nilai_2));
+  assert v_n = 0, format('%s nilai mentah masih pecahan', v_n);
+end $$;
+
+\echo '26 nilai mentah bulat: LULUS'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2013,11 +2013,11 @@ function selKomponen(k, nilai) {
   }
   if (k.form === "benar_kurang_salah") {
     return `<span class="pos-pasangan">
-      <input type="number" class="small-input" inputmode="numeric" min="0"
+      <input type="number" class="small-input" inputmode="numeric" step="1" min="0"
              data-kode="${kode}" data-slot="benar" value="${esc(angkaRapi(n1))}"
              aria-label="${esc(k.name)} — jumlah benar">
       <span class="pos-pemisah" aria-hidden="true">/</span>
-      <input type="number" class="small-input" inputmode="numeric" min="0"
+      <input type="number" class="small-input" inputmode="numeric" step="1" min="0"
              data-kode="${kode}" data-slot="salah" value="${esc(angkaRapi(n2))}"
              aria-label="${esc(k.name)} — jumlah salah">
     </span>`;
@@ -2025,7 +2025,13 @@ function selKomponen(k, nilai) {
   // Sengaja placeholder, bukan nilai tersimpan. Menyimpan keadaan ketiga
   // bernama "–" akan memaksa setiap tempat yang membaca angka ini menebak
   // maksudnya, padahal database hanya punya dua: ada barisnya, atau tidak.
-  return `<input type="number" class="small-input" inputmode="decimal" step="any"
+  // step="1" + inputmode="numeric", BUKAN step="any" + inputmode="decimal".
+  // Nilai mentah tidak pernah pecahan (migrasi 0059), dan kotak yang
+  // memanggil papan angka bertitik desimal adalah undangan mengetik koma.
+  // Ini cuma membuatnya sulit — yang benar-benar menolak adalah constraint
+  // nilai_mentah_bulat, karena import massal dan tempel dari spreadsheet
+  // tidak lewat kotak ini sama sekali.
+  return `<input type="number" class="small-input" inputmode="numeric" step="1"
                  min="${esc(k.rentang_mentah_min)}" max="${esc(k.rentang_mentah_maks)}"
                  data-kode="${kode}" value="${esc(angkaRapi(n1))}"${kosongTampak}
                  aria-label="${esc(k.name)}">`;


### PR DESCRIPTION
## What

Constraint `nilai_mentah_bulat` menolak nilai pecahan, dan kotak isian pos
berpindah dari `step="any"` + `inputmode="decimal"` ke `step="1"` +
`inputmode="numeric"`.

**Sudah diterapkan ke produksi**
([run](https://github.com/ciradyka/hrcd-rekap/actions/runs/31967696792)) —
seluruh nilai yang ada sudah bulat.

## Why

Tidak ada satu pun komponen di edisi ini yang nilai mentahnya pecahan.
Semuanya hitungan (berapa huruf semaphore benar), skor juri (angka yang
dilingkari di blangko), atau detik (dicatat dari stopwatch, diketik MM:SS).
`menaksir` pun bulat — tangganya turun 20 poin tiap **meter penuh**.

Sampai sekarang tidak ada yang menahannya, dan dua hal justru **mengundang**
koma: kolomnya `numeric`, dan kotak isiannya memanggil papan angka bertitik
desimal di HP.

Yang menolak adalah **constraint**, bukan kotak isian. `step="1"` cuma membuat
koma sulit diketik; ia tidak menahan import massal, tempel dari spreadsheet,
atau devtools — dan ketiganya jalan yang sah menuju tabel yang sama.

## Notes

Migrasinya melaporkan baris mana yang tidak lolos **sebelum** memasang
pagarnya, dan laporan itu langsung berguna: ia menemukan **4,5 untuk Merayap**
di fixture tes 08 — nilai setengah dari juri, disalin apa adanya dari lembar
asli edisi lama.

Jadi setengah nilai memang pernah ada. Merayap tidak ada lagi di konfigurasi
edisi 37, jadi tidak ada yang terhalang hari ini — tapi kalau suatu edisi
memang butuh setengah, **simpan dalam satuan terkecilnya** (sentimeter,
persepuluh detik), jangan longgarkan constraint ini.

Tes 26 sempat lulus tanpa menguji apa pun: ia mengambil wahana dan regu
terpisah, dan pasangan yang tidak punya baris membuat UPDATE-nya tidak
melanggar apa-apa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)