### PR TITLE
fix: urutan golongan, kotak jawaban Semaphore, dan bentuk pita panitia

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1090,22 +1090,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     font-size: 8pt; font-weight: 700; letter-spacing: .6pt;
     text-transform: uppercase; line-height: 1.15;
   }
-  /* Tiap kotak berdiri di bawah labelnya sendiri, dan lajur-lajurnya dibagi
-     rata — dua kotak Menaksir jadi selebar sama tanpa dipatok mm. */
+  /* Label di kiri selebar tulisannya; kotaknya mengambil sisa lebar. */
   .bl-panitia-sel {
-    display: flex; flex-direction: column;
-    flex: 1 1 0; min-width: 0;
-    border-left: 1.2pt solid #000;
+    display: flex; flex-direction: column; justify-content: center;
+    flex: 0 1 auto; max-width: 76mm; padding: 1.5mm 3mm;
   }
-  .bl-panitia-sel:first-of-type { border-left: 0; }
-  .bl-panitia-kepala { padding: 1mm 2.5mm; border-bottom: 1.2pt solid #000; }
   .bl-panitia-judul {
     display: block;
     font-size: 11pt; font-weight: 700; text-transform: uppercase;
-    letter-spacing: .4pt; line-height: 1.15;
+    letter-spacing: .4pt; line-height: 1.2;
   }
-  .bl-panitia-contoh { display: block; font-size: 8.5pt; margin-top: .4mm; }
-  .bl-panitia-kotak { flex: 1 1 auto; min-height: 10mm; }
+  .bl-panitia-contoh { display: block; font-size: 9pt; margin-top: .6mm; }
+  .bl-panitia-kotak { flex: 1 1 auto; border-left: 1.2pt solid #000; }
 
   /* Menaksir: satu kotak isian peserta, judulnya di atas. */
   .bl-taksir { margin-top: 1mm; }
@@ -1117,19 +1113,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     border: 1.2pt solid #000; border-radius: 1mm;
   }
 
-  /* Semaphore: nomor amplop di kiri, lima kotak huruf di kanan. */
+  /* Semaphore: nomor amplop di kiri, jawabannya satu kotak lebar di kanan.
+
+     Kotak nomor amplop SELEBAR LABELNYA — `flex: 0 0 auto` pada pembungkus
+     membuatnya menyusut ke isi terlebar di dalamnya, yaitu tulisan "Nomor
+     Amplop". Lebarnya sendiri karena itu sudah memberi tahu bahwa yang
+     ditulis di sana cuma satu angka, tanpa satu kata petunjuk pun. */
   .bl-amplop { display: flex; gap: 6mm; align-items: flex-end; }
-  .bl-amplop-jawab { flex: 1 1 auto; }
-  .bl-huruf-baris { display: flex; gap: 3mm; margin-top: 1.2mm; }
-  /* 30mm, bukan 20mm. Sisa ruang di kaki halaman diukur 13,6mm dan
-     diberikan ke kotak tulis — di lembar yang diisi peserta, ruang tulis
-     adalah gunanya kertas ini. Disisakan ~3mm supaya beda pembulatan antar
-     printer tidak mendorong tanda tangan keluar halaman. */
+  .bl-amplop-nomor { flex: 0 0 auto; }
+  .bl-amplop-jawab { flex: 1 1 auto; min-width: 0; }
+  /* Tingginya diambil dari sisa halaman: di lembar yang diisi peserta, ruang
+     tulis adalah gunanya kertas ini. Disisakan ~3mm di kaki supaya beda
+     pembulatan antar printer tidak mendorong tanda tangan keluar halaman. */
   .bl-kotak-huruf {
-    flex: 1 1 0; height: 27mm; border: 1.2pt solid #000; border-radius: 1mm;
+    display: block; width: 100%; height: 27mm; margin-top: 1.2mm;
+    border: 1.2pt solid #000; border-radius: 1mm;
   }
-  /* Kotak nomor amplop TIDAK ikut melar — isinya satu angka. */
-  .bl-kotak-tunggal { flex: 0 0 auto; width: 20mm; margin-top: 1.2mm; }
 
   /* Tebak Simpul: sepuluh nomor, dua lajur lima baris. */
   .bl-nomor-grid {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2642,7 +2642,13 @@ function siapkanCetakBlangko(pos, kolomLayar) {
      KATEGORI DILINGKARI, bukan ditulis. Empat golongan sudah pasti, jadi
      menuliskannya berarti menyalin dua kata yang sudah ada di kertas —
      sementara satu lingkaran tidak bisa salah eja dan terbaca dari jarak
-     satu meja. */
+     satu meja.
+
+     URUTANNYA DIBACA DARI URUT_GOLONGAN, tidak ditulis ulang di sini. Kertas
+     dan layar harus menyebut keempatnya dalam urutan yang sama — petugas yang
+     menyalin dari satu ke yang lain menghitung posisi, bukan membaca nama —
+     dan salinan kelima dari daftar ini persis yang sudah dibersihkan sekali
+     (lihat kepala URUT_GOLONGAN di util.js). */
   const identitas = `
       <table class="bl-identitas"><tbody>
         <tr>
@@ -2653,10 +2659,8 @@ function siapkanCetakBlangko(pos, kolomLayar) {
         <tr>
           <td class="bl-kategori" colspan="3">
             <span class="bl-label">Kategori &mdash; lingkari salah satu</span>
-            <span class="bl-pilihan">
-              <span>Penggalang PA</span><span>Penggalang PI</span>
-              <span>Penegak PA</span><span>Penegak PI</span>
-            </span>
+            <span class="bl-pilihan">${URUT_GOLONGAN.map(g =>
+              `<span>${esc(GOLONGAN_LABEL[g])}</span>`).join("")}</span>
           </td>
         </tr>
       </tbody></table>`;
@@ -2674,23 +2678,21 @@ function siapkanCetakBlangko(pos, kolomLayar) {
      besar — yang butuh ruang di lembar ini isian peserta, bukan isian
      panitia.
 
-     LABEL DI ATAS KOTAKNYA, bukan di sebelahnya. Bentuk pertama menaruh
-     label lalu kotak berjajar mendatar, dan pada Menaksir yang punya DUA
-     kotak hasilnya berbunyi "Jawaban Taksir [kotak] Selisih Taksir [kotak]"
-     — deretan yang sama-sama benar dibaca sebagai pasangan maju atau
-     pasangan mundur. Angka yang tertukar di sini bukan salah ketik yang
-     ketahuan: keduanya angka meter yang masuk akal. */
+     LABEL DI KIRI, kotaknya mengisi sisa lebar. Bentuk bertumpuk sempat
+     dipakai waktu Menaksir masih punya dua kotak — di sana label yang
+     berjajar mendatar terbaca sebagai pasangan maju atau pasangan mundur.
+     Sejak Menaksir tidak lagi dinilai tangan, tiap pita cuma punya SATU
+     kotak dan kekaburan itu hilang; yang tersisa keuntungannya, yaitu kotak
+     selebar sisa halaman untuk menulis angka besar-besar. */
   const pitaPanitia = (sel) => `
       <div class="bl-panitia">
         <span class="bl-panitia-siapa">Diisi panitia</span>
         ${sel.map(([judul, petunjuk]) => `
         <span class="bl-panitia-sel">
-          <span class="bl-panitia-kepala">
-            <span class="bl-panitia-judul">${esc(judul)}</span>
-            <span class="bl-panitia-contoh">${esc(petunjuk)}</span>
-          </span>
-          <span class="bl-panitia-kotak"></span>
-        </span>`).join("")}
+          <span class="bl-panitia-judul">${esc(judul)}</span>
+          <span class="bl-panitia-contoh">${esc(petunjuk)}</span>
+        </span>
+        <span class="bl-panitia-kotak"></span>`).join("")}
       </div>`;
 
   const penanda = (siapa) => `<p class="bl-siapa">${esc(siapa)}</p>`;
@@ -2716,24 +2718,25 @@ function siapkanCetakBlangko(pos, kolomLayar) {
        Panitia mencocokkan dengan kunci amplop itu lalu menghitung berapa
        huruf yang benar — 0 sampai 5, sama dengan rentang di konfigurasi.
 
-       Lima kotak huruf, bukan satu garis panjang: satu kotak per huruf
-       membuat huruf yang tertinggal terlihat sebagai kotak kosong, dan
-       tulisan tangan yang berdempetan tidak bisa dibaca dua cara. */
+       SATU kotak besar untuk kelima hurufnya, bukan lima kotak. Lima petak
+       memaksa tulisan mengikuti petaknya, dan huruf semaphore yang ditulis
+       tergesa lebih sering melebar daripada rapi — satu kotak lebar tidak
+       pernah kekurangan tempat. Kotak nomor amplopnya selebar tulisan
+       "Nomor Amplop" di atasnya, jadi lebarnya sendiri sudah memberi tahu
+       bahwa yang ditulis di sana cuma satu angka. */
     "semaphore": () => `
       ${penanda("Diisi peserta")}
       <div class="bl-amplop">
         <div class="bl-amplop-nomor">
           <span class="bl-nilai-judul">Nomor Amplop</span>
-          <div class="bl-kotak-huruf bl-kotak-tunggal"></div>
+          <div class="bl-kotak-huruf"></div>
         </div>
         <div class="bl-amplop-jawab">
           <span class="bl-nilai-judul">Jawaban Semaphore</span>
-          <div class="bl-huruf-baris">
-            ${[1, 2, 3, 4, 5].map(() => `<div class="bl-kotak-huruf"></div>`).join("")}
-          </div>
+          <div class="bl-kotak-huruf"></div>
         </div>
       </div>
-      ${pitaPanitia([["Jumlah Huruf yang Benar", "angka 0 – 5"]])}`,
+      ${pitaPanitia([["Jumlah huruf yang benar", "( 0 – 5 )"]])}`,
 
     /* TEBAK SIMPUL. SEPULUH nomor pada satu master, bukan dua master 5 dan
        10: Penggalang mengisi 1-5 dan membiarkan sisanya kosong. Dua tumpukan
@@ -2742,17 +2745,22 @@ function siapkanCetakBlangko(pos, kolomLayar) {
 
        Dua lajur lima baris, bukan satu lajur sepuluh: A5 melintang lebar dan
        pendek, dan sepuluh baris berurutan ke bawah tidak muat tanpa
-       mengecilkan barisnya sampai tidak bisa ditulisi. */
+       mengecilkan barisnya sampai tidak bisa ditulisi.
+
+       Nomornya menurun PER LAJUR — 1-5 di kiri, 6-10 di kanan — bukan
+       berselang-seling kiri-kanan. Penggalang mengisi lima yang pertama, dan
+       hanya urutan ini yang membuat kelimanya berkumpul di satu lajur alih-
+       alih tersebar di sepuluh baris. */
     "tebak-simpul": () => `
       ${penanda("Diisi peserta — nama simpulnya")}
       <div class="bl-nomor-grid">
-        ${Array.from({ length: 10 }, (_, i) => `
+        ${[0, 1, 2, 3, 4].flatMap(r => [r + 1, r + 6]).map(n => `
         <div class="bl-nomor-baris">
-          <span class="bl-nomor">${i + 1}.</span>
+          <span class="bl-nomor">${n}.</span>
           <span class="bl-nomor-garis"></span>
         </div>`).join("")}
       </div>
-      ${pitaPanitia([["Jumlah Simpul yang Benar", "angka 0 – 10 / 0 – 5"]])}`,
+      ${pitaPanitia([["Jumlah simpul yang benar", "( 0 – 5 / 0 – 10 )"]])}`,
 
     /* MENAKSIR — SATU-SATUNYA lembar tanpa bagian panitia.
 
@@ -2786,6 +2794,7 @@ function siapkanCetakBlangko(pos, kolomLayar) {
     // justru itu gunanya. Petugas menulis jumlah benar apa adanya, dan sistem
     // yang tahu 5 simpul untuk Penggalang, 10 untuk Penegak.
     const generik = () => `
+      ${penanda("Diisi panitia")}
       <div class="bl-nilai${kols.length > 1 ? " bl-nilai-banyak" : ""}">
         ${kols.map(kol => `
         <div class="bl-nilai-sel">

--- a/web/style.css
+++ b/web/style.css
@@ -1090,22 +1090,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     font-size: 8pt; font-weight: 700; letter-spacing: .6pt;
     text-transform: uppercase; line-height: 1.15;
   }
-  /* Tiap kotak berdiri di bawah labelnya sendiri, dan lajur-lajurnya dibagi
-     rata — dua kotak Menaksir jadi selebar sama tanpa dipatok mm. */
+  /* Label di kiri selebar tulisannya; kotaknya mengambil sisa lebar. */
   .bl-panitia-sel {
-    display: flex; flex-direction: column;
-    flex: 1 1 0; min-width: 0;
-    border-left: 1.2pt solid #000;
+    display: flex; flex-direction: column; justify-content: center;
+    flex: 0 1 auto; max-width: 76mm; padding: 1.5mm 3mm;
   }
-  .bl-panitia-sel:first-of-type { border-left: 0; }
-  .bl-panitia-kepala { padding: 1mm 2.5mm; border-bottom: 1.2pt solid #000; }
   .bl-panitia-judul {
     display: block;
     font-size: 11pt; font-weight: 700; text-transform: uppercase;
-    letter-spacing: .4pt; line-height: 1.15;
+    letter-spacing: .4pt; line-height: 1.2;
   }
-  .bl-panitia-contoh { display: block; font-size: 8.5pt; margin-top: .4mm; }
-  .bl-panitia-kotak { flex: 1 1 auto; min-height: 10mm; }
+  .bl-panitia-contoh { display: block; font-size: 9pt; margin-top: .6mm; }
+  .bl-panitia-kotak { flex: 1 1 auto; border-left: 1.2pt solid #000; }
 
   /* Menaksir: satu kotak isian peserta, judulnya di atas. */
   .bl-taksir { margin-top: 1mm; }
@@ -1117,19 +1113,22 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     border: 1.2pt solid #000; border-radius: 1mm;
   }
 
-  /* Semaphore: nomor amplop di kiri, lima kotak huruf di kanan. */
+  /* Semaphore: nomor amplop di kiri, jawabannya satu kotak lebar di kanan.
+
+     Kotak nomor amplop SELEBAR LABELNYA — `flex: 0 0 auto` pada pembungkus
+     membuatnya menyusut ke isi terlebar di dalamnya, yaitu tulisan "Nomor
+     Amplop". Lebarnya sendiri karena itu sudah memberi tahu bahwa yang
+     ditulis di sana cuma satu angka, tanpa satu kata petunjuk pun. */
   .bl-amplop { display: flex; gap: 6mm; align-items: flex-end; }
-  .bl-amplop-jawab { flex: 1 1 auto; }
-  .bl-huruf-baris { display: flex; gap: 3mm; margin-top: 1.2mm; }
-  /* 30mm, bukan 20mm. Sisa ruang di kaki halaman diukur 13,6mm dan
-     diberikan ke kotak tulis — di lembar yang diisi peserta, ruang tulis
-     adalah gunanya kertas ini. Disisakan ~3mm supaya beda pembulatan antar
-     printer tidak mendorong tanda tangan keluar halaman. */
+  .bl-amplop-nomor { flex: 0 0 auto; }
+  .bl-amplop-jawab { flex: 1 1 auto; min-width: 0; }
+  /* Tingginya diambil dari sisa halaman: di lembar yang diisi peserta, ruang
+     tulis adalah gunanya kertas ini. Disisakan ~3mm di kaki supaya beda
+     pembulatan antar printer tidak mendorong tanda tangan keluar halaman. */
   .bl-kotak-huruf {
-    flex: 1 1 0; height: 27mm; border: 1.2pt solid #000; border-radius: 1mm;
+    display: block; width: 100%; height: 27mm; margin-top: 1.2mm;
+    border: 1.2pt solid #000; border-radius: 1mm;
   }
-  /* Kotak nomor amplop TIDAK ikut melar — isinya satu angka. */
-  .bl-kotak-tunggal { flex: 0 0 auto; width: 20mm; margin-top: 1.2mm; }
 
   /* Tebak Simpul: sepuluh nomor, dua lajur lima baris. */
   .bl-nomor-grid {


### PR DESCRIPTION
## What

Empat pembetulan pada blangko per lomba, semuanya dari melihat hasil cetaknya.

1. **Urutan golongan** jadi Penegak PA · Penegak PI · Penggalang PA ·
   Penggalang PI — dan dibaca dari `URUT_GOLONGAN`, tidak ditulis ulang.
2. **Semaphore**: jawaban jadi **satu kotak lebar**, dan kotak Nomor Amplop
   **selebar tulisan "Nomor Amplop"** di atasnya.
3. **Tebak Simpul**: nomornya menurun per lajur — 1–5 kiri, 6–10 kanan.
4. **Pita panitia** jadi dua sel: label kiri, kotak mengambil sisa lebar.
   Rentangnya dalam kurung: `( 0 – 5 )`, `( 0 – 5 / 0 – 10 )`.

Bentuk generik (Bakiak dan kawan-kawan) ikut menyebut **Diisi panitia**.

## Why

**Layar sudah benar sejak dulu.** `URUT_GOLONGAN` memang Penegak dulu; yang
keliru cuma daftar yang saya ketik tangan di kertasnya. Kertas dan layar harus
menyebut keempatnya dalam urutan yang sama — petugas yang menyalin dari satu ke
yang lain menghitung posisi, bukan membaca nama. Sekarang blangko membaca
konstanta yang sama, jadi salinan kelima dari daftar itu tidak lahir lagi
(daftar ini sudah pernah dibersihkan sekali — lihat kepala `URUT_GOLONGAN`).

**Lima petak memaksa tulisan mengikuti petaknya**, dan huruf semaphore yang
ditulis tergesa lebih sering melebar daripada rapi. Satu kotak lebar tidak
pernah kekurangan tempat.

**Kotak nomor amplop selebar labelnya** — lebarnya sendiri yang memberi tahu
bahwa isinya cuma satu angka, tanpa satu kata petunjuk pun. Terukur: label
148px, kotak 148px.

**Nomor menurun per lajur** karena Penggalang mengisi lima yang pertama, dan
hanya urutan ini yang membuat kelimanya berkumpul di satu lajur alih-alih
tersebar di sepuluh baris.

**Pita panitia bertumpuk** dipakai waktu Menaksir masih punya dua kotak — di
sana label yang berjajar mendatar terbaca sebagai pasangan maju **atau**
mundur. Sejak Menaksir tidak lagi dinilai tangan, tiap pita cuma punya satu
kotak dan kekaburan itu hilang; yang tersisa keuntungannya, yaitu kotak
selebar sisa halaman.

**Bentuk generik ikut bertanda** karena lembar yang sebagian bertanda dan
sebagian tidak membuat penandanya berhenti berarti.

## Notes

Diukur di browser dengan `@media print` yang benar-benar berlaku, pada kotak
seukuran **isi** A5 melintang (198 × 136 mm):

| lembar | meluap | sisa di kaki | terpotong |
|---|---|---|---|
| Semaphore | tidak | 5,6 mm | 0 |
| Tebak Simpul | tidak | 4,7 mm | 0 |
| Menaksir | tidak | 3,5 mm | 0 |
| Bakiak *(generik)* | tidak | 7,6 mm | 0 |

Urutan nomor Tebak Simpul terbaca `1 6 2 7 3 8 4 9 5 10` di DOM — itu yang
menghasilkan lajur kiri 1–5 dan lajur kanan 6–10 pada grid dua kolom.

⚠️ Penilaian Menaksir belum ikut di sini; tangganya menyusul di migrasi
tersendiri.

Tidak ada perubahan database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)