### PR TITLE
fix: "Lihat" memperlihatkan semua foto lomba itu, bukan yang terakhir saja

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -774,6 +774,34 @@ export async function tautanFoto(path) {
   return `${K.supabaseUrl}/storage/v1${j.signedURL || j.signedUrl}`;
 }
 
+/** Tautan bertanda tangan untuk BANYAK berkas sekaligus.
+ *
+ *  Satu permintaan, bukan satu per foto. Di sinyal pos, sembilan permintaan
+ *  berurutan adalah sembilan kesempatan gagal dan sembilan kali menunggu.
+ *
+ *  Yang lebih penting: dengan seluruh tautan sudah di tangan, membuka foto
+ *  ukuran penuh tidak perlu `await` lagi — dan window.open() yang dipanggil
+ *  SESUDAH await diblokir browser HP sebagai popup yang tidak diminta. Itulah
+ *  sebabnya pemanggil lama harus membuka jendela kosong lebih dulu lalu
+ *  mengisinya belakangan. */
+export async function tautanFotoBanyak(paths) {
+  if (K.mode === "dev" || !paths.length) return {};
+  await pastikanSesiSegar();
+  const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}`, {
+    method: "POST",
+    headers: kepalaSupabase(),
+    body: JSON.stringify({ expiresIn: 3600, paths }),
+  });
+  const peta = {};
+  for (const b of j || []) {
+    const tanda = b.signedURL || b.signedUrl;
+    // `path` yang dikembalikan Supabase tidak berawalan bucket, sama dengan
+    // yang dikirim — dipetakan balik supaya pemanggil tidak perlu menebak.
+    if (tanda) peta[b.path] = `${K.supabaseUrl}/storage/v1${tanda}`;
+  }
+  return peta;
+}
+
 /** Pemakaian kuota. Dibaca layar supaya kehabisan ruang tidak jadi kejutan di
  *  tengah acara — dan supaya rata-rata yang membengkak (tanda pengecilan
  *  gambar gagal di sebagian HP) terlihat sebagai angka, bukan sebagai

--- a/live/style.css
+++ b/live/style.css
@@ -1726,6 +1726,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   white-space: nowrap; margin-left: auto;
 }
 
+/* Galeri seluruh foto satu lomba. Gambarnya ditumpuk ke bawah, bukan dibuka
+   satu per satu di tab baru: sembilan tab adalah sembilan kali menekan
+   "kembali" di HP, dan urutannya hilang di antaranya.
+
+   Tingginya dibatasi supaya slip yang dipotret tegak tidak memakan satu layar
+   penuh sendirian — yang dicari orang di sini "fotonya ada dan terbaca", dan
+   untuk membaca angkanya ada tautan ukuran penuh di tiap gambar. */
+.foto-galeri { list-style: none; margin: 0; padding: 0; }
+.foto-galeri li { margin-bottom: .9rem; }
+.foto-galeri li:last-child { margin-bottom: 0; }
+.fg-kepala {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: .6rem; margin-bottom: .3rem; font-size: .85rem;
+}
+.fg-kepala span { color: var(--tinta-lembut); }
+.foto-galeri img {
+  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+  border: 1px solid var(--garis); border-radius: 8px; background: var(--kertas);
+}
+
 /* Foto slip per lomba (0047). Bentuknya sengaja sama dengan .riwayat — dua
    dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua
    aplikasi berbeda. */

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -774,6 +774,34 @@ export async function tautanFoto(path) {
   return `${K.supabaseUrl}/storage/v1${j.signedURL || j.signedUrl}`;
 }
 
+/** Tautan bertanda tangan untuk BANYAK berkas sekaligus.
+ *
+ *  Satu permintaan, bukan satu per foto. Di sinyal pos, sembilan permintaan
+ *  berurutan adalah sembilan kesempatan gagal dan sembilan kali menunggu.
+ *
+ *  Yang lebih penting: dengan seluruh tautan sudah di tangan, membuka foto
+ *  ukuran penuh tidak perlu `await` lagi — dan window.open() yang dipanggil
+ *  SESUDAH await diblokir browser HP sebagai popup yang tidak diminta. Itulah
+ *  sebabnya pemanggil lama harus membuka jendela kosong lebih dulu lalu
+ *  mengisinya belakangan. */
+export async function tautanFotoBanyak(paths) {
+  if (K.mode === "dev" || !paths.length) return {};
+  await pastikanSesiSegar();
+  const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}`, {
+    method: "POST",
+    headers: kepalaSupabase(),
+    body: JSON.stringify({ expiresIn: 3600, paths }),
+  });
+  const peta = {};
+  for (const b of j || []) {
+    const tanda = b.signedURL || b.signedUrl;
+    // `path` yang dikembalikan Supabase tidak berawalan bucket, sama dengan
+    // yang dikirim — dipetakan balik supaya pemanggil tidak perlu menebak.
+    if (tanda) peta[b.path] = `${K.supabaseUrl}/storage/v1${tanda}`;
+  }
+  return peta;
+}
+
 /** Pemakaian kuota. Dibaca layar supaya kehabisan ruang tidak jadi kejutan di
  *  tengah acara — dan supaya rata-rata yang membengkak (tanda pengecilan
  *  gambar gagal di sebagian HP) terlihat sebagai angka, bukan sebagai

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -26,7 +26,7 @@ import {
   statusAcara, bolehLihat, lengkapiHakSesi,
   aturFaseLive,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun, daftarPanitia,
-  ubahUsernameAkun, daftarFitur, daftarHak, setHak,
+  ubahUsernameAkun, daftarFitur, daftarHak, setHak, tautanFotoBanyak,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
@@ -3140,11 +3140,19 @@ async function layarInputPos() {
       notif(`Daftar foto tidak bisa dibaca: ${err.message}`, true);
     }
 
+    /* SELURUH barisnya disimpan per lomba, bukan cuma yang terbaru.
+       Dulu hanya path pertama yang dipegang, jadi "Lihat" pada baris berbunyi
+       "9 foto" tetap membuka SATU gambar — dan yang delapan lagi tidak punya
+       satu pun jalan untuk dilihat. Angkanya benar, tombolnya yang berbohong.
+
+       Urutannya sudah terbaru dulu (order diunggah_pada.desc di api.js), dan
+       itu urutan yang benar: slip yang baru difoto adalah yang sedang
+       dipertanyakan orang. */
     const hitung = {};
-    const terbaru = {};
+    const perLomba = {};
     sudah.forEach(f => {
       hitung[f.kode_lomba] = (hitung[f.kode_lomba] || 0) + 1;
-      if (!terbaru[f.kode_lomba]) terbaru[f.kode_lomba] = f.path;   // sudah urut terbaru dulu
+      (perLomba[f.kode_lomba] ||= []).push(f);
     });
 
     /* Daftarnya per LOMBA, bukan per penilaian. Satu slip adalah satu lomba
@@ -3192,19 +3200,53 @@ async function layarInputPos() {
       kartu.addEventListener("click", async (e) => {
         const b = e.target.closest("[data-lihat]");
         if (!b) return;
-        const kode = b.closest("li").dataset.kode;
-        if (!terbaru[kode]) return;
-        // Jendelanya dibuka SEBELUM await. Dibuka sesudahnya, browser HP
-        // menganggapnya popup yang tidak diminta pengguna dan memblokirnya.
-        const jendela = window.open("", "_blank");
+        const li = b.closest("li");
+        const kode = li.dataset.kode, namaLomba = li.dataset.nama;
+        const daftar = perLomba[kode] || [];
+        if (!daftar.length) return;
+
+        b.disabled = true;
+        let peta = {};
         try {
-          const url = await tautanFoto(terbaru[kode]);
-          if (jendela && url) jendela.location = url;
-          else if (jendela) jendela.close();
+          peta = await tautanFotoBanyak(daftar.map(f => f.path));
         } catch (err) {
-          if (jendela) jendela.close();
+          b.disabled = false;
           notif(`Foto tidak bisa dibuka: ${err.message}`, true);
+          return;
         }
+        b.disabled = false;
+
+        /* Gambarnya dipasang langsung, tidak dibuka di tab baru satu per satu.
+           Sembilan tab adalah sembilan kali menekan "kembali" di HP, dan
+           urutannya hilang di antaranya.
+
+           Tautan penuhnya TETAP ada di tiap gambar, dan karena seluruh tanda
+           tangan sudah di tangan sebelum dialog ini digambar, membukanya tidak
+           perlu await — jadi tidak ada window.open() sesudah await yang akan
+           diblokir browser HP sebagai popup. */
+        const galeri = daftar.map((f, i) => {
+          const url = peta[f.path];
+          const ke = daftar.length - i;            // terbaru dulu, jadi dihitung mundur
+          const kapan = f.diunggah_pada ? tanggalJam(f.diunggah_pada) : "";
+          return `<li>
+            <div class="fg-kepala">
+              <strong>Foto ${esc(String(ke))}</strong>
+              <span>${esc(kapan)}</span>
+            </div>
+            ${url
+              ? `<a href="${esc(url)}" target="_blank" rel="noopener">
+                   <img src="${esc(url)}" alt="Foto ${esc(String(ke))} ${esc(namaLomba)}"
+                        loading="lazy"></a>`
+              : `<p class="keterangan">Tautan fotonya tidak bisa dibuat.</p>`}
+          </li>`;
+        }).join("");
+
+        await dialog({
+          judul: `${namaLomba} · ${daftar.length} foto`,
+          kartuHtml: `<ul class="foto-galeri">${galeri}</ul>`,
+          bacaSaja: true,
+          silangSaja: true,
+        });
       });
 
       kartu.addEventListener("change", async (e) => {
@@ -3232,7 +3274,11 @@ async function layarInputPos() {
             const hasil = await unggahFotoLembar(
               pos.nomor, kode, li.dataset.nama, dada, blob);
             hitung[kode] = (hitung[kode] || 0) + 1;
-            terbaru[kode] = hasil.path;
+            // Disisipkan DI DEPAN: daftarnya terbaru dulu, dan yang barusan
+            // difoto adalah yang paling baru. Tanpa ini "Lihat" sesudah
+            // mengunggah tidak memperlihatkan foto yang baru saja dikirim.
+            (perLomba[kode] ||= []).unshift(
+              { path: hasil.path, diunggah_pada: new Date().toISOString() });
             status.textContent = `${hitung[kode]} foto · ${ukuranRapi(blob.size)}`;
             const lihat = li.querySelector("[data-lihat]");
             if (lihat) lihat.hidden = false;

--- a/web/style.css
+++ b/web/style.css
@@ -1726,6 +1726,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   white-space: nowrap; margin-left: auto;
 }
 
+/* Galeri seluruh foto satu lomba. Gambarnya ditumpuk ke bawah, bukan dibuka
+   satu per satu di tab baru: sembilan tab adalah sembilan kali menekan
+   "kembali" di HP, dan urutannya hilang di antaranya.
+
+   Tingginya dibatasi supaya slip yang dipotret tegak tidak memakan satu layar
+   penuh sendirian — yang dicari orang di sini "fotonya ada dan terbaca", dan
+   untuk membaca angkanya ada tautan ukuran penuh di tiap gambar. */
+.foto-galeri { list-style: none; margin: 0; padding: 0; }
+.foto-galeri li { margin-bottom: .9rem; }
+.foto-galeri li:last-child { margin-bottom: 0; }
+.fg-kepala {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: .6rem; margin-bottom: .3rem; font-size: .85rem;
+}
+.fg-kepala span { color: var(--tinta-lembut); }
+.foto-galeri img {
+  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+  border: 1px solid var(--garis); border-radius: 8px; background: var(--kertas);
+}
+
 /* Foto slip per lomba (0047). Bentuknya sengaja sama dengan .riwayat — dua
    dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua
    aplikasi berbeda. */


### PR DESCRIPTION
## What

Tombol **Lihat** di dialog Foto Jawaban membuka **galeri seluruh foto** lomba
itu, bukan satu gambar.

## Why

Barisnya berbunyi "9 foto", ditekan Lihat, yang terbuka **satu** gambar — dan
yang delapan lagi tidak punya satu pun jalan untuk dilihat. Angkanya benar,
tombolnya yang berbohong.

Sebabnya cuma path pertama yang disimpan:

```js
if (!terbaru[f.kode_lomba]) terbaru[f.kode_lomba] = f.path;
```

Delapan sisanya dihitung, lalu dibuang.

**Ditumpuk ke bawah, bukan dibuka satu per satu di tab baru.** Sembilan tab
adalah sembilan kali menekan "kembali" di HP, dan urutannya hilang di
antaranya. Tautan ukuran penuh tetap ada di tiap gambar untuk yang perlu
membaca angkanya.

**Satu permintaan tanda tangan, bukan sembilan.** `tautanFotoBanyak()` memakai
endpoint sign massal Supabase; di sinyal pos, sembilan permintaan berurutan
adalah sembilan kesempatan gagal. Ia sekaligus membuang akal-akalan popup yang
lama — dengan seluruh tautan sudah di tangan, membuka gambar tidak perlu
`await`, jadi tidak ada `window.open()` sesudah await yang diblokir browser HP.

## Notes

**Jalur unggah ikut dibetulkan, dan ini yang paling mudah terlewat.** Ia dulu
menulis `terbaru[kode] = hasil.path`. Dibiarkan, ia melempar `ReferenceError`
begitu satu foto dikirim — dan `node --check` tetap hijau. Sekarang barisnya
disisipkan **di depan** daftar, jadi menekan Lihat sesudah memotret langsung
memperlihatkan yang barusan dikirim.

Diukur di browser dengan slip tegak dan slip lebar bercampur:

| yang diukur | hasil |
|---|---|
| meluap mendatar | tidak |
| tinggi gambar | berhenti di 60vh |
| bentuk gambar | tidak gepeng (`object-fit: contain`) |
| tautan ukuran penuh | ada di ketiganya |

🤖 Generated with [Claude Code](https://claude.com/claude-code)