### PR TITLE
docs: 2026 adalah pengecualian — 29 Agustus, bukan Februari/Maret

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -33,7 +33,15 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 1. HRCD adalah lomba gerak jalan alam terbuka untuk pelajar SMP dan SMA.
 2. Penyelenggara: Ambalan Ciung Wanara – Dyah Pitaloka, SMA Negeri 1 Ciamis,
    Jawa Barat.
-3. Diadakan rutin setiap tahun, biasanya Februari atau Maret.
+3. Diadakan rutin setiap tahun, biasanya Februari atau Maret. **Edisi
+   XXXVII (2026) adalah pengecualian: 29 Agustus 2026**; edisi berikutnya
+   diperkirakan kembali ke Februari/Maret. Tanggalnya **data, bukan
+   tetapan** — `edisi.tanggal_lomba`, dan seluruh perkiraan jam berangkat
+   dihitung darinya, jadi jangan menuliskannya di kode atau di skrip.
+   Migrasi `0083` ada karena tanggal contoh dari masa perancangan sempat
+   bertahan di produksi sampai sepuluh hari sebelum lomba, dan tidak ada
+   satu pun galat yang menyebutnya — jamnya tetap benar, cuma harinya
+   yang salah.
 4. Skala peserta konsisten di kisaran 300 regu, dengan batas atas sekitar 500.
 5. Sistem terbagi menjadi **dua wajah yang terpisah**:
    - **Aplikasi panitia** — satu link yang sama untuk semua panitia, dengan


### PR DESCRIPTION
## What

Bagian 1.3 `docs/alur-lomba.md` kini menyebut bahwa **edisi XXXVII (2026)
adalah pengecualian: 29 Agustus 2026**, dan edisi berikutnya diperkirakan
kembali ke Februari/Maret.

## Why

"Diadakan rutin setiap tahun, biasanya Februari atau Maret" benar untuk edisi
mana pun **kecuali yang sedang berjalan** — dan dokumen ini justru dibaca
orang yang sedang menyiapkan edisi yang sedang berjalan.

Ditulis di sana juga apa yang membuat tanggal itu penting: ia **data, bukan
tetapan**, dan seluruh perkiraan jam berangkat dihitung darinya. `0083`
disebut namanya supaya yang membaca tahu kejadiannya pernah nyata — tanggal
contoh dari masa perancangan bertahan di produksi sampai sepuluh hari sebelum
lomba **tanpa satu pun galat**, karena jamnya tetap benar dan cuma harinya
yang salah.

## Notes

Butirnya **digabung ke 1.3**, tidak ditambahkan sebagai butir baru: tiga
tempat menunjuk "bagian 1.5" — `alur-lomba.md` sendiri, `desain-sistem.md`,
dan migrasi `0026` — dan menggeser penomoran akan membuat ketiganya menunjuk
butir yang keliru.

Tidak ada perubahan kode; tidak perlu migrasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)