### PR TITLE
fix: peringkat dan nomor dada dipatok berdua saat tabel digulir

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -35,6 +35,6 @@
        halaman yang SUDAH TERBUKA: ia menjalankan kode yang dimuat waktu
        dibuka sampai di-reload. Menaikkan versinya membuat HP yang
        memuat ulang pasti mendapat berkas baru, bukan yang tersimpan. -->
-  <script src="live.js?v=8"></script>
+  <script src="live.js?v=9"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -188,13 +188,29 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 /* Nomor dada dipatok di tepi kiri: tabelnya digeser ke samping untuk melihat
    kolom pos, dan tanpa ini orang kehilangan jejak baris siapa yang sedang
    dilihatnya persis saat ia menemukan centangnya. */
-.tabel td.dada, .tabel th:first-child {
-  position: sticky; left: 0; z-index: 2;
+/* DUA kolom dipatok, bukan satu: peringkat dan nomor dada. Keduanya dulu
+   memakai kelas `dada` yang sama, jadi keduanya menempel di left:0 dan saling
+   MENIMPA — yang terlihat cuma satu, dan kolom pertama yang ikut tergeser
+   waktu tabel digulir ke samping.
+
+   Lebarnya dipatok supaya offset kolom kedua bisa dihitung. Saat fase belum
+   `penuh` kolom peringkat memang tidak ada, jadi nomor dada kembali ke
+   left:0 — itu yang dijaga kelas `ada-rank` di tabelnya. */
+.tabel td.rank-sel, .tabel th.rank-th,
+.tabel td.dada, .tabel th.dada-th {
+  position: sticky; z-index: 2;
   background: var(--kartu); font-weight: 800; font-variant-numeric: tabular-nums;
-  box-shadow: 1px 0 0 var(--garis);
 }
-.tabel tbody tr:nth-child(even) td.dada { background: #fafaf8; }
-.tabel th:first-child { z-index: 3; }
+.tabel td.rank-sel, .tabel th.rank-th {
+  left: 0; width: 46px; min-width: 46px;
+}
+.tabel td.dada, .tabel th.dada-th {
+  left: 0; box-shadow: 1px 0 0 var(--garis);
+}
+.tabel.ada-rank td.dada, .tabel.ada-rank th.dada-th { left: 46px; }
+.tabel tbody tr:nth-child(even) td.dada,
+.tabel tbody tr:nth-child(even) td.rank-sel { background: #fafaf8; }
+.tabel th.rank-th, .tabel th.dada-th { z-index: 3; }
 
 .tabel .regu { white-space: normal; min-width: 11rem; font-weight: 600; }
 .tabel .regu .sekolah {
@@ -252,7 +268,7 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 }
 .tabel td.total { font-weight: 800; font-variant-numeric: tabular-nums; }
 .tabel tr.atas { background: #fdf6e3; }
-.tabel tr.atas td.dada { background: #fdf6e3; }
+.tabel tr.atas td.dada, .tabel tr.atas td.rank-sel { background: #fdf6e3; }
 
 .kaki {
   max-width: 1200px; margin: 0 auto; padding: 0 .7rem 2rem;

--- a/live/live.js
+++ b/live/live.js
@@ -356,11 +356,11 @@ function gambarPapan() {
           <button type="button" class="tombol-kecil tombol-semua">Hapus Filter</button>
         </div>
         <div class="gulir">
-          <table class="tabel">
+          <table class="tabel ${penuh ? "ada-rank" : ""}">
             <thead>
               <tr>
-                ${penuh ? `<th rowspan="2">#</th>` : ""}
-                <th rowspan="2">No<br>Dada</th>
+                ${penuh ? `<th rowspan="2" class="rank-th">#</th>` : ""}
+                <th rowspan="2" class="dada-th">No<br>Dada</th>
                 <th rowspan="2">Regu</th>
                 <th rowspan="2" class="th-saring" tabindex="0" role="button"
                     aria-expanded="false"
@@ -401,7 +401,7 @@ function gambarPapan() {
                 return `
                 <tr data-sekolah="${esc(b.nama_sekolah || "")}"
                     class="${b.peringkat && b.peringkat <= 3 ? "atas" : ""}">
-                  ${penuh ? `<td class="dada">${MEDALI[b.peringkat] || ""}${
+                  ${penuh ? `<td class="rank-sel">${MEDALI[b.peringkat] || ""}${
                       esc(String(b.peringkat ?? ""))}</td>` : ""}
                   <td class="dada">${esc(dada(b.nomor_dada))}</td>
                   <td class="regu">${esc(b.nama_regu)}</td>


### PR DESCRIPTION
Di HP, menggulir tabel ke samping membuat kolom peringkat ikut hilang — yang tertinggal cuma nomor dada, dan kolom pertama yang terlihat malah Semaphore.

Sebabnya keduanya memakai kelas `dada` yang sama, jadi keduanya menempel di `left: 0` dan saling **menimpa**. Sekarang dua kelas terpisah dengan offset sendiri; lebarnya dipatok supaya offset kolom kedua bisa dihitung.

Saat fase belum `penuh` kolom peringkat memang tidak ada, jadi nomor dada kembali ke `left: 0` — itu yang dijaga kelas `ada-rank` di tabelnya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)