### PR TITLE
feat: blangko per lomba diisi peserta dan panitia, dengan identitas lengkap

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -964,10 +964,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
      Aturan cetak fotokopi (CLAUDE.md bagian 8) berlaku penuh di sini: tanpa
      blok, tanpa abu-abu, garis >= 0,75pt, huruf >= 7pt. */
-  @page blangko-halaman { size: A5 landscape; margin: 9mm; }
+  /* 6mm, BUKAN 9mm dan bukan pula 4mm.
+     Yang dibeli 3mm di tiap sisi: isinya jadi 198 x 136mm (dari 192 x 130),
+     dan seluruh tambahan itu jatuh ke kotak yang ditulisi tangan.
+     Batas bawahnya bukan selera: printer laser punya tepi yang memang tidak
+     bisa dicetak — umumnya 4-5mm — dan mesin fotokopi menggeser gambarnya
+     1-2mm lagi tiap kali digandakan. Di bawah 6mm, gandaan yang paling
+     pinggir mulai kehilangan garis kotaknya, dan kotak tanpa tepi bukan
+     kotak lagi (CLAUDE.md bagian 8). */
+  @page blangko-halaman { size: A5 landscape; margin: 6mm; }
   .blangko-halaman { page: blangko-halaman; }
   .blangko {
-    height: 130mm;
+    height: 136mm;
     display: flex;
     flex-direction: column;
     font-size: 10pt;
@@ -995,12 +1003,23 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas
      menuliskannya di tengah antrean, dan saat tim IT mengurutkan ratusan
      lembar lepas dengan hanya melihat sudut kertas. */
-  .bl-identitas { width: 100%; border-collapse: collapse; margin-top: 3.5mm; }
+  .bl-identitas { width: 100%; border-collapse: collapse; margin-top: 3mm; }
   .bl-identitas td {
-    border: 1pt solid #000; padding: 1.2mm 2mm; height: 20mm;
+    border: 1pt solid #000; padding: 1mm 2mm; height: 15mm;
     vertical-align: top;
   }
-  .bl-dada { width: 58mm; }
+  .bl-dada { width: 34mm; }
+  .bl-regu { width: 62mm; }
+
+  /* KATEGORI DILINGKARI. Barisnya rendah — yang ditulis cuma satu lingkaran,
+     bukan huruf — dan keempat pilihannya disebar rata supaya lingkaran yang
+     dibuat tergesa tidak mengenai dua sekaligus. */
+  .bl-kategori { height: auto !important; padding: 1.2mm 2mm 1.8mm !important; }
+  .bl-pilihan {
+    display: flex; justify-content: space-between;
+    margin-top: 1.2mm; padding: 0 4mm;
+    font-size: 11pt; font-weight: 700;
+  }
 
   /* Label tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
      Abu-abu adalah yang paling buruk ditangani mesin fotokopi: diubah jadi
@@ -1048,6 +1067,84 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kata yang membedakannya dari kriteria sebelahnya. */
   .bl-nilai-banyak .bl-nilai-kepala { min-height: 9mm; }
 
+  /* SIAPA YANG MENGISI. Satu lembar kini dipegang dua tangan — peserta
+     menulis jawabannya, panitia menulis angkanya — dan tanpa penanda ini
+     keduanya menulis di kotak yang sama. Garis tebal di bawahnya, bukan blok
+     abu-abu: blok penuh keluar belang di mesin fotokopi (bagian 8.2). */
+  .bl-siapa {
+    margin: 2mm 0 1mm; font-size: 8.5pt; font-weight: 700;
+    letter-spacing: 1pt; text-transform: uppercase;
+    border-bottom: 1.2pt solid #000; padding-bottom: .6mm;
+  }
+
+  /* PITA PANITIA: label menempel pada kotaknya, bukan melayang di atasnya.
+     Alasannya di pitaPanitia() — ruang A5 melintang, dan label yang berdiri
+     sendiri terbaca sebagai judul bagian, bukan sebagai pemilik kotak. */
+  .bl-panitia {
+    display: flex; align-items: stretch; margin-top: 2.5mm;
+    border: 1.2pt solid #000; border-radius: 1mm; min-height: 20mm;
+  }
+  .bl-panitia-siapa {
+    display: flex; align-items: center; flex: 0 0 17mm;
+    padding: 0 2mm; border-right: 1.2pt solid #000;
+    font-size: 8pt; font-weight: 700; letter-spacing: .6pt;
+    text-transform: uppercase; line-height: 1.15;
+  }
+  /* Tiap kotak berdiri di bawah labelnya sendiri, dan lajur-lajurnya dibagi
+     rata — dua kotak Menaksir jadi selebar sama tanpa dipatok mm. */
+  .bl-panitia-sel {
+    display: flex; flex-direction: column;
+    flex: 1 1 0; min-width: 0;
+    border-left: 1.2pt solid #000;
+  }
+  .bl-panitia-sel:first-of-type { border-left: 0; }
+  .bl-panitia-kepala { padding: 1mm 2.5mm; border-bottom: 1.2pt solid #000; }
+  .bl-panitia-judul {
+    display: block;
+    font-size: 11pt; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .4pt; line-height: 1.15;
+  }
+  .bl-panitia-contoh { display: block; font-size: 8.5pt; margin-top: .4mm; }
+  .bl-panitia-kotak { flex: 1 1 auto; min-height: 10mm; }
+
+  /* Menaksir: satu kotak isian peserta, judulnya di atas. */
+  .bl-taksir { margin-top: 1mm; }
+  .bl-taksir-kotak {
+    /* Lembar Menaksir tidak punya bagian panitia, jadi seluruh sisa halaman
+       jatuh ke satu kotak ini — dan memang itu yang dipakai: angka yang
+       ditulis peserta di lapangan, sering sambil berdiri. */
+    margin-top: 1mm; height: 46mm;
+    border: 1.2pt solid #000; border-radius: 1mm;
+  }
+
+  /* Semaphore: nomor amplop di kiri, lima kotak huruf di kanan. */
+  .bl-amplop { display: flex; gap: 6mm; align-items: flex-end; }
+  .bl-amplop-jawab { flex: 1 1 auto; }
+  .bl-huruf-baris { display: flex; gap: 3mm; margin-top: 1.2mm; }
+  /* 30mm, bukan 20mm. Sisa ruang di kaki halaman diukur 13,6mm dan
+     diberikan ke kotak tulis — di lembar yang diisi peserta, ruang tulis
+     adalah gunanya kertas ini. Disisakan ~3mm supaya beda pembulatan antar
+     printer tidak mendorong tanda tangan keluar halaman. */
+  .bl-kotak-huruf {
+    flex: 1 1 0; height: 27mm; border: 1.2pt solid #000; border-radius: 1mm;
+  }
+  /* Kotak nomor amplop TIDAK ikut melar — isinya satu angka. */
+  .bl-kotak-tunggal { flex: 0 0 auto; width: 20mm; margin-top: 1.2mm; }
+
+  /* Tebak Simpul: sepuluh nomor, dua lajur lima baris. */
+  .bl-nomor-grid {
+    display: grid; grid-template-columns: 1fr 1fr;
+    column-gap: 8mm; row-gap: 1.1mm;
+  }
+  .bl-nomor-baris { display: flex; align-items: flex-end; gap: 2mm; }
+  .bl-nomor { font-size: 10pt; font-weight: 700; width: 7mm; }
+  .bl-nomor-garis { flex: 1 1 auto; border-bottom: .75pt solid #000; height: 6mm; }
+
+  /* Kotak nilai yang berdampingan dengan isian peserta tidak perlu setinggi
+     kotak nilai yang berdiri sendirian — yang ditulis di dalamnya paling
+     banyak dua digit, dan tingginya diambil dari ruang tulis peserta. */
+  .bl-nilai-rendah .bl-nilai-kotak { height: 16mm; }
+
   .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
 
   /* TIGA TANDA TANGAN, berjajar di kaki halaman.
@@ -1073,7 +1170,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* 9mm ruang membubuhkan tanda tangan di antara nama dan garisnya. Lebih
      rapat dari itu, tanda tangannya menabrak tulisan "Juri 1" di atasnya. */
   .bl-ttd-garis {
-    display: block; margin-top: 9mm; border-bottom: .75pt solid #000;
+    display: block; margin-top: 7mm; border-bottom: .75pt solid #000;
   }
 
   /* ---- kerapatan baris ----

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2633,25 +2633,159 @@ function siapkanCetakBlangko(pos, kolomLayar) {
 
   const judulPos = pos.bayangan ? pos.name : `Pos ${pos.nomor} · ${pos.name}`;
 
+  /* IDENTITAS REGU — sama di semua lomba.
+
+     Nomor dada dibuat besar karena ia dibaca dua kali dalam keadaan
+     sama-sama tergesa: saat ditulis di tengah antrean, dan saat tim IT
+     mengurutkan ratusan lembar lepas dengan hanya melihat sudut kertas.
+
+     KATEGORI DILINGKARI, bukan ditulis. Empat golongan sudah pasti, jadi
+     menuliskannya berarti menyalin dua kata yang sudah ada di kertas —
+     sementara satu lingkaran tidak bisa salah eja dan terbaca dari jarak
+     satu meja. */
+  const identitas = `
+      <table class="bl-identitas"><tbody>
+        <tr>
+          <td class="bl-dada"><span class="bl-label">No Dada</span></td>
+          <td class="bl-regu"><span class="bl-label">Nama Regu</span></td>
+          <td class="bl-sekolah"><span class="bl-label">Pangkalan / Sekolah</span></td>
+        </tr>
+        <tr>
+          <td class="bl-kategori" colspan="3">
+            <span class="bl-label">Kategori &mdash; lingkari salah satu</span>
+            <span class="bl-pilihan">
+              <span>Penggalang PA</span><span>Penggalang PI</span>
+              <span>Penegak PA</span><span>Penegak PI</span>
+            </span>
+          </td>
+        </tr>
+      </tbody></table>`;
+
+  /* BAGIAN PANITIA BERBENTUK PITA, bukan kotak setinggi kotak nilai.
+
+     Satu lembar kini dipegang DUA tangan — peserta menulis jawabannya,
+     panitia menulis angkanya — jadi label "diisi panitia" harus menempel
+     pada kotaknya, bukan melayang sebagai judul di atasnya. Menempel juga
+     yang membuatnya muat: A5 melintang tidak punya ruang untuk dua judul
+     berdiri sendiri ditambah dua kotak setinggi 30mm, dan diukur memang
+     meluap 15 sampai 28mm sebelum bentuk ini dipakai.
+
+     Angkanya paling banyak dua digit, jadi 21mm sudah tinggi untuk ditulis
+     besar — yang butuh ruang di lembar ini isian peserta, bukan isian
+     panitia.
+
+     LABEL DI ATAS KOTAKNYA, bukan di sebelahnya. Bentuk pertama menaruh
+     label lalu kotak berjajar mendatar, dan pada Menaksir yang punya DUA
+     kotak hasilnya berbunyi "Jawaban Taksir [kotak] Selisih Taksir [kotak]"
+     — deretan yang sama-sama benar dibaca sebagai pasangan maju atau
+     pasangan mundur. Angka yang tertukar di sini bukan salah ketik yang
+     ketahuan: keduanya angka meter yang masuk akal. */
+  const pitaPanitia = (sel) => `
+      <div class="bl-panitia">
+        <span class="bl-panitia-siapa">Diisi panitia</span>
+        ${sel.map(([judul, petunjuk]) => `
+        <span class="bl-panitia-sel">
+          <span class="bl-panitia-kepala">
+            <span class="bl-panitia-judul">${esc(judul)}</span>
+            <span class="bl-panitia-contoh">${esc(petunjuk)}</span>
+          </span>
+          <span class="bl-panitia-kotak"></span>
+        </span>`).join("")}
+      </div>`;
+
+  const penanda = (siapa) => `<p class="bl-siapa">${esc(siapa)}</p>`;
+
+  /* ---------------------------------------------------------------------
+     BENTUK KHUSUS PER LOMBA.
+
+     Tiga lomba mengisi lembarnya berdua: peserta menulis jawaban, panitia
+     menulis angkanya. Bentuk itu TIDAK bisa diturunkan dari konfigurasi —
+     `wahana` tahu rentang dan satuan, tidak tahu bahwa Semaphore punya lima
+     amplop atau bahwa Tebak Simpul bernomor sampai sepuluh.
+
+     Kuncinya `kode_lomba` — kunci BEKU dari migrasi 0079, yang sama dengan
+     yang dipakai foto slip. Bukan `kode` wahana (Tebak Simpul punya empat,
+     satu per golongan) dan bukan namanya (mengganti nama lomba akan
+     mengembalikan lembarnya ke bentuk generik tanpa satu pun galat).
+
+     Lomba yang tidak ada di sini memakai bentuk generik di bawah, dan itu
+     keadaan yang sah — bukan kekurangan yang menunggu dilengkapi. */
+  const bentukKhusus = {
+    /* SEMAPHORE. Peserta mengambil satu dari lima amplop, tiap amplop berisi
+       lima huruf. Yang ditulis peserta: nomor amplopnya dan kelima hurufnya.
+       Panitia mencocokkan dengan kunci amplop itu lalu menghitung berapa
+       huruf yang benar — 0 sampai 5, sama dengan rentang di konfigurasi.
+
+       Lima kotak huruf, bukan satu garis panjang: satu kotak per huruf
+       membuat huruf yang tertinggal terlihat sebagai kotak kosong, dan
+       tulisan tangan yang berdempetan tidak bisa dibaca dua cara. */
+    "semaphore": () => `
+      ${penanda("Diisi peserta")}
+      <div class="bl-amplop">
+        <div class="bl-amplop-nomor">
+          <span class="bl-nilai-judul">Nomor Amplop</span>
+          <div class="bl-kotak-huruf bl-kotak-tunggal"></div>
+        </div>
+        <div class="bl-amplop-jawab">
+          <span class="bl-nilai-judul">Jawaban Semaphore</span>
+          <div class="bl-huruf-baris">
+            ${[1, 2, 3, 4, 5].map(() => `<div class="bl-kotak-huruf"></div>`).join("")}
+          </div>
+        </div>
+      </div>
+      ${pitaPanitia([["Jumlah Huruf yang Benar", "angka 0 – 5"]])}`,
+
+    /* TEBAK SIMPUL. SEPULUH nomor pada satu master, bukan dua master 5 dan
+       10: Penggalang mengisi 1-5 dan membiarkan sisanya kosong. Dua tumpukan
+       yang berbeda bentuknya adalah dua tumpukan yang bisa tertukar di
+       lapangan, dan nomor kosong tidak pernah salah dibaca sebagai jawaban.
+
+       Dua lajur lima baris, bukan satu lajur sepuluh: A5 melintang lebar dan
+       pendek, dan sepuluh baris berurutan ke bawah tidak muat tanpa
+       mengecilkan barisnya sampai tidak bisa ditulisi. */
+    "tebak-simpul": () => `
+      ${penanda("Diisi peserta — nama simpulnya")}
+      <div class="bl-nomor-grid">
+        ${Array.from({ length: 10 }, (_, i) => `
+        <div class="bl-nomor-baris">
+          <span class="bl-nomor">${i + 1}.</span>
+          <span class="bl-nomor-garis"></span>
+        </div>`).join("")}
+      </div>
+      ${pitaPanitia([["Jumlah Simpul yang Benar", "angka 0 – 10 / 0 – 5"]])}`,
+
+    /* MENAKSIR — SATU-SATUNYA lembar tanpa bagian panitia.
+
+       Yang diketik ke sistem adalah TAKSIRAN PESERTA apa adanya, bukan
+       selisihnya: jawaban sebenarnya tersimpan di konfigurasi, dan mesin
+       skor yang menghitung selisihnya. Jadi tidak ada yang perlu dinilai
+       tangan di kertas ini — panitia cuma membaca angka yang sudah ditulis
+       peserta lalu mengetiknya.
+
+       Kotak jawaban sebenarnya SENGAJA tidak dicetak. Ia sama untuk semua
+       regu, dan angka yang tercetak di 300 lembar adalah 300 kesempatan
+       peserta membacanya sebelum menaksir.
+
+       "contoh: 7.34" memakai TITIK, dan contohnya ada justru karena itu:
+       peserta menulis koma seperti kebiasaan menulis angka di Indonesia,
+       sementara yang diterima kotak isian di layar adalah titik. Satu contoh
+       nyata mencegah seluruh kelas kesalahan itu tanpa satu kalimat pun. */
+    "menaksir": () => `
+      ${penanda("Diisi peserta")}
+      <div class="bl-taksir">
+        <span class="bl-nilai-judul">Hasil Taksir</span>
+        <span class="bl-nilai-contoh">meter, dua angka di belakang koma — contoh: 7.34</span>
+        <div class="bl-taksir-kotak"></div>
+      </div>`,
+  };
+
   const satuBlangko = (lomba) => {
     const kols = lomba.kolom;
     // Varian mana pun boleh dipakai untuk menurunkan bentuknya: yang berbeda
     // antar golongan hanya skalanya, dan skala tidak dicetak di blangko —
     // justru itu gunanya. Petugas menulis jumlah benar apa adanya, dan sistem
     // yang tahu 5 simpul untuk Penggalang, 10 untuk Penegak.
-    return `
-    <article class="blangko">
-      <p class="bl-pos">${esc(judulPos)}</p>
-      <h2 class="bl-lomba">${esc(lomba.nama)}</h2>
-      <p class="bl-acara">${esc(EDISI ? EDISI.name : "")}</p>
-
-      <table class="bl-identitas"><tbody>
-        <tr>
-          <td class="bl-dada"><span class="bl-label">No Dada</span></td>
-          <td class="bl-catat"><span class="bl-label">Regu / sekolah</span></td>
-        </tr>
-      </tbody></table>
-
+    const generik = () => `
       <div class="bl-nilai${kols.length > 1 ? " bl-nilai-banyak" : ""}">
         ${kols.map(kol => `
         <div class="bl-nilai-sel">
@@ -2662,10 +2796,31 @@ function siapkanCetakBlangko(pos, kolomLayar) {
           </div>
           <div class="bl-nilai-kotak"></div>
         </div>`).join("")}
-      </div>
+      </div>`;
 
+    const khusus = bentukKhusus[lomba.kode];
+    const badan = (khusus || generik)();
+
+    /* Catatan "tulis angkanya saja" hanya di bentuk generik. Di lembar
+       khusus ia sudah dijawab dua kali — pita panitia menyebut satuan dan
+       rentangnya, dan kotaknya sendiri bernama "Jumlah ... yang Benar" —
+       sementara satu baris di A5 yang sudah penuh adalah 6mm yang dipakai
+       kotak tulis (CLAUDE.md 9.3). */
+    const catatan = khusus ? "" : `
       <p class="bl-catatan"><strong>Tulis angkanya saja — jangan menghitung
-         poin.</strong></p>
+         poin.</strong></p>`;
+
+    return `
+    <article class="blangko">
+      <p class="bl-pos">${esc(judulPos)}</p>
+      <h2 class="bl-lomba">${esc(lomba.nama)}</h2>
+      <p class="bl-acara">${esc(EDISI ? EDISI.name : "")}</p>
+
+      ${identitas}
+
+      ${badan}
+
+      ${catatan}
 
       <!-- TIGA JURI, bukan satu petugas. Satu lomba dinilai bersama, dan
            tanda tangan yang cuma satu membuat dua juri lain tidak punya

--- a/web/style.css
+++ b/web/style.css
@@ -964,10 +964,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
      Aturan cetak fotokopi (CLAUDE.md bagian 8) berlaku penuh di sini: tanpa
      blok, tanpa abu-abu, garis >= 0,75pt, huruf >= 7pt. */
-  @page blangko-halaman { size: A5 landscape; margin: 9mm; }
+  /* 6mm, BUKAN 9mm dan bukan pula 4mm.
+     Yang dibeli 3mm di tiap sisi: isinya jadi 198 x 136mm (dari 192 x 130),
+     dan seluruh tambahan itu jatuh ke kotak yang ditulisi tangan.
+     Batas bawahnya bukan selera: printer laser punya tepi yang memang tidak
+     bisa dicetak — umumnya 4-5mm — dan mesin fotokopi menggeser gambarnya
+     1-2mm lagi tiap kali digandakan. Di bawah 6mm, gandaan yang paling
+     pinggir mulai kehilangan garis kotaknya, dan kotak tanpa tepi bukan
+     kotak lagi (CLAUDE.md bagian 8). */
+  @page blangko-halaman { size: A5 landscape; margin: 6mm; }
   .blangko-halaman { page: blangko-halaman; }
   .blangko {
-    height: 130mm;
+    height: 136mm;
     display: flex;
     flex-direction: column;
     font-size: 10pt;
@@ -995,12 +1003,23 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas
      menuliskannya di tengah antrean, dan saat tim IT mengurutkan ratusan
      lembar lepas dengan hanya melihat sudut kertas. */
-  .bl-identitas { width: 100%; border-collapse: collapse; margin-top: 3.5mm; }
+  .bl-identitas { width: 100%; border-collapse: collapse; margin-top: 3mm; }
   .bl-identitas td {
-    border: 1pt solid #000; padding: 1.2mm 2mm; height: 20mm;
+    border: 1pt solid #000; padding: 1mm 2mm; height: 15mm;
     vertical-align: top;
   }
-  .bl-dada { width: 58mm; }
+  .bl-dada { width: 34mm; }
+  .bl-regu { width: 62mm; }
+
+  /* KATEGORI DILINGKARI. Barisnya rendah — yang ditulis cuma satu lingkaran,
+     bukan huruf — dan keempat pilihannya disebar rata supaya lingkaran yang
+     dibuat tergesa tidak mengenai dua sekaligus. */
+  .bl-kategori { height: auto !important; padding: 1.2mm 2mm 1.8mm !important; }
+  .bl-pilihan {
+    display: flex; justify-content: space-between;
+    margin-top: 1.2mm; padding: 0 4mm;
+    font-size: 11pt; font-weight: 700;
+  }
 
   /* Label tidak menghalangi tulisan tangan, TAPI TIDAK BOLEH ABU-ABU.
      Abu-abu adalah yang paling buruk ditangani mesin fotokopi: diubah jadi
@@ -1048,6 +1067,84 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kata yang membedakannya dari kriteria sebelahnya. */
   .bl-nilai-banyak .bl-nilai-kepala { min-height: 9mm; }
 
+  /* SIAPA YANG MENGISI. Satu lembar kini dipegang dua tangan — peserta
+     menulis jawabannya, panitia menulis angkanya — dan tanpa penanda ini
+     keduanya menulis di kotak yang sama. Garis tebal di bawahnya, bukan blok
+     abu-abu: blok penuh keluar belang di mesin fotokopi (bagian 8.2). */
+  .bl-siapa {
+    margin: 2mm 0 1mm; font-size: 8.5pt; font-weight: 700;
+    letter-spacing: 1pt; text-transform: uppercase;
+    border-bottom: 1.2pt solid #000; padding-bottom: .6mm;
+  }
+
+  /* PITA PANITIA: label menempel pada kotaknya, bukan melayang di atasnya.
+     Alasannya di pitaPanitia() — ruang A5 melintang, dan label yang berdiri
+     sendiri terbaca sebagai judul bagian, bukan sebagai pemilik kotak. */
+  .bl-panitia {
+    display: flex; align-items: stretch; margin-top: 2.5mm;
+    border: 1.2pt solid #000; border-radius: 1mm; min-height: 20mm;
+  }
+  .bl-panitia-siapa {
+    display: flex; align-items: center; flex: 0 0 17mm;
+    padding: 0 2mm; border-right: 1.2pt solid #000;
+    font-size: 8pt; font-weight: 700; letter-spacing: .6pt;
+    text-transform: uppercase; line-height: 1.15;
+  }
+  /* Tiap kotak berdiri di bawah labelnya sendiri, dan lajur-lajurnya dibagi
+     rata — dua kotak Menaksir jadi selebar sama tanpa dipatok mm. */
+  .bl-panitia-sel {
+    display: flex; flex-direction: column;
+    flex: 1 1 0; min-width: 0;
+    border-left: 1.2pt solid #000;
+  }
+  .bl-panitia-sel:first-of-type { border-left: 0; }
+  .bl-panitia-kepala { padding: 1mm 2.5mm; border-bottom: 1.2pt solid #000; }
+  .bl-panitia-judul {
+    display: block;
+    font-size: 11pt; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .4pt; line-height: 1.15;
+  }
+  .bl-panitia-contoh { display: block; font-size: 8.5pt; margin-top: .4mm; }
+  .bl-panitia-kotak { flex: 1 1 auto; min-height: 10mm; }
+
+  /* Menaksir: satu kotak isian peserta, judulnya di atas. */
+  .bl-taksir { margin-top: 1mm; }
+  .bl-taksir-kotak {
+    /* Lembar Menaksir tidak punya bagian panitia, jadi seluruh sisa halaman
+       jatuh ke satu kotak ini — dan memang itu yang dipakai: angka yang
+       ditulis peserta di lapangan, sering sambil berdiri. */
+    margin-top: 1mm; height: 46mm;
+    border: 1.2pt solid #000; border-radius: 1mm;
+  }
+
+  /* Semaphore: nomor amplop di kiri, lima kotak huruf di kanan. */
+  .bl-amplop { display: flex; gap: 6mm; align-items: flex-end; }
+  .bl-amplop-jawab { flex: 1 1 auto; }
+  .bl-huruf-baris { display: flex; gap: 3mm; margin-top: 1.2mm; }
+  /* 30mm, bukan 20mm. Sisa ruang di kaki halaman diukur 13,6mm dan
+     diberikan ke kotak tulis — di lembar yang diisi peserta, ruang tulis
+     adalah gunanya kertas ini. Disisakan ~3mm supaya beda pembulatan antar
+     printer tidak mendorong tanda tangan keluar halaman. */
+  .bl-kotak-huruf {
+    flex: 1 1 0; height: 27mm; border: 1.2pt solid #000; border-radius: 1mm;
+  }
+  /* Kotak nomor amplop TIDAK ikut melar — isinya satu angka. */
+  .bl-kotak-tunggal { flex: 0 0 auto; width: 20mm; margin-top: 1.2mm; }
+
+  /* Tebak Simpul: sepuluh nomor, dua lajur lima baris. */
+  .bl-nomor-grid {
+    display: grid; grid-template-columns: 1fr 1fr;
+    column-gap: 8mm; row-gap: 1.1mm;
+  }
+  .bl-nomor-baris { display: flex; align-items: flex-end; gap: 2mm; }
+  .bl-nomor { font-size: 10pt; font-weight: 700; width: 7mm; }
+  .bl-nomor-garis { flex: 1 1 auto; border-bottom: .75pt solid #000; height: 6mm; }
+
+  /* Kotak nilai yang berdampingan dengan isian peserta tidak perlu setinggi
+     kotak nilai yang berdiri sendirian — yang ditulis di dalamnya paling
+     banyak dua digit, dan tingginya diambil dari ruang tulis peserta. */
+  .bl-nilai-rendah .bl-nilai-kotak { height: 16mm; }
+
   .bl-catatan { margin: 2.5mm 0 0; font-size: 8pt; line-height: 1.3; }
 
   /* TIGA TANDA TANGAN, berjajar di kaki halaman.
@@ -1073,7 +1170,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* 9mm ruang membubuhkan tanda tangan di antara nama dan garisnya. Lebih
      rapat dari itu, tanda tangannya menabrak tulisan "Juri 1" di atasnya. */
   .bl-ttd-garis {
-    display: block; margin-top: 9mm; border-bottom: .75pt solid #000;
+    display: block; margin-top: 7mm; border-bottom: .75pt solid #000;
   }
 
   /* ---- kerapatan baris ----


### PR DESCRIPTION
## What

Blangko **Form per Lomba** dirombak: margin dipepetkan, identitas dilengkapi,
dan tiga lomba mendapat bentuknya sendiri karena lembarnya diisi **dua
tangan** — peserta menulis jawaban, panitia menulis angkanya.

| lembar | diisi peserta | diisi panitia |
|---|---|---|
| **Semaphore** | Nomor Amplop + lima kotak huruf | Jumlah Huruf yang Benar `0–5` |
| **Tebak Simpul** | sepuluh nomor untuk nama simpulnya | Jumlah Simpul yang Benar `0–10 / 0–5` |
| **Menaksir** | Hasil Taksir, dua angka di belakang koma | *(tidak ada)* |

Lomba lain memakai bentuk generik seperti sebelumnya, dengan identitas dan
margin baru.

## Why

**Margin 9mm → 6mm.** Isinya jadi 198 × 136 mm dari 192 × 130, dan seluruh
tambahan itu jatuh ke kotak yang ditulisi tangan. Berhenti di 6mm, bukan 4mm:
printer laser punya tepi yang memang tidak bisa dicetak (umumnya 4–5mm) dan
mesin fotokopi menggeser gambarnya 1–2mm lagi tiap kali digandakan. Di bawah
itu, gandaan yang paling pinggir mulai kehilangan garis kotaknya — dan kotak
tanpa tepi bukan kotak lagi (CLAUDE.md 8).

**Kategori dilingkari, bukan ditulis.** Empat golongan sudah pasti, jadi
menuliskannya berarti menyalin dua kata yang sudah ada di kertas — sementara
satu lingkaran tidak bisa salah eja dan terbaca dari jarak satu meja.

**Menaksir tidak punya bagian panitia** karena yang diketik ke sistem adalah
taksiran peserta apa adanya; jawaban sebenarnya tersimpan di konfigurasi dan
mesin skor yang menghitung selisihnya. Kotak jawaban sebenarnya **sengaja
tidak dicetak**: ia sama untuk semua regu, dan angka yang tercetak di 300
lembar adalah 300 kesempatan peserta membacanya sebelum menaksir.

## Notes

**Sepuluh nomor pada satu master**, bukan dua master 5 dan 10. Penggalang
mengisi 1–5 dan membiarkan sisanya kosong. Dua tumpukan yang berbeda bentuknya
adalah dua tumpukan yang bisa tertukar di lapangan, dan nomor kosong tidak
pernah salah dibaca sebagai jawaban.

**Label panitia di atas kotaknya, bukan di sebelahnya.** Bentuk pertama
menjajar label lalu kotak secara mendatar, dan pada dua kotak hasilnya terbaca
sebagai pasangan maju **atau** pasangan mundur — angka yang tertukar di sana
bukan salah ketik yang ketahuan, keduanya angka meter yang masuk akal.

**Kuncinya `kode_lomba`** — kunci beku dari migrasi `0079`, yang sama dengan
yang dipakai foto slip. Bukan `kode` wahana (Tebak Simpul punya empat, satu per
golongan) dan bukan namanya: mengganti nama lomba akan mengembalikan lembarnya
ke bentuk generik tanpa satu galat pun.

Diukur di browser dengan aturan `@media print` yang benar-benar berlaku, pada
kotak seukuran **isi** A5 melintang (198 × 136 mm):

| lembar | meluap | sisa di kaki | tulisan terpotong |
|---|---|---|---|
| Semaphore | tidak | 4,2 mm | 0 |
| Tebak Simpul | tidak | 3,3 mm | 0 |
| Menaksir | tidak | 3,5 mm | 0 |
| Bakiak *(generik)* | tidak | 15,2 mm | 0 |

Sisa itu dijaga ~3mm dengan sengaja: beda pembulatan antar printer 1–2mm sudah
cukup mendorong tanda tangan ke halaman kedua. Ketiga bentuk sempat meluap
15–28mm sebelum bagian panitia diubah jadi pita.

⚠️ **Belum termasuk perubahan mesin skor Menaksir.** Konfigurasi hari ini masih
`petunjuk: "(selisih meter)"` dan `form: bertingkat` atas `nilai_1` — artinya
yang diketik masih dianggap selisih. Menyimpan jawaban `8.55` dan menghitung
`abs()` otomatis perlu migrasi tersendiri.

Tidak ada perubahan database di PR ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)