### PR TITLE
fix: kloter tidak pernah tertutup untuk penambahan regu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,22 +321,35 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 
 ## 12. Kloter
 
-1. **Kloter tercetak masih boleh diisi selama belum berangkat.** Mencetak
-   daftar bukan penutupan; yang menutup sebuah kloter adalah `jam_berangkat`-nya
-   terisi. Sekolah yang daftar ulang setelah kertas dicetak tetap masuk ke
-   kloter paling awal yang masih longgar, dan kertasnya dicetak ulang — itu
-   murah, dan jauh lebih murah daripada kloter setengah kosong berangkat.
+1. **Kloter tidak pernah tertutup untuk penambahan regu.** Bukan tanda
+   cetaknya, bukan juga jam berangkatnya — tidak ada keadaan yang membuat
+   sebuah kloter menolak regu baru. Yang membatasi cuma kapasitas. Mencetak
+   ulang selembar daftar itu murah; memberangkatkan kloter dengan empat tempat
+   kosong tidak bisa diulang, dan jendela 07:00-10:00 di bagian 10 tidak punya
+   kelonggaran untuk itu.
 2. **Selalu isi kloter paling awal dulu sampai penuh**, bukan menyebar rata.
    Kloter 1 penuh sebelum kloter 2 dipakai. Yang berangkat pagi harus berangkat
    penuh; tempat kosong yang tertinggal di kloter awal berarti kloter terakhir
    berangkat lebih siang dari yang perlu, dan jendela 07:00–10:00 di bagian 10
    tidak punya kelonggaran untuk itu.
-3. **Kode hari ini melanggar butir 1, dan itu belum diperbaiki.** Migrasi 0008
-   menambahkan syarat `dicetak_pada is null` ke pemilihan kloter beserta trigger
-   yang menolak penambahan ke kloter tercetak; 0040 mengembalikannya setelah
-   sempat hilang. Keduanya ditulis dengan niat melindungi kertas yang sudah
-   dibagikan — tapi niat itu bukan aturan lapangan. Perbaikannya: ganti
-   syaratnya jadi `jam_berangkat is null`.
+3. **Di lapangan semua dinamis, dan itu yang membuat butir 1 sekeras itu.**
+   Peserta yang terlambat bisa memaksa berangkat, dan panitia menambahkannya di
+   depan — "mereka seakan-akan berangkat di jam tersebut". Sistem yang menolak
+   tidak menghentikan penambahan itu; ia cuma memindahkannya ke jalan yang
+   tidak tercatat.
+
+   Konsekuensi yang perlu diketahui panitia yang menyisipkan: penalti waktu
+   dihitung dari `kloter.jam_berangkat`, jadi regu yang masuk ke kloter yang
+   sudah berangkat dihitung berangkat pada jam kloter itu — bukan jam ia
+   benar-benar jalan. Kalau maksudnya regu itu berangkat sekarang, tempatnya di
+   kloter yang belum jalan.
+
+   Riwayatnya, karena mudah dipasang kembali: migrasi 0008 menambahkan
+   `dicetak_pada is null` ke pemilihan kloter beserta trigger
+   `jaga_kloter_tercetak`; 0040 mengembalikannya setelah sempat hilang;
+   **0066 membuang keduanya beserta `jam_berangkat is null`**. Ketiganya
+   ditulis dengan niat melindungi kertas yang sudah dibagikan — niat yang
+   masuk akal di meja, dan salah di lapangan. Jangan dipasang lagi.
 4. **"Bersihkan data" termasuk mengembalikan penomoran kloter ke 1**, bukan
    hanya menghapus regu dan nilai. Kloter yang masih menyandang tanda cetak atau
    jam berangkat dari percobaan sebelumnya membuat pembagian berikutnya mulai

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,22 +319,35 @@ Guidance for Claude Code when working in this repository.
 
 ## 12. Kloter
 
-1. **Kloter tercetak masih boleh diisi selama belum berangkat.** Mencetak
-   daftar bukan penutupan; yang menutup sebuah kloter adalah `jam_berangkat`-nya
-   terisi. Sekolah yang daftar ulang setelah kertas dicetak tetap masuk ke
-   kloter paling awal yang masih longgar, dan kertasnya dicetak ulang — itu
-   murah, dan jauh lebih murah daripada kloter setengah kosong berangkat.
+1. **Kloter tidak pernah tertutup untuk penambahan regu.** Bukan tanda
+   cetaknya, bukan juga jam berangkatnya — tidak ada keadaan yang membuat
+   sebuah kloter menolak regu baru. Yang membatasi cuma kapasitas. Mencetak
+   ulang selembar daftar itu murah; memberangkatkan kloter dengan empat tempat
+   kosong tidak bisa diulang, dan jendela 07:00-10:00 di bagian 10 tidak punya
+   kelonggaran untuk itu.
 2. **Selalu isi kloter paling awal dulu sampai penuh**, bukan menyebar rata.
    Kloter 1 penuh sebelum kloter 2 dipakai. Yang berangkat pagi harus berangkat
    penuh; tempat kosong yang tertinggal di kloter awal berarti kloter terakhir
    berangkat lebih siang dari yang perlu, dan jendela 07:00–10:00 di bagian 10
    tidak punya kelonggaran untuk itu.
-3. **Kode hari ini melanggar butir 1, dan itu belum diperbaiki.** Migrasi 0008
-   menambahkan syarat `dicetak_pada is null` ke pemilihan kloter beserta trigger
-   yang menolak penambahan ke kloter tercetak; 0040 mengembalikannya setelah
-   sempat hilang. Keduanya ditulis dengan niat melindungi kertas yang sudah
-   dibagikan — tapi niat itu bukan aturan lapangan. Perbaikannya: ganti
-   syaratnya jadi `jam_berangkat is null`.
+3. **Di lapangan semua dinamis, dan itu yang membuat butir 1 sekeras itu.**
+   Peserta yang terlambat bisa memaksa berangkat, dan panitia menambahkannya di
+   depan — "mereka seakan-akan berangkat di jam tersebut". Sistem yang menolak
+   tidak menghentikan penambahan itu; ia cuma memindahkannya ke jalan yang
+   tidak tercatat.
+
+   Konsekuensi yang perlu diketahui panitia yang menyisipkan: penalti waktu
+   dihitung dari `kloter.jam_berangkat`, jadi regu yang masuk ke kloter yang
+   sudah berangkat dihitung berangkat pada jam kloter itu — bukan jam ia
+   benar-benar jalan. Kalau maksudnya regu itu berangkat sekarang, tempatnya di
+   kloter yang belum jalan.
+
+   Riwayatnya, karena mudah dipasang kembali: migrasi 0008 menambahkan
+   `dicetak_pada is null` ke pemilihan kloter beserta trigger
+   `jaga_kloter_tercetak`; 0040 mengembalikannya setelah sempat hilang;
+   **0066 membuang keduanya beserta `jam_berangkat is null`**. Ketiganya
+   ditulis dengan niat melindungi kertas yang sudah dibagikan — niat yang
+   masuk akal di meja, dan salah di lapangan. Jangan dipasang lagi.
 4. **"Bersihkan data" termasuk mengembalikan penomoran kloter ke 1**, bukan
    hanya menghapus regu dan nilai. Kloter yang masih menyandang tanda cetak atau
    jam berangkat dari percobaan sebelumnya membuat pembagian berikutnya mulai

--- a/supabase/migrations/0066_kloter_boleh_ditambah.sql
+++ b/supabase/migrations/0066_kloter_boleh_ditambah.sql
@@ -1,0 +1,325 @@
+-- ============================================================================
+-- hrcd-rekap : 0066_kloter_boleh_ditambah.sql
+-- Kloter tidak pernah tertutup untuk penambahan regu.
+--
+-- KEPUTUSAN PEMILIK ACARA, DAN IA LEBIH TEGAS DARIPADA YANG DIUSULKAN
+--
+-- CLAUDE.md 12.3 sudah mencatat bahwa kode melanggar aturan lapangan: migrasi
+-- 0008 menambahkan `dicetak_pada is null` ke pemilihan kloter, dan usulan
+-- perbaikannya waktu itu "ganti syaratnya jadi `jam_berangkat is null`".
+--
+-- Usulan itu ditolak. Yang diminta: **tidak ada aturan seperti itu sama
+-- sekali.**
+--
+--   "ketika di lapangan semua dinamis, bisa jadi peserta terlambat memaksa
+--    untuk berangkat jadi mereka seakan-akan berangkat di jam tersebut. Jadi
+--    biarkan saja panitia menambah peserta di depan."
+--
+-- Jadi kedua syarat dibuang, bukan ditukar. Kloter yang kertasnya sudah
+-- dicetak boleh ditambah. Kloter yang SUDAH BERANGKAT pun boleh ditambah, dan
+-- regu yang masuk ke sana tercatat berangkat pada jam kloter itu.
+--
+-- KENAPA PAGAR ITU SALAH SEJAK AWAL
+--
+-- Ia melindungi kertas, dan kertas bukan yang paling mahal. Yang mahal kloter
+-- setengah kosong berangkat sementara ada regu yang menunggu — jendela
+-- 07:00-10:00 (CLAUDE.md bagian 10) tidak punya kelonggaran untuk itu.
+-- Mencetak ulang selembar daftar itu murah; memberangkatkan kloter dengan
+-- empat tempat kosong tidak bisa diulang.
+--
+-- Dan pagarnya bukan cuma mahal, ia juga tidak menyelesaikan apa pun: petugas
+-- yang butuh menambah regu tetap menambahnya, cuma lewat jalan yang tidak
+-- tercatat.
+--
+-- YANG IKUT BERUBAH, DAN PANTAS DIKETAHUI SEBELUM HARI-H
+--
+-- Penalti waktu dihitung dari `kloter.jam_berangkat`. Regu yang disisipkan ke
+-- kloter yang sudah berangkat karena itu dihitung berangkat pada jam kloter
+-- tersebut — bukan pada jam ia benar-benar jalan. Itu memang yang diminta
+-- ("seakan-akan berangkat di jam tersebut"), tapi konsekuensinya nyata:
+-- menyisipkan regu ke kloter yang berangkat dua jam lalu memberinya kontrak
+-- yang sudah termakan dua jam. Panitia yang menyisipkan perlu tahu itu; kalau
+-- yang dimaksud regu itu berangkat sekarang, tempatnya di kloter yang belum
+-- jalan.
+--
+-- YANG TIDAK IKUT DIBUANG
+--
+-- Kapasitas per kloter tetap dijaga — kertas boleh dilanggar, jumlah orang
+-- yang muat di satu rombongan tidak. Penyebaran sekolah (12.5) juga tetap:
+-- urutan putaran pencariannya tidak disentuh sama sekali, hanya syarat
+-- penyaringnya yang hilang.
+--
+-- Dua tempat lain yang MEMBACA `dicetak_pada`/`jam_berangkat` sengaja
+-- dibiarkan, karena keduanya bukan larangan:
+--   * `pindah_kloter` menandai regu sebagai sisipan dan mengumumkannya bila
+--     kertas tujuannya sudah beredar — itu pemberitahuan, bukan penolakan.
+--   * `tukar_nomor_dada` menaikkan penukaran ke admin bila kertasnya sudah
+--     beredar — itu eskalasi, bukan penolakan.
+-- ============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. Trigger penjaganya dibuang.
+--
+--    `jaga_kloter_tercetak` (0008) menolak SETIAP perubahan `regu.kloter_nomor`
+--    yang menyentuh kloter tercetak, dari arah mana pun. Ia dipasang untuk
+--    melindungi kertas yang sudah dibagikan — niat yang masuk akal di meja,
+--    dan salah di lapangan.
+--
+--    `pindah_kloter` sampai sekarang membukanya lewat `set_config
+--    ('hrcd.izin_pindah', ...)` — pintu darurat untuk pagar yang seharusnya
+--    tidak ada. Pemanggilannya dibiarkan (tidak berbahaya, dan menghapusnya
+--    berarti mengetik ulang fungsi 135 baris demi satu baris mati).
+-- ---------------------------------------------------------------------------
+drop trigger if exists jaga_kloter_tercetak on regu;
+drop function if exists tolak_ubah_kloter_tercetak();
+
+-- ---------------------------------------------------------------------------
+-- 2. Pemilihan kloter: delapan syarat dibuang, sisanya UTUH.
+-- ---------------------------------------------------------------------------
+create or replace function daftar_ulang_batch(
+  p_kode  text,
+  -- [{"regu_id": "...", "nomor_dada": 12}, ...] — satu entri per regu yang
+  -- belum bernomor di batch ini, tidak boleh kurang dan tidak boleh lebih.
+  p_nomor jsonb
+)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_berhak     uuid[];
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];      -- kloter yang sudah berisi sekolah ini
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+  v_salah      text;
+begin
+  if not boleh('daftar_ulang') then
+    raise exception 'tidak berhak: daftar_ulang';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Regu yang berhak: belum bernomor, tidak batal (rancangan-b.md, temuan 11).
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.is_cancelled and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Pasangan regu -> nomor dari meja. Urutan deterministik (nama regu) supaya
+  -- hasil yang dibacakan meja urut sama dengan kartu di layar.
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+         as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) as t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) as t(g) where not (t.g = any (v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+
+  if exists (select 1 from unnest(v_nomor) as t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct t.nomor) from unnest(v_nomor) as t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  -- Kunci baris stok yang diminta, urut nomor supaya dua meja yang meminta
+  -- himpunan bertumpang tindih tidak saling mengunci silang. Meja kedua
+  -- menunggu sebentar lalu ditolak pemeriksaan "sudah dipakai" di bawah,
+  -- dengan pesan yang bisa dibaca petugas — bukan galat unique mentah.
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any (v_nomor)
+  order by s.nomor
+  for update;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- Serialisasi bagian penempatan kloter (2-3 meja — advisory lock sederhana
+  -- lebih terbaca daripada retry unique-violation; lepas otomatis di akhir tx).
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  -- Sebar N regu: mulai dari kloter termuda yang layak, melompat
+  -- lompatan_kloter (alur 5.6); kloter 31.. dibuka hanya bila 1..30 tidak
+  -- menyediakan slot layak (alur 5.2). "Layak" = belum penuh + belum berisi
+  -- sekolah ini; bila tak terhindarkan, syarat sekolah dilonggarkan (alur 5.4
+  -- "sesedikit mungkin", bukan "tidak boleh").
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam
+    -- 1..kloter_dasar. Tanda cetak dan jam berangkat TIDAK ikut menyaring
+    -- (0066) — yang membatasi cuma kapasitas.
+    if v_mulai is null then
+      v_langkah := 1;  -- pencarian pertama: kloter layak termuda
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.nomor <= v_cfg.kloter_dasar
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama tapi abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: 1..kloter_dasar masih ada tempat tapi semuanya berisi
+    -- sekolah ini — sekolah sama boleh berkumpul DULU sebelum membuka
+    -- kloter cadangan (alur 5.2: 31-40 hanya bila 1-30 penuh; alur 5.4:
+    -- "sesedikit mungkin", bukan larangan mutlak). Pilih yang paling kosong.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor <= v_cfg.kloter_dasar
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan
+    -- (31..kloter_maks), hindari sekolah sama dulu lalu bebas.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),   -- false (bebas sekolah) dulu
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      -- Slot terkecil yang kosong, bukan count+1: lubang bekas koreksi admin
+      -- tidak boleh membuat slot palsu di atas 10 (temuan review).
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Buktikan pagarnya benar-benar hilang, di database ini, sekarang.
+--
+--    Bukan sekadar "tidak ada lagi kata dicetak_pada di sumbernya" — itu bisa
+--    benar sementara trigger lamanya masih terpasang dari migrasi terdahulu.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_n int;
+begin
+  select count(*) into v_n from pg_trigger
+   where tgname = 'jaga_kloter_tercetak' and not tgisinternal;
+  assert v_n = 0, 'trigger jaga_kloter_tercetak masih terpasang';
+
+  select count(*) into v_n from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public' and p.proname = 'daftar_ulang_batch'
+     and p.prosrc ~ 'dicetak_pada is null|jam_berangkat is null';
+  assert v_n = 0, 'daftar_ulang_batch masih menyaring kloter tercetak/berangkat';
+
+  raise notice '0066: pagar kloter tercetak/berangkat sudah tidak ada.';
+end $blok$;
+
+do $blok$
+declare r record;
+begin
+  for r in
+    select k.nomor, k.dicetak_pada is not null as tercetak,
+           k.jam_berangkat is not null as berangkat,
+           (select count(*) from regu x where x.kloter_nomor = k.nomor
+              and not x.is_cancelled) as isi
+      from kloter k
+     where k.dicetak_pada is not null or k.jam_berangkat is not null
+     order by k.nomor limit 5
+  loop
+    raise notice '0066: kloter % (tercetak=%, berangkat=%) berisi % regu — sekarang masih bisa ditambah',
+      r.nomor, r.tercetak, r.berangkat, r.isi;
+  end loop;
+end $blok$;
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -227,5 +227,11 @@ run tests/sql/30_hak_akses_mengikat.sql
 # lembar seluruh pos ke juri pos mana pun. Sekalian N+1 di v_rekap_penuh.
 run supabase/migrations/0065_view_hak_dan_rekap.sql
 run tests/sql/31_view_hak.sql
+# 0066 membuang larangan menambah regu ke kloter tercetak/berangkat. Tesnya
+# menekan ketiga pagar lamanya dari sisi berbeda — trigger lewat UPDATE
+# langsung, dua syarat lewat pemilihan kloter — dan sekaligus memastikan
+# KAPASITAS tidak ikut terbuka.
+run supabase/migrations/0066_kloter_boleh_ditambah.sql
+run tests/sql/32_kloter_boleh_ditambah.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/32_kloter_boleh_ditambah.sql
+++ b/tests/sql/32_kloter_boleh_ditambah.sql
@@ -1,0 +1,165 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/32_kloter_boleh_ditambah.sql
+-- Kloter tidak pernah tertutup untuk penambahan regu (migrasi 0066).
+--
+-- APA YANG DIJAGA
+--
+-- Tiga pagar pernah ada, dipasang di tiga tempat berbeda, dan menghapus satu
+-- saja tidak cukup:
+--
+--   1. `dicetak_pada is null` di pemilihan kloter `daftar_ulang_batch` (0008,
+--      dikembalikan 0040)
+--   2. `jam_berangkat is null` di tempat yang sama
+--   3. trigger `jaga_kloter_tercetak` di `regu` — ia menolak SETIAP perubahan
+--      `kloter_nomor` yang menyentuh kloter tercetak, dari arah mana pun, jadi
+--      ia tetap menolak walau kedua syarat di atas sudah hilang
+--
+-- Tes ini menekan ketiganya dari sisi yang berbeda: lewat UPDATE langsung
+-- (menabrak trigger) dan lewat alur daftar ulang (menabrak syarat pemilihan).
+--
+-- YANG TIDAK BOLEH IKUT HILANG
+--
+-- Kapasitas. Kertas boleh dilanggar; jumlah orang yang muat di satu rombongan
+-- tidak. Sebuah "perbaikan" yang membuka kloter tercetak sekaligus membuka
+-- kloter penuh bukan perbaikan.
+-- ============================================================================
+
+do $blok$
+declare
+  v_kloter    int;
+  v_regu      uuid;
+  v_maks      int;
+  v_isi       int;
+begin
+  select maks_regu_per_kloter into v_maks from edisi where is_active;
+
+  -- Cari kloter yang masih longgar, lalu tandai ia sudah dicetak DAN sudah
+  -- berangkat — keadaan yang dulu menutupnya rapat-rapat.
+  select k.nomor into v_kloter
+    from kloter k
+   where (select count(*) from regu r where r.kloter_nomor = k.nomor
+            and not r.is_cancelled) < v_maks - 1
+   order by k.nomor limit 1;
+  if v_kloter is null then
+    raise notice '32: tidak ada kloter longgar di fixture — tes dilewati';
+    return;
+  end if;
+
+  update kloter set dicetak_pada = now(), jam_berangkat = now()
+   where nomor = v_kloter;
+
+  -- Ambil satu regu dari kloter LAIN untuk dipindahkan ke sana.
+  select r.id into v_regu from regu r
+   where r.kloter_nomor is not null and r.kloter_nomor <> v_kloter
+     and not r.is_cancelled
+   limit 1;
+  if v_regu is null then
+    raise notice '32: tidak ada regu di kloter lain — tes dilewati';
+    update kloter set dicetak_pada = null, jam_berangkat = null where nomor = v_kloter;
+    return;
+  end if;
+
+  -- INI yang dulu ditolak trigger jaga_kloter_tercetak, tanpa pengecualian.
+  -- `urutan_kloter` ikut diisi: ada unique (kloter_nomor, urutan_kloter), dan
+  -- UPDATE mentah yang membawa urutan lamanya akan menabraknya. Panitia tidak
+  -- pernah melakukan ini lewat SQL — mereka lewat pindah_kloter, yang mencari
+  -- urutan kosongnya sendiri.
+  update regu set
+    kloter_nomor  = v_kloter,
+    urutan_kloter = (select min(s) from generate_series(1, v_maks) s
+                      where not exists (select 1 from regu x
+                                        where x.kloter_nomor = v_kloter
+                                          and x.urutan_kloter = s))
+   where id = v_regu;
+
+  select count(*) into v_isi from regu
+   where kloter_nomor = v_kloter and not is_cancelled;
+  assert v_isi > 0, 'regu tidak masuk ke kloter tercetak/berangkat';
+
+  raise notice '32: kloter % (tercetak + berangkat) menerima regu — pagar hilang', v_kloter;
+
+  update kloter set dicetak_pada = null, jam_berangkat = null where nomor = v_kloter;
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- Pagarnya benar-benar tidak ada lagi di katalog — bukan cuma tidak dipanggil.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_n int;
+begin
+  select count(*) into v_n from pg_trigger
+   where tgname = 'jaga_kloter_tercetak' and not tgisinternal;
+  assert v_n = 0, 'trigger jaga_kloter_tercetak masih terpasang';
+
+  select count(*) into v_n from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public' and p.proname = 'daftar_ulang_batch'
+     and p.prosrc ~ 'dicetak_pada is null|jam_berangkat is null';
+  assert v_n = 0, 'daftar_ulang_batch masih menyaring kloter tercetak/berangkat';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- Kapasitas TETAP dijaga. Ini arah kedua, dan tanpa ia tes di atas akan lulus
+-- sama gembiranya untuk perbaikan yang membuka segalanya.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_maks   int;
+  v_penuh  int;
+  v_isi    int;
+  v_regu   uuid;
+begin
+  select maks_regu_per_kloter into v_maks from edisi where is_active;
+
+  -- Fixture-nya tidak punya kloter penuh, dan tes yang MELEWATI dirinya
+  -- sendiri tidak menguji apa pun — itu persis cara tes 26 dan 27 pernah
+  -- hijau tanpa menyentuh apa pun. Jadi kondisinya dibuat: batas kapasitas
+  -- diturunkan sementara ke isi kloter yang sudah ada, bukan sepuluh regu
+  -- dipindah-pindahkan.
+  select k.nomor, (select count(*) from regu r where r.kloter_nomor = k.nomor
+                     and not r.is_cancelled)
+    into v_penuh, v_isi
+    from kloter k
+   where k.jam_berangkat is null
+     and (select count(*) from regu r where r.kloter_nomor = k.nomor
+            and not r.is_cancelled) > 0
+   order by k.nomor limit 1;
+  assert v_penuh is not null, 'fixture tidak punya kloter berisi yang belum berangkat';
+
+  update edisi set maks_regu_per_kloter = v_isi where is_active;
+
+  -- Harus yang PUNYA nomor dada: pindah_kloter mencarinya lewat nomor dada,
+  -- dan regu tanpa nomor akan ditolak "tidak dikenal" sebelum kapasitas
+  -- sempat diperiksa.
+  -- Dan regu yang kloternya juga BELUM berangkat: pindah_kloter menolak
+  -- memindahkan regu yang sudah ikut berangkat, dan penolakan itu akan
+  -- datang lebih dulu daripada kapasitas.
+  select r.id into v_regu from regu r
+   join kloter k on k.nomor = r.kloter_nomor
+   where r.kloter_nomor is distinct from v_penuh and not r.is_cancelled
+     and r.nomor_dada is not null and k.jam_berangkat is null limit 1;
+  assert v_regu is not null,
+         'fixture tidak punya regu bernomor dada di kloter lain yang belum berangkat';
+
+  -- pindah_kloter menjaga kapasitas secara eksplisit; UPDATE langsung tidak,
+  -- dan memang tidak dimaksudkan begitu — yang dipakai panitia adalah RPC-nya.
+  --
+  -- Identitas admin dipasang dulu: sejak 0064 penjaganya boleh('cetak_kloter'),
+  -- dan tanpa app.uid ia menolak lebih dulu daripada kapasitas — tesnya lalu
+  -- lulus/gagal karena alasan yang salah.
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  declare v_pesan text;
+  begin
+    begin
+      perform pindah_kloter((select nomor_dada from regu where id = v_regu),
+                            'uji kapasitas', v_penuh::smallint);
+      v_pesan := '(diterima)';
+    exception when others then
+      v_pesan := sqlerrm;
+    end;
+    update edisi set maks_regu_per_kloter = v_maks where is_active;
+    assert v_pesan like '%penuh%',
+           format('kloter penuh harus ditolak karena KAPASITAS, bukan: %s', v_pesan);
+  end;
+end $blok$;
+
+\echo '32 kloter boleh ditambah: LULUS'


### PR DESCRIPTION
## What

**Migrasi 0066.** Tiga pagar dihapus sekaligus — menghapus satu saja tidak
cukup:

| | Dari |
| --- | --- |
| `dicetak_pada is null` di pemilihan kloter (4 putaran) | 0008, dikembalikan 0040 |
| `jam_berangkat is null` di tempat yang sama (4 putaran) | 0008 |
| trigger `jaga_kloter_tercetak` di `regu` | 0008 |

Trigger-nya menolak **setiap** perubahan `kloter_nomor` yang menyentuh kloter
tercetak, dari arah mana pun — ia tetap menolak walau kedua syarat di atas
hilang.

## Why

`CLAUDE.md` 12.3 mencatat utang ini dengan usulan *"ganti syaratnya jadi
`jam_berangkat is null`"*. Usulan itu **ditolak** pemilik acara:

> Jangan ada aturan seperti itu, karena ketika di lapangan semua dinamis, bisa
> jadi peserta terlambat memaksa untuk berangkat jadi mereka seakan-akan
> berangkat di jam tersebut. Jadi biarkan saja panitia menambah peserta di
> depan.

Jadi kedua syarat **dibuang, bukan ditukar**. Kloter yang kertasnya sudah
dicetak boleh ditambah; kloter yang sudah berangkat pun boleh.

Pagar itu melindungi kertas, dan kertas bukan yang paling mahal. Yang mahal
kloter setengah kosong berangkat sementara ada regu menunggu. Dan ia tidak
menyelesaikan apa pun: petugas yang butuh menambah regu tetap menambahnya, cuma
lewat jalan yang tidak tercatat.

## Notes

**Konsekuensi yang ditulis di kepala migrasi karena panitia perlu tahu sebelum
hari-H:** penalti waktu dihitung dari `kloter.jam_berangkat`, jadi regu yang
disisipkan ke kloter yang sudah berangkat dihitung berangkat pada jam kloter
itu. Itu memang yang diminta — tapi menyisipkan regu ke kloter yang berangkat
dua jam lalu memberinya kontrak yang sudah termakan dua jam.

**Yang tidak ikut dibuang:** kapasitas per kloter, dan penyebaran sekolah
(12.5) — urutan putaran pencariannya tidak disentuh sama sekali, hanya syarat
penyaringnya yang hilang. `pindah_kloter` dan `tukar_nomor_dada` juga dibiarkan
membaca kolom itu: keduanya memberi tahu dan menaikkan ke admin, bukan menolak.

**Tes 32 memeriksa arah kedua yang mudah hilang:** kapasitas harus tetap
menolak. Pemeriksaan itu sempat melewati dirinya sendiri karena fixture-nya
tidak punya kloter penuh — persis cara tes 26 dan 27 pernah hijau tanpa
menyentuh apa pun — jadi sekarang ia menyiapkan kondisinya sendiri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)