### PR TITLE
fix: improve mobile payment receipt layout

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -922,6 +922,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* Kwitansi: nomornya yang dicari orang saat menyusun berkas, jadi itu yang
      dibesarkan — bukan judulnya. */
   .receipt-number { font-size: 20pt; font-weight: 800; margin: .2rem 0 .6rem; }
+  /* Tanggal sengaja di baris sendiri dan tidak boleh terbelah antara label
+     dengan nilainya, terutama saat dicetak dari preview HP. */
+  .receipt-date { white-space: nowrap; }
   .receipt-signature { margin-top: 10mm; width: 60mm; margin-left: auto; text-align: center; }
   .receipt-line { margin-top: 14mm; border-top: 1pt solid #000; padding-top: 2mm; }
 

--- a/live/style.css
+++ b/live/style.css
@@ -2443,6 +2443,12 @@ input.small-input { text-align: center; }
    harus ikut naik, kalau tidak tombol yang hilang itu kembali lagi.
    ========================================================================= */
 @media (max-width: 900px) {
+  /* Di dialog setelah Tandai Lunas, jumlah regu mulai di baris kedua. Nama
+     sekolah dan kode pembayaran jadi satu baris identitas yang utuh, lalu
+     jumlah dan nominal tetap berpasangan di bawahnya. */
+  .card-identity .detail-separator-mobile { display: none; }
+  .card-identity .detail-regu-mobile { display: block; }
+
   /* ---- tabel BERHENTI jadi tabel ----
      Enam kolom tidak akan pernah muat di layar sempit, dan menggeser ke
      samping menyembunyikan justru kolom aksi — panitia tidak tahu ada

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1132,8 +1132,9 @@ function cetakKwitansi(daftar) {
         <p class="receipt-number">${esc(bayar.nomor_kwitansi || "—")}</p>
         <p><strong>Diterima dari:</strong> ${esc(b.sekolah?.name || "—")}</p>
         <p><strong>Kode pembayaran:</strong> ${esc(b.kode_pembayaran)}
-           · <strong>Cara bayar:</strong> ${esc(bayar.method || "—")}
-           · <strong>Tanggal:</strong> ${esc(tanggal(bayar.verified_at))}</p>
+           · <strong>Cara bayar:</strong> ${esc(bayar.method || "—")}<br>
+           <span class="receipt-date"><strong>Tanggal:</strong>
+             ${esc(tanggal(bayar.verified_at))}</span></p>
         <p><strong>Untuk pembayaran:</strong> pendaftaran ${aktif.length} regu
            @ ${esc(rupiah(EDISI.biaya_per_regu))}</p>
         <table class="print-table">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1072,8 +1072,9 @@ async function layarPembayaran() {
           judul: "Lunas — cetak kwitansi?",
           kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
             <div class="nama">${r.nomor_kwitansi}</div>
-            <div class="detail">${b.sekolah?.name || kode} · ${kode} ·
-              ${aktif.length} regu · ${rupiah(tagihan)}</div>
+            <div class="detail">${b.sekolah?.name || kode} · ${kode}<span
+              class="detail-separator-mobile"> · </span><span
+              class="detail-regu-mobile">${aktif.length} regu · ${rupiah(tagihan)}</span></div>
           </div>`,
           labelAksi: "Cetak Kwitansi",
         });

--- a/web/style.css
+++ b/web/style.css
@@ -922,6 +922,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* Kwitansi: nomornya yang dicari orang saat menyusun berkas, jadi itu yang
      dibesarkan — bukan judulnya. */
   .receipt-number { font-size: 20pt; font-weight: 800; margin: .2rem 0 .6rem; }
+  /* Tanggal sengaja di baris sendiri dan tidak boleh terbelah antara label
+     dengan nilainya, terutama saat dicetak dari preview HP. */
+  .receipt-date { white-space: nowrap; }
   .receipt-signature { margin-top: 10mm; width: 60mm; margin-left: auto; text-align: center; }
   .receipt-line { margin-top: 14mm; border-top: 1pt solid #000; padding-top: 2mm; }
 

--- a/web/style.css
+++ b/web/style.css
@@ -2443,6 +2443,12 @@ input.small-input { text-align: center; }
    harus ikut naik, kalau tidak tombol yang hilang itu kembali lagi.
    ========================================================================= */
 @media (max-width: 900px) {
+  /* Di dialog setelah Tandai Lunas, jumlah regu mulai di baris kedua. Nama
+     sekolah dan kode pembayaran jadi satu baris identitas yang utuh, lalu
+     jumlah dan nominal tetap berpasangan di bawahnya. */
+  .card-identity .detail-separator-mobile { display: none; }
+  .card-identity .detail-regu-mobile { display: block; }
+
   /* ---- tabel BERHENTI jadi tabel ----
      Enam kolom tidak akan pernah muat di layar sempit, dan menggeser ke
      samping menyembunyikan justru kolom aksi — panitia tidak tahu ada


### PR DESCRIPTION
## What

- move the team count and payment amount to a new line in the post-payment dialog on mobile
- keep the school and payment code together on the first line
- print the receipt date on its own line and prevent the label and value from splitting
- keep shared print CSS synchronized between `web/` and `live/`

## Why

The payment summary wrapped awkwardly on narrow screens, and the printed receipt could leave the date label at the end of one line while placing its value on the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)