### PR TITLE
fix: layar login mati karena backtick di dalam komentar HTML

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -194,9 +194,16 @@ function layarLogin(pesan) {
            muncul seketika. Dengan tombol dan kelas biasa, kedua blok tetap
            ada di DOM dan tingginya bisa dijalankan pelan.
 
-           Harganya: keadaannya sekarang disimpan di kelas `.mode-daftar` pada
+           Harganya: keadaannya sekarang disimpan di kelas "mode-daftar" pada
            kartunya, bukan di atribut bawaan browser. Satu tempat, dan tombol
-           di bawah ini satu-satunya yang mengubahnya. -->
+           di bawah ini satu-satunya yang mengubahnya.
+
+           TANPA BACKTICK DI KOMENTAR INI. Seluruh markup layar login duduk di
+           dalam sebuah template literal, jadi satu backtick di sini menutup
+           string itu dan sisa kalimatnya dibaca sebagai KODE. Itu persis yang
+           terjadi sekali: layar login berhenti di "Memuat..." dengan
+           "ReferenceError: daftar is not defined", dan pemeriksaan sintaks
+           tetap hijau karena hasilnya kebetulan JavaScript yang sah. -->
       <button type="button" class="ganti-mode" id="ganti-mode"
               aria-expanded="false" aria-controls="panel-daftar">
         <span class="d-tutup">Belum punya akun? <b>Daftar</b></span>


### PR DESCRIPTION
## What

Layar login berhenti di **"Memuat…"** untuk semua orang yang belum masuk. Konsolnya: `ReferenceError: daftar is not defined`.

Penyebabnya satu backtick di komentar HTML.

## Why

Seluruh markup layar login duduk di dalam **satu template literal**. Komentar HTML yang saya tulis di dalamnya menyebut nama kelas dengan backtick — dan backtick pertama **menutup template itu**, lalu sisa kalimatnya dibaca sebagai kode: `.mode-daftar` jadi rangkaian akses properti, dan `daftar` jadi identifier yang tidak ada.

**Yang membuatnya lolos: hasilnya kebetulan JavaScript yang sah.** Pemeriksaan sintaks hijau, saya kirim, dan yang rusak baru terlihat saat layarnya benar-benar digambar — yaitu **hanya oleh orang yang tidak punya sesi**. Saya sedang login, jadi tidak pernah melewatinya.

## Notes

Larangannya ditulis di tempat kejadian: komentar di dalam markup itu sekarang menyebut aturannya sendiri, supaya yang menambah komentar berikutnya tidak mengulanginya.

Diuji dengan **mengeksekusi templatenya** di Node dan memeriksa lima penanda markup benar-benar keluar (`id="ganti-mode"`, `class="panel-daftar"`, `class="blok-masuk"`, `misal: 3`, `minimal 8 karakter`) — bukan cuma memastikan berkasnya bisa diparse. Itu bedanya dengan pemeriksaan yang meloloskan bug ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)