### PR TITLE
feat: panitia bisa mendaftar sendiri dari layar login

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -227,7 +227,7 @@ export async function masuk(username, password) {
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,
       { headers: kepala });
     if (!akun.length || !akun[0].is_active)
-      throw new ErrorApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
+      throw new ErrorApi("Akun ini belum diaktifkan. Minta admin menyalakannya di layar Akun.");
     // Hak dibawa ke dalam sesi supaya papan Home bisa memilih ubinnya tanpa
     // satu permintaan lagi tiap kali dibuka. Ini HANYA untuk menggambar —
     // yang menegakkan tetap RLS, dan sesi yang diutak-atik di devtools tidak
@@ -842,6 +842,20 @@ export async function daftarFotoBelumTaut(pos, kodeLomba) {
  *  yang menjaganya trigger audit, bukan larangan. */
 export const tautkanFoto = (id, nomorDada, cara = "tangan") =>
   rpc("tautkan_foto", { p_foto_id: id, p_nomor_dada: nomorDada, p_cara: cara });
+
+/** Pendaftaran mandiri panitia dari layar login.
+ *
+ *  Lewat gateway, bukan langsung ke Supabase: membuat user auth menuntut
+ *  service_role, dan kunci itu hidup HANYA di Worker. Yang kembali dari sini
+ *  cuma "ok" — akunnya belum bisa dipakai sampai admin menyalakannya, dan
+ *  itulah yang membuat rute ini boleh publik. */
+export async function daftarPanitia({ username, password, peran, pos }) {
+  return kirim(`${K.gatewayUrl}/akun/daftar`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password, peran, pos }),
+  });
+}
 
 /* ============================ AKUN PANITIA ==============================
    Dua jalur, dan yang menentukan bukan kerapian melainkan siapa pemegang

--- a/live/style.css
+++ b/live/style.css
@@ -3082,6 +3082,23 @@ input.small-input { text-align: center; }
    "sudah dinonaktifkan" dan "belum pernah ada" tidak terlihat sama. */
 .matriks-hak tr.mati { opacity: .55; }
 
+/* Pendaftaran mandiri di layar login. Digulung, dan ringkasannya dibuat
+   terbaca sebagai tautan — ia satu-satunya jalan keluar dari layar ini bagi
+   orang yang belum punya akun, dan ringkasan <details> bawaan terbaca seperti
+   judul yang tidak bisa ditekan. */
+.daftar-panitia {
+  margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--garis);
+}
+.daftar-panitia > summary {
+  cursor: pointer; color: var(--utama); font-weight: 700; list-style: none;
+}
+.daftar-panitia > summary::-webkit-details-marker { display: none; }
+.daftar-panitia > summary::after { content: " ▾"; }
+.daftar-panitia[open] > summary::after { content: " ▴"; }
+.daftar-panitia .field { margin-top: .8rem; }
+.daftar-panitia select, .daftar-panitia input { width: 100%; }
+.daftar-panitia .button { width: 100%; margin-top: .4rem; }
+
 /* Nama akun adalah tombol, tapi harus terbaca sebagai nama. */
 .tautan {
   background: none; border: 0; padding: 0; font: inherit; cursor: pointer;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -227,7 +227,7 @@ export async function masuk(username, password) {
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,
       { headers: kepala });
     if (!akun.length || !akun[0].is_active)
-      throw new ErrorApi("Akun ini tidak aktif di edisi sekarang. Hubungi koordinator.");
+      throw new ErrorApi("Akun ini belum diaktifkan. Minta admin menyalakannya di layar Akun.");
     // Hak dibawa ke dalam sesi supaya papan Home bisa memilih ubinnya tanpa
     // satu permintaan lagi tiap kali dibuka. Ini HANYA untuk menggambar —
     // yang menegakkan tetap RLS, dan sesi yang diutak-atik di devtools tidak
@@ -842,6 +842,20 @@ export async function daftarFotoBelumTaut(pos, kodeLomba) {
  *  yang menjaganya trigger audit, bukan larangan. */
 export const tautkanFoto = (id, nomorDada, cara = "tangan") =>
   rpc("tautkan_foto", { p_foto_id: id, p_nomor_dada: nomorDada, p_cara: cara });
+
+/** Pendaftaran mandiri panitia dari layar login.
+ *
+ *  Lewat gateway, bukan langsung ke Supabase: membuat user auth menuntut
+ *  service_role, dan kunci itu hidup HANYA di Worker. Yang kembali dari sini
+ *  cuma "ok" — akunnya belum bisa dipakai sampai admin menyalakannya, dan
+ *  itulah yang membuat rute ini boleh publik. */
+export async function daftarPanitia({ username, password, peran, pos }) {
+  return kirim(`${K.gatewayUrl}/akun/daftar`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password, peran, pos }),
+  });
+}
 
 /* ============================ AKUN PANITIA ==============================
    Dua jalur, dan yang menentukan bukan kerapian melainkan siapa pemegang

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -25,7 +25,7 @@ import {
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
   statusAcara, bolehLihat, lengkapiHakSesi,
   aturFaseLive,
-  daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun,
+  daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun, daftarPanitia,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
@@ -182,10 +182,83 @@ function layarLogin(pesan) {
         <input type="password" id="p" autocomplete="current-password">
       </div>
       <button class="button button-primary" id="masuk" type="button">Masuk</button>
+
+      <!-- Pendaftaran DIGULUNG. Yang membuka layar ini ratusan kali adalah
+           panitia yang sudah punya akun; formulir yang terbuka terus menaruh
+           enam isian di antara mereka dan tombol Masuk. Yang mendaftar
+           melakukannya sekali seumur edisi. -->
+      <details class="daftar-panitia">
+        <summary>Belum punya akun? Daftar</summary>
+        <div class="field">
+          <label for="d-u">Nama akun</label>
+          <input type="text" id="d-u" autocomplete="username" autocapitalize="none"
+                 spellcheck="false" placeholder="pos6hrcd37">
+        </div>
+        <div class="field">
+          <label for="d-p">Password</label>
+          <input type="password" id="d-p" autocomplete="new-password"
+                 placeholder="minimal 8 huruf">
+        </div>
+        <div class="field">
+          <label for="d-peran">Tugas</label>
+          <select id="d-peran" class="select-small">
+            <option value="juri_pos">Juri Pos</option>
+            <option value="koordinator_pos">Koordinator Pos</option>
+            <option value="registrasi">Registrasi</option>
+            <option value="gerbang">Gerbang</option>
+          </select>
+        </div>
+        <div class="field" id="d-pos-kotak">
+          <label for="d-pos">Pos</label>
+          <input type="number" id="d-pos" class="small-input" inputmode="numeric"
+                 min="1" max="20" placeholder="3">
+        </div>
+        <!-- Satu kalimat, dan ia membawa fakta yang TIDAK bisa dibaca dari
+             layar: akunnya belum hidup. Tanpa ini orang mendaftar, mencoba
+             masuk, gagal, lalu mendaftar lagi dengan nama lain (bagian 9.4). -->
+        <p class="keterangan">Akun baru dinyalakan admin dulu sebelum bisa dipakai.</p>
+        <button class="button" id="d-kirim" type="button">Daftar</button>
+      </details>
     </div>
   `));
   const u = document.getElementById("u");
   u.focus();
+
+  /* Kotak Pos hanya untuk Juri Pos — itu check constraint di database
+     (0058), bukan selera: peran lain WAJIB berpos kosong, dan Koordinator Pos
+     justru dikenali dari posnya yang kosong. */
+  const dPeran = document.getElementById("d-peran");
+  const dPosKotak = document.getElementById("d-pos-kotak");
+  const perluPos = () => dPeran.value === "juri_pos";
+  const setelPos = () => { dPosKotak.hidden = !perluPos(); };
+  setelPos();
+  dPeran.addEventListener("change", setelPos);
+
+  document.getElementById("d-kirim").addEventListener("click", async () => {
+    const btn = document.getElementById("d-kirim");
+    const nama = document.getElementById("d-u").value.trim().toLowerCase();
+    const sandi = document.getElementById("d-p").value;
+    const pos = perluPos() ? Number(document.getElementById("d-pos").value) || null : null;
+
+    // Diperiksa di sini SEKALIPUN gateway juga memeriksanya — bukan sebagai
+    // pagar, melainkan supaya salah ketik dijawab seketika alih-alih sesudah
+    // satu perjalanan jaringan di sinyal lapangan.
+    if (!/^[a-z0-9._-]{3,40}$/.test(nama)) {
+      notif("Nama akun hanya huruf kecil, angka, titik, dan strip (3–40).", true);
+      return;
+    }
+    if (sandi.length < 8) { notif("Password minimal 8 huruf.", true); return; }
+    if (perluPos() && !pos) { notif("Juri pos harus menyebut posnya.", true); return; }
+
+    btn.disabled = true; btn.textContent = "Mengirim…";
+    try {
+      await daftarPanitia({ username: nama, password: sandi, peran: dPeran.value, pos });
+      layarLogin(`Akun ${nama} terdaftar. Minta admin menyalakannya, lalu masuk.`);
+    } catch (e) {
+      btn.disabled = false; btn.textContent = "Daftar";
+      notif(e instanceof ErrorApi ? e.message : "Pendaftaran gagal.", true);
+    }
+  });
   const aksi = async () => {
     const btn = document.getElementById("masuk");
     btn.disabled = true; btn.textContent = "Memeriksa…";

--- a/web/style.css
+++ b/web/style.css
@@ -3082,6 +3082,23 @@ input.small-input { text-align: center; }
    "sudah dinonaktifkan" dan "belum pernah ada" tidak terlihat sama. */
 .matriks-hak tr.mati { opacity: .55; }
 
+/* Pendaftaran mandiri di layar login. Digulung, dan ringkasannya dibuat
+   terbaca sebagai tautan — ia satu-satunya jalan keluar dari layar ini bagi
+   orang yang belum punya akun, dan ringkasan <details> bawaan terbaca seperti
+   judul yang tidak bisa ditekan. */
+.daftar-panitia {
+  margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--garis);
+}
+.daftar-panitia > summary {
+  cursor: pointer; color: var(--utama); font-weight: 700; list-style: none;
+}
+.daftar-panitia > summary::-webkit-details-marker { display: none; }
+.daftar-panitia > summary::after { content: " ▾"; }
+.daftar-panitia[open] > summary::after { content: " ▴"; }
+.daftar-panitia .field { margin-top: .8rem; }
+.daftar-panitia select, .daftar-panitia input { width: 100%; }
+.daftar-panitia .button { width: 100%; margin-top: .4rem; }
+
 /* Nama akun adalah tombol, tapi harus terbaca sebagai nama. */
 .tautan {
   background: none; border: 0; padding: 0; font: inherit; cursor: pointer;

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -116,6 +116,85 @@ async function pastikanAdmin(req, env) {
 /** Buat akun panitia: user di auth.users, lalu barisnya di akun_panitia.
  *  Password digenerate dan DIKEMBALIKAN — ini satu-satunya kesempatan
  *  membacanya, persis seperti CSV hasil provision_accounts.py. */
+/** Pendaftaran mandiri seorang panitia.
+ *
+ *  Bedanya dengan buatAkun() ada tiga, dan ketiganya disengaja:
+ *
+ *  1. TIDAK ADA PEMERIKSAAN ADMIN. Siapa pun yang membuka layar login boleh
+ *     mendaftar — itu permintaannya.
+ *  2. AKUNNYA LAHIR NONAKTIF, selalu, tanpa cara mengubahnya dari sini.
+ *     Inilah yang membuat butir 1 boleh ada: yang didapat pendaftar adalah
+ *     antrean, bukan akses. Admin yang menyalakannya di layar Akun.
+ *  3. PERAN `admin` DITOLAK. Yang bisa menyalakan akun tidak boleh lahir dari
+ *     pintu yang tidak dijaga siapa pun.
+ *
+ *  Passwordnya datang dari pendaftar, tidak diacak seperti buatAkun() — ia
+ *  yang akan memakainya, dan tidak ada admin yang akan membacakannya.
+ */
+async function daftarPanitia(req, env, b) {
+  const username = String(b.username || "").trim().toLowerCase();
+  const password = String(b.password || "");
+  const peran = String(b.peran || "").trim();
+  const pos = b.pos === null || b.pos === undefined || b.pos === "" ? null : Number(b.pos);
+
+  if (!/^[a-z0-9._-]{3,40}$/.test(username))
+    return jawab(400, { message: "Nama akun hanya huruf kecil, angka, titik, dan strip (3–40)." }, req);
+  if (password.length < 8)
+    return jawab(400, { message: "Password minimal 8 huruf." }, req);
+
+  // `admin` sengaja TIDAK ada di daftar ini. Kalau suatu hari peran baru
+  // ditambahkan, ia harus ditulis di sini juga — dan kalau lupa, yang terjadi
+  // adalah penolakan, bukan kebocoran.
+  if (!["registrasi", "gerbang", "juri_pos", "koordinator_pos"].includes(peran))
+    return jawab(400, { message: "Peran harus registrasi, gerbang, juri_pos, atau koordinator_pos." }, req);
+  if ((peran === "juri_pos") !== (pos !== null))
+    return jawab(400, { message: "Juri pos wajib menyebut posnya; peran lain tanpa pos." }, req);
+  if (pos !== null && !(Number.isInteger(pos) && pos >= 1 && pos <= 20))
+    return jawab(400, { message: "Pos harus 1–20." }, req);
+
+  const email = `${username}@${DOMAIN_AKUN}`;
+  const cu = await fetch(`${env.SUPABASE_URL}/auth/v1/admin/users`, {
+    method: "POST",
+    headers: kepalaLayanan(env),
+    body: JSON.stringify({ email, password, email_confirm: true }),
+  });
+  const user = await cu.json();
+  if (!cu.ok)
+    return jawab(400, { message: "Nama akun sudah dipakai." }, req);
+
+  const ins = await fetch(`${env.SUPABASE_URL}/rest/v1/akun_panitia`, {
+    method: "POST",
+    headers: { ...kepalaLayanan(env), Prefer: "return=minimal" },
+    body: JSON.stringify({ user_id: user.id, username, peran, pos, is_active: false }),
+  });
+  if (!ins.ok) {
+    // Sama seperti buatAkun(): user auth tanpa baris akun_panitia tidak bisa
+    // login dan tidak terlihat di layar mana pun — jadi ia dibatalkan.
+    await fetch(`${env.SUPABASE_URL}/auth/v1/admin/users/${user.id}`,
+      { method: "DELETE", headers: kepalaLayanan(env) });
+    return jawab(400, { message: "Nama akun sudah dipakai." }, req);
+  }
+
+  // Centangnya diisi sekarang, bukan nanti saat diaktifkan: admin cukup
+  // menekan satu tombol, dan akun yang menyala langsung bisa bekerja. Selama
+  // is_active masih false, centang ini tidak membuka apa pun — boleh()
+  // menuntut keduanya.
+  const paket = await fetch(`${env.SUPABASE_URL}/rest/v1/rpc/paket_peran`, {
+    method: "POST", headers: kepalaLayanan(env),
+    body: JSON.stringify({ p_peran: peran }),
+  });
+  const fitur = paket.ok ? await paket.json() : [];
+  if (fitur.length) {
+    await fetch(`${env.SUPABASE_URL}/rest/v1/akun_hak`, {
+      method: "POST",
+      headers: { ...kepalaLayanan(env), Prefer: "return=minimal" },
+      body: JSON.stringify(fitur.map(f => ({ user_id: user.id, fitur: f }))),
+    });
+  }
+
+  return jawab(200, { ok: true, username }, req);
+}
+
 async function buatAkun(req, env, b) {
   const daftar = Array.isArray(b.akun) ? b.akun : [];
   if (!daftar.length) return jawab(400, { message: "Tidak ada akun untuk dibuat." }, req);
@@ -261,6 +340,23 @@ export default {
   async fetch(req, env) {
     if (req.method === "OPTIONS") return new Response(null, { headers: cors(req) });
     const url = new URL(req.url);
+
+    /* Pendaftaran mandiri panitia. PUBLIK — itu memang gunanya — dan karena
+       itu satu-satunya rute /akun yang berdiri SEBELUM pastikanAdmin().
+       Urutannya penting: `startsWith("/akun")` di bawah akan menelannya dan
+       menuntut token admin, yang berarti tidak ada satu orang pun yang bisa
+       memakainya.
+
+       Yang membuatnya boleh publik: akun yang lahir dari sini SELALU
+       nonaktif. Ia bisa dibuat, tidak bisa dipakai. Setiap pagar di database
+       menuntut `is_active` — boleh() (0057) dan peran() (0014) dua-duanya —
+       jadi akun menunggu tidak memegang satu fitur pun, dan layar login pun
+       menolaknya sebelum sesi terbentuk. */
+    if (req.method === "POST" && url.pathname === "/akun/daftar") {
+      let b;
+      try { b = await req.json(); } catch { return jawab(400, { message: "Format data salah." }, req); }
+      return daftarPanitia(req, env, b);
+    }
 
     // Rute akun: admin yang sedang login, bukan publik. Tidak kena rate limit
     // per IP — beberapa panitia menyiapkan satu edisi dari satu WiFi, dan


### PR DESCRIPTION
## What

Formulir pendaftaran **digulung** di bawah tombol Masuk: nama akun, password, tugas, dan pos kalau tugasnya juri pos.

| pilihan tugas | |
|---|---|
| Juri Pos | wajib menyebut pos |
| Koordinator Pos | tanpa pos — itu yang membuka kelima pos |
| Registrasi | |
| Gerbang | |
| ~~Admin~~ | **tidak ada di daftar** |

## Why

**Akunnya lahir nonaktif, selalu.** Itu yang membuat pintu ini boleh terbuka untuk siapa pun.

Alamat panitia beredar di WhatsApp, dan tiga peran yang bisa dipilih di sini memverifikasi pembayaran, menandai keberangkatan, dan **mengubah nilai**. Memberikannya kepada siapa saja yang menemukan alamatnya bukan pendaftaran — itu penyerahan. Yang didapat pendaftar adalah **antrean**, bukan akses; admin yang menyalakannya di layar Akun, dengan tombol yang sudah ada sejak dulu.

**Pagarnya bukan janji layar.** `boleh()` (0057) dan `peran()` (0014) dua-duanya menuntut `is_active`, dan layar login menolak akun nonaktif sebelum sesinya terbentuk. Akun menunggu tidak memegang satu fitur pun — bahkan kalau seseorang memanggil RPC-nya langsung, melewati layar sepenuhnya.

## Notes

**`admin` tidak disaring dari daftar lengkap, ia tidak pernah masuk.** Gateway menerima empat nama secara eksplisit. Kalau suatu hari peran baru ditambahkan dan lupa dituliskan di sini, akibatnya **penolakan**, bukan kebocoran.

**Rutenya berdiri sebelum `pastikanAdmin()`**, dan urutan itu bukan gaya penulisan: `startsWith("/akun")` akan menelannya dan menuntut token admin — yang berarti tidak ada satu orang pun yang bisa memakai pintu ini.

**Centangnya diisi saat mendaftar, bukan saat diaktifkan.** Admin cukup menekan satu tombol, dan akun yang menyala langsung bisa bekerja. Selama `is_active` masih false, centang itu tidak membuka apa pun — `boleh()` menuntut keduanya.

Pesan login untuk akun nonaktif diganti supaya menyebut jalan keluarnya: *"Akun ini belum diaktifkan. Minta admin menyalakannya di layar Akun."* Sebelumnya berbunyi "Hubungi koordinator", yang tidak memberi tahu apa yang harus koordinator lakukan.

**Sesudah PR ini mendarat, jalankan `deploy-gateway.yml`** — rutenya hidup di Worker, dan tanpa deploy formulirnya akan menjawab 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)