### PR TITLE
fix: menu bawah tidak lagi ikut tercetak dan menimpa kaki halaman

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -842,7 +842,20 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      huruf yang lebih rapat membuat serbuk toner menutup celah antar huruf —
      persis kegagalan yang dilarang CLAUDE.md 8.6. */
   body, .isian, .kolom-petunjuk { letter-spacing: normal; }
-  .header, .isi, .notification, .overlay { display: none !important; }
+  /* `.bottom-nav` WAJIB ikut, dan ketinggalannya merusak SETIAP cetakan dari
+     HP — bukan cuma blangko.
+
+     Ia `position: fixed; bottom: 0` di bawah 560px, dan `position: fixed` di
+     media cetak berarti ia digambar ulang DI TIAP HALAMAN, menimpa sekitar
+     20mm terbawah. Yang tertimpa di blangko justru tanda tangan juri; di
+     daftar kloter, baris regu terakhir. Tidak ada galat, tidak ada tanda —
+     yang terlihat cuma kertas yang "terpotong", dan yang mencetaknya
+     menyimpulkan tata letaknya yang salah.
+
+     Bukan cuma disembunyikan lewat `hidden`: layar yang sedang menampilkan
+     menu itu tetap menampilkannya saat dialog cetak terbuka. */
+  .header, .isi, .notification, .overlay,
+  .bottom-nav { display: none !important; }
   .printout {
     display: block !important;
     font-size: 12pt;

--- a/web/style.css
+++ b/web/style.css
@@ -842,7 +842,20 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      huruf yang lebih rapat membuat serbuk toner menutup celah antar huruf —
      persis kegagalan yang dilarang CLAUDE.md 8.6. */
   body, .isian, .kolom-petunjuk { letter-spacing: normal; }
-  .header, .isi, .notification, .overlay { display: none !important; }
+  /* `.bottom-nav` WAJIB ikut, dan ketinggalannya merusak SETIAP cetakan dari
+     HP — bukan cuma blangko.
+
+     Ia `position: fixed; bottom: 0` di bawah 560px, dan `position: fixed` di
+     media cetak berarti ia digambar ulang DI TIAP HALAMAN, menimpa sekitar
+     20mm terbawah. Yang tertimpa di blangko justru tanda tangan juri; di
+     daftar kloter, baris regu terakhir. Tidak ada galat, tidak ada tanda —
+     yang terlihat cuma kertas yang "terpotong", dan yang mencetaknya
+     menyimpulkan tata letaknya yang salah.
+
+     Bukan cuma disembunyikan lewat `hidden`: layar yang sedang menampilkan
+     menu itu tetap menampilkannya saat dialog cetak terbuka. */
+  .header, .isi, .notification, .overlay,
+  .bottom-nav { display: none !important; }
   .printout {
     display: block !important;
     font-size: 12pt;


### PR DESCRIPTION
## What

`.bottom-nav` ikut disembunyikan saat mencetak.

## Why

Menu **Home / Setelan / Akun / Keluar** tergambar **di dalam** hasil cetak dari
HP — terlihat jelas di pratinjau cetak, menutupi bagian bawah lembar. Yang
tertimpa di blangko justru **tanda tangan juri**; di daftar kloter, baris regu
terakhir.

`@media print` menyembunyikan `.header`, `.isi`, `.notification`, dan
`.overlay` — tapi **tidak** `.bottom-nav`. Menu itu `position: fixed; bottom: 0`
di bawah 560px, dan `position: fixed` di media cetak berarti ia digambar ulang
**di tiap halaman**.

**Tidak ada galat, tidak ada tanda.** Yang terlihat cuma kertas yang
"terpotong", dan yang mencetaknya menyimpulkan tata letaknya yang salah — dua
putaran merapikan blangko dihabiskan untuk mengejar sisa ruang yang sebenarnya
ditempati menu.

## Notes

Mengenai **setiap** cetakan dari HP, bukan cuma blangko: daftar kloter, lembar
pos, daftar sisipan, kwitansi. Baru terlihat sekarang karena tombol cetak
memang baru dibuka untuk koordinator pos dan admin di HP (#389).

Diperiksa dengan aturan `@media print` yang benar-benar berlaku (disalin lalu
`@media print` diganti `@media screen`, halaman berisi kepala + isi + menu +
printout):

```
bottomNav: "none"      navTergambar: false
header:    "none"      isi:          "none"
printout:  "block"
```

Tidak ada perubahan database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)