### PR TITLE
feat: kartu pra jadi ajakan mendaftar, angkanya hitung pendaftar

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -183,12 +183,14 @@ function gambarPra() {
     ? new Date(META.edisi.tanggal_lomba) : null;
   return `
     <div class="kartu tengah">
-      <h2>Belum dimulai</h2>
-      <p>Rekap live terbuka saat lomba berjalan${t
-        ? ` — ${esc(String(t.getDate()))} ${esc(BULAN[t.getMonth()])} ${esc(String(t.getFullYear()))}`
-        : ""}.</p>
-      <p class="angka-besar">${esc(String(r.jumlah_regu_lunas ?? 0))}</p>
-      <p>regu terdaftar</p>
+      <!-- Sebelum lomba, halaman ini dibuka orang yang BELUM mendaftar —
+           bukan peserta yang mencari nilainya. "Belum dimulai" menjawab
+           pertanyaan yang tidak mereka punya; ajakan mendaftar menjawab
+           yang mereka punya. Tanggal lombanya ikut hilang: ia ada di
+           halaman pendaftaran, dan di sini cuma memberi alasan menunda. -->
+      <h2>Segera daftarkan dirimu di<br>Hiking Rally Ciradyka XXXVII</h2>
+      <p class="angka-besar">${esc(String(r.jumlah_regu_daftar ?? r.jumlah_regu_lunas ?? 0))}</p>
+      <p>regu sudah mendaftar</p>
       <p><a class="tombol" href="daftar.html">Daftar Sekarang</a></p>
       <div class="pil-baris">
         ${URUT_GOLONGAN.filter(g => per[g]).map(g =>

--- a/supabase/migrations/0071_ringkas_publik_terdaftar.sql
+++ b/supabase/migrations/0071_ringkas_publik_terdaftar.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- hrcd-rekap : 0071_ringkas_publik_terdaftar.sql
+-- Angka di halaman peserta menghitung yang MENDAFTAR, bukan yang membayar.
+--
+-- KENAPA
+--
+-- Sebelum lomba, halaman peserta dibuka orang yang belum ikut — dan angka yang
+-- menarik mereka adalah "sudah berapa yang mendaftar", bukan "sudah berapa
+-- yang lunas". `v_publik_ringkas` sejak 0005 menghitung `status = 'lunas'`,
+-- jadi regu yang sudah mengisi formulir tapi belum transfer tidak terhitung —
+-- padahal merekalah bukti acaranya ramai.
+--
+-- Selisihnya nol di data contoh (semuanya lunas), jadi ini tidak akan pernah
+-- terlihat sampai ada pendaftar sungguhan yang belum bayar. Diminta pemilik
+-- acara, dua kali, dan disebutkan untuk KEDUA angka: totalnya dan pecahan per
+-- golongan.
+--
+-- NAMANYA IKUT BERGANTI
+--
+-- `jumlah_regu_lunas` -> `jumlah_regu_daftar`. Membiarkan nama lama sambil
+-- mengganti artinya adalah cara paling rapi untuk membuat orang berikutnya
+-- salah membacanya — dan angka yang salah dibaca di halaman publik tidak
+-- pernah mengeluh.
+--
+-- `live.js` membaca nama baru dengan mundur ke nama lama, jadi `live.json`
+-- yang sudah terbit tetap tergambar sampai penerbitan berikutnya.
+-- ============================================================================
+
+-- `create or replace` TIDAK bisa mengganti nama kolom view — ia menolak
+-- dengan "cannot change name of view column". Jadi view-nya dibuang dulu.
+-- TANPA cascade, sengaja: kalau ternyata ada yang bergantung padanya,
+-- perintah ini gagal keras alih-alih ikut menghapusnya diam-diam.
+drop view if exists v_publik_ringkas;
+create view v_publik_ringkas as
+select
+  (select fase_live from status_acara) as fase_live,
+  -- Yang dihitung: regu yang ADA dan tidak batal. Status pembayarannya tidak
+  -- ikut menyaring.
+  (select count(*) from regu r where not r.is_cancelled) as jumlah_regu_daftar,
+  (select jsonb_object_agg(golongan, jumlah) from (
+     select golongan, count(*) as jumlah
+     from regu r where not r.is_cancelled
+     group by golongan) g) as per_golongan;
+
+grant select on v_publik_ringkas to anon, authenticated, service_role;
+
+comment on view v_publik_ringkas is
+  'Ringkasan untuk halaman peserta. Menghitung yang MENDAFTAR, bukan yang lunas: sebelum lomba, halaman ini dibaca calon peserta, dan angka yang menarik mereka jumlah pendaftar.';
+
+do $blok$
+declare v_daftar int; v_lunas int;
+begin
+  select jumlah_regu_daftar into v_daftar from v_publik_ringkas;
+  select count(*) into v_lunas from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+   where d.status = 'lunas' and not r.is_cancelled;
+  raise notice '0071: % regu mendaftar, % di antaranya lunas.', v_daftar, v_lunas;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -254,5 +254,7 @@ run tests/sql/35_detail_live_score_panitia.sql
 # itu tidak boleh membawa kolom lain dari status_acara.
 run supabase/migrations/0070_fase_live_publik.sql
 run tests/sql/36_fase_live_publik.sql
+# 0071 mengubah angka di halaman peserta jadi jumlah MENDAFTAR, bukan lunas.
+run supabase/migrations/0071_ringkas_publik_terdaftar.sql
 
 echo "SEMUA TES LULUS"


### PR DESCRIPTION
## What

- Kartu fase `pra` di halaman peserta: **"Segera daftarkan dirimu di Hiking
  Rally Ciradyka XXXVII"**, menggantikan "Belum dimulai" dan baris tanggal.
- **Migrasi 0071:** angkanya menghitung yang **mendaftar**, bukan yang lunas —
  totalnya maupun pecahan per golongan.

## Why

Sebelum lomba, halaman ini dibuka orang yang **belum ikut** — bukan peserta yang
mencari nilainya. "Belum dimulai" menjawab pertanyaan yang tidak mereka punya;
ajakan mendaftar menjawab yang mereka punya. Tanggal lombanya ikut hilang: ia
ada di halaman pendaftaran, dan di sini cuma memberi alasan menunda.

`v_publik_ringkas` sejak 0005 menghitung `status = lunas`, jadi regu yang sudah
mengisi formulir tapi belum transfer tidak terhitung — padahal merekalah bukti
acaranya ramai. Selisihnya nol di data contoh, jadi ini tidak akan pernah
terlihat sampai ada pendaftar sungguhan yang belum bayar.

## Notes

**Nama kolomnya ikut berganti** (`jumlah_regu_lunas` → `jumlah_regu_daftar`).
Membiarkan nama lama sambil mengganti artinya adalah cara paling rapi untuk
membuat orang berikutnya salah membacanya — dan angka yang salah dibaca di
halaman publik tidak pernah mengeluh. `live.js` membaca nama baru dengan mundur
ke nama lama, jadi `live.json` yang sudah terbit tetap tergambar sampai
penerbitan berikutnya.

`create or replace view` tidak bisa mengganti nama kolom, jadi view-nya dibuang
dulu — **tanpa cascade**, sengaja: kalau ada yang bergantung padanya, perintahnya
gagal keras alih-alih ikut menghapusnya diam-diam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)