### PR TITLE
fix: enam sekolah yang luput dari pembakuan 0061

### DIFF
--- a/supabase/migrations/0062_sekolah_nama_dapodik.sql
+++ b/supabase/migrations/0062_sekolah_nama_dapodik.sql
@@ -1,0 +1,155 @@
+-- ============================================================================
+-- hrcd-rekap : 0062_sekolah_nama_dapodik.sql
+-- Enam sekolah yang luput dari pembakuan 0061, dan kenapa mereka luput.
+--
+-- APA YANG TERJADI
+--
+-- 0061 melebur 36 baris jadi 23 dengan benar, tapi hanya **17** yang nama dan
+-- alamatnya berhasil dibakukan dari daftar kurasi. Enam sisanya lewat:
+--
+--     MA ASALIMIAH                  -> MA Assalimiyah
+--     MAS AL-KAUTSAR                -> MA Al-Kautsar
+--     SMAI NURUL FIKRI              -> SMA Islam Nurul Fikri
+--     SMAT RIYADLUL ULUM            -> SMA Terpadu Riyadlul Ulum
+--     SMKS GALUH RAHAYU             -> SMK Galuh Rahayu
+--     SMPT RIYADLUL ULUM WADDAWAH   -> SMP Terpadu Riyadlul Ulum Waddawah
+--
+-- KENAPA
+--
+-- 0061 mencocokkan baris produksi dengan daftar kurasi memakai
+-- `kunci_sekolah()` — kunci yang SENGAJA jinak, karena tugasnya menolak baris
+-- kembar tanpa ada yang memeriksa. Tapi pencocokan ke daftar kurasi adalah
+-- pekerjaan yang berbeda: ia dilakukan sekali, hasilnya diperiksa, dan ia
+-- perlu tahu bahwa `ASALIMIAH` dan `Assalimiyah` adalah satu pesantren.
+-- Pengetahuan itu ada — di `kunci()` milik `tools/normalize_sekolah.py`, yang
+-- memang dibangun untuk itu — dan 0061 memakai kunci yang salah untuk
+-- langkah itu.
+--
+-- Karena itu pemetaan di bawah ditulis TANGAN, dari nama yang benar-benar
+-- ada di produksi. Tidak ada normalisasi yang perlu dipercaya: enam baris,
+-- disebut satu per satu, bisa dibaca ulang oleh siapa pun.
+--
+-- SEKALIAN: HURUF STATUS DAPODIK
+--
+-- Empat dari enam nama itu berawalan bentuk Dapodik — `MAS`, `SMKS`, `SMAS`,
+-- `MTsS` — di mana huruf `S` terakhir berarti *Swasta*. Itu status, bukan
+-- bagian dari nama sekolah, dan pembina menulis dua-duanya. `kunci_sekolah()`
+-- diperluas untuk membuangnya, jadi `SMKS Galuh Rahayu` yang diketik tahun
+-- depan mendarat di baris yang sama dengan `SMK Galuh Rahayu`.
+--
+-- `SMAI`, `SMAT`, `SMPT` TIDAK ikut diperluas, walau ketiganya juga singkatan
+-- (Islam, Terpadu). Alasannya: huruf status hanya punya satu arti, sedangkan
+-- membuang `T` dari `SMAT` akan menyamakan "SMA Terpadu X" dengan "SMA X" —
+-- dan itu bisa saja dua sekolah. Yang tidak pasti diselesaikan dengan
+-- penggantian nama seperti di atas, bukan dengan kunci yang lebih rakus.
+--
+-- URUTANNYA PENTING
+--
+-- `sekolah_kunci_unik` adalah index atas `kunci_sekolah(name)`. Mengganti isi
+-- fungsinya sementara index-nya masih berdiri meninggalkan index yang isinya
+-- dihitung dengan rumus lama — ia akan tampak sehat dan diam-diam meloloskan
+-- baris kembar. Jadi: index dibuang dulu, fungsinya diganti, baru index
+-- dipasang lagi.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Lepas index yang bergantung pada fungsinya.
+-- ---------------------------------------------------------------------------
+drop index if exists sekolah_kunci_unik;
+
+-- ---------------------------------------------------------------------------
+-- 2. Kunci yang juga membuang huruf status Dapodik.
+-- ---------------------------------------------------------------------------
+create or replace function kunci_sekolah(p_nama text)
+returns text
+language sql immutable
+set search_path = public
+as $$
+  select btrim(regexp_replace(
+           regexp_replace(
+             regexp_replace(
+               regexp_replace(lower(coalesce(p_nama, '')), '[^a-z0-9]+', ' ', 'g'),
+               -- "SMP Negeri 1" dan "SMP N 1" adalah "SMPN 1".
+               '\y(sd|smp|sma|smk|mi|mts|ma)\s+n(egeri)?\y', '\1n', 'g'),
+             -- Huruf status Dapodik di AWAL nama: SMKS, SMAS, SMPS, MAS, MTsS,
+             -- MIS. "S" itu Swasta — status, bukan nama. Diikat ke awal
+             -- (`^`) supaya tidak menyentuh kata lain yang kebetulan berakhir
+             -- begitu di tengah nama.
+             '^(sd|smp|sma|smk|mi|mts|ma)s\y', '\1', 'g'),
+           '\s+', ' ', 'g'))
+$$;
+
+comment on function kunci_sekolah(text) is
+  'Penyamaan nama sekolah untuk unique index. Sengaja jinak: besar-kecil huruf, tanda baca, bentuk "Negeri", dan huruf status Dapodik (Swasta). TIDAK membuang singkatan seperti SMAT/SMAI — itu bisa memisahkan dua sekolah yang berbeda.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Enam nama yang tertinggal, ditulis tangan dari isi produksi.
+--
+--    Alamatnya dari `tools/data/sekolah_alamat.json`, bentuk yang sama dengan
+--    0061: jalan, desa, Kec., kabupaten, provinsi + kode pos, Indonesia.
+-- ---------------------------------------------------------------------------
+drop table if exists sekolah_ganti;
+create temporary table sekolah_ganti (lama text, nama text, alamat text);
+insert into sekolah_ganti (lama, nama, alamat) values
+  ('MA ASALIMIAH',
+   'MA Assalimiyah',
+   'Jl. KH. Salim No. 1, Darmacaang, Kec. Cikoneng, Kabupaten Ciamis, Jawa Barat 46261, Indonesia'),
+  ('MAS AL-KAUTSAR',
+   'MA Al-Kautsar',
+   'Jl. Pejuang No. 100, Jajawar, Kec. Banjar, Kota Banjar, Jawa Barat 46318, Indonesia'),
+  ('SMAI NURUL FIKRI',
+   'SMA Islam Nurul Fikri',
+   'Jl. Palka, Bantarwaru, Kec. Cinangka, Kabupaten Serang, Banten 42167, Indonesia'),
+  ('SMAT RIYADLUL ULUM',
+   'SMA Terpadu Riyadlul Ulum',
+   'Komplek Pesantren Condong-Cibeurem, Setianagara, Kec. Cibeureum, Kota Tasikmalaya, Jawa Barat 46196, Indonesia'),
+  ('SMKS GALUH RAHAYU',
+   'SMK Galuh Rahayu',
+   'Jl. Raya Sukaraja, Sukaraja, Kec. Sindangkasih, Kabupaten Ciamis, Jawa Barat 46268, Indonesia'),
+  ('SMPT RIYADLUL ULUM WADDAWAH',
+   'SMP Terpadu Riyadlul Ulum Waddawah',
+   'Komplek Pesantren Condong RT 01 RW 04, Setianegara, Kec. Cibeureum, Kota Tasikmalaya, Jawa Barat 46196, Indonesia')
+;
+
+do $$
+declare r record; v_n int := 0;
+begin
+  for r in select * from sekolah_ganti order by lama loop
+    update sekolah set name = r.nama, address = r.alamat where name = r.lama;
+    if found then
+      v_n := v_n + 1;
+      raise notice '0062: % -> %', r.lama, r.nama;
+    else
+      -- Bukan galat: di database uji keenamnya memang tidak ada, dan di
+      -- produksi ia berarti migrasinya sudah pernah dijalankan.
+      raise notice '0062: % tidak ada, dilewati', r.lama;
+    end if;
+  end loop;
+  raise notice '0062: % nama dibakukan.', v_n;
+end $$;
+
+drop table sekolah_ganti;
+
+-- ---------------------------------------------------------------------------
+-- 4. Pasang lagi pagarnya, dengan rumus yang baru.
+-- ---------------------------------------------------------------------------
+create unique index sekolah_kunci_unik on sekolah (kunci_sekolah(name));
+
+comment on index sekolah_kunci_unik is
+  'Satu sekolah, satu baris. Menggantikan unique (name, address) dari 0001, yang memakai alamat sebagai pembeda dan karena itu membelah satu sekolah tiap kali alamatnya diketik berbeda.';
+
+-- ---------------------------------------------------------------------------
+-- 5. Hasilnya.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_s int; v_d int; v_tanpa int;
+begin
+  select count(*) into v_s from sekolah;
+  select count(*) into v_d from (
+    select 1 from sekolah group by kunci_sekolah(name) having count(*) > 1) x;
+  -- Alamat baku selalu berakhir "Indonesia". Yang tidak, berarti alamatnya
+  -- masih tulisan tangan pembina — sah, tapi pantas disebut.
+  select count(*) into v_tanpa from sekolah where address not like '%, Indonesia';
+  raise notice '0062: % sekolah, % nama kembar, % alamat belum baku.', v_s, v_d, v_tanpa;
+  assert v_d = 0, 'masih ada nama sekolah kembar';
+end $$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -204,6 +204,12 @@ run tests/sql/27_kelengkapan_per_golongan.sql
 # berbeda tetap boleh berdampingan — kebutuhan asli yang membuat 0001 memakai
 # alamat sebagai pembeda.
 run supabase/migrations/0061_sekolah_satu_baris.sql
+# 0062 membakukan enam nama yang luput dari 0061 dan memperluas
+# kunci_sekolah() ke huruf status Dapodik. Dijalankan SEBELUM tes 28, karena
+# tes itu menguji kunci versi terbaru — dan 0062 harus membuang index-nya
+# dulu sebelum mengganti fungsinya, kalau tidak index-nya tertinggal memakai
+# rumus lama dan diam-diam meloloskan baris kembar.
+run supabase/migrations/0062_sekolah_nama_dapodik.sql
 run tests/sql/28_sekolah_satu_baris.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/28_sekolah_satu_baris.sql
+++ b/tests/sql/28_sekolah_satu_baris.sql
@@ -39,6 +39,21 @@ begin
   assert kunci_sekolah('MTs N 5 Ciamis') = kunci_sekolah('MTsN 5 Ciamis'),
          'MTs N 5 dan MTsN 5 adalah satu sekolah';
 
+  -- Huruf status Dapodik (S = Swasta) dibuang — migrasi 0062. Ia status,
+  -- bukan nama, dan pembina menulis dua-duanya.
+  assert kunci_sekolah('SMKS Galuh Rahayu') = kunci_sekolah('SMK Galuh Rahayu'),
+         'SMKS dan SMK adalah satu sekolah';
+  assert kunci_sekolah('MAS Al-Kautsar') = kunci_sekolah('MA Al-Kautsar'),
+         'MAS dan MA adalah satu sekolah';
+  assert kunci_sekolah('MTsS Al-Fadliliyah') = kunci_sekolah('MTs Al-Fadliliyah'),
+         'MTsS dan MTs adalah satu sekolah';
+
+  -- Tapi singkatan di dalam NAMA tidak dibuang. "SMA Terpadu X" dan "SMA X"
+  -- bisa saja dua sekolah, dan kunci yang menyamakannya melebur keduanya
+  -- tanpa suara — kekeliruan yang lebih sulit ditemukan daripada baris kembar.
+  assert kunci_sekolah('SMAT Riyadlul Ulum') <> kunci_sekolah('SMA Riyadlul Ulum'),
+         'SMAT tidak boleh disamakan dengan SMA begitu saja';
+
   -- Dan TIDAK lebih jauh dari itu. Ekor kabupaten adalah satu-satunya yang
   -- memisahkan dua sekolah senama (runbook bagian 5); kunci yang membuangnya
   -- akan melebur keduanya tanpa suara.


### PR DESCRIPTION
## What

**Migrasi 0062.** 0061 melebur 36 baris jadi 23 dengan benar, tapi hanya **17**
yang berhasil dibakukan dari daftar kurasi. Enam ini ditulis tangan:

| Di produksi | Baku |
| --- | --- |
| `MA ASALIMIAH` | `MA Assalimiyah` |
| `MAS AL-KAUTSAR` | `MA Al-Kautsar` |
| `SMAI NURUL FIKRI` | `SMA Islam Nurul Fikri` |
| `SMAT RIYADLUL ULUM` | `SMA Terpadu Riyadlul Ulum` |
| `SMKS GALUH RAHAYU` | `SMK Galuh Rahayu` |
| `SMPT RIYADLUL ULUM WADDAWAH` | `SMP Terpadu Riyadlul Ulum Waddawah` |

`kunci_sekolah()` sekalian diperluas membuang **huruf status Dapodik** di awal
nama — `SMKS`, `SMAS`, `MAS`, `MTsS`. `S` itu *Swasta*: status, bukan nama.

## Why

Kunci yang salah dipakai untuk pekerjaan yang salah. 0061 mencocokkan baris
produksi dengan daftar kurasi memakai `kunci_sekolah()` — yang sengaja jinak,
karena tugasnya menolak baris kembar tanpa ada yang memeriksa. Tapi pencocokan
ke daftar kurasi dilakukan **sekali dan hasilnya diperiksa**, jadi ia justru
perlu tahu bahwa `ASALIMIAH` dan `Assalimiyah` adalah satu pesantren.
Pengetahuan itu ada di `kunci()` milik `normalize_sekolah.py`, dan 0061 tidak
memakainya.

Maka pemetaannya ditulis tangan dari nama yang benar-benar ada di produksi —
enam baris, disebut satu per satu, tidak ada normalisasi yang perlu dipercaya.

`SMAI`/`SMAT`/`SMPT` sengaja **tidak** ikut diperluas walau juga singkatan:
huruf status cuma punya satu arti, sedangkan membuang `T` dari `SMAT`
menyamakan "SMA Terpadu X" dengan "SMA X" — dan itu bisa saja dua sekolah.
Yang tidak pasti diselesaikan dengan penggantian nama, bukan dengan kunci yang
lebih rakus.

## Notes

**Urutan operasinya ikut ditulis di kepala berkas karena mudah terbalik.**
`sekolah_kunci_unik` adalah index atas `kunci_sekolah(name)`, jadi fungsinya
tidak boleh diganti selagi index-nya berdiri: index-nya akan tertinggal memakai
rumus lama, tampak sehat, dan diam-diam meloloskan baris kembar. Index dibuang
dulu, fungsinya diganti, baru dipasang lagi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)