### PR TITLE
fix: simplify registration level labels

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -21,10 +21,10 @@ import { esc, h, html, rupiah, notif, kartuGagalMuat,
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN = [
-  { kode: "penggalang_pa", label: "Penggalang Putra", ket: "SMP / MTs — putra" },
-  { kode: "penggalang_pi", label: "Penggalang Putri", ket: "SMP / MTs — putri" },
-  { kode: "penegak_pa",    label: "Penegak Putra",    ket: "SMA / SMK / MA — putra" },
-  { kode: "penegak_pi",    label: "Penegak Putri",    ket: "SMA / SMK / MA — putri" },
+  { kode: "penggalang_pa", label: "Penggalang Putra", ket: "SMP / MTs" },
+  { kode: "penggalang_pi", label: "Penggalang Putri", ket: "SMP / MTs" },
+  { kode: "penegak_pa",    label: "Penegak Putra",    ket: "SMA / SMK / MA" },
+  { kode: "penegak_pi",    label: "Penegak Putri",    ket: "SMA / SMK / MA" },
 ];
 const GOLONGAN_INTERNAL = [
   { kode: "intern_pa", label: "Intern Putra", ket: "" },


### PR DESCRIPTION
## What

- show only `SMP / MTs` for Penggalang registration rows
- show only `SMA / SMK / MA` for Penegak registration rows
- remove the repeated Putra/Putri suffix from the secondary label

## Why

Each row title already identifies Putra or Putri, so repeating it in the level label adds noise and causes unnecessary wrapping on mobile screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)