### PR TITLE
fix: store the number the juri actually typed

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -232,9 +232,23 @@ export function jamSah(teks) {
  *
  *  Menit tidak dibatasi — lomba yang molor sampai 90 menit tetap tercatat apa
  *  adanya. Detik dibatasi 0-59: "1:75" adalah salah ketik, bukan 135 detik,
- *  dan menerimanya diam-diam berarti mencatat waktu yang tidak pernah ada. */
+ *  dan menerimanya diam-diam berarti mencatat waktu yang tidak pernah ada.
+ *
+ *  TITIK DAN SPASI DITOLAK, bukan diperlakukan sebagai titik dua. Dua orang
+ *  mengetik tanda yang sama dan memaksudkan dua besaran yang berbeda: di layar
+ *  stopwatch "24.31" berarti 24,31 detik, sedangkan di tulisan tangan panitia
+ *  "1.30" berarti satu menit tiga puluh. Menebak salah satunya berarti
+ *  menyimpan waktu yang tidak pernah terjadi, tanpa satu pun tanda. Yang
+ *  ditolak berhenti sebagai baris merah dan diketik ulang jadi "24" atau
+ *  "1:30" — tiga ketukan, di layar, oleh orang yang memegang stopwatchnya.
+ *
+ *  Aturan penggantian itu diwarisi dari jamSah, tempat "7.45" memang 07:45.
+ *  Di sini akibatnya: "24.31" tersimpan sebagai 24*60+31 = 1471 detik, lolos
+ *  rentang 0-3600 tanpa galat, dan bernilai 20 poin alih-alih 100. Keempat
+ *  layar lalu sepakat pada angka yang salah, karena angka mentahnya sendiri
+ *  yang sudah salah. */
 export function detikSah(teks) {
-  const t = String(teks ?? "").trim().replace(/[.\s]/g, ":");
+  const t = String(teks ?? "").trim();
   if (t === "") return null;
   if (!/^\d+(:\d{1,2})?$/.test(t)) return null;
 

--- a/tests/nilai_mentah_input.test.mjs
+++ b/tests/nilai_mentah_input.test.mjs
@@ -1,0 +1,123 @@
+// ============================================================================
+// hrcd-rekap : tests/nilai_mentah_input.test.mjs
+//
+// YANG DIKETIK JURI HARUS SAMA DENGAN YANG TERSIMPAN.
+//
+// Poin tidak pernah disimpan; keempat layar menurunkannya dari nilai mentah.
+// Karena itu kesalahan di sini adalah kesalahan yang PALING mahal: kalau angka
+// mentahnya sudah salah, Input Nilai Pos, Live Score panitia, Rekapitulasi dan
+// Live Score peserta akan sepakat — pada angka yang salah — dan tidak ada satu
+// pun layar yang bisa membantahnya.
+//
+// Dua kegagalan yang pernah nyata dijaga di sini:
+//
+//   1. detikSah mengganti titik jadi titik dua (diwarisi dari jamSah, tempat
+//      "7.45" memang 07:45). Di stopwatch "24.31" berarti 24,31 detik, jadi
+//      yang tersimpan 1471 detik — lolos rentang 0-3600 tanpa galat, dan
+//      bernilai 20 poin alih-alih 100.
+//   2. bacaSel membaca kotak `input[type=number]` yang berisi ketikan tak
+//      terurai sebagai kotak KOSONG, karena begitulah browser melaporkannya.
+//      Kosong berarti "hapus nilainya", jadi salah ketik satu huruf menghapus
+//      angka yang sudah benar dan barisnya tetap bercentang hijau.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { detikSah, detikTeks, meterSah, meterTeks }
+  from "../web/js/util.js";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+test("detikSah menerima bentuk yang memang dijanjikan kotaknya", () => {
+  assert.equal(detikSah("32"), 32);
+  assert.equal(detikSah("95"), 95);
+  assert.equal(detikSah("0:32"), 32);
+  assert.equal(detikSah("1:10"), 70);
+  assert.equal(detikSah("00:50"), 50);
+  assert.equal(detikSah(" 1:10 "), 70);
+  // Menit tidak dibatasi: lomba yang molor tetap tercatat apa adanya.
+  assert.equal(detikSah("90:00"), 5400);
+});
+
+test("detikSah menolak titik, bukan menebaknya sebagai menit", () => {
+  // Pembacaan stopwatch. Dulu tersimpan 1471 detik tanpa satu pun tanda.
+  assert.equal(detikSah("24.31"), null);
+  // Tulisan tangan yang bermaksud satu menit tiga puluh. Ditolak juga —
+  // justru karena dua orang memaksudkan dua besaran berbeda dengan tanda yang
+  // sama, menebak salah satunya berarti menyimpan waktu yang tidak terjadi.
+  assert.equal(detikSah("1.30"), null);
+  assert.equal(detikSah("0.5"), null);
+});
+
+test("detikSah menolak spasi di tengah dan detik di atas 59", () => {
+  assert.equal(detikSah("2 4"), null);     // dulu jadi 2:4 = 124 detik
+  assert.equal(detikSah("1 30"), null);
+  assert.equal(detikSah("1:75"), null);    // salah ketik, bukan 135 detik
+  assert.equal(detikSah("00:24.31"), null);
+  assert.equal(detikSah("abc"), null);
+});
+
+test("kotak kosong bukan nol", () => {
+  // null berarti "belum dinilai". Yang menerjemahkannya jadi 0 akan mencatat
+  // regu yang belum dinilai sebagai regu yang mendapat nol.
+  assert.equal(detikSah(""), null);
+  assert.equal(detikSah("   "), null);
+  assert.equal(meterSah(""), null);
+  assert.equal(meterSah("   "), null);
+});
+
+test("meterSah tetap membaca titik dan koma sebagai desimal", () => {
+  // Kotak meter dan kotak detik mengurai tanda yang sama secara berbeda, dan
+  // itu memang disengaja — 8,55 m adalah pecahan, 1:30 adalah dua besaran.
+  assert.equal(meterSah("8"), 800);
+  assert.equal(meterSah("8.55"), 855);
+  assert.equal(meterSah("8,55"), 855);
+  assert.equal(meterSah("8.555"), 856);
+  assert.equal(meterSah("abc"), null);
+});
+
+test("digambar ulang tidak mengubah angka yang tersimpan", () => {
+  // Kotak diisi ulang dari nilai tersimpan tiap kali tabel digambar ulang.
+  // Kalau bentuk tulisnya tidak bisa dibaca kembali jadi angka yang sama,
+  // satu penyimpanan berikutnya menyimpan angka yang berbeda dari yang
+  // pernah diketik — tanpa ada yang menyentuh kotaknya.
+  for (const teks of ["32", "95", "0:32", "1:10", "90:00"]) {
+    const detik = detikSah(teks);
+    assert.equal(detikSah(detikTeks(detik)), detik,
+      `detik ${teks} berubah setelah digambar ulang`);
+  }
+  for (const teks of ["8", "8.55", "8,55", "12.05"]) {
+    const cm = meterSah(teks);
+    assert.equal(meterSah(meterTeks(cm)), cm,
+      `meter ${teks} berubah setelah digambar ulang`);
+  }
+});
+
+test("bacaSel memeriksa badInput di kotak angka bawaan browser", () => {
+  // Tes teks-sumber, dan itu memang kelemahannya: bacaSel butuh DOM sungguhan
+  // untuk dipanggil. Yang dijaga di sini cuma bahwa pemeriksaannya tidak
+  // hilang diam-diam — kalau nama fungsinya berubah, tes ini gagal keras,
+  // bukan lulus tanpa memeriksa apa pun.
+  const awal = app.indexOf("function bacaSel(tr, k) {");
+  assert.notEqual(awal, -1, "fungsi bacaSel tidak ditemukan");
+  const akhir = app.indexOf("\n}", app.indexOf("nilai_2: null };", awal));
+  assert.notEqual(akhir, -1, "akhir fungsi bacaSel tidak ditemukan");
+
+  const bacaSel = app.slice(awal, akhir);
+  assert.match(bacaSel, /validity\s*&&\s*\w+\.validity\.badInput/,
+    "bacaSel tidak lagi memeriksa validity.badInput — ketikan yang tidak "
+    + "terbaca akan kembali menghapus nilai yang sudah tersimpan");
+
+  // Cabang benar_kurang_salah memeriksa KEDUA kotaknya, dan cabang umum
+  // memeriksa kotaknya sebelum membaca value.
+  const kembar = bacaSel.slice(bacaSel.indexOf('k.form === "benar_kurang_salah"'));
+  assert.match(kembar, /takTerbaca\(kotak\[0\]\)\s*\|\|\s*takTerbaca\(kotak\[1\]\)/,
+    "kotak salah pada benar_kurang_salah tidak dijaga");
+
+  const umum = bacaSel.slice(bacaSel.lastIndexOf("const v = kotak[0].value.trim();"));
+  assert.ok(bacaSel.slice(0, bacaSel.length - umum.length)
+              .includes("if (takTerbaca(kotak[0])) return TIDAK_SAH;"),
+    "cabang umum membaca value tanpa memeriksa badInput lebih dulu");
+});

--- a/tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
+++ b/tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
@@ -56,6 +56,13 @@ declare
   v_beda     int;
   v_periksa  int;
   v_berjawab int;
+  v_dada     integer;
+  v_kloter   smallint;
+  v_jam_asli timestamptz;
+  v_fase_asli text;
+  v_ceklis   boolean := false;
+  v_b numeric; v_c numeric; v_d numeric; v_e numeric;
+  v_total_c numeric; v_total_d numeric; v_total_e numeric;
 begin
   select p.nomor, p.bobot into v_pos, v_bobot
   from pos p
@@ -197,6 +204,74 @@ begin
   raise notice '56.2 OK — % baris v_lembar_pos sama dengan klasemen, % di '
                'antaranya memuat komponen ber-jawaban benar.',
     v_periksa, v_berjawab;
+
+  -- ---------------------------------------------------------------------
+  -- 56.3 EMPAT LAYAR, SATU ANGKA.
+  --
+  --      Sampai di sini yang dibandingkan baru dua jalur. Yang dijanjikan ke
+  --      panitia lebih luas: angka yang sama harus muncul di Input Nilai Pos,
+  --      Live Score panitia, Rekapitulasi, dan Live Score peserta. Keempatnya
+  --      memang bersandar pada rantai yang sama hari ini — dan justru itu yang
+  --      perlu dijaga, karena yang merusaknya bukan perubahan besar melainkan
+  --      satu view yang dibangun ulang dari salinan lama.
+  --
+  --      Regu uji perlu dibuat "sudah berangkat" dulu: v_klasemen menolak regu
+  --      tanpa ceklis keberangkatan dan tanpa jam berangkat kloter (0005:126),
+  --      dan v_klasemen_publik hanya berisi saat fase `penuh` (0048:120).
+  --      Keduanya dikembalikan di akhir.
+  -- ---------------------------------------------------------------------
+  select r.nomor_dada, r.kloter_nomor into v_dada, v_kloter
+  from regu r where r.id = v_regu;
+  select k.jam_berangkat into v_jam_asli from kloter k where k.nomor = v_kloter;
+  update kloter set jam_berangkat = '2026-08-29 07:00:00+07'
+  where nomor = v_kloter and jam_berangkat is null;
+  if not exists (select 1 from keberangkatan_regu where regu_id = v_regu) then
+    insert into keberangkatan_regu (regu_id, recorded_by) values (v_regu, v_admin);
+    v_ceklis := true;
+  end if;
+  select fase_live into v_fase_asli from status_acara;
+  update status_acara set fase_live = 'penuh' where fase_live is distinct from 'penuh';
+
+  -- Ketiga layar panitia dibaca dari kursi panitia; berkas peserta dibaca
+  -- sebagai pemilik, karena begitulah publish-live.yml menghasilkannya
+  -- (v_klasemen_publik memang tidak diberikan ke authenticated).
+  perform set_config('app.uid', v_admin::text, true);
+  set local role authenticated;
+  select nilai_pos into v_b from v_lembar_pos
+  where regu_id = v_regu and pos = v_pos;
+  select (poin_per_pos ->> v_pos::text)::numeric, total into v_c, v_total_c
+  from klasemen_live_score() where nomor_dada = v_dada;
+  select (poin_pos ->> v_pos::text)::numeric, total into v_d, v_total_d
+  from v_rekap_penuh where regu_id = v_regu;
+  reset role;
+
+  select (poin_per_pos ->> v_pos::text)::numeric, total into v_e, v_total_e
+  from v_klasemen_publik where nomor_dada = v_dada;
+
+  assert v_b is not null and v_c is not null and v_d is not null
+         and v_e is not null,
+    format('56.3 GAGAL: regu uji tidak terbaca di keempat layar '
+           '(pos: input=%s, live panitia=%s, rekap=%s, live peserta=%s)',
+           v_b, v_c, v_d, v_e);
+
+  assert v_b = v_c and v_b = v_d and v_b = v_e,
+    format('56.3 GAGAL: Pos %s regu %s berbeda antar layar — Input Nilai Pos '
+           '%s, Live Score panitia %s, Rekapitulasi %s, Live Score peserta %s',
+           v_pos, v_dada, v_b, v_c, v_d, v_e);
+
+  assert v_total_c = v_total_d and v_total_c = v_total_e,
+    format('56.3 GAGAL: total regu %s berbeda antar layar — Live Score panitia '
+           '%s, Rekapitulasi %s, Live Score peserta %s',
+           v_dada, v_total_c, v_total_d, v_total_e);
+
+  raise notice '56.3 OK — regu %: Pos % bernilai % di keempat layar, total %.',
+    v_dada, v_pos, v_b, v_total_c;
+
+  update status_acara set fase_live = v_fase_asli
+  where fase_live is distinct from v_fase_asli;
+  if v_ceklis then delete from keberangkatan_regu where regu_id = v_regu; end if;
+  update kloter set jam_berangkat = v_jam_asli
+  where nomor = v_kloter and jam_berangkat is distinct from v_jam_asli;
 
   -- Bongkar lagi: komponen uji tidak boleh ikut terbawa ke tes sesudahnya
   -- maupun ke hitungan kelengkapan pos.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2348,7 +2348,10 @@ const judulPos = (p) => p
  *  tanpa menyentuh JavaScript:
  *
  *    form=biner        -> satu centang        (kolom "Kompas (v)")
- *    satuan=detik      -> Menit : Detik       (kolom "Menit | Detik" di Pos 4)
+ *    satuan=detik      -> SATU kotak waktu     ("47" atau "1:10" — lihat
+ *                         detikSah di util.js; dulu dua kotak Menit dan
+ *                         Detik, dan alasan menyatukannya ada di sana)
+ *    satuan=meter      -> satu kotak meter     ("8.55", disimpan sentimeter)
  *    benar_kurang_salah-> Benar / Salah
  *    sisanya           -> satu kotak angka, batasnya dari rentang wajar
  */
@@ -2467,11 +2470,27 @@ function bacaSel(tr, k) {
     const cm = meterSah(kotak[0].value);
     return cm === null ? TIDAK_SAH : { nilai_1: cm, nilai_2: null };
   }
+  // KOTAK ANGKA BAWAAN BROWSER PUNYA KEADAAN KETIGA JUGA, dan ia tidak
+  // kelihatan. `input[type=number]` yang berisi ketikan yang tidak bisa ia
+  // urai — "2 5", "25e", koma di sebagian locale — melaporkan `value` KOSONG
+  // sambil tetap MENAMPILKAN teksnya. Tanpa memeriksa `validity.badInput`,
+  // baris di bawah membacanya sebagai "kotak dikosongkan", dan jalur simpan
+  // menerjemahkan itu jadi perintah menghapus nilai yang sudah tersimpan —
+  // lalu barisnya tetap mendapat centang hijau selama komponen lain terisi.
+  // Persis kegagalan yang sudah dijaga di kotak detik dan meter di atas; yang
+  // ini ketinggalan karena kotaknya bertipe number, bukan text.
+  const takTerbaca = (el) => !!(el && el.validity && el.validity.badInput);
+
   if (k.form === "benar_kurang_salah") {
+    // Kotak SALAH ikut dijaga: kalau ia tidak terbaca, mengirim nilai_2 null
+    // berarti mencatat "tidak ada yang salah" — angka yang berbeda dari yang
+    // diketik, bukan angka yang hilang.
+    if (takTerbaca(kotak[0]) || takTerbaca(kotak[1])) return TIDAK_SAH;
     const b = kotak[0].value.trim(), sa = kotak[1].value.trim();
     if (b === "") return null;
     return { nilai_1: Number(b), nilai_2: sa === "" ? null : Number(sa) };
   }
+  if (takTerbaca(kotak[0])) return TIDAK_SAH;
   const v = kotak[0].value.trim();
   return v === "" ? null : { nilai_1: Number(v), nilai_2: null };
 }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -232,9 +232,23 @@ export function jamSah(teks) {
  *
  *  Menit tidak dibatasi — lomba yang molor sampai 90 menit tetap tercatat apa
  *  adanya. Detik dibatasi 0-59: "1:75" adalah salah ketik, bukan 135 detik,
- *  dan menerimanya diam-diam berarti mencatat waktu yang tidak pernah ada. */
+ *  dan menerimanya diam-diam berarti mencatat waktu yang tidak pernah ada.
+ *
+ *  TITIK DAN SPASI DITOLAK, bukan diperlakukan sebagai titik dua. Dua orang
+ *  mengetik tanda yang sama dan memaksudkan dua besaran yang berbeda: di layar
+ *  stopwatch "24.31" berarti 24,31 detik, sedangkan di tulisan tangan panitia
+ *  "1.30" berarti satu menit tiga puluh. Menebak salah satunya berarti
+ *  menyimpan waktu yang tidak pernah terjadi, tanpa satu pun tanda. Yang
+ *  ditolak berhenti sebagai baris merah dan diketik ulang jadi "24" atau
+ *  "1:30" — tiga ketukan, di layar, oleh orang yang memegang stopwatchnya.
+ *
+ *  Aturan penggantian itu diwarisi dari jamSah, tempat "7.45" memang 07:45.
+ *  Di sini akibatnya: "24.31" tersimpan sebagai 24*60+31 = 1471 detik, lolos
+ *  rentang 0-3600 tanpa galat, dan bernilai 20 poin alih-alih 100. Keempat
+ *  layar lalu sepakat pada angka yang salah, karena angka mentahnya sendiri
+ *  yang sudah salah. */
 export function detikSah(teks) {
-  const t = String(teks ?? "").trim().replace(/[.\s]/g, ":");
+  const t = String(teks ?? "").trim();
   if (t === "") return null;
   if (!/^\d+(:\d{1,2})?$/.test(t)) return null;
 


### PR DESCRIPTION
## What

Two entries that used to be stored as something other than what was typed are
now either read correctly or refused:

- `detikSah` no longer rewrites `.` and spaces into `:`
- `bacaSel` checks `validity.badInput` on the plain numeric cell and on both
  boxes of `benar_kurang_salah`

Plus the tests that hold both in place, and a new assertion that all four
screens report the same figure.

## Why

Points are never stored — Input Nilai Pos, Live Score panitia, Rekapitulasi and
Live Score peserta all derive them from the raw value. That makes a wrong raw
value the worst failure available: every screen agrees, on the wrong number, and
nothing in the system can contradict it.

**The dot.** `detikSah` began with `.replace(/[.\s]/g, ":")`, inherited from
`jamSah` where "7.45" really is 07:45. On a stopwatch the dot is the fraction
separator, so a juri copying `24.31` s stored `24*60+31 = 1471`. That is inside
the 0–3600 range for bakiak / lari balok / balap karung, so it saved without a
word, and the ladder scored it 20 instead of 100. An internal space did the same:
`2 4` became 124 s.

The dot is now rejected rather than guessed, and that is the whole point: `1.30`
on a handwritten sheet means one minute thirty, `24.31` from a stopwatch means
twenty-four seconds, and no rule can tell the two apart. A rejected entry stops
on screen as a red row and is retyped as `24` or `1:30`; a guessed one runs all
the way to the klasemen. The function's own docstring already promised this —
"ada titik dua berarti menit:detik, tanpa titik dua berarti detik. Tidak ada
tebakan di antaranya" — the code just did not.

**The number boxes.** The three-state read (empty / unreadable / value) existed
only on the two `type=text` boxes. A `type=number` box holding something the
browser cannot parse reports `value === ""` while still displaying the text, so
an unreadable entry was read as "cleared" and deleted the stored score, leaving
the row with a green check. That covers every ordinary scoring column — Pos 3,
4, 5 and the soal lomba.

## Notes

Chains B–E were traced end to end before this change and are clean: only two
live call sites of `hitung_poin` exist (`v_poin_wahana` and `v_lembar_pos`, made
identical by 0095), and Live Score panitia, Rekapitulasi and the published
peserta file all read `v_poin_pos`, whose `round(sum(poin) * bobot, 2)` is the
same expression `v_lembar_pos.nilai_pos` uses. Test 56.3 now pins that: one
regu, one pos, read through `v_lembar_pos`, `klasemen_live_score()`,
`v_rekap_penuh` and `v_klasemen_publik`, and every figure must match. CI:
`56.3 OK — regu 2: Pos 1 bernilai 80.00 di keempat layar`.

`tests/nilai_mentah_input.test.mjs` imports the parsers and tests their real
behaviour rather than grepping for them, including the round-trip property that
redrawing a box must not change the stored number. Both new guards were checked
against the old code before being committed: restoring the `replace` fails two
of them, and removing the `badInput` line fails a third.

`live/js/util.js` is re-synced, so `shared-files.yml` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)