### PR TITLE
fix: koordinator pos tidak bisa dipilih sendiri saat mendaftar

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -222,9 +222,28 @@ function layarLogin(pesan) {
         </div>
         <div class="field">
           <label for="d-peran">Tugas</label>
+          <!-- KOORDINATOR POS TIDAK ADA DI SINI, seperti admin. Keduanya
+               peran yang membuka lebih dari satu meja: koordinator pos punya
+               kolom pos KOSONG, dan justru itu yang membuka KELIMA pos
+               (CLAUDE.md 13.2). Pintu ini tidak dijaga siapa pun -- siapa saja
+               yang membuka layar login boleh memakainya -- jadi peran yang
+               melintasi pos hanya boleh DIBERIKAN admin di layar Akun, bukan
+               dipilih sendiri oleh yang mendaftar.
+
+               Lahir nonaktif tidak cukup sebagai pengganti: admin yang menekan
+               Aktifkan sedang menjawab "orang ini benar", dan belum tentu
+               memperhatikan peran apa yang dipilihkan orang itu untuk dirinya
+               sendiri.
+
+               Gateway menolaknya juga. Daftar di sini cuma menyembunyikan;
+               yang menegakkan workers/gateway/worker.js, karena kotak ini bisa
+               diubah dari devtools dalam sepuluh detik.
+
+               TANPA BACKTICK DI KOMENTAR INI -- lihat catatan panjang di atas
+               tombol ganti-mode. Komentar ini duduk di dalam template literal,
+               dan satu backtick menutupnya. -->
           <select id="d-peran" class="select-small">
             <option value="juri_pos">Juri Pos</option>
-            <option value="koordinator_pos">Koordinator Pos</option>
             <option value="registrasi">Registrasi</option>
             <option value="gerbang">Gerbang</option>
           </select>

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -168,11 +168,24 @@ async function daftarPanitia(req, env, b) {
   if (password.length < 8)
     return jawab(400, { message: "Password minimal 8 karakter." }, req);
 
-  // `admin` sengaja TIDAK ada di daftar ini. Kalau suatu hari peran baru
-  // ditambahkan, ia harus ditulis di sini juga — dan kalau lupa, yang terjadi
-  // adalah penolakan, bukan kebocoran.
-  if (!["registrasi", "gerbang", "juri_pos", "koordinator_pos"].includes(peran))
-    return jawab(400, { message: "Peran harus registrasi, gerbang, juri_pos, atau koordinator_pos." }, req);
+  // `admin` DAN `koordinator_pos` sengaja TIDAK ada di daftar ini, dan
+  // alasannya satu: keduanya peran yang berlaku di lebih dari satu meja, jadi
+  // keduanya harus DIBERIKAN, bukan diminta sendiri lewat pintu yang tidak
+  // dijaga siapa pun.
+  //
+  // Untuk koordinator_pos yang membukanya justru kolom `pos` yang kosong:
+  // `pos_saya()` NULL, dan pagar `pos_saya() is null or pos = pos_saya()`
+  // membuka KELIMA pos sekaligus (CLAUDE.md 13.2). Dari luar ia terlihat
+  // sesederhana "juri pos tanpa pos", dan itulah yang membuatnya mudah lolos.
+  //
+  // Akun baru memang lahir `is_active: false`, tapi itu bukan pengganti pagar
+  // ini: admin yang menekan Aktifkan sedang menjawab "orang ini benar", bukan
+  // "peran yang ia pilihkan untuk dirinya sendiri benar".
+  //
+  // Kalau suatu hari peran baru ditambahkan, ia harus ditulis di sini juga —
+  // dan kalau lupa, yang terjadi adalah penolakan, bukan kebocoran.
+  if (!["registrasi", "gerbang", "juri_pos"].includes(peran))
+    return jawab(400, { message: "Peran harus registrasi, gerbang, atau juri_pos." }, req);
   if ((peran === "juri_pos") !== (pos !== null))
     return jawab(400, { message: "Juri pos wajib menyebut posnya; peran lain tanpa pos." }, req);
   if (pos !== null && !(Number.isInteger(pos) && pos >= 1 && pos <= 20))


### PR DESCRIPTION
## What

**Koordinator Pos** dibuang dari pilihan Tugas di form pendaftaran mandiri,
dan gateway ikut menolaknya. Ia menyusul `admin`: hanya bisa **diberikan**
admin di layar Akun.

Yang **tidak** berubah: form Buat Akun dan dropdown peran per baris di layar
Akun tetap memuat kelima peran, dan rute pembuatan massal di gateway tetap
menerima `koordinator_pos` — rute itu memang sudah menuntut token admin.

## Why

Yang membuka kelima pos untuk koordinator pos justru kolom `pos` yang
**kosong**: `pos_saya()` NULL, dan pagar `pos_saya() is null or pos =
pos_saya()` lalu membuka semuanya (CLAUDE.md 13.2). Dari luar ia terlihat
sesederhana "juri pos tanpa pos" — dan itulah yang membuatnya mudah lolos dari
perhatian. Pintu pendaftaran tidak dijaga siapa pun, jadi peran yang melintasi
pos tidak boleh diminta sendiri di sana.

**Lahir nonaktif bukan pengganti pagar ini.** Admin yang menekan Aktifkan
sedang menjawab "orang ini benar", bukan "peran yang ia pilihkan untuk dirinya
sendiri benar" — dan peran itu tidak diminta ulang di layar mana pun sebelum
akunnya menyala.

**Dua tempat, dan yang menegakkan bukan yang di layar.** Opsi di form cuma
menyembunyikan; kotak `select` bisa diubah dari devtools dalam sepuluh detik.
Jadi `workers/gateway/worker.js` yang menolak, dan daftar peran di form hanya
mengikutinya.

## Notes

Diukur di dev:

| tempat | sesudah |
|---|---|
| form Daftar (layar login) | `juri_pos`, `registrasi`, `gerbang` |
| form Buat Akun (layar Akun) | kelima peran, termasuk `koordinator_pos` |
| dropdown peran per baris | kelima peran |

**Worker perlu di-deploy terpisah.** `workers/gateway/worker.js` tidak ikut
terkirim saat merge — ia dipasang lewat workflow **Deploy gateway Worker**
(`workflow_dispatch`). Sampai itu dijalankan, pagar yang benar-benar
menegakkan masih versi lama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)