### PR TITLE
fix: ubin foto kosong karena innerHTML ditulis ke DocumentFragment

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5083,10 +5083,21 @@ async function layarFoto() {
    *  Kotak nomor dada di ubin lain — beserta angka dan kursor di dalamnya —
    *  tidak boleh ikut tersentuh hanya karena satu unggahan selesai. */
   function perbarui(u) {
-    let el = elGrid.querySelector(`[data-kunci="${CSS.escape(u.kunci)}"]`);
+    const pilih = `[data-kunci="${CSS.escape(u.kunci)}"]`;
+    let el = elGrid.querySelector(pilih);
     if (!el) {
-      el = h(`<figure class="ubin-foto" data-kunci="${esc(u.kunci)}"></figure>`);
-      elGrid.append(el);
+      /* Elemennya DICARI LAGI dari DOM sesudah append, tidak dipegang dari
+         hasil h().
+
+         h() mengembalikan DocumentFragment (util.js). Begitu di-append,
+         seluruh isinya PINDAH ke DOM dan fragmennya tinggal cangkang kosong —
+         dan menulis `innerHTML` ke DocumentFragment tidak melempar galat apa
+         pun, ia cuma memasang properti yang tidak dibaca siapa-siapa. Yang
+         terlihat di layar: ubin kosong selamanya, tanpa satu baris pun di
+         konsol. */
+      elGrid.append(h(`<figure class="ubin-foto" data-kunci="${esc(u.kunci)}"></figure>`));
+      el = elGrid.querySelector(pilih);
+      if (!el) return;
       pengamat.observe(el);
     }
     el.dataset.keadaan = u.keadaan;


### PR DESCRIPTION
## What

Petak foto menampilkan **kotak kosong**: `<figure>`-nya ada di DOM, isinya tidak pernah muncul, dan konsol bersih.

Sebabnya `h()` mengembalikan **DocumentFragment**, bukan Element. Begitu di-`append`, seluruh isinya pindah ke DOM dan fragmennya tinggal cangkang kosong — lalu kode ini menulis `innerHTML` ke cangkang itu.

## Why

Menulis `innerHTML` ke DocumentFragment **tidak melempar galat apa pun**. Ia cuma memasang properti yang tidak dibaca siapa-siapa. Jadi: tidak ada galat, tidak ada peringatan, tidak ada yang berubah di layar. Yang menemukannya cuma membuka DOM-nya dan melihat `<figure class="ubin-foto" data-kunci="lokal-1"></figure>` tanpa isi.

Ini kerabat dekat pelajaran bagian 15 butir 9 — aturan yang ada, terbaca benar, dan tidak mengenai apa pun — cuma kali ini di JavaScript, bukan CSS.

## Notes

Elemennya sekarang dicari lagi dari DOM sesudah append, dan alasannya ditulis di tempatnya supaya pola `const el = h(...); parent.append(el); el.innerHTML = ...` tidak lahir lagi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)