### PR TITLE
fix: petunjuk hover di "Daftar", dan Aktifkan tanpa memuat ulang layar

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3204,6 +3204,25 @@ input.small-input { text-align: center; }
   transition: margin .3s ease, padding .3s ease;
 }
 .ganti-mode b, .ganti-mode .d-buka { color: var(--utama); font-weight: 700; }
+/* Hijau dan tebal saja belum menjawab "apakah ini bisa ditekan?" — di layar
+   ini keduanya juga dipakai judul dan angka yang cuma dibaca. Garis bawah
+   saat disentuh kursor menjawabnya, dan menjawabnya PERSIS di kata yang
+   diklik, bukan di seluruh barisnya.
+
+   Pemicunya `.ganti-mode:hover`, BUKAN `b:hover`: yang bisa diklik memang
+   seluruh tombolnya, jadi garis bawah yang hanya muncul kalau kursor tepat
+   mengenai lima huruf itu akan membuat sisa barisnya terasa mati padahal
+   ia menerima klik yang sama.
+
+   `:focus-visible` ikut, supaya yang berpindah dengan Tab mendapat petunjuk
+   yang sama dengan yang memakai kursor.
+
+   Yang digarisbawahi `b`, bukan `.d-buka` — tanda panah ▾ dan ▴ dipasang
+   lewat ::after pada span-nya, dan garis bawah pada span akan ikut menarik
+   garis di bawah panahnya. Karena itu "Login" dibungkus <b> juga, supaya
+   kedua keadaannya berperilaku sama persis. */
+.ganti-mode:hover b,
+.ganti-mode:focus-visible b { text-decoration: underline; text-underline-offset: .2em; }
 .ganti-mode .d-buka { display: none; }
 .ganti-mode .d-tutup::after { content: " ▾"; color: var(--utama); }
 .ganti-mode .d-buka::after { content: " ▴"; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -207,7 +207,7 @@ function layarLogin(pesan) {
       <button type="button" class="ganti-mode" id="ganti-mode"
               aria-expanded="false" aria-controls="panel-daftar">
         <span class="d-tutup">Belum punya akun? <b>Daftar</b></span>
-        <span class="d-buka">Login</span>
+        <span class="d-buka"><b>Login</b></span>
       </button>
       <div class="panel-daftar" id="panel-daftar">
         <div class="field">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5117,6 +5117,19 @@ async function layarAkun() {
   // Klik NAMA membuka aksi akunnya. Ditaruh di balik nama, bukan sebagai tiga
   // tombol per baris, karena barisnya sudah punya sebelas kotak centang —
   // tombol tambahan di situ akan mendorong matriksnya keluar layar HP.
+  /* Rupa baris "nonaktif": kelas peredup di <tr> dan pil kecil di sebelah
+     namanya. Ditulis sekali di sini supaya ia tidak berbeda pendapat dengan
+     template di atas — dua tempat yang menggambar keadaan yang sama adalah
+     dua tempat yang suatu hari tidak sepakat. */
+  const tandaiBarisAktif = (tr, hidup) => {
+    tr.classList.toggle("mati", !hidup);
+    const sel = tr.querySelector("td");
+    sel.querySelector(".badge")?.remove();
+    if (!hidup)
+      sel.insertAdjacentHTML("beforeend",
+        ' <span class="badge badge-gray">nonaktif</span>');
+  };
+
   tabel.addEventListener("click", async (ev) => {
     const tombol = ev.target.closest("[data-aksi]");
     if (!tombol) return;
@@ -5169,6 +5182,14 @@ async function layarAkun() {
           if (ya === null) return;
         }
         await setAktifAkun(uid, !aktif);
+        // SATU BARIS yang berubah, jadi satu baris itu yang digambar ulang.
+        // layarAkun() menarik ulang ketiga daftarnya, mengganti seluruh isi
+        // layar, lalu memindahkan fokus ke kotak "Nama akun" di atas — di
+        // tabel 13 akun yang digeser ke samping, posisi gulir mendatar dan
+        // baris yang sedang dilihat ikut hilang. Yang berubah dari
+        // mengaktifkan cuma dua hal, dan dua-duanya ada di baris ini.
+        tandaiBarisAktif(tr, !aktif);
+        return;
       }
       layarAkun();
     } catch (e) { lapor(e.message); }

--- a/web/style.css
+++ b/web/style.css
@@ -3204,6 +3204,25 @@ input.small-input { text-align: center; }
   transition: margin .3s ease, padding .3s ease;
 }
 .ganti-mode b, .ganti-mode .d-buka { color: var(--utama); font-weight: 700; }
+/* Hijau dan tebal saja belum menjawab "apakah ini bisa ditekan?" — di layar
+   ini keduanya juga dipakai judul dan angka yang cuma dibaca. Garis bawah
+   saat disentuh kursor menjawabnya, dan menjawabnya PERSIS di kata yang
+   diklik, bukan di seluruh barisnya.
+
+   Pemicunya `.ganti-mode:hover`, BUKAN `b:hover`: yang bisa diklik memang
+   seluruh tombolnya, jadi garis bawah yang hanya muncul kalau kursor tepat
+   mengenai lima huruf itu akan membuat sisa barisnya terasa mati padahal
+   ia menerima klik yang sama.
+
+   `:focus-visible` ikut, supaya yang berpindah dengan Tab mendapat petunjuk
+   yang sama dengan yang memakai kursor.
+
+   Yang digarisbawahi `b`, bukan `.d-buka` — tanda panah ▾ dan ▴ dipasang
+   lewat ::after pada span-nya, dan garis bawah pada span akan ikut menarik
+   garis di bawah panahnya. Karena itu "Login" dibungkus <b> juga, supaya
+   kedua keadaannya berperilaku sama persis. */
+.ganti-mode:hover b,
+.ganti-mode:focus-visible b { text-decoration: underline; text-underline-offset: .2em; }
 .ganti-mode .d-buka { display: none; }
 .ganti-mode .d-tutup::after { content: " ▾"; color: var(--utama); }
 .ganti-mode .d-buka::after { content: " ▴"; }


### PR DESCRIPTION
## What

Dua perbaikan kecil di layar panitia, dua-duanya diminta langsung.

1. **Layar login** — "Daftar" (dan "Login" di keadaan sebaliknya) bergaris
   bawah saat kursor menyentuh tombolnya, dan saat dijangkau dengan Tab.
2. **Layar Akun** — menekan Aktifkan tidak lagi menggambar ulang seluruh
   layar; baris yang berubah diperbarui di tempat.

## Why

**Hover.** Hijau dan tebal saja belum menjawab "apakah ini bisa ditekan?" —
di layar itu keduanya juga dipakai teks yang cuma dibaca.

Pemicunya `.ganti-mode:hover`, bukan `b:hover`: yang menerima klik adalah
seluruh tombolnya, termasuk kalimat "Belum punya akun?", jadi garis bawah
yang hanya muncul kalau kursor tepat mengenai katanya akan membuat sisa
barisnya terasa mati padahal ia menerima klik yang sama.

Yang digarisbawahi `b`, bukan span-nya — tanda ▾ dan ▴ dipasang lewat
`::after` pada span, dan garis bawah di span akan ikut menarik garis di bawah
panahnya. "Login" karena itu dibungkus `<b>` juga; sebelumnya ia satu-satunya
yang tidak, sehingga kedua keadaan tombol berperilaku berbeda.

**Muat ulang.** `layarAkun()` menarik ulang ketiga daftarnya, mengganti
seluruh isi layar, lalu memindahkan fokus ke kotak "Nama akun" di paling
atas. Yang benar-benar berubah dari mengaktifkan cuma dua hal, dan dua-duanya
ada di satu baris. Harganya bukan cuma permintaan jaringan: tabel matriks hak
digeser ke SAMPING, jadi menggambar ulang mengembalikan gulir mendatarnya ke
nol dan baris yang barusan ditekan berpindah dari bawah kursor.

## Notes

Diukur di browser, bukan dibaca — CLAUDE.md bagian 15.9.

Hover, dengan `getComputedStyle`:

| yang diuji | hasil |
|---|---|
| kursor di "Belum punya akun?" (bukan di katanya) | "Daftar" `underline` |
| span pembawa panah ▾ / ▴ | tetap `none` |
| Tab ke tombolnya, kursor di tempat lain | `:focus-visible` true, "Login" `underline` |

Aktifkan, dengan `fetch` disadap dan gulir mendatar disetel 260px:

| | sebelum | sesudah |
|---|---|---|
| permintaan | `GET /akun` + `GET /fitur` + `GET /hak` | `POST /akun/ubah` saja |
| gulir mendatar | kembali ke 0 | tetap 260 |
| fokus | pindah ke "Nama akun" | tidak berpindah |

Reset Password dan Ubah Nama Akun sengaja TETAP memanggil `layarAkun()`:
mengubah nama mengganti isi baris dan urutannya sekaligus (daftarnya
diurutkan nama), jadi menggambar ulang di tempat justru salah di sana.

`live/style.css` ikut disalin supaya tetap byte-identical (`shared-files.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)