### PR TITLE
feat: waktu ditulis menit:detik — 50 jadi 00:50, 1:20 jadi 01:20

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -245,15 +245,24 @@ export function detikSah(teks) {
   return Number(a) * 60 + d;
 }
 
-/** Kebalikan detikSah: bentuk yang akan diketik petugas untuk waktu ini.
- *  Di bawah semenit ditulis polos ("32"), semenit ke atas pakai titik dua
- *  ("1:10") — supaya angka yang tergambar ulang ke kotak persis angka yang
- *  tadi diketik, dan menyimpan ulang baris tidak pernah mengubah apa pun. */
+/** Kebalikan detikSah: SELALU menit:detik berpadding — 50 jadi "00:50", 80
+ *  jadi "01:20". Yang diketik boleh bentuk apa saja yang diterima detikSah
+ *  ("50", "1:20", "01:20"); yang TERGAMBAR selalu satu bentuk.
+ *
+ *  Dulu di bawah semenit ditulis polos ("32") dan semenit ke atas pakai titik
+ *  dua ("1:10"), supaya teksnya persis seperti yang tadi diketik. Harganya:
+ *  satu kolom waktu memuat "44" dan "1:03" bersebelahan, dan dua bentuk untuk
+ *  satu besaran membuat mata harus menerjemahkan tiap baris sebelum bisa
+ *  membandingkannya — padahal membandingkan waktu antar regu justru satu-
+ *  satunya alasan kolom itu dibaca berurutan.
+ *
+ *  Angka yang tersimpan TIDAK berubah: yang masuk database tetap detik bulat,
+ *  dan ini cuma cara menuliskannya kembali. */
 export function detikTeks(total) {
   if (total === null || total === undefined || total === "") return "";
   const d = Math.round(Number(total));
   if (!Number.isFinite(d)) return "";
-  return d < 60 ? String(d) : `${Math.floor(d / 60)}:${dua(d % 60)}`;
+  return `${dua(Math.floor(d / 60))}:${dua(d % 60)}`;
 }
 
 /** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2290,13 +2290,21 @@ function petunjukKolom(k) {
   // menyesatkan; kolom `petunjuk` (0037) ada untuk kasus seperti itu.
   if (k.petunjuk) return k.petunjuk;
   if (k.form === "biner") return "centang bila benar";
-  // "detik" saja. Sebelumnya "detik, atau m:dd" — dan bentuk kedua itu tidak
-  // pernah diminta siapa pun, cuma ditawarkan. Menawarkan dua format untuk
-  // satu angka pada kertas yang diisi tergesa di pos adalah cara sebagian
-  // petugas menulis 1:45 dan sebagian menulis 105 untuk waktu yang sama.
-  // detikSah() memang masih menerima m:dd bagi yang terlanjur hafal; yang
-  // dibuang cuma tawarannya.
-  if (k.satuan === "detik") return "detik";
+  // SATU bentuk, dan sekarang bentuk itu "menit:detik".
+  //
+  // Keterangan ini pernah berbunyi "detik, atau m:dd", lalu dipersempit jadi
+  // "detik" saja — bukan karena m:dd buruk, melainkan karena MENAWARKAN DUA
+  // bentuk untuk satu angka pada kertas yang diisi tergesa di pos adalah cara
+  // sebagian petugas menulis 1:45 dan sebagian menulis 105 untuk waktu yang
+  // sama. Keberatan itu masih berlaku dan tetap dihormati: yang disebut di
+  // sini tetap satu bentuk, cuma bentuknya yang berganti.
+  //
+  // Berganti karena layar sekarang MENULISKAN waktu dalam menit:detik
+  // (detikTeks), jadi keterangan "detik" di atas kolom berisi "01:14" akan
+  // menyebut sesuatu yang tidak terlihat di kolomnya. detikSah() tetap
+  // menerima detik polos, jadi yang terlanjur hafal mengetik 74 tidak
+  // kehilangan apa pun — ia cuma terbaca kembali sebagai 01:14.
+  if (k.satuan === "detik") return "menit:detik";
   if (k.form === "benar_kurang_salah") return "benar / salah";
   if (k.form === "benar_per_total") return `0 – ${angkaRapi(k.total_soal)}`;
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
@@ -3556,7 +3564,7 @@ async function layarInputPos() {
     if (kosong) el.removeAttribute("aria-invalid");
     else if (detik === null) el.setAttribute("aria-invalid", "true");
     else {
-      // "0:32" jadi "32", "95" jadi "1:35" — bentuk yang sama dengan yang
+      // "32" jadi "00:32", "95" jadi "01:35" — bentuk yang sama dengan yang
       // digambar ulang dari database, supaya menyimpan baris yang tidak
       // disentuh tidak pernah terlihat sebagai perubahan.
       el.value = detikTeks(detik);
@@ -3957,8 +3965,8 @@ function selRekap(w, isi) {
       ? esc(angkaRapi(a))
       : `${esc(angkaRapi(a))}<span class="pos-pemisah"> / </span>${esc(angkaRapi(b))}`;
   }
-  // Bentuk yang sama dengan yang diketik di Input Pos — 32 detik tampil "32",
-  // bukan "0:32". Dua layar yang menampilkan angka sama dengan bentuk berbeda
+  // Bentuk yang sama dengan Input Pos — 32 detik tampil "00:32" di kedua
+  // layar. Dua layar yang menampilkan angka sama dengan bentuk berbeda
   // membuat orang mengira datanya yang berbeda.
   if (w.satuan === "detik") return esc(detikTeks(a));
   return esc(angkaRapi(a));

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -245,15 +245,24 @@ export function detikSah(teks) {
   return Number(a) * 60 + d;
 }
 
-/** Kebalikan detikSah: bentuk yang akan diketik petugas untuk waktu ini.
- *  Di bawah semenit ditulis polos ("32"), semenit ke atas pakai titik dua
- *  ("1:10") — supaya angka yang tergambar ulang ke kotak persis angka yang
- *  tadi diketik, dan menyimpan ulang baris tidak pernah mengubah apa pun. */
+/** Kebalikan detikSah: SELALU menit:detik berpadding — 50 jadi "00:50", 80
+ *  jadi "01:20". Yang diketik boleh bentuk apa saja yang diterima detikSah
+ *  ("50", "1:20", "01:20"); yang TERGAMBAR selalu satu bentuk.
+ *
+ *  Dulu di bawah semenit ditulis polos ("32") dan semenit ke atas pakai titik
+ *  dua ("1:10"), supaya teksnya persis seperti yang tadi diketik. Harganya:
+ *  satu kolom waktu memuat "44" dan "1:03" bersebelahan, dan dua bentuk untuk
+ *  satu besaran membuat mata harus menerjemahkan tiap baris sebelum bisa
+ *  membandingkannya — padahal membandingkan waktu antar regu justru satu-
+ *  satunya alasan kolom itu dibaca berurutan.
+ *
+ *  Angka yang tersimpan TIDAK berubah: yang masuk database tetap detik bulat,
+ *  dan ini cuma cara menuliskannya kembali. */
 export function detikTeks(total) {
   if (total === null || total === undefined || total === "") return "";
   const d = Math.round(Number(total));
   if (!Number.isFinite(d)) return "";
-  return d < 60 ? String(d) : `${Math.floor(d / 60)}:${dua(d % 60)}`;
+  return `${dua(Math.floor(d / 60))}:${dua(d % 60)}`;
 }
 
 /** Kotak jam 24 orang-ketik. Dipasang di setiap `<input>` yang menerima jam:


### PR DESCRIPTION
## What

Kolom waktu — Pos 2: **Bakiak, Lari Balok, Balap Karung** — sekarang selalu
tertulis `menit:detik` berpadding, di **Input Nilai Pos** maupun **Live Score**.
Keterangan kolomnya ikut jadi `menit:detik`.

| diketik | tersimpan | tergambar |
|---|---|---|
| `50` | 50 | **00:50** |
| `1:20` | 80 | **01:20** |
| `01:20` | 80 | **01:20** |
| `74` | 74 | **01:14** |

## Why

Kolomnya sebelumnya memuat "44" dan "1:03" bersebelahan: di bawah semenit
ditulis polos, semenit ke atas pakai titik dua. Dua bentuk untuk satu besaran
membuat mata harus menerjemahkan tiap baris sebelum bisa membandingkannya —
padahal membandingkan waktu antar regu justru satu-satunya alasan kolom itu
dibaca berurutan.

**Yang diketik tidak dipersempit.** `detikSah()` tetap menerima detik polos,
jadi petugas yang mengetik `74` tidak kehilangan apa pun. **Angka yang
tersimpan juga tidak berubah** — yang masuk database tetap detik bulat, dan
seluruh perubahan ini ada di lapisan tulis-baca teks.

Keterangan kolom pernah dipersempit dari "detik, atau m:dd" jadi "detik" saja,
karena menawarkan **dua** bentuk membuat sebagian petugas menulis `1:45` dan
sebagian `105` untuk waktu yang sama. Keberatan itu masih dihormati: yang
disebut tetap **satu** bentuk, cuma bentuknya yang berganti. Kalau dibiarkan
"detik", keterangan itu berdiri di atas kolom berisi `01:14` dan menyebut
sesuatu yang tidak terlihat di kolomnya.

## Notes

Satu fungsi yang berubah (`detikTeks`), empat tempat yang ikut — kotak isian
Input Pos, pembetulan saat kotak ditinggalkan, penyegaran di tempat, dan angka
di Live Score. Keempatnya memang sudah sengaja memakai pembentuk yang sama,
jadi tidak ada layar yang tertinggal.

Diperiksa di browser terhadap berkasnya sendiri: `99:99` dan `abc` tetap
ditolak, dan bolak-balik detik → teks → detik **stabil** untuk 0, 5, 50, 59,
60, 74, 80, 605, dan 3600 — jadi menyimpan ulang baris yang tidak disentuh
tetap tidak pernah terlihat sebagai perubahan, sifat yang memang dijaga bentuk
lama.

`live/js/util.js` ikut disalin supaya tetap byte-identical (`shared-files.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)