### PR TITLE
chore: buang komentar lembar pos yang sudah tidak benar

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1063,14 +1063,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      12pt kalau ternyata terlalu kecil dibaca dari foto — cukup ubah angka di
      sini dan REGU_PER_LEMBAR di app.js kembali ke 37. */
   .lembar-pos .print-table td.dada { font-size: 11pt; }
-  /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
-     ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
-     tinggi hanya akan mengurangi jumlah baris per lembar. */
-  /* Kotak isian dipatok DUA ARAH, dan max-width itu yang penting. `width`
-     pada sel tabel cuma usulan: dengan table-layout auto, kolom tumbuh
-     mengisi sisa lebar. Tanpa max-width, di Pos 1 yang cuma punya tiga kotak,
-     seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
-     jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
+  /* Tinggi baris tidak dipatok — ia mengikuti huruf terbesar di baris itu,
+     yaitu nomor dada di atas. Mematoknya lebih tinggi hanya mengurangi jumlah
+     baris per lembar. */
   /* LEBAR KOLOM DIPATOK, sisanya milik kolom penilaian.
 
      Dengan table-layout auto, kolom identitas tumbuh mengikuti nama terpanjang
@@ -1108,26 +1103,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     font-size: 10pt;
   }
-  /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
-     lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
-     kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
-     dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
-     cek silang. */
-  /* Patokan LEBAR, bukan sempit — ia batas pengaman, bukan target. Kotak
-     isian yang dibatasi ketat (max-width di atas), jadi sisa lebar kertas
-     mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
-     Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
-     sisanya jatuh ke identitas juga. */
   /* Identitas DIPADATKAN, dan itu keputusan panitia: lebih baik nama terpotong
      sedikit daripada kotak nilai yang sempit. Diukur pada 10pt huruf besar
      (~2,3mm per huruf) terhadap nama terpanjang di daftar:
 
-       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 48mm
-       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 58mm
+       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 44mm
+       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 48mm
 
      Keduanya sengaja sedikit DI BAWAH kebutuhan nama terpanjang, jadi hanya
      segelintir yang kehilangan satu-dua huruf di ujung — dan regu tetap
-     dikenali dari nomor dadanya. Yang dibeli: kotak nilai naik 14mm ke 18mm.
+     dikenali dari nomor dadanya.
+
+     Yang dibeli: seluruh sisa kertas jatuh ke kolom penilaian. Identitas
+     memakai 10 + 44 + 48 + 13 = 115mm dari 277mm, jadi sisanya 162mm dibagi
+     rata — 54mm per kotak di Pos 1 yang punya tiga penilaian, 40mm di Pos 5
+     yang punya empat, 23mm di Pos 3 yang punya tujuh. Yang paling sempit pun
+     masih dua kali lipat lebar angka dua digit yang ditulis di situ.
 
      Golongan disingkat "Pgl Pa" / "Pgk Pa" (GOLONGAN_SINGKAT di app.js), jadi
      13mm cukup dan sisanya ikut pindah ke kolom nama. */

--- a/web/style.css
+++ b/web/style.css
@@ -1063,14 +1063,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      12pt kalau ternyata terlalu kecil dibaca dari foto — cukup ubah angka di
      sini dan REGU_PER_LEMBAR di app.js kembali ke 37. */
   .lembar-pos .print-table td.dada { font-size: 11pt; }
-  /* Kotak tulisnya tidak lagi dipatok tingginya — tinggi baris sudah
-     ditentukan huruf 12pt di line-height 1 (~5mm), dan mematoknya lebih
-     tinggi hanya akan mengurangi jumlah baris per lembar. */
-  /* Kotak isian dipatok DUA ARAH, dan max-width itu yang penting. `width`
-     pada sel tabel cuma usulan: dengan table-layout auto, kolom tumbuh
-     mengisi sisa lebar. Tanpa max-width, di Pos 1 yang cuma punya tiga kotak,
-     seluruh sisa masuk ke kotak isian — petak berisi satu angka dua digit
-     jadi selebar dua jari sementara nama sekolah di sebelahnya terpotong. */
+  /* Tinggi baris tidak dipatok — ia mengikuti huruf terbesar di baris itu,
+     yaitu nomor dada di atas. Mematoknya lebih tinggi hanya mengurangi jumlah
+     baris per lembar. */
   /* LEBAR KOLOM DIPATOK, sisanya milik kolom penilaian.
 
      Dengan table-layout auto, kolom identitas tumbuh mengikuti nama terpanjang
@@ -1108,26 +1103,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     font-size: 10pt;
   }
-  /* Lebar identitas dipatok, karena di 12pt merekalah yang akan menelan
-     lebar kertas dan menyisakan kotak isian selebar jari. Nama sekolah yang
-     kepanjangan dipotong dengan elipsis — regu tetap dikenali dari nomor
-     dada dan nama regunya, dan nama sekolah di kertas ini gunanya sekadar
-     cek silang. */
-  /* Patokan LEBAR, bukan sempit — ia batas pengaman, bukan target. Kotak
-     isian yang dibatasi ketat (max-width di atas), jadi sisa lebar kertas
-     mengalir ke tiga kolom ini dan nama terpanjang di daftar muat utuh.
-     Pos 3 memakai 13 + 84 + maksimum 166 = 263mm dari 277mm yang tersedia;
-     sisanya jatuh ke identitas juga. */
   /* Identitas DIPADATKAN, dan itu keputusan panitia: lebih baik nama terpotong
      sedikit daripada kotak nilai yang sempit. Diukur pada 10pt huruf besar
      (~2,3mm per huruf) terhadap nama terpanjang di daftar:
 
-       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 48mm
-       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 58mm
+       nama regu   "VICTORIA PUI CIJANTUNG"        22 huruf ~ 51mm -> 44mm
+       organisasi  "SMK SILIWANGI AMS BANJARSARI"  28 huruf ~ 64mm -> 48mm
 
      Keduanya sengaja sedikit DI BAWAH kebutuhan nama terpanjang, jadi hanya
      segelintir yang kehilangan satu-dua huruf di ujung — dan regu tetap
-     dikenali dari nomor dadanya. Yang dibeli: kotak nilai naik 14mm ke 18mm.
+     dikenali dari nomor dadanya.
+
+     Yang dibeli: seluruh sisa kertas jatuh ke kolom penilaian. Identitas
+     memakai 10 + 44 + 48 + 13 = 115mm dari 277mm, jadi sisanya 162mm dibagi
+     rata — 54mm per kotak di Pos 1 yang punya tiga penilaian, 40mm di Pos 5
+     yang punya empat, 23mm di Pos 3 yang punya tujuh. Yang paling sempit pun
+     masih dua kali lipat lebar angka dua digit yang ditulis di situ.
 
      Golongan disingkat "Pgl Pa" / "Pgk Pa" (GOLONGAN_SINGKAT di app.js), jadi
      13mm cukup dan sisanya ikut pindah ke kolom nama. */


### PR DESCRIPTION
## What

Empat blok komentar di `@media print` menerangkan pendekatan yang sudah diganti, dan tiga di antaranya berdiri **tepat di atas aturan yang menyatakan sebaliknya**:

| komentar | aturan yang sebenarnya berlaku |
|---|---|
| "tinggi baris ditentukan huruf 12pt (~5mm)" | dua baris di atasnya: `td.dada { font-size: 11pt }`, baris 4,45mm |
| "Kotak isian dipatok DUA ARAH, dan max-width itu yang penting … dengan table-layout auto" | `th.isian, td.isian { width: auto; max-width: none }` di bawah `table-layout: fixed` |
| "Lebar identitas dipatok, karena di 12pt …" | identitas sudah `font-size: 10pt` |
| "Pos 3 memakai 13 + 84 + maksimum 166 = 263mm" | tidak satu pun angka itu masih berlaku |

Angka di blok yang **disimpan** juga diluruskan: komentar menulis nama regu 48mm dan organisasi 58mm padahal aturannya 44mm dan 48mm, dan "kotak nilai naik 14mm ke 18mm" diganti hitungan sekarang — identitas 10+44+48+13 = 115mm dari 277mm, sisanya 162mm dibagi rata: **54mm** per kotak di Pos 1 (tiga penilaian), **40mm** di Pos 5 (empat), **23mm** di Pos 3 (tujuh).

## Why

Ditemukan saat memeriksa dua branch lama yang ternyata sudah usang — komentar-komentar ini peninggalan pendekatan yang branch itu wakili, tertinggal waktu aturannya diukur ulang.

Bagian 6 menggambarkan pemeliharanya: anggota ambalan yang belajar sambil jalan, tanpa konteks diskusi sebelumnya. Empat komentar yang saling bertentangan di satu blok lebih menyesatkan daripada tidak ada komentar sama sekali — dan komentar yang berbohong tentang lebar kertas persis jenis yang membuat orang mengubah angka ke arah yang salah.

## Notes

**Tidak ada satu baris aturan pun yang berubah.** `git diff` hanya menyentuh komentar — diperiksa dengan menyaring diff untuk baris yang mengandung `{`, `}`, atau `properti: nilai;` dan hasilnya kosong. `web/style.css` dan `live/style.css` tetap byte-identical (bagian 7.7 dan 8.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)