### PR TITLE
feat: lomba berkriteria banyak jadi tabel berkolom, dan KIM dipisah dua lomba

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1058,10 +1058,24 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      di dalamnya paling banyak dua digit. Yang TIDAK boleh menyusut adalah
      nomor dada dan identitasnya di atas — itu yang dibaca saat menyortir
      tumpukan. */
-  .bl-nilai-banyak { display: flex; gap: 2.5mm; align-items: stretch; }
-  .bl-nilai-banyak .bl-nilai-sel { flex: 1 1 0; min-width: 0; }
+  /* TABEL, bukan kotak-kotak yang dijejer. Sebelumnya sel-selnya dipisah
+     `gap` — celah putih tanpa garis — sehingga area tulisnya SATU kotak lebar
+     tanpa pembatas apa pun. Juri menulis lima angka ke dalam satu ruang, dan
+     yang menentukan angka mana masuk kolom mana cuma perkiraan jaraknya.
+     Garis tegak menurunkan kepala kolom sampai ke dasar kotak, jadi tiap
+     angka duduk di kolomnya sendiri. */
+  .bl-nilai-banyak { display: flex; align-items: stretch; }
+  .bl-nilai-banyak .bl-nilai-sel {
+    flex: 1 1 0; min-width: 0; border-left: 1.2pt solid #000;
+  }
+  .bl-nilai-banyak .bl-nilai-sel:first-child { border-left: 0; }
   .bl-nilai-banyak .bl-nilai-judul { font-size: 9pt; }
-  .bl-nilai-banyak .bl-nilai-kotak { min-height: 14mm; }
+  /* Kotaknya sedikit lebih rendah daripada lembar berkotak tunggal: judul
+     kriteria yang panjang membungkus jadi dua baris — "Diagnosis dan
+     Penanganan Awal" salah satunya — dan tinggi itulah yang dipinjam. Diukur
+     pada Pembidaian, lembar terpadat: sisa di kaki halaman 1mm sebelum, 5mm
+     sesudah. */
+  .bl-nilai-banyak .bl-nilai-kotak { height: 26mm; min-height: 14mm; }
   /* Judul kriteria boleh dua baris — "Diagnosis dan Penanganan Awal" tidak
      muat satu baris pada seperlima lebar A5, dan memotongnya menghilangkan
      kata yang membedakannya dari kriteria sebelahnya. */

--- a/supabase/migrations/0087_kim_dua_lomba.sql
+++ b/supabase/migrations/0087_kim_dua_lomba.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- hrcd-rekap : 0087_kim_dua_lomba.sql
+--
+-- KIM LIHAT DAN KIM CIUM ADALAH DUA LOMBA, BUKAN DUA KRITERIA SATU LOMBA.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG BERBEDA
+--
+-- Keduanya bernaung di bawah `lomba = 'KIM'`, jadi seluruh sistem
+-- memperlakukannya seperti Pembidaian: SATU lomba dengan dua kriteria yang
+-- dinilai satu juri di satu meja, satu blangko, satu kolom foto.
+--
+-- Di lapangan bukan begitu. Keduanya lomba tersendiri: peserta mengerjakan
+-- sepuluh soal Lihat, lalu sepuluh soal Cium, dan masing-masing punya lembar
+-- jawaban sendiri yang diisi PESERTA — bentuk yang sama dengan Tebak Simpul,
+-- bukan bentuk kolom-kolom yang diisi juri.
+--
+-- ---------------------------------------------------------------------------
+-- YANG BERUBAH KARENA ITU
+--
+-- `lomba` dikosongkan. Membacanya `coalesce(lomba, name)` (CLAUDE.md 11.8),
+-- jadi keduanya langsung berdiri sebagai lomba bernama "Kim Lihat" dan
+-- "Kim Cium". Tiga hal ikut terpisah tanpa satu baris kode pun:
+--
+--   blangko      dua master, masing-masing bernomor 1-10
+--   kolom foto   dua kolom, bukan satu tumpukan bernama KIM
+--   Live Score   dua lomba di papan, sesuai yang diumumkan
+--
+-- POIN TIDAK BERUBAH. `lomba` cuma pengelompokan tampilan; yang menghitung
+-- skor `poin_maks` dan `form` tiap baris wahana, dan keduanya tidak disentuh
+-- di sini. Klasemen sesudah migrasi ini sama persis dengan sebelumnya.
+--
+-- ---------------------------------------------------------------------------
+-- KUNCI FOTO IKUT BERPINDAH, DAN ITU DISENGAJA
+--
+-- `kode_lomba` dibekukan 0079 supaya mengganti NAMA lomba tidak memutus foto
+-- yang sudah diunggah. Yang terjadi di sini bukan penggantian nama melainkan
+-- PEMISAHAN: satu lomba jadi dua, dan kunci tunggal `kim` tidak bisa lagi
+-- menunjuk keduanya sekaligus. Kuncinya karena itu dipisah jadi `kim-lihat`
+-- dan `kim-cium`.
+--
+-- Konsekuensinya foto yang terlanjur diunggah dengan kunci `kim` tidak lagi
+-- ketemu dari layar mana pun. Jumlahnya dilaporkan di bawah supaya yang
+-- menjalankan tahu persis berapa — bukan diperkirakan sesudahnya. Foto itu
+-- masih ada di bucket; kalau perlu, kuncinya bisa dipindahkan tangan dengan
+-- satu UPDATE ke `foto_lembar`.
+-- ============================================================================
+
+do $blok$
+declare
+  v_edisi smallint := edisi_aktif();
+  v_baris integer;
+  v_foto  integer;
+begin
+  select count(*) into v_foto
+  from foto_lembar f
+  where f.pos = 3 and f.kode_lomba = 'kim';
+
+  update wahana set
+    lomba      = null,
+    kode_lomba = case kode when 'kim_lihat' then 'kim-lihat'
+                           when 'kim_cium'  then 'kim-cium' end
+  where edisi = v_edisi and kode in ('kim_lihat', 'kim_cium');
+
+  get diagnostics v_baris = row_count;
+
+  if v_baris = 0 then
+    raise notice '0087: komponen KIM tidak ada di edisi % — dilewati.', v_edisi;
+    return;
+  end if;
+
+  assert v_baris = 2,
+    format('0087: %s baris KIM diubah, seharusnya 2 — periksa kodenya', v_baris);
+
+  raise notice '0087: Kim Lihat dan Kim Cium kini dua lomba terpisah.';
+  if v_foto > 0 then
+    raise notice '0087: % foto masih berkunci "kim" dan tidak akan ketemu '
+                 'dari layar. Berkasnya masih ada di bucket.', v_foto;
+  end if;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -345,5 +345,12 @@ run supabase/migrations/0085_menaksir_dari_taksiran.sql
 # Dijalankan SEBELUM tes 47 supaya yang diperiksa keadaan akhirnya.
 run supabase/migrations/0086_menaksir_sentimeter.sql
 run tests/sql/47_menaksir_dari_taksiran.sql
+# 0087 memisahkan Kim Lihat dan Kim Cium jadi DUA lomba. `lomba` cuma satu
+# kolom teks, dan mengisinya kembali tidak menimbulkan galat apa pun — ia
+# hanya menggabungkan keduanya lagi di blangko, kolom foto, dan Live Score
+# sekaligus. Tes 48 menjaga ketiganya, termasuk bahwa poinnya tidak ikut
+# bergeser.
+run supabase/migrations/0087_kim_dua_lomba.sql
+run tests/sql/48_kim_dua_lomba.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/48_kim_dua_lomba.sql
+++ b/tests/sql/48_kim_dua_lomba.sql
@@ -1,0 +1,82 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/48_kim_dua_lomba.sql — migrasi 0087.
+--
+-- KENAPA PEMISAHAN INI PERLU DIJAGA MESIN.
+--
+-- `lomba` cuma satu kolom teks, dan mengisinya kembali dengan 'KIM' tidak
+-- menimbulkan galat apa pun — ia hanya menggabungkan kembali dua lomba jadi
+-- satu di tiga tempat sekaligus: blangko dicetak satu master alih-alih dua,
+-- foto slip ditumpuk jadi satu kolom, dan papan Live Score menyebut satu
+-- nama yang tidak pernah diumumkan panitia.
+--
+-- Yang diuji tiga hal:
+--   1. keduanya berdiri sendiri (`lomba` kosong);
+--   2. kunci fotonya BERBEDA — kunci yang sama berarti dua lomba berbagi
+--      satu tumpukan foto, dan itu persis keadaan yang dipisahkan;
+--   3. keduanya masih berupa lomba yang bisa dinilai — `lomba` pengelompokan
+--      tampilan, bukan bahan hitungan, jadi pemisahan ini tidak boleh
+--      menyentuh bentuk maupun poin maksimalnya.
+-- ============================================================================
+
+\echo '--- 48. Kim Lihat dan Kim Cium dua lomba terpisah'
+
+do $blok$
+declare
+  v_edisi  smallint := edisi_aktif();
+  v_lomba  integer;
+  v_kunci  integer;
+  v_maks   integer;
+begin
+  select count(*) into v_kunci
+  from wahana where edisi = v_edisi and kode in ('kim_lihat', 'kim_cium');
+
+  if v_kunci <> 2 then
+    raise notice '48 DILEWATI — edisi ini tidak punya kedua komponen KIM.';
+    return;
+  end if;
+
+  -- ---------------------------------------------------------------------
+  -- 48.1 Keduanya berdiri sendiri.
+  -- ---------------------------------------------------------------------
+  select count(*) into v_lomba
+  from wahana where edisi = v_edisi and kode in ('kim_lihat', 'kim_cium')
+    and lomba is not null;
+
+  assert v_lomba = 0,
+    format('48.1 GAGAL: %s komponen KIM masih bernaung di bawah satu lomba',
+           v_lomba);
+  raise notice '48.1 OK — keduanya lomba tersendiri.';
+
+  -- ---------------------------------------------------------------------
+  -- 48.2 Kunci fotonya berbeda.
+  -- ---------------------------------------------------------------------
+  select count(distinct kode_lomba) into v_kunci
+  from wahana where edisi = v_edisi and kode in ('kim_lihat', 'kim_cium');
+
+  assert v_kunci = 2,
+    format('48.2 GAGAL: kedua komponen KIM berbagi %s kunci foto — foto '
+           'keduanya akan menumpuk jadi satu kolom', v_kunci);
+  raise notice '48.2 OK — dua kunci foto, dua tumpukan.';
+
+  -- ---------------------------------------------------------------------
+  -- 48.3 Keduanya masih bisa dinilai.
+  --
+  --      `lomba` pengelompokan TAMPILAN; yang menghitung skor `form` dan
+  --      `poin_maks`, dan pemisahan ini tidak menyentuh keduanya. Yang
+  --      diperiksa di sini karena itu bukan angkanya — konfigurasi penilaian
+  --      berganti tiap edisi, dan tes yang memakunya akan lulus tahun depan
+  --      sambil menyembunyikan yang sudah salah — melainkan bahwa kedua
+  --      baris masih punya bentuk dan poin maksimal, yaitu masih berupa
+  --      lomba yang bisa dinilai.
+  -- ---------------------------------------------------------------------
+  select count(*) into v_maks
+  from wahana where edisi = v_edisi and kode in ('kim_lihat', 'kim_cium')
+    and (form is null or poin_maks is null);
+
+  assert v_maks = 0,
+    '48.3 GAGAL: ada komponen KIM yang kehilangan bentuk atau poin maksimalnya';
+  raise notice '48.3 OK — keduanya masih berupa lomba yang bisa dinilai.';
+end;
+$blok$;
+
+\echo '--- 48 SELESAI'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2719,6 +2719,34 @@ function siapkanCetakBlangko(pos, kolomLayar) {
 
   const penanda = (siapa) => `<p class="bl-siapa">${esc(siapa)}</p>`;
 
+  /* LEMBAR BERNOMOR — sepuluh jawaban peserta, satu angka dari panitia.
+
+     Dipakai tiga lomba yang bentuknya sama persis: Tebak Simpul, KIM Lihat,
+     KIM Cium. Yang berbeda cuma apa yang ditulis peserta dan nama hitungan
+     panitianya, jadi ketiganya memanggil bentuk ini alih-alih menyalinnya —
+     tiga salinan berarti perbaikan berikutnya harus diketik tiga kali dan
+     dua di antaranya akan terlewat.
+
+     SEPULUH nomor pada satu master. Penggalang mengisi 1-5 di Tebak Simpul
+     dan membiarkan sisanya kosong; dua tumpukan yang berbeda bentuknya adalah
+     dua tumpukan yang bisa tertukar di lapangan, dan nomor kosong tidak
+     pernah salah dibaca sebagai jawaban.
+
+     Nomornya menurun PER LAJUR — 1-5 di kiri, 6-10 di kanan — bukan
+     berselang-seling kiri-kanan. Dua lajur lima baris, bukan satu lajur
+     sepuluh: A5 melintang lebar dan pendek, dan sepuluh baris berurutan ke
+     bawah tidak muat tanpa mengecilkan barisnya sampai tidak bisa ditulisi. */
+  const lembarBernomor = (yangDitulis, judulPanitia, petunjuk) => `
+      ${penanda(`Diisi peserta — ${yangDitulis}`)}
+      <div class="bl-nomor-grid">
+        ${[0, 1, 2, 3, 4].flatMap(r => [r + 1, r + 6]).map(n => `
+        <div class="bl-nomor-baris">
+          <span class="bl-nomor">${n}.</span>
+          <span class="bl-nomor-garis"></span>
+        </div>`).join("")}
+      </div>
+      ${pitaPanitia([[judulPanitia, petunjuk]])}`;
+
   /* ---------------------------------------------------------------------
      BENTUK KHUSUS PER LOMBA.
 
@@ -2760,29 +2788,18 @@ function siapkanCetakBlangko(pos, kolomLayar) {
       </div>
       ${pitaPanitia([["Jumlah huruf yang benar", "( 0 – 5 )"]])}`,
 
-    /* TEBAK SIMPUL. SEPULUH nomor pada satu master, bukan dua master 5 dan
-       10: Penggalang mengisi 1-5 dan membiarkan sisanya kosong. Dua tumpukan
-       yang berbeda bentuknya adalah dua tumpukan yang bisa tertukar di
-       lapangan, dan nomor kosong tidak pernah salah dibaca sebagai jawaban.
+    /* Tiga lomba di bawah ini memakai bentuk yang sama; alasannya di
+       lembarBernomor(). */
+    "tebak-simpul": () => lembarBernomor(
+      "nama simpulnya", "Jumlah simpul yang benar", "( 0 – 5 / 0 – 10 )"),
 
-       Dua lajur lima baris, bukan satu lajur sepuluh: A5 melintang lebar dan
-       pendek, dan sepuluh baris berurutan ke bawah tidak muat tanpa
-       mengecilkan barisnya sampai tidak bisa ditulisi.
-
-       Nomornya menurun PER LAJUR — 1-5 di kiri, 6-10 di kanan — bukan
-       berselang-seling kiri-kanan. Penggalang mengisi lima yang pertama, dan
-       hanya urutan ini yang membuat kelimanya berkumpul di satu lajur alih-
-       alih tersebar di sepuluh baris. */
-    "tebak-simpul": () => `
-      ${penanda("Diisi peserta — nama simpulnya")}
-      <div class="bl-nomor-grid">
-        ${[0, 1, 2, 3, 4].flatMap(r => [r + 1, r + 6]).map(n => `
-        <div class="bl-nomor-baris">
-          <span class="bl-nomor">${n}.</span>
-          <span class="bl-nomor-garis"></span>
-        </div>`).join("")}
-      </div>
-      ${pitaPanitia([["Jumlah simpul yang benar", "( 0 – 5 / 0 – 10 )"]])}`,
+    /* KIM LIHAT dan KIM CIUM: dua lomba, dua lembar, bentuk yang sama dengan
+       Tebak Simpul. Peserta menuliskan sepuluh jawabannya, panitia menghitung
+       berapa yang benar. */
+    "kim-lihat": () => lembarBernomor(
+      "benda yang dilihat", "Jumlah benar", "( 0 – 10 )"),
+    "kim-cium": () => lembarBernomor(
+      "benda yang dicium", "Jumlah benar", "( 0 – 10 )"),
 
     /* MENAKSIR — SATU-SATUNYA lembar tanpa bagian panitia.
 

--- a/web/style.css
+++ b/web/style.css
@@ -1058,10 +1058,24 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      di dalamnya paling banyak dua digit. Yang TIDAK boleh menyusut adalah
      nomor dada dan identitasnya di atas — itu yang dibaca saat menyortir
      tumpukan. */
-  .bl-nilai-banyak { display: flex; gap: 2.5mm; align-items: stretch; }
-  .bl-nilai-banyak .bl-nilai-sel { flex: 1 1 0; min-width: 0; }
+  /* TABEL, bukan kotak-kotak yang dijejer. Sebelumnya sel-selnya dipisah
+     `gap` — celah putih tanpa garis — sehingga area tulisnya SATU kotak lebar
+     tanpa pembatas apa pun. Juri menulis lima angka ke dalam satu ruang, dan
+     yang menentukan angka mana masuk kolom mana cuma perkiraan jaraknya.
+     Garis tegak menurunkan kepala kolom sampai ke dasar kotak, jadi tiap
+     angka duduk di kolomnya sendiri. */
+  .bl-nilai-banyak { display: flex; align-items: stretch; }
+  .bl-nilai-banyak .bl-nilai-sel {
+    flex: 1 1 0; min-width: 0; border-left: 1.2pt solid #000;
+  }
+  .bl-nilai-banyak .bl-nilai-sel:first-child { border-left: 0; }
   .bl-nilai-banyak .bl-nilai-judul { font-size: 9pt; }
-  .bl-nilai-banyak .bl-nilai-kotak { min-height: 14mm; }
+  /* Kotaknya sedikit lebih rendah daripada lembar berkotak tunggal: judul
+     kriteria yang panjang membungkus jadi dua baris — "Diagnosis dan
+     Penanganan Awal" salah satunya — dan tinggi itulah yang dipinjam. Diukur
+     pada Pembidaian, lembar terpadat: sisa di kaki halaman 1mm sebelum, 5mm
+     sesudah. */
+  .bl-nilai-banyak .bl-nilai-kotak { height: 26mm; min-height: 14mm; }
   /* Judul kriteria boleh dua baris — "Diagnosis dan Penanganan Awal" tidak
      muat satu baris pada seperlima lebar A5, dan memotongnya menghilangkan
      kata yang membedakannya dari kriteria sebelahnya. */


### PR DESCRIPTION
## What

1. **Lembar berkriteria banyak jadi tabel berkolom** — Pos 3 Pembidaian (5),
   Pos 4 PBB (4), Pos 5 Yel-Yel (4).
2. **KIM Lihat dan KIM Cium jadi dua lomba** (migrasi `0087`), masing-masing
   dengan lembar bernomor 1–10 yang diisi peserta.

## Why

**Sel kriteria dulu dipisah `gap`** — celah putih tanpa garis — sehingga area
tulisnya **satu kotak lebar tanpa pembatas apa pun**. Juri menulis lima angka
ke dalam satu ruang, dan yang menentukan angka mana masuk kolom mana cuma
perkiraan jaraknya. Garis tegak sekarang menurunkan kepala kolom sampai ke
dasar kotak.

**KIM keduanya bernaung di bawah `lomba = 'KIM'`**, jadi seluruh sistem
memperlakukannya seperti Pembidaian: satu lomba dua kriteria, satu blangko,
satu kolom foto. Di lapangan bukan begitu — keduanya lomba tersendiri,
masing-masing punya lembar jawaban yang diisi **peserta**, bentuknya sama
dengan Tebak Simpul.

## Notes

**`lomba` dikosongkan, dan tiga hal ikut terpisah tanpa satu baris kode pun:**
blangkonya jadi dua master, kolom fotonya jadi dua, dan Live Score menyebut dua
nama sesuai yang diumumkan (CLAUDE.md 11.8: dibaca `coalesce(lomba, name)`).

**Poin tidak berubah.** `lomba` pengelompokan tampilan; yang menghitung skor
`poin_maks` dan `form`, dan keduanya tidak disentuh. Klasemen sesudah migrasi
sama persis dengan sebelumnya.

**Kunci fotonya ikut berpindah, dan itu disengaja.** `kode_lomba` dibekukan
`0079` supaya mengganti **nama** lomba tidak memutus foto — sedangkan yang
terjadi di sini **pemisahan**: satu kunci tidak bisa lagi menunjuk dua lomba.
Migrasinya melaporkan berapa foto yang masih berkunci `kim`; berkasnya masih
ada di bucket dan kuncinya bisa dipindahkan tangan kalau perlu.

**Tiga lomba kini memakai bentuk lembar bernomor yang sama** — Tebak Simpul,
KIM Lihat, KIM Cium — lewat satu fungsi, bukan tiga salinan. Tiga salinan
berarti perbaikan berikutnya harus diketik tiga kali dan dua di antaranya akan
terlewat.

Diukur di browser pada kotak seukuran **isi** A5 melintang (198 × 136 mm):

| lembar | kolom | garis pemisah | sisa di kaki | terpotong |
|---|---|---|---|---|
| Pembidaian | 5 × 39,5 mm | ada | 5,0 mm | 0 |
| KIM Lihat | — | — | 4,7 mm | 0 |
| PBB | 4 × 49,4 mm | ada | 12,9 mm | 0 |
| Yel-Yel | 4 × 49,4 mm | ada | 12,9 mm | 0 |

Kotak tulis di lembar berkolom sedikit lebih rendah (26 mm): judul kriteria
yang panjang membungkus jadi dua baris — "Diagnosis dan Penanganan Awal" salah
satunya — dan tinggi itulah yang dipinjam. Pembidaian sisa 1 mm sebelum, 5 mm
sesudah.

Tes 48 menjaga pemisahan KIM: keduanya berdiri sendiri, **kunci fotonya
berbeda** (kunci yang sama berarti dua lomba berbagi satu tumpukan foto — persis
keadaan yang dipisahkan), dan keduanya masih berupa lomba yang bisa dinilai.

⚠️ Perlu `apply-migration.yml` sesudah merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)