### PR TITLE
fix: ruang untuk bar bawah ikut safe-area iPhone

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1903,8 +1903,18 @@ input.small-input { text-align: center; }
   #nav-setting[aria-current="page"] .bottom-nav-icon { background: #f0eafe; }
   #nav-akun[aria-current="page"]    .bottom-nav-icon { background: #eef0f3; }
 
-  /* Ruang supaya baris terakhir isi halaman tidak tertutup bar. */
-  .isi { padding-bottom: 6rem; }
+  /* Ruang supaya baris terakhir isi halaman tidak tertutup bar.
+
+     ANGKANYA HARUS IKUT `env(safe-area-inset-bottom)`, dan itu bukan
+     kehati-hatian berlebihan. Bar-nya sendiri sudah menambahkan inset itu ke
+     tingginya (lihat .bottom-nav di atas), jadi di HP bergaris beranda ia
+     ~99px sementara ruang yang disediakan di sini cuma 96px — baris terakhir
+     berakhir 3px DI BAWAH tepi atas bar. Di browser desktop insetnya nol dan
+     jaraknya 31px, jadi cacat ini tidak pernah muncul waktu diukur di laptop.
+
+     6rem itu sendiri: tinggi bar 65px + jarak baca. Kalau tinggi bar diubah,
+     angka ini ikut. */
+  .isi { padding-bottom: calc(6rem + env(safe-area-inset-bottom)); }
 }
 
 /* ============================================================================

--- a/web/style.css
+++ b/web/style.css
@@ -1903,8 +1903,18 @@ input.small-input { text-align: center; }
   #nav-setting[aria-current="page"] .bottom-nav-icon { background: #f0eafe; }
   #nav-akun[aria-current="page"]    .bottom-nav-icon { background: #eef0f3; }
 
-  /* Ruang supaya baris terakhir isi halaman tidak tertutup bar. */
-  .isi { padding-bottom: 6rem; }
+  /* Ruang supaya baris terakhir isi halaman tidak tertutup bar.
+
+     ANGKANYA HARUS IKUT `env(safe-area-inset-bottom)`, dan itu bukan
+     kehati-hatian berlebihan. Bar-nya sendiri sudah menambahkan inset itu ke
+     tingginya (lihat .bottom-nav di atas), jadi di HP bergaris beranda ia
+     ~99px sementara ruang yang disediakan di sini cuma 96px — baris terakhir
+     berakhir 3px DI BAWAH tepi atas bar. Di browser desktop insetnya nol dan
+     jaraknya 31px, jadi cacat ini tidak pernah muncul waktu diukur di laptop.
+
+     6rem itu sendiri: tinggi bar 65px + jarak baca. Kalau tinggi bar diubah,
+     angka ini ikut. */
+  .isi { padding-bottom: calc(6rem + env(safe-area-inset-bottom)); }
 }
 
 /* ============================================================================


### PR DESCRIPTION
## What

`.isi { padding-bottom: 6rem }` → `calc(6rem + env(safe-area-inset-bottom))`.

## Why

Baris terakhir Home berakhir **3px di bawah** tepi atas bar menu di HP bergaris beranda.

Bar-nya sendiri sudah menambahkan `env(safe-area-inset-bottom)` ke tingginya sejak awal (`.bottom-nav`), jadi di iPhone ia ~99px. Ruang yang disediakan `.isi` dipatok mati 96px. Selisihnya tepat menutupi ujung ubin terakhir.

**Kenapa tidak pernah ketahuan:** di browser desktop insetnya nol, jaraknya 31px, dan semuanya terlihat lapang. Saya mengukur di sembilan lebar hari ini dan tidak satu pun menunjukkan cacat ini — pengukuran di laptop tidak bisa melihat inset yang cuma ada di HP.

## Notes

Sejalan dengan dua tempat lain di berkas ini yang sudah memakai pola sama (`.notification` dan tombol mengambang).

Catatan untuk yang melaporkan "menu nyangkut di tengah": itu tangkapan layar penuh yang dijahit iOS — elemen `position: fixed` dilukis sekali di posisinya saat itu, lalu sisa halaman disambung di bawahnya. Diukur di 390×818, 390×634, dan 375×560: di ketiganya bar tetap di dasar viewport, seluruh sepuluh ubin terjangkau, dan tidak ada yang tertutup. Yang nyata cuma 3px di atas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)