### PR TITLE
feat: data centang per komponen untuk halaman peserta

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -107,7 +107,7 @@ jobs:
 
           d = json.load(open('/tmp/rekap-utuh.json'))
           for k in ('dibuat_pada', 'fase', 'edisi', 'ringkas', 'pos',
-                    'kelengkapan', 'progres', 'klasemen'):
+                    'komponen', 'kelengkapan', 'progres', 'klasemen'):
               if k not in d:
                   sys.exit(f'kunci {k} hilang dari keluaran live_json.sql')
 
@@ -121,6 +121,15 @@ jobs:
               sys.exit('BOCOR: baris regu ikut tertulis padahal fase masih pra')
           if d['fase'] == 'pra' and d['kelengkapan']:
               sys.exit('BOCOR: kelengkapan pos tertulis padahal fase masih pra')
+          # Nilai asli per komponen HANYA boleh ada di fase 'penuh'. Centang
+          # (`komponen_terisi`) boleh sejak 'progres' — ia tidak menyebut satu
+          # angka pun. Pemisahan itu satu-satunya jaminan bahwa nilai yang
+          # belum diumumkan memang TIDAK ADA di CDN, bukan sekadar tidak
+          # digambar.
+          if d['fase'] != 'penuh':
+              for baris in d['progres']:
+                  if baris.get('nilai'):
+                      sys.exit('BOCOR: nilai per komponen tertulis padahal fase belum penuh')
 
           rekap = {'progres': d['progres'], 'klasemen': d['klasemen']}
           sidik = hashlib.sha256(json.dumps(
@@ -139,6 +148,7 @@ jobs:
               # di rekap.json justru karena ia berubah terus: rekap.json
               # dialamati `?v=<versi>` dan sengaja mengendap di cache, jadi
               # angka yang harus selalu segar tidak boleh menumpang di sana.
+              'komponen':    d['komponen'],
               'kelengkapan': d['kelengkapan'],
               'jumlah_regu': len(d['progres']),
           }

--- a/supabase/checks/live_json.sql
+++ b/supabase/checks/live_json.sql
@@ -43,6 +43,17 @@ select jsonb_pretty(jsonb_build_object(
                          '[]'::jsonb)
                   from v_kelengkapan_publik kl),
 
+  -- Daftar komponen. Tanpa ini halaman peserta tidak bisa menggambar kepala
+  -- tabel yang sama dengan layar panitia — ia tahu ada Pos 1, tapi tidak tahu
+  -- Pos 1 berisi Semaphore, Tebak Simpul, dan Menaksir. Isinya nama dan
+  -- golongan saja; tidak ada satu pun angka nilai di sini.
+  'komponen', (select coalesce(jsonb_agg(jsonb_build_object(
+                        'kode', w.kode, 'name', w.name, 'pos', w.pos,
+                        'golongan', w.golongan, 'lomba', w.lomba,
+                        'sort_order', w.sort_order)
+                      order by w.pos, w.sort_order, w.kode), '[]'::jsonb)
+               from wahana w where w.edisi = edisi_aktif()),
+
   'progres', (select coalesce(jsonb_agg(to_jsonb(p) order by p.nomor_dada),
                      '[]'::jsonb)
               from v_progres_publik p),

--- a/supabase/migrations/0072_progres_komponen_publik.sql
+++ b/supabase/migrations/0072_progres_komponen_publik.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- hrcd-rekap : 0072_progres_komponen_publik.sql
+-- Halaman peserta butuh data yang sama bentuknya dengan layar panitia.
+--
+-- KENAPA
+--
+-- Diminta pemilik acara: tampilan peserta sama persis dengan Live Score
+-- panitia, bedanya cuma "masking" — di fase `progres` nilainya diganti
+-- CENTANG. "Semaphore sudah masuk ✓, Tebak Simpul belum."
+--
+-- `v_progres_publik` selama ini hanya membawa `pos_terlewati`: satu boolean
+-- PER POS. Dengan itu halaman peserta tidak bisa menggambar kolom per
+-- komponen sama sekali — ia tidak tahu Semaphore dan Tebak Simpul itu dua
+-- hal berbeda.
+--
+-- DUA KOLOM BARU, DAN PEMBAGIAN TUGASNYA
+--
+--   komponen_terisi   {"1.semaphore": true, "1.tebak_simpul": false, ...}
+--                     Ada di fase `progres` MAUPUN `penuh`. Ini yang jadi
+--                     centang.
+--   nilai             {"1.semaphore": {"nilai_1": 4, "nilai_2": null}, ...}
+--                     HANYA di fase `penuh`. Di `progres` ia objek kosong —
+--                     bukan berisi angka yang disembunyikan tampilan.
+--
+-- Pemisahan itu bukan kerapian. Berkas rekap.json duduk di CDN dan bisa
+-- diminta siapa pun yang tahu alamatnya; satu-satunya jaminan bahwa nilai
+-- belum bocor adalah nilainya MEMANG TIDAK ADA DI SANA. Kalau `nilai` ikut
+-- terisi di fase `progres`, jaminan itu berubah jadi "ada tapi tidak
+-- digambar", dan centangnya jadi hiasan.
+--
+-- Kolom ditambahkan DI BELAKANG: PostgreSQL mengizinkan kolom baru di ujung
+-- pada `create or replace view`, tapi menolak kalau urutan atau tipe kolom
+-- yang sudah ada ikut bergeser.
+-- ============================================================================
+
+create or replace view v_progres_publik as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.name as nama_sekolah,
+  r.golongan,
+  (select jsonb_object_agg(p.nomor::text,
+            exists (select 1 from nilai_mentah n
+                    join wahana w on w.id = n.wahana_id
+                    where n.regu_id = r.id and w.pos = p.nomor))
+   from pos p
+   where p.edisi = edisi_aktif()
+     and exists (select 1 from wahana w
+                 where w.edisi = p.edisi and w.pos = p.nomor)) as pos_terlewati,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing,
+  r.kloter_nomor                              as kloter,
+  r.kontrak_menit,
+  k.jam_berangkat,
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+    then k.jam_berangkat + make_interval(mins => r.kontrak_menit)
+  end                                         as target_datang,
+  c.jam_datang,
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                                              as sudah_berangkat,
+
+  -- Centang per komponen. Komponen yang tidak berlaku untuk golongan regu ini
+  -- TIDAK ikut — kolomnya digambar sebagai "–" oleh halaman peserta, sama
+  -- seperti layar panitia.
+  (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+            exists (select 1 from nilai_mentah n
+                     where n.regu_id = r.id and n.wahana_id = w.id)), '{}'::jsonb)
+   from wahana w
+   where w.edisi = edisi_aktif()
+     and (w.golongan is null or w.golongan = r.golongan))    as komponen_terisi,
+
+  -- Nilai asli, HANYA saat hasil sudah diumumkan.
+  case when (select fase_live from status_acara) = 'penuh' then
+    (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+              jsonb_build_object('nilai_1', n.nilai_1, 'nilai_2', n.nilai_2)), '{}'::jsonb)
+     from nilai_mentah n join wahana w on w.id = n.wahana_id
+     where n.regu_id = r.id and w.edisi = edisi_aktif())
+  else '{}'::jsonb end                                        as nilai
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join kloter k        on k.nomor = r.kloter_nomor
+left join closing_regu c  on c.regu_id = r.id
+where not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and (select fase_live from status_acara) in ('progres', 'penuh');
+
+do $blok$
+declare v_n int; v_nilai int;
+begin
+  select count(*) into v_n from v_progres_publik;
+  select count(*) into v_nilai from v_progres_publik where nilai <> '{}'::jsonb;
+  raise notice '0072: % baris progres publik, % membawa nilai (0 kalau fase belum penuh).',
+    v_n, v_nilai;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -256,5 +256,9 @@ run supabase/migrations/0070_fase_live_publik.sql
 run tests/sql/36_fase_live_publik.sql
 # 0071 mengubah angka di halaman peserta jadi jumlah MENDAFTAR, bukan lunas.
 run supabase/migrations/0071_ringkas_publik_terdaftar.sql
+# 0072 menambah centang per komponen dan nilai (hanya saat fase penuh) ke
+# v_progres_publik, supaya halaman peserta bisa menggambar tabel yang sama
+# bentuknya dengan layar panitia.
+run supabase/migrations/0072_progres_komponen_publik.sql
 
 echo "SEMUA TES LULUS"


### PR DESCRIPTION
Langkah pertama menuju tampilan peserta yang sama bentuknya dengan layar panitia. Yang menahannya selama ini **data**, bukan tampilan: `v_progres_publik` cuma membawa `pos_terlewati`, satu boolean per pos.

Migrasi 0072 menambah `komponen_terisi` (centang, sejak fase progres) dan `nilai` (hanya saat fase penuh). Pemisahan itu satu-satunya jaminan bahwa nilai belum bocor adalah nilainya memang tidak ada di CDN — bukan sekadar tidak digambar. publish-live menolak menerbitkan kalau pagarnya dilanggar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)