### PR TITLE
fix: mengganti peran benar-benar mengisi ulang centangnya

### DIFF
--- a/supabase/migrations/0077_peran_mengisi_ulang_centang.sql
+++ b/supabase/migrations/0077_peran_mengisi_ulang_centang.sql
@@ -1,0 +1,119 @@
+-- ============================================================================
+-- hrcd-rekap : 0077_peran_mengisi_ulang_centang.sql
+--
+-- MENGGANTI PERAN BENAR-BENAR MENGISI ULANG CENTANGNYA.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG RUSAK
+--
+-- Layar Akun berbunyi "Mengganti peran mengisi ulang centangnya." Tidak ada
+-- satu baris pun di sistem ini yang melakukannya. `ubahPeranAkun()` mengubah
+-- kolom `peran` di `akun_panitia` dan berhenti di situ; `akun_hak` — yang
+-- SEBENARNYA menjadi pagar sejak 0064 — tidak tersentuh.
+--
+-- Akibatnya persis kebalikan dari yang diharapkan admin: menurunkan seseorang
+-- dari admin jadi juri pos meninggalkan sebelas centang admin utuh di
+-- tangannya. Ia tetap bisa membuka pembayaran, keberangkatan, akun, dan
+-- pengaturan. Perannya di layar berbunyi "Juri Pos", dan itulah yang dibaca
+-- orang saat memeriksa siapa boleh apa.
+--
+-- Yang membuatnya sulit dilihat: layarnya BENAR. Peran berubah, notifikasi
+-- muncul, tabelnya menampilkan peran baru. Yang tidak berubah cuma sebelas
+-- kotak yang letaknya jauh di kanan, di luar layar HP.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TRIGGER, BUKAN DUA PERMINTAAN DARI LAYAR
+--
+-- Peran bisa berubah dari EMPAT pintu: layar Akun, gateway saat provisioning,
+-- SQL langsung di dashboard, dan skrip pemeliharaan. Memperbaiki layarnya saja
+-- meninggalkan tiga pintu yang tetap menghasilkan centang basi — dan bentuk
+-- kegagalan itu persis yang bagian 13.3 gambarkan: pemeriksaan yang cakupannya
+-- lebih sempit daripada masalahnya.
+--
+-- Di database ia juga ATOMIK. Dua permintaan dari klien punya jeda di
+-- antaranya, dan jeda itu adalah akun tanpa satu centang pun — atau, kalau
+-- yang kedua gagal, akun dengan centang lama selamanya.
+--
+-- ---------------------------------------------------------------------------
+-- YANG SENGAJA TIDAK DILAKUKAN
+--
+-- Trigger ini TIDAK menyentuh INSERT. Akun baru sudah diisi centangnya oleh
+-- pembuatnya (gateway `buatAkun` dan `daftarPanitia`), dan menambah satu
+-- pengisi lagi berarti dua tempat menulis hal yang sama dengan urutan yang
+-- tidak dijamin.
+--
+-- Ia juga tidak mencoba MEMPERTAHANKAN centang yang disetel tangan. Kalau
+-- admin menambahkan `rekap` ke seorang juri pos lalu mengganti perannya,
+-- centang itu hilang. Itu memang arti kalimat di layar, dan menebak-nebak mana
+-- yang "sengaja ditambahkan" akan membuat perilakunya tidak bisa diterangkan
+-- dalam satu kalimat.
+-- ============================================================================
+
+create or replace function isi_ulang_hak_peran()
+returns trigger
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  -- Hanya kalau perannya benar-benar berganti. Tanpa penjaga ini, setiap
+  -- perubahan lain di baris yang sama — mengaktifkan akun, mengganti pos,
+  -- mengganti nama — ikut menghapus centang yang mungkin baru saja disetel
+  -- admin dengan tangan.
+  if new.peran is not distinct from old.peran then
+    return new;
+  end if;
+
+  delete from akun_hak where user_id = new.user_id;
+
+  insert into akun_hak (user_id, fitur)
+  select new.user_id, f
+  from unnest(paket_peran(new.peran)) as f
+  -- Peran yang paket_peran() tidak kenali menghasilkan array kosong, dan
+  -- akun itu berakhir tanpa centang sama sekali. Itu keadaan yang benar:
+  -- tidak bisa apa-apa lebih aman daripada memegang centang peran lamanya.
+  on conflict do nothing;
+
+  return new;
+end;
+$$;
+
+comment on function isi_ulang_hak_peran() is
+  'Mengganti peran mengisi ulang akun_hak dari paket_peran(). Dipasang sebagai '
+  'trigger supaya berlaku dari SEMUA pintu, bukan hanya dari layar Akun.';
+
+drop trigger if exists hak_ikut_peran on akun_panitia;
+create trigger hak_ikut_peran
+  after update of peran on akun_panitia
+  for each row execute function isi_ulang_hak_peran();
+
+-- ---------------------------------------------------------------------------
+-- Membetulkan yang sudah terlanjur: akun yang centangnya tidak cocok dengan
+-- perannya HARI INI. Ini bukan pembersihan kosmetik — tiap satu di antaranya
+-- adalah orang yang memegang hak yang tidak seharusnya ia pegang.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  r       record;
+  v_ubah  integer := 0;
+begin
+  for r in
+    select a.user_id, a.username, a.peran,
+           array(select h.fitur from akun_hak h where h.user_id = a.user_id
+                 order by h.fitur) as punya,
+           array(select f from unnest(paket_peran(a.peran)) f order by 1) as harus
+    from akun_panitia a
+  loop
+    if r.punya is distinct from r.harus then
+      raise notice '0077: % (%) — % centang -> %',
+        r.username, r.peran, array_length(r.punya, 1), array_length(r.harus, 1);
+      delete from akun_hak where user_id = r.user_id;
+      insert into akun_hak (user_id, fitur)
+      select r.user_id, f from unnest(paket_peran(r.peran)) f
+      on conflict do nothing;
+      v_ubah := v_ubah + 1;
+    end if;
+  end loop;
+
+  raise notice '0077: % akun diselaraskan centangnya dengan perannya.', v_ubah;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -279,5 +279,11 @@ run tests/sql/38_koordinator_pos.sql
 # sendiri; bagian B tetap berjalan dan itulah yang diuji tes 39.
 run supabase/migrations/0076_bidai_dan_lomba_soal.sql
 run tests/sql/39_lomba_soal.sql
+# 0077 membuat 'mengganti peran mengisi ulang centangnya' benar-benar
+# terjadi - selama ini kalimat itu cuma ada di layar. Tes 40 menjaga
+# akibatnya: sesudah turun dari admin, akunnya TIDAK lagi memegang akun
+# dan pengaturan.
+run supabase/migrations/0077_peran_mengisi_ulang_centang.sql
+run tests/sql/40_peran_mengisi_ulang_centang.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/40_peran_mengisi_ulang_centang.sql
+++ b/tests/sql/40_peran_mengisi_ulang_centang.sql
@@ -1,0 +1,121 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/40_peran_mengisi_ulang_centang.sql
+-- Mengganti peran mengisi ulang akun_hak (migrasi 0077).
+--
+-- KENAPA TES INI ADA
+--
+-- Layar Akun menjanjikannya dengan satu kalimat, dan selama berbulan-bulan
+-- tidak ada satu baris pun yang menepatinya. Yang membuatnya lolos: layarnya
+-- BENAR — peran berubah, notifikasi muncul, tabel menampilkan peran baru.
+-- Yang tidak berubah cuma sebelas kotak centang yang letaknya jauh di kanan.
+--
+-- Jadi yang diuji di sini bukan "triggernya ada", melainkan akibatnya: sesudah
+-- diturunkan dari admin, akun itu TIDAK LAGI memegang `akun` dan `pengaturan`.
+-- ============================================================================
+
+insert into auth.users (id, email)
+values ('00000000-0000-0000-0000-0000000000d1', 'uji.peran@uji.local')
+on conflict (id) do nothing;
+
+insert into akun_panitia (user_id, username, peran, pos, is_active)
+values ('00000000-0000-0000-0000-0000000000d1', 'uji.peran', 'admin', null, true)
+on conflict (user_id) do update set peran = 'admin', pos = null, is_active = true;
+
+insert into akun_hak (user_id, fitur)
+select '00000000-0000-0000-0000-0000000000d1', unnest(paket_peran('admin'))
+on conflict do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 40.1  Turun dari admin jadi juri pos: centang admin HILANG.
+--
+--       Ini kerugian yang sebenarnya. Tanpa ini, orang yang perannya sudah
+--       diturunkan tetap bisa membuka layar Akun dan Pengaturan — dan yang
+--       memeriksa siapa boleh apa membaca kolom `peran`, yang sudah berbunyi
+--       "Juri Pos".
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_uid uuid := '00000000-0000-0000-0000-0000000000d1'; v_n integer;
+begin
+  select count(*) into v_n from akun_hak where user_id = v_uid and fitur = 'akun';
+  assert v_n = 1, 'persiapan gagal: admin seharusnya memegang akun';
+
+  -- Peran dan pos dikirim bersama: constraint 0058 menuntut juri_pos berpos.
+  update akun_panitia set peran = 'juri_pos', pos = 1 where user_id = v_uid;
+
+  select count(*) into v_n from akun_hak
+  where user_id = v_uid and fitur in ('akun','pengaturan','pembayaran',
+                                      'keberangkatan','rekap');
+  assert v_n = 0,
+    format('%s centang admin masih tertinggal sesudah turun jadi juri pos', v_n);
+
+  select count(*) into v_n from akun_hak where user_id = v_uid;
+  assert v_n = array_length(paket_peran('juri_pos'), 1),
+    format('centangnya %s, seharusnya %s', v_n, array_length(paket_peran('juri_pos'), 1));
+
+  select count(*) into v_n from akun_hak where user_id = v_uid and fitur = 'pos';
+  assert v_n = 1, 'juri pos harus memegang fitur pos';
+
+  raise notice '40.1 OK — centang admin hilang, centang juri pos terpasang.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 40.2  Naik jadi Koordinator Pos: centangnya ikut, dan posnya wajib kosong.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_uid uuid := '00000000-0000-0000-0000-0000000000d1'; v_n integer;
+begin
+  update akun_panitia set peran = 'koordinator_pos', pos = null where user_id = v_uid;
+
+  select count(*) into v_n from akun_hak where user_id = v_uid;
+  assert v_n = array_length(paket_peran('koordinator_pos'), 1),
+    format('centangnya %s, seharusnya %s', v_n,
+           array_length(paket_peran('koordinator_pos'), 1));
+  raise notice '40.2 OK — pindah ke koordinator_pos ikut mengganti centangnya.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 40.3  Perubahan LAIN di baris yang sama tidak menyentuh centangnya.
+--
+--       Kalau penjaga `is distinct from` hilang, mengaktifkan akun atau
+--       mengganti namanya akan menghapus centang yang baru saja disetel admin
+--       dengan tangan — dan itu kerusakan yang persis sama diamnya.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_uid uuid := '00000000-0000-0000-0000-0000000000d1'; v_n integer;
+begin
+  insert into akun_hak (user_id, fitur) values (v_uid, 'rekap')
+  on conflict do nothing;
+
+  update akun_panitia set is_active = false where user_id = v_uid;
+  update akun_panitia set username = 'uji.peran.2' where user_id = v_uid;
+
+  select count(*) into v_n from akun_hak where user_id = v_uid and fitur = 'rekap';
+  assert v_n = 1,
+    'centang yang disetel tangan hilang padahal perannya tidak berubah';
+  raise notice '40.3 OK — centang tangan bertahan selama perannya tetap.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 40.4  ...dan hilang begitu perannya berganti. Itu memang arti kalimat di
+--       layar: mengganti peran MENGISI ULANG, bukan menambah.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_uid uuid := '00000000-0000-0000-0000-0000000000d1'; v_n integer;
+begin
+  update akun_panitia set peran = 'gerbang', pos = null where user_id = v_uid;
+
+  select count(*) into v_n from akun_hak where user_id = v_uid and fitur = 'rekap';
+  assert v_n = 0, 'centang tangan seharusnya ikut terhapus saat peran berganti';
+
+  select count(*) into v_n from akun_hak where user_id = v_uid;
+  assert v_n = array_length(paket_peran('gerbang'), 1),
+    format('centangnya %s, seharusnya %s', v_n, array_length(paket_peran('gerbang'), 1));
+  raise notice '40.4 OK — mengganti peran mengisi ulang, bukan menambah.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- Bersih-bersih.
+-- ---------------------------------------------------------------------------
+delete from akun_hak    where user_id = '00000000-0000-0000-0000-0000000000d1';
+delete from akun_panitia where user_id = '00000000-0000-0000-0000-0000000000d1';
+delete from auth.users   where id      = '00000000-0000-0000-0000-0000000000d1';


### PR DESCRIPTION
## What

Layar Akun berbunyi *"Mengganti peran mengisi ulang centangnya."* **Tidak ada satu baris pun di sistem ini yang melakukannya.** `ubahPeranAkun()` mengubah kolom `peran` lalu berhenti; `akun_hak` — yang sebenarnya jadi pagar sejak 0064 — tidak tersentuh.

Migrasi `0077` memasang trigger yang menepatinya, dan menyelaraskan akun yang sudah terlanjur.

## Why

Akibatnya **kebalikan** dari yang diharapkan admin: menurunkan seseorang dari admin jadi juri pos meninggalkan **sebelas centang admin utuh** di tangannya. Ia tetap bisa membuka pembayaran, keberangkatan, akun, dan pengaturan — sementara kolom perannya sudah berbunyi "Juri Pos", dan **itulah yang dibaca orang** saat memeriksa siapa boleh apa.

Yang membuatnya sulit dilihat: layarnya benar. Peran berubah, notifikasi muncul, tabel menampilkan peran baru. Yang tidak berubah cuma sebelas kotak centang yang letaknya jauh di kanan, di luar layar HP.

## Notes

**Trigger, bukan dua permintaan dari layar.** Peran bisa berubah dari empat pintu — layar Akun, gateway saat provisioning, SQL langsung di dashboard, skrip pemeliharaan. Memperbaiki layarnya saja meninggalkan tiga pintu yang tetap menghasilkan centang basi; itu bentuk kegagalan bagian 13.3. Di database ia juga **atomik**: dua permintaan dari klien punya jeda di antaranya, dan jeda itu adalah akun tanpa satu centang pun — atau, kalau yang kedua gagal, akun dengan centang lama selamanya.

**Penjaga `is distinct from` menahan kerusakan sebaliknya.** Mengaktifkan akun atau mengganti namanya **tidak** menghapus centang yang baru saja disetel admin dengan tangan. Tes 40.3 menjaga itu; 40.4 menjaga kebalikannya — begitu perannya berganti, centang tangan memang ikut hilang, karena itulah arti kalimat di layar.

**Trigger tidak menyentuh INSERT.** Akun baru sudah diisi centangnya oleh pembuatnya (gateway), dan menambah pengisi kedua berarti dua tempat menulis hal yang sama dengan urutan yang tidak dijamin.

**Sesudah PR ini mendarat, jalankan `apply-migration.yml`** dengan `supabase/migrations/0077_peran_mengisi_ulang_centang.sql`. Lognya menyebut satu per satu akun yang diselaraskan — tiap satu di antaranya orang yang memegang hak yang tidak seharusnya ia pegang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)