### PR TITLE
fix: satu-satunya contoh isian yang masih pekat ikut dipucatkan

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -722,7 +722,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   padding: .45rem .6rem; border: 2px solid #9aa3ad; border-radius: 6px;
   font-size: .9rem; font-family: inherit; background: #fff; color: #1c2430;
 }
-.isi-filter .cari-filter::placeholder { color: #6b7480; }
+/* SATU-SATUNYA contoh isian yang dulu punya warnanya sendiri (#6b7480), dan
+   karena selektornya lebih khusus ia mengalahkan aturan global — jadi kotak
+   cari inilah satu-satunya yang contohnya masih pekat sesudah semuanya
+   dipucatkan. Dibuang, bukan disamakan angkanya: dua tempat menulis satu
+   keputusan adalah dua tempat yang suatu hari tidak sepakat. */
+
 .isi-filter .cari-filter:focus {
   outline: none; border-color: #00695c; box-shadow: 0 0 0 3px rgba(0,105,92,.18);
 }

--- a/web/style.css
+++ b/web/style.css
@@ -722,7 +722,12 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   padding: .45rem .6rem; border: 2px solid #9aa3ad; border-radius: 6px;
   font-size: .9rem; font-family: inherit; background: #fff; color: #1c2430;
 }
-.isi-filter .cari-filter::placeholder { color: #6b7480; }
+/* SATU-SATUNYA contoh isian yang dulu punya warnanya sendiri (#6b7480), dan
+   karena selektornya lebih khusus ia mengalahkan aturan global — jadi kotak
+   cari inilah satu-satunya yang contohnya masih pekat sesudah semuanya
+   dipucatkan. Dibuang, bukan disamakan angkanya: dua tempat menulis satu
+   keputusan adalah dua tempat yang suatu hari tidak sepakat. */
+
 .isi-filter .cari-filter:focus {
   outline: none; border-color: #00695c; box-shadow: 0 0 0 3px rgba(0,105,92,.18);
 }


### PR DESCRIPTION
## What

Kotak cari penyaring Organisasi di papan Live Score punya warna contohnya sendiri (`#6b7480`), dan **selektornya lebih khusus** daripada aturan global — jadi ia satu-satunya yang tidak ikut dipucatkan di #345.

Aturannya **dibuang**, bukan disamakan angkanya.

## Why

Dua tempat yang menulis satu keputusan adalah dua tempat yang suatu hari tidak sepakat — dan yang kalah selalu yang tidak dicari orang. Sekarang seluruh contoh isian di aplikasi mengambil warnanya dari satu baris:

```css
::placeholder { color: #adb3bb; opacity: 1; }
```

## Notes

**Yang sengaja tetap hitam:** contoh angka di blangko cetak — `.bl-nilai-contoh`, yang berbunyi "dalam DETIK · contoh: 47". Itu **kertas**, bukan layar, dan bagian 8.4 melarang abu-abu di sana: mesin fotokopi mengubah abu-abu jadi bintik yang hilang di salinan keempat. Di kertas, yang harus pelan dibuat **kecil dan hitam pekat**, bukan pucat.

Jadi "semua contoh isian pucat" berlaku untuk layar, dan aturan cetak tetap berlaku untuk kertas — dua tempat, dua alasan, dan keduanya sudah tertulis di bagiannya masing-masing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)