### PR TITLE
feat: pergantian Masuk/Daftar dianimasikan, isian diperiksa saat diketik

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3126,44 +3126,69 @@ input.small-input { text-align: center; }
    "sudah dinonaktifkan" dan "belum pernah ada" tidak terlihat sama. */
 .matriks-hak tr.mati { opacity: .55; }
 
-/* Pendaftaran mandiri di layar login. Digulung, dan ringkasannya dibuat
-   terbaca sebagai tautan — ia satu-satunya jalan keluar dari layar ini bagi
-   orang yang belum punya akun, dan ringkasan <details> bawaan terbaca seperti
-   judul yang tidak bisa ditekan. */
-.daftar-panitia {
-  margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--garis);
+/* Masuk dan Daftar BERGANTIAN, dan pergantiannya dijalankan pelan.
+
+   `display: none` tidak bisa dianimasikan — itu sebabnya versi pertama
+   berganti dengan kedip. Yang bisa: tinggi dan kepekatan. Jadi kedua blok
+   selalu ada di DOM, dan yang sedang tidak dipakai disusutkan ke nol.
+
+   `max-height` dipakai, bukan `height`, karena tinggi isinya tidak diketahui
+   sampai digambar. 40rem cukup untuk formulir terpanjang di sini dan cukup
+   ketat supaya gerakannya tidak terasa menggantung menjelang akhir. */
+.blok-masuk, .panel-daftar { overflow: hidden; }
+.blok-masuk {
+  max-height: 40rem; opacity: 1;
+  transition: max-height .3s ease, opacity .22s ease;
 }
+/* Tertutup dari awal — dan `visibility` yang menjaganya tidak ikut ditekan
+   Tab. Isian setinggi nol tetap bisa difokus tanpa itu, dan kursor lompat ke
+   kotak yang tidak terlihat siapa pun. Transisinya 0 detik dengan JEDA,
+   supaya ia baru hilang sesudah menyusutnya selesai. */
+.panel-daftar {
+  max-height: 0; opacity: 0; visibility: hidden;
+  transition: max-height .3s ease, opacity .22s ease, visibility 0s .3s;
+}
+.card.mode-daftar .blok-masuk {
+  max-height: 0; opacity: 0; visibility: hidden;
+  transition: max-height .3s ease, opacity .22s ease, visibility 0s .3s;
+}
+.card.mode-daftar .panel-daftar {
+  max-height: 40rem; opacity: 1; visibility: visible;
+  transition: max-height .3s ease, opacity .22s ease .08s, visibility 0s;
+}
+
 /* Yang HIJAU cuma kata yang bisa ditekan. Seluruh baris berwarna membuat
    "Belum punya akun?" — sebuah pertanyaan, bukan tombol — ikut terbaca
    seperti tautan, dan mata kehilangan petunjuk mana yang sebenarnya diklik. */
-.daftar-panitia > summary {
-  cursor: pointer; color: var(--tinta); font-weight: 400; list-style: none;
+.ganti-mode {
+  display: block; width: 100%; text-align: left;
+  margin-top: 1.2rem; padding: 1rem 0 0;
+  border: 0; border-top: 1px solid var(--garis); background: none;
+  font: inherit; color: var(--tinta); cursor: pointer;
+  transition: margin .3s ease, padding .3s ease;
 }
-.daftar-panitia > summary b,
-.daftar-panitia > summary .d-buka { color: var(--utama); font-weight: 700; }
+.ganti-mode b, .ganti-mode .d-buka { color: var(--utama); font-weight: 700; }
+.ganti-mode .d-buka { display: none; }
+.ganti-mode .d-tutup::after { content: " ▾"; color: var(--utama); }
+.ganti-mode .d-buka::after { content: " ▴"; }
+.card.mode-daftar .ganti-mode .d-tutup { display: none; }
+.card.mode-daftar .ganti-mode .d-buka { display: inline; }
+/* Waktu formulir masuk sudah hilang, garis pemisahnya tidak memisahkan apa
+   pun — ia cuma garis menggantung di atas judul. */
+.card.mode-daftar .ganti-mode { margin-top: 0; border-top: 0; padding-top: 0; }
 
-/* Tertutup: ajakan. Terbuka: jalan kembali ke formulir masuk. */
-.daftar-panitia .d-buka { display: none; }
-.daftar-panitia[open] .d-tutup { display: none; }
-.daftar-panitia[open] .d-buka { display: inline; }
+.panel-daftar .field { margin-top: .8rem; }
+.panel-daftar select, .panel-daftar input { width: 100%; }
+.panel-daftar .button { width: 100%; margin-top: .4rem; }
 
-/* Formulir masuk MENGHILANG selama pendaftaran terbuka. Dua formulir
-   bertumpuk di satu kartu — dua kotak Password, dua tombol hijau — adalah cara
-   orang mengisi yang bawah lalu menekan yang atas.
-
-   `:has()` dipakai sebagai peningkatan yang boleh gagal: browser yang tidak
-   mendukungnya membuang aturan ini dan kembali ke tampilan sebelumnya, yang
-   juga bisa dipakai. */
-.card:has(.daftar-panitia[open]) .blok-masuk { display: none; }
-.card:has(.daftar-panitia[open]) .daftar-panitia {
-  margin-top: 0; padding-top: 0; border-top: 0;
+/* Yang meminta gerakan dikurangi memang meminta itu, bukan gerakan yang lebih
+   pelan. Perpindahannya jadi seketika, dan tidak ada yang hilang. */
+@media (prefers-reduced-motion: reduce) {
+  .blok-masuk, .panel-daftar, .ganti-mode,
+  .card.mode-daftar .blok-masuk, .card.mode-daftar .panel-daftar {
+    transition: none;
+  }
 }
-.daftar-panitia > summary::-webkit-details-marker { display: none; }
-.daftar-panitia > summary::after { content: " ▾"; }
-.daftar-panitia[open] > summary::after { content: " ▴"; }
-.daftar-panitia .field { margin-top: .8rem; }
-.daftar-panitia select, .daftar-panitia input { width: 100%; }
-.daftar-panitia .button { width: 100%; margin-top: .4rem; }
 
 /* Nama akun adalah tombol, tapi harus terbaca sebagai nama. */
 .tautan {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -188,21 +188,21 @@ function layarLogin(pesan) {
         <button class="button button-primary" id="masuk" type="button">Masuk</button>
       </div>
 
-      <!-- Pendaftaran DIGULUNG. Yang membuka layar ini ratusan kali adalah
-           panitia yang sudah punya akun; formulir yang terbuka terus menaruh
-           enam isian di antara mereka dan tombol Masuk. Yang mendaftar
-           melakukannya sekali seumur edisi. -->
-      <details class="daftar-panitia">
-        <!-- Dua teks, satu ringkasan. Tertutup ia ajakan; terbuka ia
-             SATU-SATUNYA jalan kembali ke formulir masuk, jadi bunyinya
-             berubah jadi "Login". Ditulis di markup, bukan diganti
-             JavaScript: <details> sudah menyimpan keadaannya sendiri, dan
-             menyalinnya ke variabel lain berarti dua sumber untuk satu
-             pertanyaan. -->
-        <summary>
-          <span class="d-tutup">Belum punya akun? <b>Daftar</b></span>
-          <span class="d-buka">Login</span>
-        </summary>
+      <!-- BUKAN <details>, dan itu keputusan yang dibayar sekali.
+           <details> menyembunyikan isinya sendiri sebelum CSS sempat ikut
+           campur, jadi tidak ada yang bisa dianimasikan: isinya lenyap dan
+           muncul seketika. Dengan tombol dan kelas biasa, kedua blok tetap
+           ada di DOM dan tingginya bisa dijalankan pelan.
+
+           Harganya: keadaannya sekarang disimpan di kelas `.mode-daftar` pada
+           kartunya, bukan di atribut bawaan browser. Satu tempat, dan tombol
+           di bawah ini satu-satunya yang mengubahnya. -->
+      <button type="button" class="ganti-mode" id="ganti-mode"
+              aria-expanded="false" aria-controls="panel-daftar">
+        <span class="d-tutup">Belum punya akun? <b>Daftar</b></span>
+        <span class="d-buka">Login</span>
+      </button>
+      <div class="panel-daftar" id="panel-daftar">
         <div class="field">
           <label for="d-u">Nama akun</label>
           <input type="text" id="d-u" autocomplete="username" autocapitalize="none"
@@ -211,7 +211,7 @@ function layarLogin(pesan) {
         <div class="field">
           <label for="d-p">Password</label>
           <input type="password" id="d-p" autocomplete="new-password"
-                 placeholder="minimal 8 huruf">
+                 placeholder="minimal 8 karakter">
         </div>
         <div class="field">
           <label for="d-peran">Tugas</label>
@@ -225,18 +225,56 @@ function layarLogin(pesan) {
         <div class="field" id="d-pos-kotak">
           <label for="d-pos">Pos</label>
           <input type="number" id="d-pos" class="small-input" inputmode="numeric"
-                 min="1" max="20" placeholder="3">
+                 min="1" max="20" placeholder="misal: 3">
         </div>
         <!-- Satu kalimat, dan ia membawa fakta yang TIDAK bisa dibaca dari
              layar: akunnya belum hidup. Tanpa ini orang mendaftar, mencoba
              masuk, gagal, lalu mendaftar lagi dengan nama lain (bagian 9.4). -->
         <p class="keterangan">Akun baru dinyalakan admin dulu sebelum bisa dipakai.</p>
         <button class="button button-primary" id="d-kirim" type="button">Daftar</button>
-      </details>
+      </div>
     </div>
   `));
   const u = document.getElementById("u");
   u.focus();
+
+  /* Berganti antara Masuk dan Daftar. Kelasnya di KARTU, bukan di panelnya:
+     yang berubah dua blok sekaligus — satu menyusut, satu tumbuh — dan dua
+     kelas untuk satu keadaan adalah dua kelas yang suatu hari tidak sepakat. */
+  const kartu = LAYAR.querySelector(".card");
+  const tombolGanti = document.getElementById("ganti-mode");
+  tombolGanti.addEventListener("click", () => {
+    const daftar = kartu.classList.toggle("mode-daftar");
+    tombolGanti.setAttribute("aria-expanded", String(daftar));
+    // Fokus dipindahkan ke isian pertama yang baru terlihat. Tanpa ini, di HP
+    // panelnya terbuka di bawah jempol sementara kursor masih di kotak yang
+    // sudah tidak ada.
+    setTimeout(() => (daftar ? document.getElementById("d-u") : u).focus(), 260);
+  });
+
+  /* PERIKSA SAAT DIKETIK, bukan saat dikirim. Nama akun dan password punya
+     syarat yang tidak bisa ditebak dari kotaknya, dan menahannya sampai tombol
+     ditekan berarti orang mengetik seluruh formulir dulu baru diberi tahu
+     yang pertama salah.
+
+     `aria-invalid` yang dipakai, bukan kelas sendiri: aturan merahnya sudah
+     ada di style.css untuk seluruh isian, dan pembaca layar ikut
+     mengumumkannya tanpa tambahan apa pun. */
+  const SAH_NAMA = /^[a-z0-9]{5,40}$/;
+  // Password BEBAS simbol — yang dibatasi cuma panjangnya. Membatasi
+  // hurufnya cuma memperkecil kemungkinan yang harus ditebak orang lain,
+  // dan tidak menolong siapa pun di sini.
+  const SAH_SANDI = /^.{8,}$/;
+  const periksa = (el, sah) => {
+    const isi = el.value.trim();
+    // Kotak KOSONG bukan kotak salah. Memerahkannya sebelum satu huruf pun
+    // diketik membuat formulir terlihat rusak saat baru dibuka.
+    el.setAttribute("aria-invalid", isi === "" ? "false" : String(!sah(isi)));
+  };
+  const dU = document.getElementById("d-u");
+  const dP = document.getElementById("d-p");
+  dU.addEventListener("input", () => periksa(dU, v => SAH_NAMA.test(v.toLowerCase())));
+  dP.addEventListener("input", () => periksa(dP, v => SAH_SANDI.test(v)));
 
   /* Kotak Pos hanya untuk Juri Pos — itu check constraint di database
      (0058), bukan selera: peran lain WAJIB berpos kosong, dan Koordinator Pos
@@ -257,11 +295,14 @@ function layarLogin(pesan) {
     // Diperiksa di sini SEKALIPUN gateway juga memeriksanya — bukan sebagai
     // pagar, melainkan supaya salah ketik dijawab seketika alih-alih sesudah
     // satu perjalanan jaringan di sinyal lapangan.
-    if (!/^[a-z0-9._-]{5,40}$/.test(nama)) {
-      notif("Nama akun minimal 5 huruf: huruf kecil, angka, titik, dan strip.", true);
-      return;
+    if (!SAH_NAMA.test(nama)) {
+      notif("Nama akun minimal 5, huruf dan angka saja.", true);
+      dU.focus(); return;
     }
-    if (sandi.length < 8) { notif("Password minimal 8 huruf.", true); return; }
+    if (!SAH_SANDI.test(sandi)) {
+      notif("Password minimal 8 karakter.", true);
+      dP.focus(); return;
+    }
     if (perluPos() && !pos) { notif("Juri pos harus menyebut posnya.", true); return; }
 
     btn.disabled = true; btn.textContent = "Mengirim…";

--- a/web/style.css
+++ b/web/style.css
@@ -3126,44 +3126,69 @@ input.small-input { text-align: center; }
    "sudah dinonaktifkan" dan "belum pernah ada" tidak terlihat sama. */
 .matriks-hak tr.mati { opacity: .55; }
 
-/* Pendaftaran mandiri di layar login. Digulung, dan ringkasannya dibuat
-   terbaca sebagai tautan — ia satu-satunya jalan keluar dari layar ini bagi
-   orang yang belum punya akun, dan ringkasan <details> bawaan terbaca seperti
-   judul yang tidak bisa ditekan. */
-.daftar-panitia {
-  margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--garis);
+/* Masuk dan Daftar BERGANTIAN, dan pergantiannya dijalankan pelan.
+
+   `display: none` tidak bisa dianimasikan — itu sebabnya versi pertama
+   berganti dengan kedip. Yang bisa: tinggi dan kepekatan. Jadi kedua blok
+   selalu ada di DOM, dan yang sedang tidak dipakai disusutkan ke nol.
+
+   `max-height` dipakai, bukan `height`, karena tinggi isinya tidak diketahui
+   sampai digambar. 40rem cukup untuk formulir terpanjang di sini dan cukup
+   ketat supaya gerakannya tidak terasa menggantung menjelang akhir. */
+.blok-masuk, .panel-daftar { overflow: hidden; }
+.blok-masuk {
+  max-height: 40rem; opacity: 1;
+  transition: max-height .3s ease, opacity .22s ease;
 }
+/* Tertutup dari awal — dan `visibility` yang menjaganya tidak ikut ditekan
+   Tab. Isian setinggi nol tetap bisa difokus tanpa itu, dan kursor lompat ke
+   kotak yang tidak terlihat siapa pun. Transisinya 0 detik dengan JEDA,
+   supaya ia baru hilang sesudah menyusutnya selesai. */
+.panel-daftar {
+  max-height: 0; opacity: 0; visibility: hidden;
+  transition: max-height .3s ease, opacity .22s ease, visibility 0s .3s;
+}
+.card.mode-daftar .blok-masuk {
+  max-height: 0; opacity: 0; visibility: hidden;
+  transition: max-height .3s ease, opacity .22s ease, visibility 0s .3s;
+}
+.card.mode-daftar .panel-daftar {
+  max-height: 40rem; opacity: 1; visibility: visible;
+  transition: max-height .3s ease, opacity .22s ease .08s, visibility 0s;
+}
+
 /* Yang HIJAU cuma kata yang bisa ditekan. Seluruh baris berwarna membuat
    "Belum punya akun?" — sebuah pertanyaan, bukan tombol — ikut terbaca
    seperti tautan, dan mata kehilangan petunjuk mana yang sebenarnya diklik. */
-.daftar-panitia > summary {
-  cursor: pointer; color: var(--tinta); font-weight: 400; list-style: none;
+.ganti-mode {
+  display: block; width: 100%; text-align: left;
+  margin-top: 1.2rem; padding: 1rem 0 0;
+  border: 0; border-top: 1px solid var(--garis); background: none;
+  font: inherit; color: var(--tinta); cursor: pointer;
+  transition: margin .3s ease, padding .3s ease;
 }
-.daftar-panitia > summary b,
-.daftar-panitia > summary .d-buka { color: var(--utama); font-weight: 700; }
+.ganti-mode b, .ganti-mode .d-buka { color: var(--utama); font-weight: 700; }
+.ganti-mode .d-buka { display: none; }
+.ganti-mode .d-tutup::after { content: " ▾"; color: var(--utama); }
+.ganti-mode .d-buka::after { content: " ▴"; }
+.card.mode-daftar .ganti-mode .d-tutup { display: none; }
+.card.mode-daftar .ganti-mode .d-buka { display: inline; }
+/* Waktu formulir masuk sudah hilang, garis pemisahnya tidak memisahkan apa
+   pun — ia cuma garis menggantung di atas judul. */
+.card.mode-daftar .ganti-mode { margin-top: 0; border-top: 0; padding-top: 0; }
 
-/* Tertutup: ajakan. Terbuka: jalan kembali ke formulir masuk. */
-.daftar-panitia .d-buka { display: none; }
-.daftar-panitia[open] .d-tutup { display: none; }
-.daftar-panitia[open] .d-buka { display: inline; }
+.panel-daftar .field { margin-top: .8rem; }
+.panel-daftar select, .panel-daftar input { width: 100%; }
+.panel-daftar .button { width: 100%; margin-top: .4rem; }
 
-/* Formulir masuk MENGHILANG selama pendaftaran terbuka. Dua formulir
-   bertumpuk di satu kartu — dua kotak Password, dua tombol hijau — adalah cara
-   orang mengisi yang bawah lalu menekan yang atas.
-
-   `:has()` dipakai sebagai peningkatan yang boleh gagal: browser yang tidak
-   mendukungnya membuang aturan ini dan kembali ke tampilan sebelumnya, yang
-   juga bisa dipakai. */
-.card:has(.daftar-panitia[open]) .blok-masuk { display: none; }
-.card:has(.daftar-panitia[open]) .daftar-panitia {
-  margin-top: 0; padding-top: 0; border-top: 0;
+/* Yang meminta gerakan dikurangi memang meminta itu, bukan gerakan yang lebih
+   pelan. Perpindahannya jadi seketika, dan tidak ada yang hilang. */
+@media (prefers-reduced-motion: reduce) {
+  .blok-masuk, .panel-daftar, .ganti-mode,
+  .card.mode-daftar .blok-masuk, .card.mode-daftar .panel-daftar {
+    transition: none;
+  }
 }
-.daftar-panitia > summary::-webkit-details-marker { display: none; }
-.daftar-panitia > summary::after { content: " ▾"; }
-.daftar-panitia[open] > summary::after { content: " ▴"; }
-.daftar-panitia .field { margin-top: .8rem; }
-.daftar-panitia select, .daftar-panitia input { width: 100%; }
-.daftar-panitia .button { width: 100%; margin-top: .4rem; }
 
 /* Nama akun adalah tombol, tapi harus terbaca sebagai nama. */
 .tautan {

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -137,13 +137,21 @@ async function daftarPanitia(req, env, b) {
   const peran = String(b.peran || "").trim();
   const pos = b.pos === null || b.pos === undefined || b.pos === "" ? null : Number(b.pos);
 
-  // Minimal LIMA, bukan tiga. Nama sependek "aji" tidak menyebut siapa pun di
-  // daftar berisi belasan akun, dan nama akun tidak bisa diganti sendiri oleh
-  // pemiliknya — hanya admin yang bisa.
-  if (!/^[a-z0-9._-]{5,40}$/.test(username))
-    return jawab(400, { message: "Nama akun minimal 5 huruf: huruf kecil, angka, titik, dan strip." }, req);
+  /* HURUF DAN ANGKA SAJA, minimal lima. Nama sependek "aji" tidak menyebut
+     siapa pun di daftar berisi belasan akun, dan nama akun tidak bisa diganti
+     sendiri oleh pemiliknya — hanya admin yang bisa.
+
+     Titik dan strip TIDAK diterima di pintu ini, sementara akun yang dibuat
+     admin (buatAkun di bawah) masih boleh memakainya — `admin.ciradyka` dan
+     `meja1hrcd37` lahir dari sana. Dua aturan untuk dua pintu memang tidak
+     rapi, tapi menyeragamkannya berarti salah satu dari dua: menolak nama
+     yang sudah dipakai orang, atau melonggarkan pintu yang tidak dijaga
+     siapa pun. */
+  if (!/^[a-z0-9]{5,40}$/.test(username))
+    return jawab(400, { message: "Nama akun minimal 5, huruf dan angka saja." }, req);
+  // Password BEBAS simbol; yang dibatasi cuma panjangnya.
   if (password.length < 8)
-    return jawab(400, { message: "Password minimal 8 huruf." }, req);
+    return jawab(400, { message: "Password minimal 8 karakter." }, req);
 
   // `admin` sengaja TIDAK ada di daftar ini. Kalau suatu hari peran baru
   // ditambahkan, ia harus ditulis di sini juga — dan kalau lupa, yang terjadi


### PR DESCRIPTION
## What

1. **Pergantian Masuk ↔ Daftar dijalankan pelan** (0,3 detik), bukan berganti seketika.
2. **Nama akun dan password diperiksa saat diketik** — merah begitu isinya belum memenuhi syarat, bukan menunggu tombol ditekan.
3. **Nama akun: huruf dan angka saja, minimal 5.** **Password: minimal 8 karakter, simbol boleh.**
4. Contoh isian Pos jadi `misal: 3`.

## Why

**`display: none` tidak bisa dianimasikan** — itu sebabnya versi pertama berganti dengan kedip. Yang bisa dijalankan pelan: tinggi dan kepekatan.

Karena itu `<details>` **diganti tombol biasa**: `<details>` menyembunyikan isinya sendiri sebelum CSS sempat ikut campur, jadi tidak ada yang tersisa untuk dianimasikan. Sekarang kedua blok selalu ada di DOM dan yang tidak dipakai disusutkan ke nol.

**Diperiksa saat diketik, bukan saat dikirim.** Nama akun dan password punya syarat yang tidak bisa ditebak dari kotaknya; menahannya sampai tombol ditekan berarti orang mengetik seluruh formulir dulu baru diberi tahu yang pertama salah. Kotak **kosong tidak dimerahkan** — memerahkannya sebelum satu huruf pun diketik membuat formulir terlihat rusak saat baru dibuka.

## Notes

**`visibility` ikut dianimasikan dengan jeda**, bukan diabaikan: isian setinggi nol tetap bisa difokus Tab, dan kursor lompat ke kotak yang tidak terlihat siapa pun. Yang meminta `prefers-reduced-motion` mendapat perpindahan seketika — mereka memang meminta itu, bukan gerakan yang lebih pelan.

Merahnya lewat `aria-invalid`, bukan kelas sendiri: aturannya sudah ada di `style.css` untuk seluruh isian, dan pembaca layar ikut mengumumkannya tanpa tambahan apa pun.

**Password sengaja tidak dibatasi hurufnya** — membatasinya cuma memperkecil kemungkinan yang harus ditebak orang lain.

**Titik dan strip tidak diterima di pintu pendaftaran**, sementara akun yang dibuat admin masih boleh memakainya (`admin.ciradyka` lahir dari sana). Dua aturan untuk dua pintu memang tidak rapi, dan menyeragamkannya berarti salah satu dari dua: menolak nama yang sudah dipakai orang, atau melonggarkan pintu yang tidak dijaga siapa pun.

**Sesudah mendarat, jalankan `deploy-gateway.yml`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)