### PR TITLE
fix: papan peserta memakai aturan bersama, bukan salinan tangan

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -35,6 +35,14 @@
        halaman yang SUDAH TERBUKA: ia menjalankan kode yang dimuat waktu
        dibuka sampai di-reload. Menaikkan versinya membuat HP yang
        memuat ulang pasti mendapat berkas baru, bukan yang tersimpan. -->
-  <script src="live.js?v=11"></script>
+  <!-- config.js DULU, dan ia memang belum pernah ada di sini. Tanpanya
+       `window.HRCD` kosong, `ambilFaseDb()` pulang di baris pertamanya, dan
+       saklar fase di layar panitia TIDAK berlaku seketika di halaman ini —
+       ia baru terasa setelah penerbitan berikutnya. CLAUDE.md 14.3 menjanjikan
+       sebaliknya, dan janji itu yang dipakai kalau nilai harus disembunyikan
+       mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
+  -->
+  <script src="config.js"></script>
+  <script type="module" src="live.js?v=12"></script>
 </body>
 </html>

--- a/live/live.js
+++ b/live/live.js
@@ -45,57 +45,38 @@
    Tanpa framework, tanpa build step, tanpa kunci apa pun.
    ========================================================================== */
 
+/* Aturan bersama diimpor, tidak lagi disalin tangan.
+   `js/util.js` di sini SALINAN BYTE-IDENTIK dari `web/js/util.js`, dan
+   `shared-files.yml` menegakkannya di CI — jadi mengubah cara menulis angka di
+   satu aplikasi tidak bisa lagi meninggalkan aplikasi satunya. Sebelum ini
+   `petunjukKolom()` ditulis dua kali dan yang di sini SUDAH menyimpang: papan
+   panitia menulis "menit:detik", papan ini masih "detik", untuk kolom sama.
+
+   Waktu juga: salinan di sini memakai zona ALAT, sementara util.js memaksa
+   Asia/Jakarta. Peserta di WITA/WIT membaca "Update terakhir" satu jam meleset
+   dan menyimpulkan datanya basi padahal baru.
+
+   Halaman ini karena itu dimuat sebagai MODUL (live/index.html). Modul juga
+   ditunda sampai DOM siap, yang justru lebih aman daripada sebelumnya. */
+import {
+  esc, dada3, jamMenit, tanggalJam, berapaLalu,
+  angkaRapi, petunjukKolom, nilaiBagian,
+} from "./js/util.js";
+
 const GOLONGAN = {
   penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
 };
 const URUT_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
 
-/** Peserta menyalin nama regu dan nama sekolah dari formulir yang mereka isi
- *  sendiri — teks dari luar, dan halaman ini dibaca ratusan orang. */
-const esc = (v) => v === null || v === undefined ? "" : String(v)
-  .replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
-  .replaceAll('"', "&quot;").replaceAll("'", "&#39;");
-
-const dada = (n) => n === null || n === undefined
-  ? "—" : String(n).padStart(3, "0");
-
-/* Bentuk waktu baku. Sengaja DISALIN dari web/js/util.js dan bukan diimpor:
-   halaman ini di-deploy sebagai Worker terpisah dan tidak boleh bergantung
-   pada berkas di proyek lain. Kalau bentuknya diubah di sana, ubah juga di
-   sini — hanya ada tiga fungsi, dan salinan yang jujur lebih baik daripada
-   ketergantungan yang diam-diam putus saat deploy. */
-const BULAN = ["Januari", "Februari", "Maret", "April", "Mei", "Juni",
-               "Juli", "Agustus", "September", "Oktober", "November", "Desember"];
-const dua = (n) => String(n).padStart(2, "0");
-
-/** "15:30" — titik dua, bukan titik: "07.04" mudah terbaca sebagai desimal. */
-const jam = (t) => {
-  if (!t) return "—";
-  const d = new Date(t);
-  return `${dua(d.getHours())}:${dua(d.getMinutes())}`;
-};
-
-/** "17 Agustus 2026 15:30" — dipakai cap update, yang bisa menunjuk hari
- *  lain: peserta membuka halaman ini kapan saja, termasuk besok paginya, dan
- *  "17:30" telanjang akan terbaca sebagai setengah jam lalu. */
-const tanggalJam = (t) => {
-  if (!t) return "—";
-  const d = new Date(t);
-  return `${d.getDate()} ${BULAN[d.getMonth()]} ${d.getFullYear()} ${jam(t)}`;
-};
+/** dada3() mengembalikan teks kosong untuk nomor yang tidak ada; di tabel ini
+ *  yang dibutuhkan tanda pisah supaya barisnya tidak terlihat bolong. */
+const dada = (n) => n === null || n === undefined ? "—" : dada3(n);
 
 const kontrak = (menit) => {
   if (!menit) return "—";
   const j = Math.floor(menit / 60), m = menit % 60;
   return m ? `${j},${m === 30 ? "5" : m} jam` : `${j} jam`;
-};
-
-const berapaLalu = (t) => {
-  const menit = Math.floor((Date.now() - new Date(t).getTime()) / 60000);
-  if (menit < 1) return "barusan";
-  if (menit < 60) return `${menit} menit lalu`;
-  return `${Math.floor(menit / 60)} jam lalu`;
 };
 
 let META = null;        // isi live.json
@@ -322,21 +303,6 @@ const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
    ------------------------------------------------------------------------- */
 let golAktif = URUT_GOLONGAN[0];
 
-/* Rentang nilai di kepala kolom — aturannya DISALIN dari petunjukKolom() di
-   layar panitia, dan memang harus sama persis: dua papan yang menulis
-   rentang berbeda untuk komponen yang sama adalah dua papan yang saling
-   membantah di depan orang yang sedang membandingkannya.
-   Yang keluar cuma batas dan satuan, tidak pernah nilai siapa pun. */
-function petunjukKolom(k) {
-  if (k.petunjuk) return k.petunjuk;
-  if (k.form === "biner") return "centang bila benar";
-  if (k.satuan === "detik") return "detik";
-  if (k.form === "benar_kurang_salah") return "benar / salah";
-  if (k.form === "benar_per_total") return `0 – ${k.total_soal}`;
-  if (k.rentang_mentah_min === null || k.rentang_mentah_min === undefined) return "";
-  return `${k.rentang_mentah_min} – ${k.rentang_mentah_maks}`;
-}
-
 function barisPapan() {
   const progres = (REKAP && REKAP.progres) || [];
   const klasemen = (REKAP && REKAP.klasemen) || [];
@@ -401,7 +367,7 @@ function gambarPapan() {
               <div class="nama">${esc(k.nama_regu)}</div>
               <div class="sekolah">${esc(k.nama_sekolah)}</div>
             </div>
-            <div class="total">${esc(String(k.total))}</div>
+            <div class="total">${esc(angkaRapi(k.total))}</div>
           </div>`).join("")}</div>`}
 
         <div class="isi-filter" hidden>
@@ -425,7 +391,8 @@ function gambarPapan() {
                     title="Klik untuk menyaring per sekolah">Organisasi
                   <span class="hitung-filter"></span> <span aria-hidden="true">▾</span></th>
                 ${perPos.map(x => `<th class="pos" colspan="${x.nama.length}"
-                  >${esc(x.pos.bayangan ? x.pos.name : `Pos ${x.pos.nomor}`)}</th>`).join("")}
+                  >${esc(x.pos.bayangan ? x.pos.name
+                        : `Pos ${x.pos.nomor} · ${x.pos.name}`)}</th>`).join("")}
                 ${penuh ? `<th rowspan="2">Penalti</th><th rowspan="2">Total</th>` : ""}
               </tr>
               <tr>${perPos.map(x => x.nama.map(nm =>
@@ -450,9 +417,12 @@ function gambarPapan() {
                   if (!v || v.nilai_1 === null || v.nilai_1 === undefined) {
                     return `<td class="pos belum">–</td>`;
                   }
-                  return `<td class="pos ada">${esc(String(v.nilai_1))}${
-                    v.nilai_2 === null || v.nilai_2 === undefined
-                      ? "" : ` / ${esc(String(v.nilai_2))}`}</td>`;
+                  // Dieja nilaiBagian() — fungsi yang sama dengan papan
+                  // panitia. Sebelumnya String() mentah: 74 detik tergambar
+                  // "74" di sini dan "01:14" di sana, untuk angka yang sama,
+                  // di fase `penuh` yang justru pengumuman juaranya.
+                  const bagian = nilaiBagian(w, v.nilai_1, v.nilai_2);
+                  return `<td class="pos ada">${bagian.map(esc).join(" / ")}</td>`;
                 }).join("")).join("");
                 const penalti = penuh
                   ? Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)
@@ -468,7 +438,8 @@ function gambarPapan() {
                   <td class="sekolah-sel">${esc(b.nama_sekolah || "—")}</td>
                   ${sel}
                   ${penuh ? `<td>${esc(String(penalti))}</td>
-                     <td class="total">${esc(String(b.total ?? "—"))}</td>` : ""}
+                     <td class="total">${b.total === null || b.total === undefined
+                       ? "—" : esc(angkaRapi(b.total))}</td>` : ""}
                 </tr>`;
               }).join("")}
             </tbody>


### PR DESCRIPTION
## What

Halaman peserta mengimpor aturan penulisan dari `js/util.js` — berkas yang
disalin byte-identik dari `web/js/util.js` dan **ditegakkan `shared-files.yml`**
— alih-alih menulis salinannya sendiri.

| | sebelum | sesudah | papan panitia |
|---|---|---|---|
| keterangan kolom waktu | `detik` | **`menit:detik`** | `menit:detik` |
| nilai waktu | `74` | **`01:14`** | `01:14` |
| total | `400.00` | **`400`** | `400` |
| kepala kolom pos | `Pos 1` | **`Pos 1 · Kepramukaan`** | `Pos 1 · Kepramukaan` |

## Why

Ketiga perbedaan pertama muncul di fase `penuh` — yang justru pengumuman
juara. Dua papan yang menampilkan angka sama dengan bentuk berbeda membuat
orang mengira datanya yang berbeda.

Nama pos **sudah** terbit ke `live.json` dan halaman ini sudah memakainya di
panel kelengkapan; hanya kepala tabelnya yang membuangnya, jadi satu halaman
menyebut pos yang sama dengan dua cara.

## Notes — satu temuan yang lebih besar dari yang dicari

**Saklar fase tidak pernah berlaku di halaman ini.** `live/index.html` tidak
pernah memuat `config.js`, jadi `window.HRCD` kosong, `ambilFaseDb()` pulang di
baris pertamanya, dan `FASE_DB` selamanya `null`. Artinya saklar "mematikan
seketika" (CLAUDE.md 14.3) **tidak berlaku sama sekali** di halaman rekap
peserta — nilai baru tersembunyi setelah penerbitan berikutnya, bukan dalam 15
detik. Itu justru kemampuan yang dipakai kalau nilai harus ditarik mendadak.

Terbukti saat menguji: begitu `config.js` terpasang, fase dari database
langsung memperketat fase berkas — uji fase `penuh` saya berubah jadi centang
sampai saya matikan sambungannya.

**Waktu ikut betul.** Salinan di sini memakai zona **alat**; `util.js` memaksa
`Asia/Jakarta`. Peserta di WITA/WIT membaca "Update terakhir" satu jam meleset
dan menyimpulkan datanya basi padahal baru.

**Modul aman di sini**: tidak ada satu pun `onclick=` di `index.html` yang
memanggil fungsinya, dan modul ditunda sampai DOM siap — lebih aman daripada
skrip biasa yang berjalan lebih awal.

## Yang sengaja TIDAK diubah

Pengelompokan kolom tetap **satu kolom per penilaian**, bukan per lomba. Audit
sempat menyebutnya perbedaan; CLAUDE.md 11.7 justru menegaskan layar memang
satu kolom per penilaian sementara blangko satu lembar per lomba, dan **keduanya
benar** — "jangan 'perbaiki' yang satu mengikuti yang lain". Papan panitia pun
begitu.

Diperiksa dengan `live.json` + `rekap.json` contoh di fase `penuh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)