### PR TITLE
feat: add internal participant categories

### DIFF
--- a/live/daftar.html
+++ b/live/daftar.html
@@ -27,6 +27,6 @@
   </main>
 
   <script src="config.js"></script>
-  <script type="module" src="js/daftar.js?v=3"></script>
+  <script type="module" src="js/daftar.js?v=4"></script>
 </body>
 </html>

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -26,9 +26,17 @@ const GOLONGAN = [
   { kode: "penegak_pa",    label: "Penegak Putra",    ket: "SMA / SMK / MA — putra" },
   { kode: "penegak_pi",    label: "Penegak Putri",    ket: "SMA / SMK / MA — putri" },
 ];
+const GOLONGAN_INTERNAL = [
+  { kode: "intern_pa", label: "Intern Putra", ket: "" },
+  { kode: "intern_pi", label: "Intern Putri", ket: "" },
+];
 const KUNCI_DRAF = "hrcd_draf";
 const KUNCI_HASIL = "hrcd_hasil";
 const MAKS_REGU = 30;
+const SEKOLAH_INTERNAL = {
+  nama: "SMAN 1 Ciamis",
+  alamat: "Jl. Gunung Galuh No. 37, Ciamis, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46211, Indonesia",
+};
 
 // Format nomor Indonesia, HANYA 08xx (bukan +62 8xx — disederhanakan sengaja
 // supaya panitia tidak perlu mikir dua format): 08, lalu kode operator
@@ -37,10 +45,15 @@ const MAKS_REGU = 30;
 const POLA_WA = /^08[1-9][0-9]{6,10}$/;
 
 const kosong = () => ({
+  jenis_peserta: null,           // "eksternal" atau "internal"
   sekolah: null,                 // {id?, nama, alamat}
   butuh_barak: null,
   jumlah_pendamping: 0,
-  rincian: { penggalang_pa: 0, penggalang_pi: 0, penegak_pa: 0, penegak_pi: 0 },
+  rincian: {
+    penggalang_pa: 0, penggalang_pi: 0,
+    penegak_pa: 0, penegak_pi: 0,
+    intern_pa: 0, intern_pi: 0,
+  },
   regu: [],                      // [{golongan, nama_regu, nama_ketua}]
   kontak_wa: "",
   nama_kontak: "",
@@ -69,6 +82,9 @@ window.addEventListener("beforeunload", (e) => {
 });
 
 const totalRincian = () => Object.values(jawab.rincian).reduce((a, b) => a + b, 0);
+const internal = () => jawab.jenis_peserta === "internal";
+
+const golonganForm = () => internal() ? GOLONGAN_INTERNAL : GOLONGAN;
 /* Penyamaan untuk PENCARIAN sekolah, bukan untuk menyimpan.
  *
  *  Pembina mengetik nama yang dia ucapkan, bukan nama yang tertulis di
@@ -91,7 +107,8 @@ const normal = s => String(s || "").toLowerCase()
   // Huruf status Dapodik di awal nama: MAS, SMKS, SMAS, SMPS, MTsS, MIS.
   .replace(/^\s*(sd|smp|sma|smk|mi|mts|ma)s\b/, "$1")
   .replace(/[^a-z0-9]/g, "");
-const labelGolongan = k => GOLONGAN.find(g => g.kode === k).label;
+const labelGolongan = k => golonganForm().find(g => g.kode === k)?.label
+  ?? [...GOLONGAN, ...GOLONGAN_INTERNAL].find(g => g.kode === k).label;
 
 /* ---------- nama regu: 20 karakter, dan tidak boleh kembar (0051) ----------
 
@@ -127,16 +144,30 @@ let jamPeriksaNama = null;
 /* ============================ RANGKA HALAMAN ============================= */
 
 function halaman() {
+  const jenisDipilih = jawab.jenis_peserta !== null;
+  const nomorJumlah = internal() ? 3 : 4;
+  const nomorRegu = nomorJumlah + 1;
+  const nomorKontak = nomorRegu + 1;
   LAYAR.replaceChildren(h(`
-    <!-- 1. Sekolah -->
+    <section class="card" id="bagian-jenis">
+      <h2><span class="section-number">1</span> Peserta</h2>
+      <div class="option-row" style="margin-top:.8rem">
+        <button class="option" id="p-eksternal" aria-pressed="${jawab.jenis_peserta === "eksternal"}" type="button">Eksternal</button>
+        <button class="option" id="p-internal" aria-pressed="${jawab.jenis_peserta === "internal"}" type="button">Internal</button>
+      </div>
+    </section>
+
+    ${!jenisDipilih ? "" : `
+    <!-- 2. Sekolah -->
     <section class="card" id="bagian-sekolah">
-      <h2><span class="section-number">1</span> Asal sekolah</h2>
+      <h2><span class="section-number">2</span> Asal sekolah</h2>
       <div id="isi-sekolah"></div>
     </section>
 
-    <!-- 2. Menginap -->
+    ${internal() ? "" : `
+    <!-- 3. Menginap -->
     <section class="card" id="bagian-barak">
-      <h2><span class="section-number">2</span> Perlu tempat menginap?</h2>
+      <h2><span class="section-number">3</span> Perlu tempat menginap?</h2>
       <p class="description">Panitia menyediakan ruang kelas untuk menginap malam
          sebelum lomba, gratis.</p>
       <div class="option-row" style="margin-top:.8rem">
@@ -146,25 +177,26 @@ function halaman() {
       <div id="isi-pendamping" style="margin-top:.9rem"></div>
       <div class="error" id="g-barak" hidden>Pilih salah satu.</div>
     </section>
+    `}
 
-    <!-- 3. Jumlah regu -->
+    <!-- Jumlah regu -->
     <section class="card" id="bagian-jumlah">
-      <h2><span class="section-number">3</span> Mendaftarkan berapa regu?</h2>
+      <h2><span class="section-number">${nomorJumlah}</span> Mendaftarkan berapa regu?</h2>
       <p class="description">1 regu = 5 orang.</p>
       <div id="isi-stepper" style="margin-top:.9rem"></div>
       <div class="total-box" id="kotak-total"></div>
       <div class="error" id="g-jumlah" hidden>Tambahkan minimal satu regu.</div>
     </section>
 
-    <!-- 4. Nama regu -->
+    <!-- Nama regu -->
     <section class="card" id="bagian-regu">
-      <h2><span class="section-number">4</span> Nama tiap regu</h2>
+      <h2><span class="section-number">${nomorRegu}</span> Nama tiap regu</h2>
       <div id="isi-regu"></div>
     </section>
 
-    <!-- 5. Kontak -->
+    <!-- Kontak -->
     <section class="card" id="bagian-kontak">
-      <h2><span class="section-number">5</span> Contact Person</h2>
+      <h2><span class="section-number">${nomorKontak}</span> Contact Person</h2>
       <p class="description">Satu orang untuk semua regu.</p>
       <div class="field" style="margin-top:.7rem">
         <label for="nama-kontak">Nama</label>
@@ -188,10 +220,30 @@ function halaman() {
         <button class="button button-primary" id="kirim" type="button">Kirim Pendaftaran</button>
       </div>
     </div>
+    `}
   `));
 
+  const pilihJenis = (jenis) => {
+    if (jawab.jenis_peserta === jenis) return;
+    jawab.jenis_peserta = jenis;
+    jawab.sekolah = jenis === "internal" ? sekolahInternal() : null;
+    jawab.butuh_barak = jenis === "internal" ? false : null;
+    jawab.jumlah_pendamping = 0;
+    jawab.rincian = {
+      penggalang_pa: 0, penggalang_pi: 0,
+      penegak_pa: 0, penegak_pi: 0,
+      intern_pa: 0, intern_pi: 0,
+    };
+    jawab.regu = [];
+    simpanDraf();
+    halaman();
+  };
+  document.getElementById("p-eksternal").addEventListener("click", () => pilihJenis("eksternal"));
+  document.getElementById("p-internal").addEventListener("click", () => pilihJenis("internal"));
+  if (!jenisDipilih) return;
+
   gambarSekolah();
-  gambarBarak();
+  if (!internal()) gambarBarak();
   gambarStepper();
   gambarRegu();
   document.getElementById("nama-kontak").value = jawab.nama_kontak;
@@ -229,6 +281,7 @@ function gambarSekolah() {
         <div class="nama">${jawab.sekolah.nama}</div>
         <div class="detail">📍 ${jawab.sekolah.alamat}</div>
       </div>`));
+    if (internal()) return;
     kotak.appendChild(h(`
       <button class="button button-secondary button-small" id="ganti-sekolah" type="button"
               style="margin-top:.6rem">Ganti sekolah</button>`));
@@ -342,6 +395,13 @@ function gambarSekolah() {
   }
 }
 
+function sekolahInternal() {
+  const tersimpan = SEKOLAH.find(s => normal(s.name) === normal(SEKOLAH_INTERNAL.nama));
+  return tersimpan
+    ? { id: tersimpan.id, nama: tersimpan.name, alamat: tersimpan.address }
+    : { ...SEKOLAH_INTERNAL };
+}
+
 /* ---------------- 2. barak ---------------- */
 
 function gambarBarak() {
@@ -377,11 +437,11 @@ function gambarBarak() {
 
 function gambarStepper() {
   document.getElementById("isi-stepper").replaceChildren(h(
-    GOLONGAN.map(g => `
+    golonganForm().map(g => `
       <div class="stepper-row">
         <div>
           <strong style="font-size:1.05rem">${g.label}</strong>
-          <div class="hint">${g.ket}</div>
+          ${g.ket ? `<div class="hint">${g.ket}</div>` : ""}
         </div>
         <div class="stepper">
           <button type="button" aria-label="kurangi ${g.label}" data-kurang="${g.kode}">−</button>
@@ -410,7 +470,7 @@ function gambarStepper() {
 function sinkronRegu() {
   const lama = jawab.regu;
   jawab.regu = [];
-  for (const g of GOLONGAN) {
+  for (const g of golonganForm()) {
     const bekas = lama.filter(r => r.golongan === g.kode);
     for (let i = 0; i < jawab.rincian[g.kode]; i++)
       jawab.regu.push(bekas[i] ?? { golongan: g.kode, nama_regu: "", nama_ketua: "" });
@@ -558,10 +618,12 @@ function periksa(gulir = true) {
 
   const tandai = (id, ada) => { const e = document.getElementById(id); if (e) e.hidden = !ada; };
 
+  if (!jawab.jenis_peserta) { galat.push({ ke: "bagian-jenis", teks: "Jenis peserta belum dipilih" }); }
+
   if (!jawab.sekolah) { galat.push({ ke: "bagian-sekolah", teks: "Sekolah belum dipilih" }); }
   tandai("g-sekolah", !jawab.sekolah);
 
-  if (jawab.butuh_barak === null) { galat.push({ ke: "bagian-barak", teks: "Belum menjawab soal menginap" }); }
+  if (!internal() && jawab.butuh_barak === null) { galat.push({ ke: "bagian-barak", teks: "Belum menjawab soal menginap" }); }
   tandai("g-barak", jawab.butuh_barak === null);
 
   if (!jawab.regu.length) { galat.push({ ke: "bagian-jumlah", teks: "Belum ada regu" }); }
@@ -778,7 +840,22 @@ async function mulai() {
     return;
   }
 
-  if (draf && (draf.sekolah || draf.regu?.length)) jawab = { ...kosong(), ...draf };
+  if (draf && (draf.sekolah || draf.regu?.length)) {
+    // Draf dari versi sebelum pilihan jenis peserta adalah jalur form lama,
+    // yaitu Eksternal. Tetapkan otomatis agar ketikan yang sudah ada tidak
+    // hilang hanya karena form mendapat satu pertanyaan baru.
+    jawab = { ...kosong(), ...draf, jenis_peserta: draf.jenis_peserta ?? "eksternal" };
+    if (jawab.jenis_peserta === "internal") {
+      jawab.sekolah = sekolahInternal();
+      jawab.butuh_barak = false;
+      jawab.jumlah_pendamping = 0;
+      jawab.rincian.penggalang_pa = 0;
+      jawab.rincian.penggalang_pi = 0;
+      jawab.rincian.penegak_pa = 0;
+      jawab.rincian.penegak_pi = 0;
+      sinkronRegu();
+    }
+  }
   halaman();
 }
 

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -974,6 +974,8 @@ export function nilaiBagian(w, a, b) {
 export const GOLONGAN_LABEL = {
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
   penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
+  intern_pa: "Intern PA", intern_pi: "Intern PI",
 };
 export const URUT_GOLONGAN =
-  ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
+  ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi",
+   "intern_pa", "intern_pi"];

--- a/supabase/migrations/0091_intern_golongan.sql
+++ b/supabase/migrations/0091_intern_golongan.sql
@@ -1,0 +1,285 @@
+-- ============================================================================
+-- hrcd-rekap : 0091_intern_golongan.sql
+-- Intern PA dan Intern PI menjadi golongan tersendiri.
+--
+-- Peserta internal berasal dari SMAN 1 Ciamis. Mereka hanya dinilai dari lima
+-- Soal Tulis dan ketepatan waktu; seluruh lomba lapangan, penalti tanpa
+-- checkout, penalti anggota, dan nilai pos terlewat tidak berlaku. Klasemennya
+-- tetap dipisah menjadi Intern PA dan Intern PI.
+-- ============================================================================
+
+alter table regu drop constraint if exists regu_golongan_check;
+alter table regu add constraint regu_golongan_check check (golongan in (
+  'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+  'intern_pa', 'intern_pi'
+));
+
+alter table wahana drop constraint if exists wahana_golongan_check;
+alter table wahana add constraint wahana_golongan_check check (
+  golongan is null or golongan in (
+    'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+    'intern_pa', 'intern_pi', 'intern'
+  )
+);
+
+create or replace function komponen_berlaku(p_golongan_wahana text,
+                                            p_golongan_regu   text)
+returns boolean
+language sql immutable
+as $$
+  select case
+    when p_golongan_regu in ('intern_pa', 'intern_pi')
+      then coalesce(p_golongan_wahana in (p_golongan_regu, 'intern'), false)
+    else p_golongan_wahana is null or p_golongan_wahana = p_golongan_regu
+  end
+$$;
+
+comment on function komponen_berlaku(text, text) is
+  'Apakah komponen berlaku untuk satu regu. Marker wahana `intern` berlaku untuk Intern PA/PI; komponen umum tidak otomatis berlaku supaya lomba lapangan tidak ikut dinilai.';
+
+-- Lima baris soal dibuat sebagai varian Intern. Baris asli tetap NULL agar
+-- empat golongan eksternal tetap membacanya; `kolomPos()` menggabungkan kedua
+-- varian berdasarkan nama sehingga layar masih menampilkan satu kolom.
+insert into wahana
+  (edisi, pos, kode, name, type, form, poin_maks,
+   raw_terbaik, raw_terburuk, poin_benar, poin_salah, total_soal,
+   rentang_mentah_min, rentang_mentah_maks, sort_order, tingkat, satuan,
+   golongan, petunjuk, judul_isian, lomba, kode_lomba, jawaban_benar)
+select
+  edisi, pos, kode || '_intern', name, type, form, poin_maks,
+  raw_terbaik, raw_terburuk, poin_benar, poin_salah, total_soal,
+  rentang_mentah_min, rentang_mentah_maks, sort_order, tingkat, satuan,
+  'intern', petunjuk, judul_isian, lomba, kode_lomba, jawaban_benar
+from wahana
+where edisi = edisi_aktif()
+  and kode in ('keagamaan', 'kepramukaan', 'kesehatan',
+               'pengetahuan_umum', 'logika')
+on conflict (edisi, pos, kode) do update set
+  name                = excluded.name,
+  type                = excluded.type,
+  form                = excluded.form,
+  poin_maks           = excluded.poin_maks,
+  raw_terbaik         = excluded.raw_terbaik,
+  raw_terburuk        = excluded.raw_terburuk,
+  poin_benar          = excluded.poin_benar,
+  poin_salah          = excluded.poin_salah,
+  total_soal          = excluded.total_soal,
+  rentang_mentah_min  = excluded.rentang_mentah_min,
+  rentang_mentah_maks = excluded.rentang_mentah_maks,
+  sort_order          = excluded.sort_order,
+  tingkat             = excluded.tingkat,
+  satuan              = excluded.satuan,
+  golongan            = excluded.golongan,
+  petunjuk            = excluded.petunjuk,
+  judul_isian         = excluded.judul_isian,
+  lomba               = excluded.lomba,
+  kode_lomba          = excluded.kode_lomba,
+  jawaban_benar       = excluded.jawaban_benar;
+
+-- Regu Intern tidak boleh muncul di lembar/input lomba lapangan. Selain
+-- mengurangi kebisingan, ini mencegah petugas mengira sel kosong sebagai
+-- pekerjaan yang belum diisi. Badan view mengikuti 0065; predikat EXISTS di
+-- akhir adalah satu-satunya perubahan.
+create or replace view v_lembar_pos as
+select
+  p.nomor       as pos,
+  p.name        as nama_pos,
+  p.bayangan,
+  r.id          as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name        as nama_sekolah,
+  r.golongan,
+  coalesce((
+    select jsonb_object_agg(w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), '{}'::jsonb) as nilai,
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_terisi,
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor
+     and komponen_berlaku(w.golongan, r.golongan))::int
+                as jumlah_komponen,
+  round(coalesce((
+    select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                           w.raw_terbaik, w.raw_terburuk,
+                           w.poin_benar, w.poin_salah, w.total_soal, w.tingkat))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), 0) * p.bobot, 2) as nilai_pos,
+  nilai_tergembok(r.id, p.nomor) as terkunci
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and boleh('pos')
+  and (pos_saya() is null or p.nomor = pos_saya())
+  and exists (
+    select 1 from wahana w
+    where w.edisi = p.edisi and w.pos = p.nomor
+      and komponen_berlaku(w.golongan, r.golongan)
+  );
+
+-- Intern hanya memperoleh poin Soal Tulis dikurangi penalti waktu. Kolom
+-- penalti lain tetap ada agar bentuk view tidak berubah, tetapi nilainya nol.
+create or replace view v_total_skor with (security_invoker = on) as
+select
+  r.id            as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name          as nama_sekolah,
+  r.golongan,
+  case when r.golongan in ('intern_pa', 'intern_pi')
+    then coalesce(pp.total_pos, 0)
+    else coalesce(pp.total_pos, 0)
+      + (((select count(*) from pos p
+            where p.edisi = edisi_aktif()
+              and exists (select 1 from wahana w
+                          where w.edisi = p.edisi and w.pos = p.nomor))
+          - coalesce(pp.jumlah_pos, 0)) * kp.nilai_pos_terlewat)
+  end                                             as total_pos,
+  pw.penalti_waktu,
+  case when r.golongan in ('intern_pa', 'intern_pi') then 0
+       when c.regu_id is null then kp.penalti_tanpa_checkout else 0 end
+                                                  as penalti_checkout,
+  case when r.golongan in ('intern_pa', 'intern_pi') then 0
+       when c.regu_id is not null
+         then (5 - c.anggota_hadir) * kp.penalti_per_anggota_hilang else 0 end
+                                                  as penalti_anggota,
+  case when r.golongan in ('intern_pa', 'intern_pi')
+    then coalesce(pp.total_pos, 0) - pw.penalti_waktu
+    else coalesce(pp.total_pos, 0)
+      + (((select count(*) from pos p
+            where p.edisi = edisi_aktif()
+              and exists (select 1 from wahana w
+                          where w.edisi = p.edisi and w.pos = p.nomor))
+          - coalesce(pp.jumlah_pos, 0)) * kp.nilai_pos_terlewat)
+      - pw.penalti_waktu
+      - case when c.regu_id is null then kp.penalti_tanpa_checkout else 0 end
+      - case when c.regu_id is not null
+          then (5 - c.anggota_hadir) * kp.penalti_per_anggota_hilang else 0 end
+  end                                             as total,
+  pw.selisih_menit
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join (select regu_id, sum(poin_pos) as total_pos, count(*) as jumlah_pos
+           from v_poin_pos group by regu_id) pp on pp.regu_id = r.id
+join v_penalti_waktu pw  on pw.regu_id = r.id
+left join closing_regu c on c.regu_id = r.id
+cross join konfig_penalti kp
+where kp.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas';
+
+-- Salinan fungsi terakhir dari 0061; hanya daftar golongan sah yang bertambah.
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', v_ada.jumlah_regu * (select biaya_per_regu from edisi where is_active),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim, nama_kontak)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''))
+  returning id into v_batch;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan'
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', v_n * (select biaya_per_regu from edisi where is_active),
+    'terkirim_ulang', false);
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -368,5 +368,9 @@ run tests/sql/50_penalti_waktu_per_menit.sql
 # tes alur sebelumnya memang membutuhkan data waktu.
 run supabase/migrations/0090_reset_event_times.sql
 run tests/sql/51_reset_event_times.sql
+# 0091 menambah Intern PA/PI sebagai klasemen tersendiri. Keduanya hanya
+# dinilai dari lima Soal Tulis dan ketepatan waktu, bukan lomba lapangan.
+run supabase/migrations/0091_intern_golongan.sql
+run tests/sql/52_intern_golongan.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/52_intern_golongan.sql
+++ b/tests/sql/52_intern_golongan.sql
@@ -1,0 +1,135 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/52_intern_golongan.sql
+-- Intern adalah dua golongan tersendiri dan hanya mengikuti Soal Tulis.
+-- ============================================================================
+
+do $blok$
+declare
+  v_hasil jsonb;
+  v_n int;
+  v_regu uuid;
+  v_total numeric;
+  v_nomor integer;
+  v_kloter smallint;
+  v_urutan smallint;
+begin
+  assert not komponen_berlaku(null, 'intern_pa'),
+         'komponen umum/lapangan tidak boleh berlaku untuk Intern PA';
+  assert not komponen_berlaku('penegak_pa', 'intern_pa'),
+         'Intern PA tidak boleh memakai komponen Penegak PA';
+  assert komponen_berlaku('intern', 'intern_pa'),
+         'komponen Soal Tulis harus berlaku untuk Intern PA';
+  assert komponen_berlaku('intern', 'intern_pi'),
+         'komponen Soal Tulis harus berlaku untuk Intern PI';
+
+  select count(*) into v_n from wahana
+  where edisi = edisi_aktif() and golongan = 'intern';
+  assert v_n = 5, format('Intern mendapat %s komponen, seharusnya 5 Soal Tulis', v_n);
+
+  select count(*) into v_n from wahana
+  where edisi = edisi_aktif() and golongan = 'intern'
+    and name in ('Keagamaan', 'Kepramukaan', 'Kesehatan',
+                 'Pengetahuan Umum', 'Logika');
+  assert v_n = 5, format('hanya %s dari lima Soal Tulis yang tersedia', v_n);
+
+  v_hasil := submit_pendaftaran(
+    'SMAN 1 Ciamis',
+    'alamat dari form tidak boleh mengganti kurasi',
+    false,
+    '081234567890',
+    '[{"nama_regu":"Uji Intern Putra","nama_ketua":"Ketua Putra","golongan":"intern_pa"},
+      {"nama_regu":"Uji Intern Putri","nama_ketua":"Ketua Putri","golongan":"intern_pi"}]'::jsonb,
+    0::smallint,
+    gen_random_uuid(),
+    'Kontak Internal'
+  );
+
+  assert (v_hasil ->> 'jumlah_regu')::int = 2,
+         format('pendaftaran internal menghasilkan %s regu', v_hasil ->> 'jumlah_regu');
+
+  select count(*) into v_n
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  join sekolah s on s.id = d.sekolah_id
+  where s.name = 'SMAN 1 Ciamis'
+    and r.golongan in ('intern_pa', 'intern_pi')
+    and r.nama_regu in ('Uji Intern Putra', 'Uji Intern Putri');
+  assert v_n = 2, format('hanya %s regu internal yang tersimpan', v_n);
+
+  select count(*) into v_n from sekolah where name = 'SMAN 1 Ciamis';
+  assert v_n = 1, format('SMAN 1 Ciamis terpecah menjadi %s baris', v_n);
+
+  select r.id into v_regu from regu r
+  where r.nama_regu = 'Uji Intern Putra';
+  update pendaftaran set status = 'lunas'
+  where id = (select pendaftaran_id from regu where id = v_regu);
+
+  insert into nilai_mentah (regu_id, wahana_id, nilai_1, source, created_by)
+  select v_regu, w.id, w.total_soal, 'manual',
+         (select id from auth.users order by id limit 1)
+  from wahana w
+  where w.edisi = edisi_aktif() and w.golongan = 'intern';
+
+  select total into v_total from v_total_skor where regu_id = v_regu;
+  assert v_total = 300,
+         format('Intern bernilai Soal Tulis penuh harus mendapat 300, bukan %s', v_total);
+
+  select penalti_checkout + penalti_anggota into v_total
+  from v_total_skor where regu_id = v_regu;
+  assert v_total = 0,
+         format('Intern terkena %s penalti selain waktu', v_total);
+
+  select n.nomor into v_nomor from nomor_dada_stok n
+  where not exists (select 1 from regu r where r.nomor_dada = n.nomor)
+  order by n.nomor desc limit 1;
+  select k.nomor into v_kloter from kloter k
+  where exists (
+    select 1 from generate_series(1, 10) u
+    where not exists (select 1 from regu r
+                      where r.kloter_nomor = k.nomor and r.urutan_kloter = u)
+  ) order by k.nomor desc limit 1;
+  select u::smallint into v_urutan from generate_series(1, 10) u
+  where not exists (select 1 from regu r
+                    where r.kloter_nomor = v_kloter and r.urutan_kloter = u)
+  order by u limit 1;
+
+  update regu set nomor_dada = v_nomor, kloter_nomor = v_kloter,
+                  urutan_kloter = v_urutan, kontrak_menit = 240
+  where id = v_regu;
+
+  set local role authenticated;
+  perform set_config('app.uid',
+                     '00000000-0000-0000-0000-00000000000a', true);
+  select count(*) into v_n from v_lembar_pos where regu_id = v_regu;
+  assert v_n = 3,
+         format('Intern muncul di %s pos; seharusnya hanya tiga pos Soal Tulis', v_n);
+  select sum(jumlah_komponen) into v_n from v_lembar_pos where regu_id = v_regu;
+  assert v_n = 5,
+         format('form Intern memuat %s komponen; seharusnya lima Soal Tulis', v_n);
+  reset role;
+
+  update kloter set jam_berangkat = '2026-08-29 07:00:00+07'
+  where nomor = v_kloter;
+  insert into keberangkatan_regu (regu_id, recorded_by)
+  values (v_regu, (select id from auth.users order by id limit 1));
+  insert into closing_regu
+    (regu_id, jam_datang, anggota_hadir, recorded_by, note)
+  values
+    (v_regu, '2026-08-29 11:03:00+07', 3,
+     (select id from auth.users order by id limit 1), 'uji Intern');
+
+  select total into v_total from v_total_skor where regu_id = v_regu;
+  assert v_total = 297,
+         format('300 Soal Tulis - 3 menit harus 297, bukan %s', v_total);
+  select penalti_checkout + penalti_anggota into v_total
+  from v_total_skor where regu_id = v_regu;
+  assert v_total = 0,
+         format('Intern terkena %s penalti checkout/anggota setelah closing', v_total);
+  select peringkat into v_n from v_klasemen where regu_id = v_regu;
+  assert v_n = 1, format('Intern PA harus memulai klasemennya sendiri di peringkat %s', v_n);
+
+  raise notice '52: Intern PA/PI terpisah dan hanya dinilai dari 5 Soal Tulis + waktu.';
+end;
+$blok$;
+
+\echo '52 golongan Intern: LULUS'

--- a/tools/periksa_urutan_golongan.py
+++ b/tools/periksa_urutan_golongan.py
@@ -35,7 +35,8 @@ import sys
 POLA_LABEL = re.compile(r"""["'](?:Penggalang PA|Penegak PA)["']""")
 POLA_URUT = re.compile(
     r"""\[\s*["']penegak_pa["']\s*,\s*["']penegak_pi["']\s*,"""
-    r"""\s*["']penggalang_pa["']\s*,\s*["']penggalang_pi["']\s*\]""")
+    r"""\s*["']penggalang_pa["']\s*,\s*["']penggalang_pi["']\s*,"""
+    r"""\s*["']intern_pa["']\s*,\s*["']intern_pi["']\s*\]""")
 
 # Komentar dibuang lebih dulu. Tanpa ini penjaga menuduh kalimat yang justru
 # MENJELASKAN kenapa label pendek ada — "Penggalang PA 13 huruf jadi Pgl Pa" —

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -59,6 +59,7 @@ const LAYAR = document.getElementById("layar");
 const GOLONGAN_SINGKAT = {
   penegak_pa: "Pgk Pa", penegak_pi: "Pgk Pi",
   penggalang_pa: "Pgl Pa", penggalang_pi: "Pgl Pi",
+  intern_pa: "Int Pa", intern_pi: "Int Pi",
 };
 let EDISI = null;
 
@@ -2399,8 +2400,11 @@ function kelompokLomba(kolom) {
   return urut;
 }
 
-const varianUntuk = (kol, golongan) =>
-  kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
+const varianUntuk = (kol, golongan) => {
+  if (golongan === "intern_pa" || golongan === "intern_pi")
+    return kol.varian.find(k => k.golongan === golongan || k.golongan === "intern") || null;
+  return kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
+};
 
 /** Kolom KERTAS untuk satu kolom layar. Sebagian memakan dua kolom, dan
  *  pembagiannya sama persis dengan kotak di layar — supaya petugas yang
@@ -2681,7 +2685,7 @@ function siapkanCetakBlangko(pos, kolomLayar) {
         <tr>
           <td class="bl-kategori" colspan="3">
             <span class="bl-label">Kategori &mdash; lingkari salah satu</span>
-            <span class="bl-pilihan">${URUT_GOLONGAN.map(g =>
+            <span class="bl-pilihan">${URUT_GOLONGAN.filter(g => !g.startsWith("intern_")).map(g =>
               `<span>${esc(GOLONGAN_LABEL[g])}</span>`).join("")}</span>
           </td>
         </tr>

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -974,6 +974,8 @@ export function nilaiBagian(w, a, b) {
 export const GOLONGAN_LABEL = {
   penegak_pa: "Penegak PA", penegak_pi: "Penegak PI",
   penggalang_pa: "Penggalang PA", penggalang_pi: "Penggalang PI",
+  intern_pa: "Intern PA", intern_pi: "Intern PI",
 };
 export const URUT_GOLONGAN =
-  ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi"];
+  ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi",
+   "intern_pa", "intern_pi"];


### PR DESCRIPTION
## What

- add Internal and External registration paths
- add separate Intern PA and Intern PI Live Score categories
- score Intern regu only from five written tests and time accuracy
- exclude Intern categories from field competition forms
- add migration and end-to-end SQL coverage

## Why

Internal SMAN 1 Ciamis participants compete in separate categories and follow a smaller assessment set than Penegak and Penggalang participants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)