### PR TITLE
fix: sebar sekolah antar kloter, dan NPSN sebagai identitas sekolah

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,3 +343,21 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    dari tengah — produksi sempat mulai dari kloter 17 karena 24 kloter pertama
    masih bertanda tercetak, dan papan seperti itu membuat panitia mencari
    keenam belas kloter yang tidak pernah ada.
+5. **Satu sekolah tidak boleh berangkat bareng di kloter yang sama.** Regu
+   dari sekolah yang sama disebar — `daftar_ulang_batch` sudah menjaganya, dan
+   jarak antar kloternya ditentukan `lompatan_kloter` (2 di edisi 37, jadi tiga
+   regu satu sekolah mendarat di kloter 1, 3, 5). Aturan ini melunak, bukan
+   putus, kalau kloter benar-benar habis — "sesedikit mungkin", bukan "tidak
+   boleh".
+6. **Jangan menomori kloter sendiri.** Penomoran menyimpan aturan yang tidak
+   kelihatan dari nomornya: butir 5 di atas dijaga di dalam
+   `daftar_ulang_batch`, bukan oleh urutan nomor dada. Skrip contoh sempat
+   menomori ulang dengan `ceil(row_number/10)` dan mendaratkan MTs Rancah
+   bertiga di kloter 1. Kalau kloter perlu disusun ulang, bersihkan lalu
+   jalankan ulang alurnya — jangan tulis nomornya langsung.
+7. **Satu sekolah, satu baris `sekolah`.** Lembar edisi lama menulis alamat
+   SMPN 2 CIPAKU dengan empat ejaan berbeda, dan `submit_pendaftaran`
+   melahirkan empat baris sekolah. Butir 5 lalu tidak berlaku di antara
+   keempatnya — mereka terbaca sebagai sekolah berlainan, dan regunya
+   berangkat bareng. Alamat yang berbeda tipis bukan sekolah yang berbeda;
+   lihat `docs/runbook-sekolah.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,9 +355,28 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    menomori ulang dengan `ceil(row_number/10)` dan mendaratkan MTs Rancah
    bertiga di kloter 1. Kalau kloter perlu disusun ulang, bersihkan lalu
    jalankan ulang alurnya — jangan tulis nomornya langsung.
-7. **Satu sekolah, satu baris `sekolah`.** Lembar edisi lama menulis alamat
-   SMPN 2 CIPAKU dengan empat ejaan berbeda, dan `submit_pendaftaran`
-   melahirkan empat baris sekolah. Butir 5 lalu tidak berlaku di antara
-   keempatnya — mereka terbaca sebagai sekolah berlainan, dan regunya
-   berangkat bareng. Alamat yang berbeda tipis bukan sekolah yang berbeda;
-   lihat `docs/runbook-sekolah.md`.
+7. **Satu sekolah, satu baris `sekolah` — dan database belum menjaminnya.**
+   `submit_pendaftaran` mencari sekolahnya dengan pasangan **(nama, alamat)
+   persis**:
+
+   ```sql
+   insert into sekolah (nama, alamat) values (trim(p_nama_sekolah), trim(p_alamat_sekolah))
+   on conflict (nama, alamat) do nothing;
+   select id into v_sekolah from sekolah where nama = ... and alamat = ...;
+   ```
+
+   Beda satu koma, beda `Jl.` dan `Jln.`, beda spasi — lahir baris baru dengan
+   id baru. `unique (nama, alamat)` di 0001 memang disengaja, supaya dua
+   sekolah senama di tempat berbeda bisa hidup berdampingan (SMPN 1 Purwadadi
+   ada di Ciamis DAN di Subang). Niatnya benar; mekanismenya terlalu harfiah —
+   ia tidak bisa membedakan "sekolah yang sama, alamatnya diketik lebih
+   sembarangan" dari "sekolah lain di tempat lain".
+8. **Akibatnya menembus ke kloter, dan itu yang paling mahal.** Butir 5
+   berhenti berlaku di antara baris-baris kembar itu: mereka terbaca sebagai
+   sekolah berlainan, jadi regunya BERANGKAT BARENG tanpa satu pun pesan
+   galat. Lembar edisi lama menulis alamat SMPN 2 CIPAKU dengan empat ejaan
+   berbeda; di data contoh itu melahirkan empat baris sekolah sekaligus.
+   `docs/runbook-sekolah.md` bagian 11 sudah meminta pagar kembar dipasang
+   sebelum tabel `sekolah` diisi — obatnya sama dengan `nama_regu` di migrasi
+   0051: unique index atas nama yang dinormalisasi. Yang belum tercatat di
+   sana adalah akibat ini.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,3 +341,21 @@ Guidance for Claude Code when working in this repository.
    dari tengah — produksi sempat mulai dari kloter 17 karena 24 kloter pertama
    masih bertanda tercetak, dan papan seperti itu membuat panitia mencari
    keenam belas kloter yang tidak pernah ada.
+5. **Satu sekolah tidak boleh berangkat bareng di kloter yang sama.** Regu
+   dari sekolah yang sama disebar — `daftar_ulang_batch` sudah menjaganya, dan
+   jarak antar kloternya ditentukan `lompatan_kloter` (2 di edisi 37, jadi tiga
+   regu satu sekolah mendarat di kloter 1, 3, 5). Aturan ini melunak, bukan
+   putus, kalau kloter benar-benar habis — "sesedikit mungkin", bukan "tidak
+   boleh".
+6. **Jangan menomori kloter sendiri.** Penomoran menyimpan aturan yang tidak
+   kelihatan dari nomornya: butir 5 di atas dijaga di dalam
+   `daftar_ulang_batch`, bukan oleh urutan nomor dada. Skrip contoh sempat
+   menomori ulang dengan `ceil(row_number/10)` dan mendaratkan MTs Rancah
+   bertiga di kloter 1. Kalau kloter perlu disusun ulang, bersihkan lalu
+   jalankan ulang alurnya — jangan tulis nomornya langsung.
+7. **Satu sekolah, satu baris `sekolah`.** Lembar edisi lama menulis alamat
+   SMPN 2 CIPAKU dengan empat ejaan berbeda, dan `submit_pendaftaran`
+   melahirkan empat baris sekolah. Butir 5 lalu tidak berlaku di antara
+   keempatnya — mereka terbaca sebagai sekolah berlainan, dan regunya
+   berangkat bareng. Alamat yang berbeda tipis bukan sekolah yang berbeda;
+   lihat `docs/runbook-sekolah.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,9 +353,28 @@ Guidance for Claude Code when working in this repository.
    menomori ulang dengan `ceil(row_number/10)` dan mendaratkan MTs Rancah
    bertiga di kloter 1. Kalau kloter perlu disusun ulang, bersihkan lalu
    jalankan ulang alurnya — jangan tulis nomornya langsung.
-7. **Satu sekolah, satu baris `sekolah`.** Lembar edisi lama menulis alamat
-   SMPN 2 CIPAKU dengan empat ejaan berbeda, dan `submit_pendaftaran`
-   melahirkan empat baris sekolah. Butir 5 lalu tidak berlaku di antara
-   keempatnya — mereka terbaca sebagai sekolah berlainan, dan regunya
-   berangkat bareng. Alamat yang berbeda tipis bukan sekolah yang berbeda;
-   lihat `docs/runbook-sekolah.md`.
+7. **Satu sekolah, satu baris `sekolah` — dan database belum menjaminnya.**
+   `submit_pendaftaran` mencari sekolahnya dengan pasangan **(nama, alamat)
+   persis**:
+
+   ```sql
+   insert into sekolah (nama, alamat) values (trim(p_nama_sekolah), trim(p_alamat_sekolah))
+   on conflict (nama, alamat) do nothing;
+   select id into v_sekolah from sekolah where nama = ... and alamat = ...;
+   ```
+
+   Beda satu koma, beda `Jl.` dan `Jln.`, beda spasi — lahir baris baru dengan
+   id baru. `unique (nama, alamat)` di 0001 memang disengaja, supaya dua
+   sekolah senama di tempat berbeda bisa hidup berdampingan (SMPN 1 Purwadadi
+   ada di Ciamis DAN di Subang). Niatnya benar; mekanismenya terlalu harfiah —
+   ia tidak bisa membedakan "sekolah yang sama, alamatnya diketik lebih
+   sembarangan" dari "sekolah lain di tempat lain".
+8. **Akibatnya menembus ke kloter, dan itu yang paling mahal.** Butir 5
+   berhenti berlaku di antara baris-baris kembar itu: mereka terbaca sebagai
+   sekolah berlainan, jadi regunya BERANGKAT BARENG tanpa satu pun pesan
+   galat. Lembar edisi lama menulis alamat SMPN 2 CIPAKU dengan empat ejaan
+   berbeda; di data contoh itu melahirkan empat baris sekolah sekaligus.
+   `docs/runbook-sekolah.md` bagian 11 sudah meminta pagar kembar dipasang
+   sebelum tabel `sekolah` diisi — obatnya sama dengan `nama_regu` di migrasi
+   0051: unique index atas nama yang dinormalisasi. Yang belum tercatat di
+   sana adalah akibat ini.

--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -136,6 +136,43 @@ berpasangan, dan urutannya penting — "biasa diucapkan" duluan.
   `SMKN 1 Manonjaya`; Dapodik ternyata mencatatnya `SMKN MANONJAYA`. Periksa
   dulu sebelum menambahkan angka.
 
+### Yang menentukan sekolah itu satu atau dua adalah NPSN — bukan namanya
+
+Nama boleh sama; NPSN tidak pernah. **NPSN dicek hanya kalau benar-benar
+ragu** — bukan untuk 189 sekolah satu per satu, tapi untuk yang namanya
+mencurigakan mirip. Begitu dua NPSN berbeda, itu dua sekolah, titik, dan
+tidak ada kesamaan alamat atau ejaan yang mengubahnya.
+
+**Maka nama di database kita harus cukup jelas untuk berdiri sendiri.** Kalau
+dua NPSN akan memakai nama tampil yang sama, nama itu diberi ekor kabupaten
+atau kota:
+
+| NPSN       | Nama tampil            |
+|------------|------------------------|
+| `20276449` | `MAN 3 Ciamis`         |
+| `20276789` | `MAN 3 Tasikmalaya`    |
+| `20280193` | `MAN 6 Ciamis`         |
+| `20276775` | `MAN 6 Tasikmalaya`    |
+
+Ini bukan gaya penulisan, dan ekornya bukan hiasan. Nama sekolah adalah yang
+dibaca panitia di layar keberangkatan, dicetak di blangko, dan dicari pembina
+di daftar. Dua sekolah bernama `MAN 3` di layar yang sama adalah kekeliruan
+yang harus diurai orang di tengah pagi.
+
+Aturannya berlaku dua arah, dan arah keduanya yang mudah terlewat: **kalau
+tidak ada tabrakan, jangan tambahkan ekor.** `MAN Darussalam` hanya ada satu,
+jadi ia tidak jadi `MAN Darussalam Ciamis` — bagian 5 sudah bilang kedekatan
+ke nama resmi tidak boleh membuat nama jadi asing, dan ekor yang tidak
+membedakan apa-apa melakukan hal yang sama. Ekor dipakai untuk memisahkan,
+bukan untuk melengkapi.
+
+`tools/periksa_sekolah.py` menjaganya dua-duanya: tidak boleh ada dua baris
+bernama sama, dan tidak boleh ada NPSN kembar.
+
+**Dan inilah yang membuat pagar kembar di database jadi sederhana.** Kalau
+nama sudah dijamin membedakan sekolah sendirian, `alamat` tidak perlu ikut
+jadi kunci — lihat bagian 11.
+
 Nama resmi yang berbeda tetap disimpan di kolom `nama_resmi`
 `sekolah_alamat.json`, jadi tidak ada yang hilang.
 
@@ -506,12 +543,27 @@ sekolah beres — atau CI-nya merah.
 Belum ada satu baris pun yang masuk tabel `sekolah`.
 
 **Sebelum memasukkannya**, pasang dulu pagar kembar di database. `sekolah`
-sekarang hanya ber-`unique (nama, alamat)` (migrasi 0001), jadi
+sekarang ber-`unique (nama, alamat)` (migrasi 0001), jadi
 `SMKN 3 Tasikmalaya` dan `SMK Negeri 3 Tasik` dengan alamat beda satu koma
 lolos berdua — satu sekolah pecah dua, regunya terbelah, rekapnya menghitung
-dua sekolah. Obatnya sama dengan yang sudah dipakai untuk `nama_regu` di
-migrasi 0051: unique index atas nama yang dinormalisasi, ditambah satu langkah
-menyamakan `SMKN` dengan `SMK NEGERI`.
+dua sekolah.
+
+Kunci itu dibuat begitu untuk alasan yang masuk akal: alur 3.2.2 ingin dua
+sekolah senama di tempat berbeda tetap bisa hidup berdampingan, dan `alamat`
+dipakai sebagai pembedanya. **Aturan NPSN di bagian 5 menjawab kebutuhan yang
+sama dengan cara yang lebih murah** — pembedanya dipindah ke dalam nama
+(`MAN 3 Ciamis` dan `MAN 3 Tasikmalaya`), di mana ia juga terbaca panitia,
+bukan hanya terbaca database. Setelah itu `alamat` tidak punya pekerjaan lagi
+sebagai kunci, dan sebaiknya berhenti jadi kunci: sebagai pembeda ia terlalu
+peka — beda satu koma sudah membelah sekolah — dan sebagai keterangan ia
+memang cuma keterangan.
+
+Jadi obatnya sama dengan yang sudah dipakai untuk `nama_regu` di migrasi 0051:
+**unique index atas nama yang dinormalisasi saja**, ditambah satu langkah
+menyamakan `SMKN` dengan `SMK NEGERI`. Yang ikut berubah: `submit_pendaftaran`
+mencari sekolahnya lewat nama, dan alamat yang diketik pembina tidak lagi
+melahirkan baris baru — baris yang sudah ada tetap dipakai dengan alamat
+kurasi yang ada di sini.
 
 **Dan akibatnya bukan cuma rekap yang menghitung dua kali.** Pembagian kloter
 menyebar regu satu sekolah supaya tidak berangkat bareng, dan penyebaran itu

--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -512,3 +512,10 @@ lolos berdua — satu sekolah pecah dua, regunya terbelah, rekapnya menghitung
 dua sekolah. Obatnya sama dengan yang sudah dipakai untuk `nama_regu` di
 migrasi 0051: unique index atas nama yang dinormalisasi, ditambah satu langkah
 menyamakan `SMKN` dengan `SMK NEGERI`.
+
+**Dan akibatnya bukan cuma rekap yang menghitung dua kali.** Pembagian kloter
+menyebar regu satu sekolah supaya tidak berangkat bareng, dan penyebaran itu
+membandingkan `sekolah_id`. Dua baris kembar terbaca sebagai dua sekolah
+berlainan, jadi regunya berangkat bareng — tanpa satu pun pesan galat. Ini
+terlihat di data contoh: lembar edisi lama menulis alamat SMPN 2 CIPAKU dengan
+empat ejaan berbeda, dan keempatnya jadi baris `sekolah` tersendiri.

--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -74,37 +74,61 @@ begin
   select * into v_e from edisi where is_active;
   raise notice 'edisi aktif: % (%)', v_e.name, v_e.nomor;
 
-  -- ------------------------------------------------------------ 0. pendaftaran
-  -- 50 regu dari Database HRCD XXXVI: nama regu, sekolah, dan golongan
+  -- ------------------------------------------------------ 0. bersihkan SEMUA
+  -- "Bersihkan data" berarti kloter ikut kembali ke 1 (CLAUDE.md 12.4), dan
+  -- itu tidak bisa dicapai dengan menomori ulang sendiri: pembagian kloter
+  -- menyimpan aturan yang tidak kelihatan dari nomornya — satu sekolah tidak
+  -- boleh berangkat bareng di kloter yang sama (12.5). Versi sebelumnya
+  -- menomori ulang dengan ceil(row_number/10) dan mendaratkan MTs Rancah
+  -- bertiga di kloter 1.
+  --
+  -- Jadi yang dibuang seluruhnya, lalu SELURUH alur dijalankan lagi dari
+  -- pendaftaran. daftar_ulang_batch yang membagi kloter, dan ia sudah tahu
+  -- kedua aturan itu.
+  delete from closing_regu;
+  delete from nilai_terkunci;
+  delete from nilai_mentah;
+  delete from keberangkatan_regu;
+  delete from pembayaran;
+  delete from regu;
+  delete from pendaftaran;
+  update kloter set jam_berangkat = null, dicetak_pada = null;
+
+  -- ------------------------------------------------------------ 1. pendaftaran
+  -- 50 regu dari Database HRCD XXXVI, DIKELOMPOKKAN PER NAMA SEKOLAH.
+  --
+  -- Mengelompokkan per (nama, alamat) memecah satu sekolah jadi beberapa:
+  -- lembar aslinya menulis alamat SMPN 2 CIPAKU dengan empat ejaan berbeda,
+  -- dan submit_pendaftaran melahirkan empat baris `sekolah`. Akibatnya
+  -- daftar_ulang_batch tidak bisa menjalankan aturannya sendiri — satu
+  -- sekolah tidak boleh berangkat bareng di kloter yang sama (CLAUDE.md
+  -- 12.5) — karena keempatnya terbaca sebagai sekolah berlainan.
+  --
+  -- Nama regu, sekolah, dan golongan
   -- diambil apa adanya, karena bentuk nama yang sebenarnya (panjang, kapital,
   -- tanda baca) justru yang perlu diuji layarnya. Nama ketua placeholder —
   -- keempat edisi lampau tidak pernah punya kolomnya.
   --
-  -- Dilewati kalau sudah ada regu: berkas ini aman diulang.
-  if not exists (select 1 from regu) then
+  -- Selalu dijalankan: bagian 2 di bawah sudah mengosongkan semuanya lebih
+  -- dulu, jadi tidak ada yang bisa terlahir dua kali.
+  if true then
     perform submit_pendaftaran('SMAN 1 Maja', 'Jln prabuwangi',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Indi homogen', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('Smk bangkit indonesia talaga', 'nan',
+    perform submit_pendaftaran('SMK BANGKIT INDONESIA TALAGA', 'Jln, ganeas no 1 kec, talaga',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Prampasu putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+        jsonb_build_object('nama_regu', 'Prampasu putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Pramapasu Putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Pramapasu Putri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMAN 1 cirebon', 'Jl siliwangi no 12',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Kandang maung', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMK BANGKIT INDONESIA TALAGA', 'Jln, ganeas no 1 kec, talaga',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Pramapasu Putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
-        jsonb_build_object('nama_regu', 'Pramapasu Putri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
     perform submit_pendaftaran('MTs Rancah', 'Jl Cibeureum No. 50',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'SIREUM ATEUL', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('MTs Rancah', 'Jl Cibeureum No 50',
-      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'SIREUM ATEUL', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'GARUDA MUDA', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'WANOJA SUNDA', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'MOJANG GALUH', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
@@ -115,15 +139,13 @@ begin
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMAN 1 CIHAURBEUTI', 'Jalan kartawijaya no. 600 Pamokolan-Cihaurbeuti,Pamokolan,Ciamis,Kabupaten Ciamis,Jawa Barat 46262',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Bombang Rarang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMAN 1 Cihaurbeuti', 'Jalan kartawijaya no. 600 Pamokolan-Cihaurbeuti,Pamokolan,Ciamis,Ciamis,Jawa Barat 46262',
-      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Bombang Rarang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Bombang Kencana', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('MAS AL-KAUTSAR', 'jln. Pejuang No. 100, Karangpucung wetan, Desa Jajawar, Kecamatan Banjar, Kota Banjar, Provinsi Jawa Barat',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Khalid bin Walid', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
+        jsonb_build_object('nama_regu', 'Khalid bin Walid', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Fatimah Azzahra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('Mts Rijalul Hikam', 'Jatinagara',
       false, '0800000000', jsonb_build_array(
@@ -131,10 +153,7 @@ begin
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('MA ASALIMIAH', 'jl. Kiayi Haji Salim, No 1 Rt 9 rw 7 Desa Darmacaang, Kec. cikoneng, Kab, Ciamis',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Abang pulan', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('MA ASALIMIAH', 'JL. Kiyai Haji Salim, no 1 rt 9 rw 7, Desa Darmacaang, kec. cikoneng',
-      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Abang pulan', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Dewi Armina', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMA TERPADU CIKANYERE', 'Kec.Rajadesa,Kab.Ciamis',
@@ -145,11 +164,8 @@ begin
     perform submit_pendaftaran('MA YPI RIJALUL HIKAM', 'Jatinagara',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Nanya ka urang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'SagombayFly', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'ZAKORAYFLY', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('MA YPI Rijalul Hikam', 'Jatinagara',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'SagombayFly', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMA Islam Ainurrafiq', 'Kec. Cigandamekar Kab. Kuningan',
       false, '0800000000', jsonb_build_array(
@@ -173,16 +189,17 @@ begin
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'ADAM MALIK', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
       0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMKN 1 Losarang', 'Ds.santing kec.losarang kab.indramayu',
+    perform submit_pendaftaran('SMKN 1 Losarang', 'Jalan Raya Pantura Losarang Desa Santing Kel. Jumbleng, Santing, Kec. Losarang, Kabupaten Indramayu, Jawa Barat 45253',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'KIWANA LAS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMK Siliwangi AMS Banjarsari', 'Ciamis,banjarsari',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Dyah Pitaloka', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
+        jsonb_build_object('nama_regu', 'KIWANA LAS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'Wana Karwek', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
+        jsonb_build_object('nama_regu', 'NYI WANA KULTUR', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'Nyi Wanagri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
+        jsonb_build_object('nama_regu', 'KiWana Tok', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMK Siliwangi AMS Banjarsari', 'Banjarsari,Ciamis, Jawa barat',
       false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Dyah Pitaloka', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
         jsonb_build_object('nama_regu', 'Prabu Siliwangi', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Maung Bodas', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
@@ -194,51 +211,25 @@ begin
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Hileud Jengke', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
       0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMPN 2 CIPAKU', 'Jl. Desa Cipaku No.05 Desa/kec Cipaku',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Swag Partners', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMPN 2 CIPAKU', 'Dusun Desa Cipaku',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Angel Wings', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
-      0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMPN 2 CIPAKU', 'Jalan Desa Cipaku no.5 desa/kec cipaku',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Badhrika Chandra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMPN 2 CIPAKU', 'JL. Desa cipaku no.5 desa/kec cipaku',
-      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Swag Partners', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
+        jsonb_build_object('nama_regu', 'Angel Wings', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
+        jsonb_build_object('nama_regu', 'Badhrika Chandra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'Pandawa Lima', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
       0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMKN 2 CIAMIS', 'Jl. Sadananya no.21',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Agresi Cakra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('MAS AL-KAUTSAR', 'Jl. Pejuang No. 100 Karangpucung Wetan. Ds. Jajawar Kec. Banjar Kota Banjar',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Fatimah Azzahra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMPN 1 CIAMIS', 'Jl. Jenderal Sudirman No. 6',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Disconnect Eror', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
     perform submit_pendaftaran('SMPN 1 CIAMIS', 'Jl. Jenderal Sudirman No. 6, Ciamis',
       false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Reconnect Afk', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMPN 1 CIAMIS', 'nan',
-      false, '0800000000', jsonb_build_array(
+        jsonb_build_object('nama_regu', 'Disconnect Eror', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
+        jsonb_build_object('nama_regu', 'Reconnect Afk', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'Saliwang Sableng', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'Pacebuk Nesa', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'Disconnect Ngelag', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'Alah Siah Boy', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
-      0::smallint, null, 'Pembina');
-    perform submit_pendaftaran('SMKN 1 Losarang', 'Jalan Raya Pantura Losarang Desa Santing Kel. Jumbleng, Santing, Kec. Losarang, Kabupaten Indramayu, Jawa Barat 45253',
-      false, '0800000000', jsonb_build_array(
-        jsonb_build_object('nama_regu', 'Wana Karwek', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
-        jsonb_build_object('nama_regu', 'NYI WANA KULTUR', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
-        jsonb_build_object('nama_regu', 'Nyi Wanagri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
-        jsonb_build_object('nama_regu', 'KiWana Tok', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
       0::smallint, null, 'Pembina');
 
     -- Lunasi lalu beri nomor dada. Nominalnya harus PAS seluruh batch —
@@ -271,9 +262,9 @@ begin
     end loop;
   end if;
   select count(*) into v_n from regu where nomor_dada is not null;
-  raise notice '0. pendaftaran: % regu bernomor dada', v_n;
+  raise notice '1. pendaftaran: % regu bernomor dada', v_n;
 
-  -- --------------------------------------------------------------- 1. kontrak
+  -- --------------------------------------------------------------- 2. kontrak
   select array_agg(menit order by menit) into v_opsi
     from kontrak_opsi where edisi = v_e.nomor;
   if v_opsi is null then
@@ -288,79 +279,7 @@ begin
     perform konfirmasi_kontrak(v_regu.id, v_opsi[1 + floor(random() * array_length(v_opsi, 1))::int]);
     v_n := v_n + 1;
   end loop;
-  raise notice '1. kontrak waktu: % regu', v_n;
-
-  -- ------------------------------------------------------- 2. kemajuan dibuang
-  -- Kemajuan disetel ulang dulu supaya berkas ini bisa dijalankan lagi dengan
-  -- pola yang berbeda. Yang dibuang HANYA jejak hari lomba; pendaftaran,
-  -- pembayaran, dan nomor dada tetap — itu yang mahal dibuat ulang dan tidak
-  -- ada alasan menyentuhnya.
-  delete from closing_regu;
-  delete from nilai_terkunci;
-  delete from nilai_mentah;
-  delete from keberangkatan_regu;
-  update kloter set jam_berangkat = null where jam_berangkat is not null;
-
-  -- Tanda cetak ikut dibuang. Kloter yang sudah DICETAK dilewati waktu daftar
-  -- ulang membagi regu (0040) — dan sisa tanda cetak dari uji coba lama
-  -- mendorong seluruh penomoran ke atas: produksi sempat mulai dari kloter 17,
-  -- bukan 1, karena 24 kloter pertama masih bertanda tercetak dari percobaan
-  -- sebelumnya. Papan yang mulai dari kloter 17 membuat panitia mencari
-  -- keenam belas kloter yang tidak pernah ada.
-  update kloter set dicetak_pada = null where dicetak_pada is not null;
-
-  -- Penomoran kloter dirapatkan dari 1, mengikuti urutan nomor dada dan
-  -- kapasitas per kloter.
-  --
-  -- Ini SATU-SATUNYA tempat berkas ini menulis langsung ke tabel, bukan lewat
-  -- RPC. Alasannya disebut supaya tidak ditiru sembarangan: mengulang
-  -- pembagian lewat daftar_ulang_batch menuntut nomor dada dilepas dulu, dan
-  -- melepas nomor dada menyentuh stok serta pensiun — reset yang jauh lebih
-  -- besar dan lebih berisiko daripada yang dibutuhkan sebuah contoh.
-  -- DIPARKIR DULU, baru ditempatkan. Dua langkah, dan keduanya perlu.
-  --
-  -- Satu UPDATE sekaligus bentrok: `unique (kloter_nomor, urutan_kloter)`
-  -- tidak deferrable, jadi ia diperiksa per baris dan keadaan ANTARA ikut
-  -- dinilai walaupun keadaan akhirnya sah. Mengosongkannya dulu juga tidak
-  -- bisa — `check ((nomor_dada is null) = (kloter_nomor is null))` melarang
-  -- regu bernomor dada tanpa kloter. Dan memindahkan satu per satu urut dari
-  -- petak terkecil hanya aman kalau penomorannya selalu merapat; ia tidak,
-  -- karena regu bisa berpindah ke urutan yang lebih besar di kloter yang sama.
-  --
-  -- Yang tersisa: pindahkan semuanya ke satu kloter yang pasti kosong, lalu
-  -- tempatkan dari sana. Tidak ada petak tujuan yang pernah ditempati di
-  -- kedua langkah, jadi tidak ada keadaan antara yang melanggar.
-  -- Parkirnya BEBERAPA kloter terakhir, bukan satu: `urutan_kloter` dibatasi
-  -- 1..maks_regu_per_kloter, jadi menumpuk lima puluh regu di satu kloter
-  -- melanggar batas itu.
-  select count(*) into v_n from regu where nomor_dada is not null and not is_cancelled;
-  select max(nomor) - ceil(v_n::numeric / v_e.maks_regu_per_kloter)::int + 1
-    into v_kloter_parkir from kloter;
-  if exists (select 1 from regu where kloter_nomor >= v_kloter_parkir) then
-    raise exception 'petak parkir mulai % ternyata berisi', v_kloter_parkir;
-  end if;
-
-  with urut as (
-    select id, row_number() over (order by nomor_dada) n
-      from regu where nomor_dada is not null and not is_cancelled
-  )
-  update regu r
-     set kloter_nomor = (v_kloter_parkir
-                         + floor((u.n - 1) / v_e.maks_regu_per_kloter))::smallint,
-         urutan_kloter = (((u.n - 1) % v_e.maks_regu_per_kloter) + 1)::smallint
-    from urut u where u.id = r.id;
-
-  with urut as (
-    select id,
-           ceil(row_number() over (order by kloter_nomor, urutan_kloter)::numeric
-                / v_e.maks_regu_per_kloter)::smallint            kloter,
-           (((row_number() over (order by kloter_nomor, urutan_kloter) - 1)
-             % v_e.maks_regu_per_kloter) + 1)::smallint          urutan
-      from regu
-     where kloter_nomor >= v_kloter_parkir and nomor_dada is not null
-  )
-  update regu r set kloter_nomor = u.kloter, urutan_kloter = u.urutan
-    from urut u where u.id = r.id;
+  raise notice '2. kontrak waktu: % regu', v_n;
 
   -- ---------------------------------------------------- 3. lomba yang BERJALAN
   --

--- a/tools/periksa_sekolah.py
+++ b/tools/periksa_sekolah.py
@@ -17,6 +17,22 @@ Yang sudah pernah terjadi, dan semuanya lolos tanpa suara:
   lengkap padahal tidak satu peserta pun pernah menuliskannya.
 - **Kolom `jalan` diisi dusun dan RT/RW**, yang bukan nama jalan (bagian 8).
 
+NPSN ADALAH IDENTITASNYA, NAMA HARUS MEMBEDAKANNYA SENDIRI
+
+Dua pemeriksaan di bawah ini kelihatan seperti kerapian, padahal keduanya
+adalah satu aturan (runbook bagian 5):
+
+- **NPSN tidak boleh kembar** — dua baris ber-NPSN sama adalah satu sekolah
+  yang tertulis dua kali, apa pun bedanya alamatnya.
+- **Nama tampil tidak boleh kembar** — karena nama itulah yang dibaca panitia
+  di layar keberangkatan dan dicetak di blangko. Kalau dua NPSN berbeda akan
+  memakai nama yang sama, namanya diberi ekor kabupaten: `MAN 3 Ciamis` dan
+  `MAN 3 Tasikmalaya`, bukan dua-duanya `MAN 3`.
+
+Yang kedua juga yang membuat pagar kembar di database bisa sesederhana satu
+unique index atas nama — `alamat` tidak perlu ikut jadi kunci. Selama
+pemeriksaan ini hidup, nama sudah cukup membedakan sekolah sendirian.
+
 Skrip ini tidak bisa tahu alamat sebuah sekolah benar atau salah. Yang bisa ia
 tahu: kedua berkas masih saling cocok, dan bentuk isiannya masih menuruti
 aturan yang sudah ditulis. Itu yang gagal diam-diam.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1634,11 +1634,11 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
 
     const baris = v.isi.map(r => bentuk === "staging"
       ? html`
-        <tr><td class="dada">${dada3(r.nomor_dada)}</td>
+        <tr><td class="kotak"></td>
+            <td class="dada">${dada3(r.nomor_dada)}</td>
             <td>${r.nama_regu}${r.sisipan ? " ★" : ""}</td>
             <td>${r.nama_sekolah}</td>
-            <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>
-            <td class="kotak"></td></tr>`
+            <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td></tr>`
       : html`
         <tr><td class="dada">${dada3(r.nomor_dada)}</td>
             <td>${r.nama_regu}</td>
@@ -1653,7 +1653,11 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
         <p><strong>${nyata ? "Berangkat" : "Perkiraan berangkat"}: ${esc(perkiraan)}</strong>
            ${nyata ? "" : " · Jam sebenarnya: ________"} · Petugas: ________________</p>
         <table class="print-table">
-          <thead><tr><th>No Dada</th><th>Nama Regu</th><th>Sekolah</th><th>Golongan</th><th>Hadir</th></tr></thead>
+          <!-- Hadir di kolom PALING KIRI, sejajar dengan tombol centang di
+               layar Keberangkatan. Petugas memegang kertas ini di satu tangan
+               dan HP di tangan lain; kalau kotak centangnya di ujung yang
+               berlawanan, matanya menyeberangi seluruh baris tiap regu. -->
+          <thead><tr><th class="kotak">Hadir</th><th>No Dada</th><th>Nama Regu</th><th>Sekolah</th><th>Golongan</th></tr></thead>
           <tbody>${baris}</tbody>
         </table>
         ${adaSisipan ? `<p class="insert-note">★ = regu sisipan, ditambahkan setelah kertas ini dicetak.</p>` : ""}


### PR DESCRIPTION
## What

**Data contoh: satu sekolah tidak lagi berangkat bareng.**
`simulasi_end_to_end.sql` sekarang membersihkan SEMUA dulu — termasuk
mengembalikan `kloter.dicetak_pada` dan `jam_berangkat` ke null — lalu
menjalankan alur asli dari pendaftaran. Pendaftarannya dikelompokkan per
**nama sekolah**, bukan per (nama, alamat); 50 regu jadi 23 sekolah dan nol
tabrakan kloter.

**CLAUDE.md / AGENTS.md bagian 12 (Kloter)**, tujuh butir — termasuk dua yang
baru: mekanisme kenapa satu sekolah bisa jadi empat baris `sekolah`, dan
akibatnya menembus ke pembagian kloter tanpa satu pun pesan galat.

**Runbook sekolah: NPSN adalah identitasnya, nama harus membedakannya
sendiri.** Dua NPSN yang akan memakai nama sama diberi ekor kabupaten
(`MAN 3 Ciamis` / `MAN 3 Tasikmalaya`); yang tidak bertabrakan tidak diberi
ekor (`MAN Darussalam` tetap polos). Alasannya ikut ditulis ke docstring
`periksa_sekolah.py`, yang sudah memeriksa nama unik dan NPSN unik sejak awal
tanpa pernah menyebut kenapa.

## Why

Keberangkatan kloter memang didesain menyebar regu satu sekolah supaya tidak
berangkat bersamaan, dan penyebarannya membandingkan `sekolah_id`. Lembar
edisi lama menulis alamat SMPN 2 CIPAKU dengan empat ejaan berbeda, dan
`submit_pendaftaran` — yang mencari sekolah lewat pasangan `(nama, alamat)`
persis — melahirkan empat baris. Keempatnya lalu terbaca sebagai empat
sekolah berlainan, jadi aturan penyebaran berhenti berlaku di antara mereka.
Diam-diam, tanpa galat.

Aturan NPSN menyelesaikannya dari hulu sekaligus menyederhanakan pagar kembar
yang direncanakan: kalau nama sudah dijamin membedakan sekolah sendirian,
`alamat` tidak perlu ikut jadi kunci, dan pagarnya cukup satu unique index
atas nama yang dinormalisasi — persis `nama_regu` di migrasi 0051.

## Notes

Pagar databasenya sendiri belum dipasang; ia menunggu tabel `sekolah` diisi
dari daftar kurasi, dan langkahnya sudah tertulis di runbook bagian 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)