### PR TITLE
fix: contoh isian kembali hitam, "misal:" yang membedakannya

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,13 +229,16 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    itself**: the figure currently in force, the state of the data right now, a
    consequence that cannot be undone, a warning that something is already
    printed or has already departed.
-5. **Contoh isian ditulis "misal: …" dan dibiarkan pucat.** Kotak kosong yang
-   berisi `aji.furqon` atau `salah nominal` terbaca seperti isian yang SUDAH
-   terisi — petugas menekan tombolnya tanpa mengetik apa pun. Warnanya sudah
-   dijaga satu aturan `::placeholder` global, jadi yang tersisa jadi kebiasaan
-   cuma awalannya. Yang BUKAN contoh tidak diberi awalan itu: "minimal 8
-   huruf" adalah aturan, dan "Cari nomor dada / regu / organisasi…" adalah
-   perintah.
+5. **Contoh isian ditulis "misal: …", dan yang membedakannya KATA itu, bukan
+   warnanya.** Kotak kosong berisi `aji.furqon` terbaca seperti isian yang
+   sudah terisi — petugas menekan tombolnya tanpa mengetik apa pun. Jalan
+   pertama yang dicoba adalah memucatkannya, dan itu gagal di lapangan: abu-abu
+   muda di layar HP di bawah matahari nyaris tidak terbaca, dan contoh yang
+   tidak terbaca tidak mencegah kesalahan apa pun. Contohnya sekarang HITAM
+   seperti teks lain, dan "misal:" yang bekerja.
+
+   Yang BUKAN contoh tidak diberi awalan itu: "minimal 8 huruf" adalah aturan,
+   dan "Cari nomor dada / regu / organisasi…" adalah perintah.
 6. **The test when unsure** — if this sentence disappeared, could the officer
    make a mistake that costs something? If not, cut it. "They might not know
    how it works" is not a cost; they will after the first time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,13 +227,16 @@ Guidance for Claude Code when working in this repository.
    itself**: the figure currently in force, the state of the data right now, a
    consequence that cannot be undone, a warning that something is already
    printed or has already departed.
-5. **Contoh isian ditulis "misal: …" dan dibiarkan pucat.** Kotak kosong yang
-   berisi `aji.furqon` atau `salah nominal` terbaca seperti isian yang SUDAH
-   terisi — petugas menekan tombolnya tanpa mengetik apa pun. Warnanya sudah
-   dijaga satu aturan `::placeholder` global, jadi yang tersisa jadi kebiasaan
-   cuma awalannya. Yang BUKAN contoh tidak diberi awalan itu: "minimal 8
-   huruf" adalah aturan, dan "Cari nomor dada / regu / organisasi…" adalah
-   perintah.
+5. **Contoh isian ditulis "misal: …", dan yang membedakannya KATA itu, bukan
+   warnanya.** Kotak kosong berisi `aji.furqon` terbaca seperti isian yang
+   sudah terisi — petugas menekan tombolnya tanpa mengetik apa pun. Jalan
+   pertama yang dicoba adalah memucatkannya, dan itu gagal di lapangan: abu-abu
+   muda di layar HP di bawah matahari nyaris tidak terbaca, dan contoh yang
+   tidak terbaca tidak mencegah kesalahan apa pun. Contohnya sekarang HITAM
+   seperti teks lain, dan "misal:" yang bekerja.
+
+   Yang BUKAN contoh tidak diberi awalan itu: "minimal 8 huruf" adalah aturan,
+   dan "Cari nomor dada / regu / organisasi…" adalah perintah.
 6. **The test when unsure** — if this sentence disappeared, could the officer
    make a mistake that costs something? If not, cut it. "They might not know
    how it works" is not a cost; they will after the first time.

--- a/live/style.css
+++ b/live/style.css
@@ -295,22 +295,21 @@ input.jam-ketik {
   border-color: var(--bahaya);
   background: var(--bahaya-muda);
 }
-/* CONTOH ISIAN JAUH LEBIH PUCAT DARIPADA ISI SUNGGUHAN.
+/* CONTOH ISIAN HITAM, DAN YANG MEMBEDAKANNYA KATA "misal:".
 
-   Tanpa aturan ini yang berlaku warna bawaan browser — di sebagian Android ia
-   nyaris sepekat teks biasa, dan "aji.furqon" di kotak Nama akun terbaca
-   seperti nama yang SUDAH terisi. Petugas lalu menekan Buat Akun tanpa
-   mengetik apa pun, atau mengira akun itu sudah ada.
+   Sempat dipucatkan sampai #adb3bb dengan alasan yang masuk akal di meja:
+   contoh yang pekat terbaca seperti isian yang sudah terisi. Di lapangan
+   alasan itu kalah oleh yang lebih mendasar — abu-abu muda di layar HP di
+   bawah matahari nyaris tidak terbaca sama sekali, dan contoh yang tidak
+   terbaca tidak mencegah kesalahan apa pun.
 
-   `opacity: 1` wajib ikut: Firefox memberi contoh isian opasitasnya sendiri,
-   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca.
+   Yang menutup risiko awalnya bukan warna melainkan KATA: tiap contoh
+   berbunyi "misal: aji.furqon", dan itu tidak bisa disalahbaca oleh layar
+   mana pun, di cahaya apa pun (bagian 9.5).
 
-   Warnanya #adb3bb, bukan #5c5c5c (--tinta-lembut) yang dipakai keterangan.
-   Keterangan MEMANG untuk dibaca; contoh isian justru harus kalah menonjol
-   dari apa pun yang diketik di atasnya, karena satu-satunya kesalahan yang
-   bisa ia sebabkan adalah disangka sudah terisi. Awalan "misal:" di tiap
-   contoh menutup sisanya — warna saja bisa berbeda-beda antar layar HP. */
-::placeholder { color: #adb3bb; opacity: 1; }
+   `opacity: 1` tetap wajib: Firefox memberi contoh isian opasitasnya sendiri,
+   dan tanpa ini ia tetap pudar meski warnanya sudah pekat. */
+::placeholder { color: var(--tinta); opacity: 1; }
 
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }

--- a/web/style.css
+++ b/web/style.css
@@ -295,22 +295,21 @@ input.jam-ketik {
   border-color: var(--bahaya);
   background: var(--bahaya-muda);
 }
-/* CONTOH ISIAN JAUH LEBIH PUCAT DARIPADA ISI SUNGGUHAN.
+/* CONTOH ISIAN HITAM, DAN YANG MEMBEDAKANNYA KATA "misal:".
 
-   Tanpa aturan ini yang berlaku warna bawaan browser — di sebagian Android ia
-   nyaris sepekat teks biasa, dan "aji.furqon" di kotak Nama akun terbaca
-   seperti nama yang SUDAH terisi. Petugas lalu menekan Buat Akun tanpa
-   mengetik apa pun, atau mengira akun itu sudah ada.
+   Sempat dipucatkan sampai #adb3bb dengan alasan yang masuk akal di meja:
+   contoh yang pekat terbaca seperti isian yang sudah terisi. Di lapangan
+   alasan itu kalah oleh yang lebih mendasar — abu-abu muda di layar HP di
+   bawah matahari nyaris tidak terbaca sama sekali, dan contoh yang tidak
+   terbaca tidak mencegah kesalahan apa pun.
 
-   `opacity: 1` wajib ikut: Firefox memberi contoh isian opasitasnya sendiri,
-   dan tanpa ini warnanya dipudarkan dua kali sampai hampir tak terbaca.
+   Yang menutup risiko awalnya bukan warna melainkan KATA: tiap contoh
+   berbunyi "misal: aji.furqon", dan itu tidak bisa disalahbaca oleh layar
+   mana pun, di cahaya apa pun (bagian 9.5).
 
-   Warnanya #adb3bb, bukan #5c5c5c (--tinta-lembut) yang dipakai keterangan.
-   Keterangan MEMANG untuk dibaca; contoh isian justru harus kalah menonjol
-   dari apa pun yang diketik di atasnya, karena satu-satunya kesalahan yang
-   bisa ia sebabkan adalah disangka sudah terisi. Awalan "misal:" di tiap
-   contoh menutup sisanya — warna saja bisa berbeda-beda antar layar HP. */
-::placeholder { color: #adb3bb; opacity: 1; }
+   `opacity: 1` tetap wajib: Firefox memberi contoh isian opasitasnya sendiri,
+   dan tanpa ini ia tetap pudar meski warnanya sudah pekat. */
+::placeholder { color: var(--tinta); opacity: 1; }
 
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }


### PR DESCRIPTION
## What

`::placeholder` kembali ke warna teks biasa (`var(--tinta)`), turun dari `#adb3bb`.

## Why

Pemucatan itu masuk akal di meja dan **kalah di lapangan**: abu-abu muda di layar HP di bawah matahari nyaris tidak terbaca, dan contoh yang tidak terbaca tidak mencegah kesalahan apa pun.

Yang sebenarnya menutup risiko awalnya — contoh disangka isian yang sudah terisi — **bukan warna melainkan kata**. Tiap contoh berbunyi `misal: aji.furqon`, dan itu tidak bisa disalahbaca oleh layar mana pun, di cahaya apa pun. Warna cuma lapis kedua, dan lapis kedua yang mengorbankan keterbacaan bukan lapis kedua.

`opacity: 1` tetap ada: Firefox memudarkan contoh isian sendiri, dan tanpa itu ia tetap pudar meski warnanya sudah pekat.

## Notes

**Dua catatan ikut diluruskan, dan itu bukan kerapian.** Komentar di `style.css` dan butir 9.5 di `CLAUDE.md`/`AGENTS.md` dua-duanya menerangkan kenapa contoh isian **pucat**. Dibiarkan, keduanya jadi catatan yang berbohong tentang baris tepat di bawahnya — persis jenis komentar basi yang dibersihkan di #321 dan dilarang bagian 15.

Butir 9.5 sekarang menyimpan percobaannya juga, bukan cuma hasilnya: memucatkan sudah dicoba dan gagal karena alasan yang tidak kelihatan dari dalam ruangan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)