### PR TITLE
fix: write history values in the same form as the input box

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -921,6 +921,32 @@ export function dada3(n) {
 export const angkaRapi = (v) =>
   v === null || v === undefined || v === "" ? "" : String(Number(v));
 
+/** NILAI MENTAH -> TEKS SEPERTI YANG TERTULIS DI KOTAK ISIANNYA.
+ *
+ *  Satu tempat untuk seluruh layar: kotak isian, penyegaran 20 detik, dan
+ *  dialog Riwayat Nilai. Aturannya sendiri sederhana — yang tidak sederhana
+ *  adalah menjaganya tetap sama di tiga tempat. Riwayat sempat memakai
+ *  angkaRapi langsung, jadi ia berbunyi "855" untuk Menaksir yang kotaknya
+ *  menuliskan "8.55", dan "47" untuk waktu yang kotaknya menuliskan "00:47".
+ *  Petugas yang membuka riwayat justru sedang membandingkan dengan kotaknya,
+ *  dan dua bentuk untuk satu angka membuat perbandingan itu harus
+ *  diterjemahkan dulu di kepala.
+ *
+ *  `k` adalah baris `wahana`-nya. Boleh kosong — komponen yang sudah dihapus
+ *  admin masih punya riwayat, dan angka polos lebih baik daripada baris yang
+ *  hilang.
+ *
+ *  Kotak centang tidak punya teks di layar, tapi riwayatnya punya: "ya" dan
+ *  "tidak" dibaca lebih cepat daripada 1 dan 0, yang di kolom berisi angka
+ *  terbaca seperti nilai. */
+export function nilaiTeks(k, n) {
+  if (n === null || n === undefined || n === "") return "";
+  if (k && k.form === "biner")  return Number(n) > 0 ? "ya" : "tidak";
+  if (k && k.satuan === "detik") return detikTeks(n);
+  if (k && k.satuan === "meter") return meterTeks(n);
+  return angkaRapi(n);
+}
+
 /** Keterangan kecil di bawah nama kolom: rentang yang boleh ditulis, atau
  *  bentuk isiannya kalau rentang saja menyesatkan. */
 export function petunjukKolom(k) {

--- a/tests/nilai_mentah_input.test.mjs
+++ b/tests/nilai_mentah_input.test.mjs
@@ -25,7 +25,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { detikSah, detikTeks, meterSah, meterTeks }
+import { detikSah, detikTeks, meterSah, meterTeks, nilaiTeks }
   from "../web/js/util.js";
 
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
@@ -93,6 +93,53 @@ test("digambar ulang tidak mengubah angka yang tersimpan", () => {
     assert.equal(meterSah(meterTeks(cm)), cm,
       `meter ${teks} berubah setelah digambar ulang`);
   }
+});
+
+test("nilaiTeks menulis angka mentah persis seperti kotaknya", () => {
+  assert.equal(nilaiTeks({ satuan: "detik" }, 47), "00:47");
+  assert.equal(nilaiTeks({ satuan: "detik" }, 95), "01:35");
+  assert.equal(nilaiTeks({ satuan: "meter" }, 855), "8.55");
+  assert.equal(nilaiTeks({ satuan: "meter" }, 800), "8.00");
+  assert.equal(nilaiTeks({ form: "biner" }, 1), "ya");
+  assert.equal(nilaiTeks({ form: "biner" }, 0), "tidak");
+  assert.equal(nilaiTeks({ form: "besar_baik" }, 25), "25");
+  // Komponen yang sudah dihapus admin masih punya riwayat: angka polos, bukan
+  // baris yang hilang.
+  assert.equal(nilaiTeks(undefined, 25), "25");
+  assert.equal(nilaiTeks({ satuan: "meter" }, null), "");
+  assert.equal(nilaiTeks({ satuan: "detik" }, null), "");
+});
+
+test("yang ditulis nilaiTeks bisa dibaca kembali jadi angka yang sama", () => {
+  // Kotak diisi oleh nilaiTeks dan dibaca kembali oleh detikSah/meterSah.
+  // Kalau keduanya tidak saling membalik, menyimpan baris yang tidak disentuh
+  // sekalipun akan menyimpan angka yang berbeda dari yang tersimpan.
+  for (const detik of [0, 47, 95, 600, 5400]) {
+    assert.equal(detikSah(nilaiTeks({ satuan: "detik" }, detik)), detik,
+      `detik ${detik} tidak kembali utuh`);
+  }
+  for (const cm of [0, 800, 855, 1205, 10000]) {
+    assert.equal(meterSah(nilaiTeks({ satuan: "meter" }, cm)), cm,
+      `meter ${cm} tidak kembali utuh`);
+  }
+});
+
+test("riwayat nilai memakai penulis yang sama dengan kotak isian", () => {
+  // Riwayat dulu memanggil angkaRapi langsung, jadi ia berbunyi "855" untuk
+  // Menaksir yang kotaknya menuliskan "8.55". Yang membuka riwayat sedang
+  // membandingkan dengan kotak itu.
+  const awal = app.indexOf("async function bukaRiwayat(tr) {");
+  assert.notEqual(awal, -1, "fungsi bukaRiwayat tidak ditemukan");
+  const akhir = app.indexOf('<ul class="riwayat">', awal);
+  assert.notEqual(akhir, -1, "daftar riwayat tidak ditemukan");
+  const daftar = app.slice(akhir, app.indexOf("</ul>", akhir));
+
+  assert.match(daftar, /nilaiTeks\(k, b\.nilai_lama\)/,
+    "nilai lama di riwayat tidak ditulis lewat nilaiTeks");
+  assert.match(daftar, /nilaiTeks\(k, b\.nilai_baru\)/,
+    "nilai baru di riwayat tidak ditulis lewat nilaiTeks");
+  assert.doesNotMatch(daftar, /angkaRapi\(/,
+    "riwayat kembali menulis angka mentah tanpa satuannya");
 });
 
 test("bacaSel memeriksa badInput di kotak angka bawaan browser", () => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -30,11 +30,11 @@ import {
   hapusFotoLembar,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapital,
-         meterSah, meterTeks,
+         meterSah,
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
-         angkaRapi, petunjukKolom, nilaiBagian,
+         angkaRapi, nilaiTeks, petunjukKolom, nilaiBagian,
          jamPadaHari, GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
 
@@ -2390,7 +2390,7 @@ function selKomponen(k, nilai) {
     // jadi yang hilang cuma tombol panah naik-turun yang memang tidak pernah
     // dipakai untuk mencatat waktu.
     return `<input type="text" class="small-input input-waktu" inputmode="numeric"
-                   data-kode="${kode}" value="${esc(detikTeks(n1))}"${kosongTampak}
+                   data-kode="${kode}" value="${esc(nilaiTeks(k, n1))}"${kosongTampak}
                    aria-label="${esc(k.name)} — detik, atau menit:detik">`;
   }
   if (k.satuan === "meter") {
@@ -2399,17 +2399,17 @@ function selKomponen(k, nilai) {
     // input[type=number] menolak koma diam-diam: kotaknya jadi kosong tanpa
     // sepatah kata, dan yang mengetiknya mengira angkanya sudah masuk.
     return `<input type="text" class="small-input input-meter" inputmode="decimal"
-                   data-kode="${kode}" value="${esc(meterTeks(n1))}"${kosongTampak}
+                   data-kode="${kode}" value="${esc(nilaiTeks(k, n1))}"${kosongTampak}
                    aria-label="${esc(k.name)} — meter, dua angka di belakang koma">`;
   }
   if (k.form === "benar_kurang_salah") {
     return `<span class="pos-pasangan">
       <input type="number" class="small-input" inputmode="numeric" step="1" min="0"
-             data-kode="${kode}" data-slot="benar" value="${esc(angkaRapi(n1))}"
+             data-kode="${kode}" data-slot="benar" value="${esc(nilaiTeks(k, n1))}"
              aria-label="${esc(k.name)} — jumlah benar">
       <span class="pos-pemisah" aria-hidden="true">/</span>
       <input type="number" class="small-input" inputmode="numeric" step="1" min="0"
-             data-kode="${kode}" data-slot="salah" value="${esc(angkaRapi(n2))}"
+             data-kode="${kode}" data-slot="salah" value="${esc(nilaiTeks(k, n2))}"
              aria-label="${esc(k.name)} — jumlah salah">
     </span>`;
   }
@@ -2424,7 +2424,7 @@ function selKomponen(k, nilai) {
   // tidak lewat kotak ini sama sekali.
   return `<input type="number" class="small-input" inputmode="numeric" step="1"
                  min="${esc(k.rentang_mentah_min)}" max="${esc(k.rentang_mentah_maks)}"
-                 data-kode="${kode}" value="${esc(angkaRapi(n1))}"${kosongTampak}
+                 data-kode="${kode}" value="${esc(nilaiTeks(k, n1))}"${kosongTampak}
                  aria-label="${esc(k.name)}">`;
 }
 
@@ -3491,13 +3491,23 @@ async function layarInputPos() {
                   aria-pressed="false">${nama}</button>`).join("")}
       </div>`;
 
-    const isi = chip + `<ul class="riwayat">${baris.map(b => html`
+    /* Angkanya ditulis PERSIS seperti kotak isiannya menulisnya — "8.55",
+       bukan 855; "00:47", bukan 47. Yang membuka riwayat sedang membandingkan
+       dengan kotak yang ada di depannya, dan dua bentuk untuk satu angka
+       membuat perbandingan itu harus diterjemahkan dulu. Komponen yang sudah
+       dihapus admin tidak ada di `komponen` lagi; nilaiTeks menuliskannya
+       polos, dan itu tetap lebih baik daripada barisnya hilang. */
+    const metaKode = new Map(komponen.map(k => [k.kode, k]));
+    const isi = chip + `<ul class="riwayat">${baris.map(b => {
+      const k = metaKode.get(b.kode_lomba);
+      return html`
       <li data-lomba="${b.kode_lomba}">
         <span class="r-lomba">${b.nama_lomba}</span>
-        <span class="r-nilai">${b.nilai_lama === null ? "—" : angkaRapi(b.nilai_lama)}
-          → <strong>${b.nilai_baru === null ? "hapus" : angkaRapi(b.nilai_baru)}</strong></span>
+        <span class="r-nilai">${b.nilai_lama === null ? "—" : nilaiTeks(k, b.nilai_lama)}
+          → <strong>${b.nilai_baru === null ? "hapus" : nilaiTeks(k, b.nilai_baru)}</strong></span>
         <span class="r-oleh">${b.oleh} · ${tanggalJam(b.changed_at)}</span>
-      </li>`).join("")}</ul>`;
+      </li>`;
+    }).join("")}</ul>`;
 
     // dialog() menempelkan kartunya ke DOM secara SINKRON sebelum janjinya
     // menunggu, jadi penyaringnya boleh dipasang sebelum di-await. Menunggu
@@ -4331,19 +4341,18 @@ async function layarInputPos() {
         if (k.form === "biner") {
           const centang = !!(nilai && Number(nilai.nilai_1) > 0);
           if (kotak[0].checked !== centang) kotak[0].checked = centang;
-        } else if (k.satuan === "detik") {
-          const teks = detikTeks(nilai ? nilai.nilai_1 : null);
-          if (kotak[0].value !== teks) kotak[0].value = teks;
-        } else if (k.satuan === "meter") {
-          const teks = meterTeks(nilai ? nilai.nilai_1 : null);
-          if (kotak[0].value !== teks) kotak[0].value = teks;
         } else if (k.form === "benar_kurang_salah") {
-          const b = angkaRapi(nilai ? nilai.nilai_1 : null);
-          const sa = angkaRapi(nilai ? nilai.nilai_2 : null);
+          const b = nilaiTeks(k, nilai ? nilai.nilai_1 : null);
+          const sa = nilaiTeks(k, nilai ? nilai.nilai_2 : null);
           if (kotak[0].value !== b) kotak[0].value = b;
           if (kotak[1] && kotak[1].value !== sa) kotak[1].value = sa;
         } else {
-          const v = angkaRapi(nilai ? nilai.nilai_1 : null);
+          // detik, meter, dan kotak angka biasa memakai satu penulis yang
+          // sama dengan selKomponen — kalau tidak, penyegaran 20 detik bisa
+          // menulis ulang kotak dengan bentuk yang berbeda dari yang tadi
+          // digambar, dan kotak yang berubah sendiri terbaca seperti nilai
+          // yang berubah sendiri.
+          const v = nilaiTeks(k, nilai ? nilai.nilai_1 : null);
           if (kotak[0].value !== v) kotak[0].value = v;
         }
       }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -921,6 +921,32 @@ export function dada3(n) {
 export const angkaRapi = (v) =>
   v === null || v === undefined || v === "" ? "" : String(Number(v));
 
+/** NILAI MENTAH -> TEKS SEPERTI YANG TERTULIS DI KOTAK ISIANNYA.
+ *
+ *  Satu tempat untuk seluruh layar: kotak isian, penyegaran 20 detik, dan
+ *  dialog Riwayat Nilai. Aturannya sendiri sederhana — yang tidak sederhana
+ *  adalah menjaganya tetap sama di tiga tempat. Riwayat sempat memakai
+ *  angkaRapi langsung, jadi ia berbunyi "855" untuk Menaksir yang kotaknya
+ *  menuliskan "8.55", dan "47" untuk waktu yang kotaknya menuliskan "00:47".
+ *  Petugas yang membuka riwayat justru sedang membandingkan dengan kotaknya,
+ *  dan dua bentuk untuk satu angka membuat perbandingan itu harus
+ *  diterjemahkan dulu di kepala.
+ *
+ *  `k` adalah baris `wahana`-nya. Boleh kosong — komponen yang sudah dihapus
+ *  admin masih punya riwayat, dan angka polos lebih baik daripada baris yang
+ *  hilang.
+ *
+ *  Kotak centang tidak punya teks di layar, tapi riwayatnya punya: "ya" dan
+ *  "tidak" dibaca lebih cepat daripada 1 dan 0, yang di kolom berisi angka
+ *  terbaca seperti nilai. */
+export function nilaiTeks(k, n) {
+  if (n === null || n === undefined || n === "") return "";
+  if (k && k.form === "biner")  return Number(n) > 0 ? "ya" : "tidak";
+  if (k && k.satuan === "detik") return detikTeks(n);
+  if (k && k.satuan === "meter") return meterTeks(n);
+  return angkaRapi(n);
+}
+
 /** Keterangan kecil di bawah nama kolom: rentang yang boleh ditulis, atau
  *  bentuk isiannya kalau rentang saja menyesatkan. */
 export function petunjukKolom(k) {


### PR DESCRIPTION
## What

`nilaiTeks(k, n)` in `web/js/util.js` is now the one place that turns a stored
raw value into the text a box shows, and all three renderers call it: the input
cell (`selKomponen`), the 20-second refresh (`segarkanLembar`), and the Riwayat
Nilai dialog.

## Why

The dialog printed the raw number as-is — `855` for a Menaksir whose box reads
`8.55`, `47` for a time whose box reads `00:47`. The person opening it is
comparing against the box in front of them, so two spellings of one number have
to be translated in their head first.

It was the same rule written out three times; the copy that never got updated
was the one furthest from the box. Making it a single function means the next
component with a unit gets all three screens at once.

## Notes

Checkboxes carry no text on screen but their history does, so `biner` now reads
`ya` / `tidak` — `1` and `0` in a column of numbers read like scores.

Components an admin has deleted still have history rows, so `nilaiTeks` falls
back to the plain number rather than dropping the line.

Tests exercise `nilaiTeks` directly, assert the round-trip property that what it
writes parses back to the same stored number (`detikSah(nilaiTeks(k, 95)) === 95`),
and fail if the dialog goes back to printing raw values — checked by reverting
one call before committing.

`meterTeks` is no longer called from `app.js` and was dropped from its import
list; `live/js/util.js` is re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)