### PR TITLE
fix: tiga chip penyaring muat satu baris di HP

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1221,6 +1221,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    "Pos 1 — Kepramukaan" tidak pernah tergencet sampai tak terbaca. */
 .baris-pos .pilih-pos-field select { width: 100%; }
 .filter-row { display: flex; gap: .4rem; flex-wrap: wrap; }
+/* Label pendek hanya hidup di HP; di layar lebar yang panjang yang dipakai. */
+.saring-pendek { display: none; }
 .option-small {
   min-height: 40px; padding: .3rem .75rem; font-size: .88rem; width: auto;
 }
@@ -1886,6 +1888,19 @@ input.small-input { text-align: center; }
 @media (max-width: 560px) {
   .table-toolbar { flex-direction: column; align-items: stretch; }
   .table-count { text-align: right; }
+
+  /* KETIGA CHIP SATU BARIS. Dengan label panjang mereka membungkus jadi dua
+     baris — dan baris kedua yang cuma berisi "Semua" terbaca seperti tombol
+     yang berdiri sendiri, bukan seperti pilihan ketiga dari tiga.
+
+     `nowrap` saja tidak cukup: chipnya akan meluap keluar kartu. Yang
+     memuatkannya label pendek — "Belum lengkap" jadi "Belum". Kata yang
+     dibuang bisa ditebak dari kolom yang sedang disaring, dan chip yang
+     menyala tetap menyebut keadaannya. */
+  .filter-row { flex-wrap: nowrap; }
+  .filter-row .option-small { flex: 1 1 auto; min-width: 0; padding-left: .5rem; padding-right: .5rem; }
+  .saring-panjang { display: none; }
+  .saring-pendek  { display: inline; }
 
   /* Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin
      fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -418,6 +418,11 @@ function layarGantiPassword() {
  *  Menyaring di browser (data sudah dimuat semua) supaya hasilnya berubah
  *  seketika sambil mengetik — di meja, menunggu server tiap huruf terasa
  *  seperti aplikasi macet. */
+/* `saringan[].pendek` — label versi HP. Ketiga chip harus muat satu baris di
+   layar 360px; "Belum lengkap / Sudah lengkap / Semua" butuh dua. Yang
+   dipendekkan hanya kata yang bisa ditebak dari konteksnya ("lengkap",
+   "bayar", "Nomor Dada"), dan chip yang sedang menyala tetap menyebut
+   keadaannya. Kalau `pendek` tidak diisi, labelnya dipakai apa adanya. */
 function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "", kanan = "" }) {
   return `
     <div class="table-toolbar">
@@ -431,7 +436,9 @@ function alatTabel({ saringan, saringAktif, jumlah, cariContoh, kiri = "", kanan
         <div class="filter-row">
           ${saringan.map(s => `
             <button type="button" class="option option-small" data-saring="${esc(s.kode)}"
-                    aria-pressed="${s.kode === saringAktif}">${esc(s.label)}</button>`).join("")}
+                    aria-pressed="${s.kode === saringAktif}"
+            ><span class="saring-panjang">${esc(s.label)}</span
+            ><span class="saring-pendek">${esc(s.pendek || s.label)}</span></button>`).join("")}
         </div>
         <span class="table-count" id="tabel-jumlah">${jumlah} baris</span>
       </div>
@@ -500,7 +507,7 @@ async function layarPembayaran() {
     <div class="card">
       ${alatTabel({
         saringan: [
-          { kode: "belum", label: "Belum bayar" },
+          { kode: "belum", label: "Belum bayar", pendek: "Belum" },
           { kode: "lunas", label: "Lunas" },
           { kode: "semua", label: "Semua" },
         ],
@@ -875,7 +882,7 @@ async function layarDaftarUlang() {
     <div class="card">
       ${alatTabel({
         saringan: [
-          { kode: "belum", label: "Perlu Nomor Dada" },
+          { kode: "belum", label: "Perlu Nomor Dada", pendek: "Belum" },
           { kode: "sudah", label: "Selesai" },
           { kode: "semua", label: "Semua" },
         ],
@@ -2652,8 +2659,8 @@ async function layarInputPos() {
         // petunjuk singkat, karena terlihat seperti layar yang rusak.
         cariContoh: "Cari nomor dada / regu / organisasi…",
         saringan: [
-          { kode: "belum", label: "Belum lengkap" },
-          { kode: "sudah", label: "Sudah lengkap" },
+          { kode: "belum", label: "Belum lengkap", pendek: "Belum" },
+          { kode: "sudah", label: "Sudah lengkap", pendek: "Sudah" },
           { kode: "semua", label: "Semua" },
         ],
         saringAktif: "semua",

--- a/web/style.css
+++ b/web/style.css
@@ -1221,6 +1221,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    "Pos 1 — Kepramukaan" tidak pernah tergencet sampai tak terbaca. */
 .baris-pos .pilih-pos-field select { width: 100%; }
 .filter-row { display: flex; gap: .4rem; flex-wrap: wrap; }
+/* Label pendek hanya hidup di HP; di layar lebar yang panjang yang dipakai. */
+.saring-pendek { display: none; }
 .option-small {
   min-height: 40px; padding: .3rem .75rem; font-size: .88rem; width: auto;
 }
@@ -1886,6 +1888,19 @@ input.small-input { text-align: center; }
 @media (max-width: 560px) {
   .table-toolbar { flex-direction: column; align-items: stretch; }
   .table-count { text-align: right; }
+
+  /* KETIGA CHIP SATU BARIS. Dengan label panjang mereka membungkus jadi dua
+     baris — dan baris kedua yang cuma berisi "Semua" terbaca seperti tombol
+     yang berdiri sendiri, bukan seperti pilihan ketiga dari tiga.
+
+     `nowrap` saja tidak cukup: chipnya akan meluap keluar kartu. Yang
+     memuatkannya label pendek — "Belum lengkap" jadi "Belum". Kata yang
+     dibuang bisa ditebak dari kolom yang sedang disaring, dan chip yang
+     menyala tetap menyebut keadaannya. */
+  .filter-row { flex-wrap: nowrap; }
+  .filter-row .option-small { flex: 1 1 auto; min-width: 0; padding-left: .5rem; padding-right: .5rem; }
+  .saring-panjang { display: none; }
+  .saring-pendek  { display: inline; }
 
   /* Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin
      fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara


### PR DESCRIPTION
## What

Di HP ketiga chip penyaring jadi **satu baris**:

```
[ Belum ] [ Sudah ] [ Semua ]
```

Lewat `saringan[].pendek` yang baru:

| layar | panjang | pendek |
|---|---|---|
| Input Nilai Pos | Belum lengkap / Sudah lengkap | **Belum / Sudah** |
| Meja Pembayaran | Belum bayar | **Belum** |
| Meja Daftar Ulang | Perlu Nomor Dada | **Belum** |

## Why

Dengan label panjang ketiganya membungkus jadi dua baris, dan baris kedua yang cuma berisi "Semua" terbaca seperti **tombol yang berdiri sendiri** — bukan seperti pilihan ketiga dari tiga.

`nowrap` saja tidak cukup: chipnya akan meluap keluar kartu. Yang memuatkannya label pendek.

Yang dipendekkan hanya kata yang bisa **ditebak dari kolom yang sedang disaring**, dan chip yang sedang menyala tetap menyebut keadaannya. Polanya sama dengan `.teks-lebar` yang sudah dipakai tombol "Cetak Kwitansi" → "Kwitansi" dan "Tandai Lunas" → "Lunas".

## Notes

Kalau `pendek` tidak diisi, labelnya dipakai apa adanya — jadi layar bersaring lain tidak perlu ikut diubah, dan yang menambah saringan baru besok tidak wajib memikirkannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)