### PR TITLE
feat: petak foto lebih besar, tombol batal, dan "Simpan"

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3006,6 +3006,18 @@ input.small-input { text-align: center; }
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .antrean-foto .a-status { flex: 0 0 auto; color: var(--tinta-lembut); }
+/* Silang pembatal. Abu-abu sampai disentuh, lalu merah — ia membuang
+   pekerjaan, dan tombol yang membuang pekerjaan tidak boleh sewarna teks
+   biasa saat jari sudah di atasnya. Sasaran sentuhnya 32px meski gambarnya
+   kecil: baris antrean rapat, dan yang di sebelahnya "Ulangi". */
+.antrean-foto .a-batal {
+  flex: 0 0 auto; width: 32px; height: 32px; padding: 0;
+  border: 0; background: none; cursor: pointer;
+  font-size: 1.3rem; line-height: 1; color: var(--tinta-lembut);
+}
+.antrean-foto .a-batal:hover, .antrean-foto .a-batal:focus-visible {
+  color: var(--bahaya);
+}
 .antrean-foto li.selesai .a-status { color: var(--hijau); font-weight: 700; }
 /* Gagal TIDAK menghilang dan tidak sekadar berubah warna: barisnya membawa
    tombol Ulangi, dan berkasnya masih dipegang layar. Petugas dengan lima
@@ -3013,17 +3025,24 @@ input.small-input { text-align: center; }
 .antrean-foto li.gagal { background: var(--bahaya-muda); }
 .antrean-foto li.gagal .a-status { color: var(--bahaya); }
 
-/* Petak foto. `auto-fill` dengan lantai 8rem: jumlah kolomnya mengikuti layar,
-   bukan dipatok per ambang.
+/* Petak foto. `auto-fill`: jumlah kolomnya mengikuti layar, bukan dipatok per
+   ambang.
 
-   8rem (128px), bukan 9rem. Terukur: dengan lantai 9rem, layar 360px jatuh ke
-   SATU kolom — 2 x 144 + 12,8 celah = 300,8px sementara isi kartunya cuma
-   284px. Satu petak selebar layar berarti petugas melihat satu foto per layar
-   dan menggulir sepanjang antrean untuk membandingkan dua kertas yang mirip.
-   Dengan 8rem: 2 x 128 + 12,8 = 268,8px, muat, dan 360px dapat dua kolom. */
+   DUA LANTAI, dan itu terpaksa. Yang dilihat di petak ini adalah tulisan
+   tangan di kertas, jadi makin besar makin berguna — 12rem cukup untuk
+   mengenali kertasnya tanpa membukanya. Tapi di HP 360px isi kartunya cuma
+   284px, dan lantai 12rem menjatuhkannya ke SATU kolom: satu petak selebar
+   layar, dan petugas menggulir sepanjang antrean untuk membandingkan dua
+   kertas yang mirip.
+
+   Jadi 12rem di layar yang sanggup, 8rem di layar yang tidak. Angka 8rem
+   diukur: 2 x 128 + 12,8 celah = 268,8px, muat di 284px. */
 .grid-foto {
   display: grid; gap: .8rem;
-  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+}
+@media (max-width: 460px) {
+  .grid-foto { grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr)); }
 }
 .ubin-foto {
   margin: 0; border: 1px solid var(--garis); border-radius: var(--radius-kecil);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5051,7 +5051,7 @@ async function layarFoto() {
                  placeholder="No dada" data-dada aria-label="Nomor dada"
                  value="${esc(String(nilai))}">
           <button type="button" class="button button-mini button-primary"
-                  data-taut>Tautkan</button>
+                  data-taut>Simpan</button>
         </figcaption>
       </figure>`;
   }
@@ -5210,18 +5210,44 @@ async function layarFoto() {
         <span class="a-status">${esc(t.pesan)}</span>
         ${t.keadaan === "gagal"
           ? `<button type="button" class="button button-mini" data-ulang>Ulangi</button>` : ""}
+        <button type="button" class="a-batal" data-batal
+          aria-label="${t.keadaan === "antre" ? "Batalkan" : "Buang dari daftar"}"
+          title="${t.keadaan === "antre" ? "Batalkan" : "Buang dari daftar"}">×</button>
       </li>`).join("")));
   }
 
+  /** Ukuran ASLI -> ukuran terkirim, ditulis di layar.
+   *
+   *  Bukan hiasan. Pengecilan di HP adalah satu-satunya yang menjaga kuota
+   *  1 GB tetap cukup untuk ~5.500 foto (migrasi 0047), dan kalau ia gagal
+   *  diam-diam di satu merek HP, yang ketahuan cuma "kuota habis di tengah
+   *  acara". Angka sebelum-sesudah di tiap baris membuat kegagalan itu
+   *  terlihat pada foto PERTAMA, bukan pada foto ke-tiga ribu. */
+  const hemat = (asli, jadi) =>
+    `${ukuranRapi(asli)} → ${ukuranRapi(jadi)}`;
+
   async function kerjakan(t) {
+    if (t.keadaan === "batal") return;
     t.keadaan = "jalan";
     try {
       t.pesan = "mengecilkan…"; gambarAntrean();
       const blob = await kecilkanFoto(t.berkas);
-      t.pesan = `mengirim ${ukuranRapi(blob.size)}…`; gambarAntrean();
+      if (t.keadaan === "batal") return;          // dibatalkan selagi mengecilkan
+
+      /* Pagar terakhir sebelum jaringan dipakai. Bucket `lembar` menolak apa
+         pun di atas 1 MB, dan penolakan itu datang sebagai galat HTTP yang
+         tidak menjelaskan apa-apa ke petugas. Diperiksa di sini, pesannya
+         menyebut angkanya. */
+      if (blob.size > 1024 * 1024) {
+        throw new Error(
+          `hasil pengecilan masih ${ukuranRapi(blob.size)}, di atas batas 1 MB`);
+      }
+
+      t.pesan = `mengirim ${hemat(t.berkas.size, blob.size)}…`; gambarAntrean();
       await unggahFotoMasuk(t.pos, t.kode, t.nama_lomba, blob);
+      if (t.keadaan === "batal") return;
       t.keadaan = "selesai";
-      t.pesan = ukuranRapi(blob.size);
+      t.pesan = hemat(t.berkas.size, blob.size);
     } catch (err) {
       t.keadaan = "gagal";
       t.pesan = err.message;
@@ -5230,12 +5256,29 @@ async function layarFoto() {
   }
 
   elAntre.addEventListener("click", async (e) => {
-    const b = e.target.closest("[data-ulang]");
-    if (!b) return;
-    const t = antrean[Number(b.closest("li").dataset.i)];
+    const li = e.target.closest("li");
+    if (!li) return;
+    const t = antrean[Number(li.dataset.i)];
     if (!t) return;
-    await kerjakan(t);
-    await muatBelum();
+
+    /* Batal hanya berarti sesuatu SEBELUM gambarnya naik. Yang sedang atau
+       sudah terkirim tidak bisa ditarik pulang — bucket `lembar` tidak punya
+       policy hapus sama sekali, dan itu disengaja sejak 0047 ("tombol hapus
+       pada backup adalah cara backup itu hilang"). Jadi untuk baris yang
+       sudah selesai, silang ini membuang BARISNYA dari daftar, bukan
+       fotonya; fotonya sudah ada di petak di bawah. */
+    if (e.target.closest("[data-batal]")) {
+      if (t.keadaan === "antre" || t.keadaan === "jalan") t.keadaan = "batal";
+      const i = antrean.indexOf(t);
+      if (i >= 0) antrean.splice(i, 1);
+      gambarAntrean();
+      return;
+    }
+
+    if (e.target.closest("[data-ulang]")) {
+      await kerjakan(t);
+      await muatBelum();
+    }
   });
 
   elAmbil.addEventListener("change", async () => {
@@ -5254,7 +5297,11 @@ async function layarFoto() {
 
     // Satu per satu, bukan serentak. Unggahan paralel dari HP di sinyal
     // lapangan saling menggerus dan menabrak batas waktu bersama-sama.
-    for (const t of antrean) if (t.keadaan === "antre") await kerjakan(t);
+    //
+    // Disalin dulu: silang "batal" membuang barisnya dari `antrean` selagi
+    // gelung ini berjalan, dan menggulung array yang sedang disunting
+    // melompati satu berkas tiap kali satu dibuang.
+    for (const t of [...antrean]) if (t.keadaan === "antre") await kerjakan(t);
 
     await muatBelum();
     try {

--- a/web/style.css
+++ b/web/style.css
@@ -3006,6 +3006,18 @@ input.small-input { text-align: center; }
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .antrean-foto .a-status { flex: 0 0 auto; color: var(--tinta-lembut); }
+/* Silang pembatal. Abu-abu sampai disentuh, lalu merah — ia membuang
+   pekerjaan, dan tombol yang membuang pekerjaan tidak boleh sewarna teks
+   biasa saat jari sudah di atasnya. Sasaran sentuhnya 32px meski gambarnya
+   kecil: baris antrean rapat, dan yang di sebelahnya "Ulangi". */
+.antrean-foto .a-batal {
+  flex: 0 0 auto; width: 32px; height: 32px; padding: 0;
+  border: 0; background: none; cursor: pointer;
+  font-size: 1.3rem; line-height: 1; color: var(--tinta-lembut);
+}
+.antrean-foto .a-batal:hover, .antrean-foto .a-batal:focus-visible {
+  color: var(--bahaya);
+}
 .antrean-foto li.selesai .a-status { color: var(--hijau); font-weight: 700; }
 /* Gagal TIDAK menghilang dan tidak sekadar berubah warna: barisnya membawa
    tombol Ulangi, dan berkasnya masih dipegang layar. Petugas dengan lima
@@ -3013,17 +3025,24 @@ input.small-input { text-align: center; }
 .antrean-foto li.gagal { background: var(--bahaya-muda); }
 .antrean-foto li.gagal .a-status { color: var(--bahaya); }
 
-/* Petak foto. `auto-fill` dengan lantai 8rem: jumlah kolomnya mengikuti layar,
-   bukan dipatok per ambang.
+/* Petak foto. `auto-fill`: jumlah kolomnya mengikuti layar, bukan dipatok per
+   ambang.
 
-   8rem (128px), bukan 9rem. Terukur: dengan lantai 9rem, layar 360px jatuh ke
-   SATU kolom — 2 x 144 + 12,8 celah = 300,8px sementara isi kartunya cuma
-   284px. Satu petak selebar layar berarti petugas melihat satu foto per layar
-   dan menggulir sepanjang antrean untuk membandingkan dua kertas yang mirip.
-   Dengan 8rem: 2 x 128 + 12,8 = 268,8px, muat, dan 360px dapat dua kolom. */
+   DUA LANTAI, dan itu terpaksa. Yang dilihat di petak ini adalah tulisan
+   tangan di kertas, jadi makin besar makin berguna — 12rem cukup untuk
+   mengenali kertasnya tanpa membukanya. Tapi di HP 360px isi kartunya cuma
+   284px, dan lantai 12rem menjatuhkannya ke SATU kolom: satu petak selebar
+   layar, dan petugas menggulir sepanjang antrean untuk membandingkan dua
+   kertas yang mirip.
+
+   Jadi 12rem di layar yang sanggup, 8rem di layar yang tidak. Angka 8rem
+   diukur: 2 x 128 + 12,8 celah = 268,8px, muat di 284px. */
 .grid-foto {
   display: grid; gap: .8rem;
-  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+}
+@media (max-width: 460px) {
+  .grid-foto { grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr)); }
 }
 .ubin-foto {
   margin: 0; border: 1px solid var(--garis); border-radius: var(--radius-kecil);


### PR DESCRIPTION
## What

Empat permintaan dari lapangan.

**1. Petak lebih besar.** Lantainya `8rem` → `12rem` — cukup untuk mengenali kertasnya tanpa membukanya. Tapi di HP 360px isi kartunya cuma 284px, dan 12rem menjatuhkannya ke **satu kolom**: satu petak selebar layar, dan petugas menggulir sepanjang antrean untuk membandingkan dua kertas yang mirip. Jadi dua lantai: **12rem di layar yang sanggup, 8rem di bawah 460px**.

**2. Ukuran sebelum → sesudah ditulis di layar.** Tiap baris antrean sekarang berbunyi `2,4 MB → 88 KB`.

**3. Pagar terakhir sebelum jaringan dipakai.** Hasil pengecilan yang masih di atas 1 MB ditolak di klien, dengan pesan yang menyebut angkanya.

**4. Silang pembatal** di tiap baris antrean.

**5.** Tombol **Tautkan** jadi **Simpan**.

## Why

**Soal "pastikan fotonya dikompres" — sudah, sejak awal, dan sekarang bisa dibuktikan dari layar.** Jalur borongan memanggil `kecilkanFoto()` yang sama dengan dialog foto per regu: abu-abu, sisi terpanjang 1400px, JPEG mutu 0,6, lalu diulang di 0,45 kalau masih di atas 150 KB. Terukur di produksi barusan: foto uji 900×1200 → **14 KB**, dan foto sungguhan yang sempat masuk → **110 KB**.

Yang kurang bukan pengecilannya, melainkan **buktinya di layar**. Anggaran 0047 adalah 1 GB untuk ~5.500 foto — ~190 KB per foto. Kalau pengecilan gagal diam-diam di satu merek HP (`createImageBitmap` menolak HEIC, misalnya), satu-satunya gejalanya adalah kuota habis di tengah acara. Angka sebelum-sesudah membuat kegagalan itu terlihat pada foto **pertama**.

**Arti silangnya sengaja dibedakan.** Yang belum naik → batal. Yang sudah naik → **barisnya** yang dibuang dari daftar, bukan fotonya. Fotonya tidak bisa ditarik pulang: bucket `lembar` tidak punya policy hapus sama sekali, dan itu disengaja sejak 0047 — *"tombol hapus pada backup adalah cara backup itu hilang"*. Fotonya sudah ada di petak di bawah, tinggal diberi nomor dada.

## Notes

Satu bug ikut diperbaiki sebelum sempat terjadi: gelung unggahnya menggulung array yang **sedang disunting** oleh silang pembatal — tiap baris yang dibuang membuat satu berkas terlewat tanpa suara. Sekarang ia menggulung salinannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)