### PR TITLE
fix: Input Nilai Pos di HP — cetak disembunyikan, cari turun, pita diringkas

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1868,6 +1868,21 @@ input.small-input { text-align: center; }
 @media (max-width: 560px) {
   .table-toolbar { flex-direction: column; align-items: stretch; }
   .table-count { text-align: right; }
+
+  /* Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin
+     fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara
+     penyaring dan tabel cuma jarak yang harus digulir ratusan kali per
+     shift. */
+  .alat-cetak { display: none; }
+
+  /* Kotak cari TEPAT DI ATAS TABEL, di bawah penyaring.
+     Di HP kotak cari adalah alat yang paling sering dipakai di layar ini —
+     nomor dada dibacakan, diketik, lalu barisnya dicari — dan tiap benda yang
+     berdiri antara kotak itu dan barisnya adalah jarak yang ditempuh mata
+     bolak-balik. Penyaring dipilih sekali di awal shift; kotak cari dipakai
+     terus. Yang jarang dipakai naik ke atas. */
+  .table-toolbar .filter-baris { order: 2; }
+  .table-toolbar .kotak-cari   { order: 3; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
 
@@ -2375,7 +2390,16 @@ input.small-input { text-align: center; }
   border-radius: 8px; font-size: .87rem; font-weight: 600;
   border: 1px solid transparent;
 }
-.pos-simpan.aman     { background: var(--hijau-muda);  color: var(--hijau);  border-color: var(--hijau); }
+/* Yang AMAN memeluk isinya, tidak melintang penuh. Isinya sekarang cuma ikon
+   dan jam; kotak hijau selebar layar untuk dua benda sekecil itu terbaca
+   seperti pengumuman, padahal ia sekadar tanda bahwa semuanya beres. Tiga
+   keadaan lain tetap melintang penuh — mereka memang pengumuman. */
+.pos-simpan.aman {
+  display: inline-flex; align-items: center; gap: .35rem;
+  background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
+  font-variant-numeric: tabular-nums;
+}
+.pos-simpan.aman .ikon { width: 1.1em; height: 1.1em; }
 .pos-simpan.menunggu { background: var(--kuning-muda); color: var(--kuning); border-color: var(--kuning); }
 /* Merah TIDAK dipudarkan seperti dua keadaan di atas. Ini satu-satunya
    keadaan yang berarti "ada nilai yang bisa hilang", dan ia harus tertangkap

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2630,10 +2630,17 @@ async function layarInputPos() {
         // Namanya memakai kosakata panitia persis — "form per lomba" dan
         // "form tabel" adalah kata yang mereka ucapkan sendiri, dan tombol
         // bernama lain memaksa penerjemahan di kepala setiap kali dipakai.
-        kanan: `<button class="button button-secondary button-small" type="button"
+        //
+        // Dibungkus `.alat-cetak` supaya bisa disembunyikan di HP: mencetak
+        // dari HP tidak pernah terjadi — kertasnya keluar dari mesin fotokopi
+        // di sekretariat — dan dua tombol selebar layar di antara penyaring
+        // dan tabel memaksa petugas menggulir melewatinya ratusan kali per
+        // shift untuk sampai ke pekerjaannya.
+        kanan: `<span class="alat-cetak">
+                <button class="button button-secondary button-small" type="button"
                         id="cetak-per-lomba">🖨️ Form per Lomba</button>
                 <button class="button button-secondary button-small" type="button"
-                        id="cetak-lembar">🖨️ Form Tabel (cadangan)</button>`,
+                        id="cetak-lembar">🖨️ Form Tabel (cadangan)</button></span>`,
         // Pendek dengan sengaja: kartunya kini selebar tabel, dan petunjuk
         // panjang terpotong di tengah kata — yang justru lebih buruk daripada
         // petunjuk singkat, karena terlihat seperti layar yang rusak.
@@ -3108,8 +3115,16 @@ async function layarInputPos() {
     }
     if (sibuk)  { pita.className = "pos-simpan menunggu"; pita.textContent = `Menyimpan… ${cap}`; return; }
     if (belum)  { pita.className = "pos-simpan menunggu"; pita.textContent = `${belum} baris belum tersimpan. ${cap}`; return; }
+    /* Keadaan AMAN diringkas jadi ikon + jam. Yang tiga di atas tetap
+       panjang, dan itu bukan ketidakkonsistenan: masing-masing menuntut
+       tindakan dan menyebut berapa baris yang bisa hilang (bagian 9.4).
+       Keadaan aman tidak menuntut apa pun — satu-satunya fakta yang tidak
+       bisa dibaca dari layar adalah KAPAN, dan itulah yang tersisa.
+
+       "Data Tersimpan" mengulang apa yang sudah dikatakan warna hijau dan
+       centangnya, dan pita ini dibaca ratusan kali per shift (bagian 9.1). */
     pita.className = "pos-simpan aman";
-    pita.textContent = `✓ Data Tersimpan · ${cap}`;
+    pita.innerHTML = `${ikon("circle-check-big")}<span>${esc(jamMenit(jamSinkron))}</span>`;
   }
 
   function ulangYangGagal() {

--- a/web/style.css
+++ b/web/style.css
@@ -1868,6 +1868,21 @@ input.small-input { text-align: center; }
 @media (max-width: 560px) {
   .table-toolbar { flex-direction: column; align-items: stretch; }
   .table-count { text-align: right; }
+
+  /* Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin
+     fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara
+     penyaring dan tabel cuma jarak yang harus digulir ratusan kali per
+     shift. */
+  .alat-cetak { display: none; }
+
+  /* Kotak cari TEPAT DI ATAS TABEL, di bawah penyaring.
+     Di HP kotak cari adalah alat yang paling sering dipakai di layar ini —
+     nomor dada dibacakan, diketik, lalu barisnya dicari — dan tiap benda yang
+     berdiri antara kotak itu dan barisnya adalah jarak yang ditempuh mata
+     bolak-balik. Penyaring dipilih sekali di awal shift; kotak cari dipakai
+     terus. Yang jarang dipakai naik ke atas. */
+  .table-toolbar .filter-baris { order: 2; }
+  .table-toolbar .kotak-cari   { order: 3; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
 
@@ -2375,7 +2390,16 @@ input.small-input { text-align: center; }
   border-radius: 8px; font-size: .87rem; font-weight: 600;
   border: 1px solid transparent;
 }
-.pos-simpan.aman     { background: var(--hijau-muda);  color: var(--hijau);  border-color: var(--hijau); }
+/* Yang AMAN memeluk isinya, tidak melintang penuh. Isinya sekarang cuma ikon
+   dan jam; kotak hijau selebar layar untuk dua benda sekecil itu terbaca
+   seperti pengumuman, padahal ia sekadar tanda bahwa semuanya beres. Tiga
+   keadaan lain tetap melintang penuh — mereka memang pengumuman. */
+.pos-simpan.aman {
+  display: inline-flex; align-items: center; gap: .35rem;
+  background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
+  font-variant-numeric: tabular-nums;
+}
+.pos-simpan.aman .ikon { width: 1.1em; height: 1.1em; }
 .pos-simpan.menunggu { background: var(--kuning-muda); color: var(--kuning); border-color: var(--kuning); }
 /* Merah TIDAK dipudarkan seperti dua keadaan di atas. Ini satu-satunya
    keadaan yang berarti "ada nilai yang bisa hilang", dan ia harus tertangkap


### PR DESCRIPTION
## What

Tiga perubahan di layar Input Nilai Pos, semuanya khusus HP kecuali yang ketiga.

**1. Tombol cetak disembunyikan di HP.** Di layar lebar keduanya tetap.

**2. Kotak cari turun, tepat di atas tabel** — di bawah penyaring, bukan di atasnya.

**3. Pita "Data Tersimpan" diringkas.** Dari `✓ Data Tersimpan · Sinkronisasi Terakhir: 13:40 (barusan)` melintang penuh, jadi **centang hijau + `13:40`** dalam kotak yang memeluk isinya.

## Why

Ketiganya soal yang sama: **jarak antara petugas dan pekerjaannya.**

Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara penyaring dan tabel cuma jarak yang harus digulir ratusan kali per shift.

Kotak cari adalah alat yang paling sering dipakai di layar ini: nomor dada dibacakan, diketik, lalu barisnya dicari. Tiap benda yang berdiri antara kotak itu dan barisnya adalah jarak yang ditempuh mata bolak-balik. Penyaring dipilih sekali di awal shift; kotak cari dipakai terus — jadi yang jarang dipakai yang naik ke atas.

"Data Tersimpan" mengulang apa yang sudah dikatakan warna hijau dan centangnya (bagian 9.3), dan pita ini dibaca ratusan kali per shift (bagian 9.1). Satu-satunya fakta yang tidak bisa dibaca dari layar adalah **kapan** — dan itulah yang tersisa (bagian 9.4).

## Notes

**Tiga keadaan lain tetap panjang dan tetap melintang penuh:** gagal terkirim, internet putus, dan masih menyimpan. Masing-masing menuntut tindakan dan menyebut berapa baris yang bisa hilang — mereka memang pengumuman, dan meringkasnya akan membuang satu-satunya peringatan bahwa ada nilai yang belum aman.

Itu sebabnya `.pos-simpan.aman` yang diberi `inline-flex`, bukan `.pos-simpan` seluruhnya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)