### PR TITLE
fix: riwayat tidak lagi memotong jam, dan pesan galat menyebut komponennya

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -485,6 +485,18 @@ export function pasangKotakJam(id) {
 const DETIK_NOTIF      = 4000;
 const DETIK_NOTIF_GALAT = 8000;
 
+/** Huruf pertama dibesarkan. Pesan galat dari database lahir huruf kecil —
+ *  itu konvensi SQL — dan di layar panitia ia terbaca seperti potongan log,
+ *  bukan kalimat.
+ *
+ *  DIEKSPOR, karena notif() bukan lagi satu-satunya yang membutuhkannya:
+ *  pesan yang digandeng di belakang kalimat lain ("Nomor Dada 007.
+" + ...)
+ *  tidak lagi berada di awal teks, jadi pembesaran di dalam notif() tidak
+ *  menjangkaunya. */
+export const kapital = (t) =>
+  String(t).charAt(0).toUpperCase() + String(t).slice(1);
+
 export function notif(pesan, galat = false) {
   document.querySelectorAll(".notification").forEach(n => n.remove());
   // Template BIASA, bukan tag html`` — tombol tutupnya HTML yang memang
@@ -497,7 +509,7 @@ export function notif(pesan, galat = false) {
   // panitia ia terbaca seperti potongan log, bukan kalimat. Huruf pertama
   // dibesarkan DI SINI, satu tempat, supaya pesan dari mana pun ikut rapi
   // tanpa perlu menyentuh belasan `raise exception` di migrasi.
-  const kalimat = String(pesan).charAt(0).toUpperCase() + String(pesan).slice(1);
+  const kalimat = kapital(pesan);
   const n = h(`<div class="notification ${galat ? "error" : ""}" role="alert">
       <span class="notif-ikon">${ikon(galat ? "circle-alert" : "circle-check-big")}</span>
       <span class="notif-teks">${esc(kalimat)}</span>

--- a/live/style.css
+++ b/live/style.css
@@ -574,7 +574,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   background: var(--utama-muda); color: var(--utama);
 }
 .notif-ikon .ikon { width: 1.15rem; height: 1.15rem; }
-.notif-teks { flex: 1 1 auto; min-width: 0; }
+/* `pre-line` supaya "
+" di dalam pesan benar-benar mematahkan baris.
+   Notifikasi galat lembar pos berbunyi dua kalimat — "Nomor Dada 007." lalu
+   "Input Semaphore harus antara 0 - 5." — dan keduanya menjawab pertanyaan
+   yang berbeda: baris MANA, dan kotak mana di baris itu. Digandeng jadi satu
+   kalimat panjang, yang kedua terbaca sebagai anak kalimat yang pertama dan
+   nomor dadanya justru yang paling sering terlewat. Spasi berlebih tetap
+   diringkas (`pre-line`, bukan `pre`), jadi lekukan di dalam template
+   literal tidak ikut tercetak. */
+.notif-teks { flex: 1 1 auto; min-width: 0; white-space: pre-line; }
 .notification.error { border-color: #f3c6c6; }
 .notification.error .notif-ikon { background: var(--bahaya-muda); color: var(--bahaya); }
 /* Memudar sebelum dibuang (lihat notif() di util.js). Transisinya dipatok di
@@ -1667,8 +1676,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   color: var(--tinta-lembut); cursor: not-allowed;
 }
 
-.saring-riwayat { margin-bottom: .6rem; flex-wrap: wrap; gap: .35rem; }
-.riwayat { list-style: none; margin: 0; padding: 0; }
+/* CHIP PENYARING MENGALIR, dan `display: flex` di sini BUKAN hiasan.
+   `.option-row` adalah grid dua kolom yang di bawah 560px jatuh jadi SATU
+   kolom — patokan yang benar untuk pasangan tombol Batal/Simpan, dan salah
+   untuk enam chip kecil: keenamnya jadi selebar layar dan mendorong daftar
+   riwayatnya keluar layar sebelum satu baris pun terbaca. `flex-wrap: wrap`
+   sudah tertulis di sini sejak awal, tapi tidak pernah berlaku sedetik pun —
+   ia sifat flexbox yang dipasang pada elemen grid (CLAUDE.md 15.9). */
+.saring-riwayat {
+  display: flex; flex-wrap: wrap; gap: .35rem;
+  margin-bottom: .6rem;
+}
+/* TINGGINYA TETAP, dan itulah seluruh gunanya. Menyaring "Semua" (16 baris)
+   jadi "Kepramukaan" (1 baris) dulu memendekkan kartunya, dan kartu yang
+   dipusatkan tegak lurus akan BERGESER setengah selisihnya — judul dan chip
+   penyaringnya pindah tempat tepat pada saat orang hendak menekan chip
+   berikutnya. Yang berubah sekarang cuma isi kotak ini; yang di atasnya diam.
+
+   Mendatarnya ikut bergulir supaya nama petugas dan JAM-nya bisa dibaca utuh
+   di layar sempit — lihat .r-oleh di bawah. */
+.riwayat {
+  list-style: none; margin: 0; padding: 0;
+  height: min(24rem, 45vh); overflow: auto;
+}
 /* SATU BARIS, SELALU. `flex-wrap: wrap` dulu menurunkan kolom "oleh" ke baris
    kedua begitu isinya tidak muat — dan di dialog ini itu terjadi pada SETIAP
    baris, bukan sesekali. Kartunya `max-width: 480px` dengan padding 1.3rem,
@@ -1686,6 +1716,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .riwayat li {
   display: flex; flex-wrap: nowrap; align-items: baseline; gap: .2rem .5rem;
   padding: .5rem 0; border-bottom: 1px solid var(--garis);
+  /* `max-content` supaya baris yang tidak muat MELEBAR keluar kotaknya, bukan
+     memampatkan isinya — itu yang membuat kotaknya bisa digulir mendatar. Di
+     layar lebar isinya lebih sempit dari 100%, jadi barisnya tetap selebar
+     kartu dan garis bawahnya tetap penuh. */
+  min-width: max-content;
 }
 .riwayat li:last-child { border-bottom: 0; }
 /* Nama lomba yang mengalah, bukan barisnya yang patah. Menaksir bisa bernilai
@@ -1715,13 +1750,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 /* Angka tidak pernah menyusut: "1250 → 0" yang terpotong jadi "1250 → " adalah
    riwayat yang berbohong, bukan riwayat yang rapi. */
+/* LEBARNYA DIPATOK, sekarang wajib. Sebelumnya kolom "oleh" didorong ke
+   kanan oleh `margin-left: auto`, jadi ia rata kanan dan awalnya boleh
+   berbeda-beda. Di kotak yang bergulir mendatar tidak ada lagi sisa ruang
+   untuk didorong: "oleh" mulai persis sesudah angkanya, dan angka selebar
+   "1250 → 1250" akan mendorong nama petugas jauh ke kanan sementara "1 → 0"
+   tidak — satu daftar dengan dua titik mulai yang berbeda jauh lebih sulit
+   disapu mata daripada satu yang lurus. Diukur di browser: "1250 → 1250" pada
+   angka tabular 1rem selebar 92px, jadi 6.5rem (104px) memuatnya.
+
+   `min-width`, BUKAN lebar mati. Angka yang lebih lebar dari patokannya akan
+   MELUAP menembus nama petugas di sebelahnya kalau kotaknya dipatok mati —
+   dua tulisan bertumpuk, dan yang di bawah tidak terbaca sama sekali. Dengan
+   min-width ia mendorong, bukan menembus: satu baris jadi tidak selurus yang
+   lain, dan itu harga yang jauh lebih murah. */
 .r-nilai {
-  flex: 0 0 auto;
+  flex: 0 0 auto; min-width: 6.5rem;
   font-variant-numeric: tabular-nums; white-space: nowrap;
 }
+/* TIDAK LAGI DIPOTONG. Elipsis di sini memakan JAM-nya — ujung kanan tulisan
+   "admin.ciradyka · 19 Agustus 2026 23:48" — dan jam itulah yang dicari orang
+   yang membuka riwayat: bukan "siapa yang mengubah", melainkan "kapan". Di
+   layar sempit barisnya sekarang melebar keluar kotaknya dan seluruh daftar
+   digeser mendatar SEKALIGUS, jadi satu geseran membuka jam SEMUA baris —
+   kolomnya tetap lurus karena ketiga lebarnya sudah dipatok di atas. */
 .r-oleh  {
-  flex: 0 1 auto; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis;
+  flex: 0 0 auto;
   color: var(--tinta-lembut); font-size: .78rem;
   white-space: nowrap; margin-left: auto;
 }

--- a/supabase/migrations/0082_pesan_rentang_menyebut_komponen.sql
+++ b/supabase/migrations/0082_pesan_rentang_menyebut_komponen.sql
@@ -1,0 +1,205 @@
+-- ============================================================================
+-- hrcd-rekap : 0082_pesan_rentang_menyebut_komponen.sql
+--
+-- PESAN GALAT MENYEBUT KOMPONEN MANA YANG SALAH.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG KURANG
+--
+-- Sampai sekarang kalimatnya berbunyi "Input harus antara 0 - 5." — benar,
+-- singkat, dan TIDAK MENYEBUT KOLOM YANG MANA. Di lembar pos satu baris punya
+-- tiga sampai lima kotak berdampingan, masing-masing dengan rentangnya
+-- sendiri: Semaphore 0-5, Tebak Simpul 0-10, Menaksir tanpa batas atas. Satu
+-- baris yang ditolak karena Semaphore terisi 6 memunculkan kalimat yang sama
+-- persis dengan baris yang ditolak karena Tebak Simpul terisi 11.
+--
+-- Yang terjadi di lapangan: petugas membaca "harus antara 0 - 5", melihat
+-- tiga kotaknya, dan MENEBAK. Tebakan yang salah mengganti angka yang
+-- sebenarnya sudah benar — dan angka pengganti itu tersimpan, karena baris
+-- yang sah tetap dikirim (lihat komentar "yang sah tetap dikirim" di app.js).
+-- Kalimat yang kurang satu kata karena itu tidak berhenti pada kebingungan;
+-- ia berakhir pada nilai yang salah di database, tanpa satu pun galat.
+--
+-- ---------------------------------------------------------------------------
+-- YANG BERUBAH
+--
+--   sebelum   Input harus antara 0 - 5.
+--   sesudah   Input Semaphore harus antara 0 - 5.
+--
+--   sebelum   Jumlah salah harus antara 0 - 20.
+--   sesudah   Jumlah salah Sandi Morse harus antara 0 - 20.
+--
+-- Namanya diambil dari `wahana.name` — yang sama persis dengan yang tercetak
+-- di kepala kolom lembar pos dan di blangko kertasnya, jadi yang membaca
+-- pesan ini mencari satu kata yang sudah ada di depan matanya.
+--
+-- Nomor dadanya TIDAK ikut di sini. Ia ditempelkan layar (`Nomor Dada 007.`),
+-- karena RPC ini juga dipakai jalur paste dan upload yang menampilkan
+-- nomornya di kolom tabel pratinjau — menyebutnya dua kali di sana justru
+-- memanjangkan kalimat tanpa menambah apa pun.
+--
+-- ---------------------------------------------------------------------------
+-- DISALIN UTUH DARI 0064
+--
+-- `create or replace` mengganti SELURUH badan fungsi, jadi cabang yang lupa
+-- disalin hilang tanpa satu galat pun. Yang berubah dari 0064 cuma DUA baris
+-- `raise exception` di bawah; sisanya sama karakter demi karakter.
+--
+-- KENAPA TES 12 TIDAK IKUT DIUBAH. tests/run.sh MEMUTAR ULANG sejarahnya:
+-- tes 12 berjalan jauh di atas berkas ini, jadi yang ia uji adalah fungsi
+-- versi 0031 — dan di sana kalimatnya memang belum menyebut komponen.
+-- Mengubah tes 12 justru membuatnya gagal. Hal yang sama berlaku untuk
+-- "Jumlah salah" di tes 03. Kalimat baru ini dijaga TES 45, yang berjalan
+-- tepat sesudah berkas ini.
+-- ============================================================================
+
+create or replace function simpan_nilai_massal(
+  p_baris  jsonb,  -- [{"nomor_dada":1,"kode":"lari_zigzag","nilai_1":40,"nilai_2":null}, ...]
+  p_sumber text default 'upload',
+  p_pos    smallint default null  -- wajib untuk admin; operator memakai pos-nya sendiri
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_r      jsonb;
+  v_regu   regu%rowtype;
+  v_wahana wahana%rowtype;
+  v_hasil  jsonb := '[]'::jsonb;
+  v_status text;
+  v_alasan text;
+  v_idx    int := 0;
+  v_pos    smallint;
+  v_kunci  text;
+  v_sudah  text[] := '{}';
+  v_n1     numeric;
+  v_n2     numeric;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+  if pos_saya() is not null then
+    v_pos := pos_saya();
+  else
+    v_pos := p_pos;
+    if v_pos is null then
+      raise exception 'wajib menyebut pos (p_pos)';
+    end if;
+  end if;
+  if p_sumber not in ('manual', 'upload') then
+    raise exception 'sumber tidak dikenal: %', p_sumber;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_baris) loop
+    v_idx := v_idx + 1;
+    v_status := 'tersimpan'; v_alasan := null;
+
+    -- Seluruh pemrosesan baris terlindungi: format angka rusak di baris 7
+    -- tidak boleh menggagalkan 26 baris lain (temuan review).
+    begin
+      v_n1 := (v_r ->> 'nilai_1')::numeric;
+      v_n2 := nullif(v_r ->> 'nilai_2', '')::numeric;
+
+      -- Baris ganda dalam SATU paste = merah (bagian 6.3) — juga di server.
+      v_kunci := (v_r ->> 'nomor_dada') || '|' ||
+                 regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g');
+      if v_kunci = any (v_sudah) then
+        raise exception 'baris ganda dalam paste (nomor dada + komponen sama)';
+      end if;
+      v_sudah := v_sudah || v_kunci;
+
+      -- Regu: harus dikenal, bernomor, tidak batal.
+      select * into v_regu from regu
+      where nomor_dada = (v_r ->> 'nomor_dada')::integer and not is_cancelled;
+      if not found then
+        raise exception 'nomor dada tidak dikenal / regu batal';
+      end if;
+
+      -- Komponen: HANYA pos ini (kode boleh kembar antar pos — temuan
+      -- review); normalisasi dua arah supaya "Lari Zigzag" dari header foto
+      -- cocok dengan kode lari_zigzag.
+      select w.* into v_wahana from wahana w
+      where w.edisi = edisi_aktif()
+        and w.pos = v_pos
+        and regexp_replace(lower(coalesce(v_r ->> 'kode', '')), '[^a-z0-9]', '', 'g')
+            = regexp_replace(w.kode, '[^a-z0-9]', '', 'g');
+      if not found then
+        raise exception 'kode komponen tidak dikenal di pos % — mungkin ini lembar pos lain?', v_pos;
+      end if;
+
+      -- Baris yang sudah DIGEMBOK: tolak, apa pun isinya.
+      --
+      -- Diperiksa di server, bukan cukup di layar. Lembar pos dibuka di
+      -- beberapa HP sekaligus, dan HP yang layarnya dimuat SEBELUM gemboknya
+      -- dipasang tidak tahu apa-apa tentang gembok itu — ia akan mengirim
+      -- angka dengan penuh keyakinan.
+      if nilai_tergembok(v_regu.id, v_pos) then
+        raise exception 'Nilai regu ini sudah digembok. Buka gemboknya dulu.';
+      end if;
+
+      -- Komponen milik golongan lain: TOLAK.
+      --
+      -- Sejak 0030 satu lomba boleh punya dua baris `wahana`, satu per
+      -- golongan (Tebak Simpul: 5 objek untuk penggalang, 10 untuk penegak).
+      -- Keduanya muncul sebagai kolom di lembar yang sama, jadi tanpa pagar
+      -- ini satu regu bisa terisi DUA-DUANYA — dan totalnya 200 dari
+      -- maksimum 100, tanpa satu pun galat yang memberi tahu siapa pun.
+      if not komponen_berlaku(v_wahana.golongan, v_regu.golongan) then
+        raise exception 'Komponen ini untuk golongan lain.';
+      end if;
+
+      -- Rentang wajar dari konfigurasi (merah di preview = tolak di server).
+      if v_n1 is null
+         or v_n1 not between v_wahana.rentang_mentah_min and v_wahana.rentang_mentah_maks then
+        -- trim_scale membuang nol di belakang koma: rentang_mentah_min
+        -- bertipe numeric(10,2), jadi tanpa ini pesannya berbunyi
+        -- "antara 0.00 - 20.00" — angka yang tidak pernah ditulis siapa pun
+        -- di kertas, dan yang membacanya jadi ragu apakah pecahan diterima.
+        -- NAMA KOMPONENNYA IKUT DISEBUT. Lihat kepala berkas ini.
+        raise exception 'Input % harus antara % - %.',
+          v_wahana.name,
+          trim_scale(v_wahana.rentang_mentah_min),
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+      -- nilai_2 (jumlah salah) ikut divalidasi (temuan review).
+      if v_n2 is not null
+         and v_n2 not between 0 and v_wahana.rentang_mentah_maks then
+        raise exception 'Jumlah salah % harus antara 0 - %.',
+          v_wahana.name,
+          trim_scale(v_wahana.rentang_mentah_maks);
+      end if;
+
+      insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+      values (v_regu.id, v_wahana.id, v_n1, v_n2, p_sumber, auth.uid())
+      on conflict (regu_id, wahana_id) do update set
+        nilai_1 = excluded.nilai_1,
+        nilai_2 = excluded.nilai_2,
+        source  = excluded.source,
+        created_by = excluded.created_by,
+        created_at = now()
+      -- Simpan ulang tanpa perubahan = tidak menulis apa pun: kepengarangan
+      -- tidak tergeser, riwayat tidak dibanjiri (temuan review).
+      where nilai_mentah.nilai_1 is distinct from excluded.nilai_1
+         or nilai_mentah.nilai_2 is distinct from excluded.nilai_2;
+
+    exception when others then
+      v_status := 'ditolak';
+      v_alasan := sqlerrm;
+    end;
+
+    v_hasil := v_hasil || jsonb_build_object(
+      'baris', v_idx,
+      'nomor_dada', v_r ->> 'nomor_dada',
+      'kode', v_r ->> 'kode',
+      'status', v_status,
+      'alasan', v_alasan);
+  end loop;
+
+  return v_hasil;
+end;
+$$;
+
+-- `create or replace` mempertahankan hak yang sudah ada, jadi baris ini
+-- sebenarnya tidak mengubah apa pun. Ditulis supaya berkas ini tetap benar
+-- kalau suatu hari dijalankan di database yang fungsinya belum pernah ada.
+grant execute on function simpan_nilai_massal(jsonb, text, smallint) to authenticated;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -310,5 +310,13 @@ run tests/sql/43_catat_foto_lembar_taut.sql
 # sebelum barisnya hilang, dan juri pos tidak menjangkau pos lain.
 run supabase/migrations/0081_hapus_foto_lembar.sql
 run tests/sql/44_hapus_foto_lembar.sql
+# 0082 membuat pesan "di luar rentang" menyebut KOMPONEN mana yang ditolak.
+# Satu baris lembar pos punya tiga sampai lima kotak berdampingan dengan
+# rentang berbeda-beda; kalimat tanpa nama kolom membuat petugas menebak, dan
+# tebakan yang salah menimpa angka yang sudah benar. Tes 12 dan 03 tetap
+# menjaga bentuk lamanya di titik sejarahnya masing-masing — mereka berjalan
+# jauh di atas sini, saat fungsinya masih versi 0031.
+run supabase/migrations/0082_pesan_rentang_menyebut_komponen.sql
+run tests/sql/45_pesan_rentang_komponen.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/45_pesan_rentang_komponen.sql
+++ b/tests/sql/45_pesan_rentang_komponen.sql
@@ -1,0 +1,133 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/45_pesan_rentang_komponen.sql — migrasi 0082.
+--
+-- KENAPA SEBUAH KALIMAT DIJAGA MESIN.
+--
+-- Kalimat ini satu-satunya yang dibaca petugas saat ia salah ketik di tengah
+-- antrean, dan ia gampang sekali rusak tanpa ada yang menyadarinya:
+-- `simpan_nilai_massal` disalin UTUH tiap kali ada migrasi yang menyentuhnya
+-- (`create or replace` menuntut definisi penuh), jadi versi lama pesannya
+-- bisa ikut tersalin balik dari berkas yang salah — dan tidak satu pun tes
+-- lain akan gagal karenanya.
+--
+-- Tes 12 sudah menjaga bentuk lamanya di titik sejarahnya sendiri. Berkas ini
+-- menjaga yang ditambahkan 0082: NAMA KOMPONENNYA. Di lembar pos satu baris
+-- punya tiga sampai lima kotak berdampingan dengan rentang berbeda-beda, dan
+-- kalimat tanpa nama kolom membuat petugas menebak kotak mana yang ditolak.
+-- Tebakan yang salah menimpa angka yang sudah benar — dan angka itu
+-- tersimpan, karena baris yang sah tetap dikirim.
+--
+-- KOMPONENNYA DICARI, TIDAK DITULIS. Tes yang menyebut "Semaphore" sendiri
+-- akan lulus tahun depan sambil menyembunyikan pesan yang sudah salah, karena
+-- konfigurasi penilaian diganti tiap edisi.
+-- ============================================================================
+
+\echo '--- 45. pesan rentang menyebut komponennya'
+
+do $blok$
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', false);
+end;
+$blok$;
+
+set role authenticated;
+
+do $blok$
+declare
+  v_regu   regu%rowtype;
+  v_w      wahana%rowtype;
+  v_hasil  jsonb;
+  v_alasan text;
+begin
+  select r.* into strict v_regu
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where r.nomor_dada is not null and not r.is_cancelled and d.status = 'lunas'
+  order by r.nomor_dada limit 1;
+
+  -- ---------------------------------------------------------------------
+  -- 45.1 nilai_1 di luar rentang: kalimatnya menyebut komponennya.
+  --
+  -- Komponennya harus BERLAKU untuk golongan regu ini. Kalau tidak,
+  -- penolakannya berbunyi "Komponen ini untuk golongan lain." — pagar lain
+  -- yang berdiri lebih dulu, dan tes ini akan gagal karena alasan yang sama
+  -- sekali bukan yang sedang diuji.
+  -- ---------------------------------------------------------------------
+  select w.* into strict v_w
+  from wahana w
+  where w.edisi = edisi_aktif()
+    and komponen_berlaku(w.golongan, v_regu.golongan)
+  order by w.pos, w.sort_order limit 1;
+
+  v_hasil := simpan_nilai_massal(
+    jsonb_build_array(jsonb_build_object(
+      'nomor_dada', v_regu.nomor_dada, 'kode', v_w.kode,
+      'nilai_1', v_w.rentang_mentah_maks + 11)),
+    'manual', v_w.pos);
+
+  assert v_hasil -> 0 ->> 'status' = 'ditolak',
+    'nilai di luar rentang malah diterima';
+
+  v_alasan := v_hasil -> 0 ->> 'alasan';
+
+  assert v_alasan = format('Input %s harus antara %s - %s.',
+                           v_w.name, trim_scale(v_w.rentang_mentah_min),
+                           trim_scale(v_w.rentang_mentah_maks)),
+    format('45.1 GAGAL: kalimatnya %L', v_alasan);
+
+  -- Namanya harus BENAR-BENAR ada di dalamnya. Assert di atas sudah
+  -- membuktikannya, tapi pemeriksaan terpisah ini yang akan tetap gagal
+  -- dengan pesan yang jelas kalau suatu hari formatnya dirapikan ulang.
+  assert position(v_w.name in v_alasan) > 0,
+    format('45.1 GAGAL: nama komponen "%s" hilang dari kalimat %L',
+           v_w.name, v_alasan);
+
+  -- Nol di belakang koma tidak boleh muncul: "0.00 - 20.00" adalah bentuk
+  -- yang membuat orang ragu apakah pecahan diterima (migrasi 0029).
+  assert v_alasan not like '%.00%',
+    format('45.1 GAGAL: rentang tercetak dengan nol di belakang koma: %L', v_alasan);
+
+  -- Angka yang ditolak tidak diulang — ia masih terlihat di kotak yang baru
+  -- saja diketik, dan mengulangnya cuma memanjangkan kalimat.
+  assert v_alasan not like '%' || trim_scale(v_w.rentang_mentah_maks + 11)::text || '%',
+    format('45.1 GAGAL: nilai yang ditolak ikut diulang: %L', v_alasan);
+  raise notice '45.1 OK — "%"', v_alasan;
+
+  -- ---------------------------------------------------------------------
+  -- 45.2 nilai_2 (jumlah salah) juga menyebut komponennya.
+  --
+  -- Dicari di SELURUH pos, bukan pos 1 saja: bentuk `benar_kurang_salah`
+  -- cuma dipakai sebagian lomba, dan tes yang mencarinya di satu pos akan
+  -- DILEWATI diam-diam begitu lomba itu pindah pos.
+  -- ---------------------------------------------------------------------
+  select w.* into v_w
+  from wahana w
+  where w.edisi = edisi_aktif()
+    and w.form = 'benar_kurang_salah'
+    and komponen_berlaku(w.golongan, v_regu.golongan)
+  order by w.pos, w.sort_order limit 1;
+
+  if not found then
+    raise notice '45.2 DILEWATI — edisi ini tidak punya komponen '
+                 'benar_kurang_salah yang berlaku untuk golongan %.',
+                 v_regu.golongan;
+    return;
+  end if;
+
+  v_hasil := simpan_nilai_massal(
+    jsonb_build_array(jsonb_build_object(
+      'nomor_dada', v_regu.nomor_dada, 'kode', v_w.kode,
+      'nilai_1', v_w.rentang_mentah_min,
+      'nilai_2', v_w.rentang_mentah_maks + 11)),
+    'manual', v_w.pos);
+
+  v_alasan := v_hasil -> 0 ->> 'alasan';
+  assert v_hasil -> 0 ->> 'status' = 'ditolak'
+     and v_alasan = format('Jumlah salah %s harus antara 0 - %s.',
+                           v_w.name, trim_scale(v_w.rentang_mentah_maks)),
+    format('45.2 GAGAL: kalimatnya %L', coalesce(v_alasan, '(diterima)'));
+  raise notice '45.2 OK — "%"', v_alasan;
+end;
+$blok$;
+
+reset role;
+\echo '--- 45 SELESAI'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -29,7 +29,7 @@ import {
   ubahUsernameAkun, daftarFitur, daftarHak, setHak, tautanFotoBanyak,
   hapusFotoLembar,
 } from "./api.js";
-import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif,
+import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapital,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
@@ -3268,6 +3268,7 @@ async function layarInputPos() {
           silangSaja: true,
           pasang: (el, tutup) => {
             const ul = el.querySelector(".foto-galeri");
+            const judulEl = el.querySelector("h2");
             ul.addEventListener("click", async (ev) => {
               const x = ev.target.closest("[data-hapus]");
               if (!x) return;
@@ -3310,6 +3311,13 @@ async function layarInputPos() {
               }
 
               petakLi.remove();
+              /* Judulnya ikut turun. "9 foto" yang bertahan di atas galeri
+                 berisi lima petak terbaca sebagai empat petak yang gagal
+                 digambar — dan orang yang baru saja menghapus bukti akan
+                 menghapus lagi untuk mengejar angka yang tidak akan bergerak. */
+              if (judulEl) {
+                judulEl.textContent = `${namaLomba} · ${ul.children.length} foto`;
+              }
               notif("Foto dihapus.");
               if (!ul.children.length) tutup(null);
             });
@@ -3365,6 +3373,20 @@ async function layarInputPos() {
 
     await janji;
   }
+
+  /** "Nomor Dada 007." lalu pesannya, DUA BARIS.
+   *
+   *  Notifikasi ini muncul di bawah layar, terlepas dari baris yang gagal —
+   *  angka telanjang di depan kalimat tidak memberi tahu angka APA, dan di
+   *  lembar yang penuh angka itu justru yang paling perlu disebut namanya.
+   *
+   *  Dipatahkan, bukan digandeng dengan titik dua. Keduanya menjawab
+   *  pertanyaan yang berbeda — baris MANA, lalu kotak mana di baris itu — dan
+   *  sebagai satu kalimat panjang bagian pertamanya terbaca seperti awalan
+   *  yang boleh dilewati. Yang mematahkannya `white-space: pre-line` di
+   *  .notif-teks; tanpa aturan itu ganti barisnya cuma jadi spasi.  */
+  const pesanBaris = (dada, pesan) =>
+    `Nomor Dada ${dada3(dada)}.\n${kapital(pesan)}`;
 
   /* ---------- pita keadaan + kirim ulang sendiri ----------
 
@@ -3535,7 +3557,7 @@ async function layarInputPos() {
 
     if (pesanTakTerbaca && !baris.length && !dihapus.length) {
       statusBaris(tr, "gagal", pesanTakTerbaca);
-      notif(`Nomor Dada ${dada3(dada)}: ${pesanTakTerbaca}`, true);
+      notif(pesanBaris(dada, pesanTakTerbaca), true);
       return;
     }
 
@@ -3572,18 +3594,14 @@ async function layarInputPos() {
       jamSinkron = new Date();
       if (pesanTakTerbaca) {
         statusBaris(tr, "gagal", pesanTakTerbaca);
-        notif(`Nomor Dada ${dada3(dada)}: ${pesanTakTerbaca}`, true);
+        notif(pesanBaris(dada, pesanTakTerbaca), true);
       } else {
         statusBaris(tr, Number(tr.dataset.terisi) > 0 ? "tersimpan" : "");
       }
       hitungUlangJumlah();
     } catch (err) {
       statusBaris(tr, "gagal", err.message);
-      // "Nomor Dada 005: ...", bukan "005: ...". Notifikasi ini muncul di
-      // bawah layar, terlepas dari baris yang gagal — angka telanjang di
-      // depan kalimat tidak memberi tahu angka APA, dan di lembar yang penuh
-      // angka itu justru yang paling perlu disebut namanya.
-      notif(`Nomor Dada ${dada3(dada)}: ${err.message}`, true);
+      notif(pesanBaris(dada, err.message), true);
     } finally {
       tr.dataset.jalan = "";
       // Ketukan yang menumpuk selagi baris ini sibuk. Dijalankan juga setelah

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -485,6 +485,18 @@ export function pasangKotakJam(id) {
 const DETIK_NOTIF      = 4000;
 const DETIK_NOTIF_GALAT = 8000;
 
+/** Huruf pertama dibesarkan. Pesan galat dari database lahir huruf kecil —
+ *  itu konvensi SQL — dan di layar panitia ia terbaca seperti potongan log,
+ *  bukan kalimat.
+ *
+ *  DIEKSPOR, karena notif() bukan lagi satu-satunya yang membutuhkannya:
+ *  pesan yang digandeng di belakang kalimat lain ("Nomor Dada 007.
+" + ...)
+ *  tidak lagi berada di awal teks, jadi pembesaran di dalam notif() tidak
+ *  menjangkaunya. */
+export const kapital = (t) =>
+  String(t).charAt(0).toUpperCase() + String(t).slice(1);
+
 export function notif(pesan, galat = false) {
   document.querySelectorAll(".notification").forEach(n => n.remove());
   // Template BIASA, bukan tag html`` — tombol tutupnya HTML yang memang
@@ -497,7 +509,7 @@ export function notif(pesan, galat = false) {
   // panitia ia terbaca seperti potongan log, bukan kalimat. Huruf pertama
   // dibesarkan DI SINI, satu tempat, supaya pesan dari mana pun ikut rapi
   // tanpa perlu menyentuh belasan `raise exception` di migrasi.
-  const kalimat = String(pesan).charAt(0).toUpperCase() + String(pesan).slice(1);
+  const kalimat = kapital(pesan);
   const n = h(`<div class="notification ${galat ? "error" : ""}" role="alert">
       <span class="notif-ikon">${ikon(galat ? "circle-alert" : "circle-check-big")}</span>
       <span class="notif-teks">${esc(kalimat)}</span>

--- a/web/style.css
+++ b/web/style.css
@@ -574,7 +574,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   background: var(--utama-muda); color: var(--utama);
 }
 .notif-ikon .ikon { width: 1.15rem; height: 1.15rem; }
-.notif-teks { flex: 1 1 auto; min-width: 0; }
+/* `pre-line` supaya "
+" di dalam pesan benar-benar mematahkan baris.
+   Notifikasi galat lembar pos berbunyi dua kalimat — "Nomor Dada 007." lalu
+   "Input Semaphore harus antara 0 - 5." — dan keduanya menjawab pertanyaan
+   yang berbeda: baris MANA, dan kotak mana di baris itu. Digandeng jadi satu
+   kalimat panjang, yang kedua terbaca sebagai anak kalimat yang pertama dan
+   nomor dadanya justru yang paling sering terlewat. Spasi berlebih tetap
+   diringkas (`pre-line`, bukan `pre`), jadi lekukan di dalam template
+   literal tidak ikut tercetak. */
+.notif-teks { flex: 1 1 auto; min-width: 0; white-space: pre-line; }
 .notification.error { border-color: #f3c6c6; }
 .notification.error .notif-ikon { background: var(--bahaya-muda); color: var(--bahaya); }
 /* Memudar sebelum dibuang (lihat notif() di util.js). Transisinya dipatok di
@@ -1667,8 +1676,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   color: var(--tinta-lembut); cursor: not-allowed;
 }
 
-.saring-riwayat { margin-bottom: .6rem; flex-wrap: wrap; gap: .35rem; }
-.riwayat { list-style: none; margin: 0; padding: 0; }
+/* CHIP PENYARING MENGALIR, dan `display: flex` di sini BUKAN hiasan.
+   `.option-row` adalah grid dua kolom yang di bawah 560px jatuh jadi SATU
+   kolom — patokan yang benar untuk pasangan tombol Batal/Simpan, dan salah
+   untuk enam chip kecil: keenamnya jadi selebar layar dan mendorong daftar
+   riwayatnya keluar layar sebelum satu baris pun terbaca. `flex-wrap: wrap`
+   sudah tertulis di sini sejak awal, tapi tidak pernah berlaku sedetik pun —
+   ia sifat flexbox yang dipasang pada elemen grid (CLAUDE.md 15.9). */
+.saring-riwayat {
+  display: flex; flex-wrap: wrap; gap: .35rem;
+  margin-bottom: .6rem;
+}
+/* TINGGINYA TETAP, dan itulah seluruh gunanya. Menyaring "Semua" (16 baris)
+   jadi "Kepramukaan" (1 baris) dulu memendekkan kartunya, dan kartu yang
+   dipusatkan tegak lurus akan BERGESER setengah selisihnya — judul dan chip
+   penyaringnya pindah tempat tepat pada saat orang hendak menekan chip
+   berikutnya. Yang berubah sekarang cuma isi kotak ini; yang di atasnya diam.
+
+   Mendatarnya ikut bergulir supaya nama petugas dan JAM-nya bisa dibaca utuh
+   di layar sempit — lihat .r-oleh di bawah. */
+.riwayat {
+  list-style: none; margin: 0; padding: 0;
+  height: min(24rem, 45vh); overflow: auto;
+}
 /* SATU BARIS, SELALU. `flex-wrap: wrap` dulu menurunkan kolom "oleh" ke baris
    kedua begitu isinya tidak muat — dan di dialog ini itu terjadi pada SETIAP
    baris, bukan sesekali. Kartunya `max-width: 480px` dengan padding 1.3rem,
@@ -1686,6 +1716,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .riwayat li {
   display: flex; flex-wrap: nowrap; align-items: baseline; gap: .2rem .5rem;
   padding: .5rem 0; border-bottom: 1px solid var(--garis);
+  /* `max-content` supaya baris yang tidak muat MELEBAR keluar kotaknya, bukan
+     memampatkan isinya — itu yang membuat kotaknya bisa digulir mendatar. Di
+     layar lebar isinya lebih sempit dari 100%, jadi barisnya tetap selebar
+     kartu dan garis bawahnya tetap penuh. */
+  min-width: max-content;
 }
 .riwayat li:last-child { border-bottom: 0; }
 /* Nama lomba yang mengalah, bukan barisnya yang patah. Menaksir bisa bernilai
@@ -1715,13 +1750,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 /* Angka tidak pernah menyusut: "1250 → 0" yang terpotong jadi "1250 → " adalah
    riwayat yang berbohong, bukan riwayat yang rapi. */
+/* LEBARNYA DIPATOK, sekarang wajib. Sebelumnya kolom "oleh" didorong ke
+   kanan oleh `margin-left: auto`, jadi ia rata kanan dan awalnya boleh
+   berbeda-beda. Di kotak yang bergulir mendatar tidak ada lagi sisa ruang
+   untuk didorong: "oleh" mulai persis sesudah angkanya, dan angka selebar
+   "1250 → 1250" akan mendorong nama petugas jauh ke kanan sementara "1 → 0"
+   tidak — satu daftar dengan dua titik mulai yang berbeda jauh lebih sulit
+   disapu mata daripada satu yang lurus. Diukur di browser: "1250 → 1250" pada
+   angka tabular 1rem selebar 92px, jadi 6.5rem (104px) memuatnya.
+
+   `min-width`, BUKAN lebar mati. Angka yang lebih lebar dari patokannya akan
+   MELUAP menembus nama petugas di sebelahnya kalau kotaknya dipatok mati —
+   dua tulisan bertumpuk, dan yang di bawah tidak terbaca sama sekali. Dengan
+   min-width ia mendorong, bukan menembus: satu baris jadi tidak selurus yang
+   lain, dan itu harga yang jauh lebih murah. */
 .r-nilai {
-  flex: 0 0 auto;
+  flex: 0 0 auto; min-width: 6.5rem;
   font-variant-numeric: tabular-nums; white-space: nowrap;
 }
+/* TIDAK LAGI DIPOTONG. Elipsis di sini memakan JAM-nya — ujung kanan tulisan
+   "admin.ciradyka · 19 Agustus 2026 23:48" — dan jam itulah yang dicari orang
+   yang membuka riwayat: bukan "siapa yang mengubah", melainkan "kapan". Di
+   layar sempit barisnya sekarang melebar keluar kotaknya dan seluruh daftar
+   digeser mendatar SEKALIGUS, jadi satu geseran membuka jam SEMUA baris —
+   kolomnya tetap lurus karena ketiga lebarnya sudah dipatok di atas. */
 .r-oleh  {
-  flex: 0 1 auto; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis;
+  flex: 0 0 auto;
   color: var(--tinta-lembut); font-size: .78rem;
   white-space: nowrap; margin-left: auto;
 }


### PR DESCRIPTION
## What

Empat perbaikan di sekitar layar **Input Nilai Pos**.

**1. Galeri foto — judulnya ikut turun.** "9 foto" jadi "8 foto", "7 foto", …
tiap satu dihapus.

**2. Riwayat nilai — jamnya tidak lagi terpotong.** Barisnya melebar keluar
kotaknya dan seluruh daftar digeser mendatar **sekaligus**.

**3. Riwayat nilai — posisinya tidak berpindah saat disaring.** Chip
penyaringnya mengalir (dulu satu per baris, selebar layar), dan tinggi
daftarnya dipatok.

**4. Pesan galat menyebut komponennya** (migrasi `0082` + tes `45`):

```
sebelum   Nomor Dada 007: Input harus antara 0 - 5.

sesudah   Nomor Dada 007.
          Input Semaphore harus antara 0 - 5.
```

## Why

**Yang keempat bukan soal kenyamanan.** Satu baris lembar pos punya tiga
sampai lima kotak berdampingan dengan rentang berbeda-beda — Semaphore 0–5,
Tebak Simpul 0–10, Menaksir tanpa batas atas. Kalimat lama tidak menyebut yang
mana, jadi petugas **menebak**; tebakan yang salah mengganti angka yang
sebenarnya sudah benar, dan angka pengganti itu **tersimpan**, karena baris
yang sah tetap dikirim. Baris 007 di layar yang melaporkan ini memang salah di
**dua** kotak sekaligus.

**Elipsis di riwayat memakan JAM-nya** — ujung kanan tulisan
`admin.ciradyka · 19 Agustus 2026 23:48` — dan jam itulah yang dicari orang
yang membuka riwayat: bukan "siapa yang mengubah", melainkan "kapan".

**Chipnya satu per baris karena `flex-wrap: wrap` tidak pernah berlaku
sedetik pun.** Ia sifat flexbox yang dipasang pada elemen grid: `.option-row`
adalah grid dua kolom yang di bawah 560px jatuh jadi satu — patokan yang benar
untuk pasangan Batal/Simpan, salah untuk enam chip kecil. Enam chip selebar
layar mendorong daftarnya keluar layar sebelum satu baris pun terbaca
(CLAUDE.md 15.9).

**Lalu kartunya bergeser.** Menyaring 16 baris jadi 1 memendekkannya, dan
kartu yang dipusatkan tegak lurus pindah setengah selisihnya — tepat saat
orang hendak menekan chip berikutnya.

## Notes

Diukur di browser, bukan dibaca (CLAUDE.md 15.9–15.11), pada 320 / 360 / 412 /
560 / 1200 px:

| yang diukur | hasil |
|---|---|
| geser judul saat disaring | 0 px |
| geser chip saat disaring | 0 px |
| kolom "oleh" terpotong | 0 dari 10 baris |
| baris chip di 360px | 3 (dulu 6) |
| kartu muat di 90vh | ya, tanpa penggulir bersarang |
| titik mulai kolom "oleh" | satu, sama di semua baris |

`.r-nilai` memakai **`min-width`, bukan lebar mati**: angka yang lebih lebar
dari patokannya akan meluap menembus nama petugas kalau kotaknya dipatok
mati — dua tulisan bertumpuk, dan yang di bawah tidak terbaca sama sekali.
Terukur `1250 → 1250` selebar 92px; patokannya 104px.

**Tes 12 dan 03 sengaja TIDAK diubah.** `tests/run.sh` memutar ulang
sejarahnya: keduanya berjalan jauh di atas `0082`, saat fungsinya masih versi
`0031` — mengubahnya justru membuatnya gagal. Kalimat baru dijaga **tes 45**,
yang berjalan tepat sesudah `0082` dan menutup kedua cabangnya
(`Input …` dan `Jumlah salah …`). Komponennya **dicari**, tidak ditulis: tes
yang menyebut "Semaphore" sendiri akan lulus tahun depan sambil menyembunyikan
pesan yang sudah salah.

**SEMUA TES LULUS** — `45.1 OK — "Input Kepramukaan Keagamaan harus antara 0 - 20."`,
`45.2 OK — "Jumlah salah Sandi Morse harus antara 0 - 20."`

⚠️ Perlu `apply-migration.yml` sesudah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)