### PR TITLE
feat: saklar fase berlaku seketika di halaman peserta

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -104,7 +104,47 @@ let versiRekap = null;  // versi milik REKAP yang sedang dipegang
 let mengambil = false;  // penjaga supaya tidak dua permintaan sekaligus
 let cari = "";
 
-const fase = () => (META && META.fase) || "pra";
+/* Fase yang BERLAKU = yang paling ketat antara berkas dan database.
+ *
+ *  `live.json` hanya berubah kalau publish-live.yml dijalankan, jadi
+ *  mematikan papan berarti membuka GitHub Actions — bukan yang dilakukan
+ *  orang saat kerumunan sedang panas. `FASE_DB` diambil langsung dari
+ *  Supabase tiap poll, jadi saklar di layar panitia berlaku dalam hitungan
+ *  detik.
+ *
+ *  Hanya MEMPERKETAT, tidak pernah membuka. Berkas yang terbit saat fase
+ *  `progres` memang TIDAK MEMUAT satu angka pun — bukan memuat angka yang
+ *  disembunyikan tampilan. Kalau saklar ini bisa membuka lebih dari isi
+ *  berkasnya, jaminan itu berubah jadi "angkanya ada di CDN, cuma tidak
+ *  digambar", dan siapa pun yang membuka rekap.json langsung melihatnya.
+ *
+ *  Jadi: mematikan seketika, menyalakan tetap lewat penerbitan. */
+const URUT_FASE = { pra: 0, progres: 1, penuh: 2 };
+let FASE_DB = null;
+
+const fase = () => {
+  const berkas = (META && META.fase) || "pra";
+  if (!FASE_DB) return berkas;
+  return URUT_FASE[FASE_DB] < URUT_FASE[berkas] ? FASE_DB : berkas;
+};
+
+async function ambilFaseDb() {
+  const K = window.HRCD || {};
+  if (!K.supabaseUrl || !K.anonKey) return;
+  try {
+    const r = await fetch(`${K.supabaseUrl}/rest/v1/v_fase_live?select=fase_live`,
+      { headers: { apikey: K.anonKey, Authorization: `Bearer ${K.anonKey}` },
+        cache: "no-store" });
+    if (!r.ok) return;                       // diamkan: berkas tetap dipakai
+    const d = await r.json();
+    if (Array.isArray(d) && d[0] && URUT_FASE[d[0].fase_live] !== undefined) {
+      FASE_DB = d[0].fase_live;
+    }
+  } catch {
+    // Sambungan ke Supabase mati bukan alasan mengosongkan papan: tanpa
+    // FASE_DB, yang berlaku fase di berkas — keadaan sebelum berkas ini ada.
+  }
+}
 const mulai = () => fase() !== "pra";
 
 /* ---------------------------------------------------------------------------
@@ -459,6 +499,9 @@ async function muatRekap() {
 
 async function muat() {
   try {
+    // Diambil bersamaan, bukan berurutan: keduanya kecil dan salah satunya
+    // boleh gagal tanpa menjatuhkan yang lain.
+    await ambilFaseDb();
     const r = await fetch(`live.json?t=${Date.now()}`, { cache: "no-store" });
     if (!r.ok) throw new Error(String(r.status));
     const baru = await r.json();

--- a/supabase/migrations/0070_fase_live_publik.sql
+++ b/supabase/migrations/0070_fase_live_publik.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- hrcd-rekap : 0070_fase_live_publik.sql
+-- Saklar fase terbaca halaman peserta seketika.
+--
+-- KENAPA
+--
+-- Diminta pemilik acara: "ada momen di mana peserta panas melihat live score,
+-- kita bisa mematikannya untuk sementara." Sekarang tidak bisa — halaman
+-- peserta membaca `live.json`, dan fase di berkas itu hanya berubah kalau
+-- publish-live.yml dijalankan. Mematikan papan berarti membuka GitHub
+-- Actions, dan itu bukan yang dilakukan orang saat kerumunan sedang panas.
+--
+-- View ini membuka SATU KOLOM ke anon: fase yang sedang berlaku. Bukan
+-- `status_acara` seluruhnya — tabel itu memuat kunci konfigurasi dan penanda
+-- hari-H yang tidak ada urusannya dengan penonton.
+--
+-- YANG TIDAK BERUBAH, DAN INI PAGARNYA
+--
+-- Fase dari sini hanya boleh MEMPERKETAT tampilan, tidak pernah membuka lebih
+-- dari yang sudah diterbitkan. Berkas yang terbit saat fase `progres` memang
+-- TIDAK MEMUAT satu angka pun — bukan memuat angka yang disembunyikan
+-- tampilan (lihat kepala publish-live.yml). Kalau saklar ini bisa membuka
+-- lebih dari isi berkasnya, jaminan itu berubah jadi "angkanya ada di CDN,
+-- cuma tidak digambar" — dan siapa pun yang membuka rekap.json langsung akan
+-- melihatnya.
+--
+-- Jadi: mematikan seketika, menyalakan tetap lewat penerbitan. Arah yang
+-- mendesak justru arah yang aman.
+-- ============================================================================
+
+create or replace view v_fase_live as
+select fase_live from status_acara;
+
+comment on view v_fase_live is
+  'Fase live yang sedang berlaku, satu kolom, untuk halaman peserta. Dipakai HANYA untuk memperketat tampilan — halaman tidak boleh menampilkan lebih dari isi rekap.json, karena berkas itulah yang menjamin angka belum terbit memang tidak ada di CDN.';
+
+grant select on v_fase_live to anon, authenticated, service_role;
+
+do $blok$
+declare v_f text;
+begin
+  select fase_live into v_f from v_fase_live;
+  raise notice '0070: fase_live yang terbaca peserta: %.', v_f;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -249,5 +249,10 @@ run tests/sql/34_atur_fase_live.sql
 # gagal di produksi) dan membuka rincian Live Score untuk semua panitia.
 run supabase/migrations/0069_publish_dan_detail_panitia.sql
 run tests/sql/35_detail_live_score_panitia.sql
+# 0070 membuka SATU kolom fase ke anon supaya saklar di layar panitia berlaku
+# seketika di halaman peserta. Tesnya menjaga yang paling mudah bocor: view
+# itu tidak boleh membawa kolom lain dari status_acara.
+run supabase/migrations/0070_fase_live_publik.sql
+run tests/sql/36_fase_live_publik.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/36_fase_live_publik.sql
+++ b/tests/sql/36_fase_live_publik.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/36_fase_live_publik.sql
+-- Fase live terbaca anon, dan HANYA fase (migrasi 0070).
+--
+-- Yang dijaga: view ini dibuka ke `anon` — pengunjung tanpa login. Satu kolom
+-- tambahan yang ikut terbawa dari `status_acara` berarti kunci konfigurasi
+-- dan penanda hari-H ikut terbaca seluruh internet, dan tidak ada satu pun
+-- layar yang akan memberi tahu.
+-- ============================================================================
+
+do $blok$
+declare v_kolom text;
+begin
+  select string_agg(column_name, ', ' order by ordinal_position)
+    into v_kolom
+    from information_schema.columns
+   where table_schema = 'public' and table_name = 'v_fase_live';
+  assert v_kolom = 'fase_live',
+         format('v_fase_live harus membawa fase_live SAJA, membawa: %s', v_kolom);
+end $blok$;
+
+do $blok$
+declare v_f text; v_n int;
+begin
+  -- Terbaca tanpa identitas sama sekali — persis keadaan pengunjung.
+  set local role anon;
+  perform set_config('app.uid', '', true);
+  select count(*) into v_n from v_fase_live;
+  select fase_live into v_f from v_fase_live;
+  reset role;
+
+  assert v_n = 1, format('v_fase_live harus satu baris, ada %s', v_n);
+  assert v_f in ('pra', 'progres', 'penuh'), format('fase tidak dikenal: %s', v_f);
+end $blok$;
+
+-- status_acara sendiri TETAP tertutup untuk anon. View di atas jendela, bukan
+-- pintu.
+do $blok$
+declare v_gagal boolean := false;
+begin
+  set local role anon;
+  begin
+    perform 1 from status_acara;
+  exception when insufficient_privilege then v_gagal := true;
+  end;
+  reset role;
+  assert v_gagal, 'status_acara terbaca anon — seharusnya hanya v_fase_live';
+end $blok$;
+
+\echo '36 fase live publik: LULUS'


### PR DESCRIPTION
## What

**Migrasi 0070:** view `v_fase_live` — satu kolom, dibuka ke `anon`.
**live.js:** fase yang berlaku = **yang paling ketat** antara `live.json` dan
database, diambil ulang tiap poll.

## Why

Diminta: *"ada momen di mana peserta panas melihat live score, kita bisa
mematikannya untuk sementara."*

Sekarang tidak bisa — halaman peserta membaca `live.json`, dan fase di berkas
itu hanya berubah kalau `publish-live.yml` dijalankan. Mematikan papan berarti
membuka GitHub Actions, dan itu bukan yang dilakukan orang saat kerumunan
sedang panas.

## Notes — pagarnya, dan kenapa arahnya tidak simetris

Fase dari database hanya boleh **memperketat**, tidak pernah membuka lebih dari
yang sudah diterbitkan.

Berkas yang terbit saat fase `progres` memang **tidak memuat satu angka pun** —
bukan memuat angka yang disembunyikan tampilan (lihat kepala
`publish-live.yml`). Kalau saklar ini bisa membuka lebih dari isi berkasnya,
jaminan itu berubah jadi *"angkanya ada di CDN, cuma tidak digambar"* — dan
siapa pun yang membuka `rekap.json` langsung melihatnya.

Jadi: **mematikan seketika, menyalakan tetap lewat penerbitan.** Arah yang
mendesak justru arah yang aman.

Sambungan ke Supabase mati bukan alasan mengosongkan papan: tanpa fase dari
database, yang berlaku fase di berkas — keadaan sebelum perubahan ini.

Tes 36 menjaga yang paling mudah bocor: view itu dibuka ke `anon`, jadi satu
kolom tambahan yang ikut terbawa dari `status_acara` berarti kunci konfigurasi
dan penanda hari-H terbaca seluruh internet tanpa satu layar pun memberi tahu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)