### PR TITLE
fix: kotak alasan diberi contoh, judul gembok menyebut nomor dada

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -725,7 +725,7 @@ async function layarPembayaran() {
             <div class="nama">${b.sekolah?.name || kode}</div>
             <div class="detail">${kode} · kwitansi ${b.pembayaran?.nomor_kwitansi || "—"}</div>
           </div>`,
-          medan: [{ label: "Alasan pembatalan" }],
+          medan: [{ label: "Alasan pembatalan", contoh: "salah nominal" }],
           labelAksi: "Batalkan",
         });
         if (!jawab) return;
@@ -1028,7 +1028,7 @@ async function layarDaftarUlang() {
           medan: [
             { label: "Nomor lama (yang rusak)", tipe: "number" },
             { label: "Nomor pengganti (dari stok)", tipe: "number" },
-            { label: "Alasan" },
+            { label: "Alasan", contoh: "kain sobek" },
           ],
           labelAksi: "Tukar nomor",
         });
@@ -1449,7 +1449,8 @@ async function layarKeberangkatan() {
               ? `Kloter ${tujuan} sudah berangkat — regu ini akan dinilai dari jam berangkat kloter itu.`
               : ""}</div>
           </div>`,
-          medan: [{ label: "Alasan pemindahan" }],
+          medan: [{ label: "Alasan pemindahan",
+                   contoh: "terlambat, menyusul kloter berikutnya" }],
           labelAksi: "Pindahkan",
         });
         // Batal (atau gagal) mengembalikan select ke "—", kalau tidak ia
@@ -2848,8 +2849,8 @@ async function layarInputPos() {
     // seluruhnya — bahwa alasannya dicatat adalah hal yang petugas pelajari
     // sekali, sedangkan kalimatnya dibaca ulang setiap kali gembok dibuka.
     const jawab = await dialog({
-      judul: `Buka gembok ${tiga}?`,
-      medan: [{ label: "Alasan membuka" }],
+      judul: `Buka Gembok No. Dada ${tiga}?`,
+      medan: [{ label: "Alasan membuka", contoh: "nilai semaphore salah ketik" }],
       labelAksi: "Buka",
     });
     if (!jawab) return;


### PR DESCRIPTION
## What

**Judul.** `Buka gembok 001?` → **`Buka Gembok No. Dada 001?`**

**Contoh isian.** Empat kotak alasan yang sebelumnya kosong tanpa petunjuk:

| kotak | contoh |
|---|---|
| Alasan pembatalan | `salah nominal` |
| Alasan (tukar nomor dada) | `kain sobek` |
| Alasan pemindahan | `terlambat, menyusul kloter berikutnya` |
| Alasan membuka gembok | `nilai semaphore salah ketik` |

## Why

Angka telanjang di judul dialog menuntut pembacanya mengingat konteks layar di belakangnya — dan dialog ini muncul di atas tabel berisi puluhan angka lain.

Kotak kosong berlabel "Alasan" membuat orang menulis "salah" atau mengosongkannya sama sekali. Alasan itulah **satu-satunya penjelasan yang tersisa di riwayat** berbulan-bulan kemudian, waktu ada yang bertanya kenapa nilai sebuah regu berubah. Satu contoh menunjukkan panjang dan bentuk yang berguna tanpa satu kalimat perintah pun (bagian 9.2).

## Notes

**Kotak nomor dada dan kotak nilai sengaja dibiarkan tanpa contoh**, sesuai permintaan: labelnya sudah menyebut persis apa yang diminta, dan angka contoh di dalam kotak angka mudah tertukar dengan nilai yang sebenarnya.

`contoh` sudah didukung `dialog()` sejak awal (`util.js:559`) dan sudah dipakai di satu tempat — ini cuma mengisinya di tempat lain, bukan menambah mekanisme baru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)