### PR TITLE
feat: rentang nilai tampil di kepala kolom Live Score

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -35,6 +35,6 @@
        halaman yang SUDAH TERBUKA: ia menjalankan kode yang dimuat waktu
        dibuka sampai di-reload. Menaikkan versinya membuat HP yang
        memuat ulang pasti mendapat berkas baru, bukan yang tersimpan. -->
-  <script src="live.js?v=10"></script>
+  <script src="live.js?v=11"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -169,6 +169,13 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 /* Kolom komponen: sempit, rata tengah, dan judulnya boleh membungkus.
    Bentuknya mengikuti tabel panitia — satu kolom per komponen, bukan per
    pos. */
+/* Rentang di bawah nama kolom: kecil, tidak tebal, tidak berteriak. Ia
+   keterangan, bukan judul — dan kalau setebal judulnya, mata membaca dua
+   judul untuk satu kolom. */
+.tabel .kolom-petunjuk {
+  display: block; font-size: .62rem; font-weight: 400; opacity: .75;
+  white-space: nowrap; letter-spacing: normal;
+}
 .tabel th.kol-komponen { font-size: .72rem; font-weight: 600; white-space: normal;
   line-height: 1.15; }
 .tabel td.pos { text-align: center; }

--- a/live/live.js
+++ b/live/live.js
@@ -287,6 +287,21 @@ const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
    ------------------------------------------------------------------------- */
 let golAktif = URUT_GOLONGAN[0];
 
+/* Rentang nilai di kepala kolom — aturannya DISALIN dari petunjukKolom() di
+   layar panitia, dan memang harus sama persis: dua papan yang menulis
+   rentang berbeda untuk komponen yang sama adalah dua papan yang saling
+   membantah di depan orang yang sedang membandingkannya.
+   Yang keluar cuma batas dan satuan, tidak pernah nilai siapa pun. */
+function petunjukKolom(k) {
+  if (k.petunjuk) return k.petunjuk;
+  if (k.form === "biner") return "centang bila benar";
+  if (k.satuan === "detik") return "detik";
+  if (k.form === "benar_kurang_salah") return "benar / salah";
+  if (k.form === "benar_per_total") return `0 – ${k.total_soal}`;
+  if (k.rentang_mentah_min === null || k.rentang_mentah_min === undefined) return "";
+  return `${k.rentang_mentah_min} – ${k.rentang_mentah_maks}`;
+}
+
 function barisPapan() {
   const progres = (REKAP && REKAP.progres) || [];
   const klasemen = (REKAP && REKAP.klasemen) || [];
@@ -321,7 +336,15 @@ function gambarPapan() {
     const milik = komponen.filter(w => w.pos === p.nomor);
     const nama = [];
     for (const w of milik) if (!nama.includes(w.name)) nama.push(w.name);
-    return { pos: p, nama, milik };
+    // Satu nama kolom bisa punya beberapa varian golongan dengan rentang
+    // berbeda (Tebak Simpul 0-5 untuk Penggalang, 0-10 untuk Penegak).
+    // Keduanya ditulis, dipisah garis miring — sama seperti blangko cetak.
+    const petunjuk = {};
+    for (const nm of nama) {
+      petunjuk[nm] = [...new Set(milik.filter(w => w.name === nm)
+        .map(petunjukKolom).filter(Boolean))].join(" / ");
+    }
+    return { pos: p, nama, milik, petunjuk };
   }).filter(x => x.nama.length);
 
   const kartu = URUT_GOLONGAN.map(g => {
@@ -371,7 +394,9 @@ function gambarPapan() {
                 ${penuh ? `<th rowspan="2">Penalti</th><th rowspan="2">Total</th>` : ""}
               </tr>
               <tr>${perPos.map(x => x.nama.map(nm =>
-                `<th class="pos kol-komponen">${esc(nm)}</th>`).join("")).join("")}</tr>
+                `<th class="pos kol-komponen">${esc(nm)}${x.petunjuk[nm]
+                  ? `<span class="kolom-petunjuk">${esc(x.petunjuk[nm])}</span>`
+                  : ""}</th>`).join("")).join("")}</tr>
             </thead>
             <tbody>
               ${baris.map(b => {

--- a/supabase/checks/live_json.sql
+++ b/supabase/checks/live_json.sql
@@ -50,7 +50,14 @@ select jsonb_pretty(jsonb_build_object(
   'komponen', (select coalesce(jsonb_agg(jsonb_build_object(
                         'kode', w.kode, 'name', w.name, 'pos', w.pos,
                         'golongan', w.golongan, 'lomba', w.lomba,
-                        'sort_order', w.sort_order)
+                        'sort_order', w.sort_order,
+                        -- Bahan untuk menulis RENTANG di kepala kolom.
+                        -- Angkanya, bukan nilai siapa pun: "0 - 5" sama
+                        -- terbukanya dengan nama komponennya sendiri.
+                        'petunjuk', w.petunjuk, 'form', w.form,
+                        'satuan', w.satuan, 'total_soal', w.total_soal,
+                        'rentang_mentah_min', w.rentang_mentah_min,
+                        'rentang_mentah_maks', w.rentang_mentah_maks)
                       order by w.pos, w.sort_order, w.kode), '[]'::jsonb)
                from wahana w where w.edisi = edisi_aktif()),
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4337,7 +4337,9 @@ async function layarLiveScore() {
                 </tr>
                 <tr>
                   ${posKolom.map(p => p.kolom.map(kol =>
-                      `<th class="pos-kol">${esc(kol.nama)}</th>`).join("")
+                      `<th class="pos-kol">${esc(kol.nama)}${kol.petunjuk
+                        ? `<span class="kolom-petunjuk">${esc(kol.petunjuk)}</span>`
+                        : ""}</th>`).join("")
                     + `<th class="pos-kol rekap-batas">Nilai</th>`).join("")}
                 </tr>
               </thead>


### PR DESCRIPTION
Rentang tiap komponen — `0 – 5`, `0 – 20`, `detik`, `selisih meter` — sekarang tertulis di bawah nama kolom, di **kedua** papan Live Score.

Tanpa itu angka 9 di kolom Tebak Simpul tidak bisa dibaca: bagus atau biasa saja tergantung batasnya 10 atau 20, dan pembacanya tidak punya cara tahu.

Aturannya **disalin dari `petunjukKolom()` layar panitia**, dan memang harus sama persis: dua papan yang menulis rentang berbeda untuk komponen yang sama adalah dua papan yang saling membantah di depan orang yang membandingkannya.

Satu nama kolom bisa punya beberapa varian golongan dengan rentang berbeda (Tebak Simpul 0–5 untuk Penggalang, 0–10 untuk Penegak). Keduanya ditulis dipisah garis miring, sama seperti blangko cetak.

`live_json.sql` ikut membawa bahannya. Yang terbit cuma **batas dan satuan** — tidak ada nilai siapa pun, jadi ia aman terbit di fase mana pun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)