### PR TITLE
fix: tampilan Foto Jawaban dari 1920px sampai 360px

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2982,6 +2982,17 @@ input.small-input { text-align: center; }
    begitu wadahnya menyempit (bagian 15). */
 .baris-pilih { display: flex; flex-wrap: wrap; gap: .8rem; }
 .baris-pilih .field { flex: 1 1 12rem; min-width: 0; margin-bottom: .6rem; }
+/* Dropdown-nya `.select-small`, kelas yang sama dengan pemilih pos di layar
+   Input Nilai Pos — dua layar bersebelahan yang menanyakan hal yang sama tidak
+   boleh terlihat berbeda. Versi pertama menulis `class="select"`, kelas yang
+   TIDAK ADA di berkas ini sama sekali: tampilannya jatuh ke gaya bawaan
+   browser, lengkap dengan panah bawaan yang menempel ke tulisannya.
+
+   Yang ditambahkan cuma lebarnya. `.select-small` sengaja `width: auto`
+   supaya "Transfer" tidak terpotong di dalam tabel; di sini ia mengisi kolom
+   yang sudah punya labelnya sendiri, jadi lebar isi tidak ada gunanya —
+   spesifisitas (0,2,1) mengalahkan `select.select-small` (0,1,1). */
+.baris-pilih select.select-small { width: 100%; min-width: 0; }
 
 /* Antrean unggah. Namanya boleh terpotong, statusnya TIDAK — status itulah
    satu-satunya alasan barisnya ada. */
@@ -3002,11 +3013,17 @@ input.small-input { text-align: center; }
 .antrean-foto li.gagal { background: var(--bahaya-muda); }
 .antrean-foto li.gagal .a-status { color: var(--bahaya); }
 
-/* Petak foto. `auto-fill` dengan lantai 9rem: di HP muat dua kolom, di laptop
-   enam sampai delapan — jumlahnya mengikuti layar, bukan dipatok per ambang. */
+/* Petak foto. `auto-fill` dengan lantai 8rem: jumlah kolomnya mengikuti layar,
+   bukan dipatok per ambang.
+
+   8rem (128px), bukan 9rem. Terukur: dengan lantai 9rem, layar 360px jatuh ke
+   SATU kolom — 2 x 144 + 12,8 celah = 300,8px sementara isi kartunya cuma
+   284px. Satu petak selebar layar berarti petugas melihat satu foto per layar
+   dan menggulir sepanjang antrean untuk membandingkan dua kertas yang mirip.
+   Dengan 8rem: 2 x 128 + 12,8 = 268,8px, muat, dan 360px dapat dua kolom. */
 .grid-foto {
   display: grid; gap: .8rem;
-  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
 }
 .ubin-foto {
   margin: 0; border: 1px solid var(--garis); border-radius: var(--radius-kecil);
@@ -3023,11 +3040,22 @@ input.small-input { text-align: center; }
   background: var(--kertas) center / cover no-repeat;
   cursor: pointer;
 }
+/* Kotak nomor dada MENUMPUK di atas tombolnya, tidak bersebelahan.
+
+   Bersebelahan terukur 52-76px untuk kotak angkanya — placeholder "No dada"
+   terpotong, dan sasaran ketik selebar dua jari kelingking untuk isian yang
+   merupakan SATU-SATUNYA pekerjaan di layar ini. Ditumpuk, kotaknya selebar
+   petak (~130px di HP) dan tombolnya jadi sasaran sentuh selebar itu juga.
+   Yang dibayar tinggi petak ~34px, dan itu murah. */
 .ubin-foto figcaption {
-  display: flex; align-items: center; gap: .4rem; padding: .45rem;
+  display: flex; flex-direction: column; gap: .35rem; padding: .45rem;
 }
-/* Kotak nomor dada mengambil sisa lebar; tombolnya seukuran isinya. Kalau
-   dibalik, tombol "Tautkan" melar selebar petak dan kotak angkanya menyusut
-   jadi dua digit — dan yang diketik di sini justru tiga digit. */
-.ubin-foto figcaption .small-input { flex: 1 1 auto; min-width: 0; width: auto; }
-.ubin-foto figcaption .button { flex: 0 0 auto; }
+/* Kotak angkanya disamakan dengan kotak nomor dada di Meja Daftar Ulang versi
+   HP: lebih tinggi, hurufnya besar dan tebal. Alasannya sama di kedua layar —
+   angka ini DIBACAKAN dari kain fisik lalu diketik sambil berdiri, dan kotak
+   setinggi 40px dengan huruf 16px adalah sasaran jempol yang meleset. */
+.ubin-foto figcaption .small-input {
+  width: 100%; min-width: 0;
+  min-height: 52px; font-size: 1.25rem; font-weight: 700;
+}
+.ubin-foto figcaption .button { width: 100%; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4970,7 +4970,7 @@ async function layarFoto() {
       <div class="baris-pilih">
         <div class="field">
           <label for="foto-pos">Pos</label>
-          <select id="foto-pos" class="select" ${terkunci ? "disabled" : ""}>
+          <select id="foto-pos" class="select-small" ${terkunci ? "disabled" : ""}>
             ${posDinilai.map(p => `<option value="${esc(p.nomor)}"
               ${Number(p.nomor) === nomorPos ? "selected" : ""}
               >${esc(judulPos(p))}</option>`).join("")}
@@ -4978,7 +4978,7 @@ async function layarFoto() {
         </div>
         <div class="field">
           <label for="foto-lomba">Lomba</label>
-          <select id="foto-lomba" class="select"></select>
+          <select id="foto-lomba" class="select-small"></select>
         </div>
       </div>
       <div class="action-row" id="foto-aksi" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -2982,6 +2982,17 @@ input.small-input { text-align: center; }
    begitu wadahnya menyempit (bagian 15). */
 .baris-pilih { display: flex; flex-wrap: wrap; gap: .8rem; }
 .baris-pilih .field { flex: 1 1 12rem; min-width: 0; margin-bottom: .6rem; }
+/* Dropdown-nya `.select-small`, kelas yang sama dengan pemilih pos di layar
+   Input Nilai Pos — dua layar bersebelahan yang menanyakan hal yang sama tidak
+   boleh terlihat berbeda. Versi pertama menulis `class="select"`, kelas yang
+   TIDAK ADA di berkas ini sama sekali: tampilannya jatuh ke gaya bawaan
+   browser, lengkap dengan panah bawaan yang menempel ke tulisannya.
+
+   Yang ditambahkan cuma lebarnya. `.select-small` sengaja `width: auto`
+   supaya "Transfer" tidak terpotong di dalam tabel; di sini ia mengisi kolom
+   yang sudah punya labelnya sendiri, jadi lebar isi tidak ada gunanya —
+   spesifisitas (0,2,1) mengalahkan `select.select-small` (0,1,1). */
+.baris-pilih select.select-small { width: 100%; min-width: 0; }
 
 /* Antrean unggah. Namanya boleh terpotong, statusnya TIDAK — status itulah
    satu-satunya alasan barisnya ada. */
@@ -3002,11 +3013,17 @@ input.small-input { text-align: center; }
 .antrean-foto li.gagal { background: var(--bahaya-muda); }
 .antrean-foto li.gagal .a-status { color: var(--bahaya); }
 
-/* Petak foto. `auto-fill` dengan lantai 9rem: di HP muat dua kolom, di laptop
-   enam sampai delapan — jumlahnya mengikuti layar, bukan dipatok per ambang. */
+/* Petak foto. `auto-fill` dengan lantai 8rem: jumlah kolomnya mengikuti layar,
+   bukan dipatok per ambang.
+
+   8rem (128px), bukan 9rem. Terukur: dengan lantai 9rem, layar 360px jatuh ke
+   SATU kolom — 2 x 144 + 12,8 celah = 300,8px sementara isi kartunya cuma
+   284px. Satu petak selebar layar berarti petugas melihat satu foto per layar
+   dan menggulir sepanjang antrean untuk membandingkan dua kertas yang mirip.
+   Dengan 8rem: 2 x 128 + 12,8 = 268,8px, muat, dan 360px dapat dua kolom. */
 .grid-foto {
   display: grid; gap: .8rem;
-  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
 }
 .ubin-foto {
   margin: 0; border: 1px solid var(--garis); border-radius: var(--radius-kecil);
@@ -3023,11 +3040,22 @@ input.small-input { text-align: center; }
   background: var(--kertas) center / cover no-repeat;
   cursor: pointer;
 }
+/* Kotak nomor dada MENUMPUK di atas tombolnya, tidak bersebelahan.
+
+   Bersebelahan terukur 52-76px untuk kotak angkanya — placeholder "No dada"
+   terpotong, dan sasaran ketik selebar dua jari kelingking untuk isian yang
+   merupakan SATU-SATUNYA pekerjaan di layar ini. Ditumpuk, kotaknya selebar
+   petak (~130px di HP) dan tombolnya jadi sasaran sentuh selebar itu juga.
+   Yang dibayar tinggi petak ~34px, dan itu murah. */
 .ubin-foto figcaption {
-  display: flex; align-items: center; gap: .4rem; padding: .45rem;
+  display: flex; flex-direction: column; gap: .35rem; padding: .45rem;
 }
-/* Kotak nomor dada mengambil sisa lebar; tombolnya seukuran isinya. Kalau
-   dibalik, tombol "Tautkan" melar selebar petak dan kotak angkanya menyusut
-   jadi dua digit — dan yang diketik di sini justru tiga digit. */
-.ubin-foto figcaption .small-input { flex: 1 1 auto; min-width: 0; width: auto; }
-.ubin-foto figcaption .button { flex: 0 0 auto; }
+/* Kotak angkanya disamakan dengan kotak nomor dada di Meja Daftar Ulang versi
+   HP: lebih tinggi, hurufnya besar dan tebal. Alasannya sama di kedua layar —
+   angka ini DIBACAKAN dari kain fisik lalu diketik sambil berdiri, dan kotak
+   setinggi 40px dengan huruf 16px adalah sasaran jempol yang meleset. */
+.ubin-foto figcaption .small-input {
+  width: 100%; min-width: 0;
+  min-height: 52px; font-size: 1.25rem; font-weight: 700;
+}
+.ubin-foto figcaption .button { width: 100%; }


### PR DESCRIPTION
## What

Tiga perbaikan tampilan di layar Foto Jawaban. Dua terukur, satu jelas salah sejak ditulis.

**1. Dropdown memakai kelas yang tidak ada.** Pemilih Pos dan Lomba ditulis `class="select"` — kelas yang **tidak ada satu baris pun** di `style.css`. Gayanya jatuh ke bawaan browser, lengkap dengan panah bawaan yang menempel ke tulisannya. Sekarang `.select-small`, kelas yang sama dengan pemilih pos di **Input Nilai Pos**.

**2. Kotak nomor dada terlalu kecil.** Terukur **52–76px lebar, 40px tinggi** karena berbagi baris dengan tombol Tautkan — placeholder "No dada" terpotong, dan itu sasaran ketik untuk satu-satunya pekerjaan di layar ini. Sekarang menumpuk di atas tombolnya, dengan perlakuan yang sama seperti kotak nomor dada di **Meja Daftar Ulang versi HP**: tinggi 52px, huruf 1,25rem tebal.

**3. Di 360px petaknya jatuh ke satu kolom.** Lantai `9rem` menuntut 2 × 144 + 12,8 = 300,8px sementara isi kartunya cuma 284px. Lantainya turun ke `8rem` → 268,8px, muat.

## Why

Yang pertama tidak akan pernah ketahuan dari membaca kode — `class="select"` terbaca benar, dan CSS tidak pernah mengeluh soal kelas yang tidak ada. Yang menemukannya adalah memeriksa apakah kelasnya benar-benar terdefinisi, dan mengukur panahnya ada atau tidak.

Yang kedua dan ketiga adalah bagian 15 butir 9 dipakai apa adanya: diukur di sembilan lebar, bukan dilihat sekilas.

## Notes

Diukur di **1920, 1440, 1280, 1024, 768, 560, 430, 390, 360** dengan menyuntik petak dan antrean contoh ke layar yang di produksi masih kosong (0 foto).

Sesudah perbaikan:

| lebar | kolom petak | ubin | kotak nomor dada | dropdown |
|---|---|---|---|---|
| 1920 | 7 | 134×284 | 118×52 | 501px |
| 1024 | 6 | 147×301 | 130×52 | 466px |
| 768 | 4 | 163×322 | 146×52 | 338px |
| 430 | 2 | 171×333 | 154×52 | 354px |
| 390 | 2 | 151×306 | 134×52 | 314px |
| 360 | **2** (sebelumnya 1) | 136×286 | 119×52 | 284px |

Di seluruh rentang: tidak ada penggulir mendatar, tidak ada sel yang meluap, kotak isian dan tombolnya tidak pernah saling tembus, dan panah dropdown ada di semuanya.

Ikut diperiksa dan benar: pengelompokan lomba. **Pos 3 menawarkan dua lomba — Pembidaian dan KIM — bukan tujuh penilaian** (bagian 11.2/11.5), Pos 4 satu (PBB), Pos 5 satu (Yel-Yel), Pos 1 tiga (Semaphore, Tebak Simpul, Menaksir) dengan Tebak Simpul sudah tergabung lintas golongan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)