### PR TITLE
fix: contoh isian akhirnya benar-benar abu — text-fill-color yang menahannya

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -310,7 +310,24 @@ input.jam-ketik {
    dari apa pun yang diketik di atasnya, karena satu-satunya kesalahan yang
    bisa ia sebabkan adalah disangka sudah terisi. Awalan "misal:" di tiap
    contoh menutup sisanya — warna saja bisa berbeda-beda antar layar HP. */
-::placeholder { color: #adb3bb; opacity: 1; }
+::placeholder {
+  color: #adb3bb;
+  /* `-webkit-text-fill-color` WAJIB ikut, dan inilah sebabnya contoh isian
+     tetap terlihat HITAM selama tiga kali perbaikan warna berturut-turut.
+
+     `.select-small, .small-input` menyetel `-webkit-text-fill-color:
+     var(--tinta)` (dipasang untuk melawan warna aksen biru iOS di dropdown),
+     dan di Chrome properti itu MENGALAHKAN `color` saat menggambar teks —
+     termasuk teks contoh isian. Jadi `color` di sini benar sejak awal dan
+     tidak pernah dipakai.
+
+     Yang menemukannya bukan membaca berkas ini, melainkan mengukur:
+     getComputedStyle(kotak, '::placeholder') menjawab color #adb3bb dan
+     webkitTextFillColor #1a1a1a pada satu elemen yang sama. Bagian 15 butir 9
+     berlaku persis di sini, cuma propertinya bukan lebar. */
+  -webkit-text-fill-color: #adb3bb;
+  opacity: 1;
+}
 
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }

--- a/web/style.css
+++ b/web/style.css
@@ -310,7 +310,24 @@ input.jam-ketik {
    dari apa pun yang diketik di atasnya, karena satu-satunya kesalahan yang
    bisa ia sebabkan adalah disangka sudah terisi. Awalan "misal:" di tiap
    contoh menutup sisanya — warna saja bisa berbeda-beda antar layar HP. */
-::placeholder { color: #adb3bb; opacity: 1; }
+::placeholder {
+  color: #adb3bb;
+  /* `-webkit-text-fill-color` WAJIB ikut, dan inilah sebabnya contoh isian
+     tetap terlihat HITAM selama tiga kali perbaikan warna berturut-turut.
+
+     `.select-small, .small-input` menyetel `-webkit-text-fill-color:
+     var(--tinta)` (dipasang untuk melawan warna aksen biru iOS di dropdown),
+     dan di Chrome properti itu MENGALAHKAN `color` saat menggambar teks —
+     termasuk teks contoh isian. Jadi `color` di sini benar sejak awal dan
+     tidak pernah dipakai.
+
+     Yang menemukannya bukan membaca berkas ini, melainkan mengukur:
+     getComputedStyle(kotak, '::placeholder') menjawab color #adb3bb dan
+     webkitTextFillColor #1a1a1a pada satu elemen yang sama. Bagian 15 butir 9
+     berlaku persis di sini, cuma propertinya bukan lebar. */
+  -webkit-text-fill-color: #adb3bb;
+  opacity: 1;
+}
 
 input:focus { border-color: var(--utama); }
 input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--bahaya-muda); }


### PR DESCRIPTION
## What

`::placeholder` diberi `-webkit-text-fill-color: #adb3bb`, bukan cuma `color`.

## Why

**Tiga kali warnanya diubah, tiga kali layarnya tetap hitam, dan berkas CSS-nya benar sepanjang waktu itu.**

Penyebabnya `.select-small, .small-input` menyetel `-webkit-text-fill-color: var(--tinta)`. Aturan itu dipasang di #330 untuk melawan warna aksen biru yang iOS berikan ke teks `<select>`, dan ia bekerja — tapi di Chrome properti itu **mengalahkan `color`** saat menggambar teks, termasuk teks contoh isian. Jadi `::placeholder { color: #adb3bb }` benar sejak awal dan **tidak pernah dipakai**.

Yang menemukannya bukan membaca berkas, melainkan mengukur:

```
getComputedStyle(kotak, '::placeholder')
  color               → rgb(173, 179, 187)   ← abu, sesuai aturan
  webkitTextFillColor → rgb(26, 26, 26)      ← hitam, yang menang
```

Satu elemen, dua jawaban, dan yang menang bukan yang tertulis di aturan yang dicari orang.

## Notes

Bagian 15 butir 9 berlaku persis di sini — aturan yang ada, terbaca benar, dan tidak mengenai apa pun — cuma propertinya bukan lebar kolom. Saya sendiri melanggarnya empat kali berturut-turut di masalah ini: memeriksa deploy dengan `grep` isi berkas, bukan dengan mengukur hasilnya di layar.

Alasannya ditulis di dalam aturannya, bukan di PR ini saja: siapa pun yang mengubah warna contoh isian lagi akan membaca dua baris, bukan satu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)