### PR TITLE
fix: compute Nilai Pos with jawaban_benar on the pos sheet

### DIFF
--- a/supabase/migrations/0095_lembar_pos_jawaban_benar.sql
+++ b/supabase/migrations/0095_lembar_pos_jawaban_benar.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- hrcd-rekap : 0095_lembar_pos_jawaban_benar.sql
+-- Nilai Pos di layar juri dihitung dengan jawaban benar, sama seperti klasemen.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SALAH
+--
+-- Poin tidak pernah disimpan; ia diturunkan tiap kali dibaca, dan diturunkan
+-- di DUA tempat:
+--
+--   v_poin_wahana  -> v_poin_pos -> v_total_skor -> v_klasemen   (klasemen)
+--   v_lembar_pos.nilai_pos                                        (layar juri)
+--
+-- 0085 menambahkan argumen ke-11 `p_jawaban_benar` ke hitung_poin dan
+-- membangun ulang KEDUANYA, dengan alasan yang ditulis di kepalanya sendiri:
+-- kalau salah satu ditinggalkan memakai bentuk lama, "layar Input Nilai Pos
+-- menampilkan Nilai Pos yang dihitung TANPA jawaban benar sementara klasemen
+-- memakai yang dengan. Dua angka untuk satu regu di dua layar, keduanya tanpa
+-- galat."
+--
+-- 0091 membangun ulang v_lembar_pos sekali lagi — untuk menambahkan pagar
+-- Intern — dan menyalin badannya dari 0065, yaitu bentuk SEBELUM 0085. Sejak
+-- itu panggilannya kembali sepuluh argumen, tanpa `w.jawaban_benar`.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TIDAK ADA GALAT SAMA SEKALI
+--
+-- Argumen ke-11 punya `default null`, jadi panggilan sepuluh argumen tetap
+-- cocok dengan fungsi yang sama. Bentuk sepuluh argumen memang sudah di-drop
+-- di akhir 0085, dan itu justru yang menyesatkan: yang dibuang overload-nya,
+-- bukan kemampuan memanggilnya dengan argumen kurang. Apply-nya berhasil,
+-- pembacaannya berhasil, dan yang berubah cuma angkanya.
+--
+-- Yang terlihat di lapangan, dengan konfigurasi Menaksir hari ini
+-- (jawaban_benar 855 cm, tangga 100/200/300/400/500 cm):
+--
+--   taksiran 830 cm  ->  klasemen  : |830-855| = 25 cm  -> 100 poin
+--                        layar juri: 830 dibaca apa adanya, lebih besar dari
+--                                    seluruh batas tangga -> 0 poin
+--
+-- Juri melihat 0 untuk regu yang sebenarnya mendapat angka penuh. Tidak ada
+-- yang merah, tidak ada yang gagal — dua layar cuma menyebut dua angka.
+-- Hanya `bertingkat` ber-jawaban_benar yang terpengaruh, yaitu Menaksir; itu
+-- sebabnya ia tidak tertangkap oleh mata siapa pun yang melihat Pos 2 sampai
+-- Pos 5.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DILAKUKAN BERKAS INI
+--
+-- Badan view disalin UTUH dari 0091 — termasuk pagar Intern
+-- (`komponen_berlaku`) dan predikat EXISTS di akhirnya. Satu-satunya yang
+-- berubah: `w.jawaban_benar` dikembalikan sebagai argumen ke-11.
+--
+-- `create or replace view` menolak daftar kolom yang berubah urutan atau
+-- tipenya, jadi kolomnya harus sama persis — dan memang begitu.
+--
+-- Argumen default-nya sengaja TIDAK dibuang. Membuangnya memang akan membuat
+-- panggilan yang lupa gagal keras, tetapi belasan tes memanggil hitung_poin
+-- dengan sepuluh argumen untuk komponen yang memang tidak punya jawaban benar
+-- (tes 08, 14, 16, 39), dan itu pemakaian yang sah. Yang menjaga supaya
+-- kejadian ini tidak terulang bukan tanda tangan fungsinya melainkan
+-- tests/sql/56_lembar_pos_sama_dengan_klasemen.sql: ia membandingkan
+-- nilai_pos milik SETIAP baris v_lembar_pos dengan jumlah v_poin_wahana untuk
+-- regu dan pos yang sama. Siapa pun yang membangun ulang salah satu view ini
+-- lagi dan lupa satu argumen akan melihat CI merah, bukan dua angka di dua
+-- layar.
+-- ============================================================================
+
+create or replace view v_lembar_pos as
+select
+  p.nomor       as pos,
+  p.name        as nama_pos,
+  p.bayangan,
+  r.id          as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name        as nama_sekolah,
+  r.golongan,
+  coalesce((
+    select jsonb_object_agg(w.kode, jsonb_build_object(
+             'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), '{}'::jsonb) as nilai,
+  (select count(*) from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor)::int
+                as jumlah_terisi,
+  (select count(*) from wahana w
+   where w.edisi = p.edisi and w.pos = p.nomor
+     and komponen_berlaku(w.golongan, r.golongan))::int
+                as jumlah_komponen,
+
+  -- INI yang berubah dari 0091: `w.jawaban_benar` sebagai argumen ke-11,
+  -- persis seperti v_poin_wahana (0085) memanggilnya.
+  round(coalesce((
+    select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                           w.raw_terbaik, w.raw_terburuk,
+                           w.poin_benar, w.poin_salah, w.total_soal, w.tingkat,
+                           w.jawaban_benar))
+    from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor
+  ), 0) * p.bobot, 2) as nilai_pos,
+
+  nilai_tergembok(r.id, p.nomor) as terkunci
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+cross join pos p
+where p.edisi = edisi_aktif()
+  and not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and boleh('pos')
+  and (pos_saya() is null or p.nomor = pos_saya())
+  and exists (
+    select 1 from wahana w
+    where w.edisi = p.edisi and w.pos = p.nomor
+      and komponen_berlaku(w.golongan, r.golongan)
+  );

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -382,6 +382,11 @@ run tests/sql/53_fifo_kloter_eksternal_intern.sql
 # boleh ditandai lagi dan timestamp-nya harus maju; kloter kosong tetap lewat.
 run supabase/migrations/0094_kloter_bisa_dicetak_ulang.sql
 run tests/sql/54_kloter_bisa_dicetak_ulang.sql
+# Layar Input Nilai Pos dan klasemen menghitung poin sendiri-sendiri, jadi
+# keduanya bisa menyimpang tanpa satu galat pun. Tes 56 membandingkan kedua
+# jalur baris per baris. Nomornya di atas 55 tetapi jalannya SEBELUM 55, karena
+# cleanup mengosongkan nilai yang justru dibandingkannya.
+run tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -383,9 +383,13 @@ run tests/sql/53_fifo_kloter_eksternal_intern.sql
 run supabase/migrations/0094_kloter_bisa_dicetak_ulang.sql
 run tests/sql/54_kloter_bisa_dicetak_ulang.sql
 # Layar Input Nilai Pos dan klasemen menghitung poin sendiri-sendiri, jadi
-# keduanya bisa menyimpang tanpa satu galat pun. Tes 56 membandingkan kedua
-# jalur baris per baris. Nomornya di atas 55 tetapi jalannya SEBELUM 55, karena
-# cleanup mengosongkan nilai yang justru dibandingkannya.
+# keduanya bisa menyimpang tanpa satu galat pun — dan 0091 memang membangun
+# ulang v_lembar_pos tanpa `jawaban_benar`, jadi Menaksir bernilai 0 di layar
+# juri sementara klasemen memberi angka penuh. 0095 mengembalikannya; tes 56
+# membandingkan kedua jalur baris per baris supaya rebuild berikutnya yang lupa
+# jatuh di sini. Nomornya di atas 55 tetapi jalannya SEBELUM 55, karena cleanup
+# mengosongkan nilai yang justru dibandingkannya.
+run supabase/migrations/0095_lembar_pos_jawaban_benar.sql
 run tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,

--- a/tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
+++ b/tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
@@ -1,0 +1,210 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/56_lembar_pos_sama_dengan_klasemen.sql — migrasi 0095.
+--
+-- SATU ANGKA, DUA LAYAR, DAN TIDAK BOLEH BERBEDA.
+--
+-- Poin tidak pernah disimpan; ia diturunkan tiap kali dibaca, dan diturunkan
+-- di dua tempat yang berbeda berkasnya:
+--
+--   v_lembar_pos.nilai_pos                      -> layar Input Nilai Pos
+--   v_poin_wahana -> ... -> v_klasemen          -> Rekap dan Live Score
+--
+-- Keduanya memanggil hitung_poin() sendiri-sendiri, jadi keduanya bisa
+-- menyimpang tanpa satu galat pun: hasilnya tetap angka, di kolom yang memang
+-- berisi angka, pada regu yang memang ikut lomba. Itu sudah terjadi. 0085
+-- menambahkan argumen `jawaban_benar` ke keduanya dan menulis peringatannya di
+-- kepala berkasnya sendiri; 0091 membangun ulang v_lembar_pos dari salinan
+-- pra-0085 dan menjatuhkan argumen itu lagi. Karena argumennya `default null`,
+-- tidak ada yang gagal — juri melihat 0 untuk taksiran yang di klasemen
+-- bernilai penuh.
+--
+-- Tes ini karena itu tidak memeriksa satu rumus. Ia memeriksa KESAMAAN kedua
+-- jalur untuk setiap baris yang ada, sehingga rebuild berikutnya yang lupa
+-- satu argumen jatuh di CI, bukan di layar juri pada hari lomba.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KOMPONENNYA DIBUAT SENDIRI DI SINI
+--
+-- Yang membedakan kedua jalur hanya komponen ber-`jawaban_benar`, dan di
+-- database uji komponen seperti itu TIDAK ADA: 0032 dan 0085 sama-sama
+-- melewati bagian datanya kalau `nilai_mentah` sudah berisi, dan di sini ia
+-- memang penuh sejak tes 02. Bersandar pada Menaksir membuat tes ini lulus
+-- tanpa pernah menyentuh perbedaannya — jadi komponennya dipasang sendiri,
+-- dipakai, lalu dibongkar lagi. Sekalian itu membuat tes ini tidak ikut
+-- membeku kalau tahun depan Menaksir diganti nama atau tangganya diatur ulang.
+-- ============================================================================
+
+\echo '--- 56. Nilai Pos di layar juri = angka yang dipakai klasemen'
+
+do $blok$
+declare
+  -- admin.ciradyka dari 01_seed_uji.sql: boleh('pos') dan pos_saya() NULL,
+  -- jadi ia melihat kelima pos — kursi yang sama dipakai tes 52.
+  v_admin    uuid := '00000000-0000-0000-0000-00000000000a';
+  v_terkunci boolean;
+  v_regu     uuid;
+  v_wahana   uuid;
+  v_pos      smallint;
+  v_bobot    numeric;
+  v_jawaban  numeric := 855;   -- 8,55 m dalam sentimeter
+  v_taksiran numeric := 734;   -- 7,34 m -> selisih 121 cm -> tingkat kedua
+  v_poin     numeric;
+  v_layar_sebelum numeric;
+  v_layar_sesudah numeric;
+  v_klas_sebelum  numeric;
+  v_klas_sesudah  numeric;
+  v_beda     int;
+  v_periksa  int;
+  v_berjawab int;
+begin
+  select p.nomor, p.bobot into v_pos, v_bobot
+  from pos p
+  where p.edisi = edisi_aktif() and not p.bayangan
+    and exists (select 1 from wahana w
+                where w.edisi = p.edisi and w.pos = p.nomor)
+  order by p.nomor limit 1;
+  assert v_pos is not null, '56 GAGAL: tidak ada pos berkomponen di edisi aktif';
+
+  -- Regu eksternal yang benar-benar muncul di v_lembar_pos: lunas, bernomor
+  -- dada, tidak dibatalkan. Yang tergembok dilewati — jalur tulisnya memang
+  -- menolak, dan tes ini tidak sedang menguji gembok.
+  select r.id into v_regu
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where d.status = 'lunas'
+    and r.nomor_dada is not null
+    and not r.is_cancelled
+    and r.golongan not in ('intern_pa', 'intern_pi')
+    and not exists (select 1 from nilai_terkunci t
+                    where t.regu_id = r.id and t.pos = v_pos)
+  order by r.nomor_dada limit 1;
+  assert v_regu is not null,
+    '56 GAGAL: tidak ada regu lunas bernomor dada untuk diuji';
+
+  -- Komponen bertingkat ber-jawaban benar, dipasang sementara. Bentuknya sama
+  -- dengan Menaksir produksi: tangga sentimeter, yang masuk tangga SELISIH
+  -- terhadap jawaban benar (0085).
+  select konfigurasi_terkunci into v_terkunci from status_acara;
+  update status_acara set konfigurasi_terkunci = false where konfigurasi_terkunci;
+
+  insert into wahana
+    (edisi, pos, kode, name, type, form, poin_maks,
+     rentang_mentah_min, rentang_mentah_maks, sort_order,
+     tingkat, satuan, jawaban_benar)
+  values
+    (edisi_aktif(), v_pos, 'uji_taksir_56', 'Uji Taksiran 56', 'wahana',
+     'bertingkat', 100, 0, 10000, 99,
+     '[{"sampai": 100, "poin": 100},
+       {"sampai": 200, "poin": 80},
+       {"sampai": 300, "poin": 60}]'::jsonb,
+     'meter', v_jawaban)
+  returning id into v_wahana;
+
+  -- Poin yang SEHARUSNYA didapat taksiran ini menurut komponen barusan —
+  -- dihitung dari wahana-nya, bukan diketik di sini.
+  select hitung_poin(w.form, v_taksiran, null, w.poin_maks,
+                     w.raw_terbaik, w.raw_terburuk,
+                     w.poin_benar, w.poin_salah, w.total_soal, w.tingkat,
+                     w.jawaban_benar)
+    into v_poin
+  from wahana w where w.id = v_wahana;
+  assert v_poin > 0,
+    format('56 GAGAL: taksiran %s bernilai %s poin, jadi tes ini tidak '
+           'membuktikan apa pun', v_taksiran, v_poin);
+
+  -- ---------------------------------------------------------------------
+  -- 56.1 Angka di layar juri ikut bergerak saat taksiran masuk.
+  --
+  --      Dibaca DUA KALI dengan satu baris berubah di antaranya. Kalau
+  --      pembacaan kedua sama dengan yang pertama, layar juri sedang
+  --      menghitung tanpa jawaban benar: 734 lebih besar daripada seluruh
+  --      batas tangga, jadi sumbangannya nol.
+  -- ---------------------------------------------------------------------
+  perform set_config('app.uid', v_admin::text, true);
+  set local role authenticated;
+  select nilai_pos into v_layar_sebelum from v_lembar_pos
+  where regu_id = v_regu and pos = v_pos;
+  select coalesce(sum(poin), 0) into v_klas_sebelum from v_poin_wahana
+  where regu_id = v_regu and pos = v_pos;
+  reset role;
+
+  assert v_layar_sebelum is not null,
+    '56 GAGAL: regu uji tidak muncul di v_lembar_pos, kursinya salah';
+
+  insert into nilai_mentah (regu_id, wahana_id, nilai_1, source, created_by)
+  values (v_regu, v_wahana, v_taksiran, 'manual', v_admin);
+
+  perform set_config('app.uid', v_admin::text, true);
+  set local role authenticated;
+  select nilai_pos into v_layar_sesudah from v_lembar_pos
+  where regu_id = v_regu and pos = v_pos;
+  select coalesce(sum(poin), 0) into v_klas_sesudah from v_poin_wahana
+  where regu_id = v_regu and pos = v_pos;
+  reset role;
+
+  assert v_klas_sesudah - v_klas_sebelum = v_poin,
+    format('56.1 GAGAL: klasemen naik %s, seharusnya %s',
+           v_klas_sesudah - v_klas_sebelum, v_poin);
+
+  assert v_layar_sesudah <> v_layar_sebelum,
+    format('56.1 GAGAL: taksiran %s cm masuk dan Nilai Pos di layar juri tetap '
+           '%s, sementara klasemen naik jadi %s — layar menghitung tanpa '
+           'jawaban benar', v_taksiran, v_layar_sebelum, v_klas_sesudah);
+
+  assert v_layar_sesudah = round(v_klas_sesudah * v_bobot, 2),
+    format('56.1 GAGAL: layar juri %s, klasemen %s untuk regu dan pos yang '
+           'sama', v_layar_sesudah, round(v_klas_sesudah * v_bobot, 2));
+
+  raise notice '56.1 OK — taksiran % cm: layar % = klasemen %.',
+    v_taksiran, v_layar_sesudah, round(v_klas_sesudah * v_bobot, 2);
+
+  -- ---------------------------------------------------------------------
+  -- 56.2 Kesamaan itu berlaku untuk SELURUH baris, bukan cuma regu uji.
+  --
+  --      Dibaca sebagai pemilik supaya tidak ada baris yang tersembunyi RLS
+  --      lalu terhitung "tidak berbeda". `app.uid` tetap dipasang karena
+  --      pagar boleh('pos') ada di dalam badan view-nya sendiri.
+  -- ---------------------------------------------------------------------
+  perform set_config('app.uid', v_admin::text, true);
+
+  select count(*) into v_periksa from v_lembar_pos;
+  assert v_periksa > 0,
+    '56.2 GAGAL: v_lembar_pos kosong, jadi perbandingan ini hampa';
+
+  select count(*) into v_beda
+  from v_lembar_pos l
+  join pos p on p.edisi = edisi_aktif() and p.nomor = l.pos
+  where l.nilai_pos <> round(coalesce((
+          select sum(pw.poin) from v_poin_wahana pw
+          where pw.regu_id = l.regu_id and pw.pos = l.pos), 0) * p.bobot, 2);
+  assert v_beda = 0,
+    format('56.2 GAGAL: %s dari %s baris v_lembar_pos menyebut Nilai Pos yang '
+           'berbeda dari klasemen', v_beda, v_periksa);
+
+  -- Perbandingan di atas hanya berarti kalau setidaknya satu baris memuat
+  -- komponen ber-jawaban_benar — di situlah kedua jalur pernah menyimpang.
+  select count(*) into v_berjawab
+  from v_lembar_pos l
+  where exists (
+    select 1 from nilai_mentah n
+    join wahana w on w.id = n.wahana_id
+    where n.regu_id = l.regu_id and w.pos = l.pos
+      and w.edisi = edisi_aktif() and w.jawaban_benar is not null);
+  assert v_berjawab > 0,
+    '56.2 GAGAL: tidak ada baris ber-jawaban_benar yang dibandingkan, jadi '
+    'tes ini lulus tanpa menyentuh perbedaan yang pernah terjadi';
+
+  raise notice '56.2 OK — % baris v_lembar_pos sama dengan klasemen, % di '
+               'antaranya memuat komponen ber-jawaban benar.',
+    v_periksa, v_berjawab;
+
+  -- Bongkar lagi: komponen uji tidak boleh ikut terbawa ke tes sesudahnya
+  -- maupun ke hitungan kelengkapan pos.
+  delete from nilai_mentah where wahana_id = v_wahana;
+  delete from wahana where id = v_wahana;
+  update status_acara set konfigurasi_terkunci = v_terkunci
+  where konfigurasi_terkunci <> v_terkunci;
+end;
+$blok$;
+
+\echo '56 nilai pos layar juri = klasemen: LULUS'


### PR DESCRIPTION
## What

Migration `0095` puts `w.jawaban_benar` back as the 11th argument of the
`hitung_poin` call inside `v_lembar_pos`, and test 56 now compares the judge's
screen against the klasemen for every row of that view.

## Why

Points are never stored — they are derived on every read, in two separate
places that each call `hitung_poin` themselves:

- `v_lembar_pos.nilai_pos` → Input Nilai Pos, the screen the judge works from
- `v_poin_wahana` → `v_poin_pos` → `v_total_skor` → `v_klasemen` → Rekap and Live Score

`0085` added the 11th argument and rebuilt both, with the reason written in its
own header. `0091` rebuilt `v_lembar_pos` once more — to add the Intern guard —
from a copy of the pre-0085 body, and the call went back to ten arguments.
Because the parameter is `default null`, the ten-argument call still resolves:
no error applying it, no error reading it, only a different number.

With today's Menaksir configuration (`jawaban_benar` 855 cm, ladder
100/200/300/400/500 cm) a taksiran of 830 cm is 25 cm off:

| | klasemen | judge's screen |
|---|---|---|
| taksiran 830 cm | \|830−855\| = 25 → **100** | 830 read as the deviation, past every rung → **0** |

Only `bertingkat` components with an answer key are affected, which today means
Menaksir alone — that is why nobody looking at Pos 2 through Pos 5 ever saw it.

## Notes

The view body is copied verbatim from `0091`, Intern guard and `EXISTS`
predicate included. The only change is the argument.

The `default null` on `p_jawaban_benar` is deliberately left alone: tests 08,
14, 16 and 39 call `hitung_poin` with ten arguments for components that
legitimately have no answer key, and that is correct usage. What keeps the two
readers from drifting again is the test, not the signature.

Test 56 was committed **before** the fix on purpose, and run on this branch to
prove it catches the drift rather than merely passing:

- test only — [run 32623739101](https://github.com/ciradyka/hrcd-rekap/actions/runs/32623739101) → red:
  `56.1 GAGAL: taksiran 734 cm masuk dan Nilai Pos di layar juri tetap 0.00, sementara klasemen naik jadi 80.00`
- with 0095 — [run 32623800537](https://github.com/ciradyka/hrcd-rekap/actions/runs/32623800537) → green:
  `56.1 OK — taksiran 734 cm: layar 80.00 = klasemen 80.00` and
  `56.2 OK — 63 baris v_lembar_pos sama dengan klasemen`

The test builds its own `bertingkat` component with an answer key and removes it
again afterwards. The test database has none: `0032` and `0085` both skip their
data section once `nilai_mentah` holds anything, and it has been full since test
02 — so leaning on Menaksir would have passed without ever touching the case
that broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)