### PR TITLE
feat: tombol Publish Live Score, kartu pemberitahuan dihapus

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -414,6 +414,18 @@ export async function cariRegu(nomorDada) {
 /** Saklar hari-H: daftar_ulang_ditutup, fase_live, konfigurasi_terkunci.
  *  Dipakai layar cetak untuk memperingatkan bahwa kertas yang dicetak
  *  sebelum daftar ulang ditutup pasti kehilangan regu yang datang setelahnya. */
+/** Buka / tutup klasemen untuk peserta.
+ *
+ *  TIDAK menerbitkan apa pun sendiri. Halaman peserta membaca live.json dan
+ *  rekap.json — berkas statis yang ditulis ulang publish-live.yml. Layar yang
+ *  memanggil ini wajib mengatakannya; tombol yang mengaku sudah menerbitkan
+ *  padahal belum adalah cara tercepat membuat panitia mengumumkan juara yang
+ *  tidak ada di layar peserta. */
+export async function aturFaseLive(fase) {
+  if (K.mode === "dev") return kirim("/atur-fase-live", { method: "POST", body: JSON.stringify({ fase }) });
+  return rpc("atur_fase_live", { p_fase: fase });
+}
+
 export async function statusAcara() {
   const d = K.mode === "dev"
     ? await baca("/status")

--- a/supabase/migrations/0068_atur_fase_live.sql
+++ b/supabase/migrations/0068_atur_fase_live.sql
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- hrcd-rekap : 0068_atur_fase_live.sql
+-- Satu tombol untuk membuka klasemen ke peserta.
+--
+-- KENAPA RPC, BUKAN UPDATE LANGSUNG
+--
+-- `status_acara` sudah bisa di-UPDATE lewat policy `adm_status_acara`
+-- (boleh('pengaturan') sejak 0064), jadi layar bisa saja menulisnya langsung.
+-- Tidak dilakukan, karena yang berpindah di sini bukan satu kolom melainkan
+-- SATU KEPUTUSAN: sejak baris ini berubah, nilai yang belum diumumkan boleh
+-- dilihat siapa saja yang membuka halaman peserta. Keputusan seperti itu
+-- pantas punya nama, pantas tercatat siapa yang menekannya, dan pantas
+-- menolak nilai yang tidak dikenal alih-alih menyimpannya diam-diam.
+--
+-- FASENYA TIGA, DAN TOMBOLNYA CUMA MENGURUS DUA
+--
+--   pra      peserta tidak melihat apa pun
+--   progres  peserta melihat KEMAJUAN input, belum nilainya
+--   penuh    peserta melihat klasemen
+--
+-- Tombol "Publish Live Score" berpindah antara `progres` dan `penuh`. `pra`
+-- tidak disentuh tombol — ia keadaan sebelum lomba dimulai, dan kembali ke
+-- sana di tengah acara bukan hal yang pantas terjadi karena satu ketukan
+-- tidak sengaja.
+--
+-- YANG TOMBOL INI TIDAK KERJAKAN, DAN HARUS DIKETAHUI
+--
+-- Halaman peserta membaca BERKAS STATIS `live.json` dan `rekap.json`, bukan
+-- database. Mengubah fase di sini tidak menerbitkan apa pun sampai
+-- `publish-live.yml` berjalan dan menulis ulang kedua berkas itu. Layarnya
+-- mengatakan begitu apa adanya — tombol yang mengaku sudah menerbitkan
+-- padahal belum adalah cara tercepat membuat panitia mengumumkan juara yang
+-- tidak ada di layar peserta.
+-- ============================================================================
+
+create or replace function atur_fase_live(p_fase text)
+returns text
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_lama text;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'tidak berhak: pengaturan';
+  end if;
+  if p_fase not in ('pra', 'progres', 'penuh') then
+    raise exception 'fase tidak dikenal: % (pra / progres / penuh)', p_fase;
+  end if;
+
+  select fase_live into v_lama from status_acara;
+  if v_lama = p_fase then
+    return v_lama;
+  end if;
+
+  update status_acara set fase_live = p_fase;
+  raise notice 'fase_live: % -> %', v_lama, p_fase;
+  return p_fase;
+end;
+$$;
+
+comment on function atur_fase_live(text) is
+  'Buka/tutup klasemen untuk peserta. TIDAK menerbitkan apa pun sendiri: halaman peserta membaca live.json dan rekap.json, yang ditulis ulang oleh publish-live.yml.';
+
+revoke all on function atur_fase_live(text) from public;
+grant execute on function atur_fase_live(text) to authenticated;
+
+do $blok$
+declare v_f text;
+begin
+  select fase_live into v_f from status_acara;
+  raise notice '0068: fase_live sekarang %.', v_f;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -239,5 +239,10 @@ run tests/sql/32_kloter_boleh_ditambah.sql
 # isolasi pos supaya tidak ikut terbuka demi mengisi papan skor.
 run supabase/migrations/0067_live_score_semua_peran.sql
 run tests/sql/33_live_score_semua_peran.sql
+# 0068 memberi tombol Publish Live Score satu RPC. Tesnya menjaga PINTUNYA,
+# bukan tombolnya: tombol di layar cuma menyembunyikan diri, RPC-nya yang
+# harus menolak — ia bisa dipanggil langsung dari devtools.
+run supabase/migrations/0068_atur_fase_live.sql
+run tests/sql/34_atur_fase_live.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/34_atur_fase_live.sql
+++ b/tests/sql/34_atur_fase_live.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/34_atur_fase_live.sql
+-- Tombol Publish Live Score (migrasi 0068).
+--
+-- Yang dijaga: pintunya, bukan tombolnya. Tombol di layar cuma menyembunyikan
+-- dirinya dari yang tidak berhak — RPC-nya yang harus menolak, karena ia bisa
+-- dipanggil langsung dari devtools oleh siapa pun yang punya sesi sah.
+-- ============================================================================
+
+do $blok$
+declare
+  v_admin uuid := '00000000-0000-0000-0000-00000000000a';
+  v_juri  uuid := '00000000-0000-0000-0000-000000000001';
+  v_awal  text;
+  v_pesan text;
+begin
+  select fase_live into v_awal from status_acara;
+
+  -- Juri pos tidak memegang `pengaturan`.
+  perform set_config('app.uid', v_juri::text, true);
+  begin
+    perform atur_fase_live('penuh');
+    v_pesan := '(diterima)';
+  exception when others then v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak berhak: pengaturan%',
+         format('juri pos seharusnya ditolak, galatnya: %s', v_pesan);
+  assert (select fase_live from status_acara) = v_awal,
+         'fase berubah padahal panggilannya ditolak';
+
+  perform set_config('app.uid', v_admin::text, true);
+
+  -- Fase karangan ditolak, bukan disimpan diam-diam.
+  begin
+    perform atur_fase_live('setengah');
+    v_pesan := '(diterima)';
+  exception when others then v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak dikenal%',
+         format('fase karangan seharusnya ditolak, galatnya: %s', v_pesan);
+
+  -- Admin membuka lalu menutup lagi.
+  assert atur_fase_live('penuh') = 'penuh', 'admin gagal membuka klasemen';
+  assert (select fase_live from status_acara) = 'penuh', 'fase tidak tersimpan';
+  -- Dipanggil dua kali dengan nilai yang sama: tidak apa-apa.
+  assert atur_fase_live('penuh') = 'penuh', 'panggilan ulang seharusnya aman';
+
+  assert atur_fase_live('progres') = 'progres', 'admin gagal menutup klasemen';
+
+  update status_acara set fase_live = v_awal;
+end $blok$;
+
+\echo '34 atur fase live: LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -414,6 +414,18 @@ export async function cariRegu(nomorDada) {
 /** Saklar hari-H: daftar_ulang_ditutup, fase_live, konfigurasi_terkunci.
  *  Dipakai layar cetak untuk memperingatkan bahwa kertas yang dicetak
  *  sebelum daftar ulang ditutup pasti kehilangan regu yang datang setelahnya. */
+/** Buka / tutup klasemen untuk peserta.
+ *
+ *  TIDAK menerbitkan apa pun sendiri. Halaman peserta membaca live.json dan
+ *  rekap.json — berkas statis yang ditulis ulang publish-live.yml. Layar yang
+ *  memanggil ini wajib mengatakannya; tombol yang mengaku sudah menerbitkan
+ *  padahal belum adalah cara tercepat membuat panitia mengumumkan juara yang
+ *  tidak ada di layar peserta. */
+export async function aturFaseLive(fase) {
+  if (K.mode === "dev") return kirim("/atur-fase-live", { method: "POST", body: JSON.stringify({ fase }) });
+  return rpc("atur_fase_live", { p_fase: fase });
+}
+
 export async function statusAcara() {
   const d = K.mode === "dev"
     ? await baca("/status")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -23,6 +23,7 @@ import {
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenLiveScore,
   statusAcara, bolehLihat, lengkapiHakSesi,
+  aturFaseLive,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak,
 } from "./api.js";
@@ -4157,12 +4158,6 @@ async function layarLiveScore() {
   if (location.hash !== layarIni) return;
 
   const fase = (status && status.fase_live) || "pra";
-  const FASE_KATA = {
-    pra: "peserta belum melihat apa pun",
-    progres: "peserta melihat kemajuan input, belum melihat nilai",
-    penuh: "peserta sudah melihat klasemen ini",
-  };
-
   // Persen dihitung di sini, bukan di view. `v_kelengkapan_pos` sudah membawa
   // `lengkap` dan `regu_total`, dan menambah view yang menghitung pembagian
   // itu adalah tempat kedua yang harus ikut benar setiap kali definisi
@@ -4332,21 +4327,60 @@ async function layarLiveScore() {
     : GOL.map(g => `<div class="panel-gol" data-gol="${esc(g)}"${
         g === golAktif ? "" : " hidden"}>${kartuGolongan(g)}</div>`).join("");
 
+  /* Kartu pemberitahuan DIHAPUS (CLAUDE.md 9.1 dan 9.3). Judul layarnya
+     sudah "Live Score" di kepala halaman; mengulanginya di dalam badan,
+     ditambah dua paragraf yang mengajarkan arti fase, adalah tiga baris yang
+     dibaca ratusan kali per shift untuk satu hal yang dipelajari sekali.
+     Fase yang sedang berlaku sekarang dibawa TOMBOLNYA — di situ ia fakta
+     yang tidak bisa dibaca dari layar, bukan pelajaran.
+
+     Tombolnya hanya untuk yang memegang `pengaturan` — bawaannya admin. Yang
+     lain tidak melihat apa pun di tempat ini, bukan tombol mati: tombol mati
+     di pojok tidak memberi tahu apa pun selain ada sesuatu yang tidak boleh
+     disentuh. */
+  const bisaPublish = bolehLihat("pengaturan");
+  const terbit = fase === "penuh";
   LAYAR.replaceChildren(h(`
-    <div class="card" style="border-color:var(--utama)">
-      <!-- Dulu "hanya admin". Sejak 0058 setiap peran memegang live_score,
-           dan sejak 0067 papannya memang terisi untuk mereka — jadi kalimat
-           itu tidak benar lagi. Yang tetap perlu disebut: ini BELUM yang
-           dilihat peserta. -->
-      <h2>Live Score — belum terlihat peserta</h2>
-      <p class="description">Fase
-        sekarang <strong>${esc(fase)}</strong> — ${esc(FASE_KATA[fase] || "")}.</p>
-      <p class="description">Jangan dibagikan sebelum
-        diumumkan.</p>
-    </div>
+    ${bisaPublish ? `
+    <div class="card">
+      <div class="table-toolbar">
+        <div>
+          <strong>Publish Live Score</strong>
+          <p class="description" style="margin:.15rem 0 0">${terbit
+            ? "Peserta melihat klasemen."
+            : "Peserta belum melihat nilai."}</p>
+        </div>
+        <button class="button ${terbit ? "" : "button-primary"}" id="btn-publish"
+                type="button">${terbit ? "Tutup" : "Publish"}</button>
+      </div>
+      <!-- Fakta yang TIDAK bisa dibaca dari layar mana pun, dan mahal kalau
+           tidak diketahui: halaman peserta membaca berkas statis. Tombol ini
+           membuka gerbangnya, bukan menerbitkan isinya. -->
+      <p class="description" id="publish-catatan"${terbit ? "" : " hidden"}>Halaman
+        peserta baru berubah setelah <strong>Publish rekap live</strong>
+        dijalankan di GitHub Actions.</p>
+    </div>` : ""}
     ${kemajuan}
     ${tab}
     ${papan}`));
+
+  const tombolPublish = document.getElementById("btn-publish");
+  if (tombolPublish) {
+    tombolPublish.addEventListener("click", async () => {
+      const ke = terbit ? "progres" : "penuh";
+      tombolPublish.disabled = true;
+      try {
+        await aturFaseLive(ke);
+        notif(ke === "penuh"
+          ? "Klasemen dibuka. Jalankan Publish rekap live di GitHub Actions."
+          : "Klasemen ditutup lagi.");
+        layarLiveScore();
+      } catch (e) {
+        tombolPublish.disabled = false;
+        notif(e.message, true);
+      }
+    });
+  }
 
   const bilah = LAYAR.querySelector(".tab-golongan");
   if (bilah) {


### PR DESCRIPTION
## What

1. Kartu **"Live Score — hanya admin"** beserta dua paragraf di bawahnya
   dihapus. `FASE_KATA` ikut dibuang — tidak ada lagi yang membacanya.
2. Tombol **Publish Live Score** (migrasi 0068, RPC `atur_fase_live`).

## Why

**Kartunya.** Judul layarnya sudah "Live Score" di kepala halaman.
Mengulanginya di dalam badan, ditambah dua paragraf yang mengajarkan arti fase,
adalah tiga baris yang dibaca ratusan kali per shift untuk satu hal yang
dipelajari sekali — `CLAUDE.md` 9.1 dan 9.3.

Fase yang sedang berlaku sekarang dibawa **tombolnya**: *"Peserta melihat
klasemen"* atau *"Peserta belum melihat nilai"*. Di situ ia fakta tentang
keadaan sekarang, bukan pelajaran tentang arti sebuah kata.

**Tombolnya** berpindah antara `progres` dan `penuh`. `pra` tidak disentuh — ia
keadaan sebelum lomba dimulai, dan kembali ke sana di tengah acara tidak pantas
terjadi karena satu ketukan tidak sengaja.

RPC, bukan UPDATE langsung walau policy-nya sudah mengizinkan: yang berpindah
bukan satu kolom melainkan satu **keputusan** — sejak baris itu berubah, nilai
yang belum diumumkan boleh dilihat siapa saja yang membuka halaman peserta.

## Notes

**Tombol ini tidak menerbitkan apa pun sendiri, dan layarnya mengatakannya.**
Halaman peserta membaca berkas **statis** `live.json` dan `rekap.json`. Mengubah
fase tidak mengubah apa pun di sana sampai **Publish rekap live** berjalan di
GitHub Actions. Kalimat itu muncul di bawah tombol begitu klasemen dibuka.

Tombol yang mengaku sudah menerbitkan padahal belum adalah cara tercepat
membuat panitia mengumumkan juara yang tidak ada di layar peserta.

Tes 34 menjaga **pintunya**, bukan tombolnya: tombol di layar cuma
menyembunyikan diri, RPC-nya yang harus menolak — ia bisa dipanggil langsung
dari devtools oleh siapa pun yang punya sesi sah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)