### PR TITLE
fix: pita keadaan naik ke atas kartu, kotak cari menempel ke tabel

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1883,6 +1883,17 @@ input.small-input { text-align: center; }
      terus. Yang jarang dipakai naik ke atas. */
   .table-toolbar .filter-baris { order: 2; }
   .table-toolbar .kotak-cari   { order: 3; }
+
+  /* Pita keadaan naik ke ATAS kartu, supaya yang benar-benar menempel di
+     tabel adalah kotak cari. Ia sekarang cuma centang dan jam — status yang
+     dilirik, bukan alat yang dipakai — jadi tempatnya di kepala kartu.
+
+     `:has()` dipakai dengan sengaja sebagai peningkatan yang boleh gagal:
+     browser lama membuang seluruh aturannya dan tata letaknya kembali seperti
+     sebelum perubahan ini, yang juga benar. Tidak ada yang rusak kalau ia
+     tidak didukung. */
+  .card:has(> .pos-simpan) { display: flex; flex-direction: column; }
+  .card > .pos-simpan { order: -1; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -1883,6 +1883,17 @@ input.small-input { text-align: center; }
      terus. Yang jarang dipakai naik ke atas. */
   .table-toolbar .filter-baris { order: 2; }
   .table-toolbar .kotak-cari   { order: 3; }
+
+  /* Pita keadaan naik ke ATAS kartu, supaya yang benar-benar menempel di
+     tabel adalah kotak cari. Ia sekarang cuma centang dan jam — status yang
+     dilirik, bukan alat yang dipakai — jadi tempatnya di kepala kartu.
+
+     `:has()` dipakai dengan sengaja sebagai peningkatan yang boleh gagal:
+     browser lama membuang seluruh aturannya dan tata letaknya kembali seperti
+     sebelum perubahan ini, yang juga benar. Tidak ada yang rusak kalau ia
+     tidak didukung. */
+  .card:has(> .pos-simpan) { display: flex; flex-direction: column; }
+  .card > .pos-simpan { order: -1; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
 


### PR DESCRIPTION
## What

Di HP, pita keadaan (`✓ 13:40`) naik ke **kepala kartu**, sehingga yang menempel tepat di atas tabel adalah **kotak cari**.

Urutan di HP sekarang: pita → pilih pos → penyaring → **kotak cari** → tabel.

## Why

Kotak cari sudah turun ke bawah penyaring di PR sebelumnya, tapi pita masih menyelip di antara kotak itu dan tabelnya — dan yang diminta menempel ke tabel adalah kotak carinya.

Pitanya sekarang cuma centang dan jam: status yang **dilirik**, bukan alat yang **dipakai**. Tempatnya di kepala kartu, bukan di antara alat dan pekerjaannya.

## Notes

`:has()` dipakai dengan sengaja sebagai **peningkatan yang boleh gagal**: browser yang tidak mendukungnya membuang seluruh aturan itu, dan tata letaknya kembali persis seperti sebelum commit ini — yang juga benar. Tidak ada yang rusak kalau ia tidak didukung, jadi tidak perlu pagar tambahan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)