### PR TITLE
feat: tanggal lomba disetel ke 29 Agustus 2026

### DIFF
--- a/supabase/checks/cleanup_data_uji.sql
+++ b/supabase/checks/cleanup_data_uji.sql
@@ -7,8 +7,8 @@
 -- membuktikan bahwa seluruh 16 sekolah di produksi memang sisa pengetesan:
 -- nama bergenerator ("SMA Tabel 054155", "SMK Uji Produksi", "SMP Uji
 -- Deploy") dan alamat isian asal ("ABC", "HEHe", "Jl"), semuanya terdaftar
--- 12-13 Agustus 2026 — jendela pengetesan, sementara lombanya Februari 2027
--- dan pendaftaran belum dibuka.
+-- 12-13 Agustus 2026 — jendela pengetesan, sementara lombanya masih dua
+-- minggu lagi (29 Agustus 2026) dan pendaftaran belum dibuka.
 --
 -- JANGAN dijalankan lagi setelah pendaftaran sungguhan dibuka. Berkas ini
 -- tidak bisa membedakan sekolah uji dari sekolah asli; ia menghapus

--- a/supabase/checks/seed_data_uji.sql
+++ b/supabase/checks/seed_data_uji.sql
@@ -181,8 +181,16 @@ begin
   join pendaftaran p on p.sekolah_id = s.id;
 
   -- Kloter berangkat mulai 07.00 WIB, berjarak 15 menit.
+  --
+  -- Tanggalnya dibaca dari `edisi`, tidak ditulis di sini. Ia sempat dipatok
+  -- 2027-02-21 — tanggal contoh dari masa perancangan — dan bertahan di sini
+  -- sesudah tanggal sungguhannya ditetapkan (migrasi 0083), sehingga data uji
+  -- lahir pada hari yang tidak ada hubungannya dengan perkiraan yang dihitung
+  -- view mana pun.
   update kloter set jam_berangkat =
-    timestamptz '2027-02-21 07:00+07' + make_interval(mins => (nomor - 1) * 15)
+    ((select tanggal_lomba + time '07:00' from edisi where is_active)
+       at time zone 'Asia/Jakarta')
+    + make_interval(mins => (nomor - 1) * 15)
   where nomor between 1 and 5;
 
   -- -------------------------------------------------------------------------

--- a/supabase/migrations/0083_tanggal_lomba_29_agustus_2026.sql
+++ b/supabase/migrations/0083_tanggal_lomba_29_agustus_2026.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- hrcd-rekap : 0083_tanggal_lomba_29_agustus_2026.sql
+--
+-- HRCD XXXVII DIADAKAN 29 AGUSTUS 2026.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SALAH SEBELUM INI
+--
+-- `edisi` diisi pertama kali dari seed dengan tahun 2027 dan tanggal
+-- 2027-02-21 — angka contoh dari masa perancangan, waktu tanggalnya memang
+-- belum ditentukan. Angka itu tidak pernah diperbaiki, dan sampai hari ini
+-- produksi masih menyimpannya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA INI BUKAN SEKADAR ANGKA DI KARTU
+--
+-- `tanggal_lomba` bukan hiasan: ia ALAS PERKIRAAN JAM BERANGKAT. Kolom
+-- `perkiraan_berangkat` di `v_keberangkatan` dan `v_daftar_kloter` dihitung
+-- sebagai `(tanggal_lomba + jam_mulai_berangkat) at time zone Asia/Jakarta`
+-- ditambah jarak antar kloter. Dengan tanggal Februari 2027, seluruh
+-- perkiraan itu jatuh pada hari yang salah — dan kertas barak yang dicetak
+-- untuk dibagikan ke pembina ikut menyandang tanggal itu.
+--
+-- Yang membuatnya berbahaya: JAM-nya tetap benar. "07:00", "07:04", "07:08"
+-- terbaca persis seperti yang diharapkan, jadi tidak ada satu pun yang
+-- terlihat rusak di layar sampai ada yang memperhatikan tanggalnya. Bagian 10
+-- rancangan menyandarkan seluruh pagi pada perkiraan ini; alasnya harus benar.
+--
+-- Penalti TIDAK dihitung dari sini — itu `kloter.jam_berangkat`, yang diketik
+-- pencatat dari jam sungguhan (bagian 10.6). Jadi nilai yang sudah tersimpan
+-- tidak bergerak sedikit pun karena migrasi ini. Yang berubah cuma perkiraan
+-- dan tanggal yang tercetak.
+--
+-- ---------------------------------------------------------------------------
+-- SEED DAN TES SENGAJA TIDAK IKUT DIUBAH
+--
+-- `supabase/seed.sql` dan tes 03-05 masih menyebut 2027-02-21, dan itu benar:
+-- `tests/run.sh` MEMUTAR ULANG sejarahnya, jadi seed adalah keadaan awal yang
+-- memang pernah begitu, dan tes yang berjalan sebelum berkas ini memang hidup
+-- di dunia itu. Mengubah seed berarti mengubah jam berangkat yang dipatok
+-- ketiga tes tadi, tanpa satu pun manfaat. Berkas ini berjalan di UJUNG
+-- rangkaian, dan tes 46 sesudahnya yang menjaga hasilnya.
+--
+-- Yang IKUT diubah di commit yang sama cuma dua skrip di supabase/checks/
+-- yang menulis tanggalnya dengan tangan — mereka bukan bagian dari
+-- pemutaran ulang, melainkan alat yang dijalankan orang hari ini.
+-- ============================================================================
+
+update edisi
+set tahun         = 2026,
+    tanggal_lomba = date '2026-08-29'
+where nomor = 37;
+
+do $blok$
+declare
+  v_tanggal date;
+  v_tahun   smallint;
+  v_mulai   time;
+  v_batas   time;
+begin
+  select tanggal_lomba, tahun, jam_mulai_berangkat, jam_batas_berangkat
+    into v_tanggal, v_tahun, v_mulai, v_batas
+  from edisi where nomor = 37;
+
+  if not found then
+    raise notice '0083: edisi 37 tidak ada di database ini — dilewati.';
+    return;
+  end if;
+
+  assert v_tanggal = date '2026-08-29',
+    format('0083: tanggal lomba masih %s', v_tanggal);
+  assert v_tahun = 2026, format('0083: tahun masih %s', v_tahun);
+
+  -- Jendelanya cuma DILAPORKAN, tidak dipaksa: 07:00-10:00 adalah
+  -- konfigurasi per edisi (bagian 10.7), bukan tetapan. Yang perlu dilihat
+  -- orang yang menjalankan migrasi ini adalah bahwa alas dan jendelanya kini
+  -- bercerita hal yang sama.
+  raise notice '0083: HRCD XXXVII, % — berangkat % sampai %.',
+    v_tanggal, v_mulai, v_batas;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -318,5 +318,12 @@ run tests/sql/44_hapus_foto_lembar.sql
 # jauh di atas sini, saat fungsinya masih versi 0031.
 run supabase/migrations/0082_pesan_rentang_menyebut_komponen.sql
 run tests/sql/45_pesan_rentang_komponen.sql
+# 0083 menyetel tanggal lomba yang sebenarnya: 29 Agustus 2026. Sampai sini
+# database uji masih memakai tanggal contoh dari seed (2027-02-21), dan itu
+# memang benar — tes 03-05 mematok jam berangkat pada hari itu, dan run.sh
+# memutar ulang sejarahnya. Karena itu berkas ini di UJUNG, bukan di dekat
+# seed. Tes 46 menjaga hasilnya, termasuk yang keluar dari v_keberangkatan.
+run supabase/migrations/0083_tanggal_lomba_29_agustus_2026.sql
+run tests/sql/46_tanggal_lomba.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/46_tanggal_lomba.sql
+++ b/tests/sql/46_tanggal_lomba.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/46_tanggal_lomba.sql — migrasi 0083.
+--
+-- KENAPA SEBUAH TANGGAL DIJAGA MESIN.
+--
+-- `tanggal_lomba` adalah ALAS seluruh perkiraan jam berangkat: kolom
+-- `perkiraan_berangkat` dihitung darinya, dan bagian 10 rancangan
+-- menyandarkan seluruh pagi pada perkiraan itu.
+--
+-- Yang membuatnya perlu tes: kalau alasnya salah, JAM-nya tetap benar.
+-- "07:00", "07:04", "07:08" terbaca persis seperti yang diharapkan, dan tidak
+-- ada satu pun galat, layar merah, atau kolom kosong yang muncul. Selama
+-- setahun penuh angka itu salah hari tanpa ada yang melihatnya.
+--
+-- Karena itu yang diuji BUKAN cuma isi kolomnya, melainkan tanggal yang
+-- benar-benar keluar dari view yang dibaca layar Keberangkatan.
+-- ============================================================================
+
+\echo '--- 46. tanggal lomba 29 Agustus 2026'
+
+do $blok$
+declare
+  v_tanggal date;
+  v_tahun   smallint;
+  v_salah   integer;
+  v_baris   integer;
+begin
+  select tanggal_lomba, tahun into strict v_tanggal, v_tahun
+  from edisi where is_active;
+
+  -- ---------------------------------------------------------------------
+  -- 46.1 Kolomnya sendiri.
+  -- ---------------------------------------------------------------------
+  assert v_tanggal = date '2026-08-29',
+    format('46.1 GAGAL: tanggal lomba %s, seharusnya 2026-08-29', v_tanggal);
+  assert v_tahun = 2026,
+    format('46.1 GAGAL: tahun %s, seharusnya 2026', v_tahun);
+  raise notice '46.1 OK — HRCD XXXVII, tanggal % (tahun %).', v_tanggal, v_tahun;
+
+  -- ---------------------------------------------------------------------
+  -- 46.2 Yang keluar dari view Keberangkatan jatuh di HARI ITU.
+  --
+  -- Dibaca dalam WIB, bukan zona sesi database: sesi Supabase berjalan di
+  -- UTC, dan 2026-08-29 07:00 WIB adalah 2026-08-28 24:00 UTC — tanggal 28
+  -- kalau dibaca mentah-mentah (pelajaran migrasi 0056). Tes yang lupa
+  -- menyebut zonanya akan gagal justru saat kodenya benar.
+  -- ---------------------------------------------------------------------
+  select count(*) into v_baris from v_keberangkatan;
+
+  if v_baris = 0 then
+    raise notice '46.2 DILEWATI — belum ada kloter berisi regu.';
+    return;
+  end if;
+
+  select count(*) into v_salah
+  from v_keberangkatan
+  where (perkiraan_berangkat at time zone 'Asia/Jakarta')::date <> v_tanggal;
+
+  assert v_salah = 0,
+    format('46.2 GAGAL: %s dari %s kloter berperkiraan di luar hari lomba',
+           v_salah, v_baris);
+  raise notice '46.2 OK — % kloter, semuanya berperkiraan pada hari lomba.',
+    v_baris;
+end;
+$blok$;
+
+\echo '--- 46 SELESAI'


### PR DESCRIPTION
## What

`edisi` 37 kini bertanggal **29 Agustus 2026**, tahun **2026**. Migrasi `0083`
+ tes `46`.

Dua skrip di `supabase/checks/` yang menulis tanggalnya dengan tangan ikut
dibetulkan.

## Why

Produksi masih menyimpan tahun **2027** dan tanggal **2027-02-21** — angka
contoh dari masa perancangan, waktu tanggalnya memang belum ditentukan, dan
tidak pernah diperbaiki sejak.

**Ini bukan sekadar angka di kartu.** `tanggal_lomba` adalah **alas seluruh
perkiraan jam berangkat**: `perkiraan_berangkat` di `v_keberangkatan` dan
`v_daftar_kloter` dihitung sebagai
`(tanggal_lomba + jam_mulai_berangkat) at time zone 'Asia/Jakarta'` ditambah
jarak antar kloter. Dengan tanggal Februari 2027, seluruh perkiraan itu jatuh
pada hari yang salah — termasuk yang tercetak di **kertas barak** yang
dibagikan ke pembina.

**Yang membuatnya bertahan setahun: jamnya tetap benar.** "07:00", "07:04",
"07:08" terbaca persis seperti yang diharapkan, jadi tidak ada satu pun yang
terlihat rusak sampai ada yang memperhatikan tanggalnya. Tidak ada galat,
tidak ada kolom kosong, tidak ada layar merah.

**Penalti tidak bergerak karenanya.** Itu dihitung dari `kloter.jam_berangkat`
yang diketik pencatat dari jam sungguhan (bagian 10.6) — nilai yang sudah
tersimpan tidak berubah sedikit pun. Yang berubah hanya perkiraan dan tanggal
yang tercetak.

## Notes

**Seed dan tes 03–05 sengaja tetap `2027-02-21`.** `tests/run.sh` memutar
ulang sejarahnya: seed adalah keadaan awal yang memang pernah begitu, dan
ketiga tes itu mematok jam berangkat pada hari tersebut. Karena itu `0083`
duduk di **ujung** rangkaian, bukan di dekat seed.

**Tes 46 tidak berhenti di kolomnya.** Ia membaca tanggal yang benar-benar
keluar dari `v_keberangkatan` — kalau alasnya salah, satu-satunya tempat
kesalahan itu terlihat adalah di sana. Dibaca dalam **WIB**, bukan zona sesi
database: `2026-08-29 07:00` WIB adalah `2026-08-28 24:00` UTC, jadi tes yang
lupa menyebut zonanya akan gagal justru saat kodenya benar (pelajaran `0056`).

```
46.1 OK — HRCD XXXVII, tanggal 2026-08-29 (tahun 2026).
46.2 OK — 14 kloter, semuanya berperkiraan pada hari lomba.
SEMUA TES LULUS
```

`seed_data_uji.sql` sekarang **membaca** tanggalnya dari `edisi` alih-alih
mematoknya — itu sebabnya ia sempat tertinggal di 2027 tanpa ada yang tahu.
Terukur di database uji: kloter 3 → `2026-08-29 07:30+07`.

⚠️ Perlu `apply-migration.yml` sesudah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)