### PR TITLE
fix: satu sekolah satu baris, dan alamat baku dari daftar kurasi

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -277,6 +277,14 @@ function gambarSekolah() {
     document.getElementById("manual").replaceChildren(h(`
       <div class="card" style="margin:.6rem 0 0;border-color:var(--utama)">
         <p style="font-weight:700">Sekolahmu belum ada di daftar?</p>
+        <!-- Satu-satunya kalimat penjelas di kartu ini, dan ia menahan
+             kekeliruan yang mahal: sejak migrasi 0061 sekolah dikenali dari
+             NAMANYA saja. Nama yang persis sama dengan sekolah lain akan
+             menyatu dengan sekolah itu — regunya ikut terhitung ke sana dan
+             pembagian kloternya ikut salah. Alamat tidak lagi memisahkan. -->
+        <p class="hint" style="margin:.4rem 0 0">Kalau ada sekolah lain yang
+          namanya persis sama, tambahkan kabupatennya — misalnya
+          <strong>MAN 3 Ciamis</strong>.</p>
         <div class="field" style="margin-top:.6rem">
           <label for="m-alamat">Alamat sekolah (jalan + kota)</label>
           <input type="text" id="m-alamat"
@@ -289,7 +297,10 @@ function gambarSekolah() {
       const alamat = document.getElementById("m-alamat").value.trim();
       if (!nama) { cari.focus(); return; }
       if (!alamat) {
-        notif("Isi alamat sekolahnya — untuk membedakan sekolah bernama sama.", true);
+        // Dulu berbunyi "untuk membedakan sekolah bernama sama". Sejak 0061
+        // alamat tidak membedakan apa-apa — nama yang membedakan — jadi
+        // alasan itu dihapus daripada dibiarkan mengajarkan yang keliru.
+        notif("Alamat sekolahnya belum diisi.", true);
         document.getElementById("m-alamat").focus();
         return;
       }

--- a/supabase/migrations/0061_sekolah_satu_baris.sql
+++ b/supabase/migrations/0061_sekolah_satu_baris.sql
@@ -1,0 +1,341 @@
+-- ============================================================================
+-- hrcd-rekap : 0061_sekolah_satu_baris.sql
+-- Satu sekolah, satu baris — dijaga database, bukan kehati-hatian pengetik.
+--
+-- APA YANG TERLIHAT
+--
+-- Di layar pendaftaran, kotak "Asal sekolah" menawarkan `SMPN 1 CIAMIS` TIGA
+-- KALI: satu beralamat `Jl. Jenderal Sudirman No. 6`, satu `Jl. Jenderal
+-- Sudirman No. 6, Ciamis`, satu lagi `nan`. Pembina memilih salah satunya —
+-- tidak ada cara menebak yang mana — dan satu sekolah jadi tiga. `SMPN 2
+-- CIPAKU` punya empat baris; seluruhnya 36 baris untuk 23 sekolah.
+--
+-- KENAPA
+--
+-- `submit_pendaftaran` mencari sekolahnya lewat pasangan (name, address)
+-- PERSIS:
+--
+--     insert into sekolah (name, address) values (trim(...), trim(...))
+--     on conflict (name, address) do nothing;
+--     select id into v_sekolah from sekolah where name = ... and address = ...;
+--
+-- Beda satu koma, beda `Jl.` dan `Jln.`, beda spasi — baris baru, id baru.
+--
+-- `unique (name, address)` di 0001 dipasang untuk alasan yang masuk akal:
+-- alur 3.2.2 ingin dua sekolah senama di tempat berbeda tetap bisa hidup
+-- berdampingan, dan `address` dipakai sebagai pembedanya. Niatnya benar.
+-- Mekanismenya terlalu harfiah: ia tidak bisa membedakan "sekolah yang sama,
+-- alamatnya diketik lebih sembarangan" dari "sekolah lain di tempat lain".
+--
+-- YANG PALING MAHAL, DAN TIDAK KELIHATAN DI LAYAR MANA PUN
+--
+-- Pembagian kloter menyebar regu satu sekolah supaya tidak berangkat bareng
+-- (CLAUDE.md 12.5), dan penyebaran itu membandingkan `sekolah_id`. Empat baris
+-- SMPN 2 Cipaku terbaca sebagai EMPAT SEKOLAH BERLAINAN, jadi aturannya
+-- berhenti berlaku di antara mereka dan regunya berangkat bersamaan — tanpa
+-- satu pun pesan galat. Itu yang benar-benar terjadi di data contoh.
+--
+-- CARA MEMPERBAIKINYA
+--
+-- Pembedanya dipindah dari `address` ke dalam `name`. Dua sekolah yang
+-- benar-benar berbeda tapi senama diberi ekor kabupaten — `MAN 3 Ciamis` dan
+-- `MAN 3 Tasikmalaya` — dan yang menentukan mereka memang dua sekolah adalah
+-- NPSN, bukan alamatnya (docs/runbook-sekolah.md bagian 5). Nama itu lalu
+-- cukup membedakan sendirian, jadi kuncinya cukup nama, dan `address` kembali
+-- jadi keterangan.
+--
+-- Alamat bakunya diambil dari daftar kurasi `tools/data/sekolah_alamat.json`:
+-- 189 sekolah yang identitas dan alamatnya sudah dilacak satu per satu ke Data
+-- Referensi Kemendikdasmen. Bentuknya seragam:
+--
+--     Jl. Jenderal Sudirman No. 6, Ciamis, Kec. Ciamis, Kabupaten Ciamis,
+--     Jawa Barat 46211, Indonesia
+--
+-- KENAPA NORMALISASINYA SEDERHANA
+--
+-- `kunci_sekolah()` di bawah jauh lebih jinak daripada `kunci()` di
+-- `tools/normalize_sekolah.py`. Yang di Python bertugas MENGGABUNGKAN 326
+-- tulisan tangan jadi klaster — ia boleh agresif, karena hasilnya diperiksa
+-- manusia sebelum dipakai. Yang di sini bertugas MENOLAK baris kembar tanpa
+-- ada yang memeriksa, jadi ia hanya boleh menyamakan yang pasti sama:
+-- besar-kecil huruf, tanda baca, dan `SMP Negeri` dengan `SMPN`. Normalisasi
+-- yang lebih rakus akan melebur dua sekolah yang berbeda, dan itu kerusakan
+-- yang jauh lebih sulit ditemukan daripada baris kembar.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kunci penyamaan nama.
+-- ---------------------------------------------------------------------------
+create or replace function kunci_sekolah(p_nama text)
+returns text
+language sql immutable
+set search_path = public
+as $$
+  select btrim(regexp_replace(
+           regexp_replace(
+             regexp_replace(lower(coalesce(p_nama, '')), '[^a-z0-9]+', ' ', 'g'),
+             -- "SMP Negeri 1" dan "SMP N 1" adalah "SMPN 1".
+             '\y(sd|smp|sma|smk|mi|mts|ma)\s+n(egeri)?\y', '\1n', 'g'),
+           '\s+', ' ', 'g'))
+$$;
+
+comment on function kunci_sekolah(text) is
+  'Penyamaan nama sekolah untuk unique index. Sengaja jinak: hanya besar-kecil huruf, tanda baca, dan bentuk "Negeri". Yang membedakan dua sekolah senama adalah ekor kabupaten di dalam namanya, bukan fungsi ini.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Laporkan dulu apa yang akan dilebur. Migrasi yang menghapus baris tanpa
+--    menyebut baris mana adalah migrasi yang tidak bisa diperiksa sesudahnya.
+-- ---------------------------------------------------------------------------
+do $$
+declare r record;
+begin
+  for r in
+    select kunci_sekolah(name) as k, count(*) as n,
+           string_agg(format('%s <%s>', name, address), ' | ' order by created_at) as isi
+      from sekolah group by 1 having count(*) > 1 order by 2 desc, 1
+  loop
+    raise notice '0061: % baris -> 1 : %', r.n, r.isi;
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Lebur. Yang bertahan adalah baris TERTUA — ia yang paling mungkin sudah
+--    dirujuk pendaftaran lain, dan namanya toh ditimpa nama baku di langkah 4.
+-- ---------------------------------------------------------------------------
+-- Tanpa `on commit drop`: psql menjalankan tiap perintah dalam transaksinya
+-- sendiri, jadi tabelnya akan lenyap sebelum baris berikutnya membacanya.
+-- Ia dibuang sendiri di ujung berkas.
+drop table if exists peta_lebur;
+create temporary table peta_lebur as
+with urut as (
+  select id,
+         first_value(id) over (partition by kunci_sekolah(name)
+                               order by created_at, id) as pemenang
+    from sekolah
+)
+select id as id_lama, pemenang from urut where id <> pemenang;
+
+do $$
+declare v_n int; v_p int;
+begin
+  select count(*) into v_n from peta_lebur;
+
+  update pendaftaran d set sekolah_id = m.pemenang
+    from peta_lebur m where d.sekolah_id = m.id_lama;
+  get diagnostics v_p = row_count;
+
+  delete from sekolah where id in (select id_lama from peta_lebur);
+  raise notice '0061: % baris kembar dihapus, % pendaftaran dialihkan.', v_n, v_p;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Nama dan alamat baku, dari daftar kurasi.
+-- ---------------------------------------------------------------------------
+drop table if exists sekolah_baku;
+create temporary table sekolah_baku (nama text, alamat text);
+insert into sekolah_baku (nama, alamat) values
+  ('MA Al-Azhar Kota Banjar',
+   'Jl. Pesantren No. 02, Kujangsari, Kec. Langensari, Kota Banjar, Jawa Barat 46345, Indonesia'),   -- NPSN 20277086
+  ('MA Al-Kautsar',
+   'Jl. Pejuang No. 100, Jajawar, Kec. Banjar, Kota Banjar, Jawa Barat 46318, Indonesia'),   -- NPSN 20277087
+  ('MA Assalimiyah',
+   'Jl. KH. Salim No. 1, Darmacaang, Kec. Cikoneng, Kabupaten Ciamis, Jawa Barat 46261, Indonesia'),   -- NPSN 20276445
+  ('MA YPI Rijalul Hikam',
+   'Jl. Raya Jatinagara No. 03, Jatinagara, Kec. Jatinagara, Kabupaten Ciamis, Jawa Barat 46273, Indonesia'),   -- NPSN 20280199
+  ('MTs Rancah',
+   'Jl. Cibeureum No. 50, Rancah, Kec. Rancah, Kabupaten Ciamis, Jawa Barat, Indonesia'),   -- NPSN 20278706
+  ('MTs Rijalul Hikam',
+   'Jl. Raya Jatinagara No. 03, Jatinagara, Kec. Jatinagara, Kabupaten Ciamis, Jawa Barat 46273, Indonesia'),   -- NPSN 20278644
+  ('SMA IT Al-Falah',
+   'Jl. Citalahab, Mekarjaya, Kec. Bungbulang, Kabupaten Garut, Jawa Barat 44165, Indonesia'),   -- NPSN 69830402
+  ('SMA Islam Ainurrafiq',
+   'Jl. Pemuda No. 001, Panawuan, Kec. Cigandamekar, Kabupaten Kuningan, Jawa Barat 45556, Indonesia'),   -- NPSN 20212946
+  ('SMA Islam Nurul Fikri',
+   'Jl. Palka, Bantarwaru, Kec. Cinangka, Kabupaten Serang, Banten 42167, Indonesia'),   -- NPSN 20607991
+  ('SMA Terpadu Cikanyere',
+   'Dusun Cigoong RT 01 RW 01, Sirnabaya, Kec. Rajadesa, Kabupaten Ciamis, Jawa Barat 46254, Indonesia'),   -- NPSN 69988141
+  ('SMA Terpadu Riyadlul Ulum',
+   'Komplek Pesantren Condong-Cibeurem, Setianagara, Kec. Cibeureum, Kota Tasikmalaya, Jawa Barat 46196, Indonesia'),   -- NPSN 20224512
+  ('SMAN 1 Cihaurbeuti',
+   'Jl. Kartawijaya No. 600, Pamokolan, Kec. Cihaurbeuti, Kabupaten Ciamis, Jawa Barat 46262, Indonesia'),   -- NPSN 20211578
+  ('SMAN 1 Cirebon',
+   'Jl. Wahidin Sudirohusodo No. 81, Sukapura, Kec. Kejaksan, Kota Cirebon, Jawa Barat 45122, Indonesia'),   -- NPSN 20222364
+  ('SMAN 1 Maja',
+   'Jl. Raya Maja Selatan No. 6, Maja Selatan, Kec. Maja, Kabupaten Majalengka, Jawa Barat 45461, Indonesia'),   -- NPSN 20213894
+  ('SMK Bangkit Indonesia Talaga',
+   'Jl. Ganeas No. 01, Ganeas, Kec. Talaga, Kabupaten Majalengka, Jawa Barat 45463, Indonesia'),   -- NPSN 69816737
+  ('SMK Galuh Rahayu',
+   'Jl. Raya Sukaraja, Sukaraja, Kec. Sindangkasih, Kabupaten Ciamis, Jawa Barat 46268, Indonesia'),   -- NPSN 20254622
+  ('SMK Siliwangi AMS Banjarsari',
+   'Jl. Raya Timur No. 60, Cibadak, Kec. Banjarsari, Kabupaten Ciamis, Jawa Barat, Indonesia'),   -- NPSN 20254624
+  ('SMKN 1 Losarang',
+   'Jl. Raya Santing, Santing, Kec. Losarang, Kabupaten Indramayu, Jawa Barat 45253, Indonesia'),   -- NPSN 20216001
+  ('SMKN 2 Ciamis',
+   'Jl. Sadananya No. 21, Maleber, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46214, Indonesia'),   -- NPSN 20211512
+  ('SMP Islam Ainurrafiq',
+   'Jl. Pemuda No. 001, Panawuan, Kec. Cigandamekar, Kabupaten Kuningan, Jawa Barat 45556, Indonesia'),   -- NPSN 20212933
+  ('SMP Terpadu Riyadlul Ulum Waddawah',
+   'Komplek Pesantren Condong RT 01 RW 04, Setianegara, Kec. Cibeureum, Kota Tasikmalaya, Jawa Barat 46196, Indonesia'),   -- NPSN 20224575
+  ('SMPN 1 Ciamis',
+   'Jl. Jenderal Sudirman No. 6, Ciamis, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46211, Indonesia'),   -- NPSN 20211519
+  ('SMPN 2 Cipaku',
+   'Jl. Desa Cipaku No. 5, Cipaku, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia')   -- NPSN 20211649
+;
+
+do $$
+declare v_n int; r record;
+begin
+  update sekolah s
+     set name = b.nama, address = b.alamat
+    from sekolah_baku b
+   where kunci_sekolah(s.name) = kunci_sekolah(b.nama);
+  get diagnostics v_n = row_count;
+  raise notice '0061: % sekolah dibakukan dari daftar kurasi.', v_n;
+
+  -- Yang tidak ada di daftar kurasi dibiarkan apa adanya, tapi disebut
+  -- namanya. Sekolah baru memang boleh lahir dari pendaftaran; yang tidak
+  -- boleh adalah ia lahir DUA KALI, dan itu dijaga langkah 5.
+  for r in
+    select s.name, s.address from sekolah s
+     where not exists (select 1 from sekolah_baku b
+                        where kunci_sekolah(b.nama) = kunci_sekolah(s.name))
+     order by s.name
+  loop
+    raise notice '0061: di luar daftar kurasi, alamat dibiarkan — % <%>', r.name, r.address;
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Pagarnya. Ini bagian yang membuat perbaikan di atas bertahan.
+-- ---------------------------------------------------------------------------
+alter table sekolah drop constraint if exists sekolah_nama_alamat_key;
+alter table sekolah drop constraint if exists sekolah_name_address_key;
+
+create unique index if not exists sekolah_kunci_unik on sekolah (kunci_sekolah(name));
+
+comment on index sekolah_kunci_unik is
+  'Satu sekolah, satu baris. Menggantikan unique (name, address) dari 0001, yang memakai alamat sebagai pembeda dan karena itu membelah satu sekolah tiap kali alamatnya diketik berbeda.';
+
+-- ---------------------------------------------------------------------------
+-- 6. Pendaftaran mencari sekolah lewat NAMA.
+--
+--    Alamat yang diketik pembina hanya dipakai kalau sekolahnya memang belum
+--    ada. Kalau sudah ada, alamat kurasi yang bertahan — pembina sedang
+--    mendaftarkan regu, bukan sedang memperbaiki data kita.
+-- ---------------------------------------------------------------------------
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+begin
+  -- Kiriman ulang dengan kunci yang sama: kembalikan hasil yang dulu.
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', v_ada.jumlah_regu * (select biaya_per_regu from edisi where is_active),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in
+       ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi') then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    -- Dua pendaftaran sekolah yang sama pada detik yang sama: yang kalah
+    -- membaca baris pemenangnya, bukan gagal.
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim, nama_kontak)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''))
+  returning id into v_batch;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan'
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', v_n * (select biaya_per_regu from edisi where is_active));
+end;
+$$;
+
+drop table peta_lebur;
+drop table sekolah_baku;
+
+-- ---------------------------------------------------------------------------
+-- 7. Hasilnya.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_s int; v_d int;
+begin
+  select count(*) into v_s from sekolah;
+  select count(*) into v_d from (
+    select 1 from sekolah group by kunci_sekolah(name) having count(*) > 1) x;
+  raise notice '0061: % sekolah, % nama kembar.', v_s, v_d;
+  assert v_d = 0, 'masih ada nama sekolah kembar';
+end $$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -198,5 +198,12 @@ run tests/sql/26_nilai_mentah_bulat.sql
 # regu hanya mengisi tiga — Tebak Simpul ada empat versi, satu per golongan.
 run supabase/migrations/0060_kelengkapan_per_golongan.sql
 run tests/sql/27_kelengkapan_per_golongan.sql
+# 0061 melebur baris sekolah kembar dan memindahkan kuncinya dari
+# (name, address) ke nama saja. Tesnya menjaga dua arah sekaligus: alamat
+# berbeda tidak lagi melahirkan baris baru, DAN dua sekolah yang memang
+# berbeda tetap boleh berdampingan — kebutuhan asli yang membuat 0001 memakai
+# alamat sebagai pembeda.
+run supabase/migrations/0061_sekolah_satu_baris.sql
+run tests/sql/28_sekolah_satu_baris.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/28_sekolah_satu_baris.sql
+++ b/tests/sql/28_sekolah_satu_baris.sql
@@ -1,0 +1,164 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/28_sekolah_satu_baris.sql
+-- Satu sekolah, satu baris (migrasi 0061).
+--
+-- Yang dijaga paling keras ada dua, dan keduanya pernah gagal diam-diam:
+--
+-- 1. **Alamat berbeda tidak lagi melahirkan baris baru.** Ini penyebab
+--    aslinya: `SMPN 1 CIAMIS` muncul tiga kali di kotak pilihan pendaftaran
+--    karena tiga pembina mengetik alamatnya dengan tiga cara.
+-- 2. **Penolakannya datang dari DATABASE.** Kotak pilihan di layar hanya
+--    menawarkan yang sudah ada; ia tidak menahan `submit_pendaftaran` yang
+--    dipanggil langsung, tidak menahan import, dan tidak menahan siapa pun
+--    yang mengetik nama sekolahnya sendiri karena sekolahnya belum terdaftar.
+--
+-- Dan satu yang harus TIDAK terjadi: dua sekolah yang memang berbeda tetap
+-- boleh hidup berdampingan. Itu kebutuhan asli yang membuat 0001 memakai
+-- alamat sebagai pembeda, dan menghapusnya sambil merusak kebutuhan itu bukan
+-- perbaikan.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kunci penyamaannya: jinak, dan cuma sejinak itu.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  -- Besar-kecil huruf dan tanda baca hilang.
+  assert kunci_sekolah('SMPN 1 CIAMIS') = kunci_sekolah('SMPN 1 Ciamis'),
+         'besar-kecil huruf seharusnya tidak membedakan';
+  assert kunci_sekolah('MTs Al-Fadliliyah') = kunci_sekolah('MTS AL FADLILIYAH'),
+         'tanda hubung seharusnya tidak membedakan';
+  assert kunci_sekolah('  SMPN   1  Ciamis  ') = kunci_sekolah('SMPN 1 Ciamis'),
+         'spasi berlebih seharusnya tidak membedakan';
+
+  -- Bentuk "Negeri" disamakan, karena pembina menulis dua-duanya.
+  assert kunci_sekolah('SMP Negeri 1 Ciamis') = kunci_sekolah('SMPN 1 Ciamis'),
+         'SMP Negeri 1 dan SMPN 1 adalah satu sekolah';
+  assert kunci_sekolah('SMK Negeri 3 Tasikmalaya') = kunci_sekolah('SMKN 3 Tasikmalaya'),
+         'SMK Negeri 3 dan SMKN 3 adalah satu sekolah';
+  assert kunci_sekolah('MTs N 5 Ciamis') = kunci_sekolah('MTsN 5 Ciamis'),
+         'MTs N 5 dan MTsN 5 adalah satu sekolah';
+
+  -- Dan TIDAK lebih jauh dari itu. Ekor kabupaten adalah satu-satunya yang
+  -- memisahkan dua sekolah senama (runbook bagian 5); kunci yang membuangnya
+  -- akan melebur keduanya tanpa suara.
+  assert kunci_sekolah('MAN 3 Ciamis') <> kunci_sekolah('MAN 3 Tasikmalaya'),
+         'MAN 3 Ciamis dan MAN 3 Tasikmalaya adalah DUA sekolah (NPSN berbeda)';
+  assert kunci_sekolah('MTs PUI Cijantung') <> kunci_sekolah('MA PUI Cijantung'),
+         'jenjang berbeda adalah sekolah berbeda';
+  assert kunci_sekolah('SMPN 1 Ciamis') <> kunci_sekolah('SMPN 2 Ciamis'),
+         'angka sekolah tidak boleh ikut hilang';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Alamat berbeda TIDAK melahirkan baris baru.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_n_awal   int;
+  v_n_akhir  int;
+  v_id_1     uuid;
+  v_id_2     uuid;
+  v_alamat   text;
+begin
+  select count(*) into v_n_awal from sekolah;
+
+  insert into sekolah (name, address)
+  values ('SMPN 9 Uji Kembar', 'Jl. Pertama No. 1')
+  returning id into v_id_1;
+
+  -- Nama sama, alamat beda: dulu lolos, sekarang ditolak.
+  begin
+    insert into sekolah (name, address)
+    values ('SMPN 9 Uji Kembar', 'Jl. Pertama No. 1, Ciamis');
+    assert false, 'nama sama dengan alamat beda seharusnya ditolak sekarang';
+  exception when unique_violation then null;
+  end;
+
+  -- Ejaan nama yang berbeda pun ditolak.
+  begin
+    insert into sekolah (name, address)
+    values ('SMP NEGERI 9 UJI KEMBAR', 'Jl. Lain Sama Sekali');
+    assert false, 'SMP Negeri 9 dan SMPN 9 seharusnya ditolak sebagai kembar';
+  exception when unique_violation then null;
+  end;
+
+  -- Sekolah yang memang berbeda tetap masuk. Ini kebutuhan asli 0001 dan ia
+  -- tidak boleh ikut mati.
+  insert into sekolah (name, address)
+  values ('SMPN 9 Uji Kembar Tasikmalaya', 'Jl. Kedua No. 2')
+  returning id into v_id_2;
+  assert v_id_1 <> v_id_2, 'dua sekolah berbeda seharusnya dua baris';
+
+  select count(*) into v_n_akhir from sekolah;
+  assert v_n_akhir = v_n_awal + 2,
+         format('seharusnya bertambah 2 baris, bertambah %s', v_n_akhir - v_n_awal);
+
+  delete from sekolah where id in (v_id_1, v_id_2);
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Lewat pintu yang sebenarnya: submit_pendaftaran.
+--
+--    Dua pembina dari sekolah yang sama, alamat diketik berbeda, dan yang
+--    kedua bahkan mengetik namanya dengan huruf kapital semua. Satu sekolah,
+--    dua pendaftaran.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_n     int;
+  v_alamat text;
+  v_regu  jsonb := jsonb_build_array(jsonb_build_object(
+            'nama_regu', 'Uji Pintu Pertama', 'nama_ketua', 'Ketua Uji',
+            'golongan', 'penggalang_pa'));
+begin
+  perform submit_pendaftaran(
+    'SMPN 8 Uji Pintu', 'Jl. Benar No. 10, Ciamis', false, '081200000001', v_regu);
+
+  perform submit_pendaftaran(
+    'SMPN 8 UJI PINTU', 'jln benar no 10', false, '081200000002',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'Uji Pintu Kedua', 'nama_ketua', 'Ketua Uji',
+      'golongan', 'penggalang_pi')));
+
+  select count(*) into v_n from sekolah
+   where kunci_sekolah(name) = kunci_sekolah('SMPN 8 Uji Pintu');
+  assert v_n = 1, format('seharusnya satu baris sekolah, ada %s', v_n);
+
+  -- Alamat kurasi bertahan. Pembina kedua sedang mendaftarkan regu, bukan
+  -- sedang memperbaiki data kita — kalau alamatnya ikut tertimpa, satu salah
+  -- ketik menghapus alamat yang sudah benar.
+  select address into v_alamat from sekolah
+   where kunci_sekolah(name) = kunci_sekolah('SMPN 8 Uji Pintu');
+  assert v_alamat = 'Jl. Benar No. 10, Ciamis',
+         format('alamat seharusnya tidak tertimpa, jadi %L', v_alamat);
+
+  -- Dua pendaftaran, dan keduanya menunjuk sekolah yang sama. Ini yang
+  -- membuat penyebaran kloter bekerja: regu kedua sekolah ini terbaca satu
+  -- sekolah, jadi mereka TIDAK berangkat bareng (CLAUDE.md 12.5).
+  select count(distinct d.sekolah_id) into v_n
+    from pendaftaran d join sekolah s on s.id = d.sekolah_id
+   where kunci_sekolah(s.name) = kunci_sekolah('SMPN 8 Uji Pintu');
+  assert v_n = 1, format('dua pendaftaran seharusnya satu sekolah_id, ada %s', v_n);
+
+  delete from regu where pendaftaran_id in (
+    select d.id from pendaftaran d join sekolah s on s.id = d.sekolah_id
+     where kunci_sekolah(s.name) = kunci_sekolah('SMPN 8 Uji Pintu'));
+  delete from pendaftaran where sekolah_id in (
+    select id from sekolah where kunci_sekolah(name) = kunci_sekolah('SMPN 8 Uji Pintu'));
+  delete from sekolah where kunci_sekolah(name) = kunci_sekolah('SMPN 8 Uji Pintu');
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Seluruh isi tabel lolos — kalau tidak, migrasinya gagal di produksi dan
+--    yang menemukannya adalah apply-migration yang merah.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_n int;
+begin
+  select count(*) into v_n from (
+    select 1 from sekolah group by kunci_sekolah(name) having count(*) > 1) x;
+  assert v_n = 0, format('%s nama sekolah masih kembar', v_n);
+end $$;
+
+\echo '28 sekolah satu baris: LULUS'


### PR DESCRIPTION
## What

**Migrasi 0061.** Kotak "Asal sekolah" di layar pendaftaran menawarkan
`SMPN 1 CIAMIS` tiga kali dengan tiga alamat berbeda; `SMPN 2 CIPAKU` empat
kali. Seluruhnya **36 baris untuk 23 sekolah**.

- `kunci_sekolah()` — penyamaan nama: besar-kecil huruf, tanda baca, dan
  `SMP Negeri` ~ `SMPN`. Sengaja jauh lebih jinak daripada `kunci()` di
  `normalize_sekolah.py`.
- 13 baris kembar dilebur, pendaftarannya dialihkan ke baris yang bertahan.
- 23 sekolah dibakukan nama **dan alamatnya** dari `tools/data/sekolah_alamat.json`,
  dalam satu bentuk seragam:
  `Jl. Jenderal Sudirman No. 6, Ciamis, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46211, Indonesia`
- `unique (name, address)` diganti `unique index (kunci_sekolah(name))`.
- `submit_pendaftaran` mencari sekolah lewat **nama**, dan alamat kurasi tidak
  tertimpa oleh yang diketik pembina.

**Layar pendaftaran.** Kalimat "isi alamat — untuk membedakan sekolah bernama
sama" sekarang keliru dan dihapus. Kartu "sekolahmu belum ada" gantinya
menyebut satu hal yang mahal kalau tidak diketahui: nama yang persis sama akan
menyatu, jadi tambahkan kabupatennya.

## Why

`submit_pendaftaran` mencari sekolah lewat pasangan `(name, address)` persis,
jadi beda satu koma melahirkan baris baru. `unique (name, address)` di 0001
memang disengaja — alur 3.2.2 ingin dua sekolah senama di tempat berbeda tetap
berdampingan, dan alamat dipakai sebagai pembedanya. Niatnya benar;
mekanismenya terlalu harfiah.

Yang paling mahal tidak kelihatan di layar mana pun: pembagian kloter menyebar
regu satu sekolah supaya tidak berangkat bareng (CLAUDE.md 12.5), dan
penyebaran itu membandingkan `sekolah_id`. Empat baris SMPN 2 Cipaku terbaca
sebagai empat sekolah berlainan, jadi aturannya berhenti berlaku di antara
mereka — tanpa satu pun pesan galat.

Pembedanya dipindah dari alamat ke dalam nama, tempat panitia juga bisa
membacanya: `MAN 3 Ciamis` dan `MAN 3 Tasikmalaya`. Yang menentukan keduanya
memang dua sekolah adalah NPSN, bukan alamatnya — runbook bagian 5.

## Notes

Tes 28 menjaga dua arah sekaligus, dan arah kedua yang mudah hilang: dua
sekolah yang memang berbeda **tetap** boleh berdampingan. Menghapus pagar lama
sambil merusak kebutuhan yang melahirkannya bukan perbaikan.

Sekolah di luar daftar kurasi tidak diapa-apakan alamatnya — migrasinya
menyebut namanya satu per satu lewat `raise notice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)