### PR TITLE
fix: centang ikut berubah saat perannya diganti, tanpa muat ulang

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5111,12 +5111,37 @@ async function layarAkun() {
     try {
       await ubahPeranAkun(tr.dataset.uid, peran, pos);
       notif(`${tr.dataset.nama} sekarang ${PERAN_LABEL[peran]}${pos ? ` pos ${pos}` : ""}.`);
+      // Kalimat "Mengganti peran mengisi ulang centangnya" di atas tabel itu
+      // BENAR — tapi yang mengisinya database (trigger 0077), bukan layar ini,
+      // jadi centang yang sedang tergambar sudah basi begitu perannya berganti.
+      // Dulu ia baru betul sesudah halamannya dimuat ulang, dan sampai itu
+      // terjadi layar memperlihatkan hak peran LAMA untuk peran BARU.
+      await segarkanCentangBaris(tr);
     } catch (e) { lapor(e.message); layarAkun(); }
   });
 
   // Klik NAMA membuka aksi akunnya. Ditaruh di balik nama, bukan sebagai tiga
   // tombol per baris, karena barisnya sudah punya sebelas kotak centang —
   // tombol tambahan di situ akan mendorong matriksnya keluar layar HP.
+  /* Centang satu baris dibaca ULANG dari server, bukan ditebak di sini.
+
+     Menyalin isi paket_peran() ke browser akan membuat centangnya muncul
+     tanpa satu permintaan pun — dan membuat dua tempat memutuskan hak yang
+     sama, yang persis dilarang CLAUDE.md 13.1. Peta itu tinggal di database,
+     dipakai trigger 0077 dan paket_peran(); salinan di layar akan benar hari
+     ini dan diam-diam salah pada edisi yang menambah satu fitur.
+
+     Harganya satu GET — jauh lebih murah daripada layarAkun(), yang menarik
+     ketiga daftarnya sekaligus lalu menggambar ulang seluruh layar. */
+  const segarkanCentangBaris = async (tr) => {
+    const hak = await daftarHak();
+    const punya = new Set(hak.filter(x => x.user_id === tr.dataset.uid)
+                             .map(x => x.fitur));
+    tr.querySelectorAll("[data-fitur]").forEach(kotak => {
+      kotak.checked = punya.has(kotak.dataset.fitur);
+    });
+  };
+
   /* Rupa baris "nonaktif": kelas peredup di <tr> dan pil kecil di sebelah
      namanya. Ditulis sekali di sini supaya ia tidak berbeda pendapat dengan
      template di atas — dua tempat yang menggambar keadaan yang sama adalah


### PR DESCRIPTION
## What

Sesudah peran sebuah akun diganti di layar Akun, centang di baris itu dibaca
ulang dari server dan langsung berubah. Sebelumnya ia baru betul setelah
halamannya dimuat ulang.

## Why

Kalimat "Mengganti peran mengisi ulang centangnya" di atas tabel memang
benar — tapi yang mengisinya **database** (trigger `hak_ikut_peran`, migrasi
0077), bukan layar ini. Layar cuma menampilkan `akun_hak` yang ditariknya saat
pertama digambar, jadi begitu perannya berganti ia menggambar hak peran LAMA
untuk peran BARU. Matriks yang sedang dilihat berbohong tentang siapa boleh
apa, sampai ada yang menekan refresh.

**Dibaca, bukan ditebak.** Menyalin isi `paket_peran()` ke browser akan
mengisi centangnya tanpa satu permintaan pun — dan membuat dua tempat
memutuskan hak yang sama, persis yang dilarang CLAUDE.md 13.1. Peta itu
tinggal di database, dipakai trigger 0077 dan `paket_peran()`; salinan di
layar akan benar hari ini dan diam-diam salah pada edisi yang menambah satu
fitur.

Ia juga harus bisa **mencabut** centang, bukan hanya menambah — turun dari
admin ke juri pos membuang sembilan di antaranya. Membaca dari server memberi
kedua arah tanpa kode tambahan; menebak di layar hampir selalu hanya mengurus
arah naik.

Harganya satu `GET`, bukan `layarAkun()` yang menarik ketiga daftarnya lalu
menggambar ulang seluruh layar — yang juga mengembalikan gulir mendatar
tabelnya ke nol, seperti yang baru diperbaiki di #360.

## Notes

Diukur di dev dengan `fetch` disadap dan gulir mendatar disetel 300px:

| perubahan | centang | permintaan | gulir |
|---|---|---|---|
| juri_pos → admin | 2 → **11** | `POST /akun/ubah` + `GET /hak` | tetap 300 |
| admin → juri_pos | 11 → **2** | `POST /akun/ubah` + `GET /hak` | tetap 300 |

Angka di layar cocok dengan database sesudahnya: `pos1hrcd37 | juri_pos |
pos=1 | hak=2`.

Mengubah **pos saja** tidak mengubah hak — trigger 0077 hanya bekerja kalau
perannya benar-benar berganti — dan pembacaan ulangnya memang mengembalikan
centang yang sama, jadi tidak ada yang berkedip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)