### PR TITLE
feat: bobot Pembidaian diatur ulang, lima lomba soal ditambahkan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,31 +289,46 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    more penilaian. Most of the system only ever modelled two — `pos` and
    `wahana` — and every place that treats a wahana as a lomba is wrong in the
    same way.
-2. **Pos 3 has two lomba, not seven.**
-   - **Pembidaian** — Diagnosis dan Penanganan Awal `0–20`, Posisi Bidai
-     `0–20`, Teknik Bidai `0–20`, Kerapihan dan Kebersihan `0–20`, Kecepatan
-     dan Kerja Sama `0–20`
+2. **Pos 3 has three lomba, not seven.**
+   - **Pembidaian** — Diagnosis dan Penanganan Awal `0–25`, Teknik Bidai
+     `0–25`, Kecepatan dan Kerja Sama `0–20`, Posisi Bidai `0–15`, Kerapihan
+     dan Kebersihan `0–15`. They sum to 100, and **that sum is what must be
+     preserved** if the weights are rebalanced again — it is what sets
+     Pembidaian's weight against every other lomba (migration `0076`).
    - **KIM** — KIM Lihat `0–10`, KIM Cium `0–10`
-3. **Pos 4 is one lomba, PBB** — Sikap Sempurna `0–20`, Gerakan Dasar `0–30`,
+   - **Logika** — 20 soal, enter the number correct `0–20`, 5 points each
+3. **A soal lomba takes ONE number: how many answers were correct.** The form
+   is `benar_per_total` and the points are `poin_maks × benar / total_soal` —
+   so "5 points per correct answer" is written as `poin_maks` 50 over 10 soal,
+   never as a literal 5 in any column. Three values must move together:
+   `total_soal`, the top of the raw range, and `poin_maks`. A raw range looser
+   than the number of soal lets an officer type 12 out of 10 (migration
+   `0076`, test 39).
+
+   Today: Pos 1 **Keagamaan** and **Kepramukaan** (10 soal, max 50), Pos 2
+   **Kesehatan** and **Pengetahuan Umum** (10 soal, max 50), Pos 3 **Logika**
+   (20 soal, max 100). Each is its own lomba — `lomba` NULL — so each prints
+   its own blangko and gets its own photo column.
+4. **Pos 4 is one lomba, PBB** — Sikap Sempurna `0–20`, Gerakan Dasar `0–30`,
    Kekompakan `0–30`, Kerapihan `0–20`.
-4. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
+5. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
    Semangat `0–20`, Penampilan `0–20`.
-5. **One lomba is one form per lomba.** Pos 3 prints two blangko masters, not
-   seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
+6. **One lomba is one form per lomba.** Pos 3 prints three blangko masters,
+   not seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
    judge writes every criterion on the sheet in front of them — a sheet per
    criterion would have the same regu handed five pieces of paper at one
    station.
-6. **The screen is the other way round: one column per penilaian.** Bidai is
+7. **The screen is the other way round: one column per penilaian.** Bidai is
    five columns on the pos sheet and one sheet on paper, and both are correct.
    Do not "fix" one to match the other.
-7. **The lomba level is `wahana.lomba`** (migration `0054`). `NULL` means the
+8. **The lomba level is `wahana.lomba`** (migration `0054`). `NULL` means the
    component is its own lomba, which is right for most rows — Semaphore,
    Menaksir, Bakiak — so only grouped components carry a value. Read it as
    `coalesce(lomba, name)`; `kelompokLomba()` in `app.js` does exactly that.
    Do **not** go back to splitting the `kode` prefix: `bidai_`, `kim_`, `pbb_`,
    `yel_` are a naming habit that nothing enforces, and it works right up until
    an edition names two unrelated components with the same first word.
-8. **`wahana.golongan` is a different axis and must not be confused with
+9. **`wahana.golongan` is a different axis and must not be confused with
    this.** Several wahana rows can be one penilaian offered to different
    golongan — that is what `kolomPos()` merges by name. Grouping by lomba is a
    third thing on top, and doing both with one mechanism is how Tebak Simpul

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,31 +287,46 @@ Guidance for Claude Code when working in this repository.
    more penilaian. Most of the system only ever modelled two — `pos` and
    `wahana` — and every place that treats a wahana as a lomba is wrong in the
    same way.
-2. **Pos 3 has two lomba, not seven.**
-   - **Pembidaian** — Diagnosis dan Penanganan Awal `0–20`, Posisi Bidai
-     `0–20`, Teknik Bidai `0–20`, Kerapihan dan Kebersihan `0–20`, Kecepatan
-     dan Kerja Sama `0–20`
+2. **Pos 3 has three lomba, not seven.**
+   - **Pembidaian** — Diagnosis dan Penanganan Awal `0–25`, Teknik Bidai
+     `0–25`, Kecepatan dan Kerja Sama `0–20`, Posisi Bidai `0–15`, Kerapihan
+     dan Kebersihan `0–15`. They sum to 100, and **that sum is what must be
+     preserved** if the weights are rebalanced again — it is what sets
+     Pembidaian's weight against every other lomba (migration `0076`).
    - **KIM** — KIM Lihat `0–10`, KIM Cium `0–10`
-3. **Pos 4 is one lomba, PBB** — Sikap Sempurna `0–20`, Gerakan Dasar `0–30`,
+   - **Logika** — 20 soal, enter the number correct `0–20`, 5 points each
+3. **A soal lomba takes ONE number: how many answers were correct.** The form
+   is `benar_per_total` and the points are `poin_maks × benar / total_soal` —
+   so "5 points per correct answer" is written as `poin_maks` 50 over 10 soal,
+   never as a literal 5 in any column. Three values must move together:
+   `total_soal`, the top of the raw range, and `poin_maks`. A raw range looser
+   than the number of soal lets an officer type 12 out of 10 (migration
+   `0076`, test 39).
+
+   Today: Pos 1 **Keagamaan** and **Kepramukaan** (10 soal, max 50), Pos 2
+   **Kesehatan** and **Pengetahuan Umum** (10 soal, max 50), Pos 3 **Logika**
+   (20 soal, max 100). Each is its own lomba — `lomba` NULL — so each prints
+   its own blangko and gets its own photo column.
+4. **Pos 4 is one lomba, PBB** — Sikap Sempurna `0–20`, Gerakan Dasar `0–30`,
    Kekompakan `0–30`, Kerapihan `0–20`.
-4. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
+5. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
    Semangat `0–20`, Penampilan `0–20`.
-5. **One lomba is one form per lomba.** Pos 3 prints two blangko masters, not
-   seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
+6. **One lomba is one form per lomba.** Pos 3 prints three blangko masters,
+   not seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
    judge writes every criterion on the sheet in front of them — a sheet per
    criterion would have the same regu handed five pieces of paper at one
    station.
-6. **The screen is the other way round: one column per penilaian.** Bidai is
+7. **The screen is the other way round: one column per penilaian.** Bidai is
    five columns on the pos sheet and one sheet on paper, and both are correct.
    Do not "fix" one to match the other.
-7. **The lomba level is `wahana.lomba`** (migration `0054`). `NULL` means the
+8. **The lomba level is `wahana.lomba`** (migration `0054`). `NULL` means the
    component is its own lomba, which is right for most rows — Semaphore,
    Menaksir, Bakiak — so only grouped components carry a value. Read it as
    `coalesce(lomba, name)`; `kelompokLomba()` in `app.js` does exactly that.
    Do **not** go back to splitting the `kode` prefix: `bidai_`, `kim_`, `pbb_`,
    `yel_` are a naming habit that nothing enforces, and it works right up until
    an edition names two unrelated components with the same first word.
-8. **`wahana.golongan` is a different axis and must not be confused with
+9. **`wahana.golongan` is a different axis and must not be confused with
    this.** Several wahana rows can be one penilaian offered to different
    golongan — that is what `kolomPos()` merges by name. Grouping by lomba is a
    third thing on top, and doing both with one mechanism is how Tebak Simpul

--- a/supabase/migrations/0076_bidai_dan_lomba_soal.sql
+++ b/supabase/migrations/0076_bidai_dan_lomba_soal.sql
@@ -1,0 +1,158 @@
+-- ============================================================================
+-- hrcd-rekap : 0076_bidai_dan_lomba_soal.sql
+--
+-- DUA PERUBAHAN PENILAIAN, DIMINTA PEMILIK ACARA:
+--
+--   A. Pembidaian (Pos 3) tidak lagi lima kriteria sama berat.
+--   B. Lima lomba SOAL baru di Pos 1, 2, dan 3.
+--
+-- ---------------------------------------------------------------------------
+-- A. PEMBIDAIAN: 20/20/20/20/20 -> 25/25/20/15/15
+--
+--   Diagnosis dan Penanganan Awal   20 -> 25
+--   Teknik Bidai                    20 -> 25
+--   Kecepatan dan Kerja Sama        20 -> 20   (tetap)
+--   Posisi Bidai                    20 -> 15
+--   Kerapihan dan Kebersihan        20 -> 15
+--                                   ---    ---
+--                                   100    100
+--
+-- Jumlahnya tetap 100, jadi bobot Pembidaian terhadap lomba lain TIDAK
+-- berubah. Yang berubah cuma pembagiannya di dalam: menilai salah pada
+-- diagnosis sekarang lebih mahal daripada menilai salah pada kerapihan, dan
+-- itu memang urutan yang benar untuk lomba pertolongan pertama.
+--
+-- TIGA kolom yang harus bergerak bersama, bukan satu. Bentuknya `besar_baik`,
+-- dan rumusnya `poin_maks * (nilai - raw_terburuk) / (raw_terbaik -
+-- raw_terburuk)`. Baris-baris ini sengaja dipasang 1:1 — poin_maks =
+-- raw_terbaik = batas atas rentang — supaya angka yang ditulis juri di kertas
+-- adalah poinnya, tanpa perkalian di kepala siapa pun. Menaikkan poin_maks
+-- saja tanpa raw_terbaik akan membuat juri yang menulis 20 mendapat 25 poin.
+--
+-- ---------------------------------------------------------------------------
+-- B. LIMA LOMBA SOAL BARU
+--
+--   Pos 1  Keagamaan          10 soal, 1 benar 5 poin -> maks  50
+--   Pos 1  Kepramukaan        10 soal, 1 benar 5 poin -> maks  50
+--   Pos 2  Kesehatan          10 soal, 1 benar 5 poin -> maks  50
+--   Pos 2  Pengetahuan Umum   10 soal, 1 benar 5 poin -> maks  50
+--   Pos 3  Logika             20 soal, 1 benar 5 poin -> maks 100
+--
+-- Bentuknya `benar_per_total`: `poin = poin_maks * benar / total_soal`.
+-- 50 x benar / 10 = 5 poin per jawaban benar; 100 x benar / 20 = 5 juga.
+-- Yang diketik petugas cuma SATU angka — jumlah jawaban benar — dan itu yang
+-- diminta: "input benar saja".
+--
+-- MASING-MASING LOMBA TERSENDIRI, bukan satu lomba berisi dua penilaian.
+-- Keputusan pemilik acara, dan konsekuensinya disebut supaya tidak jadi
+-- kejutan: Pos 1 mencetak dua blangko tambahan, bukan satu, dan tiap regu
+-- punya dua kolom foto tambahan di sana. Itulah arti `lomba` dibiarkan NULL —
+-- komponen yang berdiri sendiri adalah lombanya sendiri (CLAUDE.md 11.7).
+--
+-- BOBOTNYA MEMANG SETENGAH, dan itu bukan kelalaian. Komponen lain bernilai
+-- maksimum 100; kelima soal ini 50 (Logika 100). Klasemen menjumlahkan poin
+-- apa adanya, jadi:
+--
+--   Pos 1  300 -> 400   (Semaphore, Tebak Simpul, Menaksir, +50, +50)
+--   Pos 2  300 -> 400   (Bakiak, Lari Balok, Balap Karung, +50, +50)
+--   Pos 3  300 -> 400   (Pembidaian 100, KIM 200, +100)
+--
+-- Kalau yang dimaksud "satu benar 5 poin" adalah 10 poin supaya setara dengan
+-- lomba lain, yang diubah cukup `poin_maks` jadi 100 — angka 5 di kepala
+-- panitia tetap benar karena rumusnya membagi dengan total soal.
+-- ============================================================================
+
+do $blok$
+declare
+  v_edisi smallint := edisi_aktif();
+  v_n     integer;
+begin
+
+-- ---------------------------------------------------------------------------
+-- A. Pembidaian.
+--
+-- Dijalankan sebagai UPDATE per baris, bukan insert ... on conflict: barisnya
+-- SUDAH ADA di produksi beserta nilai yang tertaut padanya, dan `on conflict`
+-- yang salah satu kolomnya lupa disebut akan menimpanya dengan NULL.
+-- ---------------------------------------------------------------------------
+update wahana set poin_maks = 25, raw_terbaik = 25, rentang_mentah_maks = 25
+where edisi = v_edisi and pos = 3 and kode = 'bidai_diagnosis';
+
+update wahana set poin_maks = 25, raw_terbaik = 25, rentang_mentah_maks = 25
+where edisi = v_edisi and pos = 3 and kode = 'bidai_teknik';
+
+update wahana set poin_maks = 20, raw_terbaik = 20, rentang_mentah_maks = 20
+where edisi = v_edisi and pos = 3 and kode = 'bidai_kecepatan_kerja_sama';
+
+update wahana set poin_maks = 15, raw_terbaik = 15, rentang_mentah_maks = 15
+where edisi = v_edisi and pos = 3 and kode = 'bidai_posisi';
+
+update wahana set poin_maks = 15, raw_terbaik = 15, rentang_mentah_maks = 15
+where edisi = v_edisi and pos = 3 and kode = 'bidai_kerapihan';
+
+-- Pemeriksaannya dikurung "kalau lombanya memang ada". Database uji memakai
+-- seed generik yang tidak punya Pembidaian sama sekali (0032/0033 tidak
+-- berjalan di sana), dan menggagalkan seluruh rangkaian tes karena baris yang
+-- memang tidak ada akan membuat berkas ini berhenti diuji — persis kebiasaan
+-- yang bagian 7.5 larang.
+select count(*) into v_n from wahana
+where edisi = v_edisi and pos = 3 and lomba = 'Pembidaian';
+
+if v_n = 0 then
+  raise notice '0076: Pembidaian tidak ada di database ini — bagian A dilewati.';
+elsif v_n <> 5 then
+  raise warning '0076: Pembidaian punya % baris, bukan 5 — periksa kodenya.', v_n;
+else
+  select coalesce(sum(poin_maks), 0) into v_n from wahana
+  where edisi = v_edisi and pos = 3 and lomba = 'Pembidaian';
+  assert v_n = 100,
+    format('0076: Pembidaian berjumlah %s, seharusnya 100', v_n);
+  raise notice '0076: Pembidaian 25/25/20/15/15, berjumlah 100.';
+end if;
+
+-- ---------------------------------------------------------------------------
+-- B. Lima lomba soal.
+--
+-- `lomba` NULL = komponen ini lombanya sendiri. `golongan` NULL = berlaku
+-- untuk keempat golongan. `judul_isian` menamai kotaknya di layar dan di
+-- kertas: yang ditulis petugas adalah JUMLAH BENAR, bukan poin.
+-- ---------------------------------------------------------------------------
+insert into wahana
+  (edisi, pos, kode, name, type, form, poin_maks, total_soal,
+   rentang_mentah_min, rentang_mentah_maks, judul_isian, sort_order)
+values
+  (v_edisi, 1, 'keagamaan',        'Keagamaan',        'soal', 'benar_per_total',  50, 10, 0, 10, 'Benar', 4),
+  (v_edisi, 1, 'kepramukaan',      'Kepramukaan',      'soal', 'benar_per_total',  50, 10, 0, 10, 'Benar', 5),
+  (v_edisi, 2, 'kesehatan',        'Kesehatan',        'soal', 'benar_per_total',  50, 10, 0, 10, 'Benar', 4),
+  (v_edisi, 2, 'pengetahuan_umum', 'Pengetahuan Umum', 'soal', 'benar_per_total',  50, 10, 0, 10, 'Benar', 5),
+  (v_edisi, 3, 'logika',           'Logika',           'soal', 'benar_per_total', 100, 20, 0, 20, 'Benar', 8)
+on conflict (edisi, pos, kode) do update set
+  name                = excluded.name,
+  type                = excluded.type,
+  form                = excluded.form,
+  poin_maks           = excluded.poin_maks,
+  total_soal          = excluded.total_soal,
+  rentang_mentah_min  = excluded.rentang_mentah_min,
+  rentang_mentah_maks = excluded.rentang_mentah_maks,
+  judul_isian         = excluded.judul_isian,
+  sort_order          = excluded.sort_order,
+  lomba               = null,
+  golongan            = null;
+
+-- ---------------------------------------------------------------------------
+-- Laporan: bobot tiap pos SESUDAH perubahan, supaya angkanya dilihat sekarang
+-- dan bukan ditemukan waktu klasemen sudah terisi.
+-- ---------------------------------------------------------------------------
+declare
+  r record;
+begin
+  for r in
+    select pos, sum(poin_maks) as poin, count(*) as komponen
+    from wahana where edisi = v_edisi group by pos order by pos
+  loop
+    raise notice '0076: Pos % -> % poin dari % komponen.', r.pos, r.poin, r.komponen;
+  end loop;
+end;
+
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -274,5 +274,10 @@ run tests/sql/37_foto_jawaban.sql
 # namanya diterima, posnya DITOLAK, dan juri pos biasa tetap terkunci.
 run supabase/migrations/0075_koordinator_pos.sql
 run tests/sql/38_koordinator_pos.sql
+# 0076 mengubah bobot Pembidaian dan menambah lima lomba soal. Di database
+# uji Pembidaian tidak ada (seed-nya generik), jadi bagian A melewati diri
+# sendiri; bagian B tetap berjalan dan itulah yang diuji tes 39.
+run supabase/migrations/0076_bidai_dan_lomba_soal.sql
+run tests/sql/39_lomba_soal.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/39_lomba_soal.sql
+++ b/tests/sql/39_lomba_soal.sql
@@ -1,0 +1,154 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/39_lomba_soal.sql
+-- Lima lomba soal baru dan bobot Pembidaian (migrasi 0076).
+--
+-- YANG DIJAGA
+--
+-- Konfigurasi penilaian adalah DATA, bukan kode (rancangan-b) — jadi tidak ada
+-- satu baris pun di aplikasi yang akan menolak angka yang salah di sini.
+-- Kalau `poin_maks` dan `total_soal` tidak sepasang, tidak ada galat: petugas
+-- mengetik jumlah benar seperti biasa, poinnya keluar, dan angkanya salah
+-- sepanjang acara.
+--
+-- Karena itu yang diuji bukan "barisnya ada", melainkan "1 benar = 5 poin"
+-- dihitung lewat rumus yang sesungguhnya dipakai.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 39.1  Kelima komponen ada, bentuknya benar_per_total, dan berdiri sendiri.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_edisi smallint := edisi_aktif();
+  r       record;
+  v_n     integer := 0;
+begin
+  for r in
+    select kode, pos, name, type, form, poin_maks, total_soal,
+           rentang_mentah_min, rentang_mentah_maks, lomba, golongan
+    from wahana
+    where edisi = v_edisi
+      and kode in ('keagamaan','kepramukaan','kesehatan','pengetahuan_umum','logika')
+    order by pos, kode
+  loop
+    v_n := v_n + 1;
+    assert r.type = 'soal',
+      format('%s: type harus soal, bukan %s', r.kode, r.type);
+    assert r.form = 'benar_per_total',
+      format('%s: form harus benar_per_total, bukan %s', r.kode, r.form);
+    assert r.total_soal > 0,
+      format('%s: total_soal wajib terisi untuk benar_per_total', r.kode);
+    -- Batas isian HARUS sama dengan jumlah soalnya. Kalau lebih longgar,
+    -- petugas bisa mengetik 12 dari 10 soal dan poinnya melewati maksimum
+    -- sebelum di-clamp; kalau lebih ketat, jawaban sempurna ditolak.
+    assert r.rentang_mentah_maks = r.total_soal,
+      format('%s: rentang atas %s tidak sama dengan %s soal',
+             r.kode, r.rentang_mentah_maks, r.total_soal);
+    assert r.rentang_mentah_min = 0, format('%s: rentang bawah harus 0', r.kode);
+    -- Keputusan pemilik acara: masing-masing lomba tersendiri, bukan satu
+    -- lomba berisi dua penilaian. NULL yang menyatakannya (CLAUDE.md 11.7).
+    assert r.lomba is null,
+      format('%s: lomba harus NULL — ia lombanya sendiri, dapat %s', r.kode, r.lomba);
+    assert r.golongan is null,
+      format('%s: golongan harus NULL — berlaku untuk keempat golongan', r.kode);
+  end loop;
+
+  assert v_n = 5, format('seharusnya 5 komponen soal, ada %s', v_n);
+  raise notice '39.1 OK — lima komponen soal, semuanya benar_per_total dan berdiri sendiri.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 39.2  SATU BENAR = LIMA POIN. Dihitung lewat hitung_poin(), rumus yang
+--       sesungguhnya dipakai — bukan dengan mengalikan sendiri di tes ini.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_edisi smallint := edisi_aktif();
+  r       record;
+  v_satu  numeric;
+  v_penuh numeric;
+begin
+  for r in
+    select kode, poin_maks, total_soal from wahana
+    where edisi = v_edisi
+      and kode in ('keagamaan','kepramukaan','kesehatan','pengetahuan_umum','logika')
+  loop
+    v_satu := hitung_poin('benar_per_total', 1, null, r.poin_maks,
+                          null, null, null, null, r.total_soal, null);
+    assert v_satu = 5,
+      format('%s: satu jawaban benar seharusnya 5 poin, dapat %s', r.kode, v_satu);
+
+    v_penuh := hitung_poin('benar_per_total', r.total_soal, null, r.poin_maks,
+                           null, null, null, null, r.total_soal, null);
+    assert v_penuh = r.poin_maks,
+      format('%s: semua benar seharusnya %s poin, dapat %s',
+             r.kode, r.poin_maks, v_penuh);
+  end loop;
+  raise notice '39.2 OK — 1 benar = 5 poin di kelimanya, dan semua benar = poin maksimum.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 39.3  Nol benar = nol poin, dan angka di luar akal tetap terkurung.
+--
+-- Clamp-nya diuji karena rentang isian dijaga di layar dan di impor — dua
+-- tempat yang bisa dilewati, misalnya oleh baris yang ditempel dari Sheets.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_edisi smallint := edisi_aktif(); v_maks numeric; v_soal numeric; v_p numeric;
+begin
+  select poin_maks, total_soal into v_maks, v_soal from wahana
+  where edisi = v_edisi and kode = 'logika';
+
+  v_p := hitung_poin('benar_per_total', 0, null, v_maks, null, null, null, null, v_soal, null);
+  assert v_p = 0, format('nol benar seharusnya nol poin, dapat %s', v_p);
+
+  v_p := hitung_poin('benar_per_total', v_soal + 5, null, v_maks,
+                     null, null, null, null, v_soal, null);
+  assert v_p = v_maks,
+    format('lebih dari jumlah soal seharusnya tetap %s, dapat %s', v_maks, v_p);
+  raise notice '39.3 OK — nol jadi nol, dan kelebihan tetap terkurung di maksimum.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 39.4  Pembidaian berjumlah 100 dan tiap barisnya 1:1.
+--
+--       Dilewati di database uji, yang seed-nya tidak punya Pembidaian.
+--       Yang dijaga di sini: `poin_maks` tidak boleh naik sendirian.
+--       `besar_baik` menghitung poin_maks x nilai / raw_terbaik, jadi menaikkan
+--       poin_maks tanpa raw_terbaik membuat juri yang menulis 20 dapat 25.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_edisi smallint := edisi_aktif();
+  r       record;
+  v_n     integer;
+  v_jum   numeric;
+begin
+  select count(*) into v_n from wahana
+  where edisi = v_edisi and pos = 3 and lomba = 'Pembidaian';
+  if v_n = 0 then
+    raise notice '39.4 DILEWATI — Pembidaian tidak ada di database ini.';
+    return;
+  end if;
+
+  select sum(poin_maks) into v_jum from wahana
+  where edisi = v_edisi and pos = 3 and lomba = 'Pembidaian';
+  assert v_jum = 100, format('Pembidaian berjumlah %s, seharusnya 100', v_jum);
+
+  for r in
+    select kode, poin_maks, raw_terbaik, rentang_mentah_maks from wahana
+    where edisi = v_edisi and pos = 3 and lomba = 'Pembidaian'
+  loop
+    assert r.raw_terbaik = r.poin_maks,
+      format('%s: raw_terbaik %s tidak mengikuti poin_maks %s — angka yang '
+             'ditulis juri tidak lagi sama dengan poinnya',
+             r.kode, r.raw_terbaik, r.poin_maks);
+    assert r.rentang_mentah_maks = r.poin_maks,
+      format('%s: batas isian %s tidak mengikuti poin_maks %s',
+             r.kode, r.rentang_mentah_maks, r.poin_maks);
+    assert hitung_poin('besar_baik', r.poin_maks, null, r.poin_maks,
+                       r.raw_terbaik, 0, null, null, null, null) = r.poin_maks,
+      format('%s: nilai penuh tidak menghasilkan poin penuh', r.kode);
+  end loop;
+  raise notice '39.4 OK — Pembidaian 100 poin, kelimanya 1:1.';
+end $blok$;


### PR DESCRIPTION
## What

**A. Pembidaian (Pos 3) — `20/20/20/20/20` → `25/25/20/15/15`**

| penilaian | dari | jadi |
|---|---|---|
| Diagnosis dan Penanganan Awal | 20 | **25** |
| Teknik Bidai | 20 | **25** |
| Kecepatan dan Kerja Sama | 20 | 20 |
| Posisi Bidai | 20 | **15** |
| Kerapihan dan Kebersihan | 20 | **15** |
| | **100** | **100** |

**B. Lima lomba soal baru, masing-masing berdiri sendiri**

| pos | lomba | soal | maks |
|---|---|---|---|
| 1 | Keagamaan | 10 | 50 |
| 1 | Kepramukaan | 10 | 50 |
| 2 | Kesehatan | 10 | 50 |
| 2 | Pengetahuan Umum | 10 | 50 |
| 3 | Logika | 20 | 100 |

## Why

Jumlah Pembidaian tetap 100, jadi bobotnya terhadap lomba lain **tidak** berubah — yang berubah pembagiannya di dalam: menilai salah pada diagnosis sekarang lebih mahal daripada pada kerapihan.

**Tiga kolom bergerak bersama, bukan satu.** Bentuknya `besar_baik` dengan rumus `poin_maks × nilai / raw_terbaik`, dan baris-baris ini sengaja dipasang 1:1 supaya angka yang ditulis juri **adalah** poinnya. Menaikkan `poin_maks` sendirian membuat juri yang menulis 20 mendapat 25 poin — tanpa satu galat pun. Tes 39.4 menjaga ketiganya tetap sepasang.

Lomba soal memakai `benar_per_total`: `poin = poin_maks × benar / total_soal`. Jadi **"1 benar 5 poin" ditulis sebagai `poin_maks` 50 atas 10 soal**, bukan sebagai angka 5 di kolom mana pun. Yang diketik petugas satu angka saja — jumlah benar.

## Notes

**⚠ Bobotnya memang setengah, dan ini perlu Anda putuskan sebelum hari-H.** Komponen lain bernilai maksimum 100; kelima soal ini 50 (Logika 100). Klasemen menjumlahkan poin apa adanya:

```
Pos 1  300 → 400      Pos 2  300 → 400      Pos 3  300 → 400
```

Kalau yang dimaksud **setara** dengan lomba lain, yang diubah cukup `poin_maks` jadi 100 — angka 5 di kepala panitia tetap benar, karena rumusnya membagi dengan total soal.

**Konfigurasinya diambil dari produksi, bukan dari database uji.** Seed uji memakai wahana generik yang tidak punya Pembidaian sama sekali (0032/0033 tidak berjalan di sana), jadi bagian A melewati diri sendiri dan tes 39.4 ikut dilewati — dengan pesan, bukan diam-diam.

**Tes 39:** kelima komponen bentuknya benar; **1 benar = 5 poin dihitung lewat `hitung_poin()`** yang sesungguhnya dipakai, bukan dengan mengalikan sendiri di tes; nol jadi nol dan kelebihan terkurung di maksimum; batas isian sama dengan jumlah soal — kalau lebih longgar, petugas bisa mengetik 12 dari 10.

**Sesudah PR ini mendarat, jalankan `apply-migration.yml`** dengan `supabase/migrations/0076_bidai_dan_lomba_soal.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)