### PR TITLE
feat: Foto Jawaban — unggah foto borongan dari pos

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -401,8 +401,18 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    tidak bisa ditemukan kembali bukan cadangan.
 
    Harganya disebut supaya tidak jadi kejutan: slip yang hilang **di jalan**
-   antara pos dan meja IT tidak pernah difoto sama sekali. Jendela itu memang
-   tidak terlindungi.
+   antara pos dan meja IT tidak pernah difoto sama sekali.
+
+   **Jendela itu sekarang ada penutupnya — layar Foto Jawaban** (migrasi
+   `0074`). Panitia di pos memilih Pos dan Lomba, lalu mengunggah banyak foto
+   sekaligus; nomor dadanya ditautkan belakangan, satu per satu di layar itu
+   juga. Yang membuatnya boleh ada bukan pembatalan alasan di atas melainkan
+   pencabutan anggapannya: foto borongan sekarang PUNYA jalan pulang, dan yang
+   belum pulang dihitung serta ditampilkan sebagai angka di layar — antrean
+   yang tidak terlihat adalah antrean yang tidak pernah dikerjakan.
+
+   Dialog kamera per regu di meja IT **tidak diganti** dan tetap jalur utama:
+   di sana fotonya tertaut sendiri, tanpa pekerjaan tambahan.
 
    Tombolnya kamera di tiap baris lembar Input Pos; gambarnya masuk bucket
    privat `lembar` sesudah dikecilkan jadi abu-abu 1400px di HP, ~70 KB

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -757,6 +757,92 @@ export async function kuotaFoto() {
   return Array.isArray(d) ? d[0] : d;
 }
 
+/* ---------------------------- FOTO BORONGAN ----------------------------
+
+   Foto lembar jawaban yang diambil DI POS, banyak sekaligus, nomor dadanya
+   ditautkan belakangan (migrasi 0074).
+
+   Bedanya dengan unggahFotoLembar di atas cuma satu hal, tapi hal itu yang
+   mengubah segalanya: nomor dada BELUM DIKETAHUI saat gambarnya naik. Jadi
+   ia tidak ikut ke nama berkas, dan barisnya lahir tanpa regu.
+
+   Kenapa tidak menambah cabang ke unggahFotoLembar: fungsi itu menerima nomor
+   dada sebagai argumen wajib dan memakainya di dua tempat. Membuat argumen
+   wajib jadi opsional membuat pemanggil lama diam-diam boleh lupa mengisinya
+   — dan foto yang seharusnya tertaut sendiri jadi menganggur di antrean. */
+
+/** Nama objek untuk foto yang belum berdada.
+ *
+ *  TIDAK ada segmen `belum/`. Bucket `lembar` tidak punya policy UPDATE
+ *  maupun DELETE sama sekali, jadi objeknya tidak akan pernah bisa dipindah —
+ *  folder bernama "belum tertaut" akan berbohong sejak foto itu tertaut, dan
+ *  berbohong selamanya. Keadaan tautan hidup di baris database.
+ *
+ *  Segmen pertama tetap `pos<n>`: itulah yang dipagari policy storage.objects
+ *  dan diperiksa ulang catat_foto_masuk. */
+export function namaObjekFotoMasuk(pos, kodeLomba) {
+  const acak = Math.random().toString(36).slice(2, 8);
+  return `pos${pos}/${kodeLomba}/${Date.now()}-${acak}.jpg`;
+}
+
+/** Unggah satu gambar borongan, lalu catat barisnya. Mengembalikan id barisnya
+ *  — itu yang dipakai layar untuk menautkannya ke nomor dada nanti.
+ *
+ *  Urutannya sama dengan unggahFotoLembar dan sengaja: gambar dulu, baris
+ *  sesudahnya. Baris tanpa gambar adalah kebohongan; gambar tanpa baris cuma
+ *  berkas yatim yang tidak merugikan siapa pun. */
+export async function unggahFotoMasuk(pos, kodeLomba, namaLomba, blob) {
+  const path = namaObjekFotoMasuk(pos, kodeLomba);
+  const argumen = {
+    p_pos: pos, p_kode_lomba: kodeLomba, p_nama_lomba: namaLomba,
+    p_path: path, p_ukuran: blob.size,
+  };
+
+  if (K.mode === "dev") {
+    const id = await rpc("catat_foto_masuk", argumen);
+    return { id, path, ukuran: blob.size };
+  }
+
+  await pastikanSesiSegar();
+  const s = sesi();
+  await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET}/${path}`, {
+    method: "POST",
+    headers: {
+      apikey: K.anonKey,
+      Authorization: `Bearer ${s && s.token ? s.token : K.anonKey}`,
+      "Content-Type": "image/jpeg",
+      "x-upsert": "false",
+    },
+    body: blob,
+  });
+
+  const id = await rpc("catat_foto_masuk", argumen);
+  return { id, path, ukuran: blob.size };
+}
+
+/** Antrean foto yang belum punya nomor dada, satu pos satu lomba.
+ *
+ *  `nomor_dada=is.null` yang menyaringnya, bukan view kedua — v_foto_lembar
+ *  sejak 0074 memakai LEFT join justru supaya baris ini terlihat. */
+export async function daftarFotoBelumTaut(pos, kodeLomba) {
+  if (K.mode === "dev") {
+    return baca(`/foto-belum-taut?pos=${encodeURIComponent(pos)}` +
+                `&lomba=${encodeURIComponent(kodeLomba)}`);
+  }
+  return baca(null,
+    `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}` +
+    `&kode_lomba=eq.${encodeURIComponent(kodeLomba)}` +
+    `&nomor_dada=is.null&select=*&order=diunggah_pada.asc`);
+}
+
+/** Tautkan satu foto ke nomor dada.
+ *
+ *  `cara` membedakan siapa yang memutuskan: `tangan` panitia sendiri, `mesin`
+ *  usulan pembacaan gambar yang dicentang panitia. Menautkan ulang boleh —
+ *  yang menjaganya trigger audit, bukan larangan. */
+export const tautkanFoto = (id, nomorDada, cara = "tangan") =>
+  rpc("tautkan_foto", { p_foto_id: id, p_nomor_dada: nomorDada, p_cara: cara });
+
 /* ============================ AKUN PANITIA ==============================
    Dua jalur, dan yang menentukan bukan kerapian melainkan siapa pemegang
    kuncinya.

--- a/live/style.css
+++ b/live/style.css
@@ -2967,3 +2967,67 @@ input.small-input { text-align: center; }
   background: none; border: 0; padding: 0; font: inherit; cursor: pointer;
   color: var(--utama); text-decoration: underline;
 }
+
+/* ==========================================================================
+   FOTO JAWABAN — unggah borongan dari pos, penautan nomor dada menyusul.
+
+   Dua bagian yang bentuknya berbeda karena pekerjaannya berbeda: ANTREAN
+   unggah dibaca dari atas ke bawah sambil menunggu, GRID foto dibaca dengan
+   mata menyapu mencari kertas yang dikenali. Yang pertama daftar, yang kedua
+   petak.
+   ========================================================================== */
+
+/* Pos dan Lomba bersebelahan di layar lebar, menumpuk di HP. Tidak ada lebar
+   yang dipatok tangan — dua isian yang dipatok mm akan terjepit ke kanan
+   begitu wadahnya menyempit (bagian 15). */
+.baris-pilih { display: flex; flex-wrap: wrap; gap: .8rem; }
+.baris-pilih .field { flex: 1 1 12rem; min-width: 0; margin-bottom: .6rem; }
+
+/* Antrean unggah. Namanya boleh terpotong, statusnya TIDAK — status itulah
+   satu-satunya alasan barisnya ada. */
+.antrean-foto { list-style: none; margin: .6rem 0 0; padding: 0; }
+.antrean-foto li {
+  display: flex; align-items: center; gap: .6rem;
+  padding: .35rem 0; border-top: 1px solid var(--garis); font-size: .9rem;
+}
+.antrean-foto .a-nama {
+  flex: 1 1 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.antrean-foto .a-status { flex: 0 0 auto; color: var(--tinta-lembut); }
+.antrean-foto li.selesai .a-status { color: var(--hijau); font-weight: 700; }
+/* Gagal TIDAK menghilang dan tidak sekadar berubah warna: barisnya membawa
+   tombol Ulangi, dan berkasnya masih dipegang layar. Petugas dengan lima
+   puluh foto tidak akan memilih ulang dari galeri satu per satu. */
+.antrean-foto li.gagal { background: var(--bahaya-muda); }
+.antrean-foto li.gagal .a-status { color: var(--bahaya); }
+
+/* Petak foto. `auto-fill` dengan lantai 9rem: di HP muat dua kolom, di laptop
+   enam sampai delapan — jumlahnya mengikuti layar, bukan dipatok per ambang. */
+.grid-foto {
+  display: grid; gap: .8rem;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+}
+.ubin-foto {
+  margin: 0; border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  overflow: hidden; background: var(--kartu);
+}
+/* Gambarnya jadi latar tombol, bukan <img>: satu elemen, dan `cover` memotong
+   sisi panjang sendiri tanpa menghitung apa pun. Rasionya dipatok 3:4 —
+   kertas lembar jawaban selalu lebih tinggi daripada lebar, dan petak yang
+   tingginya mengikuti gambar membuat barisnya bergerigi. */
+.ubin-foto .ubin-gambar {
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; aspect-ratio: 3 / 4; padding: 0;
+  border: 0; border-bottom: 1px solid var(--garis);
+  background: var(--kertas) center / cover no-repeat;
+  cursor: pointer;
+}
+.ubin-foto figcaption {
+  display: flex; align-items: center; gap: .4rem; padding: .45rem;
+}
+/* Kotak nomor dada mengambil sisa lebar; tombolnya seukuran isinya. Kalau
+   dibalik, tombol "Tautkan" melar selebar petak dan kotak angkanya menyusut
+   jadi dua digit — dan yang diketik di sini justru tiga digit. */
+.ubin-foto figcaption .small-input { flex: 1 1 auto; min-width: 0; width: auto; }
+.ubin-foto figcaption .button { flex: 0 0 auto; }

--- a/supabase/migrations/0074_foto_jawaban.sql
+++ b/supabase/migrations/0074_foto_jawaban.sql
@@ -1,0 +1,382 @@
+-- ============================================================================
+-- hrcd-rekap : 0074_foto_jawaban.sql
+--
+-- FOTO JAWABAN: foto lembar jawaban yang diunggah BORONGAN dari pos, nomor
+-- dadanya ditautkan belakangan.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA ADA, DAN KENAPA IA MELUNAKKAN 0047
+--
+-- 0047 memutuskan foto diambil DI MEJA IT sambil mengetik nilainya, dan
+-- menolak foto borongan di pos dengan alasan yang masih benar: "backup yang
+-- tidak bisa ditemukan kembali bukan backup". Alasan itu berdiri di atas satu
+-- anggapan — bahwa tidak ada cara menemukan kembali gambar borongan selain
+-- membukanya satu per satu.
+--
+-- Migrasi ini tidak membantah alasannya, ia mencabut anggapannya. Foto
+-- borongan sekarang punya DUA jalan pulang: panitia menautkan sendiri satu per
+-- satu, atau gambarnya dibaca mesin lalu usulannya dicentang. Yang ditolak
+-- 0047 tetap ditolak — foto yang menganggur tanpa tautan tetap bukan backup,
+-- dan justru itu yang dihitung dan ditampilkan sebagai angka di layar.
+--
+-- Yang dibeli: 0047 sendiri mengakui satu lubang yang tidak ia lindungi —
+-- "slip yang HILANG DI JALAN antara pos dan meja IT tidak pernah difoto sama
+-- sekali". Difoto di pos, slip itu sudah terekam sebelum perjalanannya
+-- dimulai. Dialog per regu di meja IT TIDAK diganti; ia tetap jalur utama,
+-- karena di sana fotonya tertaut sendiri tanpa pekerjaan tambahan.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA SATU TABEL, BUKAN TABEL PENAMPUNG
+--
+-- Godaannya besar: tabel `foto_masuk` yang isinya pindah ke `foto_lembar`
+-- begitu tertaut. Ditolak karena pagar baca `foto_lembar` bertumpu pada kolom
+-- `pos` DI TABEL ITU SENDIRI (sel_foto, 0064), bukan pada regunya — jadi baris
+-- tanpa regu sudah terpagari benar tanpa mekanisme kedua. Tabel penampung
+-- berarti dua tabel, dua pagar, dua path convention, dan dua tempat yang harus
+-- dicari orang yang bertanya "fotonya mana?".
+--
+-- Harganya: `regu_id` tidak lagi `not null`. Yang menjaga artinya sekarang
+-- check constraint di bawah — tertaut berarti ADA catatan siapa, kapan, dan
+-- dengan cara apa. Baris yang setengah tertaut tidak mungkin ada.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA PATH-NYA TIDAK MENYEBUT KEADAAN TAUTAN
+--
+-- `pos3/kim/1787.....jpg`, tanpa segmen `belum/`. Sebabnya bukan selera:
+-- bucket `lembar` tidak punya policy UPDATE maupun DELETE sama sekali (0047,
+-- 0064), jadi objeknya TIDAK AKAN PERNAH bisa dipindah. Folder bernama
+-- "belum tertaut" akan berbohong sejak detik foto itu tertaut, dan berbohong
+-- selamanya. Keadaan tautan hidup di baris database; path-nya netral.
+--
+-- Yang TETAP wajib di path adalah segmen pertama `pos<n>` — itulah yang
+-- dipagari policy storage.objects, dan RPC di bawah memagarinya untuk kedua
+-- kalinya karena skema `storage` tidak ada di database uji.
+--
+-- ---------------------------------------------------------------------------
+-- KODE LOMBA: SATU SLIP = SATU LOMBA
+--
+-- CLAUDE.md 11.5 sudah menyatakannya, dan 0047 mengulangnya: satu slip adalah
+-- satu LOMBA, bukan satu penilaian. Pembidaian punya lima kriteria di SATU
+-- kertas. `catat_foto_masuk` di bawah menolak kode lomba yang bukan
+-- `slug_lomba(coalesce(wahana.lomba, wahana.name))` untuk pos itu — jadi pintu
+-- borongan tidak bisa melahirkan kode yang tidak dikenali pintu satunya.
+--
+-- Baris LAMA tidak disentuh. Sebagian di antaranya menyandang slug nama
+-- PENILAIAN, bukan lomba, karena layar lama mengelompokkan per kolom. Menulis
+-- ulang catatan bukti untuk merapikan penamaan adalah harga yang tidak sepadan;
+-- yang dilakukan migrasi ini cuma MELAPORKAN berapa banyak (raise notice di
+-- bawah), supaya angkanya diketahui dan bukan ditemukan sebagai kejutan.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Slug lomba, versi server.
+--
+-- Cermin `slugLomba()` di app.js. Dua implementasi untuk satu aturan memang
+-- mahal, tapi yang menentukan adalah yang di server: tanpa pemeriksaan di
+-- sini, satu bug klien menaruh foto di lomba yang tidak ada, dan foto itu
+-- tidak pernah ditemukan lagi oleh layar mana pun.
+-- ---------------------------------------------------------------------------
+create or replace function slug_lomba(p_nama text)
+returns text
+language sql
+immutable
+set search_path = public
+as $$
+  select coalesce(
+    nullif(trim(both '-' from regexp_replace(lower(coalesce(p_nama, '')),
+                                             '[^a-z0-9]+', '-', 'g')), ''),
+    'lomba');
+$$;
+
+comment on function slug_lomba(text) is
+  'Nama lomba -> slug aman untuk nama berkas. Cermin slugLomba() di app.js.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Foto boleh belum punya regu.
+-- ---------------------------------------------------------------------------
+alter table foto_lembar alter column regu_id drop not null;
+
+alter table foto_lembar
+  add column if not exists ditaut_oleh uuid references auth.users (id),
+  add column if not exists ditaut_pada timestamptz,
+  add column if not exists cara_taut   text;
+
+-- Baris lama semuanya tertaut sejak lahir — fotonya diambil sesudah nomor
+-- dadanya diketik. WHERE-nya berarti, bukan hiasan: `update` tanpa `where`
+-- ditolak safeupdate di produksi (CLAUDE.md 14.6).
+update foto_lembar
+set cara_taut   = coalesce(cara_taut, 'unggah'),
+    ditaut_oleh = coalesce(ditaut_oleh, diunggah_oleh),
+    ditaut_pada = coalesce(ditaut_pada, diunggah_pada)
+where regu_id is not null and cara_taut is null;
+
+-- Tiga cara sebuah foto sampai ke regunya, dan ketiganya perlu dibedakan saat
+-- membetulkan tautan yang salah:
+--   unggah  fotonya sudah tertaut sejak diunggah (dialog per regu, 0047)
+--   tangan  panitia menautkannya sendiri di layar Foto Jawaban
+--   mesin   usulan pembacaan gambar yang dicentang panitia
+do $blok$
+begin
+  alter table foto_lembar
+    add constraint foto_lembar_cara_taut_sah
+    check (cara_taut is null or cara_taut in ('unggah', 'tangan', 'mesin'));
+exception when duplicate_object then
+  raise notice '0074: constraint foto_lembar_cara_taut_sah sudah ada.';
+end;
+$blok$;
+
+-- Tertaut berarti ADA catatannya. Tidak ada keadaan setengah tertaut: baris
+-- yang punya regu tapi tidak punya jejak siapa yang menautkannya adalah baris
+-- yang tidak bisa dipertanggungjawabkan, dan foto ini gunanya justru untuk
+-- dipertanggungjawabkan.
+do $blok$
+begin
+  alter table foto_lembar
+    add constraint foto_lembar_taut_utuh
+    check ((regu_id is null) = (cara_taut is null));
+exception when duplicate_object then
+  raise notice '0074: constraint foto_lembar_taut_utuh sudah ada.';
+end;
+$blok$;
+
+-- Antrean "belum tertaut" adalah satu-satunya pertanyaan yang layar baru
+-- tanyakan berulang kali. Index parsial: barisnya sedikit dan menyusut terus,
+-- jadi index penuh cuma membayar ongkos tulis untuk baris yang tidak dicari.
+create index if not exists foto_lembar_belum_taut_idx
+  on foto_lembar (pos, kode_lomba)
+  where regu_id is null;
+
+comment on column foto_lembar.regu_id is
+  'NULL = foto borongan yang belum ditautkan ke nomor dada. Lihat cara_taut.';
+comment on column foto_lembar.cara_taut is
+  'unggah | tangan | mesin. NULL berarti belum tertaut.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Jejak audit.
+--
+-- Menautkan foto ke regu yang salah lalu membetulkannya TIDAK boleh lewat
+-- tanpa bekas. 0001 menolak menerbitkan ulang nomor dada pensiun dengan alasan
+-- harfiah "foto susulan akan menilai regu yang salah" — penautan yang menyusul
+-- adalah foto susulan yang dimaksud kalimat itu.
+-- ---------------------------------------------------------------------------
+-- Nama fungsinya TIDAK ditulis di sini, ia dibaca dari trigger yang sudah ada
+-- di tabel `regu`. Sebabnya sudah terjadi sekali di migrasi ini sendiri:
+-- versi pertama mencari `catat_riwayat`, nama yang dipakai 0002 — dan 0012
+-- baris 605 sudah me-rename-nya jadi `record_history`. Pemeriksaannya melapor
+-- "tidak ada", trigger auditnya dilewati, dan migrasinya tetap SUKSES dengan
+-- sebaris warning yang lewat begitu saja di log. Membaca nama dari trigger
+-- yang pasti hidup membuat rename berikutnya tidak bisa mengulanginya.
+--
+-- Dan kalau ia benar-benar tidak ketemu, migrasinya BERHENTI. Penautan foto
+-- tanpa jejak audit adalah tepat hal yang bagian ini janjikan; menjanjikannya
+-- lewat warning berarti tidak menjanjikan apa pun.
+do $blok$
+declare v_fungsi text;
+begin
+  select p.proname into v_fungsi
+  from pg_trigger t
+  join pg_proc p on p.oid = t.tgfoid
+  where t.tgrelid = 'regu'::regclass
+    and not t.tgisinternal
+    and t.tgname = 'audit_regu';
+
+  if v_fungsi is null then
+    raise exception '0074: fungsi audit tidak ketemu lewat trigger audit_regu. '
+      'Cari nama barunya, jangan tebak — penautan foto tanpa jejak tidak boleh '
+      'tayang.';
+  end if;
+
+  drop trigger if exists audit_foto_lembar on foto_lembar;
+  execute format(
+    'create trigger audit_foto_lembar after insert or update or delete '
+    'on foto_lembar for each row execute function %I()', v_fungsi);
+  raise notice '0074: trigger audit_foto_lembar terpasang (fungsi %).', v_fungsi;
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Mencatat foto borongan.
+--
+-- Pagarnya menyalin catat_foto_lembar versi 0064 — BUKAN versi 0047, yang
+-- masih berbunyi 'meja' / 'operator_pos', nama peran yang mati sejak 0058
+-- (CLAUDE.md 13.2).
+-- ---------------------------------------------------------------------------
+create or replace function catat_foto_masuk(
+  p_pos        smallint,
+  p_kode_lomba text,
+  p_nama_lomba text,
+  p_path       text,
+  p_ukuran     integer default null
+) returns uuid
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_id uuid;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+  if pos_saya() is not null and p_pos is distinct from pos_saya() then
+    raise exception 'operator pos % tidak boleh mengunggah foto pos %',
+      pos_saya(), p_pos;
+  end if;
+
+  if coalesce(trim(p_kode_lomba), '') = '' or coalesce(trim(p_path), '') = '' then
+    raise exception 'kode lomba dan path wajib diisi';
+  end if;
+
+  if split_part(p_path, '/', 1) <> 'pos' || p_pos::text then
+    raise exception 'path % tidak berada di folder pos %', p_path, p_pos;
+  end if;
+
+  -- Kode lomba harus benar-benar milik pos itu. Tanpa ini, salah pilih di
+  -- layar melahirkan tumpukan foto di lomba yang tidak pernah ada, dan tidak
+  -- ada layar yang akan menampilkannya lagi.
+  if not exists (
+    select 1 from wahana w
+    where w.pos = p_pos
+      and slug_lomba(coalesce(w.lomba, w.name)) = p_kode_lomba
+  ) then
+    raise exception 'lomba % bukan lomba di pos %', p_kode_lomba, p_pos;
+  end if;
+
+  -- Gambar diunggah LEBIH DULU, barisnya sesudahnya. Mengirim ulang berkas
+  -- yang sama bukan galat — jaringan lapangan memutus jawaban, bukan
+  -- permintaan. `do nothing` tidak mengembalikan baris, jadi id-nya diambil
+  -- lagi sesudahnya.
+  insert into foto_lembar
+    (regu_id, pos, kode_lomba, nama_lomba, path, ukuran_bytes, diunggah_oleh)
+  values
+    (null, p_pos, p_kode_lomba, p_nama_lomba, p_path, p_ukuran, auth.uid())
+  on conflict (path) do nothing
+  returning id into v_id;
+
+  if v_id is null then
+    select id into v_id from foto_lembar where path = p_path;
+  end if;
+  return v_id;
+end;
+$$;
+
+grant execute on function catat_foto_masuk(smallint, text, text, text, integer)
+  to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. Menautkan foto ke nomor dada.
+--
+-- Ini UPDATE, bukan insert ulang. Mencatat ulang lewat catat_foto_masuk dengan
+-- nomor dada yang benar TIDAK akan mengubah apa pun: `path` unik dan
+-- `on conflict do nothing` membuat panggilannya berhasil tanpa menulis. Layar
+-- akan tampak bekerja sementara tidak ada yang berubah.
+-- ---------------------------------------------------------------------------
+create or replace function tautkan_foto(
+  p_foto_id    uuid,
+  p_nomor_dada integer,
+  p_cara       text default 'tangan'
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_pos  smallint;
+  v_regu uuid;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+  if p_cara not in ('tangan', 'mesin') then
+    raise exception 'cara taut % tidak dikenal', p_cara;
+  end if;
+
+  select pos into v_pos from foto_lembar where id = p_foto_id;
+  if not found then
+    raise exception 'foto % tidak ada', p_foto_id;
+  end if;
+  if pos_saya() is not null and v_pos is distinct from pos_saya() then
+    raise exception 'operator pos % tidak boleh menautkan foto pos %',
+      pos_saya(), v_pos;
+  end if;
+
+  select id into v_regu from regu
+  where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal / regu batal',
+      case when p_nomor_dada between 0 and 999
+        then lpad(p_nomor_dada::text, 3, '0') else p_nomor_dada::text end;
+  end if;
+
+  -- Menautkan ulang DIBOLEHKAN, dan itu disengaja. Pembacaan mesin akan
+  -- sesekali salah satu digit, dan pembetulnya harus orang yang sedang
+  -- memegang kertasnya — bukan pemegang `pengaturan` yang tidak ada di
+  -- lapangan. Yang menjaganya bukan larangan, melainkan trigger audit di
+  -- bagian 3.
+  update foto_lembar
+  set regu_id     = v_regu,
+      ditaut_oleh = auth.uid(),
+      ditaut_pada = now(),
+      cara_taut   = p_cara
+  where id = p_foto_id;
+end;
+$$;
+
+grant execute on function tautkan_foto(uuid, integer, text) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 6. View: LEFT join, kalau tidak foto yang belum tertaut lenyap tanpa suara.
+--
+-- Badannya disalin utuh dari 0065; yang berubah hanya `join` -> `left join`
+-- dan tiga kolom tambahan. View ini BUKAN security_invoker — ia membawa
+-- pagarnya sendiri, jadi mengubah policy tabel saja tidak mengubah apa pun
+-- yang terlihat di sini (CLAUDE.md 13.3).
+-- ---------------------------------------------------------------------------
+drop view if exists v_foto_lembar;
+create or replace view v_foto_lembar as
+select
+  f.id, r.nomor_dada, f.pos, f.kode_lomba, f.nama_lomba, f.path,
+  f.ukuran_bytes,
+  coalesce(a.username, '(tidak dikenal)') as oleh,
+  f.diunggah_pada,
+  f.cara_taut,
+  f.ditaut_pada,
+  coalesce(t.username, '(tidak dikenal)') as ditaut_oleh
+from foto_lembar f
+left join regu r on r.id = f.regu_id
+left join akun_panitia a on a.user_id = f.diunggah_oleh
+left join akun_panitia t on t.user_id = f.ditaut_oleh
+where boleh('rekap')
+   or (boleh('pos') and (pos_saya() is null or f.pos = pos_saya()));
+
+-- `drop view` ikut membuang GRANT-nya. Dilupakan sekali di 0065 dan ketahuan
+-- lewat tes, bukan lewat layar.
+grant select on v_foto_lembar to authenticated;
+
+comment on view v_foto_lembar is
+  'Foto lembar jawaban. nomor_dada NULL = belum ditautkan (foto borongan).';
+
+-- ---------------------------------------------------------------------------
+-- 7. Laporan, bukan perbaikan.
+--
+-- Berapa baris lama yang kode lombanya bukan slug lomba yang sah? Angkanya
+-- diketahui sekarang, bukan ditemukan sebagai kejutan waktu foto lama dicari
+-- lewat pintu baru dan tidak ketemu.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_semua  integer;
+  v_asing  integer;
+  v_kosong integer;
+begin
+  select count(*) into v_semua from foto_lembar;
+  select count(*) into v_kosong from foto_lembar where regu_id is null;
+  select count(*) into v_asing
+  from foto_lembar f
+  where not exists (
+    select 1 from wahana w
+    where w.pos = f.pos
+      and slug_lomba(coalesce(w.lomba, w.name)) = f.kode_lomba
+  );
+  raise notice '0074: % baris foto, % belum tertaut, % berkode lomba yang '
+               'tidak cocok dengan wahana pos itu (dibiarkan apa adanya).',
+               v_semua, v_kosong, v_asing;
+end;
+$blok$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -57,6 +57,11 @@ RPC = {
     "tandai_kloter_dicetak": ["p_kloter"],
     "pindah_kloter":         ["p_nomor_dada", "p_alasan", "p_kloter"],
     "batalkan_tanda_cetak":  ["p_kloter", "p_alasan"],
+    # Foto jawaban (0074). Gambarnya sendiri TIDAK lewat sini — dev server
+    # tidak punya Storage — tapi barisnya tetap dicatat supaya alur layarnya
+    # bisa dicoba tanpa Supabase.
+    "catat_foto_masuk":      ["p_pos", "p_kode_lomba", "p_nama_lomba", "p_path", "p_ukuran"],
+    "tautkan_foto":          ["p_foto_id", "p_nomor_dada", "p_cara"],
 }
 # RPC yang hasilnya tabel (bukan skalar/jsonb).
 RPC_TABEL = {"daftar_ulang_batch"}
@@ -133,6 +138,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/status":
                 self._kirim(200, q(
                     "select * from status_acara", uid=p.get("uid"), fetch="one"))
+            elif u.path == "/foto-belum-taut":
+                # nomor_dada NULL = foto borongan yang belum ditautkan (0074).
+                self._kirim(200, q(
+                    "select * from v_foto_lembar "
+                    "where pos = %s and kode_lomba = %s and nomor_dada is null "
+                    "order by diunggah_pada",
+                    (p.get("pos") or 0, p.get("lomba") or ""), uid=p.get("uid")))
+            elif u.path == "/kuota-foto":
+                self._kirim(200, q(
+                    "select * from v_kuota_foto", uid=p.get("uid"), fetch="one"))
             elif u.path == "/pos":
                 self._kirim(200, q(
                     "select * from v_pos order by nomor", uid=p.get("uid")))

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -263,5 +263,11 @@ run supabase/migrations/0072_progres_komponen_publik.sql
 # 0073 mengganti nama satu sekolah. Ikut dijalankan supaya berkasnya tetap
 # teruji; di database uji ia memang tidak menemukan apa pun.
 run supabase/migrations/0073_nama_al_azhar_citangkolo.sql
+# 0074 membuka foto borongan: `foto_lembar.regu_id` boleh NULL, penautan
+# nomor dada menyusul lewat `tautkan_foto`. Tes 37 yang menjaga bahwa foto
+# yang belum tertaut tetap TERLIHAT — dengan `join` biasa ia lenyap dari
+# v_foto_lembar tanpa satu pun galat.
+run supabase/migrations/0074_foto_jawaban.sql
+run tests/sql/37_foto_jawaban.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/37_foto_jawaban.sql
+++ b/tests/sql/37_foto_jawaban.sql
@@ -1,0 +1,286 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/37_foto_jawaban.sql
+-- Foto borongan yang nomor dadanya ditautkan belakangan (0074).
+--
+-- YANG DIJAGA DI SINI, DAN KENAPA MASING-MASING
+--
+-- 1. Foto tanpa regu HARUS TERLIHAT. Selama v_foto_lembar masih `join regu`,
+--    setiap foto yang belum tertaut lenyap dari view tanpa satu pun galat —
+--    layar melaporkan "tidak ada foto" untuk gambar yang sudah naik dan sudah
+--    memakan kuota. Ini kegagalan yang paling mungkin dan paling sulit dilihat,
+--    jadi ia diuji lebih dulu daripada yang lain.
+--
+-- 2. Penautan harus benar-benar MENULIS. Mencatat ulang lewat catat_foto_masuk
+--    dengan nomor dada yang benar akan "berhasil" tanpa mengubah apa pun,
+--    karena `path` unik dan `on conflict do nothing`. Layar akan tampak
+--    bekerja. Yang membuktikan sebaliknya cuma membaca barisnya sesudahnya.
+--
+-- 3. Pagarnya menempati kursi, bukan memindai nama (CLAUDE.md 13.8). Panggilan
+--    yang sama dijalankan dua kali dengan satu baris `akun_hak` diubah di
+--    antaranya; kalau pesan galatnya tidak berubah, pagarnya tidak ada.
+--
+-- Yang TIDAK diuji: policy storage.objects, karena storage.objects tidak ada
+-- di Postgres lokal. Karena itulah pagar path dipasang dua kali, dan yang
+-- kedua inilah yang bisa diuji (37.4).
+-- ============================================================================
+
+-- Lomba yang benar-benar ada di Pos 1 di database uji. Diambil dari wahana,
+-- bukan dikarang: `catat_foto_masuk` menolak kode lomba yang bukan milik pos
+-- itu, jadi kode karangan akan menggagalkan seluruh berkas dengan galat yang
+-- tidak ada hubungannya dengan apa yang sedang diuji.
+create temp table t_lomba as
+select slug_lomba(coalesce(w.lomba, w.name)) as kode,
+       coalesce(w.lomba, w.name)             as nama
+from wahana w
+where w.pos = 1
+order by w.sort_order, w.kode
+limit 1;
+
+create temp table t_regu as
+select id, nomor_dada from regu
+where nomor_dada is not null and not is_cancelled
+order by nomor_dada limit 1;
+
+grant select on t_lomba, t_regu to public;
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 37.1  Foto masuk tanpa nomor dada — barisnya ada, regunya kosong.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_id uuid; v_kode text; v_nama text; v_regu uuid; v_cara text;
+begin
+  select kode, nama into v_kode, v_nama from t_lomba;
+
+  v_id := catat_foto_masuk(1::smallint, v_kode, v_nama,
+                           'pos1/' || v_kode || '/uji-borongan-a.jpg', 64000);
+  assert v_id is not null, 'catat_foto_masuk tidak mengembalikan id';
+
+  select regu_id, cara_taut into v_regu, v_cara from foto_lembar where id = v_id;
+  assert v_regu is null, 'foto borongan seharusnya belum punya regu';
+  assert v_cara is null, 'cara_taut seharusnya kosong sebelum ditautkan';
+
+  raise notice '37.1 OK — foto masuk tanpa nomor dada.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.2  Foto yang belum tertaut TERLIHAT di v_foto_lembar.
+--
+-- Inilah yang membuktikan `left join`. Dengan `join` biasa, tes ini gagal dan
+-- semua tes lain di berkas ini tetap lulus — persis bentuk kegagalannya di
+-- lapangan.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_ada integer; v_dada integer;
+begin
+  select kode into v_kode from t_lomba;
+
+  select count(*) into v_ada from v_foto_lembar
+  where path = 'pos1/' || v_kode || '/uji-borongan-a.jpg';
+  assert v_ada = 1,
+    'foto belum tertaut LENYAP dari v_foto_lembar — join-nya bukan left join';
+
+  select nomor_dada into v_dada from v_foto_lembar
+  where path = 'pos1/' || v_kode || '/uji-borongan-a.jpg';
+  assert v_dada is null, 'nomor dada seharusnya kosong';
+
+  raise notice '37.2 OK — foto belum tertaut terlihat, nomor dadanya kosong.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.3  Penautan mengisi regu DAN ketiga kolom jejaknya.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_kode text; v_id uuid; v_dada integer; v_regu uuid;
+  v_taut uuid; v_cara text; v_pada timestamptz;
+begin
+  select kode into v_kode from t_lomba;
+  select nomor_dada, id into v_dada, v_regu from t_regu;
+  select id into v_id from foto_lembar
+  where path = 'pos1/' || v_kode || '/uji-borongan-a.jpg';
+
+  perform tautkan_foto(v_id, v_dada, 'tangan');
+
+  select regu_id, ditaut_oleh, cara_taut, ditaut_pada
+    into v_regu, v_taut, v_cara, v_pada
+  from foto_lembar where id = v_id;
+
+  assert v_regu = (select id from t_regu), 'regu tidak tertaut';
+  assert v_cara = 'tangan',       'cara_taut tidak tercatat';
+  assert v_taut is not null,      'ditaut_oleh kosong';
+  assert v_pada is not null,      'ditaut_pada kosong';
+
+  raise notice '37.3 OK — penautan menulis regu dan jejaknya.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.4  Path di luar folder posnya DITOLAK.
+--
+-- Path datang dari JavaScript, dan apa pun yang datang dari JavaScript bisa
+-- dikarang. Baris tercatat sebagai milik Pos 1 sementara gambarnya di folder
+-- Pos 3: yang membaca daftar foto Pos 1 kemudian melihat kertas pos lain.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_pesan text;
+begin
+  select kode into v_kode from t_lomba;
+  begin
+    perform catat_foto_masuk(1::smallint, v_kode, 'Uji',
+                             'pos3/' || v_kode || '/nyasar.jpg', 1000);
+    assert false, 'path pos3 diterima sebagai foto pos 1';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak berada di folder pos%',
+    format('galat yang diharapkan bukan ini: %s', v_pesan);
+  raise notice '37.4 OK — path lintas pos ditolak.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.5  Kode lomba yang bukan milik pos itu DITOLAK.
+--
+-- Tanpa pagar ini, salah pilih di layar melahirkan tumpukan foto di lomba yang
+-- tidak pernah ada — dan tidak ada layar yang akan menampilkannya lagi, karena
+-- setiap layar membangun daftar lombanya dari `wahana`.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_pesan text;
+begin
+  begin
+    perform catat_foto_masuk(1::smallint, 'lomba-karangan', 'Lomba Karangan',
+                             'pos1/lomba-karangan/x.jpg', 1000);
+    assert false, 'kode lomba karangan diterima';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%bukan lomba di pos%',
+    format('galat yang diharapkan bukan ini: %s', v_pesan);
+  raise notice '37.5 OK — kode lomba asing ditolak.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.6  Nomor dada karangan ditolak, dan fotonya TETAP belum tertaut.
+--
+-- Yang diuji bukan cuma galatnya: penautan yang gagal separuh jalan akan
+-- meninggalkan baris yang punya `ditaut_pada` tapi tidak punya regu, dan
+-- constraint foto_lembar_taut_utuh ada justru untuk itu.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_id uuid; v_pesan text; v_regu uuid; v_cara text;
+begin
+  select kode into v_kode from t_lomba;
+  v_id := catat_foto_masuk(1::smallint, v_kode, 'Uji',
+                           'pos1/' || v_kode || '/uji-borongan-b.jpg', 51000);
+  begin
+    perform tautkan_foto(v_id, 999999, 'tangan');
+    assert false, 'nomor dada karangan diterima';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak dikenal%',
+    format('galat yang diharapkan bukan ini: %s', v_pesan);
+
+  select regu_id, cara_taut into v_regu, v_cara from foto_lembar where id = v_id;
+  assert v_regu is null and v_cara is null,
+    'penautan gagal meninggalkan baris setengah tertaut';
+
+  raise notice '37.6 OK — nomor dada karangan ditolak, barisnya utuh.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.7  Centang `pos` di layar Akun benar-benar jadi pagarnya.
+--
+-- Bentuk "menempati kursi" (CLAUDE.md 13.8): panggilan yang SAMA PERSIS
+-- dijalankan dua kali oleh akun yang sama, yang berubah cuma satu baris
+-- `akun_hak`. Kalau pesan galatnya tidak berubah, pagarnya tidak ada.
+-- ---------------------------------------------------------------------------
+reset role;
+do $blok$
+declare
+  v_uid   uuid;
+  v_kode  text;
+  v_pesan text;
+begin
+  select user_id into v_uid from akun_panitia
+  where peran = 'juri_pos' and is_active and pos = 1
+  order by username limit 1;
+  if v_uid is null then
+    raise notice '37.7 DILEWATI — tidak ada akun juri_pos pos 1 yang aktif.';
+    return;
+  end if;
+  select kode into v_kode from t_lomba;
+
+  perform set_config('app.uid', v_uid::text, false);
+
+  -- Masih tercentang: penjaganya lolos, yang menolak adalah isinya.
+  begin
+    perform catat_foto_masuk(1::smallint, 'lomba-karangan', 'Uji',
+                             'pos1/lomba-karangan/pagar.jpg', 1000);
+    assert false, 'kode karangan seharusnya ditolak';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%bukan lomba di pos%',
+    format('penjaga seharusnya sudah lolos, galatnya justru: %s', v_pesan);
+
+  -- Cabut satu centang. Ini yang dilakukan admin di layar Akun.
+  delete from akun_hak where user_id = v_uid and fitur = 'pos';
+
+  -- Panggilan yang sama persis.
+  begin
+    perform catat_foto_masuk(1::smallint, 'lomba-karangan', 'Uji',
+                             'pos1/lomba-karangan/pagar.jpg', 1000);
+    assert false, 'seharusnya ditolak penjaga';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak berhak: pos%',
+    format('centang seharusnya jadi pagarnya, galatnya: %s', v_pesan);
+
+  insert into akun_hak (user_id, fitur) values (v_uid, 'pos')
+  on conflict do nothing;
+
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+  raise notice '37.7 OK — centang `pos` menahan unggahan borongan.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 37.8  Penautan MENINGGALKAN JEJAK di history.
+--
+-- Menautkan ulang sengaja dibolehkan — pembacaan mesin akan sesekali salah
+-- satu digit, dan pembetulnya harus orang yang sedang memegang kertasnya. Yang
+-- menjaga kebolehan itu bukan larangan melainkan jejaknya; tanpa tes ini,
+-- trigger yang tidak terpasang tidak akan ketahuan oleh apa pun.
+--
+-- Versi pertama migrasi 0074 memang tidak memasangnya: ia mencari fungsi
+-- bernama `catat_riwayat`, padahal 0012 sudah me-rename-nya jadi
+-- `record_history`. Migrasinya sukses, warningnya lewat begitu saja.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_id uuid; v_dada integer; v_jejak integer;
+begin
+  select kode into v_kode from t_lomba;
+  select nomor_dada into v_dada from t_regu;
+  select id into v_id from foto_lembar
+  where path = 'pos1/' || v_kode || '/uji-borongan-a.jpg';
+
+  select count(*) into v_jejak from history
+  where table_name = 'foto_lembar' and row_id = v_id::text and action = 'UPDATE';
+  assert v_jejak >= 1,
+    'penautan foto tidak terekam di history — trigger auditnya tidak terpasang';
+
+  raise notice '37.8 OK — penautan terekam di history (% baris).', v_jejak;
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- Bersih-bersih. Dari akar ke daun, seperti tes lain — tanpa ini hitungan tes
+-- berikutnya ikut bergeser.
+-- ---------------------------------------------------------------------------
+reset role;
+delete from history where table_name = 'foto_lembar';
+delete from foto_lembar where path like 'pos1/%uji-borongan-%';
+drop table if exists t_lomba;
+drop table if exists t_regu;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -757,6 +757,92 @@ export async function kuotaFoto() {
   return Array.isArray(d) ? d[0] : d;
 }
 
+/* ---------------------------- FOTO BORONGAN ----------------------------
+
+   Foto lembar jawaban yang diambil DI POS, banyak sekaligus, nomor dadanya
+   ditautkan belakangan (migrasi 0074).
+
+   Bedanya dengan unggahFotoLembar di atas cuma satu hal, tapi hal itu yang
+   mengubah segalanya: nomor dada BELUM DIKETAHUI saat gambarnya naik. Jadi
+   ia tidak ikut ke nama berkas, dan barisnya lahir tanpa regu.
+
+   Kenapa tidak menambah cabang ke unggahFotoLembar: fungsi itu menerima nomor
+   dada sebagai argumen wajib dan memakainya di dua tempat. Membuat argumen
+   wajib jadi opsional membuat pemanggil lama diam-diam boleh lupa mengisinya
+   — dan foto yang seharusnya tertaut sendiri jadi menganggur di antrean. */
+
+/** Nama objek untuk foto yang belum berdada.
+ *
+ *  TIDAK ada segmen `belum/`. Bucket `lembar` tidak punya policy UPDATE
+ *  maupun DELETE sama sekali, jadi objeknya tidak akan pernah bisa dipindah —
+ *  folder bernama "belum tertaut" akan berbohong sejak foto itu tertaut, dan
+ *  berbohong selamanya. Keadaan tautan hidup di baris database.
+ *
+ *  Segmen pertama tetap `pos<n>`: itulah yang dipagari policy storage.objects
+ *  dan diperiksa ulang catat_foto_masuk. */
+export function namaObjekFotoMasuk(pos, kodeLomba) {
+  const acak = Math.random().toString(36).slice(2, 8);
+  return `pos${pos}/${kodeLomba}/${Date.now()}-${acak}.jpg`;
+}
+
+/** Unggah satu gambar borongan, lalu catat barisnya. Mengembalikan id barisnya
+ *  — itu yang dipakai layar untuk menautkannya ke nomor dada nanti.
+ *
+ *  Urutannya sama dengan unggahFotoLembar dan sengaja: gambar dulu, baris
+ *  sesudahnya. Baris tanpa gambar adalah kebohongan; gambar tanpa baris cuma
+ *  berkas yatim yang tidak merugikan siapa pun. */
+export async function unggahFotoMasuk(pos, kodeLomba, namaLomba, blob) {
+  const path = namaObjekFotoMasuk(pos, kodeLomba);
+  const argumen = {
+    p_pos: pos, p_kode_lomba: kodeLomba, p_nama_lomba: namaLomba,
+    p_path: path, p_ukuran: blob.size,
+  };
+
+  if (K.mode === "dev") {
+    const id = await rpc("catat_foto_masuk", argumen);
+    return { id, path, ukuran: blob.size };
+  }
+
+  await pastikanSesiSegar();
+  const s = sesi();
+  await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET}/${path}`, {
+    method: "POST",
+    headers: {
+      apikey: K.anonKey,
+      Authorization: `Bearer ${s && s.token ? s.token : K.anonKey}`,
+      "Content-Type": "image/jpeg",
+      "x-upsert": "false",
+    },
+    body: blob,
+  });
+
+  const id = await rpc("catat_foto_masuk", argumen);
+  return { id, path, ukuran: blob.size };
+}
+
+/** Antrean foto yang belum punya nomor dada, satu pos satu lomba.
+ *
+ *  `nomor_dada=is.null` yang menyaringnya, bukan view kedua — v_foto_lembar
+ *  sejak 0074 memakai LEFT join justru supaya baris ini terlihat. */
+export async function daftarFotoBelumTaut(pos, kodeLomba) {
+  if (K.mode === "dev") {
+    return baca(`/foto-belum-taut?pos=${encodeURIComponent(pos)}` +
+                `&lomba=${encodeURIComponent(kodeLomba)}`);
+  }
+  return baca(null,
+    `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}` +
+    `&kode_lomba=eq.${encodeURIComponent(kodeLomba)}` +
+    `&nomor_dada=is.null&select=*&order=diunggah_pada.asc`);
+}
+
+/** Tautkan satu foto ke nomor dada.
+ *
+ *  `cara` membedakan siapa yang memutuskan: `tangan` panitia sendiri, `mesin`
+ *  usulan pembacaan gambar yang dicentang panitia. Menautkan ulang boleh —
+ *  yang menjaganya trigger audit, bukan larangan. */
+export const tautkanFoto = (id, nomorDada, cara = "tangan") =>
+  rpc("tautkan_foto", { p_foto_id: id, p_nomor_dada: nomorDada, p_cara: cara });
+
 /* ============================ AKUN PANITIA ==============================
    Dua jalur, dan yang menentukan bukan kerapian melainkan siapa pemegang
    kuncinya.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -22,6 +22,7 @@ import {
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenLiveScore,
+  unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
   statusAcara, bolehLihat, lengkapiHakSesi,
   aturFaseLive,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun,
@@ -249,6 +250,9 @@ async function layarHome() {
         <a href="#/pos">
           <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos ${esc(sesi().pos)}</div>
         </a>
+        <a href="#/foto">
+          <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban</div>
+        </a>
         ${bolehLihat("live_score") ? `
         <a href="#/live-score">
           <div class="function-name">${ikonKotak("medal", "emas")} Live Score</div>
@@ -330,6 +334,10 @@ async function layarHome() {
       ${bolehLihat("pos") ? `
       <a href="#/pos">
         <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos</div>
+      </a>` : ""}
+      ${bolehLihat("pos") ? `
+      <a href="#/foto">
+        <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban</div>
       </a>` : ""}
       ${bolehLihat("live_score") ? `
       <a href="#/live-score">
@@ -4911,8 +4919,295 @@ async function layarAkun() {
 
 /* ============================ RUTE ======================================= */
 
+/* ============================== FOTO JAWABAN ==============================
+
+   Foto lembar jawaban yang diambil DI POS, banyak sekaligus, nomor dadanya
+   ditautkan belakangan (migrasi 0074).
+
+   KENAPA LAYAR INI ADA PADAHAL SUDAH ADA TOMBOL KAMERA DI MEJA IT
+
+   Tombol kamera di layar Input Pos memfoto satu regu yang nomor dadanya baru
+   saja diketik — fotonya tertaut sendiri, tanpa pekerjaan tambahan, dan itu
+   tetap jalur utamanya. Yang tidak bisa dilakukannya: memotret setumpuk
+   kertas di pos, sebelum kertas itu berangkat ke meja IT. Migrasi 0047 sendiri
+   mengakui lubang itu — "slip yang HILANG DI JALAN antara pos dan meja IT
+   tidak pernah difoto sama sekali".
+
+   Harganya jujur: foto borongan tidak tahu nomor dadanya, jadi ia menganggur
+   di antrean sampai ada yang menautkannya. Karena itu jumlah yang belum
+   tertaut ditampilkan sebagai ANGKA di layar, bukan disembunyikan — antrean
+   yang tidak terlihat adalah antrean yang tidak pernah dikerjakan.
+   ========================================================================= */
+async function layarFoto() {
+  if (!EDISI) { layarButuhEdisi("Foto Jawaban"); return; }
+  pasangKepala("Foto Jawaban", true);
+  LAYAR.replaceChildren(h(pemuat()));
+
+  const layarIni = location.hash;
+  const s = sesi();
+  let semuaPos;
+  try { semuaPos = await daftarPos(); }
+  catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarFoto)); return; }
+  if (location.hash !== layarIni) return;
+
+  const posDinilai = semuaPos.filter(p => Number(p.jumlah_komponen) > 0);
+  if (!posDinilai.length) {
+    LAYAR.replaceChildren(h(`<div class="card"><h2>Belum ada pos berpenilaian</h2></div>`));
+    return;
+  }
+
+  /* Pemilih pos muncul kalau akunnya TIDAK terkunci ke satu pos — dibaca dari
+     `sesi().pos`, bukan dari nama perannya. Sejak 0064 yang menentukan hak
+     adalah centang di layar Akun (CLAUDE.md 13.1); akun yang diberi centang
+     `pos` tanpa peran admin tetap boleh memilih pos selama posnya kosong, dan
+     memeriksa nama peran akan mengunci akun itu ke pos pertama diam-diam. */
+  const terkunci = s && s.pos != null && s.pos !== "";
+  let nomorPos = terkunci ? Number(s.pos) : Number(posDinilai[0].nomor);
+  let kodeLomba = null, namaLomba = null;
+
+  LAYAR.replaceChildren(h(`
+    <div class="card">
+      <div class="baris-pilih">
+        <div class="field">
+          <label for="foto-pos">Pos</label>
+          <select id="foto-pos" class="select" ${terkunci ? "disabled" : ""}>
+            ${posDinilai.map(p => `<option value="${esc(p.nomor)}"
+              ${Number(p.nomor) === nomorPos ? "selected" : ""}
+              >${esc(judulPos(p))}</option>`).join("")}
+          </select>
+        </div>
+        <div class="field">
+          <label for="foto-lomba">Lomba</label>
+          <select id="foto-lomba" class="select"></select>
+        </div>
+      </div>
+      <div class="action-row" id="foto-aksi" hidden>
+        <label class="button button-primary">
+          <input type="file" accept="image/*" multiple hidden id="foto-ambil">
+          ${ikon("camera")} Pilih foto
+        </label>
+        <span class="sub" id="foto-kuota"></span>
+      </div>
+      <ul class="antrean-foto" id="foto-antrean"></ul>
+    </div>
+    <div class="card">
+      <h2>Belum tertaut <span class="badge" id="foto-belum">0</span></h2>
+      <div class="grid-foto" id="foto-grid"></div>
+    </div>
+  `));
+
+  const elPos    = document.getElementById("foto-pos");
+  const elLomba  = document.getElementById("foto-lomba");
+  const elAksi   = document.getElementById("foto-aksi");
+  const elAmbil  = document.getElementById("foto-ambil");
+  const elAntre  = document.getElementById("foto-antrean");
+  const elGrid   = document.getElementById("foto-grid");
+  const elBelum  = document.getElementById("foto-belum");
+  const elKuota  = document.getElementById("foto-kuota");
+
+  const slug = (nama) => String(nama).toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
+
+  /* Daftar lomba, BUKAN daftar penilaian. Satu slip adalah satu lomba
+     (CLAUDE.md 11.5): Pembidaian punya lima kriteria di satu kertas, dan
+     menawarkan lima pilihan di sini berarti satu kertas yang sama bisa
+     mendarat di lima kode yang berbeda. kelompokLomba() yang membedakannya,
+     lewat wahana.lomba — jangan memenggal awalan kodenya (11.7). */
+  async function isiLomba() {
+    elLomba.innerHTML = `<option>memuat…</option>`;
+    let komponen;
+    try { komponen = await komponenPos(EDISI.nomor, nomorPos); }
+    catch (e) { notif(`Lomba pos ${nomorPos} tidak terbaca: ${e.message}`, true); return; }
+    const lomba = kelompokLomba(kolomPos(komponen));
+    elLomba.innerHTML = lomba.map(l =>
+      `<option value="${esc(slug(l.nama))}">${esc(l.nama)}</option>`).join("");
+    kodeLomba = lomba.length ? slug(lomba[0].nama) : null;
+    namaLomba = lomba.length ? lomba[0].nama : null;
+    elLomba.dataset.nama = namaLomba || "";
+    elAksi.hidden = !kodeLomba;
+    await muatBelum();
+  }
+
+  /** Antrean foto yang belum bernomor dada, untuk pos + lomba yang dipilih. */
+  async function muatBelum() {
+    if (!kodeLomba) return;
+    elGrid.replaceChildren(h(`<p class="keterangan">Memuat…</p>`));
+    let daftar;
+    try { daftar = await daftarFotoBelumTaut(nomorPos, kodeLomba); }
+    catch (e) { elGrid.replaceChildren(h(`<p class="keterangan">${esc(e.message)}</p>`)); return; }
+
+    elBelum.textContent = String(daftar.length);
+    if (!daftar.length) {
+      elGrid.replaceChildren(h(`<p class="keterangan">Tidak ada.</p>`));
+      return;
+    }
+
+    elGrid.replaceChildren(h(daftar.map(f => `
+      <figure class="ubin-foto" data-id="${esc(f.id)}" data-path="${esc(f.path)}">
+        <button type="button" class="ubin-gambar" data-lihat
+          title="Buka foto"><span class="keterangan">Lihat</span></button>
+        <figcaption>
+          <input type="number" class="small-input" inputmode="numeric" min="1"
+                 placeholder="No dada" data-dada aria-label="Nomor dada">
+          <button type="button" class="button button-mini button-primary"
+                  data-taut>Tautkan</button>
+        </figcaption>
+      </figure>`).join("")));
+
+    /* Thumbnail-nya TIDAK diambil sekaligus. Satu link bertanda tangan per
+       foto adalah satu permintaan jaringan, dan di sinyal lapangan dua ratus
+       permintaan sekaligus membekukan layar sebelum satu gambar pun tampil.
+       Diambil saat ubinnya benar-benar masuk layar. */
+    const pengamat = new IntersectionObserver((masuk) => {
+      for (const e of masuk) {
+        if (!e.isIntersecting) continue;
+        pengamat.unobserve(e.target);
+        gambarUbin(e.target);
+      }
+    }, { rootMargin: "200px" });
+    elGrid.querySelectorAll(".ubin-foto").forEach(u => pengamat.observe(u));
+  }
+
+  async function gambarUbin(ubin) {
+    const tombol = ubin.querySelector(".ubin-gambar");
+    try {
+      const url = await tautanFoto(ubin.dataset.path);
+      if (url) tombol.style.backgroundImage = `url("${url}")`;
+      tombol.dataset.url = url || "";
+      const ket = tombol.querySelector(".keterangan");
+      if (ket && url) ket.remove();
+    } catch { /* Ubin tanpa gambar tetap bisa ditautkan — itu yang penting. */ }
+  }
+
+  elPos.addEventListener("change", async () => {
+    nomorPos = Number(elPos.value);
+    await isiLomba();
+  });
+  elLomba.addEventListener("change", async () => {
+    kodeLomba = elLomba.value;
+    namaLomba = elLomba.options[elLomba.selectedIndex].textContent.trim();
+    await muatBelum();
+  });
+
+  /* Membuka gambar: jendelanya dibuka SEBELUM await. Dibuka sesudahnya,
+     browser HP menganggapnya popup yang tidak diminta pengguna dan
+     memblokirnya — pelajaran yang sudah dibayar di dialog foto per regu. */
+  elGrid.addEventListener("click", async (e) => {
+    const lihat = e.target.closest("[data-lihat]");
+    if (lihat) {
+      const jendela = window.open("", "_blank");
+      try {
+        const url = lihat.dataset.url
+          || await tautanFoto(lihat.closest(".ubin-foto").dataset.path);
+        if (jendela && url) jendela.location = url; else if (jendela) jendela.close();
+      } catch (err) {
+        if (jendela) jendela.close();
+        notif(`Foto tidak bisa dibuka: ${err.message}`, true);
+      }
+      return;
+    }
+
+    const taut = e.target.closest("[data-taut]");
+    if (!taut) return;
+    const ubin = taut.closest(".ubin-foto");
+    const isian = ubin.querySelector("[data-dada]");
+    const dada = Number(isian.value);
+    if (!Number.isInteger(dada) || dada <= 0) {
+      notif("Nomor dada harus angka.", true);
+      isian.focus();
+      return;
+    }
+    taut.disabled = true;
+    try {
+      await tautkanFoto(ubin.dataset.id, dada, "tangan");
+      notif(`Foto tertaut ke ${dada3(dada)}.`);
+      ubin.remove();
+      elBelum.textContent = String(elGrid.querySelectorAll(".ubin-foto").length);
+      if (!elGrid.querySelector(".ubin-foto")) {
+        elGrid.replaceChildren(h(`<p class="keterangan">Tidak ada.</p>`));
+      }
+    } catch (err) {
+      taut.disabled = false;
+      notif(`Gagal menautkan: ${err.message}`, true);
+    }
+  });
+
+  /* ---- Antrean unggah ----
+
+     Berkasnya DIPEGANG di sini, tidak dilepas setelah gagal. Gelung di dialog
+     foto per regu menuntut petugas memilih ulang berkas dari galeri setiap
+     kali jaringan putus; dengan lima puluh foto sekaligus itu bukan lagi
+     ketidaknyamanan melainkan pekerjaan yang tidak akan diselesaikan siapa
+     pun. Di sini yang gagal tetap di antrean dengan tombol "Ulangi". */
+  const antrean = [];
+
+  function gambarAntrean() {
+    elAntre.replaceChildren(h(antrean.map((t, i) => `
+      <li data-i="${i}" class="${esc(t.keadaan)}">
+        <span class="a-nama">${esc(t.nama)}</span>
+        <span class="a-status">${esc(t.pesan)}</span>
+        ${t.keadaan === "gagal"
+          ? `<button type="button" class="button button-mini" data-ulang>Ulangi</button>` : ""}
+      </li>`).join("")));
+  }
+
+  async function kerjakan(t) {
+    t.keadaan = "jalan";
+    try {
+      t.pesan = "mengecilkan…"; gambarAntrean();
+      const blob = await kecilkanFoto(t.berkas);
+      t.pesan = `mengirim ${ukuranRapi(blob.size)}…`; gambarAntrean();
+      await unggahFotoMasuk(t.pos, t.kode, t.nama_lomba, blob);
+      t.keadaan = "selesai";
+      t.pesan = ukuranRapi(blob.size);
+    } catch (err) {
+      t.keadaan = "gagal";
+      t.pesan = err.message;
+    }
+    gambarAntrean();
+  }
+
+  elAntre.addEventListener("click", async (e) => {
+    const b = e.target.closest("[data-ulang]");
+    if (!b) return;
+    const t = antrean[Number(b.closest("li").dataset.i)];
+    if (!t) return;
+    await kerjakan(t);
+    await muatBelum();
+  });
+
+  elAmbil.addEventListener("change", async () => {
+    const berkas = [...(elAmbil.files || [])];
+    // Dikosongkan supaya memilih berkas YANG SAMA lagi tetap memicu change.
+    elAmbil.value = "";
+    if (!berkas.length || !kodeLomba) return;
+
+    for (const f of berkas) {
+      antrean.push({
+        berkas: f, nama: f.name || "foto", pesan: "menunggu…", keadaan: "antre",
+        pos: nomorPos, kode: kodeLomba, nama_lomba: namaLomba,
+      });
+    }
+    gambarAntrean();
+
+    // Satu per satu, bukan serentak. Unggahan paralel dari HP di sinyal
+    // lapangan saling menggerus dan menabrak batas waktu bersama-sama.
+    for (const t of antrean) if (t.keadaan === "antre") await kerjakan(t);
+
+    await muatBelum();
+    try {
+      const k = await kuotaFoto();
+      if (k) elKuota.textContent =
+        `${k.jumlah_foto} foto · ${ukuranRapi(k.total_bytes || 0)} terpakai`;
+    } catch { /* Kuota cuma keterangan; gagal membacanya tidak menghalangi apa pun. */ }
+  });
+
+  await isiLomba();
+}
+
 const RUTE = {
   "#/home": layarHome,
+  "#/foto": layarFoto,
   "#/pembayaran": layarPembayaran,
   "#/daftar-ulang": layarDaftarUlang,
   "#/cetak-kloter": layarCetakKloter,

--- a/web/style.css
+++ b/web/style.css
@@ -2967,3 +2967,67 @@ input.small-input { text-align: center; }
   background: none; border: 0; padding: 0; font: inherit; cursor: pointer;
   color: var(--utama); text-decoration: underline;
 }
+
+/* ==========================================================================
+   FOTO JAWABAN — unggah borongan dari pos, penautan nomor dada menyusul.
+
+   Dua bagian yang bentuknya berbeda karena pekerjaannya berbeda: ANTREAN
+   unggah dibaca dari atas ke bawah sambil menunggu, GRID foto dibaca dengan
+   mata menyapu mencari kertas yang dikenali. Yang pertama daftar, yang kedua
+   petak.
+   ========================================================================== */
+
+/* Pos dan Lomba bersebelahan di layar lebar, menumpuk di HP. Tidak ada lebar
+   yang dipatok tangan — dua isian yang dipatok mm akan terjepit ke kanan
+   begitu wadahnya menyempit (bagian 15). */
+.baris-pilih { display: flex; flex-wrap: wrap; gap: .8rem; }
+.baris-pilih .field { flex: 1 1 12rem; min-width: 0; margin-bottom: .6rem; }
+
+/* Antrean unggah. Namanya boleh terpotong, statusnya TIDAK — status itulah
+   satu-satunya alasan barisnya ada. */
+.antrean-foto { list-style: none; margin: .6rem 0 0; padding: 0; }
+.antrean-foto li {
+  display: flex; align-items: center; gap: .6rem;
+  padding: .35rem 0; border-top: 1px solid var(--garis); font-size: .9rem;
+}
+.antrean-foto .a-nama {
+  flex: 1 1 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.antrean-foto .a-status { flex: 0 0 auto; color: var(--tinta-lembut); }
+.antrean-foto li.selesai .a-status { color: var(--hijau); font-weight: 700; }
+/* Gagal TIDAK menghilang dan tidak sekadar berubah warna: barisnya membawa
+   tombol Ulangi, dan berkasnya masih dipegang layar. Petugas dengan lima
+   puluh foto tidak akan memilih ulang dari galeri satu per satu. */
+.antrean-foto li.gagal { background: var(--bahaya-muda); }
+.antrean-foto li.gagal .a-status { color: var(--bahaya); }
+
+/* Petak foto. `auto-fill` dengan lantai 9rem: di HP muat dua kolom, di laptop
+   enam sampai delapan — jumlahnya mengikuti layar, bukan dipatok per ambang. */
+.grid-foto {
+  display: grid; gap: .8rem;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+}
+.ubin-foto {
+  margin: 0; border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  overflow: hidden; background: var(--kartu);
+}
+/* Gambarnya jadi latar tombol, bukan <img>: satu elemen, dan `cover` memotong
+   sisi panjang sendiri tanpa menghitung apa pun. Rasionya dipatok 3:4 —
+   kertas lembar jawaban selalu lebih tinggi daripada lebar, dan petak yang
+   tingginya mengikuti gambar membuat barisnya bergerigi. */
+.ubin-foto .ubin-gambar {
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; aspect-ratio: 3 / 4; padding: 0;
+  border: 0; border-bottom: 1px solid var(--garis);
+  background: var(--kertas) center / cover no-repeat;
+  cursor: pointer;
+}
+.ubin-foto figcaption {
+  display: flex; align-items: center; gap: .4rem; padding: .45rem;
+}
+/* Kotak nomor dada mengambil sisa lebar; tombolnya seukuran isinya. Kalau
+   dibalik, tombol "Tautkan" melar selebar petak dan kotak angkanya menyusut
+   jadi dua digit — dan yang diketik di sini justru tiga digit. */
+.ubin-foto figcaption .small-input { flex: 1 1 auto; min-width: 0; width: auto; }
+.ubin-foto figcaption .button { flex: 0 0 auto; }


### PR DESCRIPTION
## What

Layar baru **Foto Jawaban** (`#/foto`): panitia di pos memilih **Pos** dan **Lomba**, lalu mengunggah banyak foto lembar jawaban sekaligus. Nomor dadanya ditautkan belakangan — di layar yang sama, satu per satu.

Dua jalan sebuah foto sampai ke nomor dadanya, dan keduanya tercatat di kolom `cara_taut`:

| cara | kapan |
|---|---|
| `unggah` | fotonya sudah tertaut sejak diunggah — dialog kamera per regu di meja IT (0047), **tidak diganti** |
| `tangan` | panitia menautkannya sendiri di layar baru ini |
| `mesin` | usulan pembacaan gambar yang dicentang panitia — kolomnya sudah ada, jalurnya belum (lihat Notes) |

Isinya: migrasi `0074`, delapan tes SQL, dua RPC, `v_foto_lembar` yang ditulis ulang, layar + antrean unggah, dan CSS-nya.

## Why

`0047` menolak foto borongan di pos dengan alasan yang **masih benar**: "backup yang tidak bisa ditemukan kembali bukan backup". Alasan itu berdiri di atas satu anggapan — bahwa tidak ada cara menemukan kembali gambar borongan selain membukanya satu per satu. PR ini mencabut anggapannya, bukan alasannya: foto borongan sekarang punya jalan pulang, dan **yang belum pulang dihitung dan ditampilkan sebagai angka di layar**. Antrean yang tidak terlihat adalah antrean yang tidak pernah dikerjakan.

Yang dibeli: `0047` sendiri mengakui satu lubang yang tidak ia lindungi — slip yang hilang **di jalan** antara pos dan meja IT tidak pernah difoto sama sekali. Difoto di pos, slip itu sudah terekam sebelum perjalanannya dimulai.

## Notes

**Satu tabel, bukan tabel penampung.** `foto_lembar.regu_id` jadi nullable. Pagar bacanya bertumpu pada kolom `pos` di tabel itu sendiri, bukan pada regunya — jadi baris tanpa regu sudah terpagari benar tanpa mekanisme kedua. Yang menjaga artinya sekarang `check ((regu_id is null) = (cara_taut is null))`: tertaut berarti ada catatan siapa, kapan, dan dengan cara apa. Baris setengah tertaut tidak mungkin ada.

**Satu bug ditemukan sambil mengerjakan, dan bentuknya persis bagian 13.3.** Versi pertama migrasi ini memasang trigger audit dengan mencari fungsi bernama `catat_riwayat` — nama yang dipakai `0002`. `0012` baris 605 sudah me-rename-nya jadi `record_history`. Pemeriksaannya melapor "tidak ada", triggernya dilewati, dan **migrasinya tetap SUKSES** dengan sebaris warning yang lewat begitu saja. Sekarang nama fungsinya dibaca dari trigger yang pasti hidup di tabel `regu`, dan kalau tidak ketemu migrasinya berhenti.

**Delapan tes, semuanya lulus lokal.** Yang paling penting 37.2: ia membuktikan `v_foto_lembar` memakai `left join`. Dengan `join` biasa, setiap foto belum tertaut lenyap dari view tanpa satu pun galat — layar melaporkan "tidak ada foto" untuk gambar yang sudah naik dan sudah memakan kuota. 37.7 berbentuk menempati kursi (bagian 13.8): panggilan yang sama dua kali, satu baris `akun_hak` diubah di antaranya. 37.8 membuktikan penautan meninggalkan jejak di `history` — itu yang membuat penautan ulang boleh.

**Hak aksesnya memakai ulang fitur `pos`**, tidak menambah fitur ke-12. Fitur baru berarti empat pagar (policy tabel, dua policy `storage.objects`, badan RPC) harus dilebarkan serentak, dan yang lupa satu di antaranya menghasilkan petugas yang boleh mengunggah tapi ditolak Storage. Konsekuensi yang disebut terang: siapa pun yang boleh mengetik nilai juga boleh mengunggah foto borongan. Juri pos tetap terkunci ke posnya lewat `pos_saya()`.

**Antreannya memegang berkasnya.** Yang gagal tetap di antrean dengan tombol "Ulangi" — gelung di dialog lama menuntut petugas memilih ulang berkas dari galeri tiap kali jaringan putus, dan dengan lima puluh foto itu bukan ketidaknyamanan melainkan pekerjaan yang tidak akan diselesaikan siapa pun. Unggahnya satu per satu, bukan serentak.

**Yang BELUM ada, dan disengaja:** jalur pembacaan otomatis. Kolom `cara_taut = 'mesin'` dan RPC-nya sudah menerimanya, tapi belum ada yang memanggilnya. Repo ini belum pernah memanggil model apa pun, dan satu-satunya kode server (`workers/gateway`) juga satu-satunya pemegang `service_role` — menambah rute ke sana memperbesar permukaan paling sensitif di sistem. Penautan manual harus ada bagaimanapun; dibangun dulu, lalu dilihat berapa banyak yang benar-benar tersisa.

**Sesudah PR ini mendarat, migrasinya WAJIB dijalankan** lewat `apply-migration.yml` dengan `supabase/migrations/0074_foto_jawaban.sql`. Migrasi tidak pernah ikut merge (bagian 7.6), sedangkan situs panitia terbit otomatis — kalau langkah ini lalai, layar barunya tayang lebih dulu daripada RPC-nya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)