### PR TITLE
fix: pemutar menggantikan tulisan "Memuat…", teks dropdown hitam

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1755,6 +1755,24 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      karena appearance: none sudah membuang panah bawaan browser. */
   border: 1px solid var(--garis); border-radius: 8px; background-color: #fff;
   font-family: inherit;
+  /* Hitam, dan `-webkit-text-fill-color` WAJIB ikut ditulis. iOS Safari
+     mewarnai teks <select> dengan warna aksen sistem — biru — dan mengabaikan
+     `color` saja. Di layar Foto Jawaban itu membuat "Pos 1 — Kepramukaan"
+     terbaca seperti tautan yang bisa ditekan, padahal ia isian.
+
+     Dropdown di layar lain terkena hal yang sama sejak dulu; ini
+     memperbaikinya sekalian, karena kelas ini yang dipakai semuanya. */
+  color: var(--tinta);
+  -webkit-text-fill-color: var(--tinta);
+}
+/* Yang dimatikan tetap terbaca, cuma redup. Tanpa ini iOS menambahkan
+   opasitasnya sendiri dan pemilih pos milik juri pos — yang memang terkunci ke
+   posnya — tampak seperti isian yang gagal dimuat. */
+.select-small:disabled {
+  color: var(--tinta-lembut);
+  -webkit-text-fill-color: var(--tinta-lembut);
+  opacity: 1;
+  background-color: var(--kertas);
 }
 
 /* Panah dropdown digambar sendiri, bukan dibiarkan bawaan browser.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5143,16 +5143,29 @@ async function layarFoto() {
   }
 
   async function isiLomba() {
-    elLomba.innerHTML = `<option>memuat…</option>`;
+    /* Pilihan lomba TIDAK diganti jadi "memuat…". Mengganti isi <select>
+       berarti pilihan yang sedang terbaca hilang sekejap lalu muncul lagi,
+       dan di HP itu terlihat seperti dropdown yang salah tekan sendiri.
+       Selagi dimuat ia cuma dimatikan; yang berputar ada di petak di
+       bawahnya, tempat isinya memang sedang berubah. */
+    elLomba.disabled = true;
+    elPos.disabled = true;
+    elGrid.replaceChildren(h(pemuat()));
     let komponen;
     try { komponen = await komponenPos(EDISI.nomor, nomorPos); }
-    catch (e) { notif(`Lomba pos ${nomorPos} tidak terbaca: ${e.message}`, true); return; }
+    catch (e) {
+      elLomba.disabled = false; elPos.disabled = terkunci;
+      notif(`Lomba pos ${nomorPos} tidak terbaca: ${e.message}`, true);
+      return;
+    }
     const lomba = kelompokLomba(kolomPos(komponen));
     elLomba.innerHTML = lomba.map(l =>
       `<option value="${esc(slug(l.nama))}">${esc(l.nama)}</option>`).join("");
     kodeLomba = lomba.length ? slug(lomba[0].nama) : null;
     namaLomba = lomba.length ? lomba[0].nama : null;
     elAksi.hidden = !kodeLomba;
+    elLomba.disabled = false;
+    elPos.disabled = terkunci;
     await muatBelum({ bersihkan: true });
   }
 
@@ -5169,7 +5182,10 @@ async function layarFoto() {
       for (const u of ubin.values()) if (u.url && u.lokal) URL.revokeObjectURL(u.url);
       ubin.clear();
       dadaDiketik.clear();
-      elGrid.replaceChildren(h(`<p class="keterangan">Memuat…</p>`));
+      // Pemutar, bukan tulisan. Yang sedang terjadi selalu sama — sedang
+      // dimuat — jadi kata yang mengatakannya tidak menambah apa pun, dan di
+      // layar yang dipakai ratusan kali per shift ia terbaca berulang-ulang.
+      elGrid.replaceChildren(h(pemuat()));
     }
     let daftar;
     try { daftar = await daftarFotoBelumTaut(nomorPos, kodeLomba); }
@@ -5179,6 +5195,9 @@ async function layarFoto() {
       return;
     }
 
+    // Pemutar dibuang begitu daftarnya sampai.
+    const pemutar = elGrid.querySelector(".pemuat");
+    if (pemutar) pemutar.remove();
     const kosong = elGrid.querySelector(".keterangan");
     if (kosong) kosong.remove();
 

--- a/web/style.css
+++ b/web/style.css
@@ -1755,6 +1755,24 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      karena appearance: none sudah membuang panah bawaan browser. */
   border: 1px solid var(--garis); border-radius: 8px; background-color: #fff;
   font-family: inherit;
+  /* Hitam, dan `-webkit-text-fill-color` WAJIB ikut ditulis. iOS Safari
+     mewarnai teks <select> dengan warna aksen sistem — biru — dan mengabaikan
+     `color` saja. Di layar Foto Jawaban itu membuat "Pos 1 — Kepramukaan"
+     terbaca seperti tautan yang bisa ditekan, padahal ia isian.
+
+     Dropdown di layar lain terkena hal yang sama sejak dulu; ini
+     memperbaikinya sekalian, karena kelas ini yang dipakai semuanya. */
+  color: var(--tinta);
+  -webkit-text-fill-color: var(--tinta);
+}
+/* Yang dimatikan tetap terbaca, cuma redup. Tanpa ini iOS menambahkan
+   opasitasnya sendiri dan pemilih pos milik juri pos — yang memang terkunci ke
+   posnya — tampak seperti isian yang gagal dimuat. */
+.select-small:disabled {
+  color: var(--tinta-lembut);
+  -webkit-text-fill-color: var(--tinta-lembut);
+  opacity: 1;
+  background-color: var(--kertas);
 }
 
 /* Panah dropdown digambar sendiri, bukan dibiarkan bawaan browser.


### PR DESCRIPTION
## What

**1. Pemutar, bukan tulisan.** Saat pos atau lomba diganti, petaknya menampilkan `Memuat…`. Sekarang pemutar yang sudah dipakai seluruh layar lain.

Pilihan lomba juga tidak lagi diganti jadi `<option>memuat…</option>` — selagi dimuat ia cuma **dimatikan**.

**2. Teks dropdown hitam, bukan biru.**

## Why

Kata "Memuat" tidak menambah apa pun di atas pemutar yang berputar — yang sedang terjadi selalu sama. Di layar yang dibuka ratusan kali per shift, kalimat yang mengajarkan sesuatu sekali akan dibaca ulang di setiap kalinya (bagian 9.1).

Mengganti isi `<select>` jadi "memuat…" punya harga tersendiri: pilihan yang sedang terbaca **hilang sekejap lalu muncul lagi**, dan di HP itu terlihat seperti dropdown yang salah tekan sendiri.

Soal warnanya: **iOS Safari mewarnai teks `<select>` dengan warna aksen sistem dan mengabaikan `color` saja** — yang menentukan `-webkit-text-fill-color`. Akibatnya "Pos 1 — Kepramukaan" terbaca seperti tautan yang bisa ditekan, padahal ia isian. Dropdown di layar lain terkena hal yang sama sejak dulu; ini memperbaikinya sekalian, karena `.select-small` yang dipakai semuanya.

## Notes

Yang dimatikan diberi warna sendiri supaya tetap terbaca sebagai teks redup. Tanpa itu iOS menambahkan opasitasnya sendiri, dan pemilih pos milik **juri pos** — yang memang terkunci ke posnya — tampak seperti isian yang gagal dimuat, bukan isian yang sengaja dikunci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)