### PR TITLE
fix: dialog kamera dikelompokkan per lomba, bukan per penilaian

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2990,7 +2990,18 @@ async function layarInputPos() {
       if (!terbaru[f.kode_lomba]) terbaru[f.kode_lomba] = f.path;   // sudah urut terbaru dulu
     });
 
-    const lomba = [...new Map(kolom.map(k => [slugLomba(k.nama), k.nama]))];
+    /* Daftarnya per LOMBA, bukan per penilaian. Satu slip adalah satu lomba
+       (bagian 11.5): Pembidaian punya lima kriteria di SATU kertas, dan
+       menawarkan lima baris foto di sini berarti satu kertas yang sama bisa
+       mendarat di lima kode berbeda.
+
+       Ini juga yang membuat dua pintu bertemu. Layar Foto Jawaban menulis
+       `kode_lomba` dari kelompokLomba() dan RPC `catat_foto_masuk` menolak
+       kode yang bukan lomba pos itu (migrasi 0074). Selama dialog ini masih
+       memakai slug PENILAIAN, foto yang diunggah borongan tidak akan pernah
+       muncul di sini — dan justru dialog inilah yang dipakai memeriksa hasil
+       penautan. */
+    const lomba = kelompokLomba(kolom).map(l => [slugLomba(l.nama), l.nama]);
 
     /* Template BIASA, bukan tag html`` — sama alasannya dengan notif(): tag
        html`` meng-escape SETIAP sisipan, dan ikon("camera") adalah HTML yang


### PR DESCRIPTION
## What

Tombol kamera di tiap baris Input Nilai Pos membangun daftarnya dari **kolom penilaian**. Sekarang dari **lomba**.

| pos | sebelum | sesudah |
|---|---|---|
| Pos 3 | 7 baris | **2** (Pembidaian, KIM) |
| Pos 4 | 4 baris | **1** (PBB) |
| Pos 5 | 4 baris | **1** (Yel-Yel) |
| Pos 1 | 3 baris | 3 — tidak berubah |

## Why

Satu slip adalah satu lomba (bagian 11.5): Pembidaian punya lima kriteria di **satu** kertas, dan menawarkan lima baris foto berarti satu kertas yang sama bisa mendarat di lima kode berbeda.

Yang membuatnya mendesak sekarang: layar **Foto Jawaban** menulis `kode_lomba` dari `kelompokLomba()`, dan RPC `catat_foto_masuk` menolak kode yang bukan lomba pos itu (migrasi 0074). Selama dialog ini memakai slug penilaian, **foto yang diunggah borongan tidak akan pernah muncul di sini** — dan justru dialog inilah yang dipakai memeriksa hasil penautan.

Dua pintu, satu kertas, dua kode berbeda: yang satu tidak akan menemukan yang lain, dan tidak ada galat yang memberi tahu.

## Notes

Di Pos 1 keduanya kebetulan sama — Semaphore, Tebak Simpul, dan Menaksir masing-masing lomba tersendiri — jadi sembilan foto yang sudah ada di produksi tidak terpengaruh. Migrasi 0074 melaporkan **0 baris berkode tidak cocok** waktu diterapkan, jadi tidak ada catatan lama yang perlu ditulis ulang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)