### PR TITLE
fix: nama Al-Azhar Citangkolo, dan pencarian sekolah yang mengabaikan huruf status

### DIFF
--- a/live/daftar.html
+++ b/live/daftar.html
@@ -27,6 +27,6 @@
   </main>
 
   <script src="config.js"></script>
-  <script type="module" src="js/daftar.js?v=2"></script>
+  <script type="module" src="js/daftar.js?v=3"></script>
 </body>
 </html>

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -69,7 +69,28 @@ window.addEventListener("beforeunload", (e) => {
 });
 
 const totalRincian = () => Object.values(jawab.rincian).reduce((a, b) => a + b, 0);
-const normal = s => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+/* Penyamaan untuk PENCARIAN sekolah, bukan untuk menyimpan.
+ *
+ *  Pembina mengetik nama yang dia ucapkan, bukan nama yang tertulis di
+ *  Dapodik. "MAS Agro" harus tetap menemukan "MA Agrowisata Shaleha" —
+ *  huruf S di "MAS" itu status Swasta, bukan bagian nama, dan tidak ada
+ *  seorang pun yang menyebutnya.
+ *
+ *  Urutannya penting: huruf statusnya dibuang SELAGI spasinya masih ada.
+ *  Versi lama langsung membuang seluruh non-huruf, jadi "MAS Agro" jadi
+ *  "masagro" dan tidak pernah cocok dengan "maagrowisatashaleha" — sekolahnya
+ *  seolah tidak terdaftar, dan pembina mendaftarkannya lagi sebagai baris
+ *  baru.
+ *
+ *  Aturannya sama dengan kunci_sekolah() di database (migrasi 0062), dan
+ *  memang harus sama: yang satu memutuskan apa yang TERLIHAT saat mencari,
+ *  yang satu memutuskan apa yang dianggap SEKOLAH YANG SAMA saat menyimpan. */
+const normal = s => String(s || "").toLowerCase()
+  // "SMP Negeri 1" dan "SMP N 1" adalah "SMPN 1".
+  .replace(/\b(sd|smp|sma|smk|mi|mts|ma)\s+n(egeri)?\b/g, "$1n")
+  // Huruf status Dapodik di awal nama: MAS, SMKS, SMAS, SMPS, MTsS, MIS.
+  .replace(/^\s*(sd|smp|sma|smk|mi|mts|ma)s\b/, "$1")
+  .replace(/[^a-z0-9]/g, "");
 const labelGolongan = k => GOLONGAN.find(g => g.kode === k).label;
 
 /* ---------- nama regu: 20 karakter, dan tidak boleh kembar (0051) ----------

--- a/supabase/migrations/0073_nama_al_azhar_citangkolo.sql
+++ b/supabase/migrations/0073_nama_al_azhar_citangkolo.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- hrcd-rekap : 0073_nama_al_azhar_citangkolo.sql
+-- MA Al-Azhar Kota Banjar -> MA Al-Azhar Citangkolo Kota Banjar.
+--
+-- KENAPA
+--
+-- Diminta pemilik acara. "Citangkolo" adalah nama pesantrennya, dan itu yang
+-- diucapkan orang — runbook bagian 5: pakai nama yang biasa diucapkan,
+-- sedekat mungkin dengan nama resminya.
+--
+-- Ekor "Kota Banjar" TETAP. Ia bukan hiasan: aturan NPSN di runbook bagian 5
+-- meminta nama membedakan sekolah sendirian, dan ekor daerah adalah cara
+-- kita melakukannya. Menambah "Citangkolo" memperjelas, tidak menggantikan.
+--
+-- YANG TIDAK PERLU DIKHAWATIRKAN
+--
+-- `sekolah_kunci_unik` adalah unique index atas nama yang dinormalisasi, dan
+-- nama baru ini tidak bentrok dengan satu pun baris lain. Pendaftaran yang
+-- sudah menunjuk baris ini tidak tersentuh — `id`-nya tidak berubah, cuma
+-- namanya.
+-- ============================================================================
+
+do $blok$
+declare v_n int;
+begin
+  update sekolah
+     set name = 'MA Al-Azhar Citangkolo Kota Banjar'
+   where name = 'MA Al-Azhar Kota Banjar';
+  get diagnostics v_n = row_count;
+
+  if v_n = 0 then
+    -- Bukan galat: bisa jadi migrasinya dijalankan dua kali, atau tabel
+    -- sekolah belum diisi di database ini.
+    raise notice '0073: "MA Al-Azhar Kota Banjar" tidak ada — dilewati.';
+  else
+    raise notice '0073: % baris diganti namanya.', v_n;
+  end if;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -260,5 +260,8 @@ run supabase/migrations/0071_ringkas_publik_terdaftar.sql
 # v_progres_publik, supaya halaman peserta bisa menggambar tabel yang sama
 # bentuknya dengan layar panitia.
 run supabase/migrations/0072_progres_komponen_publik.sql
+# 0073 mengganti nama satu sekolah. Ikut dijalankan supaya berkasnya tetap
+# teruji; di database uji ia memang tidak menemukan apa pun.
+run supabase/migrations/0073_nama_al_azhar_citangkolo.sql
 
 echo "SEMUA TES LULUS"

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -14,7 +14,7 @@
   "catatan": "MA-nya sendiri tidak punya NPSN di referensi Kemendikdasmen — yang terdaftar di NPSN 20263112 adalah SLB Agrowisata Shaleha Panjalu, sekolah saudara di kompleks yayasan yang sama (MA di bawah Kemenag/EMIS, bukan Dapodik). Alamat dan kode pos 46264 diambil dari catatan Dapodik SLB tersebut, yang beralamat sama: Dusun Sriwinangun RT/RW 52/24, Desa Panjalu. Satu berita (dutapriangan.co.id) mengeja jalannya \"Sariwangun\", bukan \"Sriwinangun\" — Dapodik dan peserta sama-sama menulis Sriwinangun, jadi itu yang saya pakai. NPSN dan kode pos sebaiknya dikonfirmasi ke sekolah."
  },
  {
-  "nama": "MA Al-Azhar Kota Banjar",
+  "nama": "MA Al-Azhar Citangkolo Kota Banjar",
   "nama_resmi": "MAS AL AZHAR",
   "npsn": "20277086",
   "jalan": "Jl. Pesantren No. 02",

--- a/tools/data/sekolah_nama.json
+++ b/tools/data/sekolah_nama.json
@@ -2119,7 +2119,7 @@
  },
  {
   "kunci": "ma al azhar",
-  "nama": "MA Al-Azhar Kota Banjar",
+  "nama": "MA Al-Azhar Citangkolo Kota Banjar",
   "peserta": 2,
   "edisi": [
    "XXXVI"


### PR DESCRIPTION
Dua hal di layar pendaftaran.

**1. MA Al-Azhar Kota Banjar → MA Al-Azhar Citangkolo Kota Banjar.** "Citangkolo" nama pesantrennya, dan itu yang diucapkan orang. Ekor **Kota Banjar** tetap — aturan NPSN meminta nama membedakan sekolah sendirian.

**2. "MAS Agro" tidak menemukan "MA Agrowisata Shaleha".** `normal()` membuang seluruh non-huruf lebih dulu, jadi "masagro" tidak pernah cocok dengan "maagrowisatashaleha". Sekolahnya seolah tidak terdaftar — dan pembina lalu mendaftarkannya lagi sebagai baris baru, persis kerusakan yang 0061–0063 kerjakan untuk membersihkannya.

Huruf status Dapodik sekarang dibuang **selagi spasinya masih ada**. Aturannya disamakan dengan `kunci_sekolah()` di database, dan memang harus sama: yang satu memutuskan apa yang **terlihat** saat mencari, yang satu apa yang dianggap **sekolah yang sama** saat menyimpan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)