### PR TITLE
fix: tombol Publish gagal, saklar tiga keadaan, rincian untuk semua panitia

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -610,6 +610,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 .printout { display: none; }
 
+/* Saklar tiga keadaan Live Score. Tiga tombol yang menempel jadi satu
+   batang: yang sedang berlaku memakai warna utama, dua lainnya diam. Bukan
+   satu tombol yang berganti tulisan — dengan tiga terlihat sekaligus, fase
+   yang berlaku terbaca tanpa harus tahu arti tulisan tombolnya. */
+.segmen-fase { display: inline-flex; gap: 0; }
+.segmen-fase .button { border-radius: 0; margin: 0; }
+.segmen-fase .button:first-child { border-radius: 6px 0 0 6px; }
+.segmen-fase .button:last-child { border-radius: 0 6px 6px 0; }
+.segmen-fase .button + .button { border-left: none; }
+
 @media print {
   /* Perapatan huruf dibatalkan di kertas. Di layar -0.011em merapikan judul,
      tapi blangko dicetak sampai 7pt lalu difotokopi, dan pada ukuran itu

--- a/supabase/migrations/0069_publish_dan_detail_panitia.sql
+++ b/supabase/migrations/0069_publish_dan_detail_panitia.sql
@@ -1,0 +1,128 @@
+-- ============================================================================
+-- hrcd-rekap : 0069_publish_dan_detail_panitia.sql
+-- Tombol Publish gagal, dan rincian Live Score dibuka untuk semua panitia.
+--
+-- 1. "UPDATE requires a WHERE clause"
+--
+-- Itu yang muncul di layar waktu tombol Publish ditekan. Bukan galat kami:
+-- Supabase memasang `safeupdate`, pengaman yang MENOLAK setiap UPDATE tanpa
+-- WHERE. `status_acara` cuma punya satu baris, jadi 0068 menulis
+--
+--     update status_acara set fase_live = p_fase;
+--
+-- dan itu persis bentuk yang dilarang. Pengamannya benar — satu baris hari
+-- ini bukan jaminan satu baris tahun depan, dan UPDATE tanpa WHERE yang
+-- suatu hari mengenai sepuluh baris tidak akan mengeluh sedikit pun.
+--
+-- Diberi WHERE yang memang berarti: hanya menulis kalau nilainya berubah.
+--
+-- Tidak ketahuan tes 34 karena database uji tidak memasang `safeupdate`;
+-- ia ekstensi Supabase, bukan bagian dari PostgreSQL. Yang menemukannya
+-- pemilik repo, di layar, pada percobaan pertama.
+--
+-- 2. RINCIAN LIVE SCORE UNTUK SEMUA PANITIA
+--
+-- Diminta pemilik acara: setiap akun panitia boleh melihat rincian Live
+-- Score — nilai per komponen, bukan cuma totalnya. Yang tetap dibatasi hanya
+-- kemampuan MENERBITKAN ke peserta.
+--
+-- Tiga pintu harus ikut terbuka, karena rantai view Live Score
+-- `security_invoker`:
+--
+--   v_rekap_penuh    saringannya boleh('rekap') -> ditambah live_score
+--   sel_pendaftaran  di-JOIN untuk sampai ke nama sekolah
+--   sel_nilai        sumber angka per komponennya
+--
+-- DAN INI MELONGGARKAN DUA HAL. Keduanya disebut di sini supaya tidak
+-- ditemukan sebagai kejutan:
+--
+--   * Juri pos sekarang bisa membaca nilai mentah SELURUH pos, bukan cuma
+--     posnya sendiri. Isolasi per pos (R6) tetap berlaku di tempat yang
+--     menentukan — `v_lembar_pos` dan `simpan_nilai_massal`, yaitu layar
+--     tempat nilai DIUBAH — tapi untuk MEMBACA ia tidak lagi memisahkan.
+--     Itu keputusan pemilik acara, dan konsekuensinya: juri Pos 3 bisa
+--     melihat angka Pos 1 sebelum diumumkan.
+--   * `pendaftaran` memuat nomor WA dan nama kontak pembina. Membukanya ke
+--     pemegang live_score berarti seluruh panitia bisa membacanya lewat API,
+--     walau tidak ada satu layar pun yang menampilkannya.
+--
+-- Kalau salah satunya tidak dimaksudkan, yang dicabut cukup 'live_score' di
+-- policy yang bersangkutan di bawah.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. atur_fase_live dengan WHERE.
+-- ---------------------------------------------------------------------------
+create or replace function atur_fase_live(p_fase text)
+returns text
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_lama text;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'tidak berhak: pengaturan';
+  end if;
+  if p_fase not in ('pra', 'progres', 'penuh') then
+    raise exception 'fase tidak dikenal: % (pra / progres / penuh)', p_fase;
+  end if;
+
+  select fase_live into v_lama from status_acara;
+  if v_lama = p_fase then
+    return v_lama;
+  end if;
+
+  -- WHERE-nya bukan formalitas untuk menyenangkan safeupdate: ia juga yang
+  -- membuat perintah ini tidak menulis apa pun kalau nilainya sudah sama.
+  update status_acara set fase_live = p_fase
+   where fase_live is distinct from p_fase;
+
+  raise notice 'fase_live: % -> %', v_lama, p_fase;
+  return p_fase;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Rincian untuk semua pemegang live_score.
+-- ---------------------------------------------------------------------------
+drop policy if exists sel_pendaftaran on pendaftaran;
+create policy sel_pendaftaran on pendaftaran for select using (
+  boleh_apa_saja('pendaftaran', 'pembayaran', 'daftar_ulang', 'cetak_kloter',
+                 'rekap', 'live_score', 'pengaturan')
+);
+
+drop policy if exists sel_nilai on nilai_mentah;
+create policy sel_nilai on nilai_mentah for select using (
+  boleh_apa_saja('rekap', 'live_score')
+  or (boleh('pos') and (
+        pos_saya() is null
+        or exists (select 1 from wahana w
+                    where w.id = wahana_id and w.pos = pos_saya())))
+);
+
+-- v_rekap_penuh: badannya TIDAK diketik ulang. Hanya baris terakhirnya yang
+-- berubah, jadi ia dibangun ulang dari definisi yang sedang terpasang.
+do $blok$
+declare v_def text;
+begin
+  select pg_get_viewdef('v_rekap_penuh'::regclass, true) into v_def;
+  -- pg_get_viewdef mencetak argumennya LENGKAP DENGAN cast: `boleh('rekap')`
+  -- keluar sebagai `boleh('rekap'::text)`. Mencocokkan bentuk yang ditulis
+  -- tangan tidak akan pernah kena — percobaan pertama gagal persis di situ.
+  if position('boleh(''rekap''::text)' in v_def) = 0 then
+    raise exception '0069: v_rekap_penuh tidak lagi menyaring boleh(''rekap'') — periksa dulu, jangan ditimpa buta. Isinya: %',
+      right(v_def, 200);
+  end if;
+  v_def := replace(v_def, 'boleh(''rekap''::text)',
+                          'boleh_apa_saja(''rekap'', ''live_score'')');
+  execute 'create or replace view v_rekap_penuh with (security_invoker = on) as ' || v_def;
+  raise notice '0069: v_rekap_penuh dibuka untuk pemegang live_score.';
+end $blok$;
+
+do $blok$
+declare v_f text; v_n int;
+begin
+  select fase_live into v_f from status_acara;
+  select count(*) into v_n from nilai_mentah;
+  raise notice '0069: fase_live %, % baris nilai mentah.', v_f, v_n;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -244,5 +244,10 @@ run tests/sql/33_live_score_semua_peran.sql
 # harus menolak — ia bisa dipanggil langsung dari devtools.
 run supabase/migrations/0068_atur_fase_live.sql
 run tests/sql/34_atur_fase_live.sql
+# 0069 memperbaiki "UPDATE requires a WHERE clause" (pengaman safeupdate
+# Supabase, tidak ada di database uji — jadi tes 34 lulus sementara tombolnya
+# gagal di produksi) dan membuka rincian Live Score untuk semua panitia.
+run supabase/migrations/0069_publish_dan_detail_panitia.sql
+run tests/sql/35_detail_live_score_panitia.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/35_detail_live_score_panitia.sql
+++ b/tests/sql/35_detail_live_score_panitia.sql
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/35_detail_live_score_panitia.sql
+-- Rincian Live Score terbaca semua panitia (migrasi 0069).
+--
+-- Yang dijaga: baris rekap TERBACA dari kursi juri pos dan gerbang, bukan
+-- cuma admin. Sebelum 0069 keduanya mendapat nol baris — kolom Semaphore,
+-- Tebak Simpul, dan Menaksir kosong di layar mereka sementara kolom NILAI
+-- terisi, dan itu terbaca seperti nilainya hilang.
+--
+-- Sekaligus arah sebaliknya: yang TIDAK memegang live_score tetap tidak
+-- melihat apa pun.
+-- ============================================================================
+
+do $blok$
+declare
+  v_admin uuid := '00000000-0000-0000-0000-00000000000a';
+  v_juri  uuid := '00000000-0000-0000-0000-000000000001';
+  v_a int; v_j int;
+begin
+  set local role authenticated;
+
+  perform set_config('app.uid', v_admin::text, true);
+  select count(*) into v_a from v_rekap_penuh;
+  assert v_a > 0, 'fixture kosong — tes ini tidak menguji apa pun';
+
+  perform set_config('app.uid', v_juri::text, true);
+  select count(*) into v_j from v_rekap_penuh;
+  assert v_j = v_a,
+         format('juri pos melihat %s baris rekap, admin %s', v_j, v_a);
+end $blok$;
+
+do $blok$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_n int;
+begin
+  reset role;
+  delete from akun_hak where user_id = v_juri and fitur in ('live_score', 'rekap');
+
+  set local role authenticated;
+  perform set_config('app.uid', v_juri::text, true);
+  select count(*) into v_n from v_rekap_penuh;
+
+  reset role;
+  insert into akun_hak (user_id, fitur) values (v_juri, 'live_score')
+  on conflict do nothing;
+
+  assert v_n = 0,
+         format('tanpa live_score maupun rekap seharusnya nol baris, terbaca %s', v_n);
+end $blok$;
+
+-- Menulis nilai TETAP terkunci ke pos sendiri. Membaca dibuka, mengubah
+-- tidak — dan itu batas yang tidak boleh ikut hilang.
+do $blok$
+declare
+  v_juri  uuid := '00000000-0000-0000-0000-000000000001';
+  v_pesan text;
+begin
+  perform set_config('app.uid', v_juri::text, true);
+  begin
+    perform simpan_nilai_massal(
+      jsonb_build_array(jsonb_build_object(
+        'nomor_dada', 999, 'kode', 'apa_saja', 'nilai_1', 1)),
+      'manual', 5::smallint);
+    v_pesan := '(lolos)';
+  exception when others then v_pesan := sqlerrm;
+  end;
+  assert v_pesan not like '%tidak berhak%',
+         format('juri pos kehilangan hak menulis posnya sendiri: %s', v_pesan);
+end $blok$;
+
+\echo '35 detail live score panitia: LULUS'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4229,13 +4229,6 @@ async function layarLiveScore() {
         </div>`;
         return `
         <div class="card">
-          <!-- "sementara", dan kata itu yang membawa faktanya. Papan ini
-               memeringkat dari poin yang sudah terkumpul SEKARANG — regu yang
-               baru melewati dua pos berdiri di sebelah regu yang sudah lima,
-               jadi urutan di atas bisa berubah sampai pos terakhir terisi.
-               Tanpa kata itu, tiga medali di layar besar terbaca seperti
-               hasil, dan itu yang diumumkan orang. -->
-          <h2 style="margin:0 0 .6rem">Klasemen sementara</h2>
           <div class="podium">
             ${juara.map(k => `
               <div class="juara j${esc(String(k.peringkat))}">
@@ -4345,49 +4338,58 @@ async function layarLiveScore() {
      lain tidak melihat apa pun di tempat ini, bukan tombol mati: tombol mati
      di pojok tidak memberi tahu apa pun selain ada sesuatu yang tidak boleh
      disentuh. */
+  /* Judul di TENGAH, saklar tiga keadaan di KANAN, satu baris.
+     Tombol besar sebelumnya memakan tinggi layar untuk sesuatu yang ditekan
+     dua kali sepanjang acara. Tiga keadaan ditampilkan sekaligus, bukan satu
+     tombol yang berganti tulisan: dengan begitu fase yang SEDANG berlaku
+     terbaca tanpa harus tahu apa arti tulisan tombolnya.
+
+     "sementara" di judulnya membawa fakta yang tidak bisa dibaca dari layar:
+     papan ini memeringkat dari poin yang terkumpul SEKARANG, jadi urutannya
+     bisa berubah sampai pos terakhir terisi. Tanpa kata itu, tiga medali di
+     layar besar terbaca seperti hasil — dan itu yang diumumkan orang. */
   const bisaPublish = bolehLihat("pengaturan");
-  const terbit = fase === "penuh";
+  const FASE = [
+    ["pra", "Pra"], ["progres", "Progres"], ["penuh", "Live"],
+  ];
+  const saklar = !bisaPublish ? "" : `
+    <div class="segmen-fase" role="group" aria-label="Fase Live Score">
+      ${FASE.map(([kode, teks]) => `
+        <button type="button" class="button ${kode === fase ? "button-primary" : ""}"
+                data-fase="${esc(kode)}" ${kode === fase ? "aria-current=\"true\"" : ""}
+                style="padding:.3rem .7rem;font-size:.85rem">${esc(teks)}</button>`).join("")}
+    </div>`;
+
   LAYAR.replaceChildren(h(`
-    ${bisaPublish ? `
-    <div class="card">
-      <div class="table-toolbar">
-        <div>
-          <strong>Publish Live Score</strong>
-          <p class="description" style="margin:.15rem 0 0">${terbit
-            ? "Peserta melihat klasemen."
-            : "Peserta belum melihat nilai."}</p>
-        </div>
-        <button class="button ${terbit ? "" : "button-primary"}" id="btn-publish"
-                type="button">${terbit ? "Tutup" : "Publish"}</button>
-      </div>
-      <!-- Fakta yang TIDAK bisa dibaca dari layar mana pun, dan mahal kalau
-           tidak diketahui: halaman peserta membaca berkas statis. Tombol ini
-           membuka gerbangnya, bukan menerbitkan isinya. -->
-      <p class="description" id="publish-catatan"${terbit ? "" : " hidden"}>Halaman
-        peserta baru berubah setelah <strong>Publish rekap live</strong>
-        dijalankan di GitHub Actions.</p>
-    </div>` : ""}
     ${kemajuan}
     ${tab}
+    <div style="display:flex;align-items:center;gap:.5rem;margin:.8rem 0 .4rem">
+      <div style="flex:1"></div>
+      <h2 style="margin:0;text-align:center">Klasemen sementara</h2>
+      <div style="flex:1;display:flex;justify-content:flex-end">${saklar}</div>
+    </div>
     ${papan}`));
 
-  const tombolPublish = document.getElementById("btn-publish");
-  if (tombolPublish) {
-    tombolPublish.addEventListener("click", async () => {
-      const ke = terbit ? "progres" : "penuh";
-      tombolPublish.disabled = true;
+  LAYAR.querySelectorAll("[data-fase]").forEach(tb => {
+    tb.addEventListener("click", async () => {
+      const ke = tb.dataset.fase;
+      if (ke === fase) return;
+      LAYAR.querySelectorAll("[data-fase]").forEach(x => { x.disabled = true; });
       try {
         await aturFaseLive(ke);
-        notif(ke === "penuh"
-          ? "Klasemen dibuka. Jalankan Publish rekap live di GitHub Actions."
-          : "Klasemen ditutup lagi.");
+        // Fakta yang TIDAK bisa dibaca dari layar mana pun, dan mahal kalau
+        // tidak diketahui: halaman peserta membaca berkas statis. Saklar ini
+        // membuka gerbangnya, bukan menerbitkan isinya.
+        notif(ke === "pra"
+          ? "Peserta tidak melihat apa pun."
+          : "Tersimpan. Halaman peserta berubah setelah Publish rekap live dijalankan.");
         layarLiveScore();
       } catch (e) {
-        tombolPublish.disabled = false;
+        LAYAR.querySelectorAll("[data-fase]").forEach(x => { x.disabled = false; });
         notif(e.message, true);
       }
     });
-  }
+  });
 
   const bilah = LAYAR.querySelector(".tab-golongan");
   if (bilah) {

--- a/web/style.css
+++ b/web/style.css
@@ -610,6 +610,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 .printout { display: none; }
 
+/* Saklar tiga keadaan Live Score. Tiga tombol yang menempel jadi satu
+   batang: yang sedang berlaku memakai warna utama, dua lainnya diam. Bukan
+   satu tombol yang berganti tulisan — dengan tiga terlihat sekaligus, fase
+   yang berlaku terbaca tanpa harus tahu arti tulisan tombolnya. */
+.segmen-fase { display: inline-flex; gap: 0; }
+.segmen-fase .button { border-radius: 0; margin: 0; }
+.segmen-fase .button:first-child { border-radius: 6px 0 0 6px; }
+.segmen-fase .button:last-child { border-radius: 0 6px 6px 0; }
+.segmen-fase .button + .button { border-left: none; }
+
 @media print {
   /* Perapatan huruf dibatalkan di kertas. Di layar -0.011em merapikan judul,
      tapi blangko dicetak sampai 7pt lalu difotokopi, dan pada ukuran itu


### PR DESCRIPTION
## What

1. **"UPDATE requires a WHERE clause" diperbaiki** — tombol Publish gagal total.
2. Tombol besar diganti **saklar tiga keadaan** (Pra / Progres / Live) di kanan,
   sejajar judul **Klasemen sementara** yang sekarang di tengah.
3. **Rincian Live Score dibuka untuk semua akun panitia** — kolom Semaphore,
   Tebak Simpul, Menaksir tidak lagi kosong di akun juri pos.

## Why

**Galatnya bukan dari kode kami.** Supabase memasang `safeupdate`, pengaman
yang menolak setiap UPDATE tanpa WHERE. `status_acara` cuma punya satu baris,
jadi 0068 menulis `update status_acara set fase_live = p_fase;` — persis bentuk
yang dilarang. Pengamannya benar: satu baris hari ini bukan jaminan satu baris
tahun depan.

**Tes 34 lulus sementara tombolnya gagal di produksi**, karena `safeupdate`
ekstensi Supabase dan tidak ada di database uji. Yang menemukannya pemilik repo,
di layar, pada percobaan pertama.

**Saklarnya tiga keadaan sekaligus, bukan satu tombol yang berganti tulisan** —
dengan begitu fase yang sedang berlaku terbaca tanpa harus tahu arti tulisan
tombolnya. Tombol besar sebelumnya memakan tinggi layar untuk sesuatu yang
ditekan dua kali sepanjang acara.

## Notes

**Membuka rincian melonggarkan dua hal, dan keduanya ditulis di kepala
migrasi supaya tidak jadi kejutan:**

- Juri pos sekarang bisa **membaca** nilai mentah seluruh pos. Isolasi per pos
  tetap berlaku di tempat yang menentukan — `v_lembar_pos` dan
  `simpan_nilai_massal`, layar tempat nilai **diubah** — tapi untuk membaca ia
  tidak lagi memisahkan.
- `pendaftaran` memuat nomor WA dan nama kontak pembina; membukanya ke pemegang
  `live_score` berarti seluruh panitia bisa membacanya lewat API, walau tidak
  ada layar yang menampilkannya.

Kalau salah satunya tidak dimaksudkan, yang dicabut cukup `live_score` di policy
yang bersangkutan.

Tes 35 menjaga arah sebaliknya juga: menulis nilai **tetap** terkunci ke pos
sendiri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)