### PR TITLE
feat: penyaring Organisasi di papan Live Score, bisa pilih banyak sekolah

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -619,6 +619,28 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    tetap di tengah kartu — bukan di tengah sisa ruang. Dua sisi berlebar sama
    yang menjepitnya yang memastikan itu, jadi judul tidak bergeser waktu
    saklarnya tidak digambar (akun tanpa `pengaturan`). */
+/* Penyaring sekolah di papan Live Score. <details> bawaan, dirapikan.
+   Daftarnya bisa panjang — 23 sekolah hari ini, ratusan tahun depan — jadi ia
+   digulung sendiri dan tidak pernah mendorong tabel keluar layar. */
+.filter-sekolah { margin: 0 0 .6rem; }
+.filter-sekolah > summary {
+  cursor: pointer; display: inline-block; padding: .3rem .7rem;
+  border: 1px solid var(--garis); border-radius: 6px; font-size: .85rem;
+  font-weight: 600;
+}
+.filter-sekolah > summary:hover { background: var(--garis); }
+.filter-sekolah.menyaring > summary { border-color: var(--utama); color: var(--utama); }
+.filter-sekolah .isi-filter {
+  margin-top: .4rem; max-height: 40vh; overflow-y: auto;
+  border: 1px solid var(--garis); border-radius: 6px; padding: .5rem;
+  display: flex; flex-direction: column; gap: .3rem;
+}
+.filter-sekolah .isi-filter label {
+  display: flex; align-items: center; gap: .5rem; font-size: .9rem;
+  font-weight: 400; cursor: pointer;
+}
+.filter-sekolah .isi-filter input { width: 1rem; height: 1rem; }
+
 .kepala-klasemen { display: flex; align-items: center; gap: .5rem; margin: 0 0 .8rem; }
 .kepala-klasemen h2 { margin: 0; text-align: center; }
 .kepala-klasemen .sisi { flex: 1; display: flex; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4235,6 +4235,8 @@ async function layarLiveScore() {
   const kartuGolongan = (g) => {
         const baris = klasemen.filter(k => k.golongan === g);
         const juara = baris.filter(k => k.peringkat <= 3);
+        const sekolahAda = [...new Set(baris.map(k => k.nama_sekolah).filter(Boolean))]
+          .sort((a, b) => a.localeCompare(b, "id"));
         if (!baris.length) return `
         <div class="card">
           <div class="kepala-klasemen">
@@ -4275,6 +4277,23 @@ async function layarLiveScore() {
                 <div class="total">${esc(angkaRapi(k.total))}</div>
               </div>`).join("")}
           </div>
+          <!-- Penyaring sekolah. Daftarnya dibangun dari baris golongan INI,
+               bukan dari seluruh sekolah: memilih sekolah yang tidak punya
+               regu di golongan yang sedang dibuka menghasilkan tabel kosong
+               tanpa satu pun petunjuk kenapa.
+
+               <details> biasa, bukan dropdown buatan sendiri — ia sudah bisa
+               dibuka dengan sentuhan, ditutup dengan Esc, dan dibacakan
+               pembaca layar tanpa satu baris JS pun. -->
+          <details class="filter-sekolah">
+            <summary>Organisasi <span class="hitung-filter"></span></summary>
+            <div class="isi-filter">
+              <button type="button" class="button tombol-semua"
+                      style="padding:.25rem .6rem;font-size:.8rem">Semua</button>
+              ${sekolahAda.map(nm => `
+                <label><input type="checkbox" value="${esc(nm)}"> ${esc(nm)}</label>`).join("")}
+            </div>
+          </details>
           <div class="table-wrapper table-wrapper-tetap">
             <table class="table data-table table-tetap table-rekap table-live">
               <thead>
@@ -4300,7 +4319,7 @@ async function layarLiveScore() {
                   const nilai = rk.nilai || {};
                   const poin = k.poin_per_pos || {};
                   return `
-                  <tr>
+                  <tr data-sekolah="${esc(k.nama_sekolah || "")}">
                     <td class="rekap-rank">${MEDALI[k.peringkat] || ""}<span class="rank-angka">${esc(String(k.peringkat))}</span></td>
                     <td class="angka">${esc(dada3(k.nomor_dada))}</td>
                     <td>${esc(k.nama_regu)}</td>
@@ -4420,6 +4439,40 @@ async function layarLiveScore() {
       } finally {
         semua.forEach(x => { x.disabled = false; });
       }
+    });
+  });
+
+  /* Penyaring sekolah, satu per panel golongan.
+   *
+   *  Menyaring BARIS TABEL saja — podium juara dibiarkan utuh. Tiga medali
+   *  itu menjawab "siapa juara golongan ini"; menyaringnya per sekolah akan
+   *  menjadikan regu peringkat sembilan tampil sebagai Juara 1, dan itu
+   *  gambar yang difoto lalu disebarkan.
+   *
+   *  Peringkat di kolom pertama juga TIDAK dihitung ulang: ia peringkat di
+   *  golongannya, bukan nomor urut baris yang sedang tampil. Menyaring
+   *  sekolah lalu melihat "1, 4, 7" adalah jawaban yang benar. */
+  LAYAR.querySelectorAll(".panel-gol").forEach(panel => {
+    const kotak = [...panel.querySelectorAll(".isi-filter input[type=checkbox]")];
+    const hitung = panel.querySelector(".hitung-filter");
+    const semua = panel.querySelector(".tombol-semua");
+    if (!kotak.length) return;
+
+    const terapkan = () => {
+      const pilih = new Set(kotak.filter(c => c.checked).map(c => c.value));
+      panel.querySelectorAll("tbody tr[data-sekolah]").forEach(tr => {
+        tr.hidden = pilih.size > 0 && !pilih.has(tr.dataset.sekolah);
+      });
+      // Angkanya, bukan kata "aktif": panitia perlu tahu BERAPA yang sedang
+      // menyaring tanpa membuka daftarnya.
+      hitung.textContent = pilih.size ? `· ${pilih.size} dipilih` : "";
+      panel.querySelector(".filter-sekolah").classList.toggle("menyaring", pilih.size > 0);
+    };
+
+    kotak.forEach(c => c.addEventListener("change", terapkan));
+    if (semua) semua.addEventListener("click", () => {
+      kotak.forEach(c => { c.checked = false; });
+      terapkan();
     });
   });
 

--- a/web/style.css
+++ b/web/style.css
@@ -619,6 +619,28 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    tetap di tengah kartu — bukan di tengah sisa ruang. Dua sisi berlebar sama
    yang menjepitnya yang memastikan itu, jadi judul tidak bergeser waktu
    saklarnya tidak digambar (akun tanpa `pengaturan`). */
+/* Penyaring sekolah di papan Live Score. <details> bawaan, dirapikan.
+   Daftarnya bisa panjang — 23 sekolah hari ini, ratusan tahun depan — jadi ia
+   digulung sendiri dan tidak pernah mendorong tabel keluar layar. */
+.filter-sekolah { margin: 0 0 .6rem; }
+.filter-sekolah > summary {
+  cursor: pointer; display: inline-block; padding: .3rem .7rem;
+  border: 1px solid var(--garis); border-radius: 6px; font-size: .85rem;
+  font-weight: 600;
+}
+.filter-sekolah > summary:hover { background: var(--garis); }
+.filter-sekolah.menyaring > summary { border-color: var(--utama); color: var(--utama); }
+.filter-sekolah .isi-filter {
+  margin-top: .4rem; max-height: 40vh; overflow-y: auto;
+  border: 1px solid var(--garis); border-radius: 6px; padding: .5rem;
+  display: flex; flex-direction: column; gap: .3rem;
+}
+.filter-sekolah .isi-filter label {
+  display: flex; align-items: center; gap: .5rem; font-size: .9rem;
+  font-weight: 400; cursor: pointer;
+}
+.filter-sekolah .isi-filter input { width: 1rem; height: 1rem; }
+
 .kepala-klasemen { display: flex; align-items: center; gap: .5rem; margin: 0 0 .8rem; }
 .kepala-klasemen h2 { margin: 0; text-align: center; }
 .kepala-klasemen .sisi { flex: 1; display: flex; }


### PR DESCRIPTION
## What

Penyaring **Organisasi** di atas tabel klasemen — `<details>` berisi daftar
centang, bisa pilih banyak sekolah sekaligus, satu penyaring per panel golongan.
Tombol **Semua** mengosongkan pilihan.

## Why

Diminta.

**Daftarnya dibangun dari baris golongan itu**, bukan dari seluruh sekolah:
memilih sekolah yang tidak punya regu di golongan yang sedang dibuka
menghasilkan tabel kosong tanpa satu pun petunjuk kenapa.

**Menyaring baris tabel saja — podium juara dibiarkan utuh.** Tiga medali itu
menjawab *"siapa juara golongan ini"*; menyaringnya per sekolah akan menjadikan
regu peringkat sembilan tampil sebagai **Juara 1**, dan itu gambar yang difoto
lalu disebarkan.

**Peringkat di kolom pertama tidak dihitung ulang:** ia peringkat di golongannya,
bukan nomor urut baris yang sedang tampil. Menyaring sekolah lalu melihat
"1, 4, 7" adalah jawaban yang benar.

## Notes

Ringkasannya menyebut **angka** — `· 3 dipilih` — bukan kata "aktif": panitia
perlu tahu berapa yang sedang menyaring tanpa membuka daftarnya.

`<details>`, bukan dropdown buatan sendiri: ia sudah bisa dibuka dengan sentuhan,
ditutup dengan Esc, dan dibacakan pembaca layar tanpa satu baris JS pun.
Daftarnya digulung sendiri dan dibatasi `40vh`, jadi 23 sekolah hari ini maupun
ratusan tahun depan tidak pernah mendorong tabel keluar layar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)