### PR TITLE
feat: Menaksir dinilai dari taksiran peserta, selisih dihitung sistem

### DIFF
--- a/supabase/migrations/0085_menaksir_dari_taksiran.sql
+++ b/supabase/migrations/0085_menaksir_dari_taksiran.sql
@@ -1,0 +1,285 @@
+-- ============================================================================
+-- hrcd-rekap : 0085_menaksir_dari_taksiran.sql
+--
+-- MENAKSIR DINILAI DARI TAKSIRAN PESERTA, BUKAN DARI SELISIH YANG DIHITUNG
+-- TANGAN.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG BERUBAH DI LAPANGAN
+--
+-- Sebelumnya panitia menghitung sendiri selisih taksiran peserta terhadap
+-- jawaban sebenarnya, lalu mengetik selisih itu. Sekarang yang diketik
+-- ANGKA YANG DITULIS PESERTA apa adanya — 7.34 tetap 7.34 — dan mesin skor
+-- yang menghitung `abs(8.55 - 7.34)`.
+--
+-- Dua hal yang hilang bersamaan: satu pengurangan yang dikerjakan tangan
+-- ratusan kali di bawah matahari, dan satu kotak di blangko yang isinya bisa
+-- salah tanpa ketahuan. Selisih yang salah hitung tetap berupa angka meter
+-- yang masuk akal; ia tidak melanggar rentang mana pun, tidak memicu galat
+-- apa pun, dan baru terlihat kalau ada yang menghitung ulang.
+--
+-- Blangkonya sudah lebih dulu berubah: lembar Menaksir kini tidak punya
+-- bagian panitia sama sekali.
+--
+-- ---------------------------------------------------------------------------
+-- JAWABAN SEBENARNYA JADI KONFIGURASI
+--
+-- `wahana.jawaban_benar` menyimpan angka yang benar untuk komponen itu —
+-- 8.55 meter untuk Menaksir edisi XXXVII. Ia NULL untuk semua komponen lain,
+-- dan itu yang membedakan dua arti `bertingkat`:
+--
+--   jawaban_benar NULL  -> tangga dibaca atas nilai_1 apa adanya
+--                          (Pos 2: waktu tempuh, tidak berubah sedikit pun)
+--   jawaban_benar ada   -> tangga dibaca atas abs(nilai_1 - jawaban_benar)
+--
+-- Dibuat begitu, bukan bentuk konversi baru, karena yang berubah cuma APA
+-- yang masuk ke tangga — tangganya sendiri sama persis. Bentuk ketujuh
+-- berarti tujuh cabang di hitung_poin dan satu lagi yang harus diingat
+-- panitia saat mengatur komponen tahun depan.
+--
+-- ---------------------------------------------------------------------------
+-- TANGGANYA BERGESER SATU METER
+--
+--   sebelum   selisih 0 m -> 100   1 m -> 80   2 m -> 60   3 m -> 40   4 m -> 20
+--   sesudah   selisih <=1 -> 100   <=2 -> 80   <=3 -> 60   <=4 -> 40   <=5 -> 20
+--
+-- Sebabnya taksiran kini punya dua angka di belakang koma. Dengan tangga
+-- lama, peserta yang menulis 8.56 — meleset SATU SENTIMETER — selisihnya 0.01
+-- dan jatuh ke tingkat kedua: 80 poin, bukan 100. Hanya 8.55 persis yang
+-- mendapat nilai penuh, dan lomba menaksir yang menuntut ketepatan
+-- sentimeter bukan lomba menaksir lagi.
+--
+-- Keputusan pemilik acara: selisih sampai 1 meter tetap 100. Turunnya tetap
+-- 20 poin tiap meter dan tetap menyentuh 0, sama seperti yang ditetapkan di
+-- 0035 — yang bergeser batasnya, bukan polanya.
+--
+-- Tidak ada tingkat penutup: `bertingkat` memberi 0 untuk nilai di luar
+-- seluruh tingkat (0022), dan di sini 0 memang jawabannya untuk selisih
+-- lebih dari 5 meter.
+--
+-- ---------------------------------------------------------------------------
+-- SKOR DITURUNKAN SAAT DIBACA
+--
+-- Tidak ada angka poin yang tersimpan; `v_poin_wahana` menghitungnya tiap
+-- kali dibaca. Jadi migrasi ini mengubah peringkat yang sudah tampil di
+-- layar, dan nilai mentah yang TERLANJUR diketik sebagai selisih akan
+-- dibaca sebagai taksiran. Pada saat berkas ini ditulis seluruh isi produksi
+-- masih data uji; kalau suatu hari tidak, nilai Menaksir yang sudah masuk
+-- harus diketik ulang sebagai taksiran peserta.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kolomnya.
+-- ---------------------------------------------------------------------------
+alter table wahana add column if not exists jawaban_benar numeric(10,2);
+
+comment on column wahana.jawaban_benar is
+  'Jawaban sebenarnya untuk komponen yang dinilai dari SELISIH — Menaksir. '
+  'Kalau terisi, form=bertingkat membaca tangganya atas '
+  'abs(nilai_1 - jawaban_benar), bukan atas nilai_1. NULL untuk komponen '
+  'lain, dan di sana tangganya berlaku apa adanya.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Mesin skornya.
+--
+-- Disalin UTUH dari 0022 dan hanya cabang `bertingkat` yang berubah.
+-- `create or replace` mengganti seluruh badan, jadi cabang yang lupa disalin
+-- akan hilang tanpa satu galat pun — dan yang hilang di sini bukan galat
+-- melainkan poin yang jadi NULL di tengah klasemen.
+-- ---------------------------------------------------------------------------
+create or replace function hitung_poin(
+  p_bentuk        text,
+  p_nilai_1       numeric,
+  p_nilai_2       numeric,
+  p_poin_maks     numeric,
+  p_raw_terbaik   numeric,
+  p_raw_terburuk  numeric,
+  p_poin_benar    numeric,
+  p_poin_salah    numeric,
+  p_total_soal    numeric,
+  p_tingkat       jsonb,
+  p_jawaban_benar numeric default null
+) returns numeric
+language sql immutable
+as $$
+  select round(case p_bentuk
+    -- Interpolasi linear raw_terburuk→0 .. raw_terbaik→poin_maks, di-clamp.
+    -- Satu rumus untuk dua arah: kecil_baik punya terbaik < terburuk,
+    -- besar_baik sebaliknya — pembaginya ikut bertanda.
+    when 'kecil_baik' then
+      least(greatest(
+        p_poin_maks * (p_nilai_1 - p_raw_terburuk) / (p_raw_terbaik - p_raw_terburuk),
+        0), p_poin_maks)
+    when 'besar_baik' then
+      least(greatest(
+        p_poin_maks * (p_nilai_1 - p_raw_terburuk) / (p_raw_terbaik - p_raw_terburuk),
+        0), p_poin_maks)
+    -- Biner: kena/benar (nilai_1 > 0) atau tidak.
+    when 'biner' then
+      case when p_nilai_1 > 0 then p_poin_benar else p_poin_salah end
+    -- Proporsi jawaban benar.
+    when 'benar_per_total' then
+      least(greatest(p_poin_maks * p_nilai_1 / p_total_soal, 0), p_poin_maks)
+    -- Benar menambah, salah mengurangi (poin_salah disimpan negatif);
+    -- di-clamp supaya tidak minus.
+    when 'benar_kurang_salah' then
+      least(greatest(
+        p_poin_benar * p_nilai_1 + p_poin_salah * coalesce(p_nilai_2, 0),
+        0), p_poin_maks)
+    -- Tangga poin: tingkat pertama (batas atas terkecil) yang masih memuat
+    -- nilai mentahnya. Lebih besar dari semua batas = 0 — itu sebabnya
+    -- coalesce ada di luar, bukan nilai default di dalam sub-query.
+    --
+    -- SATU-SATUNYA yang berubah dari 0022: kalau komponennya punya jawaban
+    -- benar, yang masuk ke tangga adalah SELISIHNYA. Tanpa jawaban benar
+    -- (Pos 2 dan seterusnya) nilai_1 dipakai apa adanya, persis seperti dulu.
+    when 'bertingkat' then
+      coalesce((
+        select (t ->> 'poin')::numeric
+        from jsonb_array_elements(p_tingkat) t
+        where case when p_jawaban_benar is null then p_nilai_1
+                   else abs(p_nilai_1 - p_jawaban_benar) end
+              <= (t ->> 'sampai')::numeric
+        order by (t ->> 'sampai')::numeric
+        limit 1), 0)
+  end, 2)
+$$;
+
+grant execute on function hitung_poin(text, numeric, numeric, numeric,
+  numeric, numeric, numeric, numeric, numeric, jsonb, numeric)
+  to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3. View meneruskan kolom barunya.
+--
+-- Daftar kolom KELUARANNYA tidak berubah, jadi v_poin_pos yang bertumpu
+-- padanya tidak perlu ikut dibuat ulang (alasan yang sama seperti 0022).
+-- ---------------------------------------------------------------------------
+create or replace view v_poin_wahana with (security_invoker = on) as
+select
+  n.regu_id,
+  w.pos,
+  w.id   as wahana_id,
+  w.kode,
+  n.nilai_1,
+  n.nilai_2,
+  hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+              w.raw_terbaik, w.raw_terburuk,
+              w.poin_benar, w.poin_salah, w.total_soal, w.tingkat,
+              w.jawaban_benar) as poin
+from nilai_mentah n
+join wahana w on w.id = n.wahana_id
+where w.edisi = edisi_aktif();
+
+-- ---------------------------------------------------------------------------
+-- 3b. v_lembar_pos IKUT DIBUAT ULANG, dan ini bukan kerapian.
+--
+-- Ia menghitung `nilai_pos` dengan hitung_poin sendiri — jadi kalau ia
+-- ditinggalkan memakai bentuk lama, layar Input Nilai Pos menampilkan Nilai
+-- Pos yang dihitung TANPA jawaban benar sementara klasemen memakai yang
+-- dengan. Dua angka untuk satu regu di dua layar, keduanya tanpa galat, dan
+-- yang menemukannya orang yang kebetulan membandingkan.
+--
+-- Disalin UTUH dari 0065; satu-satunya yang berubah argumen tambahan pada
+-- hitung_poin. `create or replace view` menolak daftar kolom yang berubah
+-- urutan atau tipenya, jadi kolomnya harus sama persis — dan memang begitu.
+-- ---------------------------------------------------------------------------
+create or replace view v_lembar_pos as
+select
+  p.nomor       as pos,
+  p.name        as nama_pos,
+  p.bayangan,
+  r.id          as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name        as nama_sekolah,
+  r.golongan,
+
+  coalesce((
+    select jsonb_object_agg(w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), '{}'::jsonb) as nilai,
+
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_terisi,
+
+  -- INI yang berubah: hanya komponen yang berlaku untuk golongan regu ini.
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor
+     and komponen_berlaku(w.golongan, r.golongan))::int
+                as jumlah_komponen,
+
+  round(coalesce((
+    select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                           w.raw_terbaik, w.raw_terburuk,
+                           w.poin_benar, w.poin_salah, w.total_soal, w.tingkat,
+                           w.jawaban_benar))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), 0) * p.bobot, 2) as nilai_pos,
+
+  -- Gembok (0043). Kolom BARU ditaruh paling belakang: `create or replace
+  -- view` menolak daftar kolom yang berubah urutan atau tipenya, dan hanya
+  -- mengizinkan penambahan di ujung.
+  nilai_tergembok(r.id, p.nomor) as terkunci
+
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and boleh('pos')
+  and (pos_saya() is null or p.nomor = pos_saya());
+-- Bentuk 10 argumen dibuang supaya tidak ada dua hitungan yang berdampingan.
+-- Dijalankan SESUDAH kedua view dibuat ulang: view yang masih menunjuk bentuk
+-- lama akan menahan DROP-nya — dan itu memang yang terjadi waktu berkas ini
+-- ditulis, v_lembar_pos yang menahannya.
+drop function if exists hitung_poin(text, numeric, numeric, numeric,
+  numeric, numeric, numeric, numeric, numeric, jsonb);
+
+-- ---------------------------------------------------------------------------
+-- 4. Konfigurasi Menaksir edisi ini.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_baris integer;
+  v_edisi smallint := edisi_aktif();
+begin
+  update wahana set
+    jawaban_benar = 8.55,
+    tingkat = '[{"sampai": 1, "poin": 100},
+                {"sampai": 2, "poin": 80},
+                {"sampai": 3, "poin": 60},
+                {"sampai": 4, "poin": 40},
+                {"sampai": 5, "poin": 20}]'::jsonb,
+    -- Kepala kolom di layar ikut berubah: yang diketik bukan selisih lagi.
+    petunjuk = '(meter)',
+    -- Rentangnya jadi rentang TAKSIRAN, bukan rentang selisih. 999.99 longgar
+    -- untuk apa pun yang bisa ditaksir dengan mata di lapangan, dan cukup
+    -- ketat untuk menolak 8550 yang lahir dari titik yang terlewat.
+    rentang_mentah_maks = 999.99
+  where edisi = v_edisi and kode = 'menaksir';
+
+  get diagnostics v_baris = row_count;
+
+  -- Dilaporkan, bukan diandaikan: di database yang konfigurasi XXXVII-nya
+  -- belum terpasang, baris `menaksir` memang tidak ada dan UPDATE ini tidak
+  -- mengenai apa pun. Itu keadaan yang sah (pelajaran 0035).
+  if v_baris = 0 then
+    raise notice '0085: baris menaksir tidak ada di edisi % — konfigurasinya '
+                 'dilewati, fungsi dan kolomnya tetap terpasang.', v_edisi;
+  else
+    raise notice '0085: Menaksir dinilai dari taksiran; jawaban 8.55 m, '
+                 'selisih sampai 1 m tetap 100 poin.';
+  end if;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -331,5 +331,14 @@ run tests/sql/46_tanggal_lomba.sql
 # dengan galat yang menyebut kedua angkanya. Alasan lengkapnya di kepala
 # berkasnya. Dijalankan di sini supaya pemeriksaan di dalamnya ikut terbukti.
 run supabase/migrations/0084_biaya_175_ribu.sql
+# 0085 membuat Menaksir dinilai dari TAKSIRAN peserta: yang diketik angka
+# yang ditulis peserta, dan mesin skor yang menghitung selisihnya terhadap
+# jawaban benar. Poin tidak pernah disimpan — ia diturunkan saat dibaca —
+# jadi hitungan yang salah tidak menimbulkan galat apa pun, cuma angka
+# yang masuk akal di kolom yang memang berisi angka. Tes 47 menjaga
+# keempat sisinya, termasuk bahwa Pos 2 yang memakai `bertingkat` tanpa
+# jawaban benar tidak ikut berubah.
+run supabase/migrations/0085_menaksir_dari_taksiran.sql
+run tests/sql/47_menaksir_dari_taksiran.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/47_menaksir_dari_taksiran.sql
+++ b/tests/sql/47_menaksir_dari_taksiran.sql
@@ -1,0 +1,141 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/47_menaksir_dari_taksiran.sql — migrasi 0085.
+--
+-- KENAPA HITUNGAN INI PERLU MESIN.
+--
+-- Poin tidak pernah disimpan; ia diturunkan tiap kali dibaca. Jadi hitungan
+-- yang salah TIDAK menimbulkan galat apa pun — ia cuma menghasilkan angka
+-- yang masuk akal, di kolom yang memang berisi angka, pada regu yang memang
+-- ikut lomba. Yang menangkapnya bukan layar merah melainkan orang yang
+-- kebetulan menghitung ulang.
+--
+-- Empat hal yang harus benar bersamaan:
+--   1. yang masuk tangga adalah SELISIH terhadap jawaban benar, bukan
+--      angka yang diketik;
+--   2. selisih sampai 1 meter tetap 100 — inilah yang bergeser dari 0035,
+--      dan alasannya taksiran kini punya dua angka di belakang koma;
+--   3. arahnya tidak penting: menaksir lebih besar dan lebih kecil dengan
+--      selisih yang sama bernilai sama (itu gunanya abs);
+--   4. komponen TANPA jawaban benar tidak ikut berubah sedikit pun — Pos 2
+--      memakai `bertingkat` yang sama untuk waktu tempuh, dan kalau ia ikut
+--      dibaca sebagai selisih, seluruh Pos 2 salah tanpa satu tanda pun.
+-- ============================================================================
+
+\echo '--- 47. menaksir dinilai dari taksiran peserta'
+
+do $blok$
+declare
+  v_tangga jsonb := '[{"sampai": 1, "poin": 100},
+                      {"sampai": 2, "poin": 80},
+                      {"sampai": 3, "poin": 60},
+                      {"sampai": 4, "poin": 40},
+                      {"sampai": 5, "poin": 20}]'::jsonb;
+  v_poin   numeric;
+
+begin
+  -- Memanggil hitung_poin LANGSUNG, bukan lewat view: yang diuji
+  -- aritmetikanya, dan lewat view ia bergantung pada baris nilai yang
+  -- kebetulan ada di database uji.
+  -- ---------------------------------------------------------------------
+  -- 47.1 Selisih, bukan angka yang diketik.
+  --      |8.55 - 7.34| = 1.21 -> tingkat "sampai 2" -> 80.
+  -- ---------------------------------------------------------------------
+  v_poin := hitung_poin('bertingkat', 7.34, null, 100, null, null,
+                        null, null, null, v_tangga, 8.55);
+  assert v_poin = 80,
+    format('47.1 GAGAL: taksir 7.34 (selisih 1.21) bernilai %s, seharusnya 80', v_poin);
+  raise notice '47.1 OK — taksir 7.34, selisih 1.21, poin %.', v_poin;
+
+  -- ---------------------------------------------------------------------
+  -- 47.2 Selisih SATU SENTIMETER tetap 100.
+  --
+  --      Inilah yang membedakan 0085 dari 0035: dengan tangga lama, 8.56
+  --      jatuh ke tingkat kedua dan bernilai 80. Lomba menaksir yang
+  --      menuntut ketepatan sentimeter bukan lomba menaksir lagi.
+  -- ---------------------------------------------------------------------
+  v_poin := hitung_poin('bertingkat', 8.56, null, 100, null, null,
+                        null, null, null, v_tangga, 8.55);
+  assert v_poin = 100,
+    format('47.2 GAGAL: taksir 8.56 (selisih 0.01) bernilai %s, seharusnya 100', v_poin);
+
+  -- Batasnya sendiri: selisih PERSIS 1 meter masih 100, 1.01 sudah turun.
+  v_poin := hitung_poin('bertingkat', 7.55, null, 100, null, null,
+                        null, null, null, v_tangga, 8.55);
+  assert v_poin = 100,
+    format('47.2 GAGAL: selisih persis 1 m bernilai %s, seharusnya 100', v_poin);
+
+  v_poin := hitung_poin('bertingkat', 7.54, null, 100, null, null,
+                        null, null, null, v_tangga, 8.55);
+  assert v_poin = 80,
+    format('47.2 GAGAL: selisih 1.01 m bernilai %s, seharusnya 80', v_poin);
+  raise notice '47.2 OK — selisih 0.01 dan 1.00 sama-sama 100; 1.01 turun ke 80.';
+
+  -- ---------------------------------------------------------------------
+  -- 47.3 Arah tidak penting.
+  -- ---------------------------------------------------------------------
+  assert hitung_poin('bertingkat', 8.55 - 2.5, null, 100, null, null,
+                     null, null, null, v_tangga, 8.55)
+       = hitung_poin('bertingkat', 8.55 + 2.5, null, 100, null, null,
+                     null, null, null, v_tangga, 8.55),
+    '47.3 GAGAL: menaksir kurang dan lebih dengan selisih sama bernilai beda';
+  raise notice '47.3 OK — menaksir kurang dan lebih bernilai sama.';
+
+  -- Lebih dari seluruh tangga: 0, dan itu memang jawabannya.
+  v_poin := hitung_poin('bertingkat', 20, null, 100, null, null,
+                        null, null, null, v_tangga, 8.55);
+  assert v_poin = 0,
+    format('47.3 GAGAL: selisih 11.45 m bernilai %s, seharusnya 0', v_poin);
+
+  -- ---------------------------------------------------------------------
+  -- 47.4 TANPA jawaban benar, tangganya berlaku apa adanya.
+  --
+  --      Pos 2 memakai `bertingkat` yang sama untuk waktu tempuh. Kalau ia
+  --      ikut dibaca sebagai selisih, seluruh Pos 2 salah tanpa satu tanda
+  --      pun — dan itu jenis kerusakan yang cuma bisa dijaga tes.
+  -- ---------------------------------------------------------------------
+  v_poin := hitung_poin('bertingkat', 2, null, 100, null, null,
+                        null, null, null, v_tangga, null);
+  assert v_poin = 80,
+    format('47.4 GAGAL: tanpa jawaban benar, nilai 2 bernilai %s, '
+           'seharusnya 80 (tangga apa adanya)', v_poin);
+  raise notice '47.4 OK — komponen tanpa jawaban benar tidak ikut berubah.';
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 47.5 Konfigurasi Menaksir edisi ini benar-benar terpasang.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_jawab   numeric;
+  v_tingkat jsonb;
+  v_maks    numeric;
+begin
+  select jawaban_benar, tingkat, rentang_mentah_maks
+    into v_jawab, v_tingkat, v_maks
+  from wahana where edisi = edisi_aktif() and kode = 'menaksir';
+
+  if not found then
+    raise notice '47.5 DILEWATI — edisi ini tidak punya komponen menaksir.';
+    return;
+  end if;
+
+  assert v_jawab = 8.55,
+    format('47.5 GAGAL: jawaban benar %s, seharusnya 8.55', v_jawab);
+  assert jsonb_array_length(v_tingkat) = 5,
+    format('47.5 GAGAL: tangganya %s tingkat, seharusnya 5',
+           jsonb_array_length(v_tingkat));
+  assert (v_tingkat -> 0 ->> 'sampai')::numeric = 1
+     and (v_tingkat -> 0 ->> 'poin')::numeric = 100,
+    format('47.5 GAGAL: tingkat pertama %s, seharusnya sampai 1 poin 100',
+           v_tingkat -> 0);
+  -- Rentang selisih yang lama (99999999.99) akan menerima 8550 tanpa
+  -- berkedip, dan 8550 adalah 8.55 yang titiknya terlewat.
+  assert v_maks <= 1000,
+    format('47.5 GAGAL: rentang mentah maks %s masih rentang selisih', v_maks);
+  raise notice '47.5 OK — jawaban 8.55 m, tangga lima tingkat, rentang maks %.',
+    v_maks;
+end;
+$blok$;
+
+\echo '--- 47 SELESAI'


### PR DESCRIPTION
## What

Yang diketik panitia untuk Menaksir kini **angka yang ditulis peserta apa
adanya** — `7.34` tetap `7.34` — dan mesin skor yang menghitung
`abs(8.55 − 7.34)`. Migrasi `0085` + tes `47`.

Tangganya bergeser satu meter:

```
sebelum   selisih 0 m -> 100   1 m -> 80   2 m -> 60   3 m -> 40   4 m -> 20
sesudah   selisih <=1 -> 100   <=2 -> 80   <=3 -> 60   <=4 -> 40   <=5 -> 20
```

## Why

Sebelumnya panitia menghitung sendiri selisihnya lalu mengetik selisih itu.
Dua hal hilang bersamaan: satu pengurangan yang dikerjakan tangan ratusan kali
di bawah matahari, dan **satu kotak di blangko yang isinya bisa salah tanpa
ketahuan** — selisih yang salah hitung tetap berupa angka meter yang masuk
akal, tidak melanggar rentang mana pun, tidak memicu galat apa pun, dan baru
terlihat kalau ada yang menghitung ulang.

**Tangganya bergeser karena taksiran kini punya dua angka di belakang koma.**
Dengan tangga lama, peserta yang menulis `8.56` — meleset **satu sentimeter** —
selisihnya `0.01` dan jatuh ke tingkat kedua: 80 poin, bukan 100. Lomba
menaksir yang menuntut ketepatan sentimeter bukan lomba menaksir lagi. Turunnya
tetap 20 poin tiap meter dan tetap menyentuh 0, sama seperti `0035` — yang
bergeser batasnya, bukan polanya.

## Notes

**Jawaban benar jadi konfigurasi, bukan bentuk konversi baru.**
`wahana.jawaban_benar` NULL untuk semua komponen lain, dan itu yang membedakan
dua arti `bertingkat`: tanpa jawaban benar, tangganya berlaku atas `nilai_1`
apa adanya — jadi waktu tempuh Pos 2 tidak berubah sedikit pun. Bentuk ketujuh
berarti tujuh cabang di `hitung_poin` dan satu lagi yang harus diingat panitia
saat mengatur komponen tahun depan.

**`v_lembar_pos` ikut dibuat ulang, dan itu bukan kerapian.** Ia menghitung
`nilai_pos` dengan `hitung_poin` sendiri; ditinggalkan memakai bentuk lama,
layar Input Nilai Pos menampilkan Nilai Pos **tanpa** jawaban benar sementara
klasemen memakai yang **dengan** — dua angka untuk satu regu di dua layar,
keduanya tanpa galat. Ia pula yang menahan `DROP` fungsi lamanya, dan itulah
yang menunjukkan ketergantungan ini ada.

**Rentang mentahnya jadi rentang taksiran** (`999.99`), bukan rentang selisih
(`99999999.99`) — yang lama menerima `8550` tanpa berkedip, dan `8550` adalah
`8.55` yang titiknya terlewat.

Tes 47 menjaga empat sisinya:

```
47.1 OK — taksir 7.34, selisih 1.21, poin 80.00.
47.2 OK — selisih 0.01 dan 1.00 sama-sama 100; 1.01 turun ke 80.
47.3 OK — menaksir kurang dan lebih bernilai sama.
47.4 OK — komponen tanpa jawaban benar tidak ikut berubah.
SEMUA TES LULUS
```

47.4 yang paling penting dijaga mesin: kalau Pos 2 ikut dibaca sebagai
selisih, seluruh Pos 2 salah tanpa satu tanda pun.

⚠️ **Skor diturunkan saat dibaca**, jadi migrasi ini mengubah peringkat yang
sudah tampil di layar, dan nilai Menaksir yang terlanjur diketik sebagai
selisih akan dibaca sebagai taksiran. Saat ini seluruh isi produksi masih data
uji.

⚠️ Perlu `apply-migration.yml` sesudah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)