### PR TITLE
fix: nama akun boleh pakai titik — aji.furqon

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -267,7 +267,13 @@ function layarLogin(pesan) {
      `aria-invalid` yang dipakai, bukan kelas sendiri: aturan merahnya sudah
      ada di style.css untuk seluruh isian, dan pembaca layar ikut
      mengumumkannya tanpa tambahan apa pun. */
-  const SAH_NAMA = /^[a-z0-9]{5,40}$/;
+  /* Huruf, angka, dan TITIK — `aji.furqon`. Titiknya hanya boleh MEMISAHKAN,
+     tidak di ujung dan tidak dua kali berturut-turut: nama yang berbunyi
+     "....." lolos pola yang lebih longgar, lalu dipakai membentuk alamat
+     surel akun dan ditolak penyedia auth dengan pesan yang tidak menyebut
+     titik sama sekali. */
+  const SAH_NAMA = /^[a-z0-9]+(?:\.[a-z0-9]+)*$/;
+  const namaSah = (v) => v.length >= 5 && v.length <= 40 && SAH_NAMA.test(v);
   // Password BEBAS simbol — yang dibatasi cuma panjangnya. Membatasi
   // hurufnya cuma memperkecil kemungkinan yang harus ditebak orang lain,
   // dan tidak menolong siapa pun di sini.
@@ -280,7 +286,7 @@ function layarLogin(pesan) {
   };
   const dU = document.getElementById("d-u");
   const dP = document.getElementById("d-p");
-  dU.addEventListener("input", () => periksa(dU, v => SAH_NAMA.test(v.toLowerCase())));
+  dU.addEventListener("input", () => periksa(dU, v => namaSah(v.toLowerCase())));
   dP.addEventListener("input", () => periksa(dP, v => SAH_SANDI.test(v)));
 
   /* Kotak Pos hanya untuk Juri Pos — itu check constraint di database
@@ -302,8 +308,8 @@ function layarLogin(pesan) {
     // Diperiksa di sini SEKALIPUN gateway juga memeriksanya — bukan sebagai
     // pagar, melainkan supaya salah ketik dijawab seketika alih-alih sesudah
     // satu perjalanan jaringan di sinyal lapangan.
-    if (!SAH_NAMA.test(nama)) {
-      notif("Nama akun minimal 5, huruf dan angka saja.", true);
+    if (!namaSah(nama)) {
+      notif("Nama akun minimal 5: huruf, angka, dan titik.", true);
       dU.focus(); return;
     }
     if (!SAH_SANDI.test(sandi)) {

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -137,18 +137,20 @@ async function daftarPanitia(req, env, b) {
   const peran = String(b.peran || "").trim();
   const pos = b.pos === null || b.pos === undefined || b.pos === "" ? null : Number(b.pos);
 
-  /* HURUF DAN ANGKA SAJA, minimal lima. Nama sependek "aji" tidak menyebut
-     siapa pun di daftar berisi belasan akun, dan nama akun tidak bisa diganti
-     sendiri oleh pemiliknya — hanya admin yang bisa.
+  /* HURUF, ANGKA, DAN TITIK — minimal lima. Bentuk yang dipakai panitia
+     sendiri: `aji.furqon`, `admin.ciradyka`.
 
-     Titik dan strip TIDAK diterima di pintu ini, sementara akun yang dibuat
-     admin (buatAkun di bawah) masih boleh memakainya — `admin.ciradyka` dan
-     `meja1hrcd37` lahir dari sana. Dua aturan untuk dua pintu memang tidak
-     rapi, tapi menyeragamkannya berarti salah satu dari dua: menolak nama
-     yang sudah dipakai orang, atau melonggarkan pintu yang tidak dijaga
-     siapa pun. */
-  if (!/^[a-z0-9]{5,40}$/.test(username))
-    return jawab(400, { message: "Nama akun minimal 5, huruf dan angka saja." }, req);
+     Titiknya hanya boleh MEMISAHKAN, tidak di ujung dan tidak dua kali
+     berturut-turut. Nama yang berbunyi "....." lolos pola yang lebih longgar,
+     lalu dipakai membentuk alamat surel akun dan ditolak penyedia auth dengan
+     pesan yang tidak menyebut titik sama sekali.
+
+     Minimal LIMA: nama sependek "aji" tidak menyebut siapa pun di daftar
+     berisi belasan akun, dan nama akun tidak bisa diganti sendiri oleh
+     pemiliknya — hanya admin yang bisa. */
+  if (username.length < 5 || username.length > 40 ||
+      !/^[a-z0-9]+(?:\.[a-z0-9]+)*$/.test(username))
+    return jawab(400, { message: "Nama akun minimal 5: huruf, angka, dan titik." }, req);
   // Password BEBAS simbol; yang dibatasi cuma panjangnya.
   if (password.length < 8)
     return jawab(400, { message: "Password minimal 8 karakter." }, req);


### PR DESCRIPTION
## What

Nama akun menerima **huruf, angka, dan titik**, minimal 5 — bukan huruf-dan-angka-saja.

## Why

`aji.furqon` adalah bentuk yang dipakai panitia sendiri, dan `admin.ciradyka` sudah ada di daftar. Aturan sebelumnya menolak keduanya — sekaligus menolak **contoh isian yang tertulis di kotaknya sendiri**.

Titiknya hanya boleh **memisahkan**: tidak di ujung, tidak dua kali berturut-turut. Nama yang berbunyi `.....` lolos pola yang lebih longgar, lalu dipakai membentuk alamat surel akun dan ditolak penyedia auth dengan pesan yang tidak menyebut titik sama sekali — penolakan yang tidak bisa dimengerti pendaftar.

## Notes

Sepuluh bentuk diuji, dan pola yang sama persis dipakai di klien dan di gateway:

| diterima | ditolak |
|---|---|
| `aji.furqon` | `aji..furqon` |
| `admin.ciradyka` | `.ajifurqon` |
| `ajifurqon` | `ajifurqon.` |
| `pos1hrcd37` | `.....` |
| | `tkda` (4 huruf) |
| | `aji_furqon` |

Komentar di gateway yang menerangkan kenapa titik **ditolak** ikut diganti — ia sudah tidak benar sejak baris di bawahnya berubah.

**Sesudah mendarat, jalankan `deploy-gateway.yml`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)