### PR TITLE
fix: pita keadaan benar-benar sebaris dengan pemilih pos

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1209,6 +1209,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    sendiri alih-alih menggencet dropdown-nya. */
 .baris-pos { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
 .baris-pos .pos-simpan { margin: 0; }
+/* Lebarnya dulu ditulis INLINE di app.js (`min-width:210px`). Diangkat ke sini
+   karena gaya inline tidak bisa dikalahkan aturan mana pun tanpa `!important`
+   — dan justru itu yang dibutuhkan sebaris di bawah: di dalam `.baris-pos`
+   pemilih pos harus boleh MENGALAH supaya pita di sebelahnya tidak terlempar
+   ke baris berikutnya. Terukur di 390px: 225 + 10 + 84 = 319px, tepat satu
+   piksel di atas ruang yang ada, dan pitanya membungkus. */
+.pilih-pos-field { margin: 0; min-width: 210px; }
+.baris-pos .pilih-pos-field { flex: 1 1 8rem; min-width: 0; }
+/* Selectnya sendiri berhenti menyusut di 8rem (lihat .select-small), jadi
+   "Pos 1 — Kepramukaan" tidak pernah tergencet sampai tak terbaca. */
+.baris-pos .pilih-pos-field select { width: 100%; }
 .filter-row { display: flex; gap: .4rem; flex-wrap: wrap; }
 .option-small {
   min-height: 40px; padding: .3rem .75rem; font-size: .88rem; width: auto;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3626,7 +3626,7 @@ function pilihPosHtml(s, semuaPos) {
   if (s.peran !== "admin") return "";
   const dinilai = semuaPos.filter(p => Number(p.jumlah_komponen) > 0);
   return `
-    <div class="field" style="margin:0;min-width:210px">
+    <div class="field pilih-pos-field">
       <label for="pilih-pos" class="visually-hidden">Pos yang diinput</label>
       <select id="pilih-pos" class="select-small">
         ${dinilai.map(p => `<option value="${esc(p.nomor)}"

--- a/web/style.css
+++ b/web/style.css
@@ -1209,6 +1209,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    sendiri alih-alih menggencet dropdown-nya. */
 .baris-pos { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
 .baris-pos .pos-simpan { margin: 0; }
+/* Lebarnya dulu ditulis INLINE di app.js (`min-width:210px`). Diangkat ke sini
+   karena gaya inline tidak bisa dikalahkan aturan mana pun tanpa `!important`
+   — dan justru itu yang dibutuhkan sebaris di bawah: di dalam `.baris-pos`
+   pemilih pos harus boleh MENGALAH supaya pita di sebelahnya tidak terlempar
+   ke baris berikutnya. Terukur di 390px: 225 + 10 + 84 = 319px, tepat satu
+   piksel di atas ruang yang ada, dan pitanya membungkus. */
+.pilih-pos-field { margin: 0; min-width: 210px; }
+.baris-pos .pilih-pos-field { flex: 1 1 8rem; min-width: 0; }
+/* Selectnya sendiri berhenti menyusut di 8rem (lihat .select-small), jadi
+   "Pos 1 — Kepramukaan" tidak pernah tergencet sampai tak terbaca. */
+.baris-pos .pilih-pos-field select { width: 100%; }
 .filter-row { display: flex; gap: .4rem; flex-wrap: wrap; }
 .option-small {
   min-height: 40px; padding: .3rem .75rem; font-size: .88rem; width: auto;


### PR DESCRIPTION
## What

Pemindahan pita di PR sebelumnya belum sampai: di 390px ia **masih membungkus** ke baris berikutnya. Sekarang benar-benar sebaris.

```
[ Pos 1 — Kepramukaan ▾ ] [✓ 13:54]
```

## Why

Terukur: `225 + 10 + 84 = 319px` — **tepat satu piksel** di atas ruang yang ada, jadi pitanya membungkus.

Yang menahannya `min-width: 210px` yang ditulis **inline** di `pilihPosHtml`. Gaya inline tidak bisa dikalahkan aturan mana pun tanpa `!important`, jadi lebarnya diangkat ke kelas `.pilih-pos-field` — dan di dalam `.baris-pos` pemilih pos sekarang boleh mengalah sampai `8rem`.

Selectnya sendiri berhenti menyusut di `8rem` (`.select-small`), jadi "Pos 1 — Kepramukaan" tidak pernah tergencet sampai tidak terbaca.

## Notes

Yang membuat perbedaan cuma satu piksel, dan itu tidak kelihatan dari membaca aturannya — bagian 15 butir 9 lagi.

Mengangkat gaya inline ke kelas juga perbaikan tersendiri: selama ia inline, tidak ada layar lain yang bisa menyesuaikan lebar pemilih pos tanpa `!important`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)