### PR TITLE
fix: menu akun menjawab lagi — Aktifkan, Reset Password, Ubah Nama

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -582,7 +582,16 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     if (pasang) pasang(el, tutup);
     el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });
-    el.querySelector("[data-ok]").addEventListener("click", () => {
+    // `?.` DAN BUKAN PEMANGGILAN LANGSUNG, sama seperti [data-batal] di atas:
+    // `silangSaja` tidak menggambar .option-row, jadi [data-ok] TIDAK ADA. Tanpa
+    // tanda tanya ini querySelector mengembalikan null, barisnya melempar, dan
+    // lemparannya terjadi DI DALAM `new Promise` — jadi promise-nya DITOLAK.
+    // Yang memanggil menunggunya di luar `try`, sehingga penolakan itu tidak
+    // muncul di mana pun: dialognya tetap tergambar, tombol di dalamnya tetap
+    // menutup lewat `pasang`, dan yang hilang cuma JAWABANNYA. Itulah yang
+    // membuat ketiga tombol di menu akun — Reset Password, Ubah Nama Akun,
+    // Aktifkan — diam tanpa satu pun pesan galat.
+    el.querySelector("[data-ok]")?.addEventListener("click", () => {
       const nilai = medan.map((m, i) => m.tipe === "jam"
         ? (jamPasang[i]?.nilai() ?? "")
         : el.querySelector(`#dlg-${i}`).value.trim());
@@ -616,7 +625,9 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     if (p) p.focus();
     el.addEventListener("keydown", e => {
       if (e.key === "Escape") tutup(null);
-      if (e.key === "Enter") el.querySelector("[data-ok]").click();
+      // Sama sebabnya dengan di atas: pada dialog bersilang tidak ada [data-ok],
+      // dan Enter yang tidak menemukannya akan melempar ke dalam handler.
+      if (e.key === "Enter") el.querySelector("[data-ok]")?.click();
     });
   });
 }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -582,7 +582,16 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     if (pasang) pasang(el, tutup);
     el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });
-    el.querySelector("[data-ok]").addEventListener("click", () => {
+    // `?.` DAN BUKAN PEMANGGILAN LANGSUNG, sama seperti [data-batal] di atas:
+    // `silangSaja` tidak menggambar .option-row, jadi [data-ok] TIDAK ADA. Tanpa
+    // tanda tanya ini querySelector mengembalikan null, barisnya melempar, dan
+    // lemparannya terjadi DI DALAM `new Promise` — jadi promise-nya DITOLAK.
+    // Yang memanggil menunggunya di luar `try`, sehingga penolakan itu tidak
+    // muncul di mana pun: dialognya tetap tergambar, tombol di dalamnya tetap
+    // menutup lewat `pasang`, dan yang hilang cuma JAWABANNYA. Itulah yang
+    // membuat ketiga tombol di menu akun — Reset Password, Ubah Nama Akun,
+    // Aktifkan — diam tanpa satu pun pesan galat.
+    el.querySelector("[data-ok]")?.addEventListener("click", () => {
       const nilai = medan.map((m, i) => m.tipe === "jam"
         ? (jamPasang[i]?.nilai() ?? "")
         : el.querySelector(`#dlg-${i}`).value.trim());
@@ -616,7 +625,9 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     if (p) p.focus();
     el.addEventListener("keydown", e => {
       if (e.key === "Escape") tutup(null);
-      if (e.key === "Enter") el.querySelector("[data-ok]").click();
+      // Sama sebabnya dengan di atas: pada dialog bersilang tidak ada [data-ok],
+      // dan Enter yang tidak menemukannya akan melempar ke dalam handler.
+      if (e.key === "Enter") el.querySelector("[data-ok]")?.click();
     });
   });
 }


### PR DESCRIPTION
## What

`dialog()` di `web/js/util.js` memasang listener klik ke `[data-ok]` tanpa
memeriksa keberadaannya. Opsi `silangSaja: true` memang tidak menggambar
`.option-row` yang memuat tombol itu, jadi `querySelector` mengembalikan null
dan barisnya melempar.

Diperbaiki dengan `?.` di dua tempat — pemasangan listener dan pintasan Enter —
sama persis dengan baris `[data-batal]` tepat di atasnya. `live/js/util.js`
ikut disalin supaya tetap byte-identical (`shared-files.yml`).

## Why

Ketiga tombol di menu per akun (layar Akun → klik nama akun) diam tanpa satu
pun pesan galat. Ditemukan dari laporan bahwa **Aktifkan** tidak mengaktifkan
akun `aji.furqon`; ternyata **Reset Password** dan **Ubah Nama Akun** rusak
bersamaan, karena menu akun adalah satu-satunya pemakai `silangSaja`.

Yang membuatnya sulit terlihat: lemparannya terjadi di dalam `new Promise`,
jadi promise-nya **ditolak**, bukan menggantung — dan pemanggilnya menunggu
`await dialog(...)` di luar `try`, sehingga penolakan itu tidak muncul di mana
pun. `pasang` sudah lebih dulu memasang listener tiap tombol, jadi kliknya
tetap menutup dialog; hanya jawabannya yang tidak pernah sampai. Dari layar,
dialognya tampak sehat.

Tidak ada permintaan jaringan yang pernah dikirim — dipastikan dengan
menyadap `fetch` di halaman produksi: nol PATCH ke `akun_panitia`.

## Notes

Diperiksa di browser terhadap berkas ini sendiri, bukan dibaca saja:

| kasus | sebelum | sesudah |
|---|---|---|
| `silangSaja: true`, klik Aktifkan | ditolak: `Cannot read properties of null` | `"aktif"` |
| dialog biasa (`silangSaja: false`) | isian medan | isian medan (tidak berubah) |
| Enter pada dialog bersilang | melempar | tidak melakukan apa-apa |

Akun `aji.furqon` sendiri sudah diaktifkan langsung lewat PostgREST saat
menelusuri ini, jadi ia tidak menunggu deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)