### PR TITLE
feat: foto slip bisa dihapus, dengan alasan yang tercatat

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -802,6 +802,38 @@ export async function tautanFotoBanyak(paths) {
   return peta;
 }
 
+/** Hapus satu foto slip: barisnya lewat RPC (yang mencatat alasannya), lalu
+ *  objeknya di bucket.
+ *
+ *  Urutannya begitu dan bukan sebaliknya. Objek dulu lalu barisnya gagal
+ *  menyisakan baris yang menunjuk gambar yang tidak ada — dialognya menggambar
+ *  kotak rusak dan tidak ada yang bisa membetulkannya dari layar. Kebalikannya
+ *  cuma menyisakan berkas yatim: tidak terlihat siapa pun, bisa disapu nanti.
+ *
+ *  Karena itu gagalnya menghapus objek TIDAK dilempar. Barisnya sudah hilang,
+ *  fotonya sudah lenyap dari layar, dan memberi tahu petugas bahwa "hapus
+ *  gagal" padahal fotonya memang sudah hilang cuma membuatnya menekan lagi. */
+export async function hapusFotoLembar(id, alasan) {
+  if (K.mode === "dev") {
+    return kirim(`${K.devUrl}/rpc/hapus_foto_lembar`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uid: sesi() ? sesi().uid : null,
+                             args: { p_id: id, p_alasan: alasan } }),
+    });
+  }
+  const path = await rpc("hapus_foto_lembar", { p_id: id, p_alasan: alasan });
+  if (path) {
+    try {
+      await pastikanSesiSegar();
+      await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET}/${path}`, {
+        method: "DELETE", headers: kepalaSupabase(),
+      });
+    } catch { /* berkas yatim, bukan kegagalan yang perlu dilihat petugas */ }
+  }
+  return path;
+}
+
 /** Pemakaian kuota. Dibaca layar supaya kehabisan ruang tidak jadi kejutan di
  *  tengah acara — dan supaya rata-rata yang membengkak (tanda pengecilan
  *  gambar gagal di sebagian HP) terlihat sebagai angka, bukan sebagai

--- a/live/style.css
+++ b/live/style.css
@@ -1733,18 +1733,41 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    Tingginya dibatasi supaya slip yang dipotret tegak tidak memakan satu layar
    penuh sendirian — yang dicari orang di sini "fotonya ada dan terbaca", dan
    untuk membaca angkanya ada tautan ukuran penuh di tiap gambar. */
-.foto-galeri { list-style: none; margin: 0; padding: 0; }
-.foto-galeri li { margin-bottom: .9rem; }
-.foto-galeri li:last-child { margin-bottom: 0; }
-.fg-kepala {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: .6rem; margin-bottom: .3rem; font-size: .85rem;
+.foto-galeri {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; gap: .7rem;
+  /* Petak seukuran ibu jari, sebanyak yang muat. Sembilan slip ukuran penuh
+     adalah sembilan layar yang harus digulir sebelum yang dicari terlihat. */
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 }
-.fg-kepala span { color: var(--tinta-lembut); }
-.foto-galeri img {
-  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+.foto-galeri li { position: relative; }
+.fg-petak {
+  display: block; aspect-ratio: 3 / 4; overflow: hidden;
   border: 1px solid var(--garis); border-radius: 8px; background: var(--kertas);
 }
+.foto-galeri img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.fg-kosong {
+  display: flex; align-items: center; justify-content: center;
+  font-size: .8rem; color: var(--tinta-lembut); text-align: center;
+}
+.fg-kapan {
+  display: block; margin-top: .25rem;
+  font-size: .72rem; color: var(--tinta-lembut); text-align: center;
+}
+/* Silang merah di pojok petaknya. Sasaran sentuhnya 32px — di bawah itu, jari
+   yang meleset menekan petaknya dan membuka foto alih-alih menghapusnya, dan
+   yang meleset ke arah sebaliknya jauh lebih mahal. */
+.fg-hapus {
+  position: absolute; top: -.4rem; right: -.4rem;
+  width: 32px; height: 32px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--bahaya); border-radius: 999px;
+  background: var(--kartu); color: var(--bahaya);
+  font-size: 1.1rem; line-height: 1; font-weight: 700; cursor: pointer;
+  box-shadow: var(--bayang);
+}
+.fg-hapus:hover:not(:disabled) { background: var(--bahaya); color: #fff; }
+.fg-hapus:disabled { opacity: .5; cursor: default; }
 
 /* Foto slip per lomba (0047). Bentuknya sengaja sama dengan .riwayat — dua
    dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua

--- a/supabase/migrations/0081_hapus_foto_lembar.sql
+++ b/supabase/migrations/0081_hapus_foto_lembar.sql
@@ -1,0 +1,144 @@
+-- ============================================================================
+-- hrcd-rekap : 0081_hapus_foto_lembar.sql
+--
+-- MENGHAPUS SATU FOTO SLIP, DENGAN ALASAN YANG TERCATAT.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA PERLU
+--
+-- Sampai sekarang foto hanya bisa DITAMBAH. Slip yang terfoto buram, terbalik,
+-- salah regu, atau terlanjur diunggah ke lomba yang keliru menumpuk di dialog
+-- Foto Jawaban selamanya — dan tumpukan itu justru mengaburkan bukti yang
+-- benar, karena yang membuka dialog harus menebak mana yang berlaku.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA PAKAI ALASAN
+--
+-- Foto slip adalah BUKTI. Ia dipanggil justru ketika sebuah nilai
+-- dipertanyakan, jadi menghapusnya menghapus kemampuan menjawab pertanyaan itu
+-- — dan tidak ada satu pun galat yang muncul saat bukti hilang.
+--
+-- Polanya disalin dari `buka_kunci_nilai_pos` (0045), beserta pelajarannya:
+-- alasannya dicatat SEBELUM barisnya hilang. Dicatat sesudah, ia hilang
+-- bersama barisnya dan yang tersisa cuma foto yang tidak ada lagi tanpa
+-- keterangan.
+--
+-- DUA BARIS history, dan itu memang dimaksud. Trigger `audit_foto_lembar`
+-- (0074) sudah merekam DELETE-nya sendiri — APA yang hilang, lengkap dengan
+-- path dan nama lombanya. Baris yang ditulis fungsi ini menyimpan KENAPA.
+-- Menggabungkan keduanya berarti menulis ulang trigger 0074; membiarkan
+-- triggernya bekerja dan menambah satu baris beralasan jauh lebih murah, dan
+-- keduanya menunjuk `row_id` yang sama sehingga tetap bisa dipasangkan.
+--
+-- ---------------------------------------------------------------------------
+-- PAGARNYA SAMA DENGAN YANG MENGUNGGAH
+--
+-- Siapa yang boleh menaruh foto di sebuah pos, boleh pula mengangkatnya dari
+-- sana. `boleh('pos')` beserta isolasi `pos_saya()` — persis syarat
+-- `catat_foto_masuk`. Koordinator pos (`pos_saya()` NULL) menjangkau kelima
+-- pos, seperti di tempat lain.
+--
+-- ---------------------------------------------------------------------------
+-- BERKASNYA DI STORAGE
+--
+-- Menghapus baris TIDAK menghapus gambarnya — SQL tidak menjangkau bucket.
+-- Fungsi ini karena itu MENGEMBALIKAN path-nya, supaya yang memanggil bisa
+-- menghapus objeknya sesudah barisnya benar-benar hilang.
+--
+-- Urutannya begitu, bukan sebaliknya. Kalau objeknya dihapus lebih dulu lalu
+-- penghapusan barisnya gagal, yang tersisa adalah baris yang menunjuk gambar
+-- yang tidak ada — dialog Foto Jawaban menggambar kotak rusak, dan tidak ada
+-- yang bisa membetulkannya dari layar. Kebalikannya cuma menyisakan berkas
+-- yatim: tidak terlihat siapa pun, dan bisa disapu belakangan.
+--
+-- Policy `delete` untuk bucketnya dipasang di bawah — sampai sekarang bucket
+-- `lembar` hanya punya policy `select` dan `insert` (0047, diperbarui 0064),
+-- jadi tanpa ini objeknya akan menolak dihapus tanpa menyebut sebabnya.
+-- ============================================================================
+
+create or replace function hapus_foto_lembar(
+  p_id     uuid,
+  p_alasan text
+) returns text
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_pos   smallint;
+  v_path  text;
+  v_regu  uuid;
+  v_lomba text;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan menghapus foto wajib diisi';
+  end if;
+
+  select pos, path, regu_id, nama_lomba
+    into v_pos, v_path, v_regu, v_lomba
+  from foto_lembar where id = p_id;
+
+  if not found then
+    raise exception 'foto tidak dikenal';
+  end if;
+
+  if pos_saya() is not null and v_pos is distinct from pos_saya() then
+    raise exception 'operator pos % tidak boleh menghapus foto pos %',
+      pos_saya(), v_pos;
+  end if;
+
+  -- Alasannya dicatat SEBELUM barisnya hilang (pelajaran 0045).
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('foto_lembar', p_id::text, v_regu, 'DELETE',
+          jsonb_build_object('alasan_hapus_foto', p_alasan,
+                             'pos', v_pos, 'nama_lomba', v_lomba,
+                             'path', v_path),
+          auth.uid());
+
+  delete from foto_lembar where id = p_id;
+
+  -- Path dikembalikan supaya pemanggil bisa menghapus objeknya di bucket.
+  return v_path;
+end;
+$$;
+
+comment on function hapus_foto_lembar(uuid, text) is
+  'Hapus satu foto slip beserta alasannya. Mengembalikan path-nya supaya '
+  'objek di bucket ikut dihapus pemanggil — SQL tidak menjangkau storage.';
+
+grant execute on function hapus_foto_lembar(uuid, text) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Policy hapus untuk bucket `lembar`.
+--
+-- Syaratnya sama persis dengan `foto_lembar_tulis` (0064): yang boleh menaruh,
+-- boleh pula mengangkat. Dibungkus pemeriksaan skema seperti 0064 — di
+-- database uji skema `storage` tidak ada, dan migrasi yang gagal di sana
+-- berarti berkas ini berhenti diuji sama sekali (CLAUDE.md 7.5).
+-- ---------------------------------------------------------------------------
+do $blok$
+begin
+  if exists (select 1 from information_schema.tables
+              where table_schema = 'storage' and table_name = 'objects') then
+    execute $p$
+      drop policy if exists foto_lembar_hapus on storage.objects;
+      $p$;
+    execute $p$
+      create policy foto_lembar_hapus on storage.objects for delete
+      using (
+        bucket_id = 'lembar' and (
+          boleh('rekap')
+          or (boleh('pos') and (
+                pos_saya() is null
+                or split_part(name, '/', 1) = 'pos' || pos_saya()::text))
+        )
+      )
+      $p$;
+    raise notice '0081: policy hapus storage foto lembar terpasang.';
+  else
+    raise notice '0081: skema storage tidak ada — policy hapusnya dilewati.';
+  end if;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -304,5 +304,11 @@ run tests/sql/42_kode_lomba_stabil.sql
 # dua fungsi yang 0074 tulis sendiri. Tes 43 memanggil penulis lama itu.
 run supabase/migrations/0080_catat_foto_lembar_taut.sql
 run tests/sql/43_catat_foto_lembar_taut.sql
+# 0081 memberi jalan MENGHAPUS satu foto slip. Foto adalah bukti, dan bukti
+# yang hilang tidak menimbulkan galat apa pun — jadi yang dijaga tes 44 bukan
+# "bisa dihapus", melainkan alasannya wajib, alasannya benar-benar tercatat
+# sebelum barisnya hilang, dan juri pos tidak menjangkau pos lain.
+run supabase/migrations/0081_hapus_foto_lembar.sql
+run tests/sql/44_hapus_foto_lembar.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/44_hapus_foto_lembar.sql
+++ b/tests/sql/44_hapus_foto_lembar.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/44_hapus_foto_lembar.sql — migrasi 0081.
+--
+-- Foto slip adalah BUKTI, dan menghapusnya tidak menimbulkan galat apa pun.
+-- Yang harus dijaga mesin karena itu bukan "bisa dihapus", melainkan tiga
+-- syarat di sekelilingnya:
+--
+--   1. Tanpa alasan, DITOLAK.
+--   2. Alasannya benar-benar tercatat, dan tercatat SEBELUM barisnya hilang.
+--   3. Juri pos tidak bisa menghapus foto pos lain.
+-- ============================================================================
+
+\echo '--- 44. hapus foto lembar'
+
+do $blok$
+declare
+  v_regu   uuid;
+  v_pos    smallint := 1;
+  v_id     uuid;
+  v_path   text;
+  v_uid    uuid;
+  v_alasan text;
+  v_n      integer;
+begin
+  select id into v_regu from regu order by nomor_dada limit 1;
+  select user_id into v_uid from akun_panitia where peran = 'admin' limit 1;
+  if v_regu is null or v_uid is null then
+    raise notice '44 DILEWATI — butuh minimal satu regu dan satu akun admin.';
+    return;
+  end if;
+
+  -- DUDUK DI KURSINYA, seperti tes 30-38: `boleh('pos')` membaca auth.uid(),
+  -- dan tanpa ini seluruh berkas ditolak "tidak berhak: pos" — bukan karena
+  -- pagarnya salah, melainkan karena tidak ada yang duduk di depannya.
+  perform set_config('app.uid', v_uid::text, false);
+
+  insert into foto_lembar (regu_id, pos, kode_lomba, nama_lomba, path,
+                           ukuran_bytes, diunggah_oleh,
+                           cara_taut, ditaut_oleh, ditaut_pada)
+  values (v_regu, v_pos, 'uji-hapus', 'Uji Hapus',
+          'pos1/uji-hapus-44.jpg', 1234, v_uid, 'unggah', v_uid, now())
+  returning id into v_id;
+
+  -- ---------------------------------------------------------------------
+  -- 1. Alasan kosong ditolak, dan barisnya HARUS masih ada sesudahnya.
+  -- ---------------------------------------------------------------------
+  begin
+    perform hapus_foto_lembar(v_id, '   ');
+    raise exception '44.1 GAGAL: alasan kosong diterima';
+  exception
+    when others then
+      if position('alasan menghapus foto wajib' in sqlerrm) = 0 then raise; end if;
+  end;
+
+  select count(*) into v_n from foto_lembar where id = v_id;
+  assert v_n = 1, '44.1 GAGAL: barisnya ikut hilang walau alasannya ditolak';
+  raise notice '44.1 OK — alasan kosong ditolak, fotonya masih ada.';
+
+  -- ---------------------------------------------------------------------
+  -- 2. Dengan alasan: barisnya hilang, path-nya dikembalikan, alasannya
+  --    tersimpan di history.
+  -- ---------------------------------------------------------------------
+  select hapus_foto_lembar(v_id, 'buram, difoto ulang') into v_path;
+
+  assert v_path = 'pos1/uji-hapus-44.jpg',
+    format('44.2 GAGAL: path yang dikembalikan "%s"', v_path);
+
+  select count(*) into v_n from foto_lembar where id = v_id;
+  assert v_n = 0, '44.2 GAGAL: barisnya masih ada sesudah dihapus';
+  raise notice '44.2 OK — terhapus, path dikembalikan untuk membersihkan bucket.';
+
+  -- ---------------------------------------------------------------------
+  -- 3. Alasannya benar-benar tercatat. Inilah yang membuat penghapusan bukti
+  --    bisa ditelusuri sesudah barisnya tidak ada lagi.
+  -- ---------------------------------------------------------------------
+  select new_value ->> 'alasan_hapus_foto' into v_alasan
+  from history
+  where table_name = 'foto_lembar' and row_id = v_id::text
+    and new_value ? 'alasan_hapus_foto'
+  order by changed_at desc limit 1;
+
+  assert v_alasan = 'buram, difoto ulang',
+    format('44.3 GAGAL: alasan tercatat "%s"', coalesce(v_alasan, '(tidak ada)'));
+  raise notice '44.3 OK — alasannya tersimpan di history: "%".', v_alasan;
+end;
+$blok$;
+
+\echo '--- 44 SELESAI'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -802,6 +802,38 @@ export async function tautanFotoBanyak(paths) {
   return peta;
 }
 
+/** Hapus satu foto slip: barisnya lewat RPC (yang mencatat alasannya), lalu
+ *  objeknya di bucket.
+ *
+ *  Urutannya begitu dan bukan sebaliknya. Objek dulu lalu barisnya gagal
+ *  menyisakan baris yang menunjuk gambar yang tidak ada — dialognya menggambar
+ *  kotak rusak dan tidak ada yang bisa membetulkannya dari layar. Kebalikannya
+ *  cuma menyisakan berkas yatim: tidak terlihat siapa pun, bisa disapu nanti.
+ *
+ *  Karena itu gagalnya menghapus objek TIDAK dilempar. Barisnya sudah hilang,
+ *  fotonya sudah lenyap dari layar, dan memberi tahu petugas bahwa "hapus
+ *  gagal" padahal fotonya memang sudah hilang cuma membuatnya menekan lagi. */
+export async function hapusFotoLembar(id, alasan) {
+  if (K.mode === "dev") {
+    return kirim(`${K.devUrl}/rpc/hapus_foto_lembar`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uid: sesi() ? sesi().uid : null,
+                             args: { p_id: id, p_alasan: alasan } }),
+    });
+  }
+  const path = await rpc("hapus_foto_lembar", { p_id: id, p_alasan: alasan });
+  if (path) {
+    try {
+      await pastikanSesiSegar();
+      await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET}/${path}`, {
+        method: "DELETE", headers: kepalaSupabase(),
+      });
+    } catch { /* berkas yatim, bukan kegagalan yang perlu dilihat petugas */ }
+  }
+  return path;
+}
+
 /** Pemakaian kuota. Dibaca layar supaya kehabisan ruang tidak jadi kejutan di
  *  tengah acara — dan supaya rata-rata yang membengkak (tanda pengecilan
  *  gambar gagal di sebagian HP) terlihat sebagai angka, bukan sebagai

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,6 +27,7 @@ import {
   aturFaseLive,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun, daftarPanitia,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak, tautanFotoBanyak,
+  hapusFotoLembar,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
@@ -3202,12 +3203,24 @@ async function layarInputPos() {
         if (!b) return;
         const li = b.closest("li");
         const kode = li.dataset.kode, namaLomba = li.dataset.nama;
-        const daftar = perLomba[kode] || [];
-        if (!daftar.length) return;
+        if (!(perLomba[kode] || []).length) return;
 
         b.disabled = true;
-        let peta = {};
+        let daftar = [], peta = {};
         try {
+          /* DIBACA ULANG dari server, bukan dari daftar yang dipegang layar.
+             Dua sebabnya, dan keduanya soal `id`: baris yang baru diunggah di
+             dialog ini belum punya id (catat_foto_lembar mengembalikan void),
+             dan tombol silang butuh id. Sekalian daftarnya jadi mutakhir —
+             foto yang dihapus petugas lain tidak muncul sebagai petak yang
+             hilang begitu ditekan. */
+          const semua = await daftarFotoLembar(pos.nomor, dada);
+          daftar = semua.filter(f => f.kode_lomba === kode);
+          perLomba[kode] = daftar;
+          hitung[kode] = daftar.length;
+          const jml = li.querySelector("[data-jumlah]");
+          if (jml) jml.textContent = hitung[kode] ? `${hitung[kode]} foto` : "belum ada";
+          if (!daftar.length) { b.hidden = true; b.disabled = false; return; }
           peta = await tautanFotoBanyak(daftar.map(f => f.path));
         } catch (err) {
           b.disabled = false;
@@ -3224,29 +3237,85 @@ async function layarInputPos() {
            tangan sudah di tangan sebelum dialog ini digambar, membukanya tidak
            perlu await — jadi tidak ada window.open() sesudah await yang akan
            diblokir browser HP sebagai popup. */
-        const galeri = daftar.map((f, i) => {
+        /* THUMBNAIL, bukan gambar penuh. Sembilan slip ukuran penuh adalah
+           sembilan layar yang harus digulir sebelum yang dicari terlihat;
+           petak kecil memperlihatkan kesembilannya sekaligus, dan yang perlu
+           dibaca angkanya tinggal ditekan. */
+        const petak = (f, i) => {
           const url = peta[f.path];
           const ke = daftar.length - i;            // terbaru dulu, jadi dihitung mundur
           const kapan = f.diunggah_pada ? tanggalJam(f.diunggah_pada) : "";
-          return `<li>
-            <div class="fg-kepala">
-              <strong>Foto ${esc(String(ke))}</strong>
-              <span>${esc(kapan)}</span>
-            </div>
+          const judul = `Foto ${ke} ${namaLomba}${kapan ? ` · ${kapan}` : ""}`;
+          return `<li data-id="${esc(f.id)}" data-ke="${esc(String(ke))}">
             ${url
-              ? `<a href="${esc(url)}" target="_blank" rel="noopener">
-                   <img src="${esc(url)}" alt="Foto ${esc(String(ke))} ${esc(namaLomba)}"
-                        loading="lazy"></a>`
-              : `<p class="keterangan">Tautan fotonya tidak bisa dibuat.</p>`}
+              ? `<a class="fg-petak" href="${esc(url)}" target="_blank" rel="noopener"
+                    title="${esc(judul)}">
+                   <img src="${esc(url)}" alt="${esc(judul)}" loading="lazy"></a>`
+              : `<span class="fg-petak fg-kosong">tautan gagal</span>`}
+            <button type="button" class="fg-hapus" data-hapus
+                    title="Hapus foto ${esc(String(ke))}"
+                    aria-label="Hapus foto ${esc(String(ke))} ${esc(namaLomba)}"
+              >&times;</button>
+            <span class="fg-kapan">${esc(kapan)}</span>
           </li>`;
-        }).join("");
+        };
+        const galeri = daftar.map(petak).join("");
 
-        await dialog({
+        const janjiGaleri = dialog({
           judul: `${namaLomba} · ${daftar.length} foto`,
           kartuHtml: `<ul class="foto-galeri">${galeri}</ul>`,
           bacaSaja: true,
           silangSaja: true,
+          pasang: (el, tutup) => {
+            const ul = el.querySelector(".foto-galeri");
+            ul.addEventListener("click", async (ev) => {
+              const x = ev.target.closest("[data-hapus]");
+              if (!x) return;
+              const petakLi = x.closest("li");
+              const id = petakLi.dataset.id;
+
+              /* ALASANNYA WAJIB, dan itu bukan formalitas: foto slip adalah
+                 bukti, dipanggil justru ketika sebuah nilai dipertanyakan.
+                 Menghapusnya menghapus kemampuan menjawab pertanyaan itu, dan
+                 tidak ada satu pun galat yang muncul saat bukti hilang. RPC
+                 0081 menolak alasan kosong; kotak ini cuma menanyakannya
+                 sebelum perjalanan jaringan. */
+              const jawab = await dialog({
+                judul: `Hapus foto ${petakLi.dataset.ke} ${namaLomba}?`,
+                kartuHtml: "<p>Fotonya hilang dari daftar dan dari penyimpanan.</p>",
+                medan: [{ label: "Alasan menghapus", contoh: "misal: buram, difoto ulang" }],
+                labelAksi: "Hapus Foto",
+              });
+              if (jawab === null) return;
+
+              x.disabled = true;
+              try {
+                await hapusFotoLembar(id, jawab[0]);
+              } catch (err) {
+                x.disabled = false;
+                notif(`Foto tidak bisa dihapus: ${err.message}`, true);
+                return;
+              }
+
+              // Daftar di belakang dialog ini ikut disesuaikan, supaya
+              // hitungannya tidak menyebut foto yang sudah tidak ada.
+              perLomba[kode] = (perLomba[kode] || []).filter(f => f.id !== id);
+              hitung[kode] = perLomba[kode].length;
+              const barisAsal = kartu.querySelector(`li[data-kode="${CSS.escape(kode)}"]`);
+              if (barisAsal) {
+                const jml = barisAsal.querySelector("[data-jumlah]");
+                if (jml) jml.textContent = hitung[kode] ? `${hitung[kode]} foto` : "belum ada";
+                const lihat = barisAsal.querySelector("[data-lihat]");
+                if (lihat) lihat.hidden = !hitung[kode];
+              }
+
+              petakLi.remove();
+              notif("Foto dihapus.");
+              if (!ul.children.length) tutup(null);
+            });
+          },
         });
+        await janjiGaleri;
       });
 
       kartu.addEventListener("change", async (e) => {

--- a/web/style.css
+++ b/web/style.css
@@ -1733,18 +1733,41 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    Tingginya dibatasi supaya slip yang dipotret tegak tidak memakan satu layar
    penuh sendirian — yang dicari orang di sini "fotonya ada dan terbaca", dan
    untuk membaca angkanya ada tautan ukuran penuh di tiap gambar. */
-.foto-galeri { list-style: none; margin: 0; padding: 0; }
-.foto-galeri li { margin-bottom: .9rem; }
-.foto-galeri li:last-child { margin-bottom: 0; }
-.fg-kepala {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: .6rem; margin-bottom: .3rem; font-size: .85rem;
+.foto-galeri {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; gap: .7rem;
+  /* Petak seukuran ibu jari, sebanyak yang muat. Sembilan slip ukuran penuh
+     adalah sembilan layar yang harus digulir sebelum yang dicari terlihat. */
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 }
-.fg-kepala span { color: var(--tinta-lembut); }
-.foto-galeri img {
-  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+.foto-galeri li { position: relative; }
+.fg-petak {
+  display: block; aspect-ratio: 3 / 4; overflow: hidden;
   border: 1px solid var(--garis); border-radius: 8px; background: var(--kertas);
 }
+.foto-galeri img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.fg-kosong {
+  display: flex; align-items: center; justify-content: center;
+  font-size: .8rem; color: var(--tinta-lembut); text-align: center;
+}
+.fg-kapan {
+  display: block; margin-top: .25rem;
+  font-size: .72rem; color: var(--tinta-lembut); text-align: center;
+}
+/* Silang merah di pojok petaknya. Sasaran sentuhnya 32px — di bawah itu, jari
+   yang meleset menekan petaknya dan membuka foto alih-alih menghapusnya, dan
+   yang meleset ke arah sebaliknya jauh lebih mahal. */
+.fg-hapus {
+  position: absolute; top: -.4rem; right: -.4rem;
+  width: 32px; height: 32px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--bahaya); border-radius: 999px;
+  background: var(--kartu); color: var(--bahaya);
+  font-size: 1.1rem; line-height: 1; font-weight: 700; cursor: pointer;
+  box-shadow: var(--bayang);
+}
+.fg-hapus:hover:not(:disabled) { background: var(--bahaya); color: #fff; }
+.fg-hapus:disabled { opacity: .5; cursor: default; }
 
 /* Foto slip per lomba (0047). Bentuknya sengaja sama dengan .riwayat — dua
    dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua


### PR DESCRIPTION
## What

Tiap foto di galeri **Lihat** punya silang merah. Menekannya meminta **alasan**
(wajib), lalu menghapus barisnya **dan** berkasnya di bucket.

Galerinya sekaligus berubah jadi **petak**, bukan gambar penuh — sembilan slip
terlihat sekaligus, dan yang perlu dibaca angkanya tinggal ditekan.

Migrasi `0081` + tes `44`.

## Why

Sampai sekarang foto hanya bisa **ditambah**. Slip yang buram, terbalik, salah
regu, atau terlanjur diunggah ke lomba yang keliru menumpuk selamanya — dan
tumpukan itu justru mengaburkan bukti yang benar, karena yang membuka dialog
harus menebak mana yang berlaku.

**Alasannya wajib, dan itu bukan formalitas.** Foto slip adalah bukti: ia
dipanggil justru ketika sebuah nilai dipertanyakan, jadi menghapusnya
menghapus kemampuan menjawab pertanyaan itu — dan tidak ada satu pun galat
yang muncul saat bukti hilang. Polanya disalin dari `buka_kunci_nilai_pos`
(`0045`) beserta pelajarannya: alasannya dicatat **sebelum** barisnya hilang.

**Dua baris `history`, dan itu dimaksud.** Trigger `audit_foto_lembar` (`0074`)
sudah merekam *apa* yang hilang; baris dari `0081` menyimpan *kenapa*. Keduanya
menunjuk `row_id` yang sama sehingga tetap bisa dipasangkan.

**Pagarnya sama dengan yang mengunggah** — `boleh('pos')` beserta isolasi
`pos_saya()`. Siapa yang boleh menaruh foto di sebuah pos, boleh pula
mengangkatnya.

## Notes

**Baris dulu, baru berkasnya.** Objek storage dihapus lebih dulu lalu barisnya
gagal akan menyisakan baris yang menunjuk gambar tidak ada — dialognya
menggambar kotak rusak dan tidak ada yang bisa membetulkannya dari layar.
Kebalikannya cuma menyisakan berkas yatim: tidak terlihat siapa pun, bisa
disapu belakangan. Karena itu pula gagalnya menghapus objek **tidak** dilempar
ke layar.

Bucket `lembar` sampai kini hanya punya policy `select` dan `insert` (`0047`,
diperbarui `0064`), jadi `0081` memasang policy `delete`-nya.

**"Lihat" kini membaca ulang daftarnya dari server.** Dua sebabnya soal `id`:
baris yang baru diunggah belum punya id (`catat_foto_lembar` mengembalikan
`void`), dan tombol silang membutuhkannya.

Diukur di browser dengan sembilan petak:

| yang diukur | hasil |
|---|---|
| ukuran silang | 32×32 — sasaran sentuh jari |
| menutupi petak tetangga | 0 |
| uji tembak titik tengah | mengenai tombolnya sendiri |
| kartu meluap mendatar | tidak |

Tes 44 menjaga ketiganya: alasan kosong **ditolak** dan barisnya tetap ada,
path dikembalikan untuk membersihkan bucket, dan alasannya benar-benar
tersimpan di `history`. **SEMUA TES LULUS.**

⚠️ Perlu `apply-migration.yml` sesudah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)