### PR TITLE
fix: baris belum tersimpan cukup ditandai warna, bukan kalimat

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2545,15 +2545,23 @@ input.small-input { text-align: center; }
    dan jam; kotak hijau selebar layar untuk dua benda sekecil itu terbaca
    seperti pengumuman, padahal ia sekadar tanda bahwa semuanya beres. Tiga
    keadaan lain tetap melintang penuh — mereka memang pengumuman. */
-.pos-simpan.aman {
+/* BENTUK RINGKAS, dipakai keadaan aman DAN menunggu. Keduanya memakai bentuk
+   yang sama persis — ikon + jam — jadi berpindah antar keduanya hanya
+   mengganti warna dan TIDAK menggerakkan satu piksel pun. Itu yang penting:
+   pitanya duduk di `.baris-pos` yang membungkus, dan pita yang melebar
+   melempar tombol di sebelahnya ke baris berikutnya, menurunkan seluruh tabel
+   di bawah jari yang sedang mengetik. */
+.pos-simpan.ringkas {
   /* `align-self` WAJIB ikut. Ia duduk di dalam `.baris-pos` yang flex, dan
      `align-items` bawaan akan meregangkannya mengikuti tinggi dropdown di
      sebelahnya — `display: inline-flex` saja tidak menahan itu. */
   display: inline-flex; align-self: center; align-items: center; gap: .35rem;
-  background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
   font-variant-numeric: tabular-nums;
 }
-.pos-simpan.aman .ikon { width: 1.1em; height: 1.1em; }
+.pos-simpan.ringkas .ikon { width: 1.1em; height: 1.1em; }
+.pos-simpan.aman {
+  background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
+}
 .pos-simpan.menunggu { background: var(--kuning-muda); color: var(--kuning); border-color: var(--kuning); }
 /* Merah TIDAK dipudarkan seperti dua keadaan di atas. Ini satu-satunya
    keadaan yang berarti "ada nilai yang bisa hilang", dan ia harus tertangkap

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3284,6 +3284,7 @@ async function layarInputPos() {
 
     if (gagal || putus) {
       pita.className = "pos-simpan bahaya";
+      pita.removeAttribute("title");
       pita.textContent = putus
         ? `Internet putus — ${belum + gagal} baris belum tersimpan. Jangan tutup halaman ini. ${cap}.`
         // Kedua-duanya disebut. Pita yang hanya menghitung baris GAGAL sempat
@@ -3294,17 +3295,36 @@ async function layarInputPos() {
       if (gagal) jadwalkanUlang();
       return;
     }
-    if (sibuk)  { pita.className = "pos-simpan menunggu"; pita.textContent = `Menyimpan… ${cap}`; return; }
-    if (belum)  { pita.className = "pos-simpan menunggu"; pita.textContent = `${belum} baris belum tersimpan. ${cap}`; return; }
-    /* Keadaan AMAN diringkas jadi ikon + jam. Yang tiga di atas tetap
-       panjang, dan itu bukan ketidakkonsistenan: masing-masing menuntut
-       tindakan dan menyebut berapa baris yang bisa hilang (bagian 9.4).
-       Keadaan aman tidak menuntut apa pun — satu-satunya fakta yang tidak
-       bisa dibaca dari layar adalah KAPAN, dan itulah yang tersisa.
+    /* MENUNGGU diringkas seperti AMAN — ikon + jam, cuma warnanya kuning.
+       Bentuknya sengaja SAMA PERSIS supaya lebarnya tidak bergerak: pitanya
+       duduk di `.baris-pos` yang membungkus, jadi kalimat "1 baris belum
+       tersimpan. Sinkronisasi Terakhir: 23:38 (barusan)" melebarkannya sampai
+       tombol di sebelahnya terlempar ke baris berikutnya — dan seluruh tabel
+       ikut turun, tepat saat petugas sedang mengetik di dalamnya. Layar yang
+       bergeser sendiri di bawah jari lebih mahal daripada kalimat yang
+       dijelaskannya.
+
+       Kalimatnya tidak hilang tanpa ganti: baris yang bersangkutan SUDAH
+       menyandang penanda "belum" di kolom statusnya sendiri, jadi jumlahnya
+       terbaca dari tabel — pita ini cuma mengulanginya (bagian 9.3).
+
+       MERAH TETAP PANJANG, dan itu bukan ketidakkonsistenan. Hanya ia yang
+       berarti "ada nilai yang bisa hilang": ia menuntut tindakan, menyebut
+       berapa baris yang terancam, dan melarang menutup halaman (bagian 9.4).
+       Pergeseran layar sepadan untuk yang satu itu. */
+    if (sibuk || belum) {
+      pita.className = "pos-simpan menunggu ringkas";
+      pita.title = sibuk ? `Menyimpan… ${cap}` : `${belum} baris belum tersimpan. ${cap}`;
+      pita.innerHTML = `${ikon("circle-alert")}<span>${esc(jamMenit(jamSinkron))}</span>`;
+      return;
+    }
+    /* Keadaan AMAN: ikon + jam. Ia tidak menuntut apa pun — satu-satunya fakta
+       yang tidak bisa dibaca dari layar adalah KAPAN, dan itulah yang tersisa.
 
        "Data Tersimpan" mengulang apa yang sudah dikatakan warna hijau dan
        centangnya, dan pita ini dibaca ratusan kali per shift (bagian 9.1). */
-    pita.className = "pos-simpan aman";
+    pita.className = "pos-simpan aman ringkas";
+    pita.title = cap;
     pita.innerHTML = `${ikon("circle-check-big")}<span>${esc(jamMenit(jamSinkron))}</span>`;
   }
 

--- a/web/style.css
+++ b/web/style.css
@@ -2545,15 +2545,23 @@ input.small-input { text-align: center; }
    dan jam; kotak hijau selebar layar untuk dua benda sekecil itu terbaca
    seperti pengumuman, padahal ia sekadar tanda bahwa semuanya beres. Tiga
    keadaan lain tetap melintang penuh — mereka memang pengumuman. */
-.pos-simpan.aman {
+/* BENTUK RINGKAS, dipakai keadaan aman DAN menunggu. Keduanya memakai bentuk
+   yang sama persis — ikon + jam — jadi berpindah antar keduanya hanya
+   mengganti warna dan TIDAK menggerakkan satu piksel pun. Itu yang penting:
+   pitanya duduk di `.baris-pos` yang membungkus, dan pita yang melebar
+   melempar tombol di sebelahnya ke baris berikutnya, menurunkan seluruh tabel
+   di bawah jari yang sedang mengetik. */
+.pos-simpan.ringkas {
   /* `align-self` WAJIB ikut. Ia duduk di dalam `.baris-pos` yang flex, dan
      `align-items` bawaan akan meregangkannya mengikuti tinggi dropdown di
      sebelahnya — `display: inline-flex` saja tidak menahan itu. */
   display: inline-flex; align-self: center; align-items: center; gap: .35rem;
-  background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
   font-variant-numeric: tabular-nums;
 }
-.pos-simpan.aman .ikon { width: 1.1em; height: 1.1em; }
+.pos-simpan.ringkas .ikon { width: 1.1em; height: 1.1em; }
+.pos-simpan.aman {
+  background: var(--hijau-muda); color: var(--hijau); border-color: var(--hijau);
+}
 .pos-simpan.menunggu { background: var(--kuning-muda); color: var(--kuning); border-color: var(--kuning); }
 /* Merah TIDAK dipudarkan seperti dua keadaan di atas. Ini satu-satunya
    keadaan yang berarti "ada nilai yang bisa hilang", dan ia harus tertangkap


### PR DESCRIPTION
## What

Pita status di Input Nilai Pos memakai bentuk yang **sama persis** untuk
keadaan aman dan menunggu — ikon + jam — dan yang berbeda cuma warnanya:
hijau jadi kuning.

## Why

Kalimat `1 baris belum tersimpan. Sinkronisasi Terakhir: 23:38 (barusan)`
melebarkan pitanya sampai tombol di sebelahnya terlempar ke baris berikutnya.
`.baris-pos` membungkus, jadi **seluruh tabel di bawahnya ikut turun** — tepat
saat petugas sedang mengetik di dalamnya. Layar yang bergeser sendiri di bawah
jari lebih mahal daripada kalimat yang dijelaskannya.

Kalimatnya **tidak hilang tanpa ganti**: baris yang bersangkutan sudah
menyandang penanda `belum` di kolom statusnya sendiri, jadi jumlahnya terbaca
langsung dari tabel — pita ini cuma mengulanginya (CLAUDE.md 9.3). Kalimat
lengkapnya dipindah ke `title`, jadi masih bisa dibaca tanpa memakan lebar.

**Menyimpan… ikut diringkas.** Sebabnya sama persis: ia melebar lalu menyusut
lagi sedetik kemudian, jadi tabelnya turun-naik tiap kali satu baris terkirim.

**Merah tetap panjang**, dan itu bukan ketidakkonsistenan. Hanya ia yang
berarti "ada nilai yang bisa hilang": ia menuntut tindakan, menyebut berapa
baris yang terancam, dan melarang menutup halaman (CLAUDE.md 9.4). Pergeseran
layar sepadan untuk yang satu itu.

## Notes

Diukur di browser dengan markup barisnya yang sebenarnya:

| keadaan | lebar pita | tombol di | tinggi baris |
|---|---|---|---|
| aman | 84.2 | 96.2 | 108.4 |
| **menunggu** | **84.2** | **96.2** | **108.4** |
| bahaya | 615.3 | 192.6 | 204.8 |

Aman dan menunggu **identik sampai sepersepuluh piksel** — berpindah antar
keduanya tidak menggerakkan apa pun. Yang 96px turun tinggal keadaan merah,
yang memang disengaja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)