### PR TITLE
fix: stop school-filter panels piling up in <body>

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -467,6 +467,10 @@ function gambarPapan() {
   return gambarTab(semua) + kartu;
 }
 
+/* Dibatalkan tiap kali papan digambar ulang: pendengar `document` milik panel
+   lama tidak boleh ikut hidup selamanya. */
+let pengendaliFilter = null;
+
 function pasangPapan() {
   document.querySelectorAll(".tab-golongan .tab").forEach(t => {
     t.addEventListener("click", () => {
@@ -478,6 +482,20 @@ function pasangPapan() {
       });
     });
   });
+
+  /* PANEL LAMA DIBUANG DULU, dan pendengarnya ikut.
+     Tiap panel dipindah ke <body> saat dipasang (alasannya di bawah), jadi ia
+     BUKAN anak #isi lagi — dan penggambaran ulang yang mengganti innerHTML
+     #isi tidak menyentuhnya sama sekali. Tanpa baris ini tiap penggambaran
+     menambah empat panel beserta dua pendengar `document`, dan yang lebih
+     buruk daripada tumpukannya: panel yang sedang DIBUKA peserta milik
+     penggambaran sebelumnya, sehingga mencentang sekolah di dalamnya tidak
+     menyaring apa pun — `terapkan()` menyaring baris di tabel yang sudah
+     tidak ada di layar. */
+  pengendaliFilter?.abort();
+  pengendaliFilter = new AbortController();
+  const { signal } = pengendaliFilter;
+  document.querySelectorAll("body > .isi-filter").forEach(n => n.remove());
 
   document.querySelectorAll(".panel-gol").forEach(panel => {
     const kotak = [...panel.querySelectorAll(".isi-filter input[type=checkbox]")];
@@ -513,8 +531,10 @@ function pasangPapan() {
     };
     document.addEventListener("click", e => {
       if (!isi.hidden && !isi.contains(e.target) && !kepala.contains(e.target)) tutup();
-    });
-    document.addEventListener("keydown", e => { if (e.key === "Escape") tutup(); });
+    }, { signal });
+    document.addEventListener("keydown", e => {
+      if (e.key === "Escape") tutup();
+    }, { signal });
     if (cariKotak) cariKotak.addEventListener("input", () => {
       const q = cariKotak.value.trim().toLowerCase();
       // Dicari dari `isi`, BUKAN dari `panel`. Panelnya sudah dipindah ke
@@ -550,6 +570,15 @@ function pasangPapan() {
 /* ---------------------------------------------------------------------------
    Menggambar ulang seluruh badan halaman.
    ------------------------------------------------------------------------- */
+/* Apa yang SEDANG TERGAMBAR di layar, sebagai satu teks. Tiga hal menentukan
+   isi papan: versi berkas yang terbit, fase yang berlaku setelah pengetatan,
+   dan versi rekap yang sudah di tangan. Kalau ketiganya sama dengan yang
+   barusan digambar, menggambar ulang tidak mengubah satu angka pun — ia hanya
+   merusak yang sedang dipegang peserta. */
+const kunciGambar = () =>
+  [META && META.versi, fase(), REKAP && REKAP.versi].join("|");
+let kunciTergambar = null;
+
 function gambar() {
   const isi = document.getElementById("isi");
   if (!META) return;
@@ -568,6 +597,7 @@ function gambar() {
   if (mulai()) pasangPapan();
   pasangKemajuan();
   gambarSinkron();
+  kunciTergambar = kunciGambar();
 }
 
 /* ---------------------------------------------------------------------------
@@ -614,7 +644,17 @@ async function muat() {
     // tidak satu HP pun mengunduhnya dua kali.
     if (mulai() && (versiBerubah || !REKAP)) await muatRekap();
 
-    gambar();
+    /* DIGAMBAR ULANG HANYA KALAU ADA YANG BERUBAH.
+       Denyut 60 detik yang selalu menggambar ulang membuang tiga hal
+       sekaligus: panel penyaring yang sedang dibuka peserta, pilihan sekolah
+       yang sudah dicentangnya, dan posisi gulir mendatar tabel — semuanya
+       tepat ketika ia sedang membaca. Isi papan tidak berubah di antara dua
+       penerbitan, jadi menggambarnya ulang pun tidak mengubah apa pun selain
+       merusak yang sedang dipegang.
+       Cap waktu "terakhir diperbarui" tetap maju: itu yang memberi tahu
+       peserta bahwa halamannya masih hidup. */
+    if (kunciGambar() !== kunciTergambar) gambar();
+    else gambarSinkron();
   } catch {
     if (!META) {
       document.getElementById("isi").innerHTML = `

--- a/tests/filter_sekolah.test.mjs
+++ b/tests/filter_sekolah.test.mjs
@@ -1,0 +1,57 @@
+// ============================================================================
+// hrcd-rekap : tests/filter_sekolah.test.mjs
+//
+// PANEL PENYARING SEKOLAH HIDUP DI <body>, BUKAN DI DALAM TABELNYA.
+//
+// Ia dipindah ke sana supaya `position: fixed` benar-benar relatif ke layar
+// (satu leluhur ber-transform sudah cukup untuk memindahkannya entah ke mana).
+// Harganya: tidak ada satu pun penggambaran ulang yang membuangnya, karena
+// yang diganti selalu isi #isi / LAYAR sementara panelnya sudah tidak di sana.
+//
+// Tanpa pembuangan yang disengaja, tiap penggambaran menambah empat panel dan
+// dua pendengar `document`. Yang lebih buruk daripada tumpukannya: panel yang
+// sedang DIBUKA pembaca milik penggambaran sebelumnya, jadi mencentang sekolah
+// di dalamnya tidak menyaring apa pun — dan tidak ada galat apa pun.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+
+for (const [nama, kode] of [["panitia", app], ["peserta", live]]) {
+  test(`panel penyaring ${nama} dibuang sebelum dipasang lagi`, () => {
+    assert.match(kode, /document\.querySelectorAll\("body > \.isi-filter"\)[\s\S]{0,40}\.remove\(\)/,
+      `panel ${nama} dari penggambaran sebelumnya tidak dibuang dari <body>`);
+  });
+
+  test(`pendengar document panel ${nama} ikut dibatalkan`, () => {
+    // Dua pendengar per panel: klik di luar, dan Escape. Keduanya menutup
+    // panel yang sudah tidak ada di layar kalau tidak ikut dibatalkan.
+    const pasang = [...kode.matchAll(/document\.addEventListener\("(click|keydown)"/g)];
+    assert.ok(pasang.length >= 2,
+      `pendengar panel ${nama} tidak ditemukan`);
+    assert.match(kode, /new AbortController\(\)/,
+      `panel ${nama} tidak punya pengendali untuk membatalkan pendengarnya`);
+
+    // Tiap pemasangan pendengar document di berkas ini harus membawa signal.
+    for (const m of pasang) {
+      const potongan = kode.slice(m.index, kode.indexOf("});", m.index) + 3);
+      assert.match(potongan, /\{ signal \}/,
+        `satu pendengar document di ${nama} dipasang tanpa signal:\n`
+        + potongan.slice(0, 160));
+    }
+  });
+}
+
+test("papan peserta tidak digambar ulang kalau tidak ada yang berubah", () => {
+  // Denyut 60 detik yang selalu menggambar ulang membuang panel yang sedang
+  // dibuka, pilihan sekolah yang sudah dicentang, dan posisi gulir mendatar —
+  // tepat ketika peserta sedang membacanya.
+  assert.match(live, /if \(kunciGambar\(\) !== kunciTergambar\) gambar\(\);/,
+    "muat() menggambar ulang tanpa syarat");
+  assert.match(live, /const kunciGambar = \(\) =>[\s\S]{0,120}META && META\.versi[\s\S]{0,80}fase\(\)[\s\S]{0,80}REKAP && REKAP\.versi/,
+    "kunci penggambaran tidak memuat ketiga hal yang menentukan isi papan");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5068,6 +5068,10 @@ async function layarRekap() {
  *  Jadi Live Score tinggal di situs panitia, di balik login yang sudah ada,
  *  membaca database langsung. Yang dilihat admin sama persis, yang dilihat
  *  peserta belum berubah sama sekali. */
+/* Dibatalkan tiap kali layar Live Score dibuka lagi: panel penyaring hidup di
+   <body>, jadi tidak ada yang membuangnya saat pindah layar. */
+let pengendaliFilterSekolah = null;
+
 async function layarLiveScore() {
   pasangKepala("Live Score", true);
   LAYAR.replaceChildren(h(pemuat()));
@@ -5467,6 +5471,17 @@ async function layarLiveScore() {
    *  Peringkat di kolom pertama juga TIDAK dihitung ulang: ia peringkat di
    *  golongannya, bukan nomor urut baris yang sedang tampil. Menyaring
    *  sekolah lalu melihat "1, 4, 7" adalah jawaban yang benar. */
+  /* PANEL KUNJUNGAN SEBELUMNYA DIBUANG DULU, beserta pendengarnya.
+     Tiap panel dipindah ke <body> saat dipasang (alasannya beberapa baris di
+     bawah), jadi ia bukan lagi keturunan LAYAR — dan mengganti isi LAYAR saat
+     pindah layar tidak menyentuhnya. Yang tertinggal bukan cuma sampah:
+     pendengar `document` miliknya tetap jalan di SETIAP klik di layar mana
+     pun, dan kunjungan berikutnya menambah empat panel lagi. */
+  pengendaliFilterSekolah?.abort();
+  pengendaliFilterSekolah = new AbortController();
+  const { signal } = pengendaliFilterSekolah;
+  document.querySelectorAll("body > .isi-filter").forEach(n => n.remove());
+
   LAYAR.querySelectorAll(".panel-gol").forEach(panel => {
     const kotak = [...panel.querySelectorAll(".isi-filter input[type=checkbox]")];
     const hitung = panel.querySelector(".hitung-filter");
@@ -5516,8 +5531,10 @@ async function layarLiveScore() {
     document.addEventListener("click", e => {
       if (!isi.hidden && !isi.contains(e.target) && e.target !== kepala
           && !kepala.contains(e.target)) tutup();
-    });
-    document.addEventListener("keydown", e => { if (e.key === "Escape") tutup(); });
+    }, { signal });
+    document.addEventListener("keydown", e => {
+      if (e.key === "Escape") tutup();
+    }, { signal });
     if (cariKotak) cariKotak.addEventListener("input", () => {
       const q = cariKotak.value.trim().toLowerCase();
       // Dicari dari `isi`, BUKAN dari `panel`. Panelnya sudah dipindah ke


### PR DESCRIPTION
## What

Both boards remove the previous render's `.isi-filter` panels from `<body>`
before setting up new ones, and register their two `document` listeners through
an `AbortController` that the next setup aborts. The participant board also
skips the repaint entirely when nothing changed.

## Why

A panel is moved to `<body>` so `position: fixed` is relative to the viewport —
one ancestor with a transform is enough to send it somewhere else. The cost is
that no redraw removes it: what gets replaced is the innerHTML of `#isi` /
`LAYAR`, and the panel is not in there any more.

- **Participant board** (`live/live.js:499`): four more panels and two more
  `document` listeners every 60 seconds. Worse than the pile — the panel a
  reader has open belongs to the previous render, so ticking a school filters
  rows in a table that is no longer on screen. Nothing happens, and nothing
  says why.
- **Panitia board** (`web/js/app.js:5433`): the same, once per visit to Live
  Score. The orphaned listeners then run on every click on every other screen.

## Notes

The participant repaint is now conditional on a render key —
`META.versi | fase() | REKAP.versi` — which is the complete set of things that
decide what the board shows. When they are unchanged, only the "terakhir
diperbarui" stamp advances, so the page still visibly proves it is alive while
the open panel, the ticked schools and the horizontal scroll position survive.

`tests/filter_sekolah.test.mjs` asserts both files clean up, that every
`document` listener in them carries a signal, and that the participant redraw is
guarded. Both regressions were reintroduced once before committing to confirm
the assertions fire.

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)