### PR TITLE
fix: Status jadi satu baris tipis melintang yang bisa ditekan

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -230,13 +230,12 @@ function gambarKelengkapan() {
 
   return `
     <div class="kartu">
-      <h2 class="judul-status">Status</h2>
-      <button type="button" class="kemajuan-ringkas" id="kemajuan-buka"
+      <button type="button" class="judul-status" id="kemajuan-buka"
               aria-expanded="false" aria-controls="kemajuan-rinci">
-        <span class="kr-batang" aria-hidden="true"><span
+        <span class="js-teks">Status</span>
+        <span class="js-batang" aria-hidden="true"><span
           style="width:${persenSemua}%;background:${warnaPersen(persenSemua)}"></span></span>
-        <span class="kr-teks"><strong>${esc(String(persenSemua))}%</strong>
-          · ${esc(String(totalLengkap))} / ${esc(String(totalRegu))} regu</span>
+        <span class="js-persen">${esc(String(persenSemua))}%</span>
         <span class="kr-panah" aria-hidden="true">▾</span>
       </button>
       <ul class="kemajuan" id="kemajuan-rinci">
@@ -257,9 +256,10 @@ function gambarKelengkapan() {
     </div>`;
 }
 
-/* Rincian per pos dibuka/ditutup dengan menekan batangnya. Hanya berlaku di
-   HP: di layar lebar kelima cincin memang selalu tampil dan tombolnya
-   disembunyikan CSS, jadi tidak ada yang bisa ditekan. */
+/* Rincian per pos dibuka/ditutup dengan menekan JUDULNYA, di lebar mana pun.
+   Dulu yang ditekan batang ringkas yang cuma ada di HP, dan di layar lebar
+   kelima cincin selalu tampil tanpa bisa ditutup — dua perilaku untuk satu
+   kartu, jadi apa yang dilihat orang bergantung pada lebar layarnya. */
 function pasangKemajuan() {
   const tombol = document.getElementById("kemajuan-buka");
   const rinci = document.getElementById("kemajuan-rinci");

--- a/live/style.css
+++ b/live/style.css
@@ -2850,36 +2850,48 @@ input.small-input { text-align: center; }
 }
 .kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
 
-/* Batang ringkas — hanya ada di HP. Di layar lebar kelima cincin muat
-   berjajar dan tidak ada yang perlu diringkas. */
-.kemajuan-ringkas { display: none; }
-@media (max-width: 560px) {
-  /* Judulnya ikut disembunyikan: batang di bawahnya sudah berbunyi
-     "69% · 186 / 270 regu", dan kata "Status" di atasnya cuma mengulang apa
-     yang sudah jelas dari bentuknya (bagian 9.3). */
-  .judul-status { display: none; }
+/* SATU BARIS TIPIS MELINTANG, dan baris itu sendiri yang ditekan.
+   Tertutup ia sudah menjawab pertanyaan yang paling sering: "sudah berapa
+   persen". Ditekan, ia membuka rinciannya — persen per pos, yang menjawab
+   pertanyaan berikutnya: "pos mana yang tertinggal".
 
-  .kemajuan-ringkas {
-    display: flex; align-items: center; gap: .6rem; width: 100%;
-    padding: .5rem .2rem; border: 0; background: none; cursor: pointer;
-    font: inherit; color: var(--tinta); text-align: left;
-  }
-  .kr-batang {
-    flex: 1 1 auto; min-width: 0; height: 10px; border-radius: 5px;
-    background: var(--garis); overflow: hidden;
-  }
-  .kr-batang > span { display: block; height: 100%; border-radius: 5px; }
-  .kr-teks { flex: 0 0 auto; font-size: .9rem; color: var(--tinta-lembut); }
-  .kr-teks strong { color: var(--tinta); font-size: 1rem; }
-  .kr-panah { flex: 0 0 auto; color: var(--tinta-lembut); transition: transform .15s; }
-  .kemajuan-ringkas.terbuka .kr-panah { transform: rotate(180deg); }
+   Dulu bentuknya kotak kecil berbunyi "23% · 61 / 270 regu" dengan panah, dan
+   ia terbaca seperti dropdown yang salah tempat: sempit, berbingkai, duduk di
+   bawah judul yang tidak melakukan apa-apa. Sekarang judul, batang, dan
+   persennya SATU tombol selebar kartu.
 
-  /* Rinciannya tertutup sampai batangnya ditekan. Itulah yang membuat yang
-     tampil pertama di HP adalah klasemen, bukan lima cincin setinggi satu
-     layar penuh. */
-  .kemajuan { display: none; }
-  .kemajuan.terbuka { display: flex; margin-top: .6rem; }
+   Dan satu perilaku di semua lebar, bukan dua. Sebelumnya kelima cincin SELALU
+   tampil di layar lebar dan hanya bisa ditutup di HP, karena batangnya
+   disembunyikan CSS di atas 560px. Dua aturan untuk satu kartu berarti apa
+   yang dilihat orang bergantung pada lebar layarnya, dan yang menjelaskannya
+   ke panitia harus bertanya dulu "kamu buka di mana". */
+.judul-status {
+  display: flex; align-items: center; gap: .7rem; width: 100%;
+  margin: 0; padding: .3rem 0; border: 0; background: none; cursor: pointer;
+  font: inherit; color: var(--tinta); text-align: left;
 }
+.js-teks { flex: 0 0 auto; font-size: 1.1rem; font-weight: 700; }
+/* Batangnya yang melar, bukan teksnya — itu yang membuatnya melintang penuh
+   di layar selebar apa pun tanpa satu ukuran pun dipatok tangan. */
+.js-batang {
+  flex: 1 1 auto; min-width: 2rem; height: 8px; border-radius: 4px;
+  background: var(--garis); overflow: hidden;
+}
+.js-batang > span { display: block; height: 100%; border-radius: 4px; }
+.js-persen {
+  flex: 0 0 auto; font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.kr-panah {
+  flex: 0 0 auto; font-size: .8em; color: var(--tinta-lembut);
+  transition: transform .15s;
+}
+.judul-status[aria-expanded="true"] .kr-panah { transform: rotate(180deg); }
+
+/* Rinciannya tertutup sampai batangnya ditekan — di lebar mana pun. Itulah
+   yang membuat yang tampil pertama adalah klasemen, bukan lima cincin
+   setinggi satu layar penuh di HP. */
+.kemajuan { display: none; }
+.kemajuan.terbuka { display: flex; margin-top: .8rem; }
 
 /* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
    properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4440,29 +4440,18 @@ async function layarLiveScore() {
     return `hsl(${Math.round(rona)}, 72%, 40%)`;
   };
 
-  /* SATU BARIS DI HP, LIMA CINCIN DI LAYAR LEBAR.
-     Kelima cincin memakan hampir satu layar penuh di HP, dan yang dibuka
-     orang di layar ini adalah KLASEMEN — cincinnya dilirik sekali lalu
-     dilewati. Di HP mereka diringkas jadi satu batang: persen seluruh acara,
-     bisa ditekan untuk membuka rinciannya per pos.
-
-     Angkanya jumlah, bukan rata-rata dari lima persen. Rata-rata persen
-     memberi bobot sama pada pos yang jumlah regunya berbeda, dan di edisi
-     yang posnya tidak sama besar itu menghasilkan angka yang tidak berarti
-     apa-apa. */
   const totalLengkap = pos.reduce((n, p) => n + Number(p.lengkap || 0), 0);
   const totalRegu    = pos.reduce((n, p) => n + Number(p.regu_total || 0), 0);
   const persenSemua  = totalRegu ? Math.round(totalLengkap / totalRegu * 100) : 0;
 
   const kemajuan = `
     <div class="card">
-      <h2 class="judul-tengah judul-status">Status</h2>
-      <button type="button" class="kemajuan-ringkas" id="kemajuan-buka"
+      <button type="button" class="judul-status" id="kemajuan-buka"
               aria-expanded="false" aria-controls="kemajuan-rinci">
-        <span class="kr-batang" aria-hidden="true"><span
+        <span class="js-teks">Status</span>
+        <span class="js-batang" aria-hidden="true"><span
           style="width:${persenSemua}%;background:${warnaPersen(persenSemua)}"></span></span>
-        <span class="kr-teks"><strong>${esc(String(persenSemua))}%</strong>
-          · ${esc(String(totalLengkap))} / ${esc(String(totalRegu))} regu</span>
+        <span class="js-persen">${esc(String(persenSemua))}%</span>
         <span class="kr-panah" aria-hidden="true">▾</span>
       </button>
       <ul class="kemajuan" id="kemajuan-rinci">
@@ -4715,9 +4704,10 @@ async function layarLiveScore() {
      Untuk satu kolom yang berpindah itu mahal, dan yang paling terasa: papan
      berkedip dan tab golongan yang sedang dibuka kembali ke awal. Yang
      berubah di layar cuma tombol mana yang menyala. */
-  /* Rincian per pos dibuka/ditutup dengan menekan batangnya. Hanya berlaku di
-     HP: di layar lebar kelima cincin memang selalu tampil dan tombolnya
-     disembunyikan CSS, jadi tidak ada yang bisa ditekan. */
+  /* Rincian per pos dibuka/ditutup dengan menekan JUDULNYA, di lebar mana pun.
+     Dulu yang ditekan batang ringkas yang cuma ada di HP, dan di layar lebar
+     kelima cincin selalu tampil tanpa bisa ditutup — dua perilaku untuk satu
+     kartu, jadi apa yang dilihat orang bergantung pada lebar layarnya. */
   const tombolKemajuan = document.getElementById("kemajuan-buka");
   const rinciKemajuan = document.getElementById("kemajuan-rinci");
   if (tombolKemajuan && rinciKemajuan) {

--- a/web/style.css
+++ b/web/style.css
@@ -2850,36 +2850,48 @@ input.small-input { text-align: center; }
 }
 .kemajuan li { flex: 1 1 7rem; min-width: 6.5rem; text-align: center; }
 
-/* Batang ringkas — hanya ada di HP. Di layar lebar kelima cincin muat
-   berjajar dan tidak ada yang perlu diringkas. */
-.kemajuan-ringkas { display: none; }
-@media (max-width: 560px) {
-  /* Judulnya ikut disembunyikan: batang di bawahnya sudah berbunyi
-     "69% · 186 / 270 regu", dan kata "Status" di atasnya cuma mengulang apa
-     yang sudah jelas dari bentuknya (bagian 9.3). */
-  .judul-status { display: none; }
+/* SATU BARIS TIPIS MELINTANG, dan baris itu sendiri yang ditekan.
+   Tertutup ia sudah menjawab pertanyaan yang paling sering: "sudah berapa
+   persen". Ditekan, ia membuka rinciannya — persen per pos, yang menjawab
+   pertanyaan berikutnya: "pos mana yang tertinggal".
 
-  .kemajuan-ringkas {
-    display: flex; align-items: center; gap: .6rem; width: 100%;
-    padding: .5rem .2rem; border: 0; background: none; cursor: pointer;
-    font: inherit; color: var(--tinta); text-align: left;
-  }
-  .kr-batang {
-    flex: 1 1 auto; min-width: 0; height: 10px; border-radius: 5px;
-    background: var(--garis); overflow: hidden;
-  }
-  .kr-batang > span { display: block; height: 100%; border-radius: 5px; }
-  .kr-teks { flex: 0 0 auto; font-size: .9rem; color: var(--tinta-lembut); }
-  .kr-teks strong { color: var(--tinta); font-size: 1rem; }
-  .kr-panah { flex: 0 0 auto; color: var(--tinta-lembut); transition: transform .15s; }
-  .kemajuan-ringkas.terbuka .kr-panah { transform: rotate(180deg); }
+   Dulu bentuknya kotak kecil berbunyi "23% · 61 / 270 regu" dengan panah, dan
+   ia terbaca seperti dropdown yang salah tempat: sempit, berbingkai, duduk di
+   bawah judul yang tidak melakukan apa-apa. Sekarang judul, batang, dan
+   persennya SATU tombol selebar kartu.
 
-  /* Rinciannya tertutup sampai batangnya ditekan. Itulah yang membuat yang
-     tampil pertama di HP adalah klasemen, bukan lima cincin setinggi satu
-     layar penuh. */
-  .kemajuan { display: none; }
-  .kemajuan.terbuka { display: flex; margin-top: .6rem; }
+   Dan satu perilaku di semua lebar, bukan dua. Sebelumnya kelima cincin SELALU
+   tampil di layar lebar dan hanya bisa ditutup di HP, karena batangnya
+   disembunyikan CSS di atas 560px. Dua aturan untuk satu kartu berarti apa
+   yang dilihat orang bergantung pada lebar layarnya, dan yang menjelaskannya
+   ke panitia harus bertanya dulu "kamu buka di mana". */
+.judul-status {
+  display: flex; align-items: center; gap: .7rem; width: 100%;
+  margin: 0; padding: .3rem 0; border: 0; background: none; cursor: pointer;
+  font: inherit; color: var(--tinta); text-align: left;
 }
+.js-teks { flex: 0 0 auto; font-size: 1.1rem; font-weight: 700; }
+/* Batangnya yang melar, bukan teksnya — itu yang membuatnya melintang penuh
+   di layar selebar apa pun tanpa satu ukuran pun dipatok tangan. */
+.js-batang {
+  flex: 1 1 auto; min-width: 2rem; height: 8px; border-radius: 4px;
+  background: var(--garis); overflow: hidden;
+}
+.js-batang > span { display: block; height: 100%; border-radius: 4px; }
+.js-persen {
+  flex: 0 0 auto; font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.kr-panah {
+  flex: 0 0 auto; font-size: .8em; color: var(--tinta-lembut);
+  transition: transform .15s;
+}
+.judul-status[aria-expanded="true"] .kr-panah { transform: rotate(180deg); }
+
+/* Rinciannya tertutup sampai batangnya ditekan — di lebar mana pun. Itulah
+   yang membuat yang tampil pertama adalah klasemen, bukan lima cincin
+   setinggi satu layar penuh di HP. */
+.kemajuan { display: none; }
+.kemajuan.terbuka { display: flex; margin-top: .8rem; }
 
 /* Cincin dibuat dengan conic-gradient — bukan SVG, bukan library. Satu
    properti CSS, nol berkas tambahan, dan tebalnya diubah dengan mengganti


### PR DESCRIPTION
## What

Kartu **Status** — di halaman peserta dan di Live Score panitia — jadi satu
tombol selebar kartu:

```
tertutup   Status ▬▬▬▬▬▬▭▭▭▭▭▭▭▭▭▭▭▭▭▭▭▭ 23%  ▾
ditekan    ...lalu kelima cincin per pos muncul di bawahnya
```

## Why

Sebelumnya ada kotak kecil berbunyi `23% · 61 / 270 regu` dengan panah, duduk
di bawah judul yang tidak melakukan apa-apa. Ia terbaca seperti **dropdown yang
salah tempat**: sempit, berbingkai, dan menyisakan pertanyaan tombol mana
sebenarnya yang ditekan.

Tertutup, baris ini sudah menjawab pertanyaan yang paling sering ditanya —
*"sudah berapa persen"*. Ditekan, ia menjawab yang berikutnya: *"pos mana yang
tertinggal"*, dan itu yang tidak bisa dijawab satu angka gabungan.

**Satu perilaku di semua lebar, bukan dua.** Sebelumnya kelima cincin **selalu**
tampil di layar lebar dan hanya bisa ditutup di HP, karena batangnya
disembunyikan CSS di atas 560px. Dua aturan untuk satu kartu berarti apa yang
dilihat orang bergantung pada lebar layarnya, dan yang menjelaskannya ke
panitia harus bertanya dulu "kamu buka di mana".

**Kedua papan, bukan satu.** Kartu ini ada di halaman peserta **dan** di Live
Score panitia, dengan markup dan CSS yang sama persis (`web/style.css` yang
disalin ke `live/`). Mengganti satu saja akan melahirkan kembali perbedaan yang
baru saja dihapus lima PR terakhir.

## Notes

Diukur di browser dengan kelima pos:

| yang diukur | hasil |
|---|---|
| tinggi batang | 8px |
| lebar batang | 76% lebar kartu — sisanya label, persen, panah |
| isian batang | tepat 23% dari batangnya |
| tinggi kartu tertutup → terbuka | 74.8px → 230.8px |
| panah | berbalik, `aria-expanded` ikut |
| sisa `.kemajuan-ringkas` / `.kr-batang` / `.kr-teks` | tidak ada di kedua berkas |

🤖 Generated with [Claude Code](https://claude.com/claude-code)