### PR TITLE
fix: keep departure checkmark responsive

### DIFF
--- a/tests/departure_checkmark.test.mjs
+++ b/tests/departure_checkmark.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("ceklis keberangkatan tidak diredupkan selama penyimpanan", () => {
+  const awal = app.indexOf('    kotak.querySelectorAll("[data-ceklis]")');
+  const akhir = app.indexOf('    kotak.querySelectorAll("[data-kontrak]")', awal);
+
+  assert.notEqual(awal, -1, "handler ceklis keberangkatan tidak ditemukan");
+  assert.notEqual(akhir, -1, "akhir handler ceklis keberangkatan tidak ditemukan");
+
+  const handler = app.slice(awal, akhir);
+  assert.doesNotMatch(
+    handler,
+    /classList\.(?:add|toggle)\(["']saving["']\)/,
+    "ceklis keberangkatan kembali diredupkan saat request berjalan",
+  );
+  assert.match(handler, /antre = antre\.then\(/, "klik beruntun tetap harus diantrekan");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1690,15 +1690,13 @@ async function layarKeberangkatan() {
       cb.addEventListener("change", () => {
         const dada = Number(cb.dataset.ceklis);
         const mau = cb.checked;
-        cb.classList.add("saving");
         antre = antre.then(async () => {
           try {
             if (mau) await ceklisBerangkat(dada);
             else await batalCeklisBerangkat(dada);
-            // Redup dilepas begitu tulisannya masuk. Papan menyusul di bawah:
-            // menunggunya membuat centang terasa lambat sedetik padahal
-            // datanya sudah tersimpan.
-            cb.classList.remove("saving");
+            // Checkbox tetap menampilkan keadaan yang baru dipilih selama
+            // request berjalan. Meredupkannya memberi kesan kliknya gagal
+            // atau tertunda, padahal perubahan layar sudah terjadi langsung.
             // Dua dropdown di baris yang sama dikunci selama regunya
             // terceklis, dan status terkunci itu ditulis saat tabel
             // digambar. Sesudah ini yang digambar ulang hanya pita kloter di
@@ -1719,7 +1717,6 @@ async function layarKeberangkatan() {
           } catch (err) {
             notif(err.message, true);
             cb.checked = !mau;
-            cb.classList.remove("saving");
           }
         });
       });


### PR DESCRIPTION
## What

- keep the departure attendance checkmark fully visible while its request is saved
- retain queued rapid corrections and rollback on request failure
- add a regression test for the immediate visual state

## Why

The temporary reduced opacity made a successful tap look grey and delayed until the server responded, which felt like lag on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)