### PR TITLE
fix: score time accuracy per minute

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,12 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    golongan — that is what `kolomPos()` merges by name. Grouping by lomba is a
    third thing on top, and doing both with one mechanism is how Tebak Simpul
    ends up as four columns again.
+10. **Penalti waktu menilai KETEPATAN, bukan kecepatan.** Target kedatangan =
+    `kloter.jam_berangkat + regu.kontrak_menit`: berangkat 07:00 dengan
+    kontrak 4 jam berarti harus tiba tepat 11:00. Setiap satu menit terlalu
+    cepat maupun terlambat mengurangi satu poin; keduanya simetris. Sejak 0089
+    konfigurasinya `blok_menit=1` dan `penalti_per_blok=1` — jangan hidupkan
+    kembali toleransi 0–9 menit dari aturan lama.
 
 ## 12. Kloter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,6 +350,12 @@ Guidance for Claude Code when working in this repository.
    golongan — that is what `kolomPos()` merges by name. Grouping by lomba is a
    third thing on top, and doing both with one mechanism is how Tebak Simpul
    ends up as four columns again.
+10. **Penalti waktu menilai KETEPATAN, bukan kecepatan.** Target kedatangan =
+    `kloter.jam_berangkat + regu.kontrak_menit`: berangkat 07:00 dengan
+    kontrak 4 jam berarti harus tiba tepat 11:00. Setiap satu menit terlalu
+    cepat maupun terlambat mengurangi satu poin; keduanya simetris. Sejak 0089
+    konfigurasinya `blok_menit=1` dan `penalti_per_blok=1` — jangan hidupkan
+    kembali toleransi 0–9 menit dari aturan lama.
 
 ## 12. Kloter
 

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -713,10 +713,9 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    > mengubah kode, cukup mengubah angkanya.
 3. Total skor = **jumlah skor seluruh pos − seluruh penalti** (bagian 10).
 4. **Penentu peringkat saat skor seri: ketepatan waktu.** Regu dengan selisih
-   waktu lebih kecil terhadap targetnya menempati peringkat lebih tinggi. Ini
-   bekerja karena penalti waktu dibulatkan per 10 menit, sedangkan selisih
-   sebenarnya tercatat sampai satuan menit — dua regu berpenalti −10 tetap
-   dapat dibedakan antara yang meleset 11 menit dan yang meleset 18 menit.
+   waktu lebih kecil terhadap targetnya menempati peringkat lebih tinggi.
+   Selisih sebenarnya tetap dicatat bertanda sampai satuan menit supaya layar
+   dapat menjelaskan apakah regu datang terlalu cepat atau terlambat.
 5. Peringkat dihitung **terpisah untuk keempat golongan** (bagian 2.3).
 6. Yang wajib dapat dikonfigurasi ulang setiap tahun:
    - Daftar pos dan bobotnya
@@ -737,10 +736,9 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    - **Jam datang diisi tombol**: panitia mengetik nomor dada, detail regu
      muncul untuk dipastikan, lalu menekan satu tombol "Sampai di Finish".
      Di meja finish juga ada penulisan manual di kertas, **tetapi hanya untuk
-     verifikasi** — tombol laptop tetap pencatat utamanya. Selisih semenit dua
-     menit antara kertas dan tombol adalah hal wajar (menekan tombol bisa
-     terlambat sedikit) dan hampir tidak pernah mengubah penalti, karena
-     penalti dibulatkan per 10 menit.
+     verifikasi** — tombol laptop tetap pencatat utamanya. Karena satu menit
+     selisih berarti satu poin, tombol harus ditekan segera ketika regu tiba;
+     catatan kertas dipakai untuk membetulkan keterlambatan pencatatan.
      Targetnya ±3 detik per regu, sehingga 20 regu yang datang bersamaan pun
      tidak menumpuk. Jam yang tersimpan adalah **jam saat tombol ditekan di
      laptop panitia**, bukan timestamp server saat data sampai — dan tetap
@@ -748,20 +746,20 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 3. Penalti dihitung dari selisih mutlak antara jam datang dan target:
 
    ```
-   penalti = floor(|selisih dalam menit| / 10) * 10
+   penalti = floor(|selisih dalam menit| / 1) * 1
    ```
 
 4. Penalti bersifat **simetris**. Datang terlalu cepat dihukum sama beratnya
    dengan datang terlambat.
-5. Tidak ada aturan toleransi tersendiri. Selisih 0–9 menit tidak dikenai
-   penalti semata-mata sebagai akibat pembulatan ke bawah pada rumus di atas.
+5. Tidak ada toleransi menit. Setiap satu menit terlalu cepat maupun terlambat
+   mengurangi satu poin.
 
    | Selisih dari target | Penalti |
    | --- | --- |
-   | 0–9 menit | 0 |
-   | 10–19 menit | −10 |
-   | 20–29 menit | −20 |
-   | 30–39 menit | −30 |
+   | 0 menit (tepat target) | 0 |
+   | 1 menit terlalu cepat/lambat | −1 |
+   | 10 menit terlalu cepat/lambat | −10 |
+   | 30 menit terlalu cepat/lambat | −30 |
 
 6. Tidak ada batas bawah. Total skor boleh menjadi negatif.
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -87,7 +87,7 @@ penyelesaiannya dicatat di bagian 11.
 | `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
 | `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis`): bentuk konversi + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
 | `kontrak_opsi` | Pilihan kontrak waktu | `('3,5 jam',210), ('4 jam',240), ('4,5 jam',270)` |
-| `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=10, penalti_per_blok=10, penalti_tanpa_checkout=100, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
+| `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=1, penalti_per_blok=1, penalti_tanpa_checkout=100, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
 
 1. `wahana.kode` dibatasi `CHECK` huruf-kecil/angka/underscore — kode ini
    dipakai sebagai **header kolom lembar cetak sekaligus header import**,
@@ -259,7 +259,7 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
    4. `v_penalti_waktu` — `target = jam_berangkat kloter + kontrak`;
       `selisih_menit` bertanda, presisi menit;
       `penalti = floor(|selisih|/blok_menit) × penalti_per_blok` — simetris;
-      toleransi 0–9 menit **lahir dari floor**, bukan aturan tersendiri.
+      konfigurasi sekarang `1 menit → 1 poin`, jadi tidak ada toleransi menit.
    5. `v_total_skor` — Σ pos − penalti waktu − `penalti_tanpa_checkout` (bila
       tidak ada baris closing; penalti waktu saat itu 0 karena tak
       terhitung) − `(5 − anggota_hadir) × penalti_per_anggota_hilang`.
@@ -474,13 +474,12 @@ sengaja **tidak** disejajarkan dengan tombol: keduanya dipakai saat
 memperbaiki hasil cek silang, bukan pada tiap regu. Menaikkannya ke jalur
 utama akan merusak target dua-aksi.
 
-**Selisih semenit dua menit antara kertas dan tombol itu wajar** — menekan
-tombol bisa terlambat sedikit. Yang perlu diketahui panitia bukan "beda berapa
-menit", melainkan **apakah bedanya mengubah penalti**; karena penalti
-dibulatkan per 10 menit, biasanya tidak. Layar finish menjawab itu langsung:
-mengisi kolom jam memunculkan lencana **hijau** ("1 menit lebih awal — penalti
-tetap −10") atau **kuning** ("15 menit lebih awal — penalti berubah −10 → 0").
-Hanya yang kuning yang perlu diperdebatkan.
+**Selisih semenit dua menit antara kertas dan tombol tetap mungkin terjadi** —
+menekan tombol bisa terlambat sedikit — tetapi sekarang setiap menit mengubah
+penalti. Tombol karena itu ditekan segera ketika regu tiba. Bila cek silang
+menunjukkan pencatatannya terlambat, kolom jam dipakai untuk menyalin waktu
+yang benar dari kertas; lencana dampaknya memperlihatkan perubahan poin sebelum
+disimpan.
 
 Karena itu layar keberangkatan harus enak dipakai untuk **menyalin** dari
 kertas — jam wajib bisa diketik, dan urutan di layar mengikuti urutan di

--- a/supabase/migrations/0089_penalti_waktu_per_menit.sql
+++ b/supabase/migrations/0089_penalti_waktu_per_menit.sql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- hrcd-rekap : 0089_penalti_waktu_per_menit.sql
+-- Ketepatan waktu: setiap satu menit dari target mengurangi satu poin.
+--
+-- Target tetap dihitung oleh v_penalti_waktu sebagai:
+--
+--   jam_berangkat kloter + kontrak_menit
+--
+-- Jadi kloter yang berangkat 07:00 dengan kontrak 4 jam harus tiba 11:00.
+-- Datang 10:59 maupun 11:01 sama-sama meleset satu menit dan sama-sama kena
+-- satu poin. Arah selisih tetap disimpan di selisih_menit untuk menjelaskan
+-- terlalu cepat atau terlambat; penalti memakai nilai absolutnya.
+--
+-- View dan preview closing sudah membaca blok_menit serta penalti_per_blok
+-- dari satu baris konfig_penalti. Karena itu tidak ada rumus kedua yang perlu
+-- ditulis ulang: mengubah kedua angka ini langsung mengubah database dan UI.
+-- Default kolom ikut diubah supaya edisi baru tidak diam-diam kembali memakai
+-- aturan lama 10 menit -> 10 poin saat baris konfigurasinya dibuat.
+-- ============================================================================
+
+alter table konfig_penalti
+  alter column blok_menit set default 1,
+  alter column penalti_per_blok set default 1;
+
+update konfig_penalti
+set blok_menit = 1,
+    penalti_per_blok = 1
+where edisi = edisi_aktif()
+  and (blok_menit, penalti_per_blok) is distinct from (1, 1);
+
+do $blok$
+declare
+  v_edisi       smallint;
+  v_blok        smallint;
+  v_penalti     numeric;
+  v_default_blok text;
+  v_default_poin text;
+begin
+  select edisi, blok_menit, penalti_per_blok
+    into v_edisi, v_blok, v_penalti
+  from konfig_penalti
+  where edisi = edisi_aktif();
+
+  if not found then
+    raise notice '0089: edisi aktif belum punya konfig_penalti — data dilewati, default baru tetap terpasang.';
+    return;
+  end if;
+
+  assert v_blok = 1 and v_penalti = 1,
+         format('0089: edisi %s masih memakai blok %s menit -> %s poin',
+                v_edisi, v_blok, v_penalti);
+
+  select column_default into v_default_blok
+  from information_schema.columns
+  where table_schema = 'public' and table_name = 'konfig_penalti'
+    and column_name = 'blok_menit';
+
+  select column_default into v_default_poin
+  from information_schema.columns
+  where table_schema = 'public' and table_name = 'konfig_penalti'
+    and column_name = 'penalti_per_blok';
+
+  assert v_default_blok = '1' and v_default_poin = '1'::numeric::text,
+         format('0089: default belum 1 menit -> 1 poin (%s, %s)',
+                v_default_blok, v_default_poin);
+
+  raise notice '0089: edisi % — setiap 1 menit terlalu cepat/lambat = -1 poin.',
+               v_edisi;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -357,5 +357,10 @@ run tests/sql/48_kim_dua_lomba.sql
 # persis keadaan produksi: kloter 1-10 sudah jalan dan kloter 11 masih menunggu.
 run supabase/migrations/0088_daftar_ulang_lewati_kloter_berangkat.sql
 run tests/sql/49_daftar_ulang_lewati_kloter_berangkat.sql
+# 0089 mengganti blok lama 10 menit -> 10 poin menjadi setiap satu menit
+# selisih mutlak -> satu poin. Tes 50 menekan target tepat serta kedua arah:
+# terlalu cepat dan terlambat harus dihukum sama.
+run supabase/migrations/0089_penalti_waktu_per_menit.sql
+run tests/sql/50_penalti_waktu_per_menit.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/50_penalti_waktu_per_menit.sql
+++ b/tests/sql/50_penalti_waktu_per_menit.sql
@@ -1,0 +1,71 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/50_penalti_waktu_per_menit.sql
+-- Tepat target = 0; terlalu cepat/lambat = 1 poin per menit (0089).
+-- ============================================================================
+
+do $blok$
+declare
+  v_regu       uuid;
+  v_kloter     smallint;
+  v_target     timestamptz;
+  v_jam_lama   timestamptz;
+  v_berangkat_lama timestamptz;
+  v_kontrak_lama smallint;
+  v_selisih    int;
+  v_penalti    numeric;
+begin
+  select r.id, r.kloter_nomor, k.jam_berangkat, r.kontrak_menit, c.jam_datang
+    into v_regu, v_kloter, v_berangkat_lama, v_kontrak_lama, v_jam_lama
+  from regu r
+  join kloter k on k.nomor = r.kloter_nomor
+  join closing_regu c on c.regu_id = r.id
+  where k.jam_berangkat is not null and r.kontrak_menit is not null
+  order by r.nomor_dada
+  limit 1;
+
+  assert v_regu is not null,
+         'fixture tidak punya regu berangkat, berkontrak, dan sudah closing';
+  assert (select blok_menit = 1 and penalti_per_blok = 1
+          from konfig_penalti where edisi = edisi_aktif()),
+         'konfigurasi bukan 1 menit -> 1 poin';
+
+  update kloter set jam_berangkat = timestamptz '2026-08-29 07:00+07'
+  where nomor = v_kloter;
+  update regu set kontrak_menit = 240 where id = v_regu;
+  v_target := timestamptz '2026-08-29 11:00+07';
+
+  -- Kasus keputusan pemilik: kontrak 4 jam dari 07:00 menargetkan tepat 11:00.
+  update closing_regu set jam_datang = v_target where regu_id = v_regu;
+  select selisih_menit, penalti_waktu into v_selisih, v_penalti
+  from v_penalti_waktu where regu_id = v_regu;
+  assert v_selisih = 0 and v_penalti = 0,
+         format('tepat target menghasilkan selisih %s dan penalti %s', v_selisih, v_penalti);
+
+  -- Terlalu cepat dan terlambat dihukum sama beratnya.
+  update closing_regu set jam_datang = v_target - interval '1 minute' where regu_id = v_regu;
+  select selisih_menit, penalti_waktu into v_selisih, v_penalti
+  from v_penalti_waktu where regu_id = v_regu;
+  assert v_selisih = -1 and v_penalti = 1,
+         format('1 menit terlalu cepat menghasilkan selisih %s dan penalti %s', v_selisih, v_penalti);
+
+  update closing_regu set jam_datang = v_target + interval '1 minute' where regu_id = v_regu;
+  select selisih_menit, penalti_waktu into v_selisih, v_penalti
+  from v_penalti_waktu where regu_id = v_regu;
+  assert v_selisih = 1 and v_penalti = 1,
+         format('1 menit terlambat menghasilkan selisih %s dan penalti %s', v_selisih, v_penalti);
+
+  -- Bukan penalti tetap satu poin: setiap menit berikutnya ikut dihitung.
+  update closing_regu set jam_datang = v_target - interval '17 minutes' where regu_id = v_regu;
+  select selisih_menit, penalti_waktu into v_selisih, v_penalti
+  from v_penalti_waktu where regu_id = v_regu;
+  assert v_selisih = -17 and v_penalti = 17,
+         format('17 menit terlalu cepat menghasilkan selisih %s dan penalti %s', v_selisih, v_penalti);
+
+  update closing_regu set jam_datang = v_jam_lama where regu_id = v_regu;
+  update regu set kontrak_menit = v_kontrak_lama where id = v_regu;
+  update kloter set jam_berangkat = v_berangkat_lama where nomor = v_kloter;
+  raise notice '50: tepat=0, cepat 1 menit=-1, lambat 1 menit=-1, cepat 17 menit=-17.';
+end;
+$blok$;
+
+\echo '50 penalti waktu per menit: LULUS'


### PR DESCRIPTION
## What

- Set the active time-penalty configuration to one minute per one point.
- Set the same defaults for future editions while keeping the rule configurable.
- Test an exact 11:00 target, one minute early, one minute late, and a larger deviation.
- Update the synchronized maintainer and operational documentation.

## Why

The competition scores arrival accuracy, not speed. A team departing at 07:00 with a four-hour contract must arrive at 11:00, and every minute early or late must deduct one point symmetrically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)