### PR TITLE
fix: golongan satu tempat, dan dev server ikut membawa lomba

### DIFF
--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -76,11 +76,13 @@ jobs:
       - name: Setiap fungsi api.js yang dipanggil app.js benar-benar diimpor
         run: python tools/periksa_impor.py
 
-      # URUT_GOLONGAN ada dua kali dengan sengaja — app.js dan live.js
-      # di-deploy sebagai Worker terpisah. Layar Live Score menjanjikan
-      # tampilan yang identik dengan halaman peserta, dan urutan yang
-      # menyimpang membatalkan janji itu tanpa menggagalkan apa pun.
-      - name: Urutan golongan sama di layar panitia dan halaman peserta
+      # Golongan kini tinggal di web/js/util.js — berkas yang sudah dibandingkan
+      # di atas, jadi ia tidak bisa menyimpang antar situs. Yang masih perlu
+      # mesin adalah mencegah salinan BARU lahir: dulu ada TIGA, dan yang
+      # ketiga bernama URUTAN_GOLONGAN sehingga penjaga lamanya — yang mencari
+      # `const URUT_GOLONGAN` — tidak pernah melihatnya. Salinan itu justru
+      # yang dipakai layar Live Score.
+      - name: Golongan hanya didefinisikan di berkas bersama
         run: python tools/periksa_urutan_golongan.py
 
       # sekolah_nama.json dan sekolah_alamat.json dirawat terpisah dan tidak

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -902,3 +902,27 @@ export function nilaiBagian(w, a, b) {
   if (w.satuan === "detik") return [detikTeks(a)];
   return [angkaRapi(a)];
 }
+
+/** Label keempat golongan, dan URUTAN BAKU saat keempatnya dijejer.
+ *
+ *  Penegak lebih dulu, lalu Penggalang; PA sebelum PI. Ini urutan yang dipakai
+ *  panitia saat mengumumkan juara, dan layar yang berbeda urutan dari corong
+ *  memaksa pembaca acara mencocokkan sendiri di depan lapangan.
+ *
+ *  Urutannya ditulis eksplisit, bukan disandarkan pada urutan kunci LABEL:
+ *  urutan kunci objek memang terjaga di JavaScript, tapi ia tidak terlihat
+ *  sebagai keputusan — orang berikutnya yang merapikan daftar label itu secara
+ *  alfabetis akan mengubah urutan tampil tanpa pernah tahu ia melakukannya.
+ *
+ *  DULU DITULIS TIGA KALI: dua kali di app.js (GOLONGAN_LABEL/URUT_GOLONGAN
+ *  dan NAMA_GOLONGAN/URUTAN_GOLONGAN) dan sekali di live.js. Penjaganya,
+ *  tools/periksa_urutan_golongan.py, mencari pola `const URUT_GOLONGAN` — jadi
+ *  salinan KETIGA yang bernama URUTAN_GOLONGAN tidak pernah ia lihat, dan
+ *  salinan itulah yang dipakai layar Live Score. Sekarang satu tempat, dan
+ *  shared-files.yml yang menjaganya. */
+export const GOLONGAN_LABEL = {
+  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
+  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
+};
+export const URUT_GOLONGAN =
+  ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];

--- a/live/live.js
+++ b/live/live.js
@@ -61,13 +61,10 @@
 import {
   esc, dada3, jamMenit, tanggalJam, berapaLalu,
   angkaRapi, petunjukKolom, nilaiBagian,
+  GOLONGAN_LABEL, URUT_GOLONGAN,
 } from "./js/util.js";
 
-const GOLONGAN = {
-  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
-  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
-};
-const URUT_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
+const GOLONGAN = GOLONGAN_LABEL;
 
 /** dada3() mengembalikan teks kosong untuk nomor yang tidak ada; di tabel ini
  *  yang dibutuhkan tanda pisah supaya barisnya tidak terlihat bolong. */

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -156,6 +156,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select kode, name, type, form, poin_maks, raw_terbaik, "
                     "       raw_terburuk, poin_benar, poin_salah, total_soal, "
                     "       tingkat, satuan, golongan, petunjuk, judul_isian, "
+                    # `lomba` (0054) sempat TIDAK ada di sini padahal
+                    # web/js/api.js memilihnya. Akibatnya di mode dev
+                    # kelompokLomba() menerima undefined di tiap baris: Pos 3
+                    # tampil tujuh lomba bukan tiga, dan blangko mencetak tujuh
+                    # lembar bukan tiga — persis yang dilarang CLAUDE.md 11.6.
+                    # Setiap uji lokal atas pengelompokan lomba menguji dunia
+                    # yang salah, dan hasilnya terlihat masuk akal.
+                    "       lomba, "
                     "       rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() and pos = %s "
@@ -166,7 +174,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 # Rekapitulasi (#/rekap).
                 self._kirim(200, q(
                     "select pos, kode, name, type, form, poin_maks, satuan, "
-                    "       golongan, petunjuk, judul_isian, "
+                    "       golongan, petunjuk, judul_isian, lomba, "
                     "       total_soal, rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "

--- a/tools/periksa_urutan_golongan.py
+++ b/tools/periksa_urutan_golongan.py
@@ -1,69 +1,84 @@
 #!/usr/bin/env python3
-"""Pastikan URUT_GOLONGAN sama persis di layar panitia dan halaman peserta.
+"""Pastikan golongan tidak dituliskan ulang di luar berkas bersama.
 
-KENAPA PERLU DIPERIKSA MESIN
+KENAPA SKRIP INI BERUBAH ARAH
 
-Konstanta ini ada DUA KALI dengan sengaja: `web/js/app.js` melayani situs
-panitia, `live/live.js` melayani situs peserta, dan keduanya di-deploy sebagai
-Worker terpisah tanpa satu pun berkas bersama. Tidak ada cara satu konstanta
-hidup di dua akar tanpa disalin (lihat kepala shared-files.yml) — dan
-`live.js` bukan salah satu berkas yang disalin utuh, karena isinya memang
-berbeda; hanya baris inilah yang harus sama.
+Dulu konstanta ini ada DUA KALI dengan sengaja — `web/js/app.js` untuk situs
+panitia, `live/live.js` untuk situs peserta — dan skrip ini membandingkan
+keduanya. Ternyata salinannya ADA TIGA: `app.js` menulisnya dua kali, sekali
+sebagai `URUT_GOLONGAN` dan sekali lagi sebagai `URUTAN_GOLONGAN` di dekat
+layar Live Score. Skrip lama mencari pola `const URUT_GOLONGAN`, jadi salinan
+ketiga itu tidak pernah ia lihat — dan justru salinan ketiga itulah yang
+dipakai Live Score menggambar tab golongan.
 
-Layar Live Score menjanjikan satu hal: "ini persis yang akan dilihat peserta".
-Kalau urutan golongannya berbeda, janji itu bohong dengan cara yang tidak
-menggagalkan apa pun — tidak ada galat, tidak ada tes merah, cuma admin yang
-menghafal urutan salah lalu membacakan juara dengan urutan itu di depan
-lapangan.
+Sekarang definisinya tinggal di `web/js/util.js`, yang disalin byte-identik ke
+`live/js/util.js` dan sudah dijaga `shared-files.yml`. Perbandingan tidak
+diperlukan lagi: satu berkas, dijaga CI.
 
-Repo ini sudah pernah kehilangan 21 baris karena sepasang berkas yang
-"seharusnya sama" tidak ada yang memeriksanya (CLAUDE.md 7.5). Komentar yang
-menyuruh dua tempat tetap sama bukan penjaga; skrip ini yang jadi penjaganya.
+Yang tersisa dan tetap perlu mesin adalah mencegah salinan BARU lahir. Menulis
+ulang daftar golongan itu murah dan terasa wajar — empat baris, terbaca benar,
+tidak menggagalkan apa pun — dan itu persis bagaimana salinan ketiga dulu
+muncul tanpa ada yang menyadarinya. Komentar yang menyuruh orang mengimpor
+bukan penjaga; skrip ini yang jadi penjaganya.
 """
 
 import pathlib
 import re
 import sys
 
-POLA = re.compile(r"const URUT_GOLONGAN\s*=\s*\[(.*?)\]", re.S)
-BERKAS = ["web/js/app.js", "live/live.js"]
+# Dicari BENTUK PERSISNYA, bukan sekadar kata "golongan", dan itu penting.
+# Pola yang lebih longgar ikut menangkap dua daftar yang memang BOLEH berdiri
+# sendiri karena isinya fakta lain: label pendek untuk kolom cetak sempit
+# ("Pgl Pa"), dan pilihan golongan di formulir pendaftaran yang memakai kata
+# lain beserta keterangannya ("Penegak Putra — SMA / SMK / MA"). Penjaga yang
+# menuduh keduanya akan dimatikan orang, bukan dipatuhi.
+POLA_LABEL = re.compile(r"""["'](?:Penggalang PA|Penegak PA)["']""")
+POLA_URUT = re.compile(
+    r"""\[\s*["']penegak_pa["']\s*,\s*["']penegak_pi["']\s*,"""
+    r"""\s*["']penggalang_pa["']\s*,\s*["']penggalang_pi["']\s*\]""")
+
+# Komentar dibuang lebih dulu. Tanpa ini penjaga menuduh kalimat yang justru
+# MENJELASKAN kenapa label pendek ada — "Penggalang PA 13 huruf jadi Pgl Pa" —
+# dan penjaga yang menuduh komentarnya sendiri akan dimatikan orang.
+TANPA_KOMENTAR = re.compile(r"/\*.*?\*/|//[^\n]*", re.S)
+
+# util.js memang tempatnya; berkas lain harus mengimpor dari sana.
+SUMBER = "web/js/util.js"
+DIPERIKSA = ["web/js/app.js", "live/live.js", "live/js/daftar.js"]
+
+
+def kode_saja(teks):
+    return TANPA_KOMENTAR.sub("", teks)
+
 
 akar = pathlib.Path(__file__).resolve().parent.parent
-temuan = {}
 gagal = False
 
-for nama in BERKAS:
+sumber = akar / SUMBER
+if not sumber.exists():
+    print(f"GAGAL: {SUMBER} tidak ada.")
+    sys.exit(1)
+
+teks_sumber = kode_saja(sumber.read_text(encoding="utf-8"))
+if not POLA_URUT.search(teks_sumber) or not POLA_LABEL.search(teks_sumber):
+    print(f"GAGAL: {SUMBER} tidak lagi memuat definisi golongan.")
+    print("       Kalau ia sengaja dipindah, perbarui skrip ini bersamanya.")
+    sys.exit(1)
+
+for nama in DIPERIKSA:
     berkas = akar / nama
     if not berkas.exists():
-        print(f"GAGAL: {nama} tidak ada.")
-        gagal = True
         continue
-    cocok = POLA.search(berkas.read_text(encoding="utf-8"))
-    if not cocok:
-        print(f"GAGAL: {nama} tidak memuat `const URUT_GOLONGAN = [...]`.")
-        gagal = True
-        continue
-    temuan[nama] = re.findall(r'"([^"]+)"', cocok.group(1))
+    teks = kode_saja(berkas.read_text(encoding="utf-8"))
+    for pola, apa in ((POLA_LABEL, "label golongan"), (POLA_URUT, "urutan golongan")):
+        if pola.search(teks):
+            print(f"GAGAL: {nama} menuliskan {apa} sendiri.")
+            print(f"       Impor dari {SUMBER} — di sana ia dijaga")
+            print("       shared-files.yml, dan salinan yang menyimpang tidak")
+            print("       menggagalkan apa pun sampai ada yang membandingkannya.")
+            gagal = True
 
 if gagal:
     sys.exit(1)
 
-urutan = list(temuan.values())
-if urutan[0] != urutan[1]:
-    print("GAGAL: urutan golongan berbeda antara kedua berkas.")
-    for nama, isi in temuan.items():
-        print(f"  {nama:<16} {isi}")
-    print("\nSamakan keduanya — layar Live Score menjanjikan tampilan yang")
-    print("identik dengan halaman peserta.")
-    sys.exit(1)
-
-# Keempatnya harus ada. Daftar yang kebetulan sama tapi kehilangan satu
-# golongan lolos perbandingan di atas, dan golongan yang hilang tidak pernah
-# digambar sama sekali.
-WAJIB = {"penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"}
-kurang = WAJIB - set(urutan[0])
-if kurang:
-    print(f"GAGAL: golongan hilang dari URUT_GOLONGAN: {sorted(kurang)}")
-    sys.exit(1)
-
-print(f"Urutan golongan sama di kedua berkas: {urutan[0]}")
+print(f"OK — golongan hanya didefinisikan di {SUMBER}.")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -33,30 +33,9 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
          angkaRapi, petunjukKolom, nilaiBagian,
-         jamPadaHari } from "./util.js";
+         jamPadaHari, GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
-const GOLONGAN_LABEL = {
-  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
-  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
-};
-
-/** URUTAN BAKU golongan, di mana pun keempatnya dijejer.
- *
- *  Penegak lebih dulu, lalu Penggalang; PA sebelum PI. Ini urutan yang dipakai
- *  panitia saat mengumumkan juara, dan layar yang berbeda urutan dari corong
- *  memaksa pembaca acara mencocokkan sendiri di depan lapangan.
- *
- *  Ditulis eksplisit, bukan disandarkan pada urutan kunci GOLONGAN_LABEL:
- *  urutan kunci objek memang terjaga di JavaScript, tapi ia tidak terlihat
- *  sebagai keputusan — orang berikutnya yang merapikan daftar label itu secara
- *  alfabetis akan mengubah urutan tampil tanpa pernah tahu ia melakukannya.
- *
- *  Kembarannya ada di live/live.js sebagai URUT_GOLONGAN dengan isi yang sama
- *  persis. Halaman peserta berdiri sendiri (Worker terpisah, tanpa berkas
- *  bersama), jadi salinannya disengaja — dan keduanya harus tetap sama, karena
- *  layar Live Score memang menjanjikan tampilan yang identik. */
-const URUT_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
 
 /** Golongan versi pendek, HANYA untuk kertas. Di layar tetap panjang — di sana
  *  lebar tidak diperebutkan siapa pun, dan dua nama untuk satu hal cuma
@@ -3903,11 +3882,11 @@ function layarButuhEdisi(judul) {
    berbeda pendapat dengan yang pertama.
    ------------------------------------------------------------------------ */
 
-const NAMA_GOLONGAN = {
-  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
-  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
-};
-const URUTAN_GOLONGAN = ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
+// Salinan KETIGA dibuang. Ia dulu bernama lain dari yang di atas, dan itulah
+// yang membuat penjaganya tidak pernah melihatnya — padahal justru salinan ini
+// yang dipakai layar Live Score menggambar tab golongan.
+const NAMA_GOLONGAN = GOLONGAN_LABEL;
+const URUTAN_GOLONGAN = URUT_GOLONGAN;
 
 /** Satu sel nilai mentah, digambar seperti kotaknya di layar Input Pos —
  *  hanya saja mati, karena layar ini tidak pernah menulis.

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -902,3 +902,27 @@ export function nilaiBagian(w, a, b) {
   if (w.satuan === "detik") return [detikTeks(a)];
   return [angkaRapi(a)];
 }
+
+/** Label keempat golongan, dan URUTAN BAKU saat keempatnya dijejer.
+ *
+ *  Penegak lebih dulu, lalu Penggalang; PA sebelum PI. Ini urutan yang dipakai
+ *  panitia saat mengumumkan juara, dan layar yang berbeda urutan dari corong
+ *  memaksa pembaca acara mencocokkan sendiri di depan lapangan.
+ *
+ *  Urutannya ditulis eksplisit, bukan disandarkan pada urutan kunci LABEL:
+ *  urutan kunci objek memang terjaga di JavaScript, tapi ia tidak terlihat
+ *  sebagai keputusan — orang berikutnya yang merapikan daftar label itu secara
+ *  alfabetis akan mengubah urutan tampil tanpa pernah tahu ia melakukannya.
+ *
+ *  DULU DITULIS TIGA KALI: dua kali di app.js (GOLONGAN_LABEL/URUT_GOLONGAN
+ *  dan NAMA_GOLONGAN/URUTAN_GOLONGAN) dan sekali di live.js. Penjaganya,
+ *  tools/periksa_urutan_golongan.py, mencari pola `const URUT_GOLONGAN` — jadi
+ *  salinan KETIGA yang bernama URUTAN_GOLONGAN tidak pernah ia lihat, dan
+ *  salinan itulah yang dipakai layar Live Score. Sekarang satu tempat, dan
+ *  shared-files.yml yang menjaganya. */
+export const GOLONGAN_LABEL = {
+  penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
+  penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
+};
+export const URUT_GOLONGAN =
+  ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];


### PR DESCRIPTION
## What

Dua salinan tangan lagi, ditemukan audit.

1. **Golongan ditulis tiga kali** — kini satu ekspor di `web/js/util.js`.
2. **`tests/dev_server.py` tidak membawa `lomba`** — kini ikut.

Penjaga CI-nya berganti arah: dari *membandingkan dua salinan* jadi *menolak
salinan baru lahir*.

## Why

**Tiga, bukan dua.** `app.js` menulisnya sebagai `GOLONGAN_LABEL`/
`URUT_GOLONGAN` **dan sekali lagi** sebagai `NAMA_GOLONGAN`/`URUTAN_GOLONGAN`
di dekat layar Live Score; `live.js` menulisnya sekali. Penjaganya mencari pola
`const URUT_GOLONGAN`, jadi salinan ketiga yang **bernama lain** tidak pernah ia
lihat — dan justru salinan ketiga itu yang dipakai Live Score menggambar tab
golongan.

**Penjaganya sekarang menjaga hal yang benar.** Membandingkan dua salinan tidak
lagi ada gunanya; tinggal satu, dan `shared-files.yml` sudah membandingkan
`util.js` byte-per-byte. Yang masih perlu mesin adalah mencegah salinan **baru**
lahir: menulis ulang empat baris golongan itu murah dan terasa wajar, dan itu
persis bagaimana salinan ketiga dulu muncul.

Polanya sengaja **sempit**, dan komentar dibuang dulu sebelum dicocokkan. Pola
longgar ikut menuduh dua daftar yang memang boleh berdiri sendiri karena isinya
fakta lain — label pendek kolom cetak (`Pgl Pa`) dan pilihan golongan di
formulir pendaftaran (`Penegak Putra — SMA / SMK / MA`). Penjaga yang menuduh
terlalu banyak akan dimatikan orang, bukan dipatuhi.

**Dev server menguji dunia yang salah.** `dev_server.py` memilih kolom `wahana`
dengan tangan dan `lomba` (0054) tidak ada di dalamnya, padahal `web/js/api.js`
memilihnya. Di mode dev `kelompokLomba()` karena itu menerima `undefined` di
tiap baris: Pos 3 tampil **tujuh** lomba bukan tiga, dan blangko mencetak tujuh
lembar bukan tiga — persis yang dilarang CLAUDE.md 11.6. Hasilnya terlihat
masuk akal, jadi tidak ada yang curiga.

## Notes

Penjaga diuji **dua arah**: hijau apa adanya, merah begitu satu salinan palsu
ditempelkan ke `live.js`.

Dev server terukur sesudah perbaikan — `/komponen-pos?pos=3` mengembalikan 8
komponen dengan lomba **Pembidaian** (5), **KIM** (2), dan **Logika** (kosong =
lomba sendiri): tiga lomba, sesuai CLAUDE.md 11.2.

Keempat layar panitia dan halaman peserta dimuat tanpa satu pun galat JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)