### PR TITLE
fix: stop kloter print preview from hanging on iPhone

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1967,23 +1967,39 @@ async function layarCetakKloter() {
     const semuaKloter = [...perKloter.entries()];
     siapkanCetakKloter(semuaKloter, bentuk);
     window.print();
+    tanyaWaktuCetak(semuaKloter.map(([n]) => Number(n)));
+  }
 
-    // Timestamp diperbarui SETELAH dialog cetak ditutup. Ia adalah catatan
-    // cetak terakhir, bukan gembok: kloter yang sama selalu bisa dicetak lagi.
-    const lanjut = confirm([
-      "Kertasnya sudah keluar dengan benar?",
-      "",
-      "OK  = simpan waktu cetak sekarang",
-      "Batal = jangan ubah waktu cetak",
-    ].join("\n"));
-    if (!lanjut) return;
-    const nomor = semuaKloter.map(([n]) => Number(n));
-    tandaiKloterDicetak(nomor)
-      .then((n) => {
-        notif(`Waktu cetak ${n} kloter disimpan.`);
-        layarCetakKloter();
-      })
-      .catch((err) => notif(err.message, true));
+  /** Pertanyaan sesudah mencetak: kertasnya keluar atau tidak. Waktu cetak
+   *  adalah catatan cetak terakhir, bukan gembok — kloter yang sama selalu
+   *  bisa dicetak lagi (CLAUDE.md 12.1).
+   *
+   *  DIALOG SENDIRI, BUKAN `confirm()` BAWAAN BROWSER, dan itu bukan soal
+   *  selera. `confirm()` MEMBLOKIR utas utama halaman sampai dijawab. Di
+   *  iPhone `window.print()` tidak menahan JavaScript: lembar cetak iOS baru
+   *  mulai menggambar preview-nya sesudah baris itu lewat, jadi `confirm()`
+   *  yang menyusul mengunci utas yang sedang dipakai menggambar — lembar
+   *  cetaknya berhenti di "Loading Preview…" selamanya, dan pertanyaannya
+   *  sendiri tertutup di belakangnya. Cetak kwitansi dan blangko pos tidak
+   *  pernah kena karena keduanya berhenti tepat sesudah `window.print()`.
+   *
+   *  `dialog()` cuma menempelkan elemen di halaman lalu mengembalikan Promise,
+   *  jadi utasnya bebas. Overlay-nya sudah `display: none` di @media print,
+   *  jadi ia tidak ikut tercetak. */
+  async function tanyaWaktuCetak(nomor) {
+    const jawab = await dialog({
+      judul: "Kertasnya sudah keluar?",
+      kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
+        <div class="nama">${String(nomor.length)} kloter</div>
+      </div>`,
+      labelAksi: "Simpan waktu cetak",
+    });
+    if (!jawab) return;
+    try {
+      const n = await tandaiKloterDicetak(nomor);
+      notif(`Waktu cetak ${n} kloter disimpan.`);
+      layarCetakKloter();
+    } catch (err) { notif(err.message, true); }
   }
 
   document.getElementById("cetak-petugas").addEventListener("click", () => cetak("staging"));


### PR DESCRIPTION
## What

Cetak Daftar Kloter asked "Kertasnya sudah keluar dengan benar?" with the
browser's native `confirm()`, called immediately after `window.print()`.
That question now uses the app's own `dialog()`.

## Why

On iOS Safari `window.print()` does not block JavaScript: the print sheet
starts rendering its preview *after* the call returns. The `confirm()` right
behind it then locked the main thread the preview was being drawn on, so the
sheet sat on "Loading Preview…" indefinitely — and the question itself was
hidden behind the sheet, so nothing could unblock it.

Cetak Kwitansi in Meja Pembayaran shows its preview instantly because that
path stops at `window.print()`. It was the only print in the app followed by
a native modal.

`dialog()` appends an element and returns a Promise, so the thread stays free.
Its `.overlay` is already `display: none` under `@media print`, so it does not
reach the paper. Behaviour is unchanged: OK stamps the print time, Batal
leaves it alone, and the print mark still never locks a kloter (CLAUDE.md 12.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)