### PR TITLE
fix: keep kloter print inside user gesture

### DIFF
--- a/.github/workflows/sql-tests.yml
+++ b/.github/workflows/sql-tests.yml
@@ -52,8 +52,8 @@ jobs:
           psql --version
           psql -h 127.0.0.1 -p 55432 -U postgres -d postgres -c "select version();"
 
-      - name: Test kloter calculator
-        run: node --test tests/departure_calculator.test.mjs
+      - name: Test JavaScript
+        run: node --test tests/*.test.mjs
 
       - name: Jalankan seluruh tes
         env:

--- a/tests/ios_print.test.mjs
+++ b/tests/ios_print.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("cetak kloter memanggil print tanpa melewati await", () => {
+  const awal = app.indexOf("  function cetak(bentuk) {");
+  const akhir = app.indexOf(
+    '  document.getElementById("cetak-petugas")',
+    awal,
+  );
+
+  assert.notEqual(awal, -1, "fungsi cetak kloter tidak ditemukan");
+  assert.notEqual(akhir, -1, "akhir fungsi cetak kloter tidak ditemukan");
+
+  const cetak = app.slice(awal, akhir);
+  const sebelumPrint = cetak.slice(0, cetak.indexOf("window.print();"));
+
+  assert.match(cetak, /window\.print\(\);/, "window.print() tidak dipanggil");
+  assert.doesNotMatch(
+    sebelumPrint,
+    /\bawait\b|daftarKloter\s*\(/,
+    "Safari iPhone memblokir print bila request ditunggu sesudah tap",
+  );
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1950,17 +1950,15 @@ async function layarCetakKloter() {
       }).join("")));
   };
 
-  /** Cetak semua kloter berisi dalam satu bentuk kertas, termasuk yang sudah
-   *  pernah dicetak. Datanya diambil ulang tepat sebelum mencetak: layar ini
-   *  sering dibiarkan terbuka sementara meja daftar ulang terus jalan, dan
-   *  cetak ulang harus selalu memuat regu yang baru masuk. */
-  async function cetak(bentuk) {
-    let segar;
-    try { segar = await daftarKloter(); }
-    catch (err) { notif(err.message, true); return; }
-
-    perKloter = kelompokkan(segar);
-    gambarPratayang(perKloter);
+  /** Cetak semua kloter yang terlihat di pratayang, termasuk yang sudah pernah
+   *  dicetak. `window.print()` HARUS tetap berada dalam giliran event tap:
+   *  Safari iPhone memblokirnya bila ada `await` lebih dulu karena sesudah itu
+   *  panggilannya tidak lagi dianggap berasal langsung dari pengguna.
+   *
+   *  Data layar sudah diambil saat layar dibuka. Menyamakan kertas dengan
+   *  pratayang juga menghindari kertas diam-diam berbeda dari yang baru saja
+   *  diperiksa petugas. Buka ulang layar untuk mengambil perubahan terbaru. */
+  function cetak(bentuk) {
     const semuaKloter = [...perKloter.entries()];
     siapkanCetakKloter(semuaKloter, bentuk);
     window.print();
@@ -1974,12 +1972,13 @@ async function layarCetakKloter() {
       "Batal = jangan ubah waktu cetak",
     ].join("\n"));
     if (!lanjut) return;
-    try {
-      const nomor = semuaKloter.map(([n]) => Number(n));
-      const n = await tandaiKloterDicetak(nomor);
-      notif(`Waktu cetak ${n} kloter disimpan.`);
-      layarCetakKloter();
-    } catch (err) { notif(err.message, true); }
+    const nomor = semuaKloter.map(([n]) => Number(n));
+    tandaiKloterDicetak(nomor)
+      .then((n) => {
+        notif(`Waktu cetak ${n} kloter disimpan.`);
+        layarCetakKloter();
+      })
+      .catch((err) => notif(err.message, true));
   }
 
   document.getElementById("cetak-petugas").addEventListener("click", () => cetak("staging"));


### PR DESCRIPTION
## What

- print the currently inspected kloter preview synchronously from the button tap
- keep the print timestamp update asynchronous after printing
- add a regression test that prevents network waits before window.print()

## Why

Safari on iPhone blocks the print dialog when a network await separates window.print() from the user's tap. Receipt printing already works because it calls print directly from that gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)