### PR TITLE
fix: fase dipantau 15 detik dan saat HP dibuka lagi, bukan 60 detik

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,6 +30,11 @@
        SMA Negeri 1 Ciamis</p>
   </footer>
 
-  <script src="live.js?v=1"></script>
+  <!-- Versinya DINAIKKAN tiap kali live.js berubah. Cache-Control-nya
+       memang `no-cache` (selalu divalidasi), tapi itu tidak menolong
+       halaman yang SUDAH TERBUKA: ia menjalankan kode yang dimuat waktu
+       dibuka sampai di-reload. Menaikkan versinya membuat HP yang
+       memuat ulang pasti mendapat berkas baru, bukan yang tersimpan. -->
+  <script src="live.js?v=2"></script>
 </body>
 </html>

--- a/live/live.js
+++ b/live/live.js
@@ -121,6 +121,7 @@ let cari = "";
  *  Jadi: mematikan seketika, menyalakan tetap lewat penerbitan. */
 const URUT_FASE = { pra: 0, progres: 1, penuh: 2 };
 let FASE_DB = null;
+let denyutFase = null;
 
 const fase = () => {
   const berkas = (META && META.fase) || "pra";
@@ -533,6 +534,33 @@ muat();
 let denyut = null;
 const nyalakan = () => {
   if (denyut === null) denyut = setInterval(muat, 60000);
+  /* FASE dipantau TERPISAH dan jauh lebih sering.
+   *
+   *  `live.json` di-poll 60 detik, dan itu tepat untuk isinya — ia berubah
+   *  hanya ketika panitia menerbitkan ulang. Fase berbeda: ia ditekan justru
+   *  ketika keadaan sedang panas, dan menunggu semenit bukan "langsung".
+   *
+   *  Permintaannya satu baris satu kolom, jadi 15 detik masih murah — beda
+   *  jauh dari mengambil rekap.json lebih sering.
+   *
+   *  Dan yang paling menentukan di lapangan: BEGITU HP DIBUKA LAGI. Peserta
+   *  mengunci layarnya lalu membukanya menit berikutnya; tanpa baris ini ia
+   *  melihat papan basi sampai denyut berikutnya tiba. */
+  if (denyutFase === null) {
+    denyutFase = setInterval(async () => {
+      const sebelum = FASE_DB;
+      await ambilFaseDb();
+      if (FASE_DB !== sebelum) gambar();
+    }, 15000);
+    const segera = async () => {
+      if (document.visibilityState !== "visible") return;
+      const sebelum = FASE_DB;
+      await ambilFaseDb();
+      if (FASE_DB !== sebelum) gambar();
+    };
+    document.addEventListener("visibilitychange", segera);
+    window.addEventListener("focus", segera);
+  }
 };
 const matikan = () => {
   if (denyut !== null) { clearInterval(denyut); denyut = null; }


### PR DESCRIPTION
## What

- Fase dipantau **terpisah tiap 15 detik**, tidak lagi ikut denyut `live.json`
  yang 60 detik.
- Diperiksa **seketika saat HP dibuka lagi** (`visibilitychange` + `focus`).
- `live.js?v=1` → `v=2`.

## Why

Dilaporkan: menekan **Pra** tidak langsung mematikan rekap peserta. Dua sebab,
dan tidak satu pun soal fase yang salah tersimpan.

**1. Halaman yang sudah terbuka menjalankan kode yang dimuat waktu ia dibuka.**
Tab peserta yang dibuka sebelum 0070 tayang menjalankan `live.js` lama — yang
tidak punya pemantau fase sama sekali, jadi ia tidak akan pernah mati sampai
di-reload. Versinya dinaikkan supaya HP yang memuat ulang pasti mendapat berkas
baru.

**2. Fase ikut denyut 60 detik.** Itu tepat untuk **isi** berkas — ia berubah
hanya ketika panitia menerbitkan ulang. Fase berbeda: ia ditekan justru ketika
keadaan sedang panas, dan menunggu semenit bukan "langsung".

## Notes

Permintaan fasenya **satu baris satu kolom**, jadi 15 detik masih murah — beda
jauh dari mempercepat `rekap.json` yang puluhan KB.

Yang paling menentukan di lapangan justru bukan intervalnya: **begitu HP dibuka
lagi**. Peserta mengunci layarnya lalu membukanya menit berikutnya; tanpa itu ia
melihat papan basi sampai denyut berikutnya tiba.

Menggambar ulang hanya kalau fasenya **berubah** — bukan tiap 15 detik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)