### PR TITLE
fix: skip departed kloter during automatic assignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,22 +355,22 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 
 ## 12. Kloter
 
-1. **Kloter tidak pernah tertutup untuk penambahan regu.** Bukan tanda
-   cetaknya, bukan juga jam berangkatnya — tidak ada keadaan yang membuat
-   sebuah kloter menolak regu baru. Yang membatasi cuma kapasitas. Mencetak
+1. **Tanda cetak tidak pernah menutup kloter untuk penambahan regu.** Mencetak
    ulang selembar daftar itu murah; memberangkatkan kloter dengan empat tempat
-   kosong tidak bisa diulang, dan jendela 07:00-10:00 di bagian 10 tidak punya
-   kelonggaran untuk itu.
-2. **Selalu isi kloter paling awal dulu sampai penuh**, bukan menyebar rata.
-   Kloter 1 penuh sebelum kloter 2 dipakai. Yang berangkat pagi harus berangkat
-   penuh; tempat kosong yang tertinggal di kloter awal berarti kloter terakhir
-   berangkat lebih siang dari yang perlu, dan jendela 07:00–10:00 di bagian 10
-   tidak punya kelonggaran untuk itu.
-3. **Di lapangan semua dinamis, dan itu yang membuat butir 1 sekeras itu.**
-   Peserta yang terlambat bisa memaksa berangkat, dan panitia menambahkannya di
-   depan — "mereka seakan-akan berangkat di jam tersebut". Sistem yang menolak
-   tidak menghentikan penambahan itu; ia cuma memindahkannya ke jalan yang
-   tidak tercatat.
+   kosong tidak bisa diulang. Jam berangkat punya arti berbeda: pengacakan
+   otomatis `daftar_ulang_batch` HARUS melewati kloter yang sudah berangkat,
+   tetapi penyisipan manual ke sana tetap boleh bila memang itu yang terjadi
+   di lapangan. Kapasitas tetap membatasi kedua jalur.
+2. **Pengacakan otomatis selalu mengisi kloter paling awal yang BELUM
+   BERANGKAT dulu sampai penuh**, bukan menyebar rata dan bukan kembali ke slot
+   kosong di kloter lama. Kalau kloter 1-10 sudah jalan, peserta yang baru
+   menerima nomor dada mulai dari kloter 11. Sebelum lomba dimulai, akibatnya
+   tetap sama seperti aturan lama: kloter 1 penuh sebelum kloter 2 dipakai.
+3. **Di lapangan semua dinamis, jadi penyisipan manual tetap diperlukan.**
+   Peserta yang terlambat bisa memaksa berangkat, dan panitia dapat
+   menambahkannya ke kloter lama — "mereka seakan-akan berangkat di jam
+   tersebut". Itu keputusan petugas, bukan keputusan yang boleh dibuat diam-
+   diam oleh pengacakan otomatis saat nomor dada diberikan.
 
    Konsekuensi yang perlu diketahui panitia yang menyisipkan: penalti waktu
    dihitung dari `kloter.jam_berangkat`, jadi regu yang masuk ke kloter yang
@@ -378,12 +378,13 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    benar-benar jalan. Kalau maksudnya regu itu berangkat sekarang, tempatnya di
    kloter yang belum jalan.
 
-   Riwayatnya, karena mudah dipasang kembali: migrasi 0008 menambahkan
-   `dicetak_pada is null` ke pemilihan kloter beserta trigger
-   `jaga_kloter_tercetak`; 0040 mengembalikannya setelah sempat hilang;
-   **0066 membuang keduanya beserta `jam_berangkat is null`**. Ketiganya
-   ditulis dengan niat melindungi kertas yang sudah dibagikan — niat yang
-   masuk akal di meja, dan salah di lapangan. Jangan dipasang lagi.
+   Riwayatnya, karena mudah tertukar: migrasi 0008 menambahkan
+   `dicetak_pada is null` dan `jam_berangkat is null` ke pemilihan kloter
+   beserta trigger `jaga_kloter_tercetak`; 0040 mengembalikannya setelah sempat
+   hilang; 0066 membuang seluruhnya supaya sisipan lapangan tidak ditolak;
+   **0088 mengembalikan HANYA `jam_berangkat is null` di empat putaran
+   pengacakan `daftar_ulang_batch`**. Jangan kembalikan pagar tanda cetak atau
+   trigger lamanya, dan jangan membuang lagi pagar jam dari pengacakan.
 4. **"Bersihkan data" termasuk mengembalikan penomoran kloter ke 1**, bukan
    hanya menghapus regu dan nilai. Kloter yang masih menyandang tanda cetak atau
    jam berangkat dari percobaan sebelumnya membuat pembagian berikutnya mulai

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,22 +353,22 @@ Guidance for Claude Code when working in this repository.
 
 ## 12. Kloter
 
-1. **Kloter tidak pernah tertutup untuk penambahan regu.** Bukan tanda
-   cetaknya, bukan juga jam berangkatnya — tidak ada keadaan yang membuat
-   sebuah kloter menolak regu baru. Yang membatasi cuma kapasitas. Mencetak
+1. **Tanda cetak tidak pernah menutup kloter untuk penambahan regu.** Mencetak
    ulang selembar daftar itu murah; memberangkatkan kloter dengan empat tempat
-   kosong tidak bisa diulang, dan jendela 07:00-10:00 di bagian 10 tidak punya
-   kelonggaran untuk itu.
-2. **Selalu isi kloter paling awal dulu sampai penuh**, bukan menyebar rata.
-   Kloter 1 penuh sebelum kloter 2 dipakai. Yang berangkat pagi harus berangkat
-   penuh; tempat kosong yang tertinggal di kloter awal berarti kloter terakhir
-   berangkat lebih siang dari yang perlu, dan jendela 07:00–10:00 di bagian 10
-   tidak punya kelonggaran untuk itu.
-3. **Di lapangan semua dinamis, dan itu yang membuat butir 1 sekeras itu.**
-   Peserta yang terlambat bisa memaksa berangkat, dan panitia menambahkannya di
-   depan — "mereka seakan-akan berangkat di jam tersebut". Sistem yang menolak
-   tidak menghentikan penambahan itu; ia cuma memindahkannya ke jalan yang
-   tidak tercatat.
+   kosong tidak bisa diulang. Jam berangkat punya arti berbeda: pengacakan
+   otomatis `daftar_ulang_batch` HARUS melewati kloter yang sudah berangkat,
+   tetapi penyisipan manual ke sana tetap boleh bila memang itu yang terjadi
+   di lapangan. Kapasitas tetap membatasi kedua jalur.
+2. **Pengacakan otomatis selalu mengisi kloter paling awal yang BELUM
+   BERANGKAT dulu sampai penuh**, bukan menyebar rata dan bukan kembali ke slot
+   kosong di kloter lama. Kalau kloter 1-10 sudah jalan, peserta yang baru
+   menerima nomor dada mulai dari kloter 11. Sebelum lomba dimulai, akibatnya
+   tetap sama seperti aturan lama: kloter 1 penuh sebelum kloter 2 dipakai.
+3. **Di lapangan semua dinamis, jadi penyisipan manual tetap diperlukan.**
+   Peserta yang terlambat bisa memaksa berangkat, dan panitia dapat
+   menambahkannya ke kloter lama — "mereka seakan-akan berangkat di jam
+   tersebut". Itu keputusan petugas, bukan keputusan yang boleh dibuat diam-
+   diam oleh pengacakan otomatis saat nomor dada diberikan.
 
    Konsekuensi yang perlu diketahui panitia yang menyisipkan: penalti waktu
    dihitung dari `kloter.jam_berangkat`, jadi regu yang masuk ke kloter yang
@@ -376,12 +376,13 @@ Guidance for Claude Code when working in this repository.
    benar-benar jalan. Kalau maksudnya regu itu berangkat sekarang, tempatnya di
    kloter yang belum jalan.
 
-   Riwayatnya, karena mudah dipasang kembali: migrasi 0008 menambahkan
-   `dicetak_pada is null` ke pemilihan kloter beserta trigger
-   `jaga_kloter_tercetak`; 0040 mengembalikannya setelah sempat hilang;
-   **0066 membuang keduanya beserta `jam_berangkat is null`**. Ketiganya
-   ditulis dengan niat melindungi kertas yang sudah dibagikan — niat yang
-   masuk akal di meja, dan salah di lapangan. Jangan dipasang lagi.
+   Riwayatnya, karena mudah tertukar: migrasi 0008 menambahkan
+   `dicetak_pada is null` dan `jam_berangkat is null` ke pemilihan kloter
+   beserta trigger `jaga_kloter_tercetak`; 0040 mengembalikannya setelah sempat
+   hilang; 0066 membuang seluruhnya supaya sisipan lapangan tidak ditolak;
+   **0088 mengembalikan HANYA `jam_berangkat is null` di empat putaran
+   pengacakan `daftar_ulang_batch`**. Jangan kembalikan pagar tanda cetak atau
+   trigger lamanya, dan jangan membuang lagi pagar jam dari pengacakan.
 4. **"Bersihkan data" termasuk mengembalikan penomoran kloter ke 1**, bukan
    hanya menghapus regu dan nilai. Kloter yang masih menyandang tanda cetak atau
    jam berangkat dari percobaan sebelumnya membuat pembagian berikutnya mulai

--- a/supabase/migrations/0088_daftar_ulang_lewati_kloter_berangkat.sql
+++ b/supabase/migrations/0088_daftar_ulang_lewati_kloter_berangkat.sql
@@ -1,0 +1,252 @@
+-- ============================================================================
+-- hrcd-rekap : 0088_daftar_ulang_lewati_kloter_berangkat.sql
+-- Pengacakan daftar ulang hanya memilih kloter yang belum berangkat.
+--
+-- Peserta yang baru menerima nomor dada setelah lomba dimulai harus masuk ke
+-- kloter paling awal yang masih layak DAN belum berangkat. Sebelumnya 0066
+-- membuang penyaring jam_berangkat bersama penyaring dicetak_pada, sehingga
+-- slot kosong di kloter lama dipilih lebih dahulu walaupun kloternya sudah
+-- jalan. Di produksi, nomor dada 169 karena itu masuk kloter 3 alih-alih
+-- kloter 11 yang belum berangkat.
+--
+-- Perubahan ini hanya berlaku pada daftar_ulang_batch, yaitu pengacakan
+-- otomatis saat nomor dada diberikan. Kloter yang sudah dicetak tetap boleh
+-- dipilih dan jalur sisipan manual tidak ditutup: petugas masih dapat memakai
+-- pindah_kloter ketika memang bermaksud mencatat regu seakan-akan berangkat
+-- bersama kloter lama.
+-- ============================================================================
+
+create or replace function daftar_ulang_batch(
+  p_kode  text,
+  -- [{"regu_id": "...", "nomor_dada": 12}, ...] — satu entri per regu yang
+  -- belum bernomor di batch ini, tidak boleh kurang dan tidak boleh lebih.
+  p_nomor jsonb
+)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch      pendaftaran%rowtype;
+  v_berhak     uuid[];
+  v_regu       uuid[];
+  v_nomor      integer[];
+  v_n          int;
+  v_cfg        edisi%rowtype;
+  v_terpakai   int[];      -- kloter yang sudah berisi sekolah ini
+  v_kandidat   int;
+  v_mulai      int;
+  v_i          int;
+  v_langkah    int;
+  v_salah      text;
+begin
+  if not boleh('daftar_ulang') then
+    raise exception 'tidak berhak: daftar_ulang';
+  end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  -- Regu yang berhak: belum bernomor, tidak batal (rancangan-b.md, temuan 11).
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.is_cancelled and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  -- Pasangan regu -> nomor dari meja. Urutan deterministik (nama regu) supaya
+  -- hasil yang dibacakan meja urut sama dengan kartu di layar.
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+         as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) as t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) as t(g) where not (t.g = any (v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+
+  if exists (select 1 from unnest(v_nomor) as t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct t.nomor) from unnest(v_nomor) as t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  -- Kunci baris stok yang diminta, urut nomor supaya dua meja yang meminta
+  -- himpunan bertumpang tindih tidak saling mengunci silang. Meja kedua
+  -- menunggu sebentar lalu ditolak pemeriksaan "sudah dipakai" di bawah,
+  -- dengan pesan yang bisa dibaca petugas — bukan galat unique mentah.
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any (v_nomor)
+  order by s.nomor
+  for update;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+
+  select string_agg(distinct t.nomor::text, ', ' order by t.nomor::text) into v_salah
+  from unnest(v_nomor) as t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- Serialisasi bagian penempatan kloter (2-3 meja — advisory lock sederhana
+  -- lebih terbaca daripada retry unique-violation; lepas otomatis di akhir tx).
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  -- Kloter yang sudah berisi regu sekolah yang sama (batch mana pun).
+  select coalesce(array_agg(distinct r.kloter_nomor), '{}') into v_terpakai
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.sekolah_id = v_batch.sekolah_id and r.kloter_nomor is not null;
+
+  -- Sebar N regu: mulai dari kloter termuda yang layak, melompat
+  -- lompatan_kloter (alur 5.6); kloter 31.. dibuka hanya bila 1..30 tidak
+  -- menyediakan slot layak (alur 5.2). "Layak" = belum penuh + belum berisi
+  -- sekolah ini; bila tak terhindarkan, syarat sekolah dilonggarkan (alur 5.4
+  -- "sesedikit mungkin", bukan "tidak boleh").
+  v_mulai := null;
+  for v_i in 1..v_n loop
+    v_kandidat := null;
+
+    -- Putaran 1: hormati lompatan + hindari sekolah sama, dalam
+    -- 1..kloter_dasar. Tanda cetak tidak ikut menyaring, tetapi kloter yang
+    -- sudah berangkat tidak boleh dipilih oleh pengacakan otomatis (0088).
+    if v_mulai is null then
+      v_langkah := 1;  -- pencarian pertama: kloter layak termuda
+    else
+      v_langkah := v_cfg.lompatan_kloter;
+    end if;
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.jam_berangkat is null
+      and k.nomor <= v_cfg.kloter_dasar
+      and (v_mulai is null or k.nomor >= v_mulai + v_langkah)
+      and not (k.nomor = any (v_terpakai))
+      and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+          < v_cfg.maks_regu_per_kloter
+    order by k.nomor
+    limit 1;
+
+    -- Putaran 2: masih hindari sekolah sama tapi abaikan lompatan (wrap).
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.jam_berangkat is null
+        and k.nomor <= v_cfg.kloter_dasar
+        and not (k.nomor = any (v_terpakai))
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 3: 1..kloter_dasar masih ada tempat tapi semuanya berisi
+    -- sekolah ini — sekolah sama boleh berkumpul DULU sebelum membuka
+    -- kloter cadangan (alur 5.2: 31-40 hanya bila 1-30 penuh; alur 5.4:
+    -- "sesedikit mungkin", bukan larangan mutlak). Pilih yang paling kosong.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.jam_berangkat is null
+        and k.nomor <= v_cfg.kloter_dasar
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (select count(*) from regu r where r.kloter_nomor = k.nomor), k.nomor
+      limit 1;
+    end if;
+
+    -- Putaran 4: kloter dasar benar-benar penuh — buka cadangan
+    -- (31..kloter_maks), hindari sekolah sama dulu lalu bebas.
+    if v_kandidat is null then
+      select k.nomor into v_kandidat
+      from kloter k
+      where k.jam_berangkat is null
+        and k.nomor between v_cfg.kloter_dasar + 1 and v_cfg.kloter_maks
+        and (select count(*) from regu r where r.kloter_nomor = k.nomor)
+            < v_cfg.maks_regu_per_kloter
+      order by (k.nomor = any (v_terpakai)),   -- false (bebas sekolah) dulu
+               (select count(*) from regu r where r.kloter_nomor = k.nomor),
+               k.nomor
+      limit 1;
+    end if;
+
+    if v_kandidat is null then
+      raise exception 'semua kloter yang belum berangkat penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu r set
+      nomor_dada    = v_nomor[v_i],
+      kloter_nomor  = v_kandidat,
+      -- Slot terkecil yang kosong, bukan count+1: lubang bekas koreksi admin
+      -- tidak boleh membuat slot palsu di atas 10 (temuan review).
+      urutan_kloter = (select min(s) from generate_series(1, v_cfg.maks_regu_per_kloter) s
+                       where not exists (select 1 from regu x
+                                         where x.kloter_nomor = v_kandidat
+                                           and x.urutan_kloter = s))
+    where r.id = v_regu[v_i];
+
+    v_terpakai := v_terpakai || v_kandidat;
+    v_mulai := v_kandidat;
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r
+  where r.id = any (v_regu)
+  order by r.nomor_dada;
+end;
+$$;
+
+-- Pastikan keempat putaran pemilihan membawa pagar yang sama. Pemeriksaan ini
+-- sengaja menghitung sumber fungsi: satu putaran yang lupa dipagari baru akan
+-- terlihat saat susunan sekolah/kapasitas tertentu memaksanya dipakai.
+do $blok$
+declare v_n int;
+begin
+  select count(*) into v_n
+  from regexp_matches(
+    (select p.prosrc
+       from pg_proc p
+       join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'public'
+        and p.proname = 'daftar_ulang_batch'
+        and pg_get_function_identity_arguments(p.oid) = 'p_kode text, p_nomor jsonb'),
+    'jam_berangkat is null',
+    'g'
+  );
+
+  assert v_n = 4,
+         format('empat putaran pemilihan kloter harus menyaring jam_berangkat; ditemukan %s', v_n);
+  raise notice '0088: daftar ulang otomatis melewati kloter yang sudah berangkat.';
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -352,5 +352,10 @@ run tests/sql/47_menaksir_dari_taksiran.sql
 # bergeser.
 run supabase/migrations/0087_kim_dua_lomba.sql
 run tests/sql/48_kim_dua_lomba.sql
+# 0088 mencegah pengacakan nomor dada terlambat mengisi slot kosong di kloter
+# yang sudah berangkat. Kloter tercetak tetap boleh dipilih; tes 49 membuat
+# persis keadaan produksi: kloter 1-10 sudah jalan dan kloter 11 masih menunggu.
+run supabase/migrations/0088_daftar_ulang_lewati_kloter_berangkat.sql
+run tests/sql/49_daftar_ulang_lewati_kloter_berangkat.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/49_daftar_ulang_lewati_kloter_berangkat.sql
+++ b/tests/sql/49_daftar_ulang_lewati_kloter_berangkat.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/49_daftar_ulang_lewati_kloter_berangkat.sql
+-- Peserta terlambat tidak boleh diacak ke kloter yang sudah berangkat (0088).
+--
+-- Bentuk kasusnya mengikuti kejadian produksi: kloter 1-10 sudah jalan,
+-- peserta baru menerima nomor dada, dan kloter 11 masih menunggu. Kloter 11
+-- sengaja ditandai sudah dicetak untuk menjaga batas aturan: yang dilewati
+-- hanya kloter BERANGKAT, bukan kloter yang kertasnya sudah beredar.
+-- ============================================================================
+
+do $blok$
+declare
+  v_sekolah uuid;
+  v_daftar  uuid;
+  v_regu    uuid;
+  v_nomor   int;
+  v_kloter  smallint;
+  v_maks    int;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  select maks_regu_per_kloter into v_maks from edisi where is_active;
+  assert (select count(*) from regu where kloter_nomor = 11) < v_maks,
+         'fixture memenuhi kloter 11; tes tidak dapat membangun kasus produksi';
+
+  update kloter
+     set jam_berangkat = case
+       when nomor <= 10 then timestamptz '2026-08-29 07:00+07' + nomor * interval '5 minutes'
+       else null
+     end,
+         dicetak_pada = case when nomor = 11 then now() else dicetak_pada end
+   where nomor <= 11;
+
+  insert into sekolah (name, address)
+  values ('SMP Uji Peserta Terlambat', 'Ciamis')
+  returning id into v_sekolah;
+
+  insert into pendaftaran
+    (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa, status)
+  values
+    (v_sekolah, 'UJI-TERLAMBAT-KLOTER', 1, '081200000000', 'lunas')
+  returning id into v_daftar;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_daftar, 'Uji Elang Terlambat', 'Ketua Uji', 'penggalang_pa')
+  returning id into v_regu;
+
+  select min(s.nomor) into v_nomor
+    from nomor_dada_stok s
+   where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+     and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+
+  select hasil.kloter into v_kloter
+    from daftar_ulang_batch(
+      'UJI-TERLAMBAT-KLOTER',
+      jsonb_build_array(jsonb_build_object('regu_id', v_regu, 'nomor_dada', v_nomor))
+    ) hasil;
+
+  assert v_kloter = 11,
+         format('peserta terlambat seharusnya masuk kloter 11, bukan kloter %s', v_kloter);
+  assert (select dicetak_pada is not null from kloter where nomor = 11),
+         'tes tidak membuktikan kloter tercetak tetap boleh dipilih';
+
+  raise notice '49: peserta baru masuk kloter 11; kloter 1-10 yang sudah berangkat dilewati.';
+end $blok$;
+
+\echo '49 daftar ulang lewati kloter berangkat: LULUS'


### PR DESCRIPTION
## What

- Filter all four automatic kloter-selection passes by jam_berangkat is null.
- Keep printed kloter eligible and preserve the separate manual insertion path.
- Add a regression test for kloter 1-10 departed and kloter 11 waiting.
- Update the synchronized maintainer guidance.

## Why

Late registrations could be assigned to an early kloter with spare capacity even after that kloter had departed. They must instead enter the earliest eligible kloter that has not departed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)