### PR TITLE
feat: judul "Klasemen sementara" di atas podium juara

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4229,6 +4229,13 @@ async function layarLiveScore() {
         </div>`;
         return `
         <div class="card">
+          <!-- "sementara", dan kata itu yang membawa faktanya. Papan ini
+               memeringkat dari poin yang sudah terkumpul SEKARANG — regu yang
+               baru melewati dua pos berdiri di sebelah regu yang sudah lima,
+               jadi urutan di atas bisa berubah sampai pos terakhir terisi.
+               Tanpa kata itu, tiga medali di layar besar terbaca seperti
+               hasil, dan itu yang diumumkan orang. -->
+          <h2 style="margin:0 0 .6rem">Klasemen sementara</h2>
           <div class="podium">
             ${juara.map(k => `
               <div class="juara j${esc(String(k.peringkat))}">


### PR DESCRIPTION
## What

Judul **Klasemen sementara** di atas tiga kartu medali, per golongan.

## Why

Diminta. Kata **sementara** yang membawa faktanya: papan ini memeringkat dari
poin yang sudah terkumpul **sekarang** — regu yang baru melewati dua pos
berdiri di sebelah regu yang sudah lima, jadi urutan di atas bisa berubah
sampai pos terakhir terisi.

Ini bukan penjelasan cara pakai yang dilarang `CLAUDE.md` 9.1, melainkan butir
9.4: fakta tentang keadaan data yang tidak bisa dibaca dari layar sendiri.
Tanpa kata itu, tiga medali di layar besar terbaca seperti hasil — dan itu yang
diumumkan orang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)