### PR TITLE
fix: restore saved state for unchanged score

### DIFF
--- a/tests/same_value_save_state.test.mjs
+++ b/tests/same_value_save_state.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("nilai yang diketik ulang sama diselesaikan saat input kehilangan fokus", () => {
+  const awal = app.indexOf('  tbody.addEventListener("focusout"');
+  const akhir = app.indexOf("\n  });", awal);
+
+  assert.notEqual(awal, -1, "handler focusout lembar pos tidak ditemukan");
+  assert.notEqual(akhir, -1, "akhir handler focusout lembar pos tidak ditemukan");
+
+  const handler = app.slice(awal, akhir);
+  assert.match(
+    handler,
+    /dataset\.keadaan === ["']belum["']/,
+    "hanya baris kuning yang perlu diselesaikan saat kehilangan fokus",
+  );
+  assert.match(
+    handler,
+    /simpanBaris\(tr\)/,
+    "baris kuning harus dibandingkan dengan nilai tersimpan",
+  );
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4023,6 +4023,16 @@ async function layarInputPos() {
     if (tr) simpanBaris(tr);
   });
 
+  // Mengetik ulang angka yang sama memicu `input`, tetapi browser tidak
+  // selalu memicu `change`: nilai ketika fokus masuk dan keluar tetap sama.
+  // Selesaikan penanda kuning saat kotaknya ditinggalkan. Pagar `belum`
+  // mencegah focusout mengantrekan simpanan kedua ketika `change` sudah lebih
+  // dulu menjalankan simpanBaris().
+  tbody.addEventListener("focusout", (e) => {
+    const tr = e.target.closest("tr");
+    if (tr?.dataset.keadaan === "belum") simpanBaris(tr);
+  });
+
   /* ISI KOTAK DIPILIH SAAT DIKETUK, jadi ketukan pertama MENGGANTI.
 
      Kotak nilai tidak pernah dimaksudkan untuk DITAMBAHI — tidak ada juri yang


### PR DESCRIPTION
## What

- resolve a pending score row when an input loses focus
- add a regression test for retyping the stored score unchanged

## Why

Browsers may skip the `change` event when the final value matches the value at focus. The row was already marked pending by `input`, so it stayed yellow even though the displayed score matched the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)