### PR TITLE
feat: tombol Form per Lomba dan Form Tabel tampil di HP untuk yang tidak berpos

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2172,8 +2172,24 @@ input.small-input { text-align: center; }
   /* Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin
      fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara
      penyaring dan tabel cuma jarak yang harus digulir ratusan kali per
-     shift. */
+     shift.
+
+     KECUALI bagi yang tidak terkunci ke satu pos: koordinator pos dan admin.
+     Merekalah yang menyiapkan kertas untuk pos lain, sering dari HP di jalan
+     antar pos, dan bagi mereka dua tombol itu bukan jarak melainkan
+     pekerjaannya. Yang menentukan bukan nama peran melainkan kolom `pos` yang
+     kosong — patokan yang sama dengan pemilih pos di layar ini (bagian
+     13.2). */
   .alat-cetak { display: none; }
+  /* `order: 1` menaruhnya tepat di bawah pemilih pos, BUKAN di antara kotak
+     cari dan tabel. Tanpa itu ia jatuh paling akhir — .table-toolbar jadi
+     kolom di sini, dan `kanan` memang anak terakhir — persis di tempat yang
+     dikeluhkan: satu blok yang harus dilewati tiap kali turun ke tabel.
+
+     Berdampingan, bukan bertumpuk: dua tombol selebar layar adalah dua baris
+     gulir, dan keduanya cukup pendek untuk berbagi satu baris. */
+  .alat-cetak.alat-cetak-hp { display: flex; gap: .4rem; order: 1; }
+  .alat-cetak.alat-cetak-hp .button { flex: 1 1 0; min-width: 0; }
 
   /* Kotak cari TEPAT DI ATAS TABEL, di bawah penyaring.
      Di HP kotak cari adalah alat yang paling sering dipakai di layar ini —

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2757,7 +2757,12 @@ async function layarInputPos() {
   // RLS akan menolak pos lain seandainya layar ini mencoba.
   // Terkunci = punya kolom `pos`, bukan = berperan juri_pos. Koordinator Pos
   // tidak punya pos, jadi ia ikut jalur pemilih di bawah.
-  const nomorPos = (s.pos != null && s.pos !== "")
+  // SATU patokan untuk dua keputusan: pos mana yang dibuka, dan apakah tombol
+  // cetak ikut tampil di HP. Keduanya bertanya hal yang sama — "akun ini
+  // melayani satu pos, atau seluruh pos?" — dan menjawabnya dua kali dengan
+  // cara berbeda adalah cara keduanya berselisih diam-diam.
+  const terkunciPos = s.pos != null && s.pos !== "";
+  const nomorPos = terkunciPos
     ? Number(s.pos)
     : (posDipilih.nomor
        ?? (posDinilai.length ? posDinilai[0].nomor
@@ -2840,7 +2845,12 @@ async function layarInputPos() {
         // di sekretariat — dan dua tombol selebar layar di antara penyaring
         // dan tabel memaksa petugas menggulir melewatinya ratusan kali per
         // shift untuk sampai ke pekerjaannya.
-        kanan: `<span class="alat-cetak">
+        //
+        // Di HP ia tetap tampil untuk akun yang TIDAK terkunci ke satu pos —
+        // koordinator pos dan admin. Merekalah yang menyiapkan kertas untuk
+        // pos lain, dan patokannya kolom `pos` yang kosong, bukan nama
+        // perannya (patokan yang sama dengan pemilih pos di bawah).
+        kanan: `<span class="alat-cetak${terkunciPos ? "" : " alat-cetak-hp"}">
                 <button class="button button-secondary button-small" type="button"
                         id="cetak-per-lomba">🖨️ Form per Lomba</button>
                 <button class="button button-secondary button-small" type="button"

--- a/web/style.css
+++ b/web/style.css
@@ -2172,8 +2172,24 @@ input.small-input { text-align: center; }
   /* Mencetak dari HP tidak pernah terjadi — kertasnya keluar dari mesin
      fotokopi di sekretariat (bagian 8.10). Dua tombol selebar layar di antara
      penyaring dan tabel cuma jarak yang harus digulir ratusan kali per
-     shift. */
+     shift.
+
+     KECUALI bagi yang tidak terkunci ke satu pos: koordinator pos dan admin.
+     Merekalah yang menyiapkan kertas untuk pos lain, sering dari HP di jalan
+     antar pos, dan bagi mereka dua tombol itu bukan jarak melainkan
+     pekerjaannya. Yang menentukan bukan nama peran melainkan kolom `pos` yang
+     kosong — patokan yang sama dengan pemilih pos di layar ini (bagian
+     13.2). */
   .alat-cetak { display: none; }
+  /* `order: 1` menaruhnya tepat di bawah pemilih pos, BUKAN di antara kotak
+     cari dan tabel. Tanpa itu ia jatuh paling akhir — .table-toolbar jadi
+     kolom di sini, dan `kanan` memang anak terakhir — persis di tempat yang
+     dikeluhkan: satu blok yang harus dilewati tiap kali turun ke tabel.
+
+     Berdampingan, bukan bertumpuk: dua tombol selebar layar adalah dua baris
+     gulir, dan keduanya cukup pendek untuk berbagi satu baris. */
+  .alat-cetak.alat-cetak-hp { display: flex; gap: .4rem; order: 1; }
+  .alat-cetak.alat-cetak-hp .button { flex: 1 1 0; min-width: 0; }
 
   /* Kotak cari TEPAT DI ATAS TABEL, di bawah penyaring.
      Di HP kotak cari adalah alat yang paling sering dipakai di layar ini —


### PR DESCRIPTION
## What

**Form per Lomba** dan **Form Tabel (cadangan)** kini tampil di HP untuk
**koordinator pos dan admin**. Untuk juri pos ia tetap disembunyikan seperti
sebelumnya.

## Why

Kedua tombol disembunyikan di HP sejak awal, dan alasannya masih benar —
untuk juri pos: mencetak dari HP tidak pernah terjadi (kertasnya keluar dari
mesin fotokopi di sekretariat, CLAUDE.md 8.10), dan dua tombol selebar layar
di antara penyaring dan tabel cuma jarak yang harus digulir ratusan kali per
shift.

Yang keliru adalah menerapkannya ke **semua orang**. Koordinator pos dan admin
justru merekalah yang menyiapkan kertas untuk pos lain, sering dari HP di
jalan antar pos, dan bagi mereka dua tombol itu bukan jarak melainkan
pekerjaannya.

## Notes

**Patokannya kolom `pos` yang kosong, bukan nama peran.** Itu patokan yang
sama dengan pemilih pos di layar ini: koordinator pos adalah juri pos yang
kolom `pos`-nya kosong (CLAUDE.md 13.2), dan admin juga kosong. Memakai
`peran === '...'` akan melahirkan mekanisme kedua untuk satu pertanyaan — dan
yang satu bisa diubah panitia lewat matriks Akun sementara yang satu tidak
(13.1).

`terkunciPos` karena itu dihitung **sekali** dan dipakai dua-duanya: menentukan
pos mana yang dibuka, dan apakah tombolnya ikut tampil. Dua jawaban untuk satu
pertanyaan adalah cara keduanya berselisih diam-diam.

**Di HP tombolnya berdampingan dan naik ke bawah pemilih pos** (`order: 1`).
Tanpa `order` ia jatuh paling akhir — `.table-toolbar` jadi kolom di sana dan
`kanan` memang anak terakhir — persis di tempat yang dulu dikeluhkan.

Diukur di browser pada 320 / 360 / 412 px:

| yang diukur | hasil |
|---|---|
| urutan tampil | pemilih pos → tombol cetak → penyaring → kotak cari |
| isi tombol terpotong | 0 dari 2 |
| badan menggulir mendatar | tidak |
| `.alat-cetak` di HP | `flex` (berdampingan) |

Tidak ada perubahan database; tidak perlu migrasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)