### PR TITLE
fix: remove storage photos during participant cleanup

### DIFF
--- a/.github/workflows/apply-migration.yml
+++ b/.github/workflows/apply-migration.yml
@@ -33,6 +33,8 @@
 # Butuh secret SUPABASE_DB_URL: connection string Postgres (Session pooler,
 # port 5432 — BUKAN Direct connection yang IPv6-only dan tak terjangkau
 # runner GitHub, bukan pula transaction pooler 6543 yang menolak sebagian DDL).
+# Khusus cleanup_data_uji.sql, SUPABASE_URL dan SUPABASE_SERVICE_KEY juga
+# dipakai untuk menghapus file fisik di bucket Storage `lembar` lewat API.
 # ============================================================================
 
 name: Apply migration to Supabase
@@ -51,6 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        if: inputs.berkas == 'supabase/checks/cleanup_data_uji.sql'
+        with:
+          python-version: '3.12'
 
       - name: Periksa berkasnya ada
         # Lewat env var, BUKAN interpolasi ${{ }} langsung ke shell — input
@@ -73,9 +80,16 @@ jobs:
         env:
           BERKAS: ${{ inputs.berkas }}
           DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: |
           if [ -z "$DB_URL" ]; then
             echo "Secret SUPABASE_DB_URL belum diisi."
+            exit 1
+          fi
+          if [ "$BERKAS" = "supabase/checks/cleanup_data_uji.sql" ] && \
+             { [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_KEY" ]; }; then
+            echo "Cleanup foto butuh SUPABASE_URL dan SUPABASE_SERVICE_KEY."
             exit 1
           fi
           # --single-transaction: kalau ada satu statement yang gagal, SELURUH
@@ -85,4 +99,21 @@ jobs:
             --single-transaction \
             -v ON_ERROR_STOP=1 \
             -f "$BERKAS"
+
+          if [ "$BERKAS" = "supabase/checks/cleanup_data_uji.sql" ]; then
+            DAFTAR_FOTO="$RUNNER_TEMP/lembar-objects.json"
+            psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
+              -c "select coalesce(json_agg(name order by name), '[]'::json) from storage.objects where bucket_id = 'lembar'" \
+              > "$DAFTAR_FOTO"
+
+            python scripts/delete_storage_objects.py lembar "$DAFTAR_FOTO"
+
+            SISA_FOTO=$(psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
+              -c "select count(*) from storage.objects where bucket_id = 'lembar'")
+            if [ "$SISA_FOTO" != "0" ]; then
+              echo "Cleanup belum tuntas: masih ada $SISA_FOTO objek di bucket lembar."
+              exit 1
+            fi
+            echo "BUCKET FOTO BERSIH: lembar"
+          fi
           echo "MIGRASI BERHASIL: $BERKAS"

--- a/scripts/delete_storage_objects.py
+++ b/scripts/delete_storage_objects.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# ============================================================================
+# hrcd-rekap : delete_storage_objects.py — hapus objek Supabase Storage lewat
+# API resminya.
+#
+# Jangan mengganti ini dengan DELETE langsung ke storage.objects. Baris di
+# Postgres hanyalah metadata; file aslinya ada di object storage dan hanya
+# Storage API yang menghapus keduanya dengan benar.
+#
+# PAKAI:
+#   SUPABASE_URL=https://xxxx.supabase.co \
+#   SUPABASE_SERVICE_KEY=sb_secret_... \
+#   python scripts/delete_storage_objects.py lembar daftar-path.json
+#
+# daftar-path.json berisi array JSON nama objek, misalnya:
+#   ["pos-1/foto-a.jpg", "pos-2/foto-b.jpg"]
+# ============================================================================
+import json
+import os
+import sys
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "").rstrip("/")
+SERVICE_KEY = os.environ.get("SUPABASE_SERVICE_KEY", "")
+MAKS_PER_PERMINTAAN = 1000
+
+
+def potong(daftar, ukuran):
+    for awal in range(0, len(daftar), ukuran):
+        yield daftar[awal:awal + ukuran]
+
+
+def hapus_objek(bucket, paths):
+    terhapus = 0
+    url = f"{SUPABASE_URL}/storage/v1/object/{quote(bucket, safe='')}"
+    headers = {
+        "apikey": SERVICE_KEY,
+        "Authorization": f"Bearer {SERVICE_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    for kelompok in potong(paths, MAKS_PER_PERMINTAAN):
+        request = Request(
+            url,
+            data=json.dumps({"prefixes": kelompok}).encode("utf-8"),
+            headers=headers,
+            method="DELETE",
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                hasil = json.load(response)
+        except HTTPError as error:
+            pesan = error.read().decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(
+                f"Storage API menolak penghapusan (HTTP {error.code}): {pesan}"
+            ) from error
+
+        if not isinstance(hasil, list):
+            raise RuntimeError("Respons Storage API bukan daftar objek.")
+        terhapus += len(hasil)
+
+    return terhapus
+
+
+def main():
+    if not SUPABASE_URL or not SERVICE_KEY:
+        print("SUPABASE_URL dan SUPABASE_SERVICE_KEY wajib diisi.")
+        sys.exit(1)
+    if len(sys.argv) != 3:
+        print("Pakai: python delete_storage_objects.py <bucket> <daftar-path.json>")
+        sys.exit(1)
+
+    bucket = sys.argv[1]
+    with open(sys.argv[2], encoding="utf-8") as daftar_file:
+        paths = json.load(daftar_file)
+
+    if not isinstance(paths, list) or not all(isinstance(path, str) for path in paths):
+        print("Daftar path harus berupa array JSON berisi string.")
+        sys.exit(1)
+
+    # DISTINCT di query workflow seharusnya sudah menjamin ini. Menjaganya di
+    # sini juga membuat skrip aman dipakai sendiri dengan berkas buatan tangan.
+    paths = list(dict.fromkeys(paths))
+    terhapus = hapus_objek(bucket, paths) if paths else 0
+    print(f"Storage `{bucket}`: {terhapus} objek dihapus dari {len(paths)} path.")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/checks/cleanup_data_uji.sql
+++ b/supabase/checks/cleanup_data_uji.sql
@@ -31,10 +31,9 @@
 -- 7.5): daftar yang ditulis tangan tidak ikut tumbuh sendiri.
 --
 -- Yang TIDAK bisa dijangkau SQL: berkas foto di bucket Storage `lembar`.
--- Menghapus baris `foto_lembar` tidak menghapus gambarnya. Saat ini bucket
--- itu kosong (0 baris), jadi tidak ada yang tertinggal — tapi kalau berkas
--- ini dijalankan lagi setelah ada foto, buckets-nya harus dibersihkan
--- terpisah lewat dashboard Supabase.
+-- Menghapus baris `foto_lembar` tidak menghapus gambarnya. Workflow
+-- apply-migration.yml karena itu menyambung transaksi ini dengan penghapusan
+-- seluruh objek bucket lewat Storage API, lalu membuktikan hitungannya nol.
 --
 -- ---------------------------------------------------------------------------
 -- JALAN KETIGA: 20 AGUSTUS 2026
@@ -58,8 +57,9 @@
 -- Selain slip yang sengaja diunggah, ada berkas YATIM dari tiap percobaan
 -- unggah per regu yang gagal sebelum migrasi 0080: gambarnya naik ke bucket
 -- lebih dulu, barisnya ditolak constraint sesudahnya. SQL tidak bisa
--- menjangkau satu pun di antaranya. Bersihkan bucket `lembar` lewat dashboard
--- Supabase SESUDAH berkas ini dijalankan.
+-- menjangkau satu pun di antaranya. Sejak workflow cleanup diperbaiki, semua
+-- path diambil langsung dari storage.objects dan file dihapus lewat Storage
+-- API sesudah transaksi ini berhasil — termasuk gambar yatim seperti itu.
 --
 -- ---------------------------------------------------------------------------
 -- KENAPA HARUS BERSIH SEBELUM KONFIGURASI DIGANTI
@@ -80,8 +80,10 @@
 --   pos / wahana     Konfigurasi penilaian; itu urusan 0033.
 --
 -- Urutannya mengikuti foreign key dari daun ke akar. Dijalankan lewat
--- workflow "Apply migration to Supabase", yang membungkusnya dalam SATU
--- transaksi: kalau ada satu statement gagal, tidak ada yang terhapus.
+-- workflow "Apply migration to Supabase", yang membungkus SQL dalam SATU
+-- transaksi: kalau ada satu statement SQL gagal, tidak ada data database yang
+-- terhapus. Setelah commit, workflow menghapus seluruh isi bucket `lembar`
+-- lewat Storage API dan gagal merah kalau verifikasi bucket belum nol.
 -- ============================================================================
 
 \echo '=== SEBELUM ==='


### PR DESCRIPTION
## What

- delete every object in the lembar Storage bucket during participant cleanup
- batch Storage API deletions and verify no object metadata remains
- keep the cleanup idempotent when participant tables are already empty

## Why

Deleting foto_lembar rows does not remove the physical Storage objects. The go-live cleanup must leave both participant data and uploaded photos empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)