### PR TITLE
fix: let the start line record kontrak waktu

### DIFF
--- a/supabase/migrations/0097_kontrak_boleh_dari_gerbang.sql
+++ b/supabase/migrations/0097_kontrak_boleh_dari_gerbang.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- hrcd-rekap : 0097_kontrak_boleh_dari_gerbang.sql
+-- Petugas gerbang boleh mengisi kontrak waktu.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SALAH, DAN KENAPA IA MENGHENTIKAN PAGI HARI-H
+--
+-- `konfirmasi_kontrak` dipagari `boleh('daftar_ulang')`. Satu-satunya yang
+-- memanggilnya di seluruh aplikasi adalah kolom "Kontrak waktu" di layar
+-- Keberangkatan (web/js/app.js), dan layar itu digerbangi hak `keberangkatan`.
+-- Kedua hak itu tidak pernah bertemu di satu peran:
+--
+--   registrasi  pendaftaran, pembayaran, daftar_ulang, cetak_kloter,
+--               live_score          -> punya haknya, tidak bisa buka layarnya
+--   gerbang     keberangkatan, kedatangan, live_score
+--                                   -> bisa buka layarnya, tidak punya haknya
+--
+-- Jadi selain admin, TIDAK ADA yang bisa mengisi `regu.kontrak_menit`. Dan
+-- `berangkatkan_kloter` (0064) menolak kloter yang masih memuat regu tanpa
+-- kontrak — jadi Kloter 1 tidak bisa diberangkatkan pukul 07:00 sementara
+-- upacara sudah berjalan, tanpa jalan keluar dari layar itu.
+--
+-- Ini sisa pemetaan 0064. Peran lama `meja` memegang meja pendaftaran DAN
+-- garis start sekaligus (0018 menulis pagarnya `peran() not in ('admin',
+-- 'meja')`), lalu 0058 memecahnya jadi registrasi + gerbang. Saat 0064
+-- menerjemahkan seluruh pagar ke `boleh()`, `ceklis_berangkat` di berkas yang
+-- sama dipetakan ke `keberangkatan` dengan benar; yang ini ikut terbawa ke
+-- `daftar_ulang` karena dulu satu peran mengerjakan keduanya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DUA HAK, BUKAN DIPINDAH KE `keberangkatan` SAJA
+--
+-- Konfirmasi kontrak memang pekerjaan garis start — `v_keberangkatan` bahkan
+-- punya posisi 'konfirmasi_kontrak' untuk kloter yang masih tiga giliran lagi,
+-- supaya petugas staging menanyakannya sebelum kloternya maju. Tetapi meja
+-- daftar ulang juga menanyakannya saat menyerahkan nomor dada, dan sebelum
+-- 0058 memang satu orang yang mengerjakan keduanya. Mencabutnya dari
+-- `daftar_ulang` akan menutup pintu yang selama ini terbuka untuk admin dan
+-- registrasi tanpa satu pun alasan lapangan.
+--
+-- `boleh_apa_saja()` (0064) sudah ada persis untuk hal seperti ini.
+--
+-- Yang TIDAK berubah: pagar "regu ini sudah berangkat" tetap hanya bisa
+-- ditembus pemegang `pengaturan`. Kontrak menentukan penalti yang sudah
+-- berjalan, dan itu koreksi yang harus meninggalkan jejak.
+-- ============================================================================
+
+create or replace function konfirmasi_kontrak(
+  p_regu  uuid,
+  p_menit smallint
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_kloter smallint;
+begin
+  -- INI yang berubah. Dua pintu untuk satu pekerjaan, karena dua meja memang
+  -- mengerjakannya: garis start saat memanggil kloter, dan meja daftar ulang
+  -- saat menyerahkan nomor dada.
+  if not boleh_apa_saja('keberangkatan', 'daftar_ulang') then
+    raise exception 'tidak berhak: keberangkatan';
+  end if;
+  if not exists (select 1 from kontrak_opsi
+                 where edisi = edisi_aktif() and menit = p_menit) then
+    raise exception 'kontrak % menit bukan pilihan edisi ini', p_menit;
+  end if;
+
+  select kloter_nomor into v_kloter from regu where id = p_regu;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_kloter is null then
+    raise exception 'regu belum daftar ulang (belum punya kloter)';
+  end if;
+  -- Setelah REGU INI tercatat berangkat, kontraknya menentukan penalti yang
+  -- sudah berjalan — perbaikan susulan hanya lewat admin. Kloter yang pergi
+  -- tanpa dia tidak menghalangi apa pun.
+  if not boleh('pengaturan') and regu_sudah_berangkat(p_regu) then
+    raise exception 'regu ini sudah berangkat — koreksi kontrak hanya lewat admin';
+  end if;
+
+  update regu set kontrak_menit = p_menit where id = p_regu;
+end;
+$$;
+
+comment on function konfirmasi_kontrak(uuid, smallint) is
+  'Mencatat kontrak waktu satu regu. Boleh dari garis start (hak keberangkatan) maupun dari meja daftar ulang (hak daftar_ulang) — keduanya menanyakannya, dan sebelum 0058 keduanya satu peran.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -398,6 +398,11 @@ run tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
 # aturannya, bukan angkanya.
 run supabase/migrations/0096_kelengkapan_mengenal_intern.sql
 run tests/sql/57_kelengkapan_intern.sql
+# 0097 membuka konfirmasi_kontrak untuk pemegang hak keberangkatan. Sebelumnya
+# ia menuntut daftar_ulang, hak yang justru tidak dimiliki peran gerbang —
+# satu-satunya peran yang bisa membuka layar tempat RPC itu dipanggil. Tes 58
+# menduduki kursi gerbang dan mencabut centangnya di antara dua panggilan.
+run tests/sql/58_kontrak_dari_gerbang.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -402,6 +402,7 @@ run tests/sql/57_kelengkapan_intern.sql
 # ia menuntut daftar_ulang, hak yang justru tidak dimiliki peran gerbang —
 # satu-satunya peran yang bisa membuka layar tempat RPC itu dipanggil. Tes 58
 # menduduki kursi gerbang dan mencabut centangnya di antara dua panggilan.
+run supabase/migrations/0097_kontrak_boleh_dari_gerbang.sql
 run tests/sql/58_kontrak_dari_gerbang.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,

--- a/tests/sql/58_kontrak_dari_gerbang.sql
+++ b/tests/sql/58_kontrak_dari_gerbang.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/58_kontrak_dari_gerbang.sql — migrasi 0097.
+--
+-- PETUGAS GARIS START HARUS BISA MENGISI KONTRAK WAKTU.
+--
+-- Bentuknya mengikuti tes 30-36 (CLAUDE.md 13.8): panggilan yang SAMA PERSIS
+-- dijalankan dua kali oleh akun yang sama, dan yang berubah di antaranya cuma
+-- satu baris `akun_hak` — persis yang dilakukan centang di layar Akun. Kalau
+-- pesannya tidak berubah, pagarnya bukan centang itu.
+--
+-- Yang dijaga bukan sekadar "gerbang boleh". Yang dijaga adalah RANTAINYA:
+-- layar Keberangkatan digerbangi hak `keberangkatan`, jadi RPC yang hanya
+-- bisa dipanggil dari layar itu tidak boleh menuntut hak yang pemegang
+-- `keberangkatan` tidak punya. Sebelum 0097 ia menuntut `daftar_ulang`, dan
+-- akibatnya tidak ada satu peran pun selain admin yang bisa mengisi kontrak —
+-- lalu `berangkatkan_kloter` menolak seluruh kloter karena regunya belum
+-- berkontrak.
+-- ============================================================================
+
+\echo '--- 58. kontrak waktu bisa diisi dari garis start'
+
+do $blok$
+declare
+  v_gerbang uuid := '00000000-0000-0000-0000-0000000000c1';
+  v_regu    uuid;
+  v_menit   smallint;
+  v_semula  smallint;
+  v_pesan   text;
+  v_dapat   smallint;
+begin
+  -- Akun gerbang: belum ada di seed (01_seed_uji hanya punya admin, dua juri
+  -- pos, dan tiga meja). Dibuat lewat PERGANTIAN PERAN, jalan yang sama dengan
+  -- layar Akun, supaya centangnya diisi trigger hak_ikut_peran (0077) dari
+  -- paket_peran('gerbang') — haknya jadi persis seperti akun gerbang
+  -- sungguhan, bukan karangan tes ini.
+  --
+  -- Trigger itu `after update of peran`, jadi INSERT saja tidak mengisi
+  -- apa-apa; barisnya lahir sebagai juri_pos lalu diganti. (Check 0058
+  -- menuntut juri_pos punya pos dan peran lain tidak, jadi pos ikut diganti
+  -- di pernyataan yang sama.)
+  insert into auth.users (id, email) values (v_gerbang, 'gerbang.uji@uji.local')
+  on conflict (id) do nothing;
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_gerbang, 'gerbang.uji', 'juri_pos', 1, true)
+  on conflict (user_id) do update set peran = 'juri_pos', pos = 1, is_active = true;
+  update akun_panitia set peran = 'gerbang', pos = null where user_id = v_gerbang;
+
+  select count(*)::int into v_dapat from akun_hak
+  where user_id = v_gerbang and fitur = 'keberangkatan';
+  assert v_dapat = 1,
+    'akun gerbang tidak mendapat hak keberangkatan dari paket_peran()';
+  select count(*)::int into v_dapat from akun_hak
+  where user_id = v_gerbang and fitur = 'daftar_ulang';
+  assert v_dapat = 0,
+    'akun gerbang mendapat hak daftar_ulang — tes ini jadi tidak membuktikan '
+    'apa pun, karena itulah hak yang dulu dituntut';
+
+  -- Regu yang berkloter dan kloternya belum berangkat: pagar "sudah berangkat"
+  -- adalah pagar lain, dan bukan itu yang diuji di sini.
+  select r.id, r.kontrak_menit into v_regu, v_semula
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  join kloter k on k.nomor = r.kloter_nomor
+  where not r.is_cancelled and d.status = 'lunas'
+    and r.kloter_nomor is not null
+    and k.jam_berangkat is null
+    and not exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+  order by r.nomor_dada limit 1;
+  assert v_regu is not null,
+    '58 GAGAL: tidak ada regu berkloter yang belum berangkat untuk diuji';
+
+  select menit into v_menit from kontrak_opsi
+  where edisi = edisi_aktif() order by menit limit 1;
+  assert v_menit is not null, '58 GAGAL: edisi ini tidak punya pilihan kontrak';
+
+  -- ---------------------------------------------------------------------
+  -- 58.1 Dengan centang `keberangkatan`, petugas gerbang berhasil.
+  -- ---------------------------------------------------------------------
+  perform set_config('app.uid', v_gerbang::text, true);
+  perform konfirmasi_kontrak(v_regu, v_menit);
+
+  select kontrak_menit into v_dapat from regu where id = v_regu;
+  assert v_dapat = v_menit,
+    format('58.1 GAGAL: kontrak tersimpan %s, seharusnya %s', v_dapat, v_menit);
+  raise notice '58.1 OK — akun gerbang mengisi kontrak % menit.', v_menit;
+
+  -- ---------------------------------------------------------------------
+  -- 58.2 Centangnya dicabut, panggilan yang sama ditolak.
+  --
+  --      Inilah yang membuktikan pagarnya benar-benar `keberangkatan` dan
+  --      bukan sesuatu yang kebetulan terbuka.
+  -- ---------------------------------------------------------------------
+  delete from akun_hak where user_id = v_gerbang and fitur = 'keberangkatan';
+  begin
+    perform konfirmasi_kontrak(v_regu, v_menit);
+    assert false, '58.2 GAGAL: kontrak tetap bisa diisi tanpa satu hak pun';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak berhak%',
+    format('58.2 GAGAL: ditolak dengan pesan lain — %s', v_pesan);
+  raise notice '58.2 OK — centang dicabut, pintunya tertutup: %', v_pesan;
+
+  -- ---------------------------------------------------------------------
+  -- 58.3 Meja daftar ulang tetap boleh. Perbaikan ini menambah pintu, bukan
+  --      memindahkannya — sebelum 0058 satu orang mengerjakan keduanya.
+  -- ---------------------------------------------------------------------
+  insert into akun_hak (user_id, fitur) values (v_gerbang, 'daftar_ulang')
+  on conflict do nothing;
+  perform konfirmasi_kontrak(v_regu, v_menit);
+  raise notice '58.3 OK — hak daftar_ulang saja juga masih membuka pintunya.';
+
+  -- Kembalikan keadaan: hak gerbang seperti paketnya, dan kontrak regu uji
+  -- seperti semula supaya penalti tes lain tidak bergeser.
+  delete from akun_hak where user_id = v_gerbang and fitur = 'daftar_ulang';
+  insert into akun_hak (user_id, fitur) values (v_gerbang, 'keberangkatan')
+  on conflict do nothing;
+  perform set_config('app.uid', '', true);
+  update regu set kontrak_menit = v_semula
+  where id = v_regu and kontrak_menit is distinct from v_semula;
+end;
+$blok$;
+
+\echo '58 kontrak waktu dari garis start: LULUS'


### PR DESCRIPTION
## What

Migration `0097` changes the guard on `konfirmasi_kontrak` from
`boleh('daftar_ulang')` to `boleh_apa_saja('keberangkatan','daftar_ulang')`.

## Why

The only caller is the "Kontrak waktu" dropdown on the Keberangkatan screen
(`web/js/app.js:1746`), and that screen is gated on the `keberangkatan` right.
The two rights never meet in one role:

| role | rights | can open the screen? | holds the right the RPC wanted? |
|---|---|---|---|
| `registrasi` | pendaftaran, pembayaran, daftar_ulang, cetak_kloter, live_score | no | yes |
| `gerbang` | keberangkatan, kedatangan, live_score | yes | no |

So nobody except admin could record a kontrak — and `berangkatkan_kloter`
(`0064:352`) refuses a kloter that still holds a regu without one. Kloter 1
could not be dispatched at 07:00, with no way out of that screen. Worse
downstream: `ceklis_berangkat` refuses a late checkmark without a kontrak, and
`catat_closing` refuses a regu with no departure row, so a team that walked
anyway could not be recorded at the finish either.

Leftover from `0064`. The old `meja` role covered the registration desk and the
start line at once, so `0018` wrote the guard as `peran() not in ('admin','meja')`.
`0058` split that role in two; when `0064` translated every guard to `boleh()`,
`ceklis_berangkat` in the same file landed on `keberangkatan` correctly and this
one followed the desk half.

## Notes

A door added, not moved: the start line asks for the contract when it calls a
kloter (`v_keberangkatan` even has a `konfirmasi_kontrak` position for the
kloter three turns out), and the daftar ulang desk asks when it hands over the
nomor dada. Removing `daftar_ulang` would close a door that has been open all
along. The "already departed" guard still belongs to `pengaturan` alone.

Test 58 takes the gerbang seat and revokes one `akun_hak` row between two
identical calls — the shape of tests 30–36. Committed before the migration and
run on this branch to prove it catches the real thing:

- test only — [run 32635750964](https://github.com/ciradyka/hrcd-rekap/actions/runs/32635750964) → red: `ERROR: tidak berhak: daftar_ulang`
- with 0097 — [run 32635835593](https://github.com/ciradyka/hrcd-rekap/actions/runs/32635835593) → green: `58.1 OK — akun gerbang mengisi kontrak 210 menit`, `58.2 OK — centang dicabut, pintunya tertutup: tidak berhak: keberangkatan`, `58.3 OK — hak daftar_ulang saja juga masih membuka pintunya`

Found while writing the test, not filed here: `hak_ikut_peran` (0077) is an
`after update of peran` trigger, so an account created by a plain INSERT — which
is what the gateway's `/akun/daftar` does — gets no `akun_hak` rows at all until
someone changes its peran afterwards. Worth its own issue.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)