### PR TITLE
fix: taksiran diketik dua angka di belakang koma, disimpan sentimeter bulat

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -245,6 +245,40 @@ export function detikSah(teks) {
   return Number(a) * 60 + d;
 }
 
+/** METER, DISIMPAN SEBAGAI SENTIMETER BULAT.
+ *
+ *  Alasannya ditulis di kepala migrasi 0059, dan berlaku persis seperti untuk
+ *  `detik`: nilai mentah tidak punya koma. Pecahan yang masuk ke satu kolom
+ *  menyebar ke setiap tempat yang membacanya — jadi yang disimpan satuan
+ *  terkecil yang bulat, dan yang dilihat orang satuan yang ia ucapkan.
+ *
+ *    "8"     -> 800 cm       "8.1"  -> 810 cm
+ *    "8.55"  -> 855 cm       "8,55" -> 855 cm
+ *
+ *  KOMA IKUT DITERIMA, dan itu bukan kelonggaran. Peserta menulis "8,55" di
+ *  blangko karena begitulah angka ditulis dalam bahasa Indonesia; petugas
+ *  yang menyalinnya mengetik apa yang ia baca. Menolaknya berarti menolak
+ *  angka yang benar karena tanda bacanya, di tengah antrean.
+ *
+ *  Lebih dari dua angka di belakang koma dibulatkan, bukan ditolak: yang
+ *  mengetik "8.555" bermaksud 8,55 atau 8,56 — keduanya jauh lebih dekat ke
+ *  kebenaran daripada kotak yang dikosongkan karena ditolak. */
+export function meterSah(teks) {
+  const t = String(teks ?? "").trim().replace(",", ".");
+  if (!t || !/^\d+(\.\d+)?$/.test(t)) return null;
+  return Math.round(Number(t) * 100);
+}
+
+/** Kebalikan meterSah: SELALU dua angka di belakang koma — 800 jadi "8.00",
+ *  810 jadi "8.10". Bentuk yang tetap membuat kolom angka bisa dibandingkan
+ *  sekilas dari atas ke bawah, dan membuat "8" yang diketik terbaca kembali
+ *  sebagai 8,00 meter alih-alih 8 sesuatu. */
+export function meterTeks(cm) {
+  if (cm === null || cm === undefined || cm === "") return "";
+  const n = Number(cm);
+  return Number.isFinite(n) ? (n / 100).toFixed(2) : "";
+}
+
 /** Kebalikan detikSah: SELALU menit:detik berpadding — 50 jadi "00:50", 80
  *  jadi "01:20". Yang diketik boleh bentuk apa saja yang diterima detikSah
  *  ("50", "1:20", "01:20"); yang TERGAMBAR selalu satu bentuk.
@@ -890,6 +924,10 @@ export function petunjukKolom(k) {
   // disebut tetap satu bentuk. detikSah() masih menerima detik polos, jadi
   // yang mengetik 74 tidak kehilangan apa pun — ia terbaca kembali 01:14.
   if (k.satuan === "detik") return "menit:detik";
+  // Rentangnya TIDAK disebut untuk meter. Ia disimpan dalam sentimeter, jadi
+  // "0 – 10000" di kepala kolom adalah angka yang tidak pernah diketik
+  // siapa pun — satuannya sendiri yang jadi keterangan.
+  if (k.satuan === "meter") return "meter";
   if (k.form === "benar_kurang_salah") return "benar / salah";
   if (k.form === "benar_per_total") return `0 – ${angkaRapi(k.total_soal)}`;
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
@@ -912,6 +950,7 @@ export function nilaiBagian(w, a, b) {
       ? [angkaRapi(a)] : [angkaRapi(a), angkaRapi(b)];
   }
   if (w.satuan === "detik") return [detikTeks(a)];
+  if (w.satuan === "meter") return [meterTeks(a)];
   return [angkaRapi(a)];
 }
 

--- a/supabase/migrations/0086_menaksir_sentimeter.sql
+++ b/supabase/migrations/0086_menaksir_sentimeter.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- hrcd-rekap : 0086_menaksir_sentimeter.sql
+--
+-- TAKSIRAN DISIMPAN DALAM SENTIMETER BULAT, DITAMPILKAN DALAM METER.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG RUSAK
+--
+-- 0085 membuat panitia mengetik taksiran peserta apa adanya — dan taksiran
+-- peserta berkoma. Petugas yang mengetik `8.55` mendapat penolakan:
+--
+--   New row for relation "nilai_mentah" violates check constraint
+--   "nilai_mentah_bulat"
+--
+-- Constraint itu (0059) menolak SEMUA pecahan di nilai mentah, dan ia benar:
+-- kolomnya `numeric` dan kotak isiannya mengundang koma, jadi juri yang
+-- mengetik "4,85" untuk Semaphore dulu diterima tanpa sepatah kata dan
+-- angkanya ikut dihitung ke klasemen seolah-olah ia berarti.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DILAKUKAN, DAN KENAPA BUKAN MELONGGARKAN CONSTRAINT
+--
+-- Kepala 0059 sudah menuliskan jalan keluarnya, dan berkas ini menempuhnya
+-- persis:
+--
+--   "Jangan melonggarkan constraint ini diam-diam. Yang benar: simpan
+--    angkanya dalam satuan terkecil yang bulat — sentimeter alih-alih meter."
+--
+-- Jadi 8,55 m disimpan sebagai 855. Bukan aturan baru: `detik` sudah begitu
+-- sejak awal — kertas berbunyi 00:47, database menyimpan 47, dan tidak ada
+-- petugas yang pernah melihat angka 47 itu.
+--
+-- Melonggarkan constraint bukan pilihan yang lebih murah, ia pilihan yang
+-- lebih mahal: check constraint tidak bisa memuat sub-query, jadi "boleh
+-- pecahan HANYA untuk komponen tertentu" menuntut trigger — pagar yang lebih
+-- banyak mesinnya dan lebih sedikit dibaca orang. Yang tersisa cuma membuang
+-- pagarnya untuk semua komponen, dan itu mengembalikan persis kerusakan yang
+-- 0059 dipasang untuk mencegah.
+--
+-- ---------------------------------------------------------------------------
+-- ANGKA YANG IKUT BERPINDAH SATUAN
+--
+--   jawaban_benar        8.55 m   -> 855 cm
+--   tangga               1..5 m   -> 100..500 cm  (poin tetap 100..20)
+--   rentang_mentah_maks  999.99   -> 10000        (100 m)
+--   satuan               null     -> 'meter'
+--
+-- `satuan` itulah yang memberi tahu layar bahwa isinya sentimeter dan yang
+-- ditampilkan meter — penanda yang sama persis dengan `detik`, dibaca di
+-- kotak isian, kepala kolom, rekap, dan blangko. Tanpa penanda itu angkanya
+-- akan tampil apa adanya sebagai 855.
+--
+-- RENTANGNYA DIPERKETAT, bukan sekadar dikonversi. 999,99 m tidak menolak
+-- apa pun yang bisa salah ketik; 100 m menolak "855" yang lahir dari titik
+-- yang terlewat, sementara masih longgar untuk apa pun yang bisa ditaksir
+-- dengan mata di lapangan.
+--
+-- ---------------------------------------------------------------------------
+-- NILAI YANG SUDAH TERLANJUR MASUK
+--
+-- Tidak ada yang dikonversi otomatis, dan itu disengaja: baris menaksir yang
+-- ada sekarang lahir sebelum 0085, jadi isinya SELISIH dalam meter — bukan
+-- taksiran, bukan sentimeter. Mengalikannya 100 hanya akan mengubah angka
+-- yang salah jadi angka yang salah dan besar. Yang benar mengetiknya ulang
+-- dari kertas. Pada saat berkas ini ditulis seluruh isi produksi masih data
+-- uji; jumlahnya dilaporkan di bawah supaya yang menjalankan tahu persis
+-- berapa yang perlu diketik ulang.
+-- ============================================================================
+
+do $blok$
+declare
+  v_baris integer;
+  v_nilai integer;
+  v_edisi smallint := edisi_aktif();
+begin
+  select count(*) into v_nilai
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where w.edisi = v_edisi and w.kode = 'menaksir';
+
+  update wahana set
+    satuan        = 'meter',
+    jawaban_benar = 855,
+    tingkat = '[{"sampai": 100, "poin": 100},
+                {"sampai": 200, "poin": 80},
+                {"sampai": 300, "poin": 60},
+                {"sampai": 400, "poin": 40},
+                {"sampai": 500, "poin": 20}]'::jsonb,
+    rentang_mentah_min  = 0,
+    rentang_mentah_maks = 10000
+  where edisi = v_edisi and kode = 'menaksir';
+
+  get diagnostics v_baris = row_count;
+
+  if v_baris = 0 then
+    raise notice '0086: baris menaksir tidak ada di edisi % — dilewati.', v_edisi;
+  else
+    raise notice '0086: taksiran disimpan sentimeter; jawaban 855 cm (8,55 m), '
+                 'selisih sampai 100 cm tetap 100 poin.';
+    if v_nilai > 0 then
+      raise notice '0086: % nilai menaksir sudah tersimpan dan TIDAK '
+                   'dikonversi — isinya selisih meter dari sebelum 0085. '
+                   'Ketik ulang dari kertas.', v_nilai;
+    end if;
+  end if;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -339,6 +339,11 @@ run supabase/migrations/0084_biaya_175_ribu.sql
 # keempat sisinya, termasuk bahwa Pos 2 yang memakai `bertingkat` tanpa
 # jawaban benar tidak ikut berubah.
 run supabase/migrations/0085_menaksir_dari_taksiran.sql
+# 0086 memindahkan taksiran ke SENTIMETER bulat. `nilai_mentah_bulat` (0059)
+# menolak semua pecahan, dan kepalanya sendiri sudah menuliskan jalan
+# keluarnya: simpan satuan terkecil yang bulat, persis seperti `detik`.
+# Dijalankan SEBELUM tes 47 supaya yang diperiksa keadaan akhirnya.
+run supabase/migrations/0086_menaksir_sentimeter.sql
 run tests/sql/47_menaksir_dari_taksiran.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/47_menaksir_dari_taksiran.sql
+++ b/tests/sql/47_menaksir_dari_taksiran.sql
@@ -12,7 +12,7 @@
 -- Empat hal yang harus benar bersamaan:
 --   1. yang masuk tangga adalah SELISIH terhadap jawaban benar, bukan
 --      angka yang diketik;
---   2. selisih sampai 1 meter tetap 100 — inilah yang bergeser dari 0035,
+--   2. selisih sampai 1 meter (100 cm) tetap 100 — yang bergeser dari 0035,
 --      dan alasannya taksiran kini punya dua angka di belakang koma;
 --   3. arahnya tidak penting: menaksir lebih besar dan lebih kecil dengan
 --      selisih yang sama bernilai sama (itu gunanya abs);
@@ -25,11 +25,13 @@
 
 do $blok$
 declare
-  v_tangga jsonb := '[{"sampai": 1, "poin": 100},
-                      {"sampai": 2, "poin": 80},
-                      {"sampai": 3, "poin": 60},
-                      {"sampai": 4, "poin": 40},
-                      {"sampai": 5, "poin": 20}]'::jsonb;
+  -- Tangga dalam SENTIMETER, sama dengan yang dipasang 0086. Angka di tes
+  -- ini pun sentimeter: 734 adalah taksiran 7,34 m yang diketik petugas.
+  v_tangga jsonb := '[{"sampai": 100, "poin": 100},
+                      {"sampai": 200, "poin": 80},
+                      {"sampai": 300, "poin": 60},
+                      {"sampai": 400, "poin": 40},
+                      {"sampai": 500, "poin": 20}]'::jsonb;
   v_poin   numeric;
 
 begin
@@ -38,13 +40,14 @@ begin
   -- kebetulan ada di database uji.
   -- ---------------------------------------------------------------------
   -- 47.1 Selisih, bukan angka yang diketik.
-  --      |8.55 - 7.34| = 1.21 -> tingkat "sampai 2" -> 80.
+  --      |855 - 734| = 121 cm -> tingkat "sampai 200" -> 80.
   -- ---------------------------------------------------------------------
-  v_poin := hitung_poin('bertingkat', 7.34, null, 100, null, null,
-                        null, null, null, v_tangga, 8.55);
+  v_poin := hitung_poin('bertingkat', 734, null, 100, null, null,
+                        null, null, null, v_tangga, 855);
   assert v_poin = 80,
-    format('47.1 GAGAL: taksir 7.34 (selisih 1.21) bernilai %s, seharusnya 80', v_poin);
-  raise notice '47.1 OK — taksir 7.34, selisih 1.21, poin %.', v_poin;
+    format('47.1 GAGAL: taksir 734 cm (selisih 121) bernilai %s, seharusnya 80',
+           v_poin);
+  raise notice '47.1 OK — taksir 734 cm, selisih 121 cm, poin %.', v_poin;
 
   -- ---------------------------------------------------------------------
   -- 47.2 Selisih SATU SENTIMETER tetap 100.
@@ -53,38 +56,39 @@ begin
   --      jatuh ke tingkat kedua dan bernilai 80. Lomba menaksir yang
   --      menuntut ketepatan sentimeter bukan lomba menaksir lagi.
   -- ---------------------------------------------------------------------
-  v_poin := hitung_poin('bertingkat', 8.56, null, 100, null, null,
-                        null, null, null, v_tangga, 8.55);
+  v_poin := hitung_poin('bertingkat', 856, null, 100, null, null,
+                        null, null, null, v_tangga, 855);
   assert v_poin = 100,
-    format('47.2 GAGAL: taksir 8.56 (selisih 0.01) bernilai %s, seharusnya 100', v_poin);
+    format('47.2 GAGAL: taksir 856 cm (selisih 1 cm) bernilai %s, seharusnya 100',
+           v_poin);
 
   -- Batasnya sendiri: selisih PERSIS 1 meter masih 100, 1.01 sudah turun.
-  v_poin := hitung_poin('bertingkat', 7.55, null, 100, null, null,
-                        null, null, null, v_tangga, 8.55);
+  v_poin := hitung_poin('bertingkat', 755, null, 100, null, null,
+                        null, null, null, v_tangga, 855);
   assert v_poin = 100,
-    format('47.2 GAGAL: selisih persis 1 m bernilai %s, seharusnya 100', v_poin);
+    format('47.2 GAGAL: selisih persis 100 cm bernilai %s, seharusnya 100', v_poin);
 
-  v_poin := hitung_poin('bertingkat', 7.54, null, 100, null, null,
-                        null, null, null, v_tangga, 8.55);
+  v_poin := hitung_poin('bertingkat', 754, null, 100, null, null,
+                        null, null, null, v_tangga, 855);
   assert v_poin = 80,
-    format('47.2 GAGAL: selisih 1.01 m bernilai %s, seharusnya 80', v_poin);
-  raise notice '47.2 OK — selisih 0.01 dan 1.00 sama-sama 100; 1.01 turun ke 80.';
+    format('47.2 GAGAL: selisih 101 cm bernilai %s, seharusnya 80', v_poin);
+  raise notice '47.2 OK — selisih 1 cm dan 100 cm sama-sama 100; 101 cm turun ke 80.';
 
   -- ---------------------------------------------------------------------
   -- 47.3 Arah tidak penting.
   -- ---------------------------------------------------------------------
-  assert hitung_poin('bertingkat', 8.55 - 2.5, null, 100, null, null,
-                     null, null, null, v_tangga, 8.55)
-       = hitung_poin('bertingkat', 8.55 + 2.5, null, 100, null, null,
-                     null, null, null, v_tangga, 8.55),
+  assert hitung_poin('bertingkat', 855 - 250, null, 100, null, null,
+                     null, null, null, v_tangga, 855)
+       = hitung_poin('bertingkat', 855 + 250, null, 100, null, null,
+                     null, null, null, v_tangga, 855),
     '47.3 GAGAL: menaksir kurang dan lebih dengan selisih sama bernilai beda';
   raise notice '47.3 OK — menaksir kurang dan lebih bernilai sama.';
 
   -- Lebih dari seluruh tangga: 0, dan itu memang jawabannya.
-  v_poin := hitung_poin('bertingkat', 20, null, 100, null, null,
-                        null, null, null, v_tangga, 8.55);
+  v_poin := hitung_poin('bertingkat', 2000, null, 100, null, null,
+                        null, null, null, v_tangga, 855);
   assert v_poin = 0,
-    format('47.3 GAGAL: selisih 11.45 m bernilai %s, seharusnya 0', v_poin);
+    format('47.3 GAGAL: selisih 1145 cm bernilai %s, seharusnya 0', v_poin);
 
   -- ---------------------------------------------------------------------
   -- 47.4 TANPA jawaban benar, tangganya berlaku apa adanya.
@@ -93,10 +97,10 @@ begin
   --      ikut dibaca sebagai selisih, seluruh Pos 2 salah tanpa satu tanda
   --      pun — dan itu jenis kerusakan yang cuma bisa dijaga tes.
   -- ---------------------------------------------------------------------
-  v_poin := hitung_poin('bertingkat', 2, null, 100, null, null,
+  v_poin := hitung_poin('bertingkat', 200, null, 100, null, null,
                         null, null, null, v_tangga, null);
   assert v_poin = 80,
-    format('47.4 GAGAL: tanpa jawaban benar, nilai 2 bernilai %s, '
+    format('47.4 GAGAL: tanpa jawaban benar, nilai 200 bernilai %s, '
            'seharusnya 80 (tangga apa adanya)', v_poin);
   raise notice '47.4 OK — komponen tanpa jawaban benar tidak ikut berubah.';
 end;
@@ -110,9 +114,10 @@ declare
   v_jawab   numeric;
   v_tingkat jsonb;
   v_maks    numeric;
+  v_satuan  text;
 begin
-  select jawaban_benar, tingkat, rentang_mentah_maks
-    into v_jawab, v_tingkat, v_maks
+  select jawaban_benar, tingkat, rentang_mentah_maks, satuan
+    into v_jawab, v_tingkat, v_maks, v_satuan
   from wahana where edisi = edisi_aktif() and kode = 'menaksir';
 
   if not found then
@@ -120,21 +125,27 @@ begin
     return;
   end if;
 
-  assert v_jawab = 8.55,
-    format('47.5 GAGAL: jawaban benar %s, seharusnya 8.55', v_jawab);
+  -- SENTIMETER, bukan meter (0086). Nilai mentah tidak punya koma, jadi yang
+  -- disimpan satuan terkecil yang bulat dan yang dilihat orang meter — aturan
+  -- yang sama dengan `detik`: kertas berbunyi 00:47, database menyimpan 47.
+  assert v_jawab = 855,
+    format('47.5 GAGAL: jawaban benar %s, seharusnya 855 (sentimeter)', v_jawab);
   assert jsonb_array_length(v_tingkat) = 5,
     format('47.5 GAGAL: tangganya %s tingkat, seharusnya 5',
            jsonb_array_length(v_tingkat));
-  assert (v_tingkat -> 0 ->> 'sampai')::numeric = 1
+  assert (v_tingkat -> 0 ->> 'sampai')::numeric = 100
      and (v_tingkat -> 0 ->> 'poin')::numeric = 100,
-    format('47.5 GAGAL: tingkat pertama %s, seharusnya sampai 1 poin 100',
+    format('47.5 GAGAL: tingkat pertama %s, seharusnya sampai 100 cm poin 100',
            v_tingkat -> 0);
-  -- Rentang selisih yang lama (99999999.99) akan menerima 8550 tanpa
-  -- berkedip, dan 8550 adalah 8.55 yang titiknya terlewat.
-  assert v_maks <= 1000,
-    format('47.5 GAGAL: rentang mentah maks %s masih rentang selisih', v_maks);
-  raise notice '47.5 OK — jawaban 8.55 m, tangga lima tingkat, rentang maks %.',
-    v_maks;
+  -- 10000 cm = 100 m menolak "855" yang lahir dari titik yang terlewat, dan
+  -- masih longgar untuk apa pun yang bisa ditaksir dengan mata.
+  assert v_maks = 10000,
+    format('47.5 GAGAL: rentang mentah maks %s, seharusnya 10000 cm', v_maks);
+  assert v_satuan = 'meter',
+    format('47.5 GAGAL: satuan %L — tanpa penanda ini layar menampilkan '
+           'sentimeter apa adanya', v_satuan);
+  raise notice '47.5 OK — jawaban 855 cm, lima tingkat, maks % cm, satuan %.',
+    v_maks, v_satuan;
 end;
 $blok$;
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -30,6 +30,7 @@ import {
   hapusFotoLembar,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapital,
+         meterSah, meterTeks,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
@@ -2241,6 +2242,15 @@ function selKomponen(k, nilai) {
                    data-kode="${kode}" value="${esc(detikTeks(n1))}"${kosongTampak}
                    aria-label="${esc(k.name)} — detik, atau menit:detik">`;
   }
+  if (k.satuan === "meter") {
+    // Bertipe text, bukan number, karena isinya boleh memuat KOMA — peserta
+    // menulis "8,55" di blangko dan petugas mengetik apa yang ia baca.
+    // input[type=number] menolak koma diam-diam: kotaknya jadi kosong tanpa
+    // sepatah kata, dan yang mengetiknya mengira angkanya sudah masuk.
+    return `<input type="text" class="small-input input-meter" inputmode="decimal"
+                   data-kode="${kode}" value="${esc(meterTeks(n1))}"${kosongTampak}
+                   aria-label="${esc(k.name)} — meter, dua angka di belakang koma">`;
+  }
   if (k.form === "benar_kurang_salah") {
     return `<span class="pos-pasangan">
       <input type="number" class="small-input" inputmode="numeric" step="1" min="0"
@@ -2299,6 +2309,15 @@ function bacaSel(tr, k) {
     if (!kotak[0].value.trim()) return null;
     const detik = detikSah(kotak[0].value);
     return detik === null ? TIDAK_SAH : { nilai_1: detik, nilai_2: null };
+  }
+  if (k.satuan === "meter") {
+    // TIGA keadaan, sama seperti detik: kosong berarti "hapus nilainya",
+    // tidak terbaca berarti "jangan kirim apa pun". Menyamakan keduanya
+    // membuat salah ketik satu huruf MENGHAPUS angka yang sudah benar,
+    // lalu barisnya tetap mendapat centang hijau.
+    if (!kotak[0].value.trim()) return null;
+    const cm = meterSah(kotak[0].value);
+    return cm === null ? TIDAK_SAH : { nilai_1: cm, nilai_2: null };
   }
   if (k.form === "benar_kurang_salah") {
     const b = kotak[0].value.trim(), sa = kotak[1].value.trim();
@@ -2395,6 +2414,7 @@ const kolomCetakPos = (kolom) => kolom.flatMap(kol => {
   // petugas memecah angka stopwatch sebelum menuliskannya; satu petak
   // menerima "32" maupun "1:10" apa adanya, persis seperti kotak di layar.
   if (k.satuan === "detik") return [{ nama: kol.nama, petunjuk: kol.petunjuk }];
+  if (k.satuan === "meter") return [{ nama: kol.nama, petunjuk: kol.petunjuk }];
   if (k.form === "benar_kurang_salah") return [
     { nama: kol.nama, petunjuk: "benar" }, { nama: "", petunjuk: "salah" }];
   return [{ nama: kol.nama, petunjuk: kol.petunjuk }];
@@ -2554,6 +2574,7 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris) {
 function judulIsian(k) {
   if (k.judul_isian) return k.judul_isian;
   if (k.satuan === "detik") return "Waktu tempuh";
+  if (k.satuan === "meter") return "Hasil taksir";
   if (k.form === "biner") return "Kena / tidak";
   if (k.form === "benar_kurang_salah") return "Benar dan salah";
   if (k.form === "bertingkat") return "Data mentah";
@@ -2584,6 +2605,7 @@ function contohIsian(kol) {
   // yang menyadarinya. Contohnya tetap ada, karena contoh nyata mencegah
   // sekelas kesalahan yang tidak bisa dicegah kalimat mana pun.
   if (k.satuan === "detik") return `${kol.petunjuk} · contoh: 00:47`;
+  if (k.satuan === "meter") return `${kol.petunjuk} · contoh: 8.55`;
   // Keterangan yang ditulis panitia sendiri dipakai apa adanya — ia sudah
   // berupa kalimat, bukan rentang yang perlu diberi kata "angka".
   if (k.petunjuk || k.form === "biner") return kol.petunjuk;
@@ -4114,6 +4136,9 @@ async function layarInputPos() {
           if (kotak[0].checked !== centang) kotak[0].checked = centang;
         } else if (k.satuan === "detik") {
           const teks = detikTeks(nilai ? nilai.nilai_1 : null);
+          if (kotak[0].value !== teks) kotak[0].value = teks;
+        } else if (k.satuan === "meter") {
+          const teks = meterTeks(nilai ? nilai.nilai_1 : null);
           if (kotak[0].value !== teks) kotak[0].value = teks;
         } else if (k.form === "benar_kurang_salah") {
           const b = angkaRapi(nilai ? nilai.nilai_1 : null);

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -245,6 +245,40 @@ export function detikSah(teks) {
   return Number(a) * 60 + d;
 }
 
+/** METER, DISIMPAN SEBAGAI SENTIMETER BULAT.
+ *
+ *  Alasannya ditulis di kepala migrasi 0059, dan berlaku persis seperti untuk
+ *  `detik`: nilai mentah tidak punya koma. Pecahan yang masuk ke satu kolom
+ *  menyebar ke setiap tempat yang membacanya — jadi yang disimpan satuan
+ *  terkecil yang bulat, dan yang dilihat orang satuan yang ia ucapkan.
+ *
+ *    "8"     -> 800 cm       "8.1"  -> 810 cm
+ *    "8.55"  -> 855 cm       "8,55" -> 855 cm
+ *
+ *  KOMA IKUT DITERIMA, dan itu bukan kelonggaran. Peserta menulis "8,55" di
+ *  blangko karena begitulah angka ditulis dalam bahasa Indonesia; petugas
+ *  yang menyalinnya mengetik apa yang ia baca. Menolaknya berarti menolak
+ *  angka yang benar karena tanda bacanya, di tengah antrean.
+ *
+ *  Lebih dari dua angka di belakang koma dibulatkan, bukan ditolak: yang
+ *  mengetik "8.555" bermaksud 8,55 atau 8,56 — keduanya jauh lebih dekat ke
+ *  kebenaran daripada kotak yang dikosongkan karena ditolak. */
+export function meterSah(teks) {
+  const t = String(teks ?? "").trim().replace(",", ".");
+  if (!t || !/^\d+(\.\d+)?$/.test(t)) return null;
+  return Math.round(Number(t) * 100);
+}
+
+/** Kebalikan meterSah: SELALU dua angka di belakang koma — 800 jadi "8.00",
+ *  810 jadi "8.10". Bentuk yang tetap membuat kolom angka bisa dibandingkan
+ *  sekilas dari atas ke bawah, dan membuat "8" yang diketik terbaca kembali
+ *  sebagai 8,00 meter alih-alih 8 sesuatu. */
+export function meterTeks(cm) {
+  if (cm === null || cm === undefined || cm === "") return "";
+  const n = Number(cm);
+  return Number.isFinite(n) ? (n / 100).toFixed(2) : "";
+}
+
 /** Kebalikan detikSah: SELALU menit:detik berpadding — 50 jadi "00:50", 80
  *  jadi "01:20". Yang diketik boleh bentuk apa saja yang diterima detikSah
  *  ("50", "1:20", "01:20"); yang TERGAMBAR selalu satu bentuk.
@@ -890,6 +924,10 @@ export function petunjukKolom(k) {
   // disebut tetap satu bentuk. detikSah() masih menerima detik polos, jadi
   // yang mengetik 74 tidak kehilangan apa pun — ia terbaca kembali 01:14.
   if (k.satuan === "detik") return "menit:detik";
+  // Rentangnya TIDAK disebut untuk meter. Ia disimpan dalam sentimeter, jadi
+  // "0 – 10000" di kepala kolom adalah angka yang tidak pernah diketik
+  // siapa pun — satuannya sendiri yang jadi keterangan.
+  if (k.satuan === "meter") return "meter";
   if (k.form === "benar_kurang_salah") return "benar / salah";
   if (k.form === "benar_per_total") return `0 – ${angkaRapi(k.total_soal)}`;
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
@@ -912,6 +950,7 @@ export function nilaiBagian(w, a, b) {
       ? [angkaRapi(a)] : [angkaRapi(a), angkaRapi(b)];
   }
   if (w.satuan === "detik") return [detikTeks(a)];
+  if (w.satuan === "meter") return [meterTeks(a)];
   return [angkaRapi(a)];
 }
 


### PR DESCRIPTION
## What

Mengetik `8.55` untuk Menaksir ditolak database. Sekarang bisa, dan angkanya
dirapikan ke dua angka di belakang koma:

```
ketik 8      -> 8.00        ketik 8.1   -> 8.10
ketik 8.55   -> 8.55        ketik 8,55  -> 8.55
```

Migrasi `0086` + `meterSah`/`meterTeks` di `util.js`.

## Why

```
New row for relation "nilai_mentah" violates check constraint
"nilai_mentah_bulat"
```

Constraint itu (`0059`) menolak **semua** pecahan di nilai mentah, dan ia
benar: kolomnya `numeric` dan kotak isiannya mengundang koma, jadi juri yang
mengetik "4,85" untuk Semaphore dulu diterima tanpa sepatah kata dan angkanya
ikut dihitung ke klasemen seolah-olah ia berarti. **Yang keliru bukan pagarnya
melainkan satuan yang dipakai `0085`.**

**Kepala `0059` sudah menuliskan jalan keluarnya**, dan PR ini menempuhnya
persis:

> "Jangan melonggarkan constraint ini diam-diam. Yang benar: simpan angkanya
> dalam satuan terkecil yang bulat — sentimeter alih-alih meter."

Bukan aturan baru: **`detik` sudah begitu sejak awal** — kertas berbunyi
`00:47`, database menyimpan `47`, dan tidak ada petugas yang pernah melihat
angka itu.

**Melonggarkan constraint bukan pilihan yang lebih murah melainkan lebih
mahal.** Check constraint tidak bisa memuat sub-query, jadi "boleh pecahan
hanya untuk komponen tertentu" menuntut trigger — pagar yang lebih banyak
mesinnya dan lebih sedikit dibaca orang. Yang tersisa cuma membuang pagarnya
untuk semua komponen, dan itu mengembalikan persis kerusakan yang `0059`
dipasang untuk mencegah.

## Notes

**Koma ikut diterima, dan itu bukan kelonggaran.** Peserta menulis `8,55` di
blangko karena begitulah angka ditulis dalam bahasa Indonesia; petugas yang
menyalinnya mengetik apa yang ia baca. Menolaknya berarti menolak angka yang
benar karena tanda bacanya, di tengah antrean. Lebih dari dua angka di
belakang koma **dibulatkan, bukan ditolak**: yang mengetik `8.555` bermaksud
8,55 atau 8,56, dan keduanya jauh lebih dekat ke kebenaran daripada kotak yang
dikosongkan.

**Kotaknya bertipe `text`, bukan `number`**, karena isinya boleh memuat koma.
`input[type=number]` menolak koma **diam-diam**: kotaknya jadi kosong tanpa
sepatah kata, dan yang mengetiknya mengira angkanya sudah masuk.

**Tiga keadaan saat membaca kotak**, cerminan cabang `detik`: kosong berarti
"hapus nilainya", tidak terbaca berarti "jangan kirim apa pun". Menyamakan
keduanya membuat salah ketik satu huruf **menghapus** angka yang sudah benar,
lalu barisnya tetap mendapat centang hijau.

Angka yang ikut berpindah satuan:

| | sebelum | sesudah |
|---|---|---|
| `jawaban_benar` | 8.55 m | 855 cm |
| tangga | 1–5 m | 100–500 cm |
| `rentang_mentah_maks` | 999.99 | 10000 (100 m) |
| `satuan` | — | `meter` |

`satuan` itulah yang memberi tahu layar bahwa isinya sentimeter dan yang
ditampilkan meter — penanda yang sama persis dengan `detik`, dibaca di kotak
isian, kepala kolom, rekap, dan blangko.

**Rentangnya diperketat, bukan sekadar dikonversi**: 100 m menolak `855` yang
lahir dari titik yang terlewat.

⚠️ **Nilai menaksir yang sudah tersimpan tidak dikonversi otomatis** — isinya
selisih meter dari sebelum `0085`, jadi mengalikannya 100 hanya mengubah angka
yang salah jadi angka yang salah dan besar. Migrasinya melaporkan berapa
banyak yang perlu diketik ulang.

⚠️ Perlu `apply-migration.yml` sesudah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)