### PR TITLE
fix: kotak waktu Pos 2 tidak lagi memotong menit:detik

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2055,6 +2055,18 @@ select {
 /* Lebar ringkas HANYA untuk kotak ANGKA. Dropdown cara bayar harus selebar
    isinya — dipaksa 4.5rem, "Transfer" terpotong jadi "Tuna". */
 input.small-input { width: 4.5rem; }
+/* KOTAK WAKTU LEBIH LEBAR, dan ini bukan selera.
+   `00:30` butuh ~48px isi pada Inter, sementara 4.5rem menyisakan 44px
+   sesudah padding dan garis — jadi digit terakhirnya terpotong di SETIAP
+   baris Pos 2. Terukur di browser: scrollWidth 73 lawan clientWidth 68.
+
+   Kenapa selisih sekecil itu bisa lolos sampai lapangan: lebarnya dipatok
+   `rem` (ikut 16px), tapi UKURAN HURUFNYA bisa lebih besar dari itu — Chrome
+   punya setelan "ukuran font minimum", dan pada mesin yang menyetelnya 17px
+   teksnya membesar sementara kotaknya tidak. Karena itu lebarnya diberi
+   kelonggaran, bukan dipaskan: 5.6rem memuat `59:59` bahkan saat huruf
+   minimumnya dinaikkan sampai 20px. */
+input.small-input.input-waktu { width: 5.6rem; }
 /* min-width naik dari 6.5rem: panah yang digambar sendiri memakan 2rem
    padding kanan, dan tanpa tambahan itu "Transfer" terpotong demi memberi
    ruang bagi panah yang baru saja ditambahkan. */
@@ -2672,6 +2684,10 @@ input.small-input { text-align: center; }
      di sini hanya jaraknya. */
   .table-pos th, .table-pos td { padding: .3rem .3rem; }
   .table-pos input.small-input { width: 3.6rem; }
+  /* Di HP pun waktu tidak boleh terpotong. Tabelnya memang jadi lebih lebar,
+     dan itu tidak apa-apa: .table-wrapper sudah menggulir mendatar, sedangkan
+     angka yang terpotong tidak bisa diperbaiki dengan menggulir apa pun. */
+  .table-pos input.small-input.input-waktu { width: 5rem; }
   .table-pos .pos-pasangan input.small-input { width: 2.9rem; }
   .table-pos td:nth-child(2), .table-pos td:nth-child(3) { min-width: 7.5rem; }
 }

--- a/web/style.css
+++ b/web/style.css
@@ -2055,6 +2055,18 @@ select {
 /* Lebar ringkas HANYA untuk kotak ANGKA. Dropdown cara bayar harus selebar
    isinya — dipaksa 4.5rem, "Transfer" terpotong jadi "Tuna". */
 input.small-input { width: 4.5rem; }
+/* KOTAK WAKTU LEBIH LEBAR, dan ini bukan selera.
+   `00:30` butuh ~48px isi pada Inter, sementara 4.5rem menyisakan 44px
+   sesudah padding dan garis — jadi digit terakhirnya terpotong di SETIAP
+   baris Pos 2. Terukur di browser: scrollWidth 73 lawan clientWidth 68.
+
+   Kenapa selisih sekecil itu bisa lolos sampai lapangan: lebarnya dipatok
+   `rem` (ikut 16px), tapi UKURAN HURUFNYA bisa lebih besar dari itu — Chrome
+   punya setelan "ukuran font minimum", dan pada mesin yang menyetelnya 17px
+   teksnya membesar sementara kotaknya tidak. Karena itu lebarnya diberi
+   kelonggaran, bukan dipaskan: 5.6rem memuat `59:59` bahkan saat huruf
+   minimumnya dinaikkan sampai 20px. */
+input.small-input.input-waktu { width: 5.6rem; }
 /* min-width naik dari 6.5rem: panah yang digambar sendiri memakan 2rem
    padding kanan, dan tanpa tambahan itu "Transfer" terpotong demi memberi
    ruang bagi panah yang baru saja ditambahkan. */
@@ -2672,6 +2684,10 @@ input.small-input { text-align: center; }
      di sini hanya jaraknya. */
   .table-pos th, .table-pos td { padding: .3rem .3rem; }
   .table-pos input.small-input { width: 3.6rem; }
+  /* Di HP pun waktu tidak boleh terpotong. Tabelnya memang jadi lebih lebar,
+     dan itu tidak apa-apa: .table-wrapper sudah menggulir mendatar, sedangkan
+     angka yang terpotong tidak bisa diperbaiki dengan menggulir apa pun. */
+  .table-pos input.small-input.input-waktu { width: 5rem; }
   .table-pos .pos-pasangan input.small-input { width: 2.9rem; }
   .table-pos td:nth-child(2), .table-pos td:nth-child(3) { min-width: 7.5rem; }
 }


### PR DESCRIPTION
## What

Kotak isian waktu di Pos 2 — Bakiak, Lari Balok, Balap Karung — dilebarkan
dari `4.5rem` jadi `5.6rem` (`5rem` di bawah 560px).

## Why

`00:30` tercetak `00:3` di **setiap** baris. Terukur di browser:
`scrollWidth 73` lawan `clientWidth 68` — kurang lima piksel.

**Kenapa selisih sekecil itu lolos sampai lapangan.** Lebarnya dipatok `rem`,
jadi ikut 16px — tapi ukuran hurufnya tidak selalu 16px. Chrome punya setelan
**"ukuran font minimum"**, dan pada mesin yang menyetelnya 17px teksnya
membesar sementara kotaknya diam. Di mesin dengan setelan bawaan kotak itu
justru pas, dengan 3 piksel tersisa — jadi memeriksanya di satu mesin saja
tidak menemukan apa pun.

Karena itu lebarnya sekarang diberi **kelonggaran, bukan dipaskan**.

## Notes

Diukur di browser dengan Inter yang sungguhan termuat — ini bagian yang
menentukan: harness pertama saya lupa menyalin `fonts/inter-latin.woff2`, jatuh
ke font sistem yang lebih sempit, dan melaporkan "tidak ada yang terpotong".
Baru setelah font aslinya ikut, keluhannya terulang persis.

| nilai | sisa ruang sesudah perbaikan |
|---|---|
| `00:30` | 14 px |
| `59:59` | 15 px |
| `100:00` | 7 px |

`masihTerpotong: []` di seluruh baris.

**Yang dilebarkan hanya kotak waktu** (`input.small-input.input-waktu`). Kotak
angka biasa — Kesehatan, Pengetahuan Umum — tetap `4.5rem`: isinya paling
banyak dua digit, dan melebarkan semuanya cuma mendorong tabel yang sudah
lebar. Terukur: kotak angka tetap 72px, kotak waktu jadi 90px.

Di bawah 560px kotak waktunya `5rem`. Tabelnya jadi lebih lebar dan itu tidak
apa-apa: `.table-wrapper` sudah menggulir mendatar, sedangkan angka yang
terpotong tidak bisa diperbaiki dengan menggulir apa pun.

Tidak ada perubahan database; tidak perlu migrasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
