### PR TITLE
fix: kloter mulai dari 1 jam 07:00, bukan 17 jam 14:00

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,3 +318,28 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    golongan — that is what `kolomPos()` merges by name. Grouping by lomba is a
    third thing on top, and doing both with one mechanism is how Tebak Simpul
    ends up as four columns again.
+
+## 12. Kloter
+
+1. **Kloter tercetak masih boleh diisi selama belum berangkat.** Mencetak
+   daftar bukan penutupan; yang menutup sebuah kloter adalah `jam_berangkat`-nya
+   terisi. Sekolah yang daftar ulang setelah kertas dicetak tetap masuk ke
+   kloter paling awal yang masih longgar, dan kertasnya dicetak ulang — itu
+   murah, dan jauh lebih murah daripada kloter setengah kosong berangkat.
+2. **Selalu isi kloter paling awal dulu sampai penuh**, bukan menyebar rata.
+   Kloter 1 penuh sebelum kloter 2 dipakai. Yang berangkat pagi harus berangkat
+   penuh; tempat kosong yang tertinggal di kloter awal berarti kloter terakhir
+   berangkat lebih siang dari yang perlu, dan jendela 07:00–10:00 di bagian 10
+   tidak punya kelonggaran untuk itu.
+3. **Kode hari ini melanggar butir 1, dan itu belum diperbaiki.** Migrasi 0008
+   menambahkan syarat `dicetak_pada is null` ke pemilihan kloter beserta trigger
+   yang menolak penambahan ke kloter tercetak; 0040 mengembalikannya setelah
+   sempat hilang. Keduanya ditulis dengan niat melindungi kertas yang sudah
+   dibagikan — tapi niat itu bukan aturan lapangan. Perbaikannya: ganti
+   syaratnya jadi `jam_berangkat is null`.
+4. **"Bersihkan data" termasuk mengembalikan penomoran kloter ke 1**, bukan
+   hanya menghapus regu dan nilai. Kloter yang masih menyandang tanda cetak atau
+   jam berangkat dari percobaan sebelumnya membuat pembagian berikutnya mulai
+   dari tengah — produksi sempat mulai dari kloter 17 karena 24 kloter pertama
+   masih bertanda tercetak, dan papan seperti itu membuat panitia mencari
+   keenam belas kloter yang tidak pernah ada.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,3 +316,28 @@ Guidance for Claude Code when working in this repository.
    golongan — that is what `kolomPos()` merges by name. Grouping by lomba is a
    third thing on top, and doing both with one mechanism is how Tebak Simpul
    ends up as four columns again.
+
+## 12. Kloter
+
+1. **Kloter tercetak masih boleh diisi selama belum berangkat.** Mencetak
+   daftar bukan penutupan; yang menutup sebuah kloter adalah `jam_berangkat`-nya
+   terisi. Sekolah yang daftar ulang setelah kertas dicetak tetap masuk ke
+   kloter paling awal yang masih longgar, dan kertasnya dicetak ulang — itu
+   murah, dan jauh lebih murah daripada kloter setengah kosong berangkat.
+2. **Selalu isi kloter paling awal dulu sampai penuh**, bukan menyebar rata.
+   Kloter 1 penuh sebelum kloter 2 dipakai. Yang berangkat pagi harus berangkat
+   penuh; tempat kosong yang tertinggal di kloter awal berarti kloter terakhir
+   berangkat lebih siang dari yang perlu, dan jendela 07:00–10:00 di bagian 10
+   tidak punya kelonggaran untuk itu.
+3. **Kode hari ini melanggar butir 1, dan itu belum diperbaiki.** Migrasi 0008
+   menambahkan syarat `dicetak_pada is null` ke pemilihan kloter beserta trigger
+   yang menolak penambahan ke kloter tercetak; 0040 mengembalikannya setelah
+   sempat hilang. Keduanya ditulis dengan niat melindungi kertas yang sudah
+   dibagikan — tapi niat itu bukan aturan lapangan. Perbaikannya: ganti
+   syaratnya jadi `jam_berangkat is null`.
+4. **"Bersihkan data" termasuk mengembalikan penomoran kloter ke 1**, bukan
+   hanya menghapus regu dan nilai. Kloter yang masih menyandang tanda cetak atau
+   jam berangkat dari percobaan sebelumnya membuat pembagian berikutnya mulai
+   dari tengah — produksi sempat mulai dari kloter 17 karena 24 kloter pertama
+   masih bertanda tercetak, dan papan seperti itu membuat panitia mencari
+   keenam belas kloter yang tidak pernah ada.

--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -300,6 +300,29 @@ begin
   delete from keberangkatan_regu;
   update kloter set jam_berangkat = null where jam_berangkat is not null;
 
+  -- Tanda cetak ikut dibuang. Kloter yang sudah DICETAK dilewati waktu daftar
+  -- ulang membagi regu (0040) — dan sisa tanda cetak dari uji coba lama
+  -- mendorong seluruh penomoran ke atas: produksi sempat mulai dari kloter 17,
+  -- bukan 1, karena 24 kloter pertama masih bertanda tercetak dari percobaan
+  -- sebelumnya. Papan yang mulai dari kloter 17 membuat panitia mencari
+  -- keenam belas kloter yang tidak pernah ada.
+  update kloter set dicetak_pada = null where dicetak_pada is not null;
+
+  -- Penomoran kloter dirapatkan dari 1, mengikuti urutan nomor dada dan
+  -- kapasitas per kloter.
+  --
+  -- Ini SATU-SATUNYA tempat berkas ini menulis langsung ke tabel, bukan lewat
+  -- RPC. Alasannya disebut supaya tidak ditiru sembarangan: mengulang
+  -- pembagian lewat daftar_ulang_batch menuntut nomor dada dilepas dulu, dan
+  -- melepas nomor dada menyentuh stok serta pensiun — reset yang jauh lebih
+  -- besar dan lebih berisiko daripada yang dibutuhkan sebuah contoh.
+  with urut as (
+    select id, ceil(row_number() over (order by nomor_dada)::numeric
+                    / v_e.maks_regu_per_kloter)::smallint kloter
+      from regu where nomor_dada is not null and not is_cancelled
+  )
+  update regu r set kloter_nomor = u.kloter from urut u where u.id = r.id;
+
   -- ---------------------------------------------------- 3. lomba yang BERJALAN
   --
   -- Bukan lomba yang sudah selesai. Papan yang semuanya 100% tidak
@@ -334,10 +357,16 @@ begin
     loop
       perform ceklis_berangkat(v_dada);
     end loop;
+    -- `at time zone 'Asia/Jakarta'`, BUKAN `::timestamptz`. Cast itu
+    -- menafsirkan waktu polos menurut zona SESI: di laptop yang berzona WIB ia
+    -- benar, di Supabase yang berjalan UTC ia menyimpan 07:00 UTC — 14:00 WIB.
+    -- Produksi sempat memuat seluruh keberangkatan tujuh jam meleset karena
+    -- ini, dan migrasi 0056 lahir dari kekeliruan yang sama persis.
     perform berangkatkan_kloter(
       v_kloter.nomor,
       (v_e.tanggal_lomba + v_e.jam_mulai_berangkat
-       + make_interval(mins => v_i * v_e.interval_berangkat_menit))::timestamptz);
+       + make_interval(mins => v_i * v_e.interval_berangkat_menit))
+      at time zone 'Asia/Jakarta');
 
     -- Berapa pos yang sudah dilewati kloter ini. Yang berangkat pertama sudah
     -- melewati semuanya; yang terakhir baru satu.

--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -51,6 +51,7 @@ declare
   v_kloter_semua     int;
   v_kloter_berangkat int;
   v_pos_selesai      int;
+  v_kloter_parkir    smallint;
   v_jml_pos          int;
 begin
   -- Identitas pelaku. Semua RPC mencatat `recorded_by`/`verified_by` dari
@@ -316,12 +317,50 @@ begin
   -- pembagian lewat daftar_ulang_batch menuntut nomor dada dilepas dulu, dan
   -- melepas nomor dada menyentuh stok serta pensiun — reset yang jauh lebih
   -- besar dan lebih berisiko daripada yang dibutuhkan sebuah contoh.
+  -- DIPARKIR DULU, baru ditempatkan. Dua langkah, dan keduanya perlu.
+  --
+  -- Satu UPDATE sekaligus bentrok: `unique (kloter_nomor, urutan_kloter)`
+  -- tidak deferrable, jadi ia diperiksa per baris dan keadaan ANTARA ikut
+  -- dinilai walaupun keadaan akhirnya sah. Mengosongkannya dulu juga tidak
+  -- bisa — `check ((nomor_dada is null) = (kloter_nomor is null))` melarang
+  -- regu bernomor dada tanpa kloter. Dan memindahkan satu per satu urut dari
+  -- petak terkecil hanya aman kalau penomorannya selalu merapat; ia tidak,
+  -- karena regu bisa berpindah ke urutan yang lebih besar di kloter yang sama.
+  --
+  -- Yang tersisa: pindahkan semuanya ke satu kloter yang pasti kosong, lalu
+  -- tempatkan dari sana. Tidak ada petak tujuan yang pernah ditempati di
+  -- kedua langkah, jadi tidak ada keadaan antara yang melanggar.
+  -- Parkirnya BEBERAPA kloter terakhir, bukan satu: `urutan_kloter` dibatasi
+  -- 1..maks_regu_per_kloter, jadi menumpuk lima puluh regu di satu kloter
+  -- melanggar batas itu.
+  select count(*) into v_n from regu where nomor_dada is not null and not is_cancelled;
+  select max(nomor) - ceil(v_n::numeric / v_e.maks_regu_per_kloter)::int + 1
+    into v_kloter_parkir from kloter;
+  if exists (select 1 from regu where kloter_nomor >= v_kloter_parkir) then
+    raise exception 'petak parkir mulai % ternyata berisi', v_kloter_parkir;
+  end if;
+
   with urut as (
-    select id, ceil(row_number() over (order by nomor_dada)::numeric
-                    / v_e.maks_regu_per_kloter)::smallint kloter
+    select id, row_number() over (order by nomor_dada) n
       from regu where nomor_dada is not null and not is_cancelled
   )
-  update regu r set kloter_nomor = u.kloter from urut u where u.id = r.id;
+  update regu r
+     set kloter_nomor = (v_kloter_parkir
+                         + floor((u.n - 1) / v_e.maks_regu_per_kloter))::smallint,
+         urutan_kloter = (((u.n - 1) % v_e.maks_regu_per_kloter) + 1)::smallint
+    from urut u where u.id = r.id;
+
+  with urut as (
+    select id,
+           ceil(row_number() over (order by kloter_nomor, urutan_kloter)::numeric
+                / v_e.maks_regu_per_kloter)::smallint            kloter,
+           (((row_number() over (order by kloter_nomor, urutan_kloter) - 1)
+             % v_e.maks_regu_per_kloter) + 1)::smallint          urutan
+      from regu
+     where kloter_nomor >= v_kloter_parkir and nomor_dada is not null
+  )
+  update regu r set kloter_nomor = u.kloter, urutan_kloter = u.urutan
+    from urut u where u.id = r.id;
 
   -- ---------------------------------------------------- 3. lomba yang BERJALAN
   --


### PR DESCRIPTION
## What

Dua cacat pada dummy data, keduanya terlihat di layar Keberangkatan produksi.
**Sudah diterapkan** ([run](https://github.com/ciradyka/hrcd-rekap/actions/runs/31970798222)) —
sekarang kloter 1–4 berangkat 07:00, 07:04, 07:08, 07:12, dan nol kloter
bertanda tercetak.

Ikut: aturan kloter masuk ke CLAUDE.md/AGENTS.md bagian 12.

## Why

**Kloter mulai dari 17.** Kloter yang sudah dicetak dilewati waktu daftar
ulang membagi regu (0040) — dan produksi masih memuat **24 kloter bertanda
tercetak** dari uji coba sebelumnya. Papan yang mulai dari kloter 17 membuat
panitia mencari keenam belas kloter yang tidak pernah ada.

**Jam 14:00, bukan 07:00.** Saya memakai `::timestamptz`, yang menafsirkan
waktu polos menurut zona **sesi**: di laptop berzona WIB benar, di Supabase
yang berjalan UTC ia menyimpan 07:00 UTC — 14:00 WIB. Migrasi 0056 dan tes 23
lahir dari kekeliruan yang sama persis, dan saya mengulanginya.

## Notes

Merapatkan penomoran ternyata terkunci tiga constraint sekaligus:

| constraint | akibatnya |
| --- | --- |
| `unique (kloter_nomor, urutan_kloter)` tidak deferrable | keadaan **antara** ikut dinilai walau akhirnya sah |
| `check ((nomor_dada is null) = (kloter_nomor is null))` | tidak bisa dikosongkan dulu |
| `check (urutan_kloter between 1 and 10)` | tidak bisa ditumpuk di satu kloter sebagai parkir |

Memindahkan satu per satu urut dari petak terkecil juga tidak cukup — itu
hanya aman kalau penomoran selalu merapat, dan regu bisa berpindah ke urutan
yang **lebih besar** di kloter yang sama. Yang bekerja: parkir ke beberapa
kloter terakhir yang kosong, lalu tempatkan dari sana.

**Utang yang dicatat, bukan disamarkan** — CLAUDE.md bagian 12 butir 3: kode
hari ini melarang penambahan ke kloter tercetak (0008 + 0040), padahal aturan
lapangannya "tercetak masih boleh diisi selama belum berangkat". Perbaikannya
mengganti syarat itu jadi `jam_berangkat is null`, dan itu migrasi tersendiri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)