### PR TITLE
fix: 1,9mm menganggur di kaki lembar cadangan

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -849,7 +849,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .lembar-pos .print-note { text-align: center; line-height: 1.1; }
   .lembar-pos .lembar-kepala { font-size: 8pt; margin: 0 0 0.5pt; }
   .lembar-pos .insert-note { font-size: 7.5pt; margin: 0 0 0.5pt; }
-  .lembar-pos .print-note { font-size: 7pt; margin-top: 1pt; }
+  /* margin DIRINGKAS EMPAT ARAH, bukan cuma atasnya.
+     `.printout p { margin: .45rem 0 }` di atas berlaku untuk paragraf ini
+     juga, dan menimpa hanya `margin-top` meninggalkan 0,45rem = 1,9mm
+     menganggur DI BAWAH catatan — persis ruang kosong di kaki halaman yang
+     dilaporkan, dan ia tidak kelihatan dari aturan .lembar-pos mana pun. */
+  .lembar-pos .print-note { font-size: 7pt; margin: 1pt 0 0; }
   .lembar-pos .print-table { margin-top: 0; }
   /* 12pt untuk ISI — ukuran yang sama dengan cetakan Excel yang selama ini
      dipakai panitia, dan memang seharusnya: yang tertulis di sini dibaca

--- a/web/style.css
+++ b/web/style.css
@@ -849,7 +849,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .lembar-pos .print-note { text-align: center; line-height: 1.1; }
   .lembar-pos .lembar-kepala { font-size: 8pt; margin: 0 0 0.5pt; }
   .lembar-pos .insert-note { font-size: 7.5pt; margin: 0 0 0.5pt; }
-  .lembar-pos .print-note { font-size: 7pt; margin-top: 1pt; }
+  /* margin DIRINGKAS EMPAT ARAH, bukan cuma atasnya.
+     `.printout p { margin: .45rem 0 }` di atas berlaku untuk paragraf ini
+     juga, dan menimpa hanya `margin-top` meninggalkan 0,45rem = 1,9mm
+     menganggur DI BAWAH catatan — persis ruang kosong di kaki halaman yang
+     dilaporkan, dan ia tidak kelihatan dari aturan .lembar-pos mana pun. */
+  .lembar-pos .print-note { font-size: 7pt; margin: 1pt 0 0; }
   .lembar-pos .print-table { margin-top: 0; }
   /* 12pt untuk ISI — ukuran yang sama dengan cetakan Excel yang selama ini
      dipakai panitia, dan memang seharusnya: yang tertulis di sini dibaca


### PR DESCRIPTION
## What

`.lembar-pos .print-note` diberi `margin: 1pt 0 0` — sebelumnya hanya
`margin-top` yang ditimpa.

## Why

Dilaporkan: masih ada ruang kosong di atas dan bawah. Margin halaman memang
sudah 6mm (dari 10mm), tapi ada 1,9mm lain yang tidak kelihatan dari aturan
`.lembar-pos` mana pun:

```css
.printout p { margin: .45rem 0; }              /* berlaku untuk catatan juga */
.lembar-pos .print-note { margin-top: 1pt; }   /* hanya ATAS yang ditimpa */
```

`.45rem` = 1,9mm menganggur **di bawah** catatan, di setiap halaman.

## Notes

Sisa ruang naik dari 2,35mm ke **4,25mm** — masih di bawah 4,45mm yang
dibutuhkan baris ke-41, jadi jumlah barisnya tetap 40. Yang berubah: ruang
kosong di kaki halaman hilang.

**Margin halaman tidak diturunkan lagi di bawah 6mm.** Turun ke 5mm hanya
menambah 2mm — tetap tidak cukup untuk baris ke-41 — sementara printer kantor
umumnya tidak bisa mencetak di 4–5mm terluar, dan halaman yang tidak muat akan
**diskalakan** browser: seluruh ukuran ikut mengecil tanpa satu pun tanda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)