### PR TITLE
fix: form Buat Akun penuh selebar kartu, seperti form pendaftaran

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -633,6 +633,19 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    bukan menempel di tepi kanan layar. */
 .table-daftar-ulang .kol-tukar { text-align: left; }
 
+/* Form Buat Akun: menumpuk dan penuh di HP, sebaris di layar lebar.
+   Tidak ada lebar yang dipatok tangan — itu yang dulu membuat ketiga
+   isiannya terjepit ke kanan begitu wadahnya menyempit. */
+.form-akun { display: grid; gap: .7rem; align-items: end; }
+.form-akun .field { margin: 0; }
+.form-akun .field label { display: block; text-align: left; }
+.form-akun input, .form-akun select { width: 100%; box-sizing: border-box; }
+.form-akun .button { width: 100%; }
+@media (min-width: 720px) {
+  .form-akun { grid-template-columns: 2fr 1.4fr .7fr auto; }
+  .form-akun .button { width: auto; }
+}
+
 .th-saring { cursor: pointer; user-select: none; }
 .th-saring:hover { background: var(--garis); }
 .th-saring.menyaring { color: var(--utama); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4636,16 +4636,25 @@ async function layarAkun() {
            kotak carinya visually-hidden sehingga tidak memakan tinggi, di
            sini labelnya terlihat — dan rata tengah membuat tombolnya melayang
            setinggi label, tidak sejajar dengan kotak isian di sebelahnya. -->
-      <div class="table-toolbar" style="align-items:flex-end">
+      <!-- Bentuknya sama dengan form pendaftaran: label di atas, isian
+           SELEBAR kartunya. Sebelumnya ia .table-toolbar dengan lebar
+           dipatok inline (14rem, 5rem) — di HP ketiganya terjepit ke kanan,
+           labelnya melayang di tengah, dan kotak Pos menyusut jadi seukuran
+           ibu jari. Lebar tetap di dalam wadah yang menyempit selalu
+           berakhir begitu.
+
+           Di layar lebar ia kembali sebaris lewat grid, tanpa satu pun ukuran
+           dipatok tangan. -->
+      <div class="form-akun">
         <div class="field"><label for="ak-nama">Nama akun</label>
           <input id="ak-nama" type="text" class="small-input" autocomplete="off"
-            placeholder="pos1hrcd37" style="width:14rem"></div>
+            placeholder="pos1hrcd37"></div>
         <div class="field"><label for="ak-peran">Peran</label>
-          <select id="ak-peran" class="select-small">${opsiPeran("meja")}</select></div>
+          <select id="ak-peran" class="select-small">${opsiPeran("registrasi")}</select></div>
         <div class="field"><label for="ak-pos">Pos</label>
           <input id="ak-pos" type="number" class="small-input" inputmode="numeric"
-            min="1" max="20" style="width:5rem" disabled></div>
-        <button class="button button-primary option-small" id="ak-buat" type="button">Buat Akun</button>
+            min="1" max="20" disabled></div>
+        <button class="button button-primary" id="ak-buat" type="button">Buat Akun</button>
       </div>
       <details>
         <summary>Buat banyak sekaligus</summary>

--- a/web/style.css
+++ b/web/style.css
@@ -633,6 +633,19 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    bukan menempel di tepi kanan layar. */
 .table-daftar-ulang .kol-tukar { text-align: left; }
 
+/* Form Buat Akun: menumpuk dan penuh di HP, sebaris di layar lebar.
+   Tidak ada lebar yang dipatok tangan — itu yang dulu membuat ketiga
+   isiannya terjepit ke kanan begitu wadahnya menyempit. */
+.form-akun { display: grid; gap: .7rem; align-items: end; }
+.form-akun .field { margin: 0; }
+.form-akun .field label { display: block; text-align: left; }
+.form-akun input, .form-akun select { width: 100%; box-sizing: border-box; }
+.form-akun .button { width: 100%; }
+@media (min-width: 720px) {
+  .form-akun { grid-template-columns: 2fr 1.4fr .7fr auto; }
+  .form-akun .button { width: auto; }
+}
+
 .th-saring { cursor: pointer; user-select: none; }
 .th-saring:hover { background: var(--garis); }
 .th-saring.menyaring { color: var(--utama); }


### PR DESCRIPTION
Di HP ketiga isiannya terjepit ke kanan, labelnya melayang di tengah, dan kotak Pos menyusut jadi seukuran ibu jari.

Sebabnya `.table-toolbar` dengan lebar dipatok inline (`14rem`, `5rem`). Lebar tetap di dalam wadah yang menyempit selalu berakhir begitu. Sekarang grid: menumpuk penuh di HP, kembali sebaris di layar lebar, tanpa satu pun ukuran dipatok tangan.

Sekalian: `opsiPeran("meja")` — nama peran yang **sudah tidak ada sejak 0058** — diganti `"registrasi"`. Ia tidak pernah terlihat karena select-nya diam-diam jatuh ke pilihan pertama, tapi ia sisa terakhir nama peran mati di seluruh kode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)