### PR TITLE
fix: contoh isian berawalan "misal:" dan warnanya lebih pucat

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -303,8 +303,14 @@ input.jam-ketik {
    mengetik apa pun, atau mengira akun itu sudah ada.
 
    `opacity: 1` wajib ikut: Firefox memberi contoh isian opasitasnya sendiri,
-   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca. */
-::placeholder { color: #9aa0a8; opacity: 1; }
+   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca.
+
+   Warnanya #adb3bb, bukan #5c5c5c (--tinta-lembut) yang dipakai keterangan.
+   Keterangan MEMANG untuk dibaca; contoh isian justru harus kalah menonjol
+   dari apa pun yang diketik di atasnya, karena satu-satunya kesalahan yang
+   bisa ia sebabkan adalah disangka sudah terisi. Awalan "misal:" di tiap
+   contoh menutup sisanya — warna saja bisa berbeda-beda antar layar HP. */
+::placeholder { color: #adb3bb; opacity: 1; }
 
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -192,7 +192,7 @@ function layarLogin(pesan) {
         <div class="field">
           <label for="d-u">Nama akun</label>
           <input type="text" id="d-u" autocomplete="username" autocapitalize="none"
-                 spellcheck="false" placeholder="aji.furqon">
+                 spellcheck="false" placeholder="misal: aji.furqon">
         </div>
         <div class="field">
           <label for="d-p">Password</label>
@@ -798,7 +798,7 @@ async function layarPembayaran() {
             <div class="nama">${b.sekolah?.name || kode}</div>
             <div class="detail">${kode} · kwitansi ${b.pembayaran?.nomor_kwitansi || "—"}</div>
           </div>`,
-          medan: [{ label: "Alasan pembatalan", contoh: "salah nominal" }],
+          medan: [{ label: "Alasan pembatalan", contoh: "misal: salah nominal" }],
           labelAksi: "Batalkan",
         });
         if (!jawab) return;
@@ -1101,7 +1101,7 @@ async function layarDaftarUlang() {
           medan: [
             { label: "Nomor lama (yang rusak)", tipe: "number" },
             { label: "Nomor pengganti (dari stok)", tipe: "number" },
-            { label: "Alasan", contoh: "kain sobek" },
+            { label: "Alasan", contoh: "misal: kain sobek" },
           ],
           labelAksi: "Tukar nomor",
         });
@@ -1523,7 +1523,7 @@ async function layarKeberangkatan() {
               : ""}</div>
           </div>`,
           medan: [{ label: "Alasan pemindahan",
-                   contoh: "terlambat, menyusul kloter berikutnya" }],
+                   contoh: "misal: terlambat, menyusul kloter berikutnya" }],
           labelAksi: "Pindahkan",
         });
         // Batal (atau gagal) mengembalikan select ke "—", kalau tidak ia
@@ -1582,7 +1582,7 @@ async function layarKeberangkatan() {
         medan: [
           { label: "Jam berangkat yang benar", tipe: "jam",
             nilai: jamMenit(info.jam_berangkat) },
-          { label: "Alasan koreksi", contoh: "salah input" },
+          { label: "Alasan koreksi", contoh: "misal: salah input" },
         ],
         labelAksi: "Simpan Koreksi",
       });
@@ -2923,7 +2923,7 @@ async function layarInputPos() {
     // sekali, sedangkan kalimatnya dibaca ulang setiap kali gembok dibuka.
     const jawab = await dialog({
       judul: `Buka Gembok No. Dada ${tiga}?`,
-      medan: [{ label: "Alasan membuka", contoh: "nilai semaphore salah ketik" }],
+      medan: [{ label: "Alasan membuka", contoh: "misal: nilai semaphore salah ketik" }],
       labelAksi: "Buka",
     });
     if (!jawab) return;
@@ -4839,7 +4839,7 @@ async function layarAkun() {
       <div class="form-akun">
         <div class="field"><label for="ak-nama">Nama akun</label>
           <input id="ak-nama" type="text" class="small-input" autocomplete="off"
-            placeholder="aji.furqon"></div>
+            placeholder="misal: aji.furqon"></div>
         <div class="field"><label for="ak-peran">Peran</label>
           <select id="ak-peran" class="select-small">${opsiPeran("registrasi")}</select></div>
         <div class="field" id="ak-pos-kotak" hidden><label for="ak-pos">Pos</label>

--- a/web/style.css
+++ b/web/style.css
@@ -303,8 +303,14 @@ input.jam-ketik {
    mengetik apa pun, atau mengira akun itu sudah ada.
 
    `opacity: 1` wajib ikut: Firefox memberi contoh isian opasitasnya sendiri,
-   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca. */
-::placeholder { color: #9aa0a8; opacity: 1; }
+   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca.
+
+   Warnanya #adb3bb, bukan #5c5c5c (--tinta-lembut) yang dipakai keterangan.
+   Keterangan MEMANG untuk dibaca; contoh isian justru harus kalah menonjol
+   dari apa pun yang diketik di atasnya, karena satu-satunya kesalahan yang
+   bisa ia sebabkan adalah disangka sudah terisi. Awalan "misal:" di tiap
+   contoh menutup sisanya — warna saja bisa berbeda-beda antar layar HP. */
+::placeholder { color: #adb3bb; opacity: 1; }
 
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }


### PR DESCRIPTION
## What

| | dari | jadi |
|---|---|---|
| Nama akun (2 tempat) | `aji.furqon` | **`misal: aji.furqon`** |
| Lima kotak Alasan | `salah nominal` | **`misal: salah nominal`** |
| warna contoh isian | `#9aa0a8` | **`#adb3bb`** |

## Why

Dua hal yang sama-sama menjawab satu pertanyaan: **apakah yang tertulis di kotak itu contoh, atau isi yang sudah ada.**

**Warna saja tidak cukup.** Ia berbeda-beda antar layar HP, dan di bawah matahari lapangan perbedaan pucat dan pekat nyaris hilang. Kata "misal:" tidak bisa disalahbaca oleh layar mana pun.

Dipasang di **tujuh** tempat, bukan satu. Kelima kotak Alasan kelas kebingungan yang sama — `nilai semaphore salah ketik` di kotak kosong berlabel "Alasan membuka" sama mudahnya disangka sudah terisi.

Warnanya sengaja **tidak** memakai `--tinta-lembut` (#5c5c5c) yang dipakai keterangan. Keterangan memang untuk dibaca; contoh isian justru harus kalah menonjol dari apa pun yang diketik di atasnya — satu-satunya kesalahan yang bisa ia sebabkan adalah disangka sudah terisi.

## Notes

**Yang tidak diberi awalan**, dan itu disengaja: `minimal 8 huruf` — itu aturan, bukan contoh — dan kotak cari yang isinya perintah (`Cari nomor dada / regu / organisasi…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)