### PR TITLE
fix: kartu HP daftar ulang dua kolom, sama seperti meja pembayaran

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1986,19 +1986,31 @@ input.small-input { text-align: center; }
      rata tengah, yang meleset isinya. */
   .data-table tbody tr[data-baris] .button-detail { margin-top: 0; }
 
-  /* MEJA DAFTAR ULANG di HP.
-     FLEX, bukan grid — dan itu keputusan setelah grid gagal dua kali.
+  /* MEJA DAFTAR ULANG di HP — bentuknya SAMA dengan kartu Meja Pembayaran:
 
-     Dengan grid, tiap sel harus diberi baris dan kolomnya sendiri; yang lupa
-     diberi ikut penempatan otomatis dan MENUMPUK sel lain. Hasilnya tombol
-     Tukar tercetak di atas pil nomor dada, dan kolom nama sekolah menyusut
-     sampai namanya patah satu huruf per baris.
+         HRCD37-01C122   SMPN 1 Ciamis
+         001 K1  002 K3  003 K5  004 K7
+         [      Tukar nomor rusak…     ]
 
-     Flex tidak punya penempatan otomatis: urutannya urutan sumber, dan
-     `flex-basis: 100%` memaksa baris baru. Tidak ada yang bisa bertabrakan
-     karena tidak ada yang ditempatkan. */
+     GRID dengan dua kolom `max-content 1fr`, bukan flex. Bedanya kelihatan
+     justru saat namanya panjang: dengan flex, nama sekolah mengalir tepat di
+     sebelah kodenya, jadi tepi kirinya berpindah-pindah dari kartu ke kartu
+     dan "SMK Bangkit Indonesia Talaga" terlempar ke baris sendiri. Dengan
+     grid, kolom kirinya selebar kode pembayaran — yang panjangnya selalu
+     sama — jadi seluruh nama sekolah berbaris lurus dan yang panjang
+     membungkus DI DALAM kolomnya. Persis kartu meja pembayaran, dan dua
+     layar ini memang dibaca berurutan oleh petugas yang sama.
+
+     SYARATNYA SATU, DAN INI YANG DULU BIKIN RUSAK: tiap sel harus diberi
+     petaknya sendiri. Sel yang lupa ditempatkan ikut penempatan otomatis dan
+     MENUMPUK sel lain — itulah tombol Tukar yang tercetak di atas pil nomor
+     dada. Empat sel, empat `grid-area` di bawah ini; kalau menambah kolom,
+     tambahkan petaknya juga. */
   .table-daftar-ulang tbody tr[data-baris] {
-    display: flex; flex-wrap: wrap; align-items: baseline; gap: .15rem .6rem;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: .2rem .8rem;
+    align-items: baseline;
   }
   /* Label kolom dibuang — kekhususannya harus menandingi aturan label umum
      (0,4,2), yang punya `.data-table` dan `:not([data-label=""])`. */
@@ -2006,17 +2018,19 @@ input.small-input { text-align: center; }
     > td[data-label]:not([data-label=""])::before { content: none; }
 
   .table-daftar-ulang tbody tr[data-baris] > td[data-label="Kode Bayar"] {
-    flex: 0 0 auto; font-size: .95rem;
+    grid-area: 1 / 1; font-size: .95rem;
   }
-  /* min-width:0 wajib: tanpa itu lebar minimum sebuah item flex adalah lebar
+  /* min-width:0 wajib: tanpa itu lebar minimum sebuah petak grid adalah lebar
      kata terpanjangnya, dan "Citangkolo" mendorong kartunya melewati layar. */
   .table-daftar-ulang tbody tr[data-baris] > td[data-label="Sekolah"] {
-    flex: 1 1 auto; min-width: 0; white-space: normal; font-size: .95rem;
+    grid-area: 1 / 2; min-width: 0; white-space: normal; font-size: .95rem;
   }
-  /* Nomor dada lalu tombol, masing-masing selebar kartu, dalam urutan itu. */
-  .table-daftar-ulang tbody tr[data-baris] > td.kol-dada,
+  /* Nomor dada lalu tombol, masing-masing melintang penuh, dalam urutan itu. */
+  .table-daftar-ulang tbody tr[data-baris] > td.kol-dada {
+    grid-area: 2 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
+  }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-tukar {
-    flex: 1 0 100%; width: auto; white-space: normal; margin-top: .35rem;
+    grid-area: 3 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
   }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .pill-row,
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .sub {

--- a/web/style.css
+++ b/web/style.css
@@ -1986,19 +1986,31 @@ input.small-input { text-align: center; }
      rata tengah, yang meleset isinya. */
   .data-table tbody tr[data-baris] .button-detail { margin-top: 0; }
 
-  /* MEJA DAFTAR ULANG di HP.
-     FLEX, bukan grid — dan itu keputusan setelah grid gagal dua kali.
+  /* MEJA DAFTAR ULANG di HP — bentuknya SAMA dengan kartu Meja Pembayaran:
 
-     Dengan grid, tiap sel harus diberi baris dan kolomnya sendiri; yang lupa
-     diberi ikut penempatan otomatis dan MENUMPUK sel lain. Hasilnya tombol
-     Tukar tercetak di atas pil nomor dada, dan kolom nama sekolah menyusut
-     sampai namanya patah satu huruf per baris.
+         HRCD37-01C122   SMPN 1 Ciamis
+         001 K1  002 K3  003 K5  004 K7
+         [      Tukar nomor rusak…     ]
 
-     Flex tidak punya penempatan otomatis: urutannya urutan sumber, dan
-     `flex-basis: 100%` memaksa baris baru. Tidak ada yang bisa bertabrakan
-     karena tidak ada yang ditempatkan. */
+     GRID dengan dua kolom `max-content 1fr`, bukan flex. Bedanya kelihatan
+     justru saat namanya panjang: dengan flex, nama sekolah mengalir tepat di
+     sebelah kodenya, jadi tepi kirinya berpindah-pindah dari kartu ke kartu
+     dan "SMK Bangkit Indonesia Talaga" terlempar ke baris sendiri. Dengan
+     grid, kolom kirinya selebar kode pembayaran — yang panjangnya selalu
+     sama — jadi seluruh nama sekolah berbaris lurus dan yang panjang
+     membungkus DI DALAM kolomnya. Persis kartu meja pembayaran, dan dua
+     layar ini memang dibaca berurutan oleh petugas yang sama.
+
+     SYARATNYA SATU, DAN INI YANG DULU BIKIN RUSAK: tiap sel harus diberi
+     petaknya sendiri. Sel yang lupa ditempatkan ikut penempatan otomatis dan
+     MENUMPUK sel lain — itulah tombol Tukar yang tercetak di atas pil nomor
+     dada. Empat sel, empat `grid-area` di bawah ini; kalau menambah kolom,
+     tambahkan petaknya juga. */
   .table-daftar-ulang tbody tr[data-baris] {
-    display: flex; flex-wrap: wrap; align-items: baseline; gap: .15rem .6rem;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: .2rem .8rem;
+    align-items: baseline;
   }
   /* Label kolom dibuang — kekhususannya harus menandingi aturan label umum
      (0,4,2), yang punya `.data-table` dan `:not([data-label=""])`. */
@@ -2006,17 +2018,19 @@ input.small-input { text-align: center; }
     > td[data-label]:not([data-label=""])::before { content: none; }
 
   .table-daftar-ulang tbody tr[data-baris] > td[data-label="Kode Bayar"] {
-    flex: 0 0 auto; font-size: .95rem;
+    grid-area: 1 / 1; font-size: .95rem;
   }
-  /* min-width:0 wajib: tanpa itu lebar minimum sebuah item flex adalah lebar
+  /* min-width:0 wajib: tanpa itu lebar minimum sebuah petak grid adalah lebar
      kata terpanjangnya, dan "Citangkolo" mendorong kartunya melewati layar. */
   .table-daftar-ulang tbody tr[data-baris] > td[data-label="Sekolah"] {
-    flex: 1 1 auto; min-width: 0; white-space: normal; font-size: .95rem;
+    grid-area: 1 / 2; min-width: 0; white-space: normal; font-size: .95rem;
   }
-  /* Nomor dada lalu tombol, masing-masing selebar kartu, dalam urutan itu. */
-  .table-daftar-ulang tbody tr[data-baris] > td.kol-dada,
+  /* Nomor dada lalu tombol, masing-masing melintang penuh, dalam urutan itu. */
+  .table-daftar-ulang tbody tr[data-baris] > td.kol-dada {
+    grid-area: 2 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
+  }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-tukar {
-    flex: 1 0 100%; width: auto; white-space: normal; margin-top: .35rem;
+    grid-area: 3 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
   }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .pill-row,
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .sub {


### PR DESCRIPTION
## What

Kartu HP Meja Daftar Ulang memakai bentuk yang sama dengan Meja Pembayaran: **kode pembayaran di kolom kiri, nama sekolah di kolom kanan**.

```
HRCD37-01C122   SMPN 1 Ciamis
001 K1  002 K3  003 K5  004 K7
[      Tukar nomor rusak…     ]
```

Grid dua kolom `max-content 1fr`, dan **keempat selnya diberi petak masing-masing**.

## Why

Dengan flex, nama sekolah mengalir tepat di sebelah kodenya, jadi tepi kirinya berpindah-pindah dari kartu ke kartu dan nama panjang seperti "SMK Bangkit Indonesia Talaga" terlempar ke baris sendiri. Kolom kiri yang selebar kode pembayaran — panjangnya selalu sama — membuat seluruh nama sekolah berbaris lurus, dan yang panjang membungkus **di dalam kolomnya**. Dua layar ini dibaca berurutan oleh petugas yang sama, jadi bentuknya tidak boleh berbeda.

Grid sempat dibuang karena dituduh sebagai penyebab tombol Tukar menumpuk pil nomor dada. Yang salah bukan grid-nya: **sel yang lupa ditempatkan** ikut penempatan otomatis dan menumpuk sel lain. Empat sel, empat `grid-area`.

## Notes

Diukur di 12 lebar dari 900px sampai 320px:

| | hasil |
|---|---|
| tepi kiri kolom sekolah | **satu nilai** untuk semua kartu (163/164px) |
| penggulir mendatar | tidak ada |
| sel yang isinya meluap | 0 |
| kotak saling tembus | 0 |
| tombol Tukar di bawah daftar nomor dada | ya, di semua lebar |

Rentang ≥ 941px tidak tersentuh — diperiksa ulang di tujuh lebar (1920, 1440, 1100, 1024, 941, 940, 901), kotak nomor dada tetap **0px** dari tombol yang membukanya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)