### PR TITLE
fix: judul Live Score, kartu kemajuan diringkas, kolom Daftar Ulang dipisah

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Rekap Live — Hiking Rally Ciradyka</title>
+  <title>Live Score — Hiking Rally Ciradyka</title>
   <meta name="description" content="Rekap live Hiking Rally Ciradyka — periksa nilai regu sudah masuk atau belum.">
   <!-- Halaman ini TIDAK memuat kunci apa pun: tidak ada anon key, tidak ada
        alamat Supabase, tidak ada kotak login. Seluruh isinya datang dari dua
@@ -16,7 +16,7 @@
 <body>
   <header class="kepala">
     <div class="kepala-isi">
-      <h1 id="judul">Rekap Live</h1>
+      <h1 id="judul">Live Score</h1>
       <p class="sinkron" id="sinkron">Memuat…</p>
     </div>
   </header>

--- a/live/live.js
+++ b/live/live.js
@@ -350,8 +350,7 @@ function gambarKelengkapan() {
 
   return `
     <div class="kartu">
-      <h2>Kemajuan input</h2>
-      <p class="keterangan">Angka ini bukan nilai — nilai baru terbit saat hasil diumumkan.</p>
+      <h2>Status</h2>
       <ul class="kemajuan">
         ${daftar.map(p => {
           const persen = Number(p.persen) || 0;
@@ -450,8 +449,8 @@ function gambar() {
   if (!META) return;
 
   document.getElementById("judul").textContent =
-    `Rekap Live${META.edisi ? ` — ${META.edisi.name}` : ""}`;
-  document.title = `Rekap Live — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
+    `Live Score${META.edisi ? ` — ${META.edisi.name}` : ""}`;
+  document.title = `Live Score — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
 
   isi.innerHTML = !mulai()
     ? gambarPra()

--- a/live/style.css
+++ b/live/style.css
@@ -622,6 +622,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Penyaring sekolah di papan Live Score. <details> bawaan, dirapikan.
    Daftarnya bisa panjang — 23 sekolah hari ini, ratusan tahun depan — jadi ia
    digulung sendiri dan tidak pernah mendorong tabel keluar layar. */
+/* Meja Daftar Ulang: nomor dada RATA KIRI dan selebar isinya saja.
+   Sebelumnya nomor dan tombol tukar berbagi satu kolom yang mengambil seluruh
+   sisa lebar, jadi pilnya terdorong jauh ke kanan — mata harus menyeberangi
+   ruang kosong dari nama sekolah ke nomornya. */
+.table-daftar-ulang .kol-dada { width: 1%; white-space: nowrap; text-align: left; }
+.table-daftar-ulang .kol-dada .pill-row,
+.table-daftar-ulang .kol-dada .sub { justify-content: flex-start; }
+/* Tombol tukar mengambil sisanya, rata kiri juga — ia mengikuti nomornya,
+   bukan menempel di tepi kanan layar. */
+.table-daftar-ulang .kol-tukar { text-align: left; }
+
 .th-saring { cursor: pointer; user-select: none; }
 .th-saring:hover { background: var(--garis); }
 .th-saring.menyaring { color: var(--utama); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -875,7 +875,12 @@ async function layarDaftarUlang() {
                    kolom sendiri hanya untuk mengulanginya adalah lebar yang
                    terbuang — di jendela sempit lebar itulah yang membuat
                    tombolnya terdorong keluar layar. -->
-              <th>Kode Bayar</th><th>Sekolah</th><th></th>
+              <!-- Empat kolom, dua terakhir tanpa judul: nomor dada, lalu
+                   tombol tukar. Dulu keduanya berbagi satu kolom, dan
+                   tombolnya jatuh ke baris kedua tiap kali nomornya lebih
+                   dari dua — tinggi baris jadi dua kali lipat untuk
+                   sebagian sekolah saja, dan tabelnya bergerigi. -->
+              <th>Kode Bayar</th><th>Sekolah</th><th></th><th></th>
             </tr>
           </thead>
           <tbody id="isi-tabel"></tbody>
@@ -898,7 +903,7 @@ async function layarDaftarUlang() {
     const tbody = document.getElementById("isi-tabel");
 
     if (!baris.length) {
-      tbody.replaceChildren(h(`<tr><td colspan="3" class="table-empty">
+      tbody.replaceChildren(h(`<tr><td colspan="4" class="table-empty">
         Tidak ada yang cocok.</td></tr>`));
       return;
     }
@@ -926,8 +931,8 @@ async function layarDaftarUlang() {
                    data-isi="${kode}" data-jumlah="${menunggu.length}"
                    aria-expanded="${terbuka}">
              ${terbuka ? "▾" : "▸"} Isi ${menunggu.length} Nomor Dada
-           </button>${nomorHtml ? `<div class="sub">${nomorHtml} ${tombolTukar}</div>` : ""}`
-        : `<div class="pill-row">${nomorHtml} ${tombolTukar}</div>`;
+           </button>${nomorHtml ? `<div class="sub">${nomorHtml}</div>` : ""}`
+        : `<div class="pill-row">${nomorHtml}</div>`;
 
       // Template biasa (lihat catatan sama di layar Pembayaran).
       return `
@@ -943,11 +948,12 @@ async function layarDaftarUlang() {
           <td data-label="Sekolah">
             <strong>${esc(b.sekolah?.name || "—")}</strong>
           </td>
-          <td data-label="">${aksi}</td>
+          <td data-label="" class="kol-dada">${aksi}</td>
+          <td data-label="" class="kol-tukar">${tombolTukar}</td>
         </tr>
         ${!menunggu.length ? "" : `
         <tr class="detail-row" data-nomor-untuk="${kode}" ${terbuka ? "" : "hidden"}>
-          <td colspan="3" class="detail-cell-flush">
+          <td colspan="4" class="detail-cell-flush">
             <table class="detail-table detail-table-dada">
               <thead>
                 <tr><th>Regu</th><th>Kategori</th><th>Ketua</th><th>Nomor dada</th></tr>

--- a/web/style.css
+++ b/web/style.css
@@ -622,6 +622,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Penyaring sekolah di papan Live Score. <details> bawaan, dirapikan.
    Daftarnya bisa panjang — 23 sekolah hari ini, ratusan tahun depan — jadi ia
    digulung sendiri dan tidak pernah mendorong tabel keluar layar. */
+/* Meja Daftar Ulang: nomor dada RATA KIRI dan selebar isinya saja.
+   Sebelumnya nomor dan tombol tukar berbagi satu kolom yang mengambil seluruh
+   sisa lebar, jadi pilnya terdorong jauh ke kanan — mata harus menyeberangi
+   ruang kosong dari nama sekolah ke nomornya. */
+.table-daftar-ulang .kol-dada { width: 1%; white-space: nowrap; text-align: left; }
+.table-daftar-ulang .kol-dada .pill-row,
+.table-daftar-ulang .kol-dada .sub { justify-content: flex-start; }
+/* Tombol tukar mengambil sisanya, rata kiri juga — ia mengikuti nomornya,
+   bukan menempel di tepi kanan layar. */
+.table-daftar-ulang .kol-tukar { text-align: left; }
+
 .th-saring { cursor: pointer; user-select: none; }
 .th-saring:hover { background: var(--garis); }
 .th-saring.menyaring { color: var(--utama); }


### PR DESCRIPTION
Tiga permintaan: judul situs peserta jadi Live Score, kalimat penjelas di kartu kemajuan dibuang (judulnya jadi Status seperti layar panitia), dan tombol Tukar nomor rusak di Meja Daftar Ulang pindah ke kolom sendiri tanpa judul.

Di Daftar Ulang, nomor dada dan tombol tukar dulu berbagi satu kolom yang mengambil seluruh sisa lebar, jadi pilnya terdorong jauh ke kanan dan tombolnya jatuh ke baris kedua tiap kali nomornya lebih dari dua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)