### PR TITLE
fix: lebar kolom No Dada tidak pernah berlaku, dan Gol. jadi terpotong

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -876,9 +876,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      Lebih sempit dari ini berarti mengecilkan angkanya, dan itu ditolak:
      nomor dada adalah kunci yang dibaca ulang dari FOTO lembar, dan 12pt
      dipilih justru untuk ujian itu. */
-  .lembar-pos .print-table .dada {
-    font-size: 12pt; width: 10mm; padding-left: 1pt; padding-right: 1pt;
+  /* Lebarnya dipasang di TH JUGA, dan itu bukan kerapian.
+     `table-layout: fixed` mengambil lebar kolom dari BARIS PERTAMA — yaitu
+     <thead><tr><th>. Aturan yang cuma menyebut `.dada` (kelas di <td>) tidak
+     pernah berlaku: kolomnya diam-diam melebar mengikuti judul "NO DADA"
+     yang 13,04mm satu baris. Terlihat di lembar tercetak — judulnya tidak
+     pernah membungkus, padahal 10mm mestinya memaksanya. */
+  .lembar-pos .print-table td.dada,
+  .lembar-pos .print-table th:nth-child(1) {
+    width: 10mm; max-width: 10mm; padding-left: 1pt; padding-right: 1pt;
   }
+  .lembar-pos .print-table td.dada { font-size: 12pt; }
   /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
      ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
      tinggi hanya akan mengurangi jumlah baris per lembar. */
@@ -955,10 +963,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      tercetak: "SMK Bangkit Indonesia…", "SMA Terpadu Riyadlul …". */
   .lembar-pos .print-table td:nth-child(3),
   .lembar-pos .print-table th:nth-child(3) { width: 48mm; max-width: 48mm; }
-  /* 13mm cukup untuk "Pgl Pi" di 10pt; judulnya sudah dipendekkan jadi
-     "Gol." di app.js supaya ia tidak lagi yang menentukan lebar. */
+  /* Golongan terpanjang BUKAN "Pgl Pi" (9,35mm) melainkan "Pgk Pa" —
+     11,56mm di 10pt, karena k dan a lebih lebar dari l dan i. Dengan padding
+     umum 3pt (2,12mm) ia butuh 14,2mm dan terpotong jadi "Pgk …" di lembar
+     tercetak. Padding 1pt membuatnya 12,8mm, jadi 13mm cukup — lebarnya
+     tetap hemat, yang mengalah paddingnya. */
   .lembar-pos .print-table td:nth-child(4),
-  .lembar-pos .print-table th:nth-child(4) { width: 13mm; max-width: 13mm; }
+  .lembar-pos .print-table th:nth-child(4) {
+    width: 13mm; max-width: 13mm; padding-left: 1pt; padding-right: 1pt;
+  }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }

--- a/web/style.css
+++ b/web/style.css
@@ -876,9 +876,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      Lebih sempit dari ini berarti mengecilkan angkanya, dan itu ditolak:
      nomor dada adalah kunci yang dibaca ulang dari FOTO lembar, dan 12pt
      dipilih justru untuk ujian itu. */
-  .lembar-pos .print-table .dada {
-    font-size: 12pt; width: 10mm; padding-left: 1pt; padding-right: 1pt;
+  /* Lebarnya dipasang di TH JUGA, dan itu bukan kerapian.
+     `table-layout: fixed` mengambil lebar kolom dari BARIS PERTAMA — yaitu
+     <thead><tr><th>. Aturan yang cuma menyebut `.dada` (kelas di <td>) tidak
+     pernah berlaku: kolomnya diam-diam melebar mengikuti judul "NO DADA"
+     yang 13,04mm satu baris. Terlihat di lembar tercetak — judulnya tidak
+     pernah membungkus, padahal 10mm mestinya memaksanya. */
+  .lembar-pos .print-table td.dada,
+  .lembar-pos .print-table th:nth-child(1) {
+    width: 10mm; max-width: 10mm; padding-left: 1pt; padding-right: 1pt;
   }
+  .lembar-pos .print-table td.dada { font-size: 12pt; }
   /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
      ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
      tinggi hanya akan mengurangi jumlah baris per lembar. */
@@ -955,10 +963,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      tercetak: "SMK Bangkit Indonesia…", "SMA Terpadu Riyadlul …". */
   .lembar-pos .print-table td:nth-child(3),
   .lembar-pos .print-table th:nth-child(3) { width: 48mm; max-width: 48mm; }
-  /* 13mm cukup untuk "Pgl Pi" di 10pt; judulnya sudah dipendekkan jadi
-     "Gol." di app.js supaya ia tidak lagi yang menentukan lebar. */
+  /* Golongan terpanjang BUKAN "Pgl Pi" (9,35mm) melainkan "Pgk Pa" —
+     11,56mm di 10pt, karena k dan a lebih lebar dari l dan i. Dengan padding
+     umum 3pt (2,12mm) ia butuh 14,2mm dan terpotong jadi "Pgk …" di lembar
+     tercetak. Padding 1pt membuatnya 12,8mm, jadi 13mm cukup — lebarnya
+     tetap hemat, yang mengalah paddingnya. */
   .lembar-pos .print-table td:nth-child(4),
-  .lembar-pos .print-table th:nth-child(4) { width: 13mm; max-width: 13mm; }
+  .lembar-pos .print-table th:nth-child(4) {
+    width: 13mm; max-width: 13mm; padding-left: 1pt; padding-right: 1pt;
+  }
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }


### PR DESCRIPTION
## What

1. Lebar kolom `No Dada` dipasang di `th:nth-child(1)` juga, bukan hanya di
   `td.dada`.
2. Padding kolom `Gol.` dipangkas ke `1pt` supaya `Pgk Pa` muat.

## Why

**Dua cacat, dan yang pertama membuat laporan saya sebelumnya keliru.**

`table-layout: fixed` mengambil lebar kolom dari **baris pertama** — yaitu
`<thead><tr><th>`. Aturan lebarnya dipasang di `.dada`, kelas yang ada di
`<td>`, jadi **tidak pernah berlaku sama sekali**. Kolomnya melebar mengikuti
judul `NO DADA` yang 13,04mm satu baris.

Tandanya ada di lembar tercetak dan sempat saya lewatkan: judulnya tidak pernah
membungkus, padahal 10mm mestinya memaksanya. Saya menjawab "10mm sudah batas
bawahnya" berdasarkan aturan yang tidak pernah jalan.

**Golongan terpanjang bukan `Pgl Pi`** (9,35mm) melainkan `Pgk Pa` — 11,56mm di
10pt, karena `k` dan `a` lebih lebar dari `l` dan `i`. Saya mengukur yang salah
waktu memangkas 14mm ke 13mm, dan hasilnya `Pgk …` terpotong di seluruh baris
Penggalang. Padding 1pt membuatnya 12,8mm, jadi 13mm cukup.

Angkanya diukur di Inter pada ukuran yang benar-benar dipakai lewat
`canvas.measureText`, bukan ditaksir dari jumlah huruf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)