### PR TITLE
chore: reset event departure and arrival times

### DIFF
--- a/supabase/migrations/0090_reset_event_times.sql
+++ b/supabase/migrations/0090_reset_event_times.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- hrcd-rekap : 0090_reset_event_times.sql
+-- Reset waktu operasional sebelum keberangkatan sebenarnya dimulai.
+--
+-- KEPUTUSAN PEMILIK, 21 AGUSTUS 2026
+--
+-- Seluruh jam berangkat dan jam datang di production harus dibersihkan agar
+-- semua kloter kembali terlihat belum berangkat dan belum ada regu yang
+-- closing. `closing_regu.jam_datang` wajib terisi, jadi "hapus jam datang"
+-- berarti menghapus baris closing beserta anggota_hadir, note, dan jejak siapa
+-- yang mencatatnya. History audit tetap dipertahankan.
+--
+-- Ceklis `keberangkatan_regu` ikut dihapus. Walaupun tabel itu tidak menyimpan
+-- jam, v_kemajuan_hari membacanya sebagai peserta sudah berangkat; membiarkan
+-- ceklis akan membuat layar tetap melaporkan keberangkatan setelah jam kloter
+-- dikosongkan.
+--
+-- Yang sengaja TIDAK disentuh:
+--   - kontrak_menit: pilihan kontrak waktu peserta tetap ada;
+--   - nomor dada, penempatan kloter, nilai, dan tanda cetak kloter.
+--
+-- Kedua tulisan memakai WHERE eksplisit. Supabase production mengaktifkan
+-- safeupdate dan akan menolak UPDATE/DELETE seluruh tabel tanpa WHERE, meski
+-- perintah yang sama lolos di database tes lokal.
+-- ============================================================================
+
+do $blok$
+declare
+  v_kloter_sebelum  int;
+  v_closing_sebelum int;
+  v_ceklis_sebelum  int;
+  v_kloter_sesudah  int;
+  v_closing_sesudah int;
+  v_ceklis_sesudah  int;
+begin
+  select count(*) into v_kloter_sebelum
+  from kloter where jam_berangkat is not null;
+
+  select count(*) into v_closing_sebelum
+  from closing_regu where regu_id is not null;
+
+  select count(*) into v_ceklis_sebelum
+  from keberangkatan_regu where regu_id is not null;
+
+  delete from closing_regu
+  where regu_id is not null;
+
+  delete from keberangkatan_regu
+  where regu_id is not null;
+
+  update kloter
+  set jam_berangkat = null
+  where jam_berangkat is not null;
+
+  select count(*) into v_kloter_sesudah
+  from kloter where jam_berangkat is not null;
+
+  select count(*) into v_closing_sesudah
+  from closing_regu where regu_id is not null;
+
+  select count(*) into v_ceklis_sesudah
+  from keberangkatan_regu where regu_id is not null;
+
+  assert v_kloter_sesudah = 0,
+         format('0090: masih ada %s kloter dengan jam berangkat', v_kloter_sesudah);
+  assert v_closing_sesudah = 0,
+         format('0090: masih ada %s regu dengan jam datang', v_closing_sesudah);
+  assert v_ceklis_sesudah = 0,
+         format('0090: masih ada %s peserta berstatus berangkat', v_ceklis_sesudah);
+
+  raise notice '0090: % jam kloter, % ceklis berangkat, dan % baris closing dihapus; semuanya kembali belum berangkat/belum datang.',
+               v_kloter_sebelum, v_ceklis_sebelum, v_closing_sebelum;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -362,5 +362,11 @@ run tests/sql/49_daftar_ulang_lewati_kloter_berangkat.sql
 # terlalu cepat dan terlambat harus dihukum sama.
 run supabase/migrations/0089_penalti_waktu_per_menit.sql
 run tests/sql/50_penalti_waktu_per_menit.sql
+# 0090 adalah reset data production yang disengaja sebelum lomba sebenarnya:
+# hapus seluruh jam berangkat, ceklis, dan baris closing, tetapi pertahankan
+# kontrak, nomor dada, kloter, dan nilai. Ditaruh paling akhir karena seluruh
+# tes alur sebelumnya memang membutuhkan data waktu.
+run supabase/migrations/0090_reset_event_times.sql
+run tests/sql/51_reset_event_times.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/51_reset_event_times.sql
+++ b/tests/sql/51_reset_event_times.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/51_reset_event_times.sql
+-- Reset waktu mengosongkan seluruh status keberangkatan dan closing.
+-- ============================================================================
+
+do $blok$
+declare
+  v_n           int;
+  v_regu        int;
+  v_kontrak     int;
+  v_berangkat   int;
+  v_datang      int;
+begin
+  select count(*) into v_n from kloter where jam_berangkat is not null;
+  assert v_n = 0, format('%s kloter masih punya jam berangkat', v_n);
+
+  select count(*) into v_n from closing_regu;
+  assert v_n = 0, format('%s regu masih punya jam datang', v_n);
+
+  select count(*) into v_n from keberangkatan_regu;
+  assert v_n = 0, format('%s peserta masih berstatus berangkat', v_n);
+
+  -- Reset status bukan reset peserta: nomor dada, kloter, dan kontrak bertahan.
+  select count(*) into v_regu from regu
+  where nomor_dada is not null and kloter_nomor is not null;
+  select count(*) into v_kontrak from regu where kontrak_menit is not null;
+  assert v_regu > 0 and v_kontrak > 0,
+         format('data peserta ikut hilang: %s bernomor/berkloter, %s berkontrak',
+                v_regu, v_kontrak);
+
+  select regu_berangkat, regu_datang into v_berangkat, v_datang
+  from v_kemajuan_hari;
+  assert v_berangkat = 0 and v_datang = 0,
+         format('kemajuan hari masih melaporkan %s berangkat / %s datang',
+                v_berangkat, v_datang);
+
+  select count(*) into v_n from v_klasemen;
+  assert v_n = 0, format('%s regu masih masuk klasemen sebelum berangkat', v_n);
+
+  raise notice '51: keberangkatan dan closing nol; % peserta tetap bernomor/berkloter.',
+               v_regu;
+end;
+$blok$;
+
+\echo '51 reset waktu acara: LULUS'


### PR DESCRIPTION
## What

- clear every `kloter.jam_berangkat`
- delete all participant departure checklists and closing records
- preserve nomor dada, kloter assignments, contracts, scores, and printed flags
- add regression coverage for operational summaries and standings

## Why

Production must return to a fully pre-departure and pre-arrival state before the actual event starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
