### PR TITLE
fix: cincin fokus tidak lagi terpotong, dan kotak isian berhenti tersendat

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3135,7 +3135,12 @@ input.small-input { text-align: center; }
    `max-height` dipakai, bukan `height`, karena tinggi isinya tidak diketahui
    sampai digambar. 40rem cukup untuk formulir terpanjang di sini dan cukup
    ketat supaya gerakannya tidak terasa menggantung menjelang akhir. */
-.blok-masuk, .panel-daftar { overflow: hidden; }
+/* `overflow` DIATUR JavaScript, bukan di sini — lihat bergerak() di app.js.
+   Ia hanya boleh `hidden` selama gerakannya berlangsung: kalau ia menempel
+   sesudahnya, cincin fokus kotak isian di dalamnya terpotong di tepi, dan
+   browser HP terasa tersendat tiap kali kotaknya disentuh. Yang tertulis di
+   sini cuma keadaan awal untuk panel yang memang tertutup. */
+.panel-daftar { overflow: hidden; }
 .blok-masuk {
   max-height: 40rem; opacity: 1;
   transition: max-height .3s ease, opacity .22s ease;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -250,9 +250,34 @@ function layarLogin(pesan) {
      kelas untuk satu keadaan adalah dua kelas yang suatu hari tidak sepakat. */
   const kartu = LAYAR.querySelector(".card");
   const tombolGanti = document.getElementById("ganti-mode");
+  const blokMasuk = LAYAR.querySelector(".blok-masuk");
+  const panelDaftar = document.getElementById("panel-daftar");
+
+  /* `overflow: hidden` HANYA selama bergerak, tidak sesudahnya.
+
+     Ia wajib ada saat menyusut dan tumbuh — tanpa itu isinya tumpah keluar
+     kotak setinggi nol dan animasinya tidak menyembunyikan apa pun. Tapi
+     kalau ia tetap menempel sesudah gerakannya selesai, dua hal rusak di
+     kotak isian di dalamnya: cincin fokus birunya TERPOTONG di tepi, dan
+     browser HP yang menggeser isian ke dalam wadah terpotong terasa
+     tersendat sepersekian detik tiap kali kotak disentuh.
+
+     Jadi ia dipasang saat pergantian dimulai dan dilepas begitu selesai. */
+  const bergerak = (ms = 340) => {
+    blokMasuk.style.overflow = "hidden";
+    panelDaftar.style.overflow = "hidden";
+    setTimeout(() => {
+      const terbuka = kartu.classList.contains("mode-daftar") ? panelDaftar : blokMasuk;
+      terbuka.style.overflow = "visible";
+    }, ms);
+  };
+  // Keadaan awal: yang terbuka sudah diam, jadi ia tidak perlu menunggu.
+  blokMasuk.style.overflow = "visible";
+
   tombolGanti.addEventListener("click", () => {
     const daftar = kartu.classList.toggle("mode-daftar");
     tombolGanti.setAttribute("aria-expanded", String(daftar));
+    bergerak();
     // Fokus dipindahkan ke isian pertama yang baru terlihat. Tanpa ini, di HP
     // panelnya terbuka di bawah jempol sementara kursor masih di kotak yang
     // sudah tidak ada.

--- a/web/style.css
+++ b/web/style.css
@@ -3135,7 +3135,12 @@ input.small-input { text-align: center; }
    `max-height` dipakai, bukan `height`, karena tinggi isinya tidak diketahui
    sampai digambar. 40rem cukup untuk formulir terpanjang di sini dan cukup
    ketat supaya gerakannya tidak terasa menggantung menjelang akhir. */
-.blok-masuk, .panel-daftar { overflow: hidden; }
+/* `overflow` DIATUR JavaScript, bukan di sini — lihat bergerak() di app.js.
+   Ia hanya boleh `hidden` selama gerakannya berlangsung: kalau ia menempel
+   sesudahnya, cincin fokus kotak isian di dalamnya terpotong di tepi, dan
+   browser HP terasa tersendat tiap kali kotaknya disentuh. Yang tertulis di
+   sini cuma keadaan awal untuk panel yang memang tertutup. */
+.panel-daftar { overflow: hidden; }
 .blok-masuk {
   max-height: 40rem; opacity: 1;
   transition: max-height .3s ease, opacity .22s ease;


### PR DESCRIPTION
## What

`overflow: hidden` pada blok Masuk dan panel Daftar sekarang hanya menempel **selama gerakannya berlangsung** — dipasang saat pergantian dimulai, dilepas 340ms kemudian.

## Why

Dua keluhan, satu akar. `overflow: hidden` dipasang untuk animasi pergantian Masuk/Daftar (#352), tapi ia tetap menempel **sesudah** gerakannya selesai.

**Cincin fokus terpotong.** Cincin biru kotak Username digambar di **luar** tepi elemennya, jadi wadah yang memotong isinya memotong cincin itu juga — terlihat sebagai garis biru yang terputus di kiri dan kanan.

**Kotak isian terasa tersendat.** Browser HP menggeser isian yang baru disentuh ke dalam wadah yang bisa digulir, dan wadah terpotong membuatnya menghitung ulang posisi tiap kali — jeda sepersekian detik yang terasa seperti ngelag saat kotaknya diklik.

## Notes

`overflow: hidden` tetap **wajib** selama menyusut dan tumbuh: tanpa itu isinya tumpah keluar kotak setinggi nol dan animasinya tidak menyembunyikan apa pun. Yang berubah cuma **kapan** ia berlaku.

340ms, sepuluh milidetik sesudah transisi 0,3 detik berakhir. Yang tertinggal di CSS cuma keadaan awal panel yang memang tertutup — alasannya ditulis di situ supaya tidak ada yang mengembalikannya ke CSS "supaya rapi".

🤖 Generated with [Claude Code](https://claude.com/claude-code)