### PR TITLE
fix: blangko tiga juri, kepala tanpa "Petugas", lomba soal tidak dicetak

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1049,8 +1049,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .bl-nilai-banyak .bl-nilai-kepala { min-height: 9mm; }
 
   .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
-  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 8pt; }
-  .bl-garis { margin: 7mm auto 0; width: 70mm; border-bottom: .75pt solid #000; }
+
+  /* TIGA TANDA TANGAN, berjajar di kaki halaman.
+
+     `margin: auto 0 0` yang mendorongnya ke bawah: .blangko adalah kolom flex
+     setinggi satu halaman, jadi berapa pun tinggi kotak nilainya, tanda
+     tangan berhenti di tempat yang sama pada setiap lembar. Petugas yang
+     menandatangani ratusan lembar tidak mencari-cari letaknya.
+
+     Namanya TIDAK dicetak. Siapa yang berjaga di sebuah pos berganti
+     sepanjang pagi, dan blangko sudah difotokopi jauh sebelum itu diputuskan
+     — nama tercetak yang salah lebih buruk daripada garis kosong.
+
+     Garisnya .75pt, batas bawah aturan fotokopi (CLAUDE.md 8.5): di bawah itu
+     ia hilang sama sekali pada gandaan kedua, dan tanda tangan yang melayang
+     tanpa garis terbaca seperti coretan. */
+  /* 3mm menahan garisnya dari tepi bawah. Tanpa itu ia berhenti tepat di
+     batas cetak, dan ekor tanda tangan yang turun sedikit saja jatuh di luar
+     kertas — tepat pada gandaan yang paling pinggir. */
+  .bl-ttd { margin: auto 0 3mm; display: flex; gap: 6mm; font-size: 8pt; }
+  .bl-ttd-sel { flex: 1 1 0; min-width: 0; text-align: center; }
+  .bl-ttd-nama { display: block; }
+  /* 9mm ruang membubuhkan tanda tangan di antara nama dan garisnya. Lebih
+     rapat dari itu, tanda tangannya menabrak tulisan "Juri 1" di atasnya. */
+  .bl-ttd-garis {
+    display: block; margin-top: 9mm; border-bottom: .75pt solid #000;
+  }
 
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2632,7 +2632,7 @@ function siapkanCetakBlangko(pos, kolomLayar) {
     <article class="blangko">
       <p class="bl-pos">${esc(judulPos)}</p>
       <h2 class="bl-lomba">${esc(lomba.nama)}</h2>
-      <p class="bl-acara">${esc(EDISI ? EDISI.name : "")} · Petugas: ____________</p>
+      <p class="bl-acara">${esc(EDISI ? EDISI.name : "")}</p>
 
       <table class="bl-identitas"><tbody>
         <tr>
@@ -2655,8 +2655,19 @@ function siapkanCetakBlangko(pos, kolomLayar) {
 
       <p class="bl-catatan"><strong>Tulis angkanya saja — jangan menghitung
          poin.</strong></p>
-      <p class="bl-ttd">Petugas ${esc(lomba.nama)}</p>
-      <p class="bl-garis"></p>
+
+      <!-- TIGA JURI, bukan satu petugas. Satu lomba dinilai bersama, dan
+           tanda tangan yang cuma satu membuat dua juri lain tidak punya
+           tempat menyatakan bahwa angka itu juga angka mereka. Namanya
+           ditulis tangan: yang bertugas di sebuah pos berganti sepanjang
+           pagi, dan blangko sudah difotokopi jauh sebelum itu diputuskan. -->
+      <div class="bl-ttd">
+        ${[1, 2, 3].map(i => `
+        <div class="bl-ttd-sel">
+          <span class="bl-ttd-nama">Juri ${i}</span>
+          <span class="bl-ttd-garis"></span>
+        </div>`).join("")}
+      </div>
     </article>`;
   };
 
@@ -2671,7 +2682,18 @@ function siapkanCetakBlangko(pos, kolomLayar) {
   // Jadi keluarannya tiga halaman untuk Pos 1: Semaphore, Tebak Simpul,
   // Menaksir. Panitia menggandakan tiap halaman sebanyak yang dibutuhkan, dan
   // tiap tumpukan otomatis berisi satu lomba saja.
-  const daftarLomba = kelompokLomba(kolomLayar);
+  /* LOMBA SOAL TIDAK PUNYA BLANGKO, dan itu bukan penghematan kertas.
+     Kepramukaan, Keagamaan, Kesehatan, Pengetahuan Umum, dan Logika dijawab
+     peserta di LEMBAR SOALNYA SENDIRI — lembar itulah bukti dan lembar itu
+     pula yang dikumpulkan. Blangko kosong di sampingnya cuma kertas kedua
+     untuk satu angka yang sudah tertulis di kertas pertama, dan kertas kedua
+     yang tidak dipakai tetap difotokopi 1.500 kali.
+
+     Dikenali dari `type`, bukan dari namanya: `soal` adalah kolom di database
+     dan panitia yang menentukan isinya (0076). Menyaring dengan daftar nama
+     berarti lomba soal tahun depan tercetak lagi tanpa ada yang tahu kenapa. */
+  const lombaSoal = (l) => l.kolom.every(kol => kol.varian[0].type === "soal");
+  const daftarLomba = kelompokLomba(kolomLayar).filter(l => !lombaSoal(l));
   const cetakan = daftarLomba.map(l => `
     <section class="print-page blangko-halaman">${satuBlangko(l)}</section>`).join("");
 
@@ -3798,6 +3820,15 @@ async function layarInputPos() {
       // pun tidak. Blangkonya kosong; berapa banyak yang dibutuhkan diputuskan
       // di mesin fotokopi, bukan di layar ini.
       const n = siapkanCetakBlangko(pos, kolom);
+      // Nol berarti pos ini seluruhnya lomba soal — dijawab di lembar soalnya
+      // sendiri, jadi tidak ada blangko yang perlu dicetak. Tanpa cabang ini
+      // browser membuka dialog cetak untuk halaman kosong, dan yang menekan
+      // tombolnya menyimpulkan bahwa pencetakannya rusak.
+      if (!n) {
+        notif("Pos ini seluruhnya lomba soal — dijawab di lembar soalnya "
+              + "sendiri, jadi tidak ada blangko yang perlu dicetak.", true);
+        return;
+      }
       notif(`${n} master A5 melintang, satu per lomba.`);
     } else {
       siapkanCetakLembarPos(pos, kolom, semua);

--- a/web/style.css
+++ b/web/style.css
@@ -1049,8 +1049,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .bl-nilai-banyak .bl-nilai-kepala { min-height: 9mm; }
 
   .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
-  .bl-ttd { margin: auto 0 0; text-align: center; font-size: 8pt; }
-  .bl-garis { margin: 7mm auto 0; width: 70mm; border-bottom: .75pt solid #000; }
+
+  /* TIGA TANDA TANGAN, berjajar di kaki halaman.
+
+     `margin: auto 0 0` yang mendorongnya ke bawah: .blangko adalah kolom flex
+     setinggi satu halaman, jadi berapa pun tinggi kotak nilainya, tanda
+     tangan berhenti di tempat yang sama pada setiap lembar. Petugas yang
+     menandatangani ratusan lembar tidak mencari-cari letaknya.
+
+     Namanya TIDAK dicetak. Siapa yang berjaga di sebuah pos berganti
+     sepanjang pagi, dan blangko sudah difotokopi jauh sebelum itu diputuskan
+     — nama tercetak yang salah lebih buruk daripada garis kosong.
+
+     Garisnya .75pt, batas bawah aturan fotokopi (CLAUDE.md 8.5): di bawah itu
+     ia hilang sama sekali pada gandaan kedua, dan tanda tangan yang melayang
+     tanpa garis terbaca seperti coretan. */
+  /* 3mm menahan garisnya dari tepi bawah. Tanpa itu ia berhenti tepat di
+     batas cetak, dan ekor tanda tangan yang turun sedikit saja jatuh di luar
+     kertas — tepat pada gandaan yang paling pinggir. */
+  .bl-ttd { margin: auto 0 3mm; display: flex; gap: 6mm; font-size: 8pt; }
+  .bl-ttd-sel { flex: 1 1 0; min-width: 0; text-align: center; }
+  .bl-ttd-nama { display: block; }
+  /* 9mm ruang membubuhkan tanda tangan di antara nama dan garisnya. Lebih
+     rapat dari itu, tanda tangannya menabrak tulisan "Juri 1" di atasnya. */
+  .bl-ttd-garis {
+    display: block; margin-top: 9mm; border-bottom: .75pt solid #000;
+  }
 
   /* ---- kerapatan baris ----
      Yang harus muat dalam satu A4 potret: kepala halaman + 30 baris + catatan


### PR DESCRIPTION
## What

Tiga hal di **Form per Lomba**:

1. **Lomba soal tidak lagi dicetak blangkonya** — Pos 1 menghasilkan tiga
   master (Semaphore, Tebak Simpul, Menaksir), bukan lima.
2. **Kepala halaman tinggal `HRCD XXXVII`** — `· Petugas: ____________`
   dibuang.
3. **Tiga tanda tangan** — Juri 1, Juri 2, Juri 3, berjajar di kaki halaman.

## Why

**Lomba soal dijawab di lembar soalnya sendiri.** Kepramukaan, Keagamaan,
Kesehatan, Pengetahuan Umum, dan Logika — lembar itulah bukti, dan lembar itu
pula yang dikumpulkan. Blangko kosong di sampingnya cuma kertas kedua untuk
satu angka yang sudah tertulis di kertas pertama, dan kertas kedua yang tidak
dipakai **tetap difotokopi 1.500 kali**.

Dikenali dari **`wahana.type`**, bukan dari daftar nama: `soal` adalah kolom
di database dan panitia yang menentukan isinya (`0076`). Menyaring dengan nama
berarti lomba soal tahun depan tercetak lagi tanpa ada yang tahu kenapa.

**"Petugas" di kepala meminta hal yang sama dengan tanda tangan di kaki**, dan
dua tempat untuk satu nama berarti separuh blangko terisi di atas dan separuh
di bawah.

**Satu lomba dinilai bersama.** Tanda tangan tunggal membuat dua juri lain
tidak punya tempat menyatakan bahwa angka itu juga angka mereka. Namanya
**tidak dicetak**: siapa yang berjaga di sebuah pos berganti sepanjang pagi,
dan blangko sudah difotokopi jauh sebelum itu diputuskan.

## Notes

Kalau seluruh lomba sebuah pos ternyata lomba soal, tombolnya **berhenti
dengan kalimat yang menjelaskan** — bukan membuka dialog cetak untuk halaman
kosong, yang terbaca seperti pencetakannya rusak. Hari ini tidak ada pos
seperti itu; besok bisa ada.

Diukur di browser dengan aturan `@media print` yang benar-benar berlaku, pada
kotak seukuran **isi** A5 melintang (192 × 130 mm):

| yang diukur | SEMAPHORE | PEMBIDAIAN | BAKIAK |
|---|---|---|---|
| tinggi isi | 129,9 mm | 129,9 mm | 129,9 mm |
| meluap halaman | tidak | tidak | tidak |
| garis ke tepi bawah | 3 mm | 3 mm | 3 mm |
| ketiga garis sejajar | ya | ya | ya |
| lebar tiap garis | 60 mm | 60 mm | 60 mm |
| judul kriteria terpotong | 0 | 0 | 0 |

Tiga bentuk yang paling berbeda sengaja diukur bersama: satu kotak, lima kotak
(Pembidaian), dan kotak waktu. **3 mm dari tepi** supaya ekor tanda tangan
yang turun sedikit tidak jatuh di luar kertas — tepat pada gandaan yang paling
pinggir. Garisnya `.75pt`, batas bawah aturan fotokopi (CLAUDE.md 8.5).

Tidak ada perubahan database; tidak perlu migrasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)