### PR TITLE
feat: tabel peserta berbentuk sama dengan layar panitia, dengan masking centang

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -35,6 +35,6 @@
        halaman yang SUDAH TERBUKA: ia menjalankan kode yang dimuat waktu
        dibuka sampai di-reload. Menaikkan versinya membuat HP yang
        memuat ulang pasti mendapat berkas baru, bukan yang tersimpan. -->
-  <script src="live.js?v=2"></script>
+  <script src="live.js?v=3"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -109,6 +109,15 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
    sini deretan centang per pos — bentuk baris itulah isinya, dan menumpuknya
    membuat satu regu memakan satu layar penuh. */
 .gulir { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+/* Kolom komponen: sempit, rata tengah, dan judulnya boleh membungkus.
+   Bentuknya mengikuti tabel panitia — satu kolom per komponen, bukan per
+   pos. */
+.tabel th.kol-komponen { font-size: .72rem; font-weight: 600; white-space: normal;
+  line-height: 1.15; }
+.tabel td.pos { text-align: center; }
+.tabel td.pos.ada { font-weight: 700; }
+.tabel td.pos.belum { color: #9aa3ad; }
+
 .tabel { width: 100%; border-collapse: collapse; font-size: .9rem; white-space: nowrap; }
 .tabel th {
   text-align: left; font-size: .7rem; text-transform: uppercase;

--- a/live/live.js
+++ b/live/live.js
@@ -265,14 +265,32 @@ function gambarHasil() {
     sekolah.get(k).push(b);
   }
 
-  const kepalaPos = pos.map(p =>
-    `<th class="pos">${esc(p.bayangan ? p.name : `Pos ${p.nomor}`)}</th>`).join("");
+  /* Kepala tabel DUA BARIS, bentuknya sama dengan layar panitia: baris atas
+     nama posnya, baris bawah nama tiap komponennya. Sebelumnya satu kolom
+     per POS — dan dengan itu peserta tidak pernah tahu Pos 1 berisi tiga hal
+     yang dinilai terpisah.
+
+     Komponen yang khusus satu golongan (Tebak Simpul punya empat versi)
+     digabung jadi SATU kolom bernama sama, persis seperti kolomPos() di layar
+     panitia. Yang membedakan barisnya: tiap regu hanya punya versi
+     golongannya sendiri. */
+  const komponen = (META && META.komponen) || [];
+  const perPos = pos.map(p => {
+    const milik = komponen.filter(w => w.pos === p.nomor);
+    const nama = [];
+    for (const w of milik) if (!nama.includes(w.name)) nama.push(w.name);
+    return { pos: p, nama, milik };
+  }).filter(x => x.nama.length);
+
+  const kepalaPos = perPos.map(x =>
+    `<th class="pos" colspan="${x.nama.length}">${
+      esc(x.pos.bayangan ? x.pos.name : `Pos ${x.pos.nomor}`)}</th>`).join("");
+  const kepalaKomponen = perPos.map(x => x.nama.map(nm =>
+    `<th class="pos kol-komponen">${esc(nm)}</th>`).join("")).join("");
 
   return [...sekolah.entries()].sort((a, b) => a[0].localeCompare(b[0], "id"))
     .map(([nama, isi]) => {
       isi.sort((a, b) => (a.nomor_dada ?? 1e9) - (b.nomor_dada ?? 1e9));
-      const kolomEkstra = penuh
-        ? `<th>Kloter</th><th>Kontrak</th><th>Berangkat</th><th>Datang</th>` : "";
       return `
         <div class="kartu">
           <h2>${esc(nama)}</h2>
@@ -281,17 +299,46 @@ function gambarHasil() {
             <table class="tabel">
               <thead>
                 <tr>
-                  <th>No<br>Dada</th><th>Regu</th><th>Golongan</th>
-                  ${kolomEkstra}${kepalaPos}
+                  <th rowspan="2">No<br>Dada</th><th rowspan="2">Regu</th>
+                  <th rowspan="2">Golongan</th>
+                  ${penuh ? `<th rowspan="2">Kloter</th><th rowspan="2">Kontrak</th>
+                     <th rowspan="2">Berangkat</th><th rowspan="2">Datang</th>` : ""}
+                  ${kepalaPos}
                 </tr>
+                <tr>${kepalaKomponen}</tr>
               </thead>
               <tbody>
                 ${isi.map(b => {
-                  const lewat = b.pos_terlewati || {};
-                  const sel = pos.map(p => {
-                    const ada = lewat[String(p.nomor)];
-                    return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : "–"}</td>`;
-                  }).join("");
+                  /* Inilah "masking"-nya. Bentuk tabelnya sama persis dengan
+                     layar panitia; yang berbeda hanya ISI SELNYA:
+
+                       progres  ✓ kalau nilainya sudah masuk, kosong kalau
+                                belum. Tidak ada satu angka pun.
+                       penuh    angka yang sebenarnya.
+
+                     Dan itu bukan sekadar tampilan: di fase progres,
+                     `nilai` memang objek kosong di rekap.json (0072). Yang
+                     disembunyikan tidak ada di berkasnya. */
+                  const terisi = b.komponen_terisi || {};
+                  const angka = b.nilai || {};
+                  const sel = perPos.map(x => x.nama.map(nm => {
+                    // Versi komponen yang berlaku untuk golongan regu INI.
+                    const w = x.milik.find(k =>
+                      k.name === nm && (!k.golongan || k.golongan === b.golongan));
+                    if (!w) return `<td class="pos belum">–</td>`;
+                    const kunci = `${x.pos.nomor}.${w.kode}`;
+                    if (!penuh) {
+                      const ada = terisi[kunci];
+                      return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : ""}</td>`;
+                    }
+                    const v = angka[kunci];
+                    if (!v || v.nilai_1 === null || v.nilai_1 === undefined) {
+                      return `<td class="pos belum">–</td>`;
+                    }
+                    return `<td class="pos ada">${esc(String(v.nilai_1))}${
+                      v.nilai_2 === null || v.nilai_2 === undefined
+                        ? "" : ` / ${esc(String(v.nilai_2))}`}</td>`;
+                  }).join("")).join("");
                   const ekstra = penuh ? `
                     <td>${b.kloter ? esc(String(b.kloter)) : "—"}</td>
                     <td>${esc(kontrak(b.kontrak_menit))}</td>


### PR DESCRIPTION
Kepala tabel dua baris — atas nama pos, bawah nama tiap komponen — persis bentuk Live Score panitia. Yang berbeda hanya isi selnya: **centang** saat fase progres, **angka** saat penuh.

Dan itu bukan sekadar tampilan: di fase progres kolom `nilai` memang objek kosong di rekap.json (0072). Centangnya bukan tirai di depan angka — angkanya belum diterbitkan.

Komponen khusus golongan (Tebak Simpul, empat versi) digabung jadi satu kolom bernama sama, seperti `kolomPos()` di panitia; yang tidak berlaku untuk regu itu digambar `–`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)