### PR TITLE
fix: saringan sekolah diklik dari kepala kolom Organisasi

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -622,24 +622,20 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Penyaring sekolah di papan Live Score. <details> bawaan, dirapikan.
    Daftarnya bisa panjang — 23 sekolah hari ini, ratusan tahun depan — jadi ia
    digulung sendiri dan tidak pernah mendorong tabel keluar layar. */
-.filter-sekolah { margin: 0 0 .6rem; }
-.filter-sekolah > summary {
-  cursor: pointer; display: inline-block; padding: .3rem .7rem;
-  border: 1px solid var(--garis); border-radius: 6px; font-size: .85rem;
-  font-weight: 600;
-}
-.filter-sekolah > summary:hover { background: var(--garis); }
-.filter-sekolah.menyaring > summary { border-color: var(--utama); color: var(--utama); }
-.filter-sekolah .isi-filter {
+.th-saring { cursor: pointer; user-select: none; }
+.th-saring:hover { background: var(--garis); }
+.th-saring.menyaring { color: var(--utama); }
+.th-saring .hitung-filter { font-weight: 700; }
+.isi-filter {
   margin-top: .4rem; max-height: 40vh; overflow-y: auto;
   border: 1px solid var(--garis); border-radius: 6px; padding: .5rem;
   display: flex; flex-direction: column; gap: .3rem;
 }
-.filter-sekolah .isi-filter label {
+.isi-filter label {
   display: flex; align-items: center; gap: .5rem; font-size: .9rem;
   font-weight: 400; cursor: pointer;
 }
-.filter-sekolah .isi-filter input { width: 1rem; height: 1rem; }
+.isi-filter input { width: 1rem; height: 1rem; }
 
 .kepala-klasemen { display: flex; align-items: center; gap: .5rem; margin: 0 0 .8rem; }
 .kepala-klasemen h2 { margin: 0; text-align: center; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4285,15 +4285,16 @@ async function layarLiveScore() {
                <details> biasa, bukan dropdown buatan sendiri — ia sudah bisa
                dibuka dengan sentuhan, ditutup dengan Esc, dan dibacakan
                pembaca layar tanpa satu baris JS pun. -->
-          <details class="filter-sekolah">
-            <summary>Organisasi <span class="hitung-filter"></span></summary>
-            <div class="isi-filter">
-              <button type="button" class="button tombol-semua"
-                      style="padding:.25rem .6rem;font-size:.8rem">Semua</button>
-              ${sekolahAda.map(nm => `
-                <label><input type="checkbox" value="${esc(nm)}"> ${esc(nm)}</label>`).join("")}
-            </div>
-          </details>
+          <!-- Panelnya di ATAS tabel, tapi yang diklik KEPALA KOLOMNYA.
+               Panel ini tidak bisa ditaruh di dalam <th>: tabelnya duduk di
+               dalam wadah bergulir, dan apa pun yang mengambang di dalam sana
+               terpotong begitu daftarnya lebih tinggi dari kepala tabel. -->
+          <div class="isi-filter" hidden>
+            <button type="button" class="button tombol-semua"
+                    style="padding:.25rem .6rem;font-size:.8rem">Hapus saringan</button>
+            ${sekolahAda.map(nm => `
+              <label><input type="checkbox" value="${esc(nm)}"> ${esc(nm)}</label>`).join("")}
+          </div>
           <div class="table-wrapper table-wrapper-tetap">
             <table class="table data-table table-tetap table-rekap table-live">
               <thead>
@@ -4301,7 +4302,14 @@ async function layarLiveScore() {
                   <th rowspan="2">#</th>
                   <th rowspan="2">No<br>Dada</th>
                   <th rowspan="2">Regu</th>
-                  <th rowspan="2" class="rekap-batas">Organisasi</th>
+                  <!-- Kepala kolomnya SENDIRI yang jadi tombol saringan.
+                       Tombol terpisah di atas tabel menjauhkan aksinya dari
+                       kolom yang disaringnya, dan menambah satu benda lagi di
+                       layar yang sudah padat. -->
+                  <th rowspan="2" class="rekap-batas th-saring" tabindex="0"
+                      role="button" aria-expanded="false"
+                      title="Klik untuk menyaring per sekolah">Organisasi
+                    <span class="hitung-filter"></span> <span aria-hidden="true">▾</span></th>
                   ${posKolom.map(p => `<th colspan="${p.kolom.length + 1}"
                     class="rekap-batas">Pos ${esc(String(p.nomor))} · ${esc(p.name)}</th>`).join("")}
                   <th rowspan="2">Penalti</th>
@@ -4465,9 +4473,24 @@ async function layarLiveScore() {
       });
       // Angkanya, bukan kata "aktif": panitia perlu tahu BERAPA yang sedang
       // menyaring tanpa membuka daftarnya.
-      hitung.textContent = pilih.size ? `· ${pilih.size} dipilih` : "";
-      panel.querySelector(".filter-sekolah").classList.toggle("menyaring", pilih.size > 0);
+      hitung.textContent = pilih.size ? `(${pilih.size})` : "";
+      panel.querySelector(".th-saring").classList.toggle("menyaring", pilih.size > 0);
     };
+
+    const kepala = panel.querySelector(".th-saring");
+    const isi = panel.querySelector(".isi-filter");
+    const buka = () => {
+      isi.hidden = !isi.hidden;
+      kepala.setAttribute("aria-expanded", String(!isi.hidden));
+    };
+    if (kepala) {
+      kepala.addEventListener("click", buka);
+      // Keyboard juga: <th> bukan tombol, jadi Enter/Space tidak datang
+      // sendiri walau tabindex dan role sudah dipasang.
+      kepala.addEventListener("keydown", e => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); buka(); }
+      });
+    }
 
     kotak.forEach(c => c.addEventListener("change", terapkan));
     if (semua) semua.addEventListener("click", () => {

--- a/web/style.css
+++ b/web/style.css
@@ -622,24 +622,20 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Penyaring sekolah di papan Live Score. <details> bawaan, dirapikan.
    Daftarnya bisa panjang — 23 sekolah hari ini, ratusan tahun depan — jadi ia
    digulung sendiri dan tidak pernah mendorong tabel keluar layar. */
-.filter-sekolah { margin: 0 0 .6rem; }
-.filter-sekolah > summary {
-  cursor: pointer; display: inline-block; padding: .3rem .7rem;
-  border: 1px solid var(--garis); border-radius: 6px; font-size: .85rem;
-  font-weight: 600;
-}
-.filter-sekolah > summary:hover { background: var(--garis); }
-.filter-sekolah.menyaring > summary { border-color: var(--utama); color: var(--utama); }
-.filter-sekolah .isi-filter {
+.th-saring { cursor: pointer; user-select: none; }
+.th-saring:hover { background: var(--garis); }
+.th-saring.menyaring { color: var(--utama); }
+.th-saring .hitung-filter { font-weight: 700; }
+.isi-filter {
   margin-top: .4rem; max-height: 40vh; overflow-y: auto;
   border: 1px solid var(--garis); border-radius: 6px; padding: .5rem;
   display: flex; flex-direction: column; gap: .3rem;
 }
-.filter-sekolah .isi-filter label {
+.isi-filter label {
   display: flex; align-items: center; gap: .5rem; font-size: .9rem;
   font-weight: 400; cursor: pointer;
 }
-.filter-sekolah .isi-filter input { width: 1rem; height: 1rem; }
+.isi-filter input { width: 1rem; height: 1rem; }
 
 .kepala-klasemen { display: flex; align-items: center; gap: .5rem; margin: 0 0 .8rem; }
 .kepala-klasemen h2 { margin: 0; text-align: center; }


### PR DESCRIPTION
## What

Tombol **Organisasi** yang berdiri sendiri di atas tabel dihapus. Yang diklik
sekarang **kepala kolom ORGANISASI** di dalam tabel — ia membuka daftar centang,
dan menampilkan jumlah yang sedang menyaring: `ORGANISASI (3) ▾`.

## Why

Diminta. Tombol terpisah menjauhkan aksinya dari kolom yang disaringnya, dan
menambah satu benda lagi di layar yang sudah padat.

## Notes

**Panel centangnya tetap di atas tabel, bukan di dalam `<th>`** — tabelnya duduk
di wadah bergulir, dan apa pun yang mengambang di dalam sana terpotong begitu
daftarnya lebih tinggi dari kepala tabel. Yang pindah pemicunya, bukan panelnya.

`<th>` bukan tombol, jadi Enter dan Space tidak datang sendiri walau `tabindex`
dan `role="button"` sudah dipasang — keduanya dipasang eksplisit.

Tombolnya sekarang berbunyi **Hapus saringan**, bukan "Semua": yang ditekan
orang saat ingin kembali melihat semuanya adalah kalimat itu, bukan kata benda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)