### PR TITLE
fix: kepala kolom Live Score benar-benar rata tengah

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2970,6 +2970,20 @@ input.small-input { text-align: center; }
   font-variant-numeric: tabular-nums;
 }
 
+/* RANTAI `th.pos-kol`, BUKAN `.pos-kol` SAJA — dan itu bukan kerapian.
+   `.pos-kol` sendirian berkekhususan (0,1,0), kalah dari `.table th` (0,1,1)
+   yang menyetel `text-align: left` untuk semua kepala tabel. Aturan tengah di
+   sini karena itu TIDAK PERNAH berlaku: terukur, kepala kolomnya rata kiri dan
+   titik tengah namanya meleset ~7px dari titik tengah selnya. Yang paling
+   terlihat bukan namanya — ia hampir selebar selnya sehingga meleset sedikit
+   tidak kentara — melainkan rentang di bawahnya, yang jauh lebih pendek dan
+   karena itu berdiri jelas di tepi kiri sementara angka-angka di bawahnya
+   ditengahkan.
+
+   Kedua situs disebut. Halaman peserta memakai `.tabel`, bukan `.table`, dan
+   `.tabel th` juga menyetel rata kiri — jadi bug yang sama ada di sana. */
+.table th.pos-kol,
+.tabel th.pos-kol,
 .pos-kol {
   text-align: center; font-variant-numeric: tabular-nums;
   white-space: nowrap; padding-left: .3rem; padding-right: .3rem;

--- a/web/style.css
+++ b/web/style.css
@@ -2970,6 +2970,20 @@ input.small-input { text-align: center; }
   font-variant-numeric: tabular-nums;
 }
 
+/* RANTAI `th.pos-kol`, BUKAN `.pos-kol` SAJA — dan itu bukan kerapian.
+   `.pos-kol` sendirian berkekhususan (0,1,0), kalah dari `.table th` (0,1,1)
+   yang menyetel `text-align: left` untuk semua kepala tabel. Aturan tengah di
+   sini karena itu TIDAK PERNAH berlaku: terukur, kepala kolomnya rata kiri dan
+   titik tengah namanya meleset ~7px dari titik tengah selnya. Yang paling
+   terlihat bukan namanya — ia hampir selebar selnya sehingga meleset sedikit
+   tidak kentara — melainkan rentang di bawahnya, yang jauh lebih pendek dan
+   karena itu berdiri jelas di tepi kiri sementara angka-angka di bawahnya
+   ditengahkan.
+
+   Kedua situs disebut. Halaman peserta memakai `.tabel`, bukan `.table`, dan
+   `.tabel th` juga menyetel rata kiri — jadi bug yang sama ada di sana. */
+.table th.pos-kol,
+.tabel th.pos-kol,
 .pos-kol {
   text-align: center; font-variant-numeric: tabular-nums;
   white-space: nowrap; padding-left: .3rem; padding-right: .3rem;


### PR DESCRIPTION
## What

Nama kolom **dan** rentangnya (`0 – 5`) kini benar-benar ditengahkan di atas
kolom angkanya, di Live Score panitia maupun peserta.

## Why

`.pos-kol` **sudah** menyetel `text-align: center` — dan aturan itu tidak
pernah berlaku sedetik pun. Sebabnya kekhususan, bukan nilainya:

| selektor | kekhususan | menang? |
|---|---|---|
| `.pos-kol` | (0,1,0) | ✗ |
| `.table th` → `text-align: left` | (0,1,1) | ✓ |

Terukur sebelum perbaikan: `getComputedStyle(th).textAlign` mengembalikan
`"left"`, dan titik tengah nama kolomnya meleset **~7px** dari titik tengah
selnya.

Yang paling terlihat bukan namanya. "SEMAPHORE" hampir selebar selnya sendiri,
jadi meleset sedikit tidak kentara; **rentangnya** jauh lebih pendek dan karena
itu berdiri jelas di tepi kiri — tepat di atas kolom angka yang rapi
ditengahkan.

**Kedua situs, bukan satu.** Halaman peserta memakai `.tabel`, bukan `.table`,
dan `.tabel th` juga menyetel rata kiri — jadi bug yang sama ada di sana dan
sama tidak terlihatnya. Rantainya menyebut keduanya.

## Notes

Ditulis sebagai rantai `th.pos-kol` yang mengalahkan keduanya, **bukan aturan
baru yang membatalkan yang lama** — yang salah memang bukan nilainya melainkan
kekhususannya (CLAUDE.md 15.12: cari dulu aturan yang menang, jangan menambah
aturan untuk membatalkannya).

Terukur sesudahnya: `textAlign` jadi `center`, dan titik tengah nama maupun
rentang meleset paling jauh **0.5px** dari titik tengah selnya — sisa
pembulatan subpiksel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)