### PR TITLE
feat: kunci lomba dibekukan — ganti nama tidak lagi menghilangkan fotonya

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -555,7 +555,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,kode_lomba,kode_lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }
@@ -569,7 +569,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
-    `golongan,petunjuk,judul_isian,lomba,` +
+    `golongan,petunjuk,judul_isian,lomba,kode_lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/supabase/migrations/0079_kode_lomba_stabil.sql
+++ b/supabase/migrations/0079_kode_lomba_stabil.sql
@@ -1,0 +1,199 @@
+-- ============================================================================
+-- hrcd-rekap : 0079_kode_lomba_stabil.sql
+--
+-- MENGGANTI NAMA LOMBA TIDAK BOLEH MENGHILANGKAN FOTONYA.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG RUSAK SEBELUM INI
+--
+-- `foto_lembar.kode_lomba` (0047) menyimpan SLUG DARI NAMA lomba: "Semaphore"
+-- disimpan sebagai `semaphore`. Kuncinya diturunkan ulang tiap kali dibaca —
+-- `slug_lomba(coalesce(w.lomba, w.name))` di `catat_foto_masuk` (0074:238) dan
+-- di layar lewat `slugLomba()`.
+--
+-- Artinya nama lomba adalah IDENTITASNYA. Ganti "Semaphore" jadi "Bendera" —
+-- satu UPDATE yang terlihat tidak berbahaya, dan memang itu yang diminta kalau
+-- lombanya berganti — dan seluruh foto yang sudah diunggah untuk lomba itu
+-- lenyap dari layar: dialog mencari `bendera`, barisnya menyandang `semaphore`.
+-- RPC-nya pun menolak kode lama, jadi foto lama tidak bisa ditulis ulang.
+-- Tidak ada galat. Fotonya masih ada di storage, tidak ada satu pun layar yang
+-- menemukannya lagi.
+--
+-- Itu jenis kerusakan yang paling mahal di acara ini: bukti yang hilang justru
+-- saat ada yang mempertanyakan sebuah nilai.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DIKERJAKAN: KUNCINYA DIBEKUKAN, BUKAN DIHITUNG ULANG
+--
+-- `wahana.kode_lomba` menyimpan kunci itu SEBAGAI DATA. Isinya diisi persis
+-- dengan yang dihitung hari ini — `slug_lomba(coalesce(lomba, name))` — jadi
+-- pada saat migrasi ini jalan TIDAK ADA satu pun kunci yang berubah, dan
+-- seluruh foto yang sudah ada tetap ketemu. Yang berubah cuma sifatnya:
+-- sesudah ini nama boleh berganti dan kuncinya diam.
+--
+-- Dibekukan, bukan diganti jadi `kode`. Menurunkan kunci dari `wahana.kode`
+-- terdengar lebih bersih, tapi itu MEMUTUS foto yang sudah ada: Tebak Simpul
+-- bernama sama di empat baris dengan kode berbeda (tebak_simpul_pg_pa dan
+-- kawan-kawan), jadi kuncinya hari ini `tebak-simpul` dan bukan salah satu
+-- kodenya. Migrasi yang membetulkan kerusakan tidak boleh membuat kerusakan
+-- yang sama arah.
+--
+-- Kolomnya BOLEH NULL, dan pembacanya memakai
+-- `coalesce(kode_lomba, slug_lomba(coalesce(lomba, name)))`. Baris yang lahir
+-- dari migrasi lama yang tidak menyebut kolom ini karena itu tetap bekerja
+-- seperti sebelumnya — dan trigger di bawah mengisinya begitu ia masuk, jadi
+-- baris baru langsung ikut terlindungi.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kolomnya.
+-- ---------------------------------------------------------------------------
+alter table wahana add column if not exists kode_lomba text;
+
+comment on column wahana.kode_lomba is
+  'Kunci TETAP lomba tempat komponen ini bernaung, dipakai foto_lembar. '
+  'Dibekukan saat 0079 dari slug nama lomba yang berlaku waktu itu; sesudah '
+  'itu nama boleh berganti tanpa memutus foto yang sudah diunggah.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Diisi dengan yang berlaku HARI INI, supaya tidak ada yang berubah.
+-- ---------------------------------------------------------------------------
+update wahana
+set kode_lomba = slug_lomba(coalesce(lomba, name))
+where kode_lomba is null;
+
+-- ---------------------------------------------------------------------------
+-- 3. Baris baru ikut terisi sendiri.
+--
+-- Tanpa ini, komponen yang ditambahkan migrasi berikutnya lahir tanpa kunci
+-- dan kembali bersandar pada namanya — lubang yang sama, cuma lebih sepi.
+-- ---------------------------------------------------------------------------
+create or replace function isi_kode_lomba()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if new.kode_lomba is null then
+    new.kode_lomba := slug_lomba(coalesce(new.lomba, new.name));
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists kode_lomba_terisi on wahana;
+create trigger kode_lomba_terisi
+  before insert on wahana
+  for each row execute function isi_kode_lomba();
+
+-- ---------------------------------------------------------------------------
+-- 4. Pembacanya berhenti menurunkan kunci dari nama.
+--
+-- `catat_foto_masuk` memeriksa kode lomba yang dikirim layar benar-benar milik
+-- pos itu. Pemeriksaannya kini memakai kolom, dengan cadangan perhitungan lama
+-- supaya baris tanpa kolom tetap lolos.
+-- ---------------------------------------------------------------------------
+create or replace function kode_lomba_wahana(p_kode_lomba text, p_lomba text,
+                                             p_name text)
+returns text
+language sql
+immutable
+set search_path = public
+as $$
+  select coalesce(p_kode_lomba, slug_lomba(coalesce(p_lomba, p_name)));
+$$;
+
+comment on function kode_lomba_wahana(text, text, text) is
+  'Kunci lomba sebuah baris wahana: kolomnya kalau ada, hitungan lama kalau '
+  'belum. Satu tempat supaya RPC dan pemeriksaan tidak berbeda pendapat.';
+
+do $blok$
+declare
+  v_n integer;
+begin
+  select count(*) into v_n from wahana where kode_lomba is null;
+  assert v_n = 0, format('0079: %s baris wahana masih tanpa kode_lomba', v_n);
+
+  -- Yang paling penting dibuktikan di sini: tidak ada foto yang berpindah.
+  select count(*) into v_n
+  from foto_lembar f
+  where not exists (
+    select 1 from wahana w
+    where w.pos = f.pos
+      and kode_lomba_wahana(w.kode_lomba, w.lomba, w.name) = f.kode_lomba
+  );
+  raise notice '0079: kode lomba dibekukan; % baris foto masih tidak cocok '
+               '(angka ini harus sama dengan sebelum migrasi).', v_n;
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 5. catat_foto_masuk memakai kunci beku.
+--
+-- Disalin UTUH dari 0074 dan hanya satu blok yang berubah — pemeriksaan "kode
+-- lomba ini milik pos itu". `create or replace` mengganti seluruh badan, jadi
+-- cabang yang lupa disalin akan hilang tanpa satu galat pun.
+-- ---------------------------------------------------------------------------
+create or replace function catat_foto_masuk(
+  p_pos        smallint,
+  p_kode_lomba text,
+  p_nama_lomba text,
+  p_path       text,
+  p_ukuran     integer default null
+) returns uuid
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_id uuid;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+  if pos_saya() is not null and p_pos is distinct from pos_saya() then
+    raise exception 'operator pos % tidak boleh mengunggah foto pos %',
+      pos_saya(), p_pos;
+  end if;
+
+  if coalesce(trim(p_kode_lomba), '') = '' or coalesce(trim(p_path), '') = '' then
+    raise exception 'kode lomba dan path wajib diisi';
+  end if;
+
+  if split_part(p_path, '/', 1) <> 'pos' || p_pos::text then
+    raise exception 'path % tidak berada di folder pos %', p_path, p_pos;
+  end if;
+
+  -- Kode lomba harus benar-benar milik pos itu. Tanpa ini, salah pilih di
+  -- layar melahirkan tumpukan foto di lomba yang tidak pernah ada, dan tidak
+  -- ada layar yang akan menampilkannya lagi.
+  --
+  -- SATU-SATUNYA yang berubah dari 0074: kuncinya dibaca dari kolom, bukan
+  -- diturunkan lagi dari nama. Sesudah ini mengganti nama lomba tidak lagi
+  -- membuat RPC ini menolak kode yang sudah dipakai fotonya.
+  if not exists (
+    select 1 from wahana w
+    where w.pos = p_pos
+      and kode_lomba_wahana(w.kode_lomba, w.lomba, w.name) = p_kode_lomba
+  ) then
+    raise exception 'lomba % bukan lomba di pos %', p_kode_lomba, p_pos;
+  end if;
+
+  -- Gambar diunggah LEBIH DULU, barisnya sesudahnya. Mengirim ulang berkas
+  -- yang sama bukan galat — jaringan lapangan memutus jawaban, bukan
+  -- permintaan. `do nothing` tidak mengembalikan baris, jadi id-nya diambil
+  -- lagi sesudahnya.
+  insert into foto_lembar
+    (regu_id, pos, kode_lomba, nama_lomba, path, ukuran_bytes, diunggah_oleh)
+  values
+    (null, p_pos, p_kode_lomba, p_nama_lomba, p_path, p_ukuran, auth.uid())
+  on conflict (path) do nothing
+  returning id into v_id;
+
+  if v_id is null then
+    select id into v_id from foto_lembar where path = p_path;
+  end if;
+  return v_id;
+end;
+$$;
+
+grant execute on function catat_foto_masuk(smallint, text, text, text, integer)
+  to authenticated;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -163,7 +163,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     # lembar bukan tiga — persis yang dilarang CLAUDE.md 11.6.
                     # Setiap uji lokal atas pengelompokan lomba menguji dunia
                     # yang salah, dan hasilnya terlihat masuk akal.
-                    "       lomba, "
+                    "       lomba, kode_lomba, "
                     "       rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() and pos = %s "
@@ -174,7 +174,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 # Rekapitulasi (#/rekap).
                 self._kirim(200, q(
                     "select pos, kode, name, type, form, poin_maks, satuan, "
-                    "       golongan, petunjuk, judul_isian, lomba, "
+                    "       golongan, petunjuk, judul_isian, lomba, kode_lomba, "
                     "       total_soal, rentang_mentah_min, "
                     "       rentang_mentah_maks, sort_order "
                     "from wahana where edisi = edisi_aktif() "

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -290,5 +290,12 @@ run tests/sql/40_peran_mengisi_ulang_centang.sql
 # dan `_` tetap membedakan dua orang.
 run supabase/migrations/0078_kunci_akun.sql
 run tests/sql/41_kunci_akun.sql
+# 0079 membekukan kunci lomba yang dipakai foto. Sebelumnya kunci itu
+# DITURUNKAN dari nama tiap kali dibaca, jadi mengganti nama lomba memutus
+# seluruh foto yang sudah diunggah untuknya — tanpa galat dan tanpa satu pun
+# layar merah. Tes 42 menjaga yang tidak bersuara itu: namanya diganti, dan
+# kuncinya harus DIAM.
+run supabase/migrations/0079_kode_lomba_stabil.sql
+run tests/sql/42_kode_lomba_stabil.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/42_kode_lomba_stabil.sql
+++ b/tests/sql/42_kode_lomba_stabil.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/42_kode_lomba_stabil.sql — migrasi 0079.
+--
+-- YANG DIUJI, dan kenapa ia perlu mesin:
+--
+-- Sebelum 0079, kunci foto sebuah lomba DITURUNKAN dari namanya tiap kali
+-- dibaca. Mengganti nama lomba karena itu memutus seluruh foto yang sudah
+-- diunggah untuknya — tanpa galat, tanpa layar merah, tanpa satu pun tanda.
+-- Kerusakan yang tidak bersuara hanya bisa dijaga tes.
+--
+-- Tiga hal yang harus benar bersamaan:
+--   1. Baris baru mendapat kunci tanpa diminta (trigger).
+--   2. Kunci itu TIDAK bergerak waktu namanya diganti.
+--   3. Kunci lama tetap terbaca untuk baris yang kolomnya belum terisi.
+-- ============================================================================
+
+\echo '--- 42. kode lomba tetap walau namanya berganti'
+
+do $blok$
+declare
+  v_edisi  smallint := edisi_aktif();
+  v_kunci  text;
+  v_kunci2 text;
+begin
+  -- Pos 19 dipakai sebagai ruang kerja: di luar 1-5 yang dipakai lomba
+  -- sungguhan, jadi tes ini tidak pernah bertabrakan dengan konfigurasi edisi
+  -- mana pun (pos_nomor_check mengizinkan 1-20 sejak 0021).
+  delete from wahana where edisi = v_edisi and pos = 19;
+  delete from pos where edisi = v_edisi and nomor = 19;
+  -- wahana menunjuk pos (edisi, nomor), jadi posnya harus ada lebih dulu.
+  insert into pos (edisi, nomor, name, bobot) values (v_edisi, 19, 'Uji 42', 1.00);
+
+  -- ---------------------------------------------------------------------
+  -- 1. Baris baru mendapat kunci sendiri.
+  -- ---------------------------------------------------------------------
+  -- raw_terbaik/raw_terburuk wajib untuk bentuk besar_baik (wahana_check1).
+  insert into wahana (edisi, pos, kode, name, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk,
+                      rentang_mentah_min, rentang_mentah_maks, sort_order)
+  values (v_edisi, 19, 'uji_bendera', 'Semaphore', 'wahana', 'besar_baik',
+          100, 5, 0, 0, 5, 1);
+
+  select kode_lomba into v_kunci
+  from wahana where edisi = v_edisi and pos = 19 and kode = 'uji_bendera';
+
+  assert v_kunci = 'semaphore',
+    format('42.1 GAGAL: kunci baris baru "%s", seharusnya "semaphore"', v_kunci);
+  raise notice '42.1 OK — baris baru mendapat kunci "%" tanpa diminta.', v_kunci;
+
+  -- ---------------------------------------------------------------------
+  -- 2. Namanya diganti — kuncinya tidak boleh ikut.
+  --
+  -- Inilah yang dulu rusak: "Semaphore" jadi "Bendera" membuat kuncinya jadi
+  -- `bendera`, dan seluruh foto berkode `semaphore` tidak ketemu lagi.
+  -- ---------------------------------------------------------------------
+  update wahana set name = 'Bendera', rentang_mentah_maks = 10
+  where edisi = v_edisi and pos = 19 and kode = 'uji_bendera';
+
+  select kode_lomba into v_kunci2
+  from wahana where edisi = v_edisi and pos = 19 and kode = 'uji_bendera';
+
+  assert v_kunci2 = v_kunci,
+    format('42.2 GAGAL: kunci berpindah dari "%s" jadi "%s" hanya karena '
+           'namanya diganti — foto lama akan hilang', v_kunci, v_kunci2);
+  raise notice '42.2 OK — nama jadi "Bendera 0-10", kunci tetap "%".', v_kunci2;
+
+  -- ---------------------------------------------------------------------
+  -- 3. Baris yang kolomnya BELUM terisi tetap terbaca dengan kunci lama.
+  --
+  -- Migrasi lama menyisipkan wahana tanpa menyebut kolom ini; pembacanya harus
+  -- tetap menemukan mereka, kalau tidak foto yang sudah ada justru diputus
+  -- oleh migrasi yang dibuat untuk mencegah itu.
+  -- ---------------------------------------------------------------------
+  update wahana set kode_lomba = null
+  where edisi = v_edisi and pos = 19 and kode = 'uji_bendera';
+
+  select kode_lomba_wahana(kode_lomba, lomba, name) into v_kunci2
+  from wahana where edisi = v_edisi and pos = 19 and kode = 'uji_bendera';
+
+  assert v_kunci2 = 'bendera',
+    format('42.3 GAGAL: cadangan menghasilkan "%s", seharusnya "bendera"',
+           v_kunci2);
+  raise notice '42.3 OK — kolom kosong jatuh ke hitungan lama ("%").', v_kunci2;
+
+  -- ---------------------------------------------------------------------
+  -- 4. Komponen berkelompok memakai nama LOMBA-nya, bukan nama sendiri.
+  -- ---------------------------------------------------------------------
+  insert into wahana (edisi, pos, kode, name, lomba, type, form, poin_maks,
+                      raw_terbaik, raw_terburuk,
+                      rentang_mentah_min, rentang_mentah_maks, sort_order)
+  values (v_edisi, 19, 'uji_bidai_a', 'Teknik Bidai', 'Pembidaian',
+          'wahana', 'besar_baik', 25, 25, 0, 0, 25, 2);
+
+  select kode_lomba into v_kunci
+  from wahana where edisi = v_edisi and pos = 19 and kode = 'uji_bidai_a';
+
+  assert v_kunci = 'pembidaian',
+    format('42.4 GAGAL: kunci komponen berkelompok "%s", seharusnya '
+           '"pembidaian"', v_kunci);
+  raise notice '42.4 OK — komponen berkelompok berkunci "%".', v_kunci;
+
+  delete from wahana where edisi = v_edisi and pos = 19;
+  delete from pos where edisi = v_edisi and nomor = 19;
+end;
+$blok$;
+
+\echo '--- 42 SELESAI'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -555,7 +555,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,kode_lomba,kode_lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }
@@ -569,7 +569,7 @@ export async function komponenSemua(edisi) {
   return baca(null,
     `wahana?edisi=eq.${encodeURIComponent(edisi)}` +
     `&select=pos,kode,name,type,form,poin_maks,satuan,total_soal,` +
-    `golongan,petunjuk,judul_isian,lomba,` +
+    `golongan,petunjuk,judul_isian,lomba,kode_lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=pos.asc,sort_order.asc`);
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2352,9 +2352,15 @@ function kolomPos(komponen) {
 function kelompokLomba(kolom) {
   const urut = [], peta = new Map();
   for (const kol of kolom) {
-    const nama = kol.varian[0].lomba || kol.nama;
+    const k = kol.varian[0];
+    const nama = k.lomba || kol.nama;
     if (!peta.has(nama)) {
-      peta.set(nama, { nama, kolom: [] });
+      // `kode` adalah kunci TETAP lomba ini (0079), dan ia dibaca dari
+      // database — bukan diturunkan dari namanya. Foto slip disimpan dengan
+      // kunci itu, jadi menurunkannya dari nama berarti mengganti nama lomba
+      // menghilangkan seluruh fotonya tanpa satu pun galat. Cadangan slug
+      // dipakai hanya untuk baris yang kolomnya belum terisi.
+      peta.set(nama, { nama, kode: k.kode_lomba || slugLomba(nama), kolom: [] });
       urut.push(peta.get(nama));
     }
     peta.get(nama).kolom.push(kol);
@@ -3152,7 +3158,7 @@ async function layarInputPos() {
        memakai slug PENILAIAN, foto yang diunggah borongan tidak akan pernah
        muncul di sini — dan justru dialog inilah yang dipakai memeriksa hasil
        penautan. */
-    const lomba = kelompokLomba(kolom).map(l => [slugLomba(l.nama), l.nama]);
+    const lomba = kelompokLomba(kolom).map(l => [l.kode, l.nama]);
 
     /* Template BIASA, bukan tag html`` — sama alasannya dengan notif(): tag
        html`` meng-escape SETIAP sisipan, dan ikon("camera") adalah HTML yang


### PR DESCRIPTION
## What

`wahana.kode_lomba` menyimpan kunci lomba **sebagai data**, bukan menurunkannya
dari nama tiap kali dibaca. Migrasi `0079` + tes `42`.

## Why

`foto_lembar.kode_lomba` menyimpan **slug dari nama** lomba, dan kuncinya
dihitung ulang tiap kali dibaca (`slug_lomba(coalesce(w.lomba, w.name))`).
Artinya **nama lomba adalah identitasnya**.

Ganti "Semaphore" jadi "Bendera" — satu `UPDATE` yang terlihat tidak berbahaya,
dan justru itu yang diminta kalau lombanya berganti — dan seluruh foto yang
sudah diunggah untuknya **lenyap dari layar**: dialog mencari `bendera`,
barisnya menyandang `semaphore`, dan RPC-nya menolak kode lama. Tidak ada
galat. Fotonya masih ada di storage; tidak ada satu pun layar yang menemukannya
lagi.

Itu jenis kerusakan yang paling mahal di acara ini: **bukti yang hilang justru
saat ada yang mempertanyakan sebuah nilai.**

## Notes

**Dibekukan, bukan dihitung ulang.** Kolomnya diisi persis dengan yang berlaku
hari ini, jadi saat migrasi jalan **tidak ada satu pun kunci yang berubah** dan
seluruh foto lama tetap ketemu. Yang berubah cuma sifatnya.

**Dibekukan, bukan diganti jadi `kode`.** Menurunkan kunci dari `wahana.kode`
terdengar lebih bersih tapi **memutus foto yang sudah ada**: Tebak Simpul
bernama sama di empat baris dengan kode berbeda, jadi kuncinya hari ini
`tebak-simpul` dan bukan salah satu kodenya. Migrasi yang membetulkan kerusakan
tidak boleh membuat kerusakan yang sama arah.

Trigger mengisi baris baru, jadi komponen yang ditambahkan migrasi berikutnya
tidak diam-diam kembali bersandar pada namanya. Kolomnya boleh `NULL` dan
pembacanya memakai cadangan hitungan lama, jadi baris dari migrasi lama tetap
bekerja.

Tes 42 menjaga yang tidak bersuara itu — **42.2 adalah contoh pemilik acara apa
adanya**:

| | hasil |
|---|---|
| 42.1 baris baru dapat kunci sendiri | `semaphore` |
| **42.2 nama diganti jadi "Bendera 0-10", kunci DIAM** | **`semaphore`** |
| 42.3 kolom kosong jatuh ke hitungan lama | `bendera` |
| 42.4 komponen berkelompok pakai nama lombanya | `pembidaian` |

Ditambahkan ke `tests/run.sh` pada commit yang sama (CLAUDE.md 7.5).
**SEMUA TES LULUS**, dan `hrcd_dev` tetap terbangun.

⚠️ **Perlu `apply-migration.yml` sesudah merge** — migrasi tidak ikut terkirim
saat merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)