### PR TITLE
feat: show kloter departure time in preview

### DIFF
--- a/tests/ios_print.test.mjs
+++ b/tests/ios_print.test.mjs
@@ -26,3 +26,23 @@ test("cetak kloter memanggil print tanpa melewati await", () => {
     "Safari iPhone memblokir print bila request ditunggu sesudah tap",
   );
 });
+
+
+test("tanggal cetak kloter hanya dirender di lembar print", () => {
+  const awalPratayang = app.indexOf("  const gambarPratayang = (peta) => {");
+  const akhirPratayang = app.indexOf("  /** Cetak semua kloter", awalPratayang);
+  const pratayang = app.slice(awalPratayang, akhirPratayang);
+
+  assert.doesNotMatch(pratayang, /Dicetak/, "tanggal cetak masih tampil di kartu layar");
+
+  const awalLembar = app.indexOf("function siapkanCetakKloter(");
+  const akhirLembar = app.indexOf("/* ============================ INPUT POS", awalLembar);
+  const lembar = app.slice(awalLembar, akhirLembar);
+
+  assert.match(
+    lembar,
+    /const dicetak = tanggalJam\(new Date\(\)\.toISOString\(\)\)/,
+    "waktu print tidak dibuat saat tombol cetak ditekan",
+  );
+  assert.match(lembar, /Dicetak \$\{esc\(dicetak\)\}/, "waktu print tidak ada di lembar");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1903,7 +1903,6 @@ async function layarCetakKloter() {
     const peta = new Map();
     for (const b of rows) {
       if (!peta.has(b.kloter)) peta.set(b.kloter, {
-        dicetak: b.dicetak_pada,
         jamBerangkat: b.jam_berangkat,
         perkiraanBerangkat: b.perkiraan_berangkat,
         isi: [],
@@ -1951,9 +1950,6 @@ async function layarCetakKloter() {
               ? "Jam berangkat"
               : "Estimasi jam berangkat"}:</strong>
               ${esc(jamMenit(v.jamBerangkat || v.perkiraanBerangkat))}</p>
-            ${v.dicetak
-              ? `<p class="sub">Dicetak: ${esc(tanggalJam(v.dicetak))}</p>`
-              : ""}
             <table class="table">${baris}</table>
           </div>`;
       }).join("")));
@@ -2005,6 +2001,7 @@ async function layarCetakKloter() {
  */
 function siapkanCetakKloter(dipakai, bentuk = "staging") {
   document.getElementById("cetakan")?.remove();
+  const dicetak = tanggalJam(new Date().toISOString());
 
   const halaman = dipakai.map(([nomor, v]) => {
     const contoh = v.isi[0] || {};
@@ -2039,6 +2036,7 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
           <tbody>${baris}</tbody>
         </table>
         ${adaSisipan ? `<p class="insert-note">★ = regu sisipan, ditambahkan setelah kertas ini dicetak.</p>` : ""}
+        <p class="print-note">Dicetak ${esc(dicetak)}.</p>
       </section>` : `
       <section class="print-page">
         <h1>KLOTER ${esc(nomor)}</h1>
@@ -2049,7 +2047,8 @@ function siapkanCetakKloter(dipakai, bentuk = "staging") {
         </table>
         <p class="print-note">Bersiap di staging paling lambat 15 menit sebelum
            perkiraan berangkat.<br>
-           Jam sebenarnya bisa bergeser, ikuti panggilan petugas.</p>
+           Jam sebenarnya bisa bergeser, ikuti panggilan petugas.<br>
+           Dicetak ${esc(dicetak)}.</p>
       </section>`;
   }).join("");
   document.body.appendChild(h(`<div id="cetakan" class="printout">${halaman}</div>`));

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1902,7 +1902,12 @@ async function layarCetakKloter() {
   const kelompokkan = (rows) => {
     const peta = new Map();
     for (const b of rows) {
-      if (!peta.has(b.kloter)) peta.set(b.kloter, { dicetak: b.dicetak_pada, isi: [] });
+      if (!peta.has(b.kloter)) peta.set(b.kloter, {
+        dicetak: b.dicetak_pada,
+        jamBerangkat: b.jam_berangkat,
+        perkiraanBerangkat: b.perkiraan_berangkat,
+        isi: [],
+      });
       peta.get(b.kloter).isi.push(b);
     }
     return peta;
@@ -1942,6 +1947,10 @@ async function layarCetakKloter() {
         return `
           <div class="card">
             <h2>Kloter ${esc(nomor)}</h2>
+            <p><strong>${v.jamBerangkat
+              ? "Jam berangkat"
+              : "Estimasi jam berangkat"}:</strong>
+              ${esc(jamMenit(v.jamBerangkat || v.perkiraanBerangkat))}</p>
             ${v.dicetak
               ? `<p class="sub">Dicetak: ${esc(tanggalJam(v.dicetak))}</p>`
               : ""}


### PR DESCRIPTION
## What

- show the estimated departure time for kloter that have not left
- switch the preview to the recorded departure time after departure
- remove the print timestamp from the screen preview
- add the current print timestamp only to the printed staff and participant layouts
- add a regression test for print-only timestamp rendering

## Why

The Daftar Kloter preview should distinguish planning time from the actual recorded departure. The administrative print timestamp belongs on the paper, not in the operational screen card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)