### PR TITLE
fix: rename kloter calculator feature

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -520,7 +520,7 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("pengaturan") ? `
       <a href="#/pengaturan-kloter">
-        <div class="function-name">${ikonKotak("settings", "abu")} Pengaturan Kloter</div>
+        <div class="function-name">${ikonKotak("settings", "abu")} Kalkulator Keberangkatan</div>
       </a>` : ""}
     </div>
   `));
@@ -529,9 +529,9 @@ async function layarHome() {
 /* ============================ PENGATURAN KLOTER ========================== */
 
 async function layarPengaturanKloter() {
-  pasangKepala("Pengaturan Kloter");
+  pasangKepala("Kalkulator Keberangkatan");
   if (!bolehLihat("pengaturan")) {
-    LAYAR.replaceChildren(kartuGalat("Akun ini tidak berhak membuka Pengaturan Kloter."));
+    LAYAR.replaceChildren(kartuGalat("Akun ini tidak berhak membuka Kalkulator Keberangkatan."));
     return;
   }
   LAYAR.replaceChildren(h(pemuat()));
@@ -554,7 +554,6 @@ async function layarPengaturanKloter() {
 
   LAYAR.replaceChildren(h(`
     <div class="card">
-      <h2>Kalkulator Keberangkatan</h2>
       <div class="two-column">
         <div class="field">
           <label>Waktu Berangkat Pertama</label>

--- a/web/js/departure-calculator.mjs
+++ b/web/js/departure-calculator.mjs
@@ -2,7 +2,7 @@
    Kalkulator pembagian kloter dan waktu keberangkatan.
 
    Murni perhitungan: tidak membaca DOM dan tidak menyimpan ke database. Karena
-   itu rumus yang sama bisa diuji di Node dan dipakai layar Pengaturan Kloter.
+   itu rumus yang sama bisa diuji di Node dan dipakai Kalkulator Keberangkatan.
    ========================================================================== */
 
 function menitDariJam(jam) {


### PR DESCRIPTION
## What

- rename the user-facing feature to Kalkulator Keberangkatan
- remove the repeated card heading from the calculator screen

## Why

The feature name should describe its actual purpose directly and appear consistently on Home and the screen header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)