### PR TITLE
fix: count kelengkapan with the same golongan rule as scoring

### DIFF
--- a/supabase/migrations/0096_kelengkapan_mengenal_intern.sql
+++ b/supabase/migrations/0096_kelengkapan_mengenal_intern.sql
@@ -1,0 +1,192 @@
+-- ============================================================================
+-- hrcd-rekap : 0096_kelengkapan_mengenal_intern.sql
+-- Kelengkapan pos memakai aturan golongan yang sama dengan penilaian.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SALAH
+--
+-- `komponen_pos_golongan()` adalah PENYEBUT kelengkapan: berapa komponen yang
+-- harus diisi satu regu bergolongan tertentu di satu pos. Sejak 0060 ia
+-- menuliskan sendiri aturan golongannya:
+--
+--     w.golongan is null or w.golongan = p_golongan
+--
+-- 0091 mengubah aturan itu dan memberinya nama: `komponen_berlaku()`. Untuk
+-- Intern PA/PI komponen berlaku hanya kalau `wahana.golongan` bernilai
+-- 'intern_pa', 'intern_pi', atau penanda 'intern' — dan komponen ber-golongan
+-- NULL justru TIDAK berlaku, karena Intern tidak mengikuti lomba lapangan.
+-- 0091 memperbarui `v_lembar_pos` dan `simpan_nilai_massal`, tetapi salinan
+-- aturan di dalam fungsi ini tertinggal.
+--
+-- Akibatnya, dengan 300 Eksternal + 50 Intern:
+--
+--   Pos 1  regu Intern mengisi 2 Soal Tulis, penyebutnya dihitung 4
+--          (dua Soal Tulis + Semaphore + Menaksir) -> selamanya 'sebagian'
+--   Pos 4  regu Intern tidak punya komponen sama sekali, penyebutnya 4
+--          -> selamanya 'kosong', dan sesudah checkout ikut jadi 'hilang'
+--
+-- `lengkap` karena itu tidak pernah memuat satu pun regu Intern, dan papan
+-- Kelengkapan berhenti di bawah 100% seharian sambil melaporkan puluhan regu
+-- yang seolah belum dinilai. Itu persis kegagalan yang 0060 ditulis untuk
+-- memperbaiki, dan kepalanya sendiri menyebutkan akibatnya: "panitia yang
+-- melihat papan itu akan menyimpulkan juri Pos 1 belum memasukkan apa pun dan
+-- pergi mencari orang yang sebenarnya sudah selesai."
+--
+-- ---------------------------------------------------------------------------
+-- DUA PERUBAHAN, DAN YANG KEDUA BUKAN SEKADAR IKUTAN
+--
+-- 1. Penyebutnya memanggil `komponen_berlaku()` — satu aturan, satu tempat.
+--
+-- 2. Regu yang di satu pos TIDAK punya komponen apa pun dikeluarkan dari
+--    hitungan pos itu, bukan dihitung sebagai 'kosong'.
+--
+--    Tanpa yang kedua, Pos 4 dan Pos 5 tetap melaporkan 50 regu 'kosong'
+--    selamanya — angka yang benar secara aritmetika ("mereka memang belum
+--    dinilai") dan salah secara arti: mereka tidak akan pernah dinilai di
+--    sana, karena mereka memang tidak berlomba di sana. Penyebut nol bukan
+--    "belum selesai" melainkan "tidak ikut", dan papan yang tidak bisa
+--    membedakan keduanya mengirim panitia mencari juri yang tidak punya
+--    pekerjaan.
+--
+--    Ini juga yang membuat `persen` di halaman peserta bisa kembali mencapai
+--    100: penyebutnya sekarang regu yang memang dinilai di pos itu.
+--
+-- Yang TIDAK diubah: `v_pos.jumlah_komponen` tetap lebar blangko — ia menjawab
+-- pertanyaan lain, dan blangko memang memuat seluruh golongan (catatan yang
+-- sama sudah ada di 0060).
+--
+-- Bentuk kedua view disalin utuh dari 0060; yang berubah cuma baris
+-- `left join regu_ikut ri on true` jadi bersyarat.
+-- ============================================================================
+
+create or replace function komponen_pos_golongan(p_pos smallint, p_golongan text)
+returns int
+language sql stable
+set search_path = public
+as $fn$
+  select count(*)::int
+    from wahana w
+   where w.edisi = edisi_aktif()
+     and w.pos = p_pos
+     -- SATU aturan golongan untuk seluruh sistem (0091). Menuliskannya ulang
+     -- di sini adalah cara satu salinan ketinggalan tanpa ada yang tahu.
+     and komponen_berlaku(w.golongan, p_golongan)
+$fn$;
+
+comment on function komponen_pos_golongan(smallint, text) is
+  'Berapa komponen yang HARUS diisi satu regu bergolongan ini di pos ini, menurut komponen_berlaku(). Nol berarti regu itu tidak berlomba di pos ini dan tidak ikut dihitung. Penyebut kelengkapan; v_pos.jumlah_komponen menjawab pertanyaan lain (lebar blangko).';
+
+-- ---------------------------------------------------------------------------
+-- 1. Papan panitia.
+-- ---------------------------------------------------------------------------
+drop view if exists v_kelengkapan_pos;
+create view v_kelengkapan_pos as
+with regu_ikut as (
+  select
+    r.id,
+    r.golongan,
+    (k.jam_berangkat is not null)                                as sudah_berangkat,
+    exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+  from regu r
+  join pendaftaran d  on d.id = r.pendaftaran_id
+  left join kloter k  on k.nomor = r.kloter_nomor
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor                       as pos,
+  p.name                        as nama_pos,
+  p.bayangan,
+  p.jumlah_komponen,
+  count(ri.id)::int                                      as regu_total,
+  count(ri.id) filter (where ri.sudah_berangkat)::int    as regu_berangkat,
+  count(ri.id) filter (where ri.sudah_closing)::int      as regu_closing,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0)
+          = komponen_pos_golongan(p.nomor, ri.golongan))::int as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as sebagian,
+  count(ri.id) filter (where coalesce(t.jumlah, 0) = 0)::int  as kosong,
+  count(ri.id) filter (
+    where ri.sudah_closing
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as hilang
+from v_pos p
+-- INI yang berubah: regu yang tidak punya komponen apa pun di pos ini tidak
+-- ikut dihitung sama sekali. Barisnya tetap muncul walau tidak ada satu regu
+-- pun yang lolos syaratnya, karena join-nya tetap LEFT.
+left join regu_ikut ri on komponen_pos_golongan(p.nomor, ri.golongan) > 0
+left join terisi t     on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+group by p.nomor, p.name, p.bayangan, p.jumlah_komponen;
+
+grant select on v_kelengkapan_pos to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. Papan peserta. Syarat fasenya tetap: tanpa itu kemajuan bocor sebelum
+--    admin membukanya.
+-- ---------------------------------------------------------------------------
+create or replace view v_kelengkapan_publik as
+with regu_ikut as (
+  select r.id, r.golongan
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor          as pos,
+  p.name           as nama_pos,
+  p.jumlah_komponen,
+  count(ri.id)::int as regu_total,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0)
+          = komponen_pos_golongan(p.nomor, ri.golongan))::int as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as sebagian,
+  -- Dibulatkan ke bawah, bukan ke terdekat: 99,6% yang tampil sebagai "100%"
+  -- padahal masih ada dua regu tertinggal adalah persis kekeliruan yang
+  -- membuat orang berhenti mencari.
+  case when count(ri.id) = 0 then 0 else
+    floor(100.0 * count(ri.id) filter (
+      where coalesce(t.jumlah, 0)
+            = komponen_pos_golongan(p.nomor, ri.golongan)) / count(ri.id))::int
+  end              as persen
+from v_pos p
+left join regu_ikut ri on komponen_pos_golongan(p.nomor, ri.golongan) > 0
+left join terisi t     on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and (select fase_live from status_acara) in ('progres', 'penuh')
+group by p.nomor, p.name, p.jumlah_komponen;
+
+grant select on v_kelengkapan_publik to anon, authenticated, service_role;
+
+do $blok$
+declare r record;
+begin
+  for r in select pos, nama_pos, lengkap, regu_total from v_kelengkapan_pos order by pos
+  loop
+    raise notice '0096: pos % (%) — % dari % regu dihitung lengkap',
+      r.pos, r.nama_pos, r.lengkap, r.regu_total;
+  end loop;
+end $blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -391,6 +391,12 @@ run tests/sql/54_kloter_bisa_dicetak_ulang.sql
 # mengosongkan nilai yang justru dibandingkannya.
 run supabase/migrations/0095_lembar_pos_jawaban_benar.sql
 run tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
+# 0096 membuat penyebut kelengkapan memakai komponen_berlaku(), aturan golongan
+# yang sama dengan penilaian — 0091 mengubah aturannya dan melewatkan salinan
+# di komponen_pos_golongan(), jadi regu Intern tidak pernah bisa terhitung
+# lengkap dan di Pos 4/5 dihitung kosong selamanya. Tes 57 menguji kesamaan
+# aturannya, bukan angkanya.
+run tests/sql/57_kelengkapan_intern.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -396,6 +396,7 @@ run tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
 # di komponen_pos_golongan(), jadi regu Intern tidak pernah bisa terhitung
 # lengkap dan di Pos 4/5 dihitung kosong selamanya. Tes 57 menguji kesamaan
 # aturannya, bukan angkanya.
+run supabase/migrations/0096_kelengkapan_mengenal_intern.sql
 run tests/sql/57_kelengkapan_intern.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,

--- a/tests/sql/57_kelengkapan_intern.sql
+++ b/tests/sql/57_kelengkapan_intern.sql
@@ -1,0 +1,148 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/57_kelengkapan_intern.sql — migrasi 0096.
+--
+-- PENYEBUT KELENGKAPAN HARUS MEMAKAI ATURAN GOLONGAN YANG SAMA DENGAN
+-- PENILAIAN.
+--
+-- Ada dua salinan aturan itu di sistem: `komponen_berlaku()` yang dipakai
+-- v_lembar_pos dan simpan_nilai_massal, dan satu lagi yang dulu diketik ulang
+-- di dalam `komponen_pos_golongan()`. 0091 mengubah yang pertama dan
+-- melewatkan yang kedua, jadi regu Intern tidak pernah bisa terhitung lengkap
+-- di pos mana pun — dan di Pos 4 dan Pos 5, tempat mereka memang tidak
+-- berlomba, mereka dihitung 'kosong' selamanya lalu ikut jadi 'hilang'
+-- sesudah checkout.
+--
+-- Yang diuji di sini bukan angkanya, melainkan KESAMAAN aturannya: penyebut
+-- kelengkapan harus sama persis dengan apa yang boleh diisi juri. Tes ini
+-- bersandar pada regu Intern yang dibuat tes 52.
+-- ============================================================================
+
+\echo '--- 57. penyebut kelengkapan mengikuti aturan golongan penilaian'
+
+do $blok$
+declare
+  v_regu    uuid;
+  v_gol     text;
+  v_pos_ada smallint;   -- pos tempat regu Intern memang berlomba
+  v_pos_tak smallint;   -- pos tempat ia tidak punya komponen sama sekali
+  v_wajib   int;
+  v_terisi  int;
+  v_lengkap int;
+  v_sesudah int;
+  v_total   int;
+  v_semua   int;
+  v_intern  int;
+  v_wahana  uuid;
+  v_n1      numeric;
+  v_n2      numeric;
+  v_sumber  text;
+  v_oleh    uuid;
+begin
+  select r.id, r.golongan into v_regu, v_gol
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where r.golongan in ('intern_pa', 'intern_pi')
+    and r.nomor_dada is not null
+    and not r.is_cancelled
+    and d.status = 'lunas'
+  order by r.nomor_dada limit 1;
+  assert v_regu is not null,
+    '57 GAGAL: tidak ada regu Intern bernomor dada — tes 52 seharusnya membuatnya';
+
+  -- ---------------------------------------------------------------------
+  -- 57.1 Penyebutnya = jumlah komponen yang BOLEH diisi juri untuk regu itu.
+  --
+  --      Dua sisi dari satu aturan: `komponen_berlaku()` menentukan apa yang
+  --      boleh diisi, `komponen_pos_golongan()` menghitung apa yang harus
+  --      diisi. Kalau keduanya berbeda, regu itu tidak akan pernah lengkap
+  --      tanpa satu pun galat muncul.
+  -- ---------------------------------------------------------------------
+  for v_pos_ada, v_wajib in
+    select p.nomor, komponen_pos_golongan(p.nomor, v_gol)
+    from v_pos p where p.jumlah_komponen > 0 order by p.nomor
+  loop
+    select count(*)::int into v_terisi
+    from wahana w
+    where w.edisi = edisi_aktif() and w.pos = v_pos_ada
+      and komponen_berlaku(w.golongan, v_gol);
+    assert v_wajib = v_terisi,
+      format('57.1 GAGAL: Pos %s menuntut %s komponen dari %s, padahal yang '
+             'berlaku untuknya %s', v_pos_ada, v_wajib, v_gol, v_terisi);
+  end loop;
+  raise notice '57.1 OK — penyebut tiap pos sama dengan komponen yang berlaku untuk %.', v_gol;
+
+  -- ---------------------------------------------------------------------
+  -- 57.2 Regu Intern yang sudah mengisi seluruh komponennya TERHITUNG
+  --      lengkap.
+  --
+  --      Dibaca dua kali dengan satu baris nilai dihapus di antaranya —
+  --      kalau angkanya tidak bergerak, regu itu memang tidak pernah ikut
+  --      dihitung lengkap sejak awal.
+  -- ---------------------------------------------------------------------
+  select p.nomor into v_pos_ada
+  from v_pos p
+  where p.jumlah_komponen > 0 and komponen_pos_golongan(p.nomor, v_gol) > 0
+  order by p.nomor limit 1;
+  assert v_pos_ada is not null,
+    format('57 GAGAL: %s tidak berlomba di pos mana pun', v_gol);
+
+  select lengkap into v_lengkap from v_kelengkapan_pos where pos = v_pos_ada;
+
+  select n.wahana_id, n.nilai_1, n.nilai_2, n.source, n.created_by
+    into v_wahana, v_n1, v_n2, v_sumber, v_oleh
+  from nilai_mentah n join wahana w on w.id = n.wahana_id
+  where n.regu_id = v_regu and w.pos = v_pos_ada and w.edisi = edisi_aktif()
+  limit 1;
+  assert v_wahana is not null,
+    format('57 GAGAL: regu Intern belum punya nilai di Pos %s', v_pos_ada);
+
+  delete from nilai_mentah where regu_id = v_regu and wahana_id = v_wahana;
+  select lengkap into v_sesudah from v_kelengkapan_pos where pos = v_pos_ada;
+  insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+  values (v_regu, v_wahana, v_n1, v_n2, v_sumber, v_oleh);
+
+  assert v_lengkap - v_sesudah = 1,
+    format('57.2 GAGAL: menghapus satu nilai regu Intern mengubah "lengkap" '
+           'Pos %s dari %s jadi %s — seharusnya turun satu. Regu Intern tidak '
+           'ikut terhitung lengkap.', v_pos_ada, v_lengkap, v_sesudah);
+  raise notice '57.2 OK — regu Intern terhitung lengkap di Pos %.', v_pos_ada;
+
+  -- ---------------------------------------------------------------------
+  -- 57.3 Di pos yang tidak ia ikuti, ia tidak dihitung sama sekali.
+  --
+  --      Penyebut nol bukan "belum selesai" melainkan "tidak ikut". Dihitung
+  --      'kosong' di sana membuat papan mengirim panitia mencari juri yang
+  --      tidak punya pekerjaan.
+  -- ---------------------------------------------------------------------
+  select p.nomor into v_pos_tak
+  from v_pos p
+  where p.jumlah_komponen > 0 and komponen_pos_golongan(p.nomor, v_gol) = 0
+  order by p.nomor limit 1;
+  assert v_pos_tak is not null,
+    '57 GAGAL: tidak ada pos yang tidak diikuti Intern — fikstur tes berubah, '
+    'tes 57.3 tidak lagi memeriksa apa pun';
+
+  select regu_total into v_total from v_kelengkapan_pos where pos = v_pos_tak;
+  select count(*)::int into v_semua
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is not null
+    and komponen_pos_golongan(v_pos_tak, r.golongan) > 0;
+
+  assert v_total = v_semua,
+    format('57.3 GAGAL: Pos %s menghitung %s regu, padahal yang berlomba di '
+           'sana %s', v_pos_tak, v_total, v_semua);
+
+  select count(*)::int into v_intern
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is not null
+    and r.golongan in ('intern_pa', 'intern_pi');
+  assert v_intern > 0,
+    '57.3 GAGAL: tidak ada regu Intern yang dikecualikan, jadi angka di atas '
+    'sama saja dengan sebelum perbaikan';
+
+  raise notice '57.3 OK — Pos % menghitung % regu, % regu Intern dikecualikan.',
+    v_pos_tak, v_total, v_intern;
+end;
+$blok$;
+
+\echo '57 kelengkapan mengenal Intern: LULUS'

--- a/tests/sql/57_kelengkapan_intern.sql
+++ b/tests/sql/57_kelengkapan_intern.sql
@@ -37,6 +37,7 @@ declare
   v_n2      numeric;
   v_sumber  text;
   v_oleh    uuid;
+  v_tambah  uuid[];
 begin
   select r.id, r.golongan into v_regu, v_gol
   from regu r
@@ -85,6 +86,24 @@ begin
   order by p.nomor limit 1;
   assert v_pos_ada is not null,
     format('57 GAGAL: %s tidak berlomba di pos mana pun', v_gol);
+
+  -- Nilainya diisi DI SINI, bukan diwarisi dari tes sebelumnya: beberapa tes
+  -- membuat regu Intern untuk keperluan lain (tes 53 mengujinya sebagai kuota
+  -- FIFO) dan mana yang kebetulan sudah dinilai bukan sesuatu yang boleh
+  -- diandalkan. Yang ditambahkan di sini dibongkar lagi di akhir.
+  select array_agg(w.id) into v_tambah
+  from wahana w
+  where w.edisi = edisi_aktif() and w.pos = v_pos_ada
+    and komponen_berlaku(w.golongan, v_gol)
+    and not exists (select 1 from nilai_mentah n
+                    where n.regu_id = v_regu and n.wahana_id = w.id);
+
+  if v_tambah is not null then
+    insert into nilai_mentah (regu_id, wahana_id, nilai_1, source, created_by)
+    select v_regu, w.id, greatest(w.rentang_mentah_min, 0), 'manual',
+           (select id from auth.users order by id limit 1)
+    from wahana w where w.id = any(v_tambah);
+  end if;
 
   select lengkap into v_lengkap from v_kelengkapan_pos where pos = v_pos_ada;
 
@@ -142,6 +161,11 @@ begin
 
   raise notice '57.3 OK — Pos % menghitung % regu, % regu Intern dikecualikan.',
     v_pos_tak, v_total, v_intern;
+
+  -- Nilai yang ditambahkan tes ini dibongkar lagi.
+  if v_tambah is not null then
+    delete from nilai_mentah where regu_id = v_regu and wahana_id = any(v_tambah);
+  end if;
 end;
 $blok$;
 


### PR DESCRIPTION
## What

Migration `0096` makes `komponen_pos_golongan()` call `komponen_berlaku()`, and
leaves a regu out of a pos entirely when it has no components there.

## Why

`komponen_pos_golongan()` is the denominator behind every completeness figure on
both boards. Since `0060` it hand-wrote the golongan rule:

```sql
w.golongan is null or w.golongan = p_golongan
```

`0091` replaced that rule with `komponen_berlaku()` — for Intern PA/PI a
component applies only when `wahana.golongan` is `intern_pa`, `intern_pi` or the
`intern` marker, and NULL-golongan components explicitly do **not** apply — and
updated `v_lembar_pos` and `simpan_nilai_massal`. This copy was left behind.

With 300 Eksternal and 50 Intern:

| | denominator | filled | verdict |
|---|---|---|---|
| Pos 1, Intern regu | 4 (2 Soal Tulis + Semaphore + Menaksir) | 2 | `sebagian`, forever |
| Pos 4, Intern regu | 4 (PBB criteria) | 0 | `kosong` all day, then `hilang` after checkout |

`lengkap` therefore never included a single Intern regu: the board sits below
100% for the whole event while reporting dozens of teams as unjudged. That is
the exact failure `0060` was written to fix, and its own header spells out the
consequence — panitia go looking for a judge who has already finished.

## Notes

The second change is not a follow-on. Without it Pos 4 and Pos 5 would keep
reporting 50 `kosong` regu forever — arithmetically true ("they have not been
judged") and wrong in meaning: they never will be, because they do not compete
there. A denominator of zero is not "unfinished", it is "not entered", and a
board that cannot tell those apart is what sends someone across the field for
nothing. It also lets `persen` reach 100 again on the participant page.

`v_pos.jumlah_komponen` is untouched — it answers a different question (how wide
the blangko is), and the blangko does carry every golongan.

Test 57 checks the two sides of one rule against each other rather than against
a number: what the denominator demands must equal what a juri may enter. It was
committed before the migration and run on this branch to prove it catches the
drift:

- test only — [run 32628427513](https://github.com/ciradyka/hrcd-rekap/actions/runs/32628427513) → red:
  `57.1 GAGAL: Pos 1 menuntut 8 komponen dari intern_pa, padahal yang berlaku untuknya 2`
- with 0096 — [run 32628632153](https://github.com/ciradyka/hrcd-rekap/actions/runs/32628632153) → green:
  `57.2 OK — regu Intern terhitung lengkap di Pos 1`, `57.3 OK — Pos 4 menghitung 8 regu, 5 regu Intern dikecualikan`

Still open and deliberately not bundled here: #447, the publish step filters
Intern out of `progres`/`klasemen`/`komponen` but not out of `kelengkapan`, so
the participant ring counts Intern regu at the pos they legitimately compete in
while the table below lists Eksternal only.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)