### PR TITLE
fix: papan Home juri pos menampilkan kode SVG, bukan ikon

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -233,11 +233,25 @@ async function layarHome() {
   // Yang hanya memegang pos tidak punya layar meja sama sekali; papan penuh
   // untuknya adalah papan berisi ubin yang semuanya menjawab kosong.
   if (bolehLihat("pos") && !bolehLihat("pembayaran") && !bolehLihat("keberangkatan")) {
-    LAYAR.replaceChildren(h(html`
+    // Template BIASA, bukan html`` — dan itu bukan kelalaian yang dirapikan
+    // belakangan. html`` meng-escape SETIAP sisipan, sedangkan ikonKotak()
+    // mengembalikan markup; disisipkan ke sana ia tampil sebagai kode SVG
+    // mentah sepanjang empat baris, bukan sebagai ikon. Menu di bawah ini
+    // memakai template biasa untuk alasan yang sama.
+    //
+    // Cacat ini hanya terlihat oleh akun juri pos, dan tidak ada yang login
+    // sebagai juri pos sampai hari simulasi.
+    //
+    // Yang tetap wajib di-escape: nilai dari database. Di sini cuma `pos`.
+    LAYAR.replaceChildren(h(`
       <div class="function-menu">
         <a href="#/pos">
-          <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos ${sesi().pos}</div>
+          <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos ${esc(sesi().pos)}</div>
         </a>
+        ${bolehLihat("live_score") ? `
+        <a href="#/live-score">
+          <div class="function-name">${ikonKotak("medal", "emas")} Live Score</div>
+        </a>` : ""}
       </div>
 `));
     return;


### PR DESCRIPTION
## What

Cabang Home untuk akun juri pos memakai `` html` `` — tag template yang
**meng-escape setiap sisipan**. `ikonKotak()` mengembalikan markup, jadi ia
tampil sebagai empat baris kode SVG mentah, bukan sebagai ikon. Diganti
template biasa, sama seperti menu utama di bawahnya.

Sekalian: ubin **Live Score** ditambahkan ke cabang itu.

## Why

Dilaporkan setelah login sebagai `pos1hrcd37` — akun juri pos pertama yang
benar-benar dipakai. Bukan galat jaringan: seluruh request 200, termasuk
`v_edisi_publik`.

Cacatnya **hanya terlihat oleh akun juri pos**, dan tidak ada yang login
sebagai juri pos sampai hari simulasi. Itu pola yang sama dengan dua temuan
sebelumnya hari ini — 0064 (nama peran lama di RPC) dan 0065 (nama peran lama
di view) juga hanya menggigit akun non-admin, dan juga lolos karena semua
pengujian dilakukan dari akun admin.

Ubin Live Score: `paket_peran('juri_pos')` memuat `live_score`, dan aturannya
"semua role dapat akses ke Live Score versi panitia". Cabang ini menampilkan
hanya satu ubin, jadi juri pos tidak punya jalan ke sana dari Home kecuali
mengetik alamatnya sendiri.

## Notes

Seluruh berkas layar disisir untuk pola yang sama — pembantu penghasil markup
(`ikonKotak`, `ikon`, `lencana`, `pemuat`, `kartuGalat`) yang disisipkan ke
dalam `` html` ``. Satu tempat ditemukan, sekarang nol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)