### PR TITLE
fix: alamat layar Akun jadi #/account, dan #/akun dialihkan ke sana

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -129,7 +129,7 @@ function pasangKepala(judul, lebar = false) {
     document.getElementById("nav-setting")
       .setAttribute("aria-current", location.hash === "#/ganti-password" ? "page" : "false");
     document.getElementById("nav-akun")
-      .setAttribute("aria-current", location.hash === "#/akun" ? "page" : "false");
+      .setAttribute("aria-current", location.hash === "#/account" ? "page" : "false");
   }
   // Akun hanya untuk admin. Disembunyikan, BUKAN dinonaktifkan: tombol mati di
   // pojok header tidak memberi tahu apa pun selain bahwa ada sesuatu yang
@@ -5703,7 +5703,7 @@ const RUTE = {
   "#/rekap": layarRekap,
   "#/live-score": layarLiveScore,
   "#/ganti-password": layarGantiPassword,
-  "#/akun": layarAkun,
+  "#/account": layarAkun,
 };
 
 async function arahkan() {
@@ -5717,6 +5717,14 @@ async function arahkan() {
     try { EDISI = await infoEdisi(); }
     catch (e) { layarButuhEdisi("Sistem Panitia"); return; }
   }
+  // Alamat lamanya `#/akun`, dan itu masih duduk di riwayat browser dan
+  // bookmark panitia. Dialihkan, bukan didiamkan: rute yang tidak dikenal
+  // jatuh ke layar Home, jadi tautan lama akan membuka layar yang SALAH
+  // tanpa satu pun pesan — kegagalan yang paling sulit dilaporkan orang,
+  // karena layarnya terlihat baik-baik saja. Mengganti hash memicu
+  // hashchange, jadi fungsi ini berjalan sekali lagi; `return` menahannya
+  // supaya layarnya tidak digambar dua kali.
+  if (location.hash === "#/akun") { location.hash = "#/account"; return; }
   (RUTE[location.hash] || layarHome)();
 }
 
@@ -5731,7 +5739,7 @@ const keSetelan = () => {
   else location.hash = "#/ganti-password";
 };
 const keAkun = () => {
-  if (location.hash === "#/akun") arahkan(); else location.hash = "#/akun";
+  if (location.hash === "#/account") arahkan(); else location.hash = "#/account";
 };
 const keluarSekarang = () => { keluar(); EDISI = null; location.hash = ""; arahkan(); };
 


### PR DESCRIPTION
## What

Rute layar Akun berganti dari `#/akun` jadi `#/account`, dan alamat lamanya
dialihkan ke sana.

## Why

Rute yang lain sudah memisahkannya begitu: yang menyebut istilah domain tetap
Indonesia — `#/daftar-ulang`, `#/cetak-kloter`, `#/keberangkatan` — dan yang
bukan memakai kata industrinya: `#/home`, `#/finish`, `#/live-score`. "Akun"
tidak ada di daftar istilah domain CLAUDE.md 5.3, dan `account` adalah kata
yang sudah dipakai semua orang (5.10), jadi tempatnya di kelompok kedua.

Alamat lama **dialihkan**, tidak sekadar dibuang. Rute yang tidak dikenal
jatuh ke layar Home, jadi bookmark dan riwayat browser yang masih menyimpan
`#/akun` akan membuka layar yang SALAH tanpa satu pun pesan galat — kegagalan
yang paling sulit dilaporkan orang, karena layarnya terlihat baik-baik saja.

## Notes

Yang **tidak** ikut berganti, dan itu disengaja:

* **Judul layarnya tetap "Akun".** Itu teks UI, jadi bahasanya ditentukan
  pembacanya (CLAUDE.md 5.2), bukan oleh alamatnya.
* **Kode fitur `akun` di database tetap.** Ia dipakai `boleh('akun')`,
  `akun_hak.fitur`, dan `paket_peran()`; menggantinya menuntut migrasi dan
  menyentuh seluruh policy — pekerjaan yang tidak diminta oleh alamat halaman.

Diukur di dev:

| yang diuji | hasil |
|---|---|
| buka `#/akun` (alamat lama) | mendarat di `#/account`, tabel tergambar |
| berapa kali layarnya digambar | **sekali** — satu putaran `/akun` + `/fitur` + `/hak`, bukan dua |
| ikon Akun di header | mendarat di `#/account` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)