### PR TITLE
fix: contoh isian dibuat pucat, nama akun rata kiri, contohnya aji.furqon

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -295,6 +295,17 @@ input.jam-ketik {
   border-color: var(--bahaya);
   background: var(--bahaya-muda);
 }
+/* CONTOH ISIAN JAUH LEBIH PUCAT DARIPADA ISI SUNGGUHAN.
+
+   Tanpa aturan ini yang berlaku warna bawaan browser — di sebagian Android ia
+   nyaris sepekat teks biasa, dan "aji.furqon" di kotak Nama akun terbaca
+   seperti nama yang SUDAH terisi. Petugas lalu menekan Buat Akun tanpa
+   mengetik apa pun, atau mengira akun itu sudah ada.
+
+   `opacity: 1` wajib ikut: Firefox memberi contoh isian opasitasnya sendiri,
+   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca. */
+::placeholder { color: #9aa0a8; opacity: 1; }
+
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }
 
@@ -1834,6 +1845,11 @@ input.small-input { width: 4.5rem; }
    Kalau menambah properti pada dropdown lagi, periksa `.select-small` dulu. */
 select.select-small { width: auto; min-width: 8rem; padding-right: 2rem; }
 input.small-input { text-align: center; }
+/* KECUALI yang isinya NAMA. `.small-input` ditengahkan karena isinya angka —
+   nomor dada, jumlah benar — dan angka yang ditengahkan lebih mudah
+   dibandingkan antar baris. Nama akun bukan angka: ditengahkan, ia terbaca
+   seperti judul, dan contoh isiannya makin terlihat seperti nilai sungguhan. */
+.form-akun input.small-input { text-align: left; }
 /* Isian yang ditolak sebelum dikirim — memerah di tempatnya supaya petugas
    tahu BARIS MANA yang salah, bukan cuma bahwa "ada yang salah". */
 .input-error { border-color: var(--bahaya); background: var(--bahaya-muda); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -192,7 +192,7 @@ function layarLogin(pesan) {
         <div class="field">
           <label for="d-u">Nama akun</label>
           <input type="text" id="d-u" autocomplete="username" autocapitalize="none"
-                 spellcheck="false" placeholder="pos6hrcd37">
+                 spellcheck="false" placeholder="aji.furqon">
         </div>
         <div class="field">
           <label for="d-p">Password</label>
@@ -4839,7 +4839,7 @@ async function layarAkun() {
       <div class="form-akun">
         <div class="field"><label for="ak-nama">Nama akun</label>
           <input id="ak-nama" type="text" class="small-input" autocomplete="off"
-            placeholder="pos1hrcd37"></div>
+            placeholder="aji.furqon"></div>
         <div class="field"><label for="ak-peran">Peran</label>
           <select id="ak-peran" class="select-small">${opsiPeran("registrasi")}</select></div>
         <div class="field" id="ak-pos-kotak" hidden><label for="ak-pos">Pos</label>

--- a/web/style.css
+++ b/web/style.css
@@ -295,6 +295,17 @@ input.jam-ketik {
   border-color: var(--bahaya);
   background: var(--bahaya-muda);
 }
+/* CONTOH ISIAN JAUH LEBIH PUCAT DARIPADA ISI SUNGGUHAN.
+
+   Tanpa aturan ini yang berlaku warna bawaan browser — di sebagian Android ia
+   nyaris sepekat teks biasa, dan "aji.furqon" di kotak Nama akun terbaca
+   seperti nama yang SUDAH terisi. Petugas lalu menekan Buat Akun tanpa
+   mengetik apa pun, atau mengira akun itu sudah ada.
+
+   `opacity: 1` wajib ikut: Firefox memberi contoh isian opasitasnya sendiri,
+   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca. */
+::placeholder { color: #9aa0a8; opacity: 1; }
+
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }
 
@@ -1834,6 +1845,11 @@ input.small-input { width: 4.5rem; }
    Kalau menambah properti pada dropdown lagi, periksa `.select-small` dulu. */
 select.select-small { width: auto; min-width: 8rem; padding-right: 2rem; }
 input.small-input { text-align: center; }
+/* KECUALI yang isinya NAMA. `.small-input` ditengahkan karena isinya angka —
+   nomor dada, jumlah benar — dan angka yang ditengahkan lebih mudah
+   dibandingkan antar baris. Nama akun bukan angka: ditengahkan, ia terbaca
+   seperti judul, dan contoh isiannya makin terlihat seperti nilai sungguhan. */
+.form-akun input.small-input { text-align: left; }
 /* Isian yang ditolak sebelum dikirim — memerah di tempatnya supaya petugas
    tahu BARIS MANA yang salah, bukan cuma bahwa "ada yang salah". */
 .input-error { border-color: var(--bahaya); background: var(--bahaya-muda); }


### PR DESCRIPTION
## What

Tiga perubahan, dan ketiganya penyebab **satu** kebingungan yang sama: contoh isian di kotak Nama akun terbaca seperti nama yang sudah terisi.

| | dari | jadi |
|---|---|---|
| warna contoh | bawaan browser | `#9aa0a8` + `opacity: 1` |
| perataan Nama akun | tengah | **kiri** |
| contohnya | `pos1hrcd37` | `aji.furqon` |

## Why

**Tidak ada satu pun aturan `::placeholder` di berkas ini.** Yang berlaku warna bawaan browser, dan di sebagian Android ia nyaris sepekat teks biasa. `opacity: 1` ikut ditulis karena Firefox memudarkannya sekali lagi sendiri — tanpa itu contohnya nyaris tak terbaca di sana.

**Perataannya ikut menipu.** Kotak Nama akun memakai `.small-input`, yang **ditengahkan** — aturan itu ditulis untuk kotak **angka** (nomor dada, jumlah benar), tempat angka yang ditengahkan lebih mudah dibandingkan antar baris. Nama yang ditengahkan terbaca seperti judul, bukan seperti isian.

**Dan contohnya menunjuk baris nyata.** `pos1hrcd37` adalah nama akun yang **benar-benar ada** di tabel tepat di bawahnya — contoh seperti itu yang paling mudah disangka isi. `aji.furqon` jelas bentuk nama orang, dan tidak ada akun bernama begitu.

## Notes

Aturan `::placeholder` berlaku global, jadi ikut memperbaiki kotak cari, formulir pendaftaran mandiri di layar login, dan keempat kotak "Alasan" yang baru diberi contoh di #340.

Perataan kiri dikurung ke `.form-akun` saja — kotak nomor dada dan jumlah benar tetap di tengah, dan itu memang benar untuk angka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)