### PR TITLE
fix: preserve schools when resetting event data

### DIFF
--- a/supabase/checks/cleanup_data_uji.sql
+++ b/supabase/checks/cleanup_data_uji.sql
@@ -1,7 +1,8 @@
 -- ============================================================================
 -- hrcd-rekap : cleanup_data_uji.sql
 --
--- MENGHAPUS SELURUH DATA PESERTA EDISI AKTIF. Tidak bisa dibatalkan.
+-- MENGHAPUS SELURUH DATA OPERASIONAL PESERTA EDISI AKTIF. Tidak bisa
+-- dibatalkan. Master Asal Sekolah (`sekolah`) tetap disimpan.
 --
 -- Dijalankan sekali, atas permintaan pemilik, setelah `isi_edisi.sql`
 -- membuktikan bahwa seluruh 16 sekolah di produksi memang sisa pengetesan:
@@ -11,8 +12,9 @@
 -- minggu lagi (29 Agustus 2026) dan pendaftaran belum dibuka.
 --
 -- JANGAN dijalankan lagi setelah pendaftaran sungguhan dibuka. Berkas ini
--- tidak bisa membedakan sekolah uji dari sekolah asli; ia menghapus
--- SEMUANYA. Yang membedakan hanya orang yang menjalankannya.
+-- menghapus seluruh pendaftaran beserta regu dan catatan operasionalnya tanpa
+-- membedakan data uji dari data asli. Baris master sekolah tidak ikut dihapus,
+-- sehingga tetap tersedia sebagai Asal Sekolah untuk pendaftaran berikutnya.
 --
 -- ---------------------------------------------------------------------------
 -- JALAN KEDUA: 16 AGUSTUS 2026
@@ -78,6 +80,8 @@
 --   nomor_dada_stok  Stok nomor fisik adalah konfigurasi, bukan data peserta.
 --   akun_panitia     Akun panitia tidak ada hubungannya dengan pendaftaran.
 --   pos / wahana     Konfigurasi penilaian; itu urusan 0033.
+--   sekolah          Master Asal Sekolah dipakai kembali lintas reset. Yang
+--                    dibuang hanya pendaftaran yang merujuk kepadanya.
 --
 -- Urutannya mengikuti foreign key dari daun ke akar. Dijalankan lewat
 -- workflow "Apply migration to Supabase", yang membungkus SQL dalam SATU
@@ -123,7 +127,6 @@ delete from penempatan_barak;
 delete from pembayaran;
 delete from regu;
 delete from pendaftaran;
-delete from sekolah;
 
 -- Nomor dada yang dipensiunkan saat menguji penukaran: dikembalikan ke
 -- antrean, karena regu yang pernah memakainya sudah tidak ada.

--- a/supabase/checks/seed_data_uji.sql
+++ b/supabase/checks/seed_data_uji.sql
@@ -4,8 +4,8 @@
 -- DATA UJI untuk melihat layar Input Pos dan Rekapitulasi terisi. BUKAN
 -- migrasi — jangan pernah dijalankan setelah pendaftaran asli dibuka.
 --
--- Pasangannya `cleanup_data_uji.sql`, yang membuang persis apa yang berkas ini
--- pasang. Keduanya memakai kosakata yang sama supaya jelas mereka sepasang.
+-- Pasangannya `cleanup_data_uji.sql`, yang membuang data operasional yang
+-- dipasang berkas ini tetapi sengaja mempertahankan master Asal Sekolah.
 --
 -- ---------------------------------------------------------------------------
 -- ASALNYA DATA INI
@@ -22,9 +22,8 @@
 --     Dibuang atas permintaan panitia, karena XXXVII tidak punya golongan
 --     intern dan memaksakannya ke `penegak_pa` akan membuat mereka muncul di
 --     klasemen Penegak PA seolah sekolah luar. Sisa 46 regu.
---   * Alamat setiap sekolah ditulis "(data uji — HRCD XXXVI)". Ini penanda
---     yang disengaja: `cleanup_data_uji.sql` tidak bisa membedakan sekolah uji
---     dari sekolah sungguhan, jadi pembedanya harus terbaca mata manusia.
+--   * Sekolah yang belum ada diberi alamat "(data uji — HRCD XXXVI)". Bila
+--     sekolah sudah ada di master, alamat kurasinya tidak ditimpa.
 --
 -- ---------------------------------------------------------------------------
 -- SENGAJA TIDAK LENGKAP
@@ -62,17 +61,16 @@ declare
   v_nilai  int;
 begin
   -- -------------------------------------------------------------------------
-  -- Penjaga: berkas ini hanya untuk database kosong. Kalau sudah ada sekolah,
-  -- kita tidak bisa tahu mana yang uji dan mana yang sungguhan — dan menimpa
-  -- pendaftaran asli dengan data karangan bukan kesalahan yang bisa diurungkan
-  -- dengan git revert.
+  -- Penjaga: master sekolah boleh sudah terisi, tetapi data operasional harus
+  -- kosong. Menimpa pendaftaran asli dengan data karangan bukan kesalahan yang
+  -- bisa diurungkan dengan git revert.
   -- -------------------------------------------------------------------------
-  select count(*) into v_ada from sekolah;
+  select count(*) into v_ada from pendaftaran;
   if v_ada > 0 then
     raise exception
-      'Sudah ada % sekolah di database. Berkas ini hanya untuk database '
-      'kosong — jalankan cleanup_data_uji.sql dulu kalau memang isinya data '
-      'uji, dan JANGAN jalankan sama sekali kalau isinya pendaftaran asli.',
+      'Sudah ada % pendaftaran di database. Jalankan cleanup_data_uji.sql '
+      'dulu kalau memang isinya data uji, dan JANGAN jalankan sama sekali '
+      'kalau isinya pendaftaran asli.',
       v_ada;
   end if;
 
@@ -147,7 +145,8 @@ begin
   -- yang membuat layar Daftar Ulang punya sesuatu untuk dikelompokkan.
   -- -------------------------------------------------------------------------
   insert into sekolah (name, address)
-  select distinct sekolah, '(data uji — HRCD XXXVI)' from daftar_uji;
+  select distinct sekolah, '(data uji — HRCD XXXVI)' from daftar_uji
+  on conflict (kunci_sekolah(name)) do nothing;
 
   insert into pendaftaran (sekolah_id, kode_pembayaran, kontak_wa,
                            jumlah_regu, jumlah_pendamping, butuh_barak, status)
@@ -158,7 +157,8 @@ begin
          1,
          (count(d.nomor_dada) > 2),   -- sekolah besar menginap
          'lunas'
-  from sekolah s join daftar_uji d on d.sekolah = s.name
+  from sekolah s
+  join daftar_uji d on kunci_sekolah(d.sekolah) = kunci_sekolah(s.name)
   group by s.id, s.name;
 
   -- -------------------------------------------------------------------------
@@ -177,7 +177,7 @@ begin
          (array[210, 240, 270])[(d.nomor_dada % 3) + 1]
   from (select *, row_number() over (order by nomor_dada) as rn
         from daftar_uji) d
-  join sekolah s     on s.name = d.sekolah
+  join sekolah s     on kunci_sekolah(s.name) = kunci_sekolah(d.sekolah)
   join pendaftaran p on p.sekolah_id = s.id;
 
   -- Kloter berangkat mulai 07.00 WIB, berjarak 15 menit.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -378,5 +378,9 @@ run tests/sql/52_intern_golongan.sql
 run supabase/migrations/0092_fifo_kloter_eksternal_intern.sql
 run supabase/migrations/0093_configure_fifo_capacity.sql
 run tests/sql/53_fifo_kloter_eksternal_intern.sql
+# Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
+# Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
+# nilai, dan data operasional lain yang dipakai tes sebelumnya.
+run tests/sql/54_cleanup_preserves_schools.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/54_cleanup_preserves_schools.sql
+++ b/tests/sql/54_cleanup_preserves_schools.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Cleanup data operasional tidak boleh menghapus master Asal Sekolah.
+--
+-- Snapshot menyimpan seluruh isi sekolah, bukan hanya jumlahnya. Dengan itu
+-- tes juga menangkap perubahan id, nama, alamat, atau timestamp yang tidak
+-- sengaja dilakukan oleh script reset.
+-- ============================================================================
+
+create temporary table sekolah_sebelum_cleanup as table sekolah;
+
+\ir ../../supabase/checks/cleanup_data_uji.sql
+
+do $$
+begin
+  assert not exists (
+    (select * from sekolah_sebelum_cleanup except select * from sekolah)
+    union all
+    (select * from sekolah except select * from sekolah_sebelum_cleanup)
+  ), 'cleanup mengubah master Asal Sekolah';
+
+  assert (select count(*) from pendaftaran) = 0,
+         'cleanup tidak menghapus seluruh pendaftaran';
+  assert (select count(*) from regu) = 0,
+         'cleanup tidak menghapus seluruh regu';
+end;
+$$;


### PR DESCRIPTION
## What

- preserve every `sekolah` row when resetting event data
- let test-data seeding reuse existing schools without overwriting curated addresses
- add a regression test that compares the complete school master before and after cleanup

## Why

Asal Sekolah is reusable master data, not operational event data. Resetting registrations, regu, scores, and departure records must not remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)