### PR TITLE
feat: Live Score HP satu batang, pita keadaan di sebelah pemilih pos

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -237,10 +237,31 @@ function gambarKelengkapan() {
   const daftar = (META && META.kelengkapan) || [];
   if (!daftar.length) return "";
 
+  /* SATU BATANG DI HP, LIMA CINCIN DI LAYAR LEBAR — sama persis dengan layar
+     panitia. Kelima cincin memakan hampir satu layar penuh di HP, dan yang
+     dibuka orang di halaman ini adalah KLASEMEN; cincinnya dilirik sekali
+     lalu dilewati.
+
+     Angkanya JUMLAH, bukan rata-rata dari lima persen. Rata-rata persen
+     memberi bobot sama pada pos yang jumlah regunya berbeda, dan di edisi
+     yang posnya tidak sama besar itu menghasilkan angka yang tidak berarti
+     apa-apa. */
+  const totalLengkap = daftar.reduce((n, p) => n + Number(p.lengkap || 0), 0);
+  const totalRegu    = daftar.reduce((n, p) => n + Number(p.regu_total || 0), 0);
+  const persenSemua  = totalRegu ? Math.round(totalLengkap / totalRegu * 100) : 0;
+
   return `
     <div class="kartu">
-      <h2>Status</h2>
-      <ul class="kemajuan">
+      <h2 class="judul-status">Status</h2>
+      <button type="button" class="kemajuan-ringkas" id="kemajuan-buka"
+              aria-expanded="false" aria-controls="kemajuan-rinci">
+        <span class="kr-batang" aria-hidden="true"><span
+          style="width:${persenSemua}%;background:${warnaPersen(persenSemua)}"></span></span>
+        <span class="kr-teks"><strong>${esc(String(persenSemua))}%</strong>
+          · ${esc(String(totalLengkap))} / ${esc(String(totalRegu))} regu</span>
+        <span class="kr-panah" aria-hidden="true">▾</span>
+      </button>
+      <ul class="kemajuan" id="kemajuan-rinci">
         ${daftar.map(p => {
           const persen = Number(p.persen) || 0;
           return `
@@ -256,6 +277,20 @@ function gambarKelengkapan() {
         }).join("")}
       </ul>
     </div>`;
+}
+
+/* Rincian per pos dibuka/ditutup dengan menekan batangnya. Hanya berlaku di
+   HP: di layar lebar kelima cincin memang selalu tampil dan tombolnya
+   disembunyikan CSS, jadi tidak ada yang bisa ditekan. */
+function pasangKemajuan() {
+  const tombol = document.getElementById("kemajuan-buka");
+  const rinci = document.getElementById("kemajuan-rinci");
+  if (!tombol || !rinci) return;
+  tombol.addEventListener("click", () => {
+    const buka = rinci.classList.toggle("terbuka");
+    tombol.setAttribute("aria-expanded", String(buka));
+    tombol.classList.toggle("terbuka", buka);
+  });
 }
 
 /* Emas, perak, perunggu. Angka peringkat tetap ada di bawahnya untuk yang
@@ -549,6 +584,7 @@ function gambar() {
     : gambarKelengkapan() + gambarPapan();
 
   if (mulai()) pasangPapan();
+  pasangKemajuan();
   gambarSinkron();
 }
 

--- a/live/style.css
+++ b/live/style.css
@@ -1202,6 +1202,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   margin-bottom: .8rem;
 }
 .table-toolbar .field { margin-bottom: 0; }
+/* Pemilih pos dan pita keadaan berdampingan. Keduanya menjawab pertanyaan yang
+   sama — "saya di pos mana, dan apakah ketikan saya sudah aman" — jadi mereka
+   satu lirikan, bukan dua tempat yang harus dicari bergantian.
+   `wrap` supaya keadaan MERAH, yang kalimatnya panjang, turun ke barisnya
+   sendiri alih-alih menggencet dropdown-nya. */
+.baris-pos { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
+.baris-pos .pos-simpan { margin: 0; }
 .filter-row { display: flex; gap: .4rem; flex-wrap: wrap; }
 .option-small {
   min-height: 40px; padding: .3rem .75rem; font-size: .88rem; width: auto;
@@ -1884,16 +1891,6 @@ input.small-input { text-align: center; }
   .table-toolbar .filter-baris { order: 2; }
   .table-toolbar .kotak-cari   { order: 3; }
 
-  /* Pita keadaan naik ke ATAS kartu, supaya yang benar-benar menempel di
-     tabel adalah kotak cari. Ia sekarang cuma centang dan jam — status yang
-     dilirik, bukan alat yang dipakai — jadi tempatnya di kepala kartu.
-
-     `:has()` dipakai dengan sengaja sebagai peningkatan yang boleh gagal:
-     browser lama membuang seluruh aturannya dan tata letaknya kembali seperti
-     sebelum perubahan ini, yang juga benar. Tidak ada yang rusak kalau ia
-     tidak didukung. */
-  .card:has(> .pos-simpan) { display: flex; flex-direction: column; }
-  .card > .pos-simpan { order: -1; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
 
@@ -2406,7 +2403,10 @@ input.small-input { text-align: center; }
    seperti pengumuman, padahal ia sekadar tanda bahwa semuanya beres. Tiga
    keadaan lain tetap melintang penuh — mereka memang pengumuman. */
 .pos-simpan.aman {
-  display: inline-flex; align-items: center; gap: .35rem;
+  /* `align-self` WAJIB ikut. Ia duduk di dalam `.baris-pos` yang flex, dan
+     `align-items` bawaan akan meregangkannya mengikuti tinggi dropdown di
+     sebelahnya — `display: inline-flex` saja tidak menahan itu. */
+  display: inline-flex; align-self: center; align-items: center; gap: .35rem;
   background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
   font-variant-numeric: tabular-nums;
 }
@@ -2692,6 +2692,37 @@ input.small-input { text-align: center; }
   display: flex; flex-wrap: wrap; gap: 1rem .6rem;
 }
 .kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
+
+/* Batang ringkas — hanya ada di HP. Di layar lebar kelima cincin muat
+   berjajar dan tidak ada yang perlu diringkas. */
+.kemajuan-ringkas { display: none; }
+@media (max-width: 560px) {
+  /* Judulnya ikut disembunyikan: batang di bawahnya sudah berbunyi
+     "69% · 186 / 270 regu", dan kata "Status" di atasnya cuma mengulang apa
+     yang sudah jelas dari bentuknya (bagian 9.3). */
+  .judul-status { display: none; }
+
+  .kemajuan-ringkas {
+    display: flex; align-items: center; gap: .6rem; width: 100%;
+    padding: .5rem .2rem; border: 0; background: none; cursor: pointer;
+    font: inherit; color: var(--tinta); text-align: left;
+  }
+  .kr-batang {
+    flex: 1 1 auto; min-width: 0; height: 10px; border-radius: 5px;
+    background: var(--garis); overflow: hidden;
+  }
+  .kr-batang > span { display: block; height: 100%; border-radius: 5px; }
+  .kr-teks { flex: 0 0 auto; font-size: .9rem; color: var(--tinta-lembut); }
+  .kr-teks strong { color: var(--tinta); font-size: 1rem; }
+  .kr-panah { flex: 0 0 auto; color: var(--tinta-lembut); transition: transform .15s; }
+  .kemajuan-ringkas.terbuka .kr-panah { transform: rotate(180deg); }
+
+  /* Rinciannya tertutup sampai batangnya ditekan. Itulah yang membuat yang
+     tampil pertama di HP adalah klasemen, bukan lima cincin setinggi satu
+     layar penuh. */
+  .kemajuan { display: none; }
+  .kemajuan.terbuka { display: flex; margin-top: .6rem; }
+}
 
 /* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
    properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2621,7 +2621,13 @@ async function layarInputPos() {
   LAYAR.replaceChildren(h(`
     <div class="card">
       ${alatTabel({
-        kiri: pilihPosHtml(s, semuaPos),
+        /* Pita keadaan duduk DI SEBELAH pemilih pos, bukan di baris sendiri.
+           Keduanya menjawab pertanyaan yang sama — "saya sedang di pos mana,
+           dan apakah yang saya ketik sudah aman" — dan itu satu lirikan, bukan
+           dua. Di HP baris sendiri berarti satu baris lagi yang harus digulir
+           sebelum sampai ke tabelnya. */
+        kiri: `<div class="baris-pos">${pilihPosHtml(s, semuaPos)}
+                 <div id="pos-simpan" class="pos-simpan aman"></div></div>`,
         // Dua bentuk kertas, dan URUTANNYA menyatakan mana yang utama.
         // Form per lomba dipakai setiap hari lomba di setiap pos; form tabel
         // hanya kalau slipnya habis atau sinyal mati. Tombol cadangan yang
@@ -2657,11 +2663,11 @@ async function layarInputPos() {
            tabelnya bergulir sendiri (max-height), jadi apa pun yang ditaruh
            di bawah bisa berada di luar layar justru saat petugas sedang
            mengetik di baris ke-80. -->
-      <!-- SELALU terlihat, tidak pernah hidden. Pita yang hanya muncul saat
-           ada masalah tidak bisa dipercaya: petugas tidak punya cara
+      <!-- Pita keadaannya ada DI DALAM toolbar, di sebelah pemilih pos.
+           SELALU terlihat, tidak pernah hidden: pita yang hanya muncul saat
+           ada masalah tidak bisa dipercaya, karena petugas tidak punya cara
            membedakan "semuanya aman" dari "pitanya sedang rusak". Google
            Sheets menampilkan capnya terus-menerus untuk alasan yang sama. -->
-      <div id="pos-simpan" class="pos-simpan aman"></div>
       <!-- table-tetap: di HP lembar ini TETAP tabel dan digeser ke samping,
            tidak ditumpuk jadi kartu seperti layar meja. Alasannya di
            style.css, bagian LEMBAR INPUT POS. -->
@@ -4227,10 +4233,32 @@ async function layarLiveScore() {
     return `hsl(${Math.round(rona)}, 72%, 40%)`;
   };
 
+  /* SATU BARIS DI HP, LIMA CINCIN DI LAYAR LEBAR.
+     Kelima cincin memakan hampir satu layar penuh di HP, dan yang dibuka
+     orang di layar ini adalah KLASEMEN — cincinnya dilirik sekali lalu
+     dilewati. Di HP mereka diringkas jadi satu batang: persen seluruh acara,
+     bisa ditekan untuk membuka rinciannya per pos.
+
+     Angkanya jumlah, bukan rata-rata dari lima persen. Rata-rata persen
+     memberi bobot sama pada pos yang jumlah regunya berbeda, dan di edisi
+     yang posnya tidak sama besar itu menghasilkan angka yang tidak berarti
+     apa-apa. */
+  const totalLengkap = pos.reduce((n, p) => n + Number(p.lengkap || 0), 0);
+  const totalRegu    = pos.reduce((n, p) => n + Number(p.regu_total || 0), 0);
+  const persenSemua  = totalRegu ? Math.round(totalLengkap / totalRegu * 100) : 0;
+
   const kemajuan = `
     <div class="card">
-      <h2 class="judul-tengah">Status</h2>
-      <ul class="kemajuan">
+      <h2 class="judul-tengah judul-status">Status</h2>
+      <button type="button" class="kemajuan-ringkas" id="kemajuan-buka"
+              aria-expanded="false" aria-controls="kemajuan-rinci">
+        <span class="kr-batang" aria-hidden="true"><span
+          style="width:${persenSemua}%;background:${warnaPersen(persenSemua)}"></span></span>
+        <span class="kr-teks"><strong>${esc(String(persenSemua))}%</strong>
+          · ${esc(String(totalLengkap))} / ${esc(String(totalRegu))} regu</span>
+        <span class="kr-panah" aria-hidden="true">▾</span>
+      </button>
+      <ul class="kemajuan" id="kemajuan-rinci">
         ${pos.map(p => {
           const s = persenPos(p);
           return `
@@ -4480,6 +4508,19 @@ async function layarLiveScore() {
      Untuk satu kolom yang berpindah itu mahal, dan yang paling terasa: papan
      berkedip dan tab golongan yang sedang dibuka kembali ke awal. Yang
      berubah di layar cuma tombol mana yang menyala. */
+  /* Rincian per pos dibuka/ditutup dengan menekan batangnya. Hanya berlaku di
+     HP: di layar lebar kelima cincin memang selalu tampil dan tombolnya
+     disembunyikan CSS, jadi tidak ada yang bisa ditekan. */
+  const tombolKemajuan = document.getElementById("kemajuan-buka");
+  const rinciKemajuan = document.getElementById("kemajuan-rinci");
+  if (tombolKemajuan && rinciKemajuan) {
+    tombolKemajuan.addEventListener("click", () => {
+      const buka = rinciKemajuan.classList.toggle("terbuka");
+      tombolKemajuan.setAttribute("aria-expanded", String(buka));
+      tombolKemajuan.classList.toggle("terbuka", buka);
+    });
+  }
+
   LAYAR.querySelectorAll("[data-fase]").forEach(tb => {
     tb.addEventListener("click", async () => {
       const ke = tb.dataset.fase;

--- a/web/style.css
+++ b/web/style.css
@@ -1202,6 +1202,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   margin-bottom: .8rem;
 }
 .table-toolbar .field { margin-bottom: 0; }
+/* Pemilih pos dan pita keadaan berdampingan. Keduanya menjawab pertanyaan yang
+   sama — "saya di pos mana, dan apakah ketikan saya sudah aman" — jadi mereka
+   satu lirikan, bukan dua tempat yang harus dicari bergantian.
+   `wrap` supaya keadaan MERAH, yang kalimatnya panjang, turun ke barisnya
+   sendiri alih-alih menggencet dropdown-nya. */
+.baris-pos { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
+.baris-pos .pos-simpan { margin: 0; }
 .filter-row { display: flex; gap: .4rem; flex-wrap: wrap; }
 .option-small {
   min-height: 40px; padding: .3rem .75rem; font-size: .88rem; width: auto;
@@ -1884,16 +1891,6 @@ input.small-input { text-align: center; }
   .table-toolbar .filter-baris { order: 2; }
   .table-toolbar .kotak-cari   { order: 3; }
 
-  /* Pita keadaan naik ke ATAS kartu, supaya yang benar-benar menempel di
-     tabel adalah kotak cari. Ia sekarang cuma centang dan jam — status yang
-     dilirik, bukan alat yang dipakai — jadi tempatnya di kepala kartu.
-
-     `:has()` dipakai dengan sengaja sebagai peningkatan yang boleh gagal:
-     browser lama membuang seluruh aturannya dan tata letaknya kembali seperti
-     sebelum perubahan ini, yang juga benar. Tidak ada yang rusak kalau ia
-     tidak didukung. */
-  .card:has(> .pos-simpan) { display: flex; flex-direction: column; }
-  .card > .pos-simpan { order: -1; }
   .departure-bar .button { width: 100%; min-width: 0; }
 }
 
@@ -2406,7 +2403,10 @@ input.small-input { text-align: center; }
    seperti pengumuman, padahal ia sekadar tanda bahwa semuanya beres. Tiga
    keadaan lain tetap melintang penuh — mereka memang pengumuman. */
 .pos-simpan.aman {
-  display: inline-flex; align-items: center; gap: .35rem;
+  /* `align-self` WAJIB ikut. Ia duduk di dalam `.baris-pos` yang flex, dan
+     `align-items` bawaan akan meregangkannya mengikuti tinggi dropdown di
+     sebelahnya — `display: inline-flex` saja tidak menahan itu. */
+  display: inline-flex; align-self: center; align-items: center; gap: .35rem;
   background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
   font-variant-numeric: tabular-nums;
 }
@@ -2692,6 +2692,37 @@ input.small-input { text-align: center; }
   display: flex; flex-wrap: wrap; gap: 1rem .6rem;
 }
 .kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
+
+/* Batang ringkas — hanya ada di HP. Di layar lebar kelima cincin muat
+   berjajar dan tidak ada yang perlu diringkas. */
+.kemajuan-ringkas { display: none; }
+@media (max-width: 560px) {
+  /* Judulnya ikut disembunyikan: batang di bawahnya sudah berbunyi
+     "69% · 186 / 270 regu", dan kata "Status" di atasnya cuma mengulang apa
+     yang sudah jelas dari bentuknya (bagian 9.3). */
+  .judul-status { display: none; }
+
+  .kemajuan-ringkas {
+    display: flex; align-items: center; gap: .6rem; width: 100%;
+    padding: .5rem .2rem; border: 0; background: none; cursor: pointer;
+    font: inherit; color: var(--tinta); text-align: left;
+  }
+  .kr-batang {
+    flex: 1 1 auto; min-width: 0; height: 10px; border-radius: 5px;
+    background: var(--garis); overflow: hidden;
+  }
+  .kr-batang > span { display: block; height: 100%; border-radius: 5px; }
+  .kr-teks { flex: 0 0 auto; font-size: .9rem; color: var(--tinta-lembut); }
+  .kr-teks strong { color: var(--tinta); font-size: 1rem; }
+  .kr-panah { flex: 0 0 auto; color: var(--tinta-lembut); transition: transform .15s; }
+  .kemajuan-ringkas.terbuka .kr-panah { transform: rotate(180deg); }
+
+  /* Rinciannya tertutup sampai batangnya ditekan. Itulah yang membuat yang
+     tampil pertama di HP adalah klasemen, bukan lima cincin setinggi satu
+     layar penuh. */
+  .kemajuan { display: none; }
+  .kemajuan.terbuka { display: flex; margin-top: .6rem; }
+}
 
 /* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
    properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti


### PR DESCRIPTION
## What

**1. Live Score di HP: lima cincin jadi satu batang.**

```
▓▓▓▓▓▓▓▓▓▓▓▓░░░░░  69% · 186 / 270 regu   ▾
```

Ditekan → rincian per pos terbuka. Di layar lebar kelima cincin tetap seperti sekarang.

**2. Pita keadaan Input Pos pindah ke sebelah pemilih pos.**

```
[ Pos 1 — Kepramukaan ▾ ]  [✓ 13:49]
```

## Why

Dua layar, satu bentuk keluhan yang sama: **yang dicari ada di bawah, yang dilirik sekali menempati layar pertama.**

Lima cincin memakan hampir satu layar penuh di HP, dan yang dibuka orang di Live Score adalah **klasemen**. Cincinnya dilirik sekali lalu dilewati — jadi ia diringkas, bukan dihapus.

Pemilih pos dan pita keadaan menjawab pertanyaan yang sama: *"saya di pos mana, dan apakah ketikan saya sudah aman"*. Itu satu lirikan, bukan dua tempat yang dicari bergantian. Di HP, baris sendiri juga berarti satu baris lagi yang harus digulir sebelum sampai ke tabelnya.

## Notes

**Angkanya jumlah, bukan rata-rata dari lima persen.** Rata-rata memberi bobot sama pada pos yang jumlah regunya berbeda; di edisi yang posnya tidak sama besar itu menghasilkan angka yang tidak berarti apa-apa.

**Dikerjakan di dua berkas.** Layar panitia (`web/js/app.js`) dan halaman peserta (`live/live.js`) punya `gambarKelengkapan()` masing-masing — keduanya harus sama, dan tangkapan layar yang dilaporkan justru dari halaman peserta.

Aturan `:has()` dari PR #332 **dibuang**: pitanya bukan anak langsung `.card` lagi, jadi aturan itu tidak akan mengenai apa pun — dan aturan yang tidak mengenai apa pun persis yang bagian 15 minta jangan ditinggalkan.

Keadaan **merah** tetap panjang, dan sekarang turun ke barisnya sendiri lewat `flex-wrap` alih-alih menggencet dropdown — ia satu-satunya keadaan yang berarti "ada nilai yang bisa hilang".

🤖 Generated with [Claude Code](https://claude.com/claude-code)