### PR TITLE
fix: keep the pos sheet print inside the tap gesture

### DIFF
--- a/tests/ios_print.test.mjs
+++ b/tests/ios_print.test.mjs
@@ -46,3 +46,22 @@ test("tanggal cetak kloter hanya dirender di lembar print", () => {
   );
   assert.match(lembar, /Dicetak \$\{esc\(dicetak\)\}/, "waktu print tidak ada di lembar");
 });
+
+test("cetak lembar pos memanggil print tanpa melewati await", () => {
+  // Jalur kedua yang memanggil window.print() dari sebuah tombol. Dulu ia
+  // menunggu batasNomorDada() dan statusAcara() lebih dulu — yang kedua
+  // bahkan tidak pernah dibaca — jadi di iPhone lembar cetaknya tidak pernah
+  // terbuka sementara tombol kloter di layar sebelah bekerja. Yang membuat
+  // laporannya terdengar seperti masalah HP, bukan masalah kode.
+  const awal = app.indexOf("  const cetak = (slip) => {");
+  assert.notEqual(awal, -1,
+    "handler cetak lembar pos tidak ditemukan — kalau ia jadi `async` lagi, "
+    + "`await` di dalamnya berhenti jadi galat sintaks dan print bisa lepas "
+    + "dari giliran tap");
+
+  const akhir = app.indexOf("window.print();", awal);
+  assert.notEqual(akhir, -1, "window.print() tidak dipanggil di jalur cetak pos");
+
+  assert.doesNotMatch(app.slice(awal, akhir), /await/,
+    "Safari iPhone memblokir print bila ada request ditunggu sesudah tap");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3151,10 +3151,19 @@ async function layarInputPos() {
   pasangKepala(`Input ${judulPos(pos)}`, "lembar");
 
   let komponen, lembar;
+  // Batas stok nomor dada diambil DI SINI, bukan saat tombol cetak ditekan.
+  // Alasannya bukan kecepatan: `window.print()` harus tetap berada di giliran
+  // event tap, dan Safari iPhone memblokirnya begitu ada satu `await` lebih
+  // dulu (lihat catatan yang sama di layarCetakKloter). Stok nomor dada juga
+  // tidak berubah di tengah lomba — ia dicetak di kain, bukan di database.
+  // Gagal membacanya tidak boleh menghalangi apa pun: nol berarti lembar
+  // dicetak apa adanya, tanpa baris kosong penambal.
+  let batasStok = 0;
   try {
-    [komponen, lembar] = await Promise.all([
+    [komponen, lembar, batasStok] = await Promise.all([
       komponenPos(EDISI.nomor, pos.nomor),
       lembarPos(pos.nomor),
+      batasNomorDada().catch(() => 0),
     ]);
   } catch (e) {
     LAYAR.replaceChildren(kartuGagalMuat(e.message, layarInputPos)); return;
@@ -4182,7 +4191,12 @@ async function layarInputPos() {
   // Dua kebutuhan berbeda terlayani satu tombol: sebelum lomba cetak "Semua"
   // untuk lembar kosong, dan di tengah lomba saring "Belum lengkap" dulu
   // supaya kertas susulan hanya memuat regu yang memang belum dinilai.
-  const cetak = async (slip) => {
+  /* TIDAK async, dan itu disengaja. `window.print()` di bawah harus tetap
+     berada dalam giliran event tap — Safari iPhone memblokirnya kalau ada
+     `await` lebih dulu, dan yang terlihat cuma tombol yang tidak melakukan
+     apa-apa. Fungsi biasa membuat pelanggarannya jadi galat sintaks, bukan
+     bug yang cuma muncul di iPhone orang lain. */
+  const cetak = (slip) => {
     const tampil = [...tbody.children].filter(tr => !tr.hidden)
       .map(tr => lembar.find(r => Number(r.nomor_dada) === Number(tr.dataset.dada)))
       .filter(Boolean);
@@ -4211,22 +4225,11 @@ async function layarInputPos() {
        sebagian regu — menyisipkan seluruh nomor kosong ke dalamnya
        mengembalikan tumpukan kertas yang tadi sengaja dipersempit. */
     let semua = tampil;
-    if (!slip && [...tbody.children].every(tr => !tr.hidden)) {
-      let batas = 0;
-      try { batas = await batasNomorDada(); } catch { /* jatuh ke daftar apa adanya */ }
-      if (batas > 0) {
-        const peta = new Map(tampil.map(r => [Number(r.nomor_dada), r]));
-        semua = Array.from({ length: batas }, (_, i) =>
-          peta.get(i + 1) || { nomor_dada: i + 1, kosong: true });
-      }
+    if (!slip && batasStok > 0 && [...tbody.children].every(tr => !tr.hidden)) {
+      const peta = new Map(tampil.map(r => [Number(r.nomor_dada), r]));
+      semua = Array.from({ length: batasStok }, (_, i) =>
+        peta.get(i + 1) || { nomor_dada: i + 1, kosong: true });
     }
-
-    // Dibaca saat menekan, bukan saat layar dimuat: layar pos sering
-    // dibiarkan terbuka berjam-jam, dan status daftar ulang berubah di
-    // tengahnya. Gagal membacanya tidak boleh menghalangi cetak — paling
-    // buruk peringatannya ikut tercetak padahal sudah tidak berlaku.
-    let ditutup = false;
-    try { ditutup = !!(await statusAcara()).daftar_ulang_ditutup; } catch { /* cetak tetap jalan */ }
 
     if (slip) {
       // Yang dicetak MASTER, bukan tumpukannya — jadi daftar ulang yang belum


### PR DESCRIPTION
## What

The Input Nilai Pos print handler no longer awaits anything before
`window.print()`, and is no longer `async`.

## Why

It awaited `batasNomorDada()` (unfiltered branch) and `statusAcara()` (every
press). Safari iPhone refuses a print call that has left the user-gesture turn,
so the print sheet never opened for a juri pos on an iPhone — while the kloter
button on the same phone worked, which makes the report sound like a phone
problem. `web/js/app.js:1956` already forbids exactly this for the kloter path,
and `tests/ios_print.test.mjs` guarded only that one.

`statusAcara()` bought nothing at all: `ditutup` was assigned and never read.
The stock limit is now fetched with the rest of the screen data — nomor dada
stock is printed on cloth, not changed mid-race — and a failure still falls back
to `0`, i.e. print the sheet without the blank filler rows.

## Notes

Making the handler a plain function turns a future `await` into a syntax error
that `node --input-type=module --check` catches, which is a stronger guard than
any test. The test covers the rest: it fails if the handler goes back to being
`async`, and it fails if an `await` appears before the print call. Checked by
reverting to `async` before committing — the assertion fires with the reason
spelled out.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)