### PR TITLE
fix: kotak Pos hanya untuk Juri Pos, nama akun divalidasi, dialog pakai silang

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -530,14 +530,23 @@ export function notif(pesan, galat = false) {
    jawabannya. Dipakai layar Akun — menu aksi per akun adalah tiga tombol,
    bukan tiga kotak isian, dan memaksanya jadi `medan` akan meminta orang
    MENGETIK pilihannya. */
+/** `silangSaja: true` mengganti tombol aksi di bawah dengan SILANG MERAH di
+ *  pojok kanan atas.
+ *
+ *  Untuk dialog yang isinya sendiri sudah berupa pilihan — menu aksi per akun
+ *  adalah tiga tombol besar — tombol keempat bertuliskan "Tutup" berdiri
+ *  sejajar ketiganya dan terbaca seperti pilihan keempat. Silang di pojok
+ *  tidak pernah salah dibaca sebagai aksi. */
 export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan",
-                         bacaSaja = false, pasang = null }) {
+                         bacaSaja = false, silangSaja = false, pasang = null }) {
   return new Promise(resolve => {
     const wadah = h(html`<div class="overlay" role="dialog" aria-modal="true"></div>`);
     document.body.appendChild(wadah);
     const el = document.body.lastElementChild;
     el.innerHTML = `
       <div class="dialog">
+        ${silangSaja ? `<button class="dialog-silang" data-batal type="button"
+          aria-label="Tutup">&times;</button>` : ""}
         <h2>${esc(judul)}</h2>
         ${kartuHtml}
         ${medan.map((m, i) => `
@@ -551,11 +560,12 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
             ${m.bantuan ? `<div class="hint">${esc(m.bantuan)}</div>` : ""}
           </div>`).join("")}
         <div class="dialog-error error" hidden></div>
+        ${silangSaja ? "" : `
         <div class="option-row">
           ${bacaSaja ? "" : `<button class="button button-secondary" data-batal
             type="button">Batal</button>`}
           <button class="button button-primary" data-ok type="button">${esc(labelAksi)}</button>
-        </div>
+        </div>`}
       </div>`;
 
     /* tipe "jam" memakai kotak HH:MM buatan sendiri, BUKAN <input type="time">.

--- a/live/style.css
+++ b/live/style.css
@@ -636,6 +636,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Form Buat Akun: menumpuk dan penuh di HP, sebaris di layar lebar.
    Tidak ada lebar yang dipatok tangan — itu yang dulu membuat ketiga
    isiannya terjepit ke kanan begitu wadahnya menyempit. */
+.dialog { position: relative; }
+/* Silang MERAH, bukan abu: ia satu-satunya jalan keluar dari dialog ini, dan
+   jalan keluar yang harus dicari dulu bukan jalan keluar. */
+.dialog-silang {
+  position: absolute; top: .5rem; right: .6rem;
+  width: 2rem; height: 2rem; line-height: 1;
+  border: none; background: none; cursor: pointer;
+  font-size: 1.6rem; color: var(--bahaya, #c62828); font-weight: 700;
+  border-radius: 999px;
+}
+.dialog-silang:hover { background: var(--bahaya-muda, #fdecea); }
+
 .form-akun { display: grid; gap: .7rem; align-items: end; }
 .form-akun .field { margin: 0; }
 .form-akun .field label { display: block; text-align: left; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4651,7 +4651,7 @@ async function layarAkun() {
             placeholder="pos1hrcd37"></div>
         <div class="field"><label for="ak-peran">Peran</label>
           <select id="ak-peran" class="select-small">${opsiPeran("registrasi")}</select></div>
-        <div class="field"><label for="ak-pos">Pos</label>
+        <div class="field" id="ak-pos-kotak" hidden><label for="ak-pos">Pos</label>
           <input id="ak-pos" type="number" class="small-input" inputmode="numeric"
             min="1" max="20" disabled></div>
         <button class="button button-primary" id="ak-buat" type="button">Buat Akun</button>
@@ -4715,12 +4715,29 @@ async function layarAkun() {
   const peranBaru = document.getElementById("ak-peran");
   const posBaru = document.getElementById("ak-pos");
 
-  // Pos hanya milik juri_pos — itu check constraint di database, bukan
-  // selera. Kotaknya dimatikan supaya bentroknya ketahuan sebelum dikirim.
-  peranBaru.addEventListener("change", () => {
-    posBaru.disabled = peranBaru.value !== "juri_pos";
-    if (posBaru.disabled) posBaru.value = "";
-  });
+  /* Pos hanya milik juri_pos — itu check constraint di database, bukan
+     selera. Kotaknya DISEMBUNYIKAN, bukan sekadar dimatikan: kotak mati
+     tetap memakan sebaris di layar HP dan tetap mengajukan pertanyaan yang
+     jawabannya tidak ada. Yang tidak berlaku sebaiknya tidak terlihat. */
+  const posKotak = document.getElementById("ak-pos-kotak");
+  const setelPos = () => {
+    const perlu = peranBaru.value === "juri_pos";
+    posKotak.hidden = !perlu;
+    posBaru.disabled = !perlu;
+    if (!perlu) posBaru.value = "";
+  };
+  peranBaru.addEventListener("change", setelPos);
+  setelPos();
+
+  /* Nama akun jadi alamat email: `<nama>@ciradyka.com` (worker gateway).
+     Jadi yang boleh hanya yang sah di bagian sebelum @ — huruf, angka, dan
+     titik — dan titiknya tidak boleh di ujung atau berdempetan.
+
+     Ditolak DI SINI supaya pesannya menyebut apa yang salah. Tanpa ini
+     GoTrue yang menolak, dengan kalimat Inggris tentang format email yang
+     tidak menyebut kotak mana yang harus dibetulkan. */
+  const POLA_NAMA = /^[a-z0-9]+(\.[a-z0-9]+)*$/;
+  const namaSah = (t) => POLA_NAMA.test(t);
 
   async function kirimBuat(daftar, tombol) {
     galat.hidden = true;
@@ -4738,8 +4755,14 @@ async function layarAkun() {
   }
 
   document.getElementById("ak-buat").addEventListener("click", (ev) => {
-    const nama = document.getElementById("ak-nama").value.trim();
+    const nama = document.getElementById("ak-nama").value.trim().toLowerCase();
     if (!nama) { lapor("Nama akun wajib diisi."); return; }
+    if (!namaSah(nama)) {
+      lapor("Nama akun hanya boleh huruf, angka, dan titik — dan titik tidak "
+            + "boleh di awal, di akhir, atau berdempetan. Contoh: pos1hrcd37 "
+            + "atau aji.furqon.");
+      return;
+    }
     kirimBuat([{ username: nama, peran: peranBaru.value,
       pos: peranBaru.value === "juri_pos" ? Number(posBaru.value) || null : null }],
       ev.currentTarget);
@@ -4821,7 +4844,7 @@ async function layarAkun() {
     const pilih = await dialog({
       judul: nama,
       bacaSaja: true,
-      labelAksi: "Tutup",
+      silangSaja: true,
       kartuHtml: `
         <div class="option-row" style="flex-direction:column;gap:8px;align-items:stretch">
           <button class="button button-primary" data-pilih="password" type="button">Reset Password</button>
@@ -4832,7 +4855,7 @@ async function layarAkun() {
       pasang: (el, tutup) => el.querySelectorAll("[data-pilih]").forEach(b =>
         b.addEventListener("click", () => tutup(b.dataset.pilih))),
     });
-    // Tombol "Tutup" mengembalikan array kosong (tidak ada medan), dan array
+    // Silang di pojok mengembalikan hal yang sama dengan Batal, dan array
     // kosong itu truthy — jadi yang diperiksa jenisnya, bukan kebenarannya.
     if (typeof pilih !== "string") return;
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -530,14 +530,23 @@ export function notif(pesan, galat = false) {
    jawabannya. Dipakai layar Akun — menu aksi per akun adalah tiga tombol,
    bukan tiga kotak isian, dan memaksanya jadi `medan` akan meminta orang
    MENGETIK pilihannya. */
+/** `silangSaja: true` mengganti tombol aksi di bawah dengan SILANG MERAH di
+ *  pojok kanan atas.
+ *
+ *  Untuk dialog yang isinya sendiri sudah berupa pilihan — menu aksi per akun
+ *  adalah tiga tombol besar — tombol keempat bertuliskan "Tutup" berdiri
+ *  sejajar ketiganya dan terbaca seperti pilihan keempat. Silang di pojok
+ *  tidak pernah salah dibaca sebagai aksi. */
 export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan",
-                         bacaSaja = false, pasang = null }) {
+                         bacaSaja = false, silangSaja = false, pasang = null }) {
   return new Promise(resolve => {
     const wadah = h(html`<div class="overlay" role="dialog" aria-modal="true"></div>`);
     document.body.appendChild(wadah);
     const el = document.body.lastElementChild;
     el.innerHTML = `
       <div class="dialog">
+        ${silangSaja ? `<button class="dialog-silang" data-batal type="button"
+          aria-label="Tutup">&times;</button>` : ""}
         <h2>${esc(judul)}</h2>
         ${kartuHtml}
         ${medan.map((m, i) => `
@@ -551,11 +560,12 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
             ${m.bantuan ? `<div class="hint">${esc(m.bantuan)}</div>` : ""}
           </div>`).join("")}
         <div class="dialog-error error" hidden></div>
+        ${silangSaja ? "" : `
         <div class="option-row">
           ${bacaSaja ? "" : `<button class="button button-secondary" data-batal
             type="button">Batal</button>`}
           <button class="button button-primary" data-ok type="button">${esc(labelAksi)}</button>
-        </div>
+        </div>`}
       </div>`;
 
     /* tipe "jam" memakai kotak HH:MM buatan sendiri, BUKAN <input type="time">.

--- a/web/style.css
+++ b/web/style.css
@@ -636,6 +636,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Form Buat Akun: menumpuk dan penuh di HP, sebaris di layar lebar.
    Tidak ada lebar yang dipatok tangan — itu yang dulu membuat ketiga
    isiannya terjepit ke kanan begitu wadahnya menyempit. */
+.dialog { position: relative; }
+/* Silang MERAH, bukan abu: ia satu-satunya jalan keluar dari dialog ini, dan
+   jalan keluar yang harus dicari dulu bukan jalan keluar. */
+.dialog-silang {
+  position: absolute; top: .5rem; right: .6rem;
+  width: 2rem; height: 2rem; line-height: 1;
+  border: none; background: none; cursor: pointer;
+  font-size: 1.6rem; color: var(--bahaya, #c62828); font-weight: 700;
+  border-radius: 999px;
+}
+.dialog-silang:hover { background: var(--bahaya-muda, #fdecea); }
+
 .form-akun { display: grid; gap: .7rem; align-items: end; }
 .form-akun .field { margin: 0; }
 .form-akun .field label { display: block; text-align: left; }


### PR DESCRIPTION
Tiga hal di layar Akun.

**1. Kotak Pos disembunyikan** kecuali peran Juri Pos — bukan sekadar dimatikan. Kotak mati tetap memakan sebaris di layar HP dan tetap mengajukan pertanyaan yang jawabannya tidak ada.

**2. Nama akun divalidasi.** Ia jadi alamat email `<nama>@ciradyka.com`, jadi yang boleh hanya huruf, angka, dan titik — dan titiknya tidak boleh di ujung atau berdempetan. Ditolak di layar supaya pesannya menyebut apa yang salah; tanpa ini GoTrue yang menolak, dengan kalimat Inggris tentang format email yang tidak menyebut kotak mana yang harus dibetulkan. Sembilan pola diuji, termasuk yang harus ditolak.

**3. Dialog aksi akun pakai silang merah** di pojok kanan atas. Isinya sendiri sudah berupa tiga tombol besar; tombol keempat bertuliskan "Tutup" berdiri sejajar ketiganya dan terbaca seperti pilihan keempat. Merah, bukan abu: ia satu-satunya jalan keluar, dan jalan keluar yang harus dicari dulu bukan jalan keluar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)