### PR TITLE
fix: unggah foto per regu bisa menulis lagi

### DIFF
--- a/supabase/migrations/0080_catat_foto_lembar_taut.sql
+++ b/supabase/migrations/0080_catat_foto_lembar_taut.sql
@@ -1,0 +1,128 @@
+-- ============================================================================
+-- hrcd-rekap : 0080_catat_foto_lembar_taut.sql
+--
+-- UNGGAH FOTO PER REGU BERHENTI TOTAL SEJAK 0074.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG RUSAK
+--
+-- 0074 menambahkan tiga kolom jejak penautan ke `foto_lembar` — `cara_taut`,
+-- `ditaut_oleh`, `ditaut_pada` — lalu menguncinya dengan
+--
+--     constraint foto_lembar_taut_utuh
+--     check ((regu_id is null) = (cara_taut is null))
+--
+-- Aturannya benar dan tidak diubah di sini: baris yang punya regu tapi tidak
+-- punya jejak siapa yang menautkannya adalah baris yang tidak bisa
+-- dipertanggungjawabkan, dan foto ini gunanya justru untuk dipertanggung-
+-- jawabkan.
+--
+-- Yang tidak dilakukan 0074 adalah memberi tahu SATU-SATUNYA penulis lama
+-- tentang aturan barunya. `catat_foto_lembar` — dialog "Foto Jawaban" per
+-- regu, dipakai sejak 0047 dan terakhir disentuh 0064 — menyisipkan
+--
+--     (regu_id, pos, kode_lomba, nama_lomba, path, ukuran_bytes, diunggah_oleh)
+--
+-- dengan `regu_id` SELALU terisi (fungsinya menolak nomor dada yang tidak
+-- dikenal) dan `cara_taut` tidak pernah disebut, jadi NULL. Sisi kiri
+-- constraint `false`, sisi kanan `true`. Setiap panggilan ditolak.
+--
+-- Dua fungsi yang 0074 buat sendiri lolos, dan itulah yang menyembunyikannya:
+-- `catat_foto_masuk` menulis `regu_id = null` tanpa `cara_taut` (kedua sisi
+-- `true`), `tautkan_foto` menulis keempat kolom sekaligus. Jalur borongan
+-- bekerja, jalur per regu mati — dan keduanya ada di layar yang sama.
+--
+-- Akibatnya di lapangan: gambarnya SUDAH naik ke bucket `lembar` (unggahan
+-- storage terjadi lebih dulu, barisnya sesudahnya), lalu pencatatannya gagal.
+-- Kuota terpakai, berkasnya ada, dan tidak ada satu pun baris yang menunjuk
+-- ke sana — foto yatim yang tidak akan ditemukan layar mana pun. Petugas
+-- melihat "gagal terkirim" dan menekan kirim ulang, yang menambah satu
+-- gambar yatim lagi setiap kali.
+--
+-- Kenapa lolos sampai produksi: tes 37 menguji `catat_foto_masuk` dan
+-- `tautkan_foto` — dua fungsi yang 0074 tulis — dan tidak pernah memanggil
+-- `catat_foto_lembar` sama sekali. Menambahkan constraint tanpa memanggil
+-- setiap penulis yang sudah ada adalah lubang yang sama bentuknya dengan
+-- 0074 bagian 3 (mencari nama fungsi yang sudah di-rename); tes 43 menutupnya
+-- dengan memanggil penulis lama itu.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DIUBAH
+--
+-- Hanya `insert`-nya. Seluruh pagar 0064 disalin apa adanya — hak `pos`,
+-- kunci pos operator, wajib isi, folder path, nomor dada dikenal, dan
+-- `on conflict (path) do nothing` untuk kirim ulang.
+--
+-- `cara_taut` diisi 'unggah', persis nilai yang dipakai 0074 saat menambal
+-- baris lama: foto yang sudah tertaut sejak lahir karena nomor dadanya
+-- diketik SEBELUM gambarnya diambil. Baris baru dari dialog ini lahir dengan
+-- cara yang sama, jadi ia harus menyandang nama yang sama — kalau tidak,
+-- `v_foto_lembar` akan memisahkan dua kelompok baris yang identik asal-usulnya.
+--
+-- `ditaut_oleh`/`ditaut_pada` sama dengan `diunggah_oleh`/`diunggah_pada`:
+-- di jalur ini keduanya memang satu peristiwa, satu orang, satu detik.
+-- ============================================================================
+
+create or replace function catat_foto_lembar(
+  p_nomor_dada integer,
+  p_pos        smallint,
+  p_kode_lomba text,
+  p_nama_lomba text,
+  p_path       text,
+  p_ukuran     integer default null
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_regu uuid;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+  if pos_saya() is not null then
+    if p_pos is distinct from pos_saya() then
+      raise exception 'operator pos % tidak boleh mengunggah foto pos %',
+        pos_saya(), p_pos;
+    end if;
+  end if;
+
+  if coalesce(trim(p_kode_lomba), '') = '' or coalesce(trim(p_path), '') = '' then
+    raise exception 'kode lomba dan path wajib diisi';
+  end if;
+
+  -- Path harus berada di dalam folder posnya. Tanpa ini seorang operator bisa
+  -- mencatat baris pos-nya sendiri yang menunjuk gambar milik pos lain.
+  if split_part(p_path, '/', 1) <> 'pos' || p_pos::text then
+    raise exception 'path % tidak berada di folder pos %', p_path, p_pos;
+  end if;
+
+  select id into v_regu from regu
+  where nomor_dada = p_nomor_dada and not is_cancelled;
+  if not found then
+    raise exception 'nomor dada % tidak dikenal / regu batal',
+      case when p_nomor_dada between 0 and 999
+        then lpad(p_nomor_dada::text, 3, '0') else p_nomor_dada::text end;
+  end if;
+
+  -- Tertaut sejak lahir, jadi jejak tautnya ditulis BERSAMA barisnya. Kolom
+  -- taut tidak boleh menyusul lewat update terpisah: foto_lembar_taut_utuh
+  -- memeriksa per baris, jadi baris tanpa jejak tidak akan pernah sempat ada.
+  insert into foto_lembar
+    (regu_id, pos, kode_lomba, nama_lomba, path, ukuran_bytes, diunggah_oleh,
+     cara_taut, ditaut_oleh, ditaut_pada)
+  values
+    (v_regu, p_pos, p_kode_lomba, p_nama_lomba, p_path, p_ukuran, auth.uid(),
+     'unggah', auth.uid(), now())
+  -- Mengirim ulang berkas yang sama bukan galat: jaringan lapangan memutus
+  -- jawaban, bukan permintaan, dan petugas yang menekan "kirim ulang" tidak
+  -- melakukan kesalahan apa pun.
+  on conflict (path) do nothing;
+end;
+$$;
+
+revoke all on function catat_foto_lembar(integer, smallint, text, text, text, integer) from public;
+grant execute on function catat_foto_lembar(integer, smallint, text, text, text, integer) to authenticated;
+
+comment on function catat_foto_lembar(integer, smallint, text, text, text, integer) is
+  'Foto per regu: nomor dadanya sudah diketik sebelum gambarnya diambil, jadi '
+  'barisnya lahir sudah tertaut dengan cara_taut = ''unggah''.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -297,5 +297,12 @@ run tests/sql/41_kunci_akun.sql
 # kuncinya harus DIAM.
 run supabase/migrations/0079_kode_lomba_stabil.sql
 run tests/sql/42_kode_lomba_stabil.sql
+# 0080 menyalakan kembali unggah foto PER REGU. 0074 menambah constraint
+# foto_lembar_taut_utuh tapi tidak memberi tahu penulis lamanya, jadi
+# catat_foto_lembar menyisipkan regu_id tanpa cara_taut dan SETIAP unggahan
+# per regu ditolak — sementara tes 37 tetap hijau karena ia cuma memanggil
+# dua fungsi yang 0074 tulis sendiri. Tes 43 memanggil penulis lama itu.
+run supabase/migrations/0080_catat_foto_lembar_taut.sql
+run tests/sql/43_catat_foto_lembar_taut.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/43_catat_foto_lembar_taut.sql
+++ b/tests/sql/43_catat_foto_lembar_taut.sql
@@ -1,0 +1,152 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/43_catat_foto_lembar_taut.sql
+-- Unggah foto PER REGU tetap bisa menulis sesudah 0074 (perbaikan 0080).
+--
+-- YANG DIJAGA DI SINI, DAN KENAPA
+--
+-- 1. Yang diuji adalah `catat_foto_lembar` — penulis LAMA, dari 0047/0064.
+--    Tes 37 menguji dua fungsi yang ditulis 0074 sendiri (`catat_foto_masuk`,
+--    `tautkan_foto`) dan keduanya lolos constraint barunya, jadi tes 37 hijau
+--    sementara dialog per regu di layar menolak setiap unggahan. Constraint
+--    baru harus diuji lewat SETIAP penulis yang sudah ada, bukan cuma lewat
+--    penulis yang lahir bersamanya.
+--
+-- 2. Yang dibaca bukan cuma "tidak galat", tapi ISI barisnya. `on conflict
+--    (path) do nothing` membuat panggilan yang tidak menulis apa pun tetap
+--    kembali dengan sukses — sama persis seperti yang sudah menipu tes 37.2.
+--    Karena itu 43.1 memakai path yang pasti baru dan membaca barisnya.
+--
+-- 3. `cara_taut` harus 'unggah', bukan sekadar "terisi". Nilai itulah yang
+--    dipakai 0074 untuk baris lama yang tertaut sejak lahir; kalau jalur ini
+--    memakai nama lain, dua kelompok baris yang identik asal-usulnya akan
+--    terpisah di layar tanpa satu pun galat.
+-- ============================================================================
+
+create temp table t43_lomba as
+select slug_lomba(coalesce(w.lomba, w.name)) as kode,
+       coalesce(w.lomba, w.name)             as nama
+from wahana w
+where w.pos = 1
+order by w.sort_order, w.kode
+limit 1;
+
+create temp table t43_regu as
+select id, nomor_dada from regu
+where nomor_dada is not null and not is_cancelled
+order by nomor_dada limit 1;
+
+grant select on t43_lomba, t43_regu to public;
+
+select set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+set role authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 43.1  Unggahan per regu MENULIS, dan barisnya lahir sudah tertaut.
+--
+-- Ini pengganti langsung dari galat yang dilihat petugas di lapangan:
+--   new row for relation "foto_lembar" violates check constraint
+--   "foto_lembar_taut_utuh"
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_kode text; v_nama text; v_nomor integer; v_path text;
+  v_regu uuid; v_cara text; v_oleh uuid; v_pada timestamptz; v_regu_asli uuid;
+begin
+  select kode, nama into v_kode, v_nama from t43_lomba;
+  select id, nomor_dada into v_regu_asli, v_nomor from t43_regu;
+  v_path := 'pos1/' || v_kode || '/uji-per-regu-a.jpg';
+
+  perform catat_foto_lembar(v_nomor, 1::smallint, v_kode, v_nama, v_path, 48000);
+
+  select regu_id, cara_taut, ditaut_oleh, ditaut_pada
+    into v_regu, v_cara, v_oleh, v_pada
+  from foto_lembar where path = v_path;
+
+  assert v_regu is not null, 'baris tidak tertulis — unggahan per regu masih tertolak';
+  assert v_regu = v_regu_asli,
+    format('foto tertaut ke regu yang salah: %s bukan %s', v_regu, v_regu_asli);
+  assert v_cara = 'unggah',
+    format('cara_taut seharusnya ''unggah'', bukan %L', v_cara);
+  assert v_oleh is not null, 'ditaut_oleh kosong padahal regunya terisi';
+  assert v_pada is not null, 'ditaut_pada kosong padahal regunya terisi';
+
+  raise notice '43.1 OK — foto per regu tertulis dan lahir sudah tertaut.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 43.2  Kirim ulang berkas yang sama tetap bukan galat.
+--
+-- Jaringan lapangan memutus jawaban, bukan permintaan. Kalau perbaikan 0080
+-- menghapus `on conflict do nothing`, petugas yang menekan "kirim ulang" akan
+-- melihat layar merah untuk unggahan yang sebenarnya sudah berhasil.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_nama text; v_nomor integer; v_path text; v_jumlah integer;
+begin
+  select kode, nama into v_kode, v_nama from t43_lomba;
+  select nomor_dada into v_nomor from t43_regu;
+  v_path := 'pos1/' || v_kode || '/uji-per-regu-a.jpg';
+
+  perform catat_foto_lembar(v_nomor, 1::smallint, v_kode, v_nama, v_path, 48000);
+
+  select count(*) into v_jumlah from foto_lembar where path = v_path;
+  assert v_jumlah = 1,
+    format('kirim ulang seharusnya menyisakan satu baris, ada %s', v_jumlah);
+
+  raise notice '43.2 OK — kirim ulang tidak menggandakan dan tidak menggalat.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 43.3  Nomor dada karangan tetap ditolak, dan TIDAK meninggalkan baris.
+--
+-- Pagar 0064 harus selamat dari penyalinan di 0080. Yang kedua lebih penting
+-- daripada galatnya: baris yatim di sini berarti gambar yang memakan kuota
+-- tanpa pernah muncul di layar mana pun.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_nama text; v_path text; v_pesan text; v_jumlah integer;
+begin
+  select kode, nama into v_kode, v_nama from t43_lomba;
+  v_path := 'pos1/' || v_kode || '/uji-per-regu-b.jpg';
+
+  begin
+    perform catat_foto_lembar(999999, 1::smallint, v_kode, v_nama, v_path, 1000);
+    assert false, 'nomor dada karangan diterima';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+
+  assert v_pesan like '%tidak dikenal%',
+    format('galat yang diharapkan bukan ini: %s', v_pesan);
+
+  select count(*) into v_jumlah from foto_lembar where path = v_path;
+  assert v_jumlah = 0,
+    format('unggahan gagal meninggalkan %s baris yatim', v_jumlah);
+
+  raise notice '43.3 OK — nomor dada karangan ditolak tanpa meninggalkan baris.';
+end $blok$;
+
+-- ---------------------------------------------------------------------------
+-- 43.4  Path di luar folder posnya tetap ditolak.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_kode text; v_nama text; v_nomor integer; v_pesan text;
+begin
+  select kode, nama into v_kode, v_nama from t43_lomba;
+  select nomor_dada into v_nomor from t43_regu;
+
+  begin
+    perform catat_foto_lembar(v_nomor, 1::smallint, v_kode, v_nama,
+                              'pos9/' || v_kode || '/uji-per-regu-c.jpg', 1000);
+    assert false, 'path pos lain diterima';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+
+  assert v_pesan like '%tidak berada di folder pos%',
+    format('galat yang diharapkan bukan ini: %s', v_pesan);
+
+  raise notice '43.4 OK — path di luar folder pos ditolak.';
+end $blok$;
+
+reset role;


### PR DESCRIPTION
## Gejala

Unggah foto lewat dialog **Foto Jawaban** per regu selalu gagal:

```
Foto 001 Tebak Simpul gagal terkirim: new row for relation "foto_lembar"
violates check constraint "foto_lembar_taut_utuh"
```

## Sebabnya

`0074` menambahkan constraint

```sql
check ((regu_id is null) = (cara_taut is null))
```

tetapi tidak memperbarui `catat_foto_lembar` — satu-satunya penulis lama (0047, terakhir disentuh 0064). Fungsi itu SELALU mengisi `regu_id` dan tidak pernah menyebut `cara_taut`, jadi setiap panggilan melanggar constraint.

Dua fungsi yang `0074` tulis sendiri lolos, dan itu yang menyembunyikannya: `catat_foto_masuk` menulis `regu_id = null` tanpa `cara_taut`, `tautkan_foto` menulis keempat kolom. Jalur borongan hidup, jalur per regu mati — dan keduanya ada di layar yang sama.

Gambarnya diunggah ke bucket LEBIH DULU, jadi tiap percobaan meninggalkan berkas yatim yang tidak ditunjuk baris mana pun; petugas yang menekan kirim ulang menambah satu lagi setiap kali.

## Kenapa CI hijau

`tests/sql/37` hanya memanggil `catat_foto_masuk` dan `tautkan_foto`. Penulis lamanya tidak pernah dipanggil satu kali pun sesudah constraint-nya ada.

## Perbaikan

`0080` menulis ulang `catat_foto_lembar` dengan seluruh pagar 0064 disalin apa adanya, dan `insert`-nya kini mengisi `cara_taut = 'unggah'`, `ditaut_oleh`, `ditaut_pada` — nilai yang sama dengan yang dipakai 0074 untuk menambal baris lama yang tertaut sejak lahir.

## Validasi

`bash tests/run.sh` di Postgres lokal — **SEMUA TES LULUS**, termasuk 43.1–43.4 yang baru.

Tes 43 dibuktikan benar-benar menangkap bugnya: dijalankan sekali lagi dengan baris `0080` sengaja dilewati, dan 43.1 gagal dengan galat yang persis sama dengan laporan lapangan, `DETAIL`-nya menunjukkan tiga kolom terakhir `null, null, null`.

## Sesudah merge

Migrasi tidak ikut jalan saat merge. Jalankan `apply-migration.yml` dengan `supabase/migrations/0080_catat_foto_lembar_taut.sql` secara sengaja.