### PR TITLE
feat: formulir masuk dan daftar bergantian, bukan bertumpuk

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3133,8 +3133,30 @@ input.small-input { text-align: center; }
 .daftar-panitia {
   margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--garis);
 }
+/* Yang HIJAU cuma kata yang bisa ditekan. Seluruh baris berwarna membuat
+   "Belum punya akun?" — sebuah pertanyaan, bukan tombol — ikut terbaca
+   seperti tautan, dan mata kehilangan petunjuk mana yang sebenarnya diklik. */
 .daftar-panitia > summary {
-  cursor: pointer; color: var(--utama); font-weight: 700; list-style: none;
+  cursor: pointer; color: var(--tinta); font-weight: 400; list-style: none;
+}
+.daftar-panitia > summary b,
+.daftar-panitia > summary .d-buka { color: var(--utama); font-weight: 700; }
+
+/* Tertutup: ajakan. Terbuka: jalan kembali ke formulir masuk. */
+.daftar-panitia .d-buka { display: none; }
+.daftar-panitia[open] .d-tutup { display: none; }
+.daftar-panitia[open] .d-buka { display: inline; }
+
+/* Formulir masuk MENGHILANG selama pendaftaran terbuka. Dua formulir
+   bertumpuk di satu kartu — dua kotak Password, dua tombol hijau — adalah cara
+   orang mengisi yang bawah lalu menekan yang atas.
+
+   `:has()` dipakai sebagai peningkatan yang boleh gagal: browser yang tidak
+   mendukungnya membuang aturan ini dan kembali ke tampilan sebelumnya, yang
+   juga bisa dipakai. */
+.card:has(.daftar-panitia[open]) .blok-masuk { display: none; }
+.card:has(.daftar-panitia[open]) .daftar-panitia {
+  margin-top: 0; padding-top: 0; border-top: 0;
 }
 .daftar-panitia > summary::-webkit-details-marker { display: none; }
 .daftar-panitia > summary::after { content: " ▾"; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -170,25 +170,39 @@ function layarLogin(pesan) {
   pasangKepala("Sistem Panitia");
   LAYAR.replaceChildren(h(`
     <div class="card" style="max-width:480px;margin:2rem auto">
-      <h2>Masuk Panitia</h2>
-      ${pesan ? `<div class="error" style="margin-top:.5rem">${esc(pesan)}</div>` : ""}
-      <div class="field" style="margin-top:1rem">
-        <label for="u">Username</label>
-        <input type="text" id="u" autocomplete="username" autocapitalize="none"
-               spellcheck="false">
+      <!-- Dibungkus supaya HILANG saat pendaftaran dibuka. Dua formulir
+           bertumpuk di satu kartu — dua kotak Password, dua tombol hijau —
+           adalah cara orang mengisi yang bawah lalu menekan yang atas. -->
+      <div class="blok-masuk">
+        <h2>Masuk Panitia</h2>
+        ${pesan ? `<div class="error" style="margin-top:.5rem">${esc(pesan)}</div>` : ""}
+        <div class="field" style="margin-top:1rem">
+          <label for="u">Username</label>
+          <input type="text" id="u" autocomplete="username" autocapitalize="none"
+                 spellcheck="false">
+        </div>
+        <div class="field">
+          <label for="p">Password</label>
+          <input type="password" id="p" autocomplete="current-password">
+        </div>
+        <button class="button button-primary" id="masuk" type="button">Masuk</button>
       </div>
-      <div class="field">
-        <label for="p">Password</label>
-        <input type="password" id="p" autocomplete="current-password">
-      </div>
-      <button class="button button-primary" id="masuk" type="button">Masuk</button>
 
       <!-- Pendaftaran DIGULUNG. Yang membuka layar ini ratusan kali adalah
            panitia yang sudah punya akun; formulir yang terbuka terus menaruh
            enam isian di antara mereka dan tombol Masuk. Yang mendaftar
            melakukannya sekali seumur edisi. -->
       <details class="daftar-panitia">
-        <summary>Belum punya akun? Daftar</summary>
+        <!-- Dua teks, satu ringkasan. Tertutup ia ajakan; terbuka ia
+             SATU-SATUNYA jalan kembali ke formulir masuk, jadi bunyinya
+             berubah jadi "Login". Ditulis di markup, bukan diganti
+             JavaScript: <details> sudah menyimpan keadaannya sendiri, dan
+             menyalinnya ke variabel lain berarti dua sumber untuk satu
+             pertanyaan. -->
+        <summary>
+          <span class="d-tutup">Belum punya akun? <b>Daftar</b></span>
+          <span class="d-buka">Login</span>
+        </summary>
         <div class="field">
           <label for="d-u">Nama akun</label>
           <input type="text" id="d-u" autocomplete="username" autocapitalize="none"
@@ -217,7 +231,7 @@ function layarLogin(pesan) {
              layar: akunnya belum hidup. Tanpa ini orang mendaftar, mencoba
              masuk, gagal, lalu mendaftar lagi dengan nama lain (bagian 9.4). -->
         <p class="keterangan">Akun baru dinyalakan admin dulu sebelum bisa dipakai.</p>
-        <button class="button" id="d-kirim" type="button">Daftar</button>
+        <button class="button button-primary" id="d-kirim" type="button">Daftar</button>
       </details>
     </div>
   `));
@@ -243,8 +257,8 @@ function layarLogin(pesan) {
     // Diperiksa di sini SEKALIPUN gateway juga memeriksanya — bukan sebagai
     // pagar, melainkan supaya salah ketik dijawab seketika alih-alih sesudah
     // satu perjalanan jaringan di sinyal lapangan.
-    if (!/^[a-z0-9._-]{3,40}$/.test(nama)) {
-      notif("Nama akun hanya huruf kecil, angka, titik, dan strip (3–40).", true);
+    if (!/^[a-z0-9._-]{5,40}$/.test(nama)) {
+      notif("Nama akun minimal 5 huruf: huruf kecil, angka, titik, dan strip.", true);
       return;
     }
     if (sandi.length < 8) { notif("Password minimal 8 huruf.", true); return; }

--- a/web/style.css
+++ b/web/style.css
@@ -3133,8 +3133,30 @@ input.small-input { text-align: center; }
 .daftar-panitia {
   margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--garis);
 }
+/* Yang HIJAU cuma kata yang bisa ditekan. Seluruh baris berwarna membuat
+   "Belum punya akun?" — sebuah pertanyaan, bukan tombol — ikut terbaca
+   seperti tautan, dan mata kehilangan petunjuk mana yang sebenarnya diklik. */
 .daftar-panitia > summary {
-  cursor: pointer; color: var(--utama); font-weight: 700; list-style: none;
+  cursor: pointer; color: var(--tinta); font-weight: 400; list-style: none;
+}
+.daftar-panitia > summary b,
+.daftar-panitia > summary .d-buka { color: var(--utama); font-weight: 700; }
+
+/* Tertutup: ajakan. Terbuka: jalan kembali ke formulir masuk. */
+.daftar-panitia .d-buka { display: none; }
+.daftar-panitia[open] .d-tutup { display: none; }
+.daftar-panitia[open] .d-buka { display: inline; }
+
+/* Formulir masuk MENGHILANG selama pendaftaran terbuka. Dua formulir
+   bertumpuk di satu kartu — dua kotak Password, dua tombol hijau — adalah cara
+   orang mengisi yang bawah lalu menekan yang atas.
+
+   `:has()` dipakai sebagai peningkatan yang boleh gagal: browser yang tidak
+   mendukungnya membuang aturan ini dan kembali ke tampilan sebelumnya, yang
+   juga bisa dipakai. */
+.card:has(.daftar-panitia[open]) .blok-masuk { display: none; }
+.card:has(.daftar-panitia[open]) .daftar-panitia {
+  margin-top: 0; padding-top: 0; border-top: 0;
 }
 .daftar-panitia > summary::-webkit-details-marker { display: none; }
 .daftar-panitia > summary::after { content: " ▾"; }

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -137,8 +137,11 @@ async function daftarPanitia(req, env, b) {
   const peran = String(b.peran || "").trim();
   const pos = b.pos === null || b.pos === undefined || b.pos === "" ? null : Number(b.pos);
 
-  if (!/^[a-z0-9._-]{3,40}$/.test(username))
-    return jawab(400, { message: "Nama akun hanya huruf kecil, angka, titik, dan strip (3–40)." }, req);
+  // Minimal LIMA, bukan tiga. Nama sependek "aji" tidak menyebut siapa pun di
+  // daftar berisi belasan akun, dan nama akun tidak bisa diganti sendiri oleh
+  // pemiliknya — hanya admin yang bisa.
+  if (!/^[a-z0-9._-]{5,40}$/.test(username))
+    return jawab(400, { message: "Nama akun minimal 5 huruf: huruf kecil, angka, titik, dan strip." }, req);
   if (password.length < 8)
     return jawab(400, { message: "Password minimal 8 huruf." }, req);
 


### PR DESCRIPTION
## What

```
tertutup                          terbuka
─────────────────────────         ─────────────────────────
Masuk Panitia                     Login            ← hijau, jalan kembali
[ Username ]                      Nama akun
[ Password ]                      [ misal: aji.furqon ]
[     Masuk     ]                 Password
Belum punya akun? Daftar          [ minimal 8 huruf ]
        ▲ hijau                   Tugas  [ Juri Pos ▾ ]
                                  [     Daftar     ]  ← hijau
```

1. Membuka pendaftaran **menyembunyikan** formulir masuk.
2. Ringkasannya berubah jadi **"Login"** saat terbuka.
3. Yang hijau **cuma kata yang bisa ditekan** — "Belum punya akun?" jadi teks biasa. Tombol Daftar jadi tombol utama.
4. Nama akun **minimal 5 huruf**, naik dari 3.

## Why

Dua formulir bertumpuk di satu kartu — **dua kotak Password, dua tombol hijau** — adalah cara orang mengisi yang bawah lalu menekan yang atas, lalu melihat "Username atau password salah" untuk akun yang memang belum ada.

Begitu formulir masuk hilang, ringkasan itu jadi **satu-satunya jalan kembali**; tanpa perubahan bunyinya, satu-satunya jalan keluar adalah memuat ulang halaman.

Seluruh baris berwarna membuat "Belum punya akun?" — sebuah **pertanyaan**, bukan tombol — ikut terbaca seperti tautan, dan mata kehilangan petunjuk mana yang sebenarnya diklik. Tombol Daftar dinaikkan jadi tombol utama karena begitu formulir masuk hilang ia satu-satunya aksi di kartu itu, dan tombol abu di posisi itu terbaca seperti tombol yang sedang dimatikan.

Nama sependek `aji` tidak menyebut siapa pun di daftar berisi belasan akun — dan nama akun **tidak bisa diganti sendiri** oleh pemiliknya, hanya admin yang bisa.

## Notes

Bunyi ringkasannya ditulis sebagai dua `<span>` di markup, bukan diganti JavaScript: `<details>` sudah menyimpan keadaannya sendiri, dan menyalinnya ke variabel lain berarti dua sumber untuk satu pertanyaan.

Batas 5 huruf dipasang di **klien dan gateway** — yang di klien untuk menjawab seketika tanpa perjalanan jaringan, yang di gateway yang benar-benar menahan.

`:has()` dipakai sebagai peningkatan yang boleh gagal: browser yang tidak mendukungnya menampilkan keduanya seperti sebelumnya — tetap bisa dipakai, cuma kurang rapi.

**Sesudah mendarat, jalankan `deploy-gateway.yml`** untuk batas 5 huruf di sisi server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)