### PR TITLE
feat: titik diabaikan di nama akun — aji.furqon = ajifurqon

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -216,12 +216,40 @@ export async function masuk(username, password) {
       body: JSON.stringify({ username, password }),
     });
   } else {
-    const email = username.includes("@") ? username : `${username}@${K.domainAkun}`;
-    const j = await kirim(`${K.supabaseUrl}/auth/v1/token?grant_type=password`, {
+    /* TITIK TIDAK MENJADIKANNYA AKUN LAIN — `aji.furqon` dan `ajifurqon`
+       masuk ke akun yang sama, seperti Gmail.
+
+       Yang mencocokkan akun di sini adalah `auth.users.email`, bukan
+       `akun_panitia.username`: barisnya baru dibaca sesudah token didapat.
+       Jadi penyamaannya harus terjadi SEBELUM surelnya dikirim, dan akun baru
+       memang dibuat dengan surel berkunci (gateway kunciAkun()).
+
+       DUA PERCOBAAN, dan yang kedua bukan kemalasan. Akun yang lahir sebelum
+       aturan ini — `admin.ciradyka` salah satunya — surelnya masih mengandung
+       titik di GoTrue. Mengganti surel mereka menuntut service_role, dan
+       kalau berhenti di tengah yang terkunci justru satu-satunya admin yang
+       bisa membetulkannya. Percobaan kedua menanggung mereka tanpa menyentuh
+       satu baris data pun, dan hanya berjalan kalau yang pertama gagal DAN
+       namanya memang bertitik. */
+    const kunciAkun = (n) => n.toLowerCase().replace(/\./g, "");
+    const surel = (n) => n.includes("@")
+      ? `${kunciAkun(n.slice(0, n.lastIndexOf("@")))}${n.slice(n.lastIndexOf("@"))}`
+      : `${kunciAkun(n)}@${K.domainAkun}`;
+    const apaAdanya = username.includes("@") ? username : `${username}@${K.domainAkun}`;
+
+    const minta = (email) => kirim(`${K.supabaseUrl}/auth/v1/token?grant_type=password`, {
       method: "POST",
       headers: { "Content-Type": "application/json", apikey: K.anonKey },
       body: JSON.stringify({ email, password }),
     });
+
+    let j;
+    try {
+      j = await minta(surel(username));
+    } catch (e) {
+      if (surel(username) === apaAdanya) throw e;
+      j = await minta(apaAdanya);
+    }
     const kepala = { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` };
     const akun = await kirim(
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,

--- a/supabase/migrations/0078_kunci_akun.sql
+++ b/supabase/migrations/0078_kunci_akun.sql
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- hrcd-rekap : 0078_kunci_akun.sql
+--
+-- NAMA AKUN DISAMAKAN SEPERTI GMAIL: TITIK TIDAK MENJADIKANNYA AKUN LAIN.
+-- `aji.furqon` dan `ajifurqon` orang yang sama.
+--
+-- ---------------------------------------------------------------------------
+-- POLANYA SUDAH ADA DI RUMAH INI
+--
+-- Ini `kunci_sekolah()` (0061/0062) diterapkan ke akun: nama DISIMPAN seperti
+-- diketik, keunikannya dijaga atas KUNCInya, dan pencarian lewat kunci itu.
+-- Satu konsep untuk dua tabel, bukan dua mekanisme yang mirip.
+--
+-- Karena itu `admin.ciradyka` tetap terbaca bertitik di daftar Akun, di kolom
+-- "oleh" seluruh riwayat yang sudah dicatat, di simulasi_end_to_end.sql, dan
+-- di change_password.py. Tidak ada satu baris pun yang ditulis ulang.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA HANYA TITIK, DAN KENAPA ITU PENTING
+--
+-- CLAUDE.md 12.10 memberi ukurannya: kunci database menolak baris TANPA ADA
+-- YANG MEMERIKSA, jadi ia hanya boleh menyamakan yang PASTI sama. Untuk akun
+-- itu berarti titik dan besar-kecil huruf, TIDAK LEBIH.
+--
+-- `-` dan `_` sengaja TIDAK ikut walaupun gateway pernah menerimanya: melebur
+-- `aji-furqon` dengan `ajifurqon` berarti melebur dua ORANG, dan itu jauh
+-- lebih sulit ketahuan daripada dua baris sekolah kembar — yang satu tidak
+-- bisa login dan tidak tahu kenapa. Ekor `+tag` gaya Gmail juga tidak ikut.
+--
+-- ---------------------------------------------------------------------------
+-- YANG TIDAK DIKERJAKAN DI SINI
+--
+-- Login TIDAK dijaga oleh index ini. Yang mencocokkan akun saat login adalah
+-- `auth.users.email`, bukan tabel ini — barisnya baru dibaca sesudah token
+-- didapat. Jadi index ini menjaga syarat "tidak boleh keduanya terdaftar";
+-- syarat "login dengan salah satu bentuk menemukan akun yang sama" dikerjakan
+-- di klien dan gateway, dan tidak bisa dipindahkan ke sini.
+-- ============================================================================
+
+create or replace function kunci_akun(p_nama text)
+returns text
+language sql
+immutable
+set search_path = public
+as $$
+  select lower(replace(coalesce(p_nama, ''), '.', ''));
+$$;
+
+comment on function kunci_akun(text) is
+  'Kunci penyamaan nama akun: huruf kecil, titik dibuang. HANYA titik — '
+  'melebur - atau _ berarti melebur dua orang (CLAUDE.md 12.10).';
+
+-- ---------------------------------------------------------------------------
+-- Melapor DULU, baru memasang. Dua akun yang cuma beda titik TIDAK BISA
+-- dilebur seperti dua baris sekolah (0061): ada dua user auth, dua password,
+-- dua orang. Yang benar adalah berhenti dan menyerahkannya ke manusia.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  r      record;
+  v_n    integer := 0;
+begin
+  for r in
+    select kunci_akun(username) as kunci, count(*) as jml,
+           string_agg(username, ' | ' order by username) as nama
+    from akun_panitia group by 1 having count(*) > 1
+  loop
+    raise warning '0078: TABRAKAN — % menunjuk % akun: %', r.kunci, r.jml, r.nama;
+    v_n := v_n + 1;
+  end loop;
+
+  if v_n > 0 then
+    raise exception '0078: % kunci bertabrakan. Index tidak dipasang. Dua akun '
+      'yang cuma beda titik tidak bisa dilebur — pilih yang bertahan, '
+      'nonaktifkan yang lain, lalu jalankan lagi.', v_n;
+  end if;
+end;
+$blok$;
+
+create unique index if not exists akun_kunci_unik
+  on akun_panitia (kunci_akun(username));
+
+do $blok$
+declare v_n integer;
+begin
+  select count(*) into v_n from akun_panitia;
+  raise notice '0078: kunci akun terpasang, % akun, tidak ada yang bertabrakan.', v_n;
+end;
+$blok$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -306,7 +306,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "       coalesce(array_agg(h.fitur) filter (where h.fitur is not null),"
                     "                '{}') as hak "
                     "from akun_panitia a left join akun_hak h on h.user_id = a.user_id "
-                    "where a.username = %s and a.is_active "
+                    "where kunci_akun(a.username) = kunci_akun(%s) and a.is_active "
                     "group by a.user_id, a.username, a.peran, a.pos",
                     (b.get("username", ""),), role="service_role", fetch="one")
                 # Dev server: password apa pun diterima — auth sungguhan milik

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -285,5 +285,10 @@ run tests/sql/39_lomba_soal.sql
 # dan pengaturan.
 run supabase/migrations/0077_peran_mengisi_ulang_centang.sql
 run tests/sql/40_peran_mengisi_ulang_centang.sql
+# 0078 menyamakan nama akun seperti Gmail: titik tidak menjadikannya akun
+# lain. Tes 41 menjaga BATASNYA — hanya titik dan besar-kecil huruf; `-`
+# dan `_` tetap membedakan dua orang.
+run supabase/migrations/0078_kunci_akun.sql
+run tests/sql/41_kunci_akun.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/41_kunci_akun.sql
+++ b/tests/sql/41_kunci_akun.sql
@@ -1,0 +1,128 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/41_kunci_akun.sql
+-- Titik tidak menjadikan nama akun jadi akun lain (migrasi 0078).
+--
+-- YANG DIJAGA DAN YANG TIDAK
+--
+-- Index ini menjaga SATU dari dua syarat: `aji.furqon` dan `ajifurqon` tidak
+-- bisa sama-sama terdaftar. Syarat keduanya — login dengan salah satu bentuk
+-- menemukan akun yang sama — TIDAK bisa diuji di sini: yang mencocokkan akun
+-- saat login adalah `auth.users.email`, dan barisnya baru dibaca sesudah token
+-- didapat. Itu dijaga di klien dan gateway.
+--
+-- Yang paling penting di berkas ini justru 41.3: kunci ini HANYA menyamakan
+-- titik. Melebur `aji-furqon` dengan `ajifurqon` berarti melebur dua ORANG,
+-- dan orang yang terlebur tidak bisa login tanpa tahu kenapa.
+-- ============================================================================
+
+insert into auth.users (id, email)
+values ('00000000-0000-0000-0000-0000000000e1', 'uji.kunci@uji.local')
+on conflict (id) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 41.1  Nama bertitik boleh, dan tersimpan APA ADANYA.
+--
+-- Kalau yang tersimpan ikut dibakukan, `admin.ciradyka` akan terbaca
+-- `adminciradyka` di seluruh riwayat yang sudah dicatat — dan pola
+-- kunci_sekolah justru dipilih untuk menghindari itu.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_nama text;
+begin
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values ('00000000-0000-0000-0000-0000000000e1', 'uji.kunci', 'gerbang', null, false);
+
+  select username into v_nama from akun_panitia
+  where user_id = '00000000-0000-0000-0000-0000000000e1';
+  assert v_nama = 'uji.kunci',
+    format('nama tersimpan berubah jadi %s — seharusnya apa adanya', v_nama);
+  raise notice '41.1 OK — nama bertitik tersimpan apa adanya.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 41.2  Bentuk tanpa titik DITOLAK sebagai akun baru.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_pesan text;
+begin
+  insert into auth.users (id, email)
+  values ('00000000-0000-0000-0000-0000000000e2', 'ujikunci@uji.local')
+  on conflict (id) do nothing;
+
+  begin
+    insert into akun_panitia (user_id, username, peran, pos, is_active)
+    values ('00000000-0000-0000-0000-0000000000e2', 'ujikunci', 'gerbang', null, false);
+    assert false, 'ujikunci seharusnya bertabrakan dengan uji.kunci';
+  exception when unique_violation then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan is not null, 'unique index atas kunci_akun tidak terpasang';
+  raise notice '41.2 OK — ujikunci ditolak karena uji.kunci sudah ada.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 41.3  TAPI `-` dan `_` TETAP akun lain. Ini batas yang disengaja.
+--
+-- Kunci yang terlalu rakus melebur dua orang, dan yang terlebur tidak pernah
+-- diberi tahu — ia cuma tidak bisa login (CLAUDE.md 12.10).
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_n integer;
+begin
+  insert into auth.users (id, email)
+  values ('00000000-0000-0000-0000-0000000000e3', 'uji-kunci@uji.local')
+  on conflict (id) do nothing;
+
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values ('00000000-0000-0000-0000-0000000000e3', 'uji-kunci', 'gerbang', null, false);
+
+  select count(*) into v_n from akun_panitia
+  where username in ('uji.kunci', 'uji-kunci');
+  assert v_n = 2, format('uji-kunci seharusnya akun tersendiri, ada %s baris', v_n);
+  raise notice '41.3 OK — tanda strip tetap membedakan dua orang.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 41.4  Besar-kecil huruf ikut disamakan.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_pesan text;
+begin
+  insert into auth.users (id, email)
+  values ('00000000-0000-0000-0000-0000000000e4', 'ujikuncibesar@uji.local')
+  on conflict (id) do nothing;
+
+  begin
+    insert into akun_panitia (user_id, username, peran, pos, is_active)
+    values ('00000000-0000-0000-0000-0000000000e4', 'Uji.Kunci', 'gerbang', null, false);
+    assert false, 'Uji.Kunci seharusnya bertabrakan dengan uji.kunci';
+  exception when unique_violation then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan is not null, 'besar-kecil huruf tidak ikut disamakan';
+  raise notice '41.4 OK — besar-kecil huruf ikut disamakan.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 41.5  Fungsi kuncinya sendiri, diperiksa langsung.
+-- ---------------------------------------------------------------------------
+do $blok$
+begin
+  assert kunci_akun('aji.furqon') = 'ajifurqon', 'titik seharusnya dibuang';
+  assert kunci_akun('AJI.FURQON') = 'ajifurqon', 'huruf besar seharusnya diturunkan';
+  assert kunci_akun('aji..furqon') = 'ajifurqon', 'titik ganda seharusnya dibuang';
+  assert kunci_akun('aji-furqon') = 'aji-furqon', 'strip TIDAK boleh dibuang';
+  assert kunci_akun('aji_furqon') = 'aji_furqon', 'garis bawah TIDAK boleh dibuang';
+  assert kunci_akun(null) = '', 'null seharusnya jadi teks kosong, bukan null';
+  raise notice '41.5 OK — kunci hanya membuang titik dan menurunkan huruf.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- Bersih-bersih.
+-- ---------------------------------------------------------------------------
+delete from akun_panitia where username in ('uji.kunci', 'uji-kunci');
+delete from auth.users where id in (
+  '00000000-0000-0000-0000-0000000000e1',
+  '00000000-0000-0000-0000-0000000000e2',
+  '00000000-0000-0000-0000-0000000000e3',
+  '00000000-0000-0000-0000-0000000000e4');

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -216,12 +216,40 @@ export async function masuk(username, password) {
       body: JSON.stringify({ username, password }),
     });
   } else {
-    const email = username.includes("@") ? username : `${username}@${K.domainAkun}`;
-    const j = await kirim(`${K.supabaseUrl}/auth/v1/token?grant_type=password`, {
+    /* TITIK TIDAK MENJADIKANNYA AKUN LAIN — `aji.furqon` dan `ajifurqon`
+       masuk ke akun yang sama, seperti Gmail.
+
+       Yang mencocokkan akun di sini adalah `auth.users.email`, bukan
+       `akun_panitia.username`: barisnya baru dibaca sesudah token didapat.
+       Jadi penyamaannya harus terjadi SEBELUM surelnya dikirim, dan akun baru
+       memang dibuat dengan surel berkunci (gateway kunciAkun()).
+
+       DUA PERCOBAAN, dan yang kedua bukan kemalasan. Akun yang lahir sebelum
+       aturan ini — `admin.ciradyka` salah satunya — surelnya masih mengandung
+       titik di GoTrue. Mengganti surel mereka menuntut service_role, dan
+       kalau berhenti di tengah yang terkunci justru satu-satunya admin yang
+       bisa membetulkannya. Percobaan kedua menanggung mereka tanpa menyentuh
+       satu baris data pun, dan hanya berjalan kalau yang pertama gagal DAN
+       namanya memang bertitik. */
+    const kunciAkun = (n) => n.toLowerCase().replace(/\./g, "");
+    const surel = (n) => n.includes("@")
+      ? `${kunciAkun(n.slice(0, n.lastIndexOf("@")))}${n.slice(n.lastIndexOf("@"))}`
+      : `${kunciAkun(n)}@${K.domainAkun}`;
+    const apaAdanya = username.includes("@") ? username : `${username}@${K.domainAkun}`;
+
+    const minta = (email) => kirim(`${K.supabaseUrl}/auth/v1/token?grant_type=password`, {
       method: "POST",
       headers: { "Content-Type": "application/json", apikey: K.anonKey },
       body: JSON.stringify({ email, password }),
     });
+
+    let j;
+    try {
+      j = await minta(surel(username));
+    } catch (e) {
+      if (surel(username) === apaAdanya) throw e;
+      j = await minta(apaAdanya);
+    }
     const kepala = { apikey: K.anonKey, Authorization: `Bearer ${j.access_token}` };
     const akun = await kirim(
       `${K.supabaseUrl}/rest/v1/akun_panitia?user_id=eq.${j.user.id}&select=username,peran,pos,is_active`,

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -237,7 +237,7 @@ function layarLogin(pesan) {
         <!-- Satu kalimat, dan ia membawa fakta yang TIDAK bisa dibaca dari
              layar: akunnya belum hidup. Tanpa ini orang mendaftar, mencoba
              masuk, gagal, lalu mendaftar lagi dengan nama lain (bagian 9.4). -->
-        <p class="keterangan">Akun baru dinyalakan admin dulu sebelum bisa dipakai.</p>
+        <p class="keterangan">Setelah daftar, harus diaktivasi manual oleh admin.</p>
         <button class="button button-primary" id="d-kirim" type="button">Daftar</button>
       </div>
     </div>

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -36,6 +36,19 @@ const ASAL_BOLEH = [ASAL_PESERTA, ASAL_PANITIA];
 // akun yang dibuat di sini harus bisa login lewat kotak login yang sama.
 const DOMAIN_AKUN = "ciradyka.com";
 
+/** Kunci penyamaan nama akun — cermin kunci_akun() di migrasi 0078.
+ *
+ *  Titik tidak menjadikan nama jadi akun lain: `aji.furqon` dan `ajifurqon`
+ *  orang yang sama, seperti Gmail. HANYA titik dan besar-kecil huruf; `-` dan
+ *  `_` TIDAK ikut, karena meleburnya berarti melebur dua ORANG dan yang
+ *  terlebur tidak pernah diberi tahu — ia cuma tidak bisa login.
+ *
+ *  Dipakai membentuk ALAMAT SUREL, bukan menggantikan nama yang disimpan.
+ *  Nama disimpan seperti diketik; yang dibakukan cuma alamat yang dipakai
+ *  GoTrue mencocokkan akun. Dengan begitu satu orang punya satu surel, apa
+ *  pun bentuk titik yang ia ketik. */
+const kunciAkun = (nama) => String(nama || "").toLowerCase().replace(/\./g, "");
+
 // Tanpa karakter yang gampang tertukar saat diketik ulang di lapangan —
 // sama dengan SAFE_ALPHABET di scripts/provision_accounts.py. Panitia
 // mengetik password ini dari layar HP koordinator ke HP-nya sendiri, dan
@@ -165,7 +178,7 @@ async function daftarPanitia(req, env, b) {
   if (pos !== null && !(Number.isInteger(pos) && pos >= 1 && pos <= 20))
     return jawab(400, { message: "Pos harus 1–20." }, req);
 
-  const email = `${username}@${DOMAIN_AKUN}`;
+  const email = `${kunciAkun(username)}@${DOMAIN_AKUN}`;
   const cu = await fetch(`${env.SUPABASE_URL}/auth/v1/admin/users`, {
     method: "POST",
     headers: kepalaLayanan(env),
@@ -223,8 +236,13 @@ async function buatAkun(req, env, b) {
     // yang salah tidak sempat melahirkan user auth yatim: auth.users sudah
     // terbuat, lalu insert akun_panitia gagal, dan usernamenya jadi tidak
     // bisa dipakai lagi tanpa dibersihkan lewat dashboard.
-    if (!/^[a-z0-9._-]{3,40}$/.test(username)) {
-      hasil.push({ username, ok: false, pesan: "Nama akun hanya huruf kecil, angka, titik, dan strip (3–40)." });
+    // Pola yang SAMA dengan pendaftaran mandiri. Dulu pintu ini lebih longgar
+    // (menerima `-`, `_`, titik ganda, titik di ujung, minimal 3), dan itu
+    // berarti "akun ini sudah ada atau belum" dijawab berbeda tergantung pintu
+    // mana yang dipakai.
+    if (username.length < 5 || username.length > 40 ||
+        !/^[a-z0-9]+(?:\.[a-z0-9]+)*$/.test(username)) {
+      hasil.push({ username, ok: false, pesan: "Nama akun minimal 5: huruf, angka, dan titik." });
       continue;
     }
     if (!["admin", "registrasi", "gerbang", "juri_pos", "koordinator_pos"]
@@ -244,7 +262,7 @@ async function buatAkun(req, env, b) {
     }
 
     const password = passwordAcak();
-    const email = `${username}@${DOMAIN_AKUN}`;
+    const email = `${kunciAkun(username)}@${DOMAIN_AKUN}`;
     const cu = await fetch(`${env.SUPABASE_URL}/auth/v1/admin/users`, {
       method: "POST",
       headers: kepalaLayanan(env),
@@ -319,7 +337,8 @@ async function ubahUsername(req, env, b) {
   const uid = String(b.user_id || "");
   const username = String(b.username || "").trim().toLowerCase();
   if (!uid) return jawab(400, { message: "Akun tidak disebut." }, req);
-  if (!/^[a-z0-9._-]{3,40}$/.test(username))
+  if (username.length < 5 || username.length > 40 ||
+      !/^[a-z0-9]+(?:\.[a-z0-9]+)*$/.test(username))
     return jawab(400, { message: "Nama akun hanya huruf kecil, angka, titik, dan strip (3–40)." }, req);
 
   // Barisnya dulu: kalau usernamenya sudah dipakai orang lain, UNIQUE
@@ -337,7 +356,7 @@ async function ubahUsername(req, env, b) {
   const em = await fetch(`${env.SUPABASE_URL}/auth/v1/admin/users/${uid}`, {
     method: "PUT",
     headers: kepalaLayanan(env),
-    body: JSON.stringify({ email: `${username}@${DOMAIN_AKUN}`, email_confirm: true }),
+    body: JSON.stringify({ email: `${kunciAkun(username)}@${DOMAIN_AKUN}`, email_confirm: true }),
   });
   if (!em.ok) {
     const e = await em.json().catch(() => ({}));


### PR DESCRIPTION
## What

Seperti Gmail: `aji.furqon` dan `ajifurqon` orang yang sama.

| bentuk yang diketik | surel yang dipakai login |
|---|---|
| `aji.furqon` | `ajifurqon@ciradyka.com` |
| `ajifurqon` | `ajifurqon@ciradyka.com` |
| `AJI.FURQON` | `ajifurqon@ciradyka.com` |
| `aji-furqon` | `aji-furqon@…` — **akun lain** |

## Why

Dua syarat, dijaga di dua tempat karena memang dua mekanisme berbeda.

**(a) Tidak boleh keduanya terdaftar** — migrasi `0078`. Pola `kunci_sekolah` (0061/0062) diterapkan ke akun: nama **disimpan seperti diketik**, unik atas `kunci_akun(username)`. Karena itu `admin.ciradyka` tetap terbaca bertitik di daftar Akun, di kolom "oleh" seluruh riwayat, di `simulasi_end_to_end.sql`, dan di `change_password.py` — **tidak ada satu baris pun ditulis ulang**.

**(b) Login menemukan akun yang sama** — klien dan gateway. Yang mencocokkan akun saat login adalah `auth.users.email`, **bukan** `akun_panitia.username`; barisnya baru dibaca sesudah token didapat. Jadi penyamaannya harus terjadi sebelum surelnya dikirim, dan index database tidak bisa menjangkaunya.

## Notes

**`masuk()` mencoba dua bentuk, dan yang kedua bukan kemalasan.** Akun yang lahir sebelum aturan ini — `admin.ciradyka` — surelnya masih bertitik di GoTrue. Menggantinya menuntut `service_role`, dan kalau berhenti di tengah, **yang terkunci justru satu-satunya admin yang bisa membetulkannya**. Percobaan kedua menanggung mereka tanpa menyentuh satu baris data pun, dan hanya berjalan kalau yang pertama gagal **dan** namanya bertitik.

**Migrasinya melapor dulu lalu berhenti** kalau ada tabrakan. Dua akun yang cuma beda titik **tidak bisa dilebur** seperti dua baris sekolah: ada dua user auth, dua password, dua orang. Yang memilih pemenang harus manusia.

**Hanya titik dan besar-kecil huruf.** `-` dan `_` sengaja tidak ikut — meleburnya berarti melebur dua **orang**, dan yang terlebur tidak pernah diberi tahu; ia cuma tidak bisa login. Bagian 12.10 memberi ukurannya, dan tes 41.3 menjaganya.

**Tiga pintu disamakan polanya.** `buatAkun` dan `ubahUsername` dulu menerima `-`, `_`, titik ganda, titik di ujung, dan minimal 3 — sementara pendaftaran mandiri tidak. Selama itu berbeda, "akun ini sudah ada atau belum" dijawab berbeda tergantung pintu mana yang dipakai.

`tests/dev_server.py` ikut memakai kuncinya, supaya dev dan produksi menjawab pertanyaan yang sama (bagian 14.6).

**Sesudah mendarat: `apply-migration.yml` dengan `0078_kunci_akun.sql`, lalu `deploy-gateway.yml`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)