### PR TITLE
fix: kotak ketik di saringan Organisasi tidak menyaring apa-apa

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -35,6 +35,6 @@
        halaman yang SUDAH TERBUKA: ia menjalankan kode yang dimuat waktu
        dibuka sampai di-reload. Menaikkan versinya membuat HP yang
        memuat ulang pasti mendapat berkas baru, bukan yang tersimpan. -->
-  <script src="live.js?v=7"></script>
+  <script src="live.js?v=8"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -43,6 +43,12 @@
 .isi-filter .tombol-kecil:hover { background: #004d43; border-color: #004d43; }
 .isi-filter .daftar-filter { overflow-y: auto; display: flex;
   flex-direction: column; gap: .3rem; max-height: 30vh; }
+/* `label[hidden]` HARUS disebut ulang — sebab yang sama dengan
+   `.isi-filter[hidden]` di atas: `display: flex` di baris berikutnya
+   mengalahkan `[hidden] { display: none }` bawaan browser, jadi baris yang
+   disaring tetap terlihat. Ini kedua kalinya jebakan yang sama menggigit di
+   berkas ini. */
+.isi-filter label[hidden] { display: none; }
 .isi-filter label { display: flex; align-items: center; gap: .5rem;
   font-size: .9rem; cursor: pointer; }
 .tombol-kecil { padding: .25rem .6rem; font-size: .8rem; border-radius: 6px;

--- a/live/live.js
+++ b/live/live.js
@@ -475,7 +475,11 @@ function pasangPapan() {
     document.addEventListener("keydown", e => { if (e.key === "Escape") tutup(); });
     if (cariKotak) cariKotak.addEventListener("input", () => {
       const q = cariKotak.value.trim().toLowerCase();
-      panel.querySelectorAll(".daftar-filter label").forEach(l => {
+      // Dicari dari `isi`, BUKAN dari `panel`. Panelnya sudah dipindah ke
+      // <body> saat dipasang, jadi ia bukan lagi keturunan .panel-gol dan
+      // querySelectorAll dari sana mengembalikan nol elemen — kotak ketiknya
+      // tampak mati padahal huruf-hurufnya masuk.
+      isi.querySelectorAll(".daftar-filter label").forEach(l => {
         l.hidden = q.length > 0 && !l.textContent.toLowerCase().includes(q);
       });
     });

--- a/live/style.css
+++ b/live/style.css
@@ -667,6 +667,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   overflow-y: auto; display: flex; flex-direction: column; gap: .3rem;
   max-height: 30vh;
 }
+/* `label[hidden]` HARUS disebut ulang — sebab yang sama dengan
+   `.isi-filter[hidden]` di atas: `display: flex` di baris berikutnya
+   mengalahkan `[hidden] { display: none }` bawaan browser, jadi baris yang
+   disaring tetap terlihat. Ini kedua kalinya jebakan yang sama menggigit di
+   berkas ini. */
+.isi-filter label[hidden] { display: none; }
 .isi-filter label {
   display: flex; align-items: center; gap: .5rem; font-size: .9rem;
   font-weight: 400; cursor: pointer;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4533,7 +4533,11 @@ async function layarLiveScore() {
     document.addEventListener("keydown", e => { if (e.key === "Escape") tutup(); });
     if (cariKotak) cariKotak.addEventListener("input", () => {
       const q = cariKotak.value.trim().toLowerCase();
-      panel.querySelectorAll(".daftar-filter label").forEach(l => {
+      // Dicari dari `isi`, BUKAN dari `panel`. Panelnya sudah dipindah ke
+      // <body> saat dipasang, jadi ia bukan lagi keturunan .panel-gol dan
+      // querySelectorAll dari sana mengembalikan nol elemen — kotak ketiknya
+      // tampak mati padahal huruf-hurufnya masuk.
+      isi.querySelectorAll(".daftar-filter label").forEach(l => {
         l.hidden = q.length > 0 && !l.textContent.toLowerCase().includes(q);
       });
     });

--- a/web/style.css
+++ b/web/style.css
@@ -667,6 +667,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   overflow-y: auto; display: flex; flex-direction: column; gap: .3rem;
   max-height: 30vh;
 }
+/* `label[hidden]` HARUS disebut ulang — sebab yang sama dengan
+   `.isi-filter[hidden]` di atas: `display: flex` di baris berikutnya
+   mengalahkan `[hidden] { display: none }` bawaan browser, jadi baris yang
+   disaring tetap terlihat. Ini kedua kalinya jebakan yang sama menggigit di
+   berkas ini. */
+.isi-filter label[hidden] { display: none; }
 .isi-filter label {
   display: flex; align-items: center; gap: .5rem; font-size: .9rem;
   font-weight: 400; cursor: pointer;


### PR DESCRIPTION
Mengetik di kotak saringan tidak menyembunyikan satu baris pun. **Dua sebab, keduanya diam.**

1. Pencariannya menyisir `panel.querySelectorAll(...)`, padahal panelnya **sudah dipindah ke `<body>`** waktu dipasang — supaya `position:fixed` benar-benar relatif ke viewport. Ia bukan lagi keturunan `.panel-gol`, jadi query dari sana mengembalikan nol elemen.
2. `label[hidden]` kalah oleh `display: flex` di kelasnya. **Kedua kalinya** jebakan yang sama menggigit berkas ini.

Perbaikan pertama saja tidak akan terlihat (elemennya ketemu, `hidden` dipasang, layar tidak berubah); yang kedua saja juga tidak (tidak ada elemen yang disentuh). Keduanya harus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)