### PR TITLE
fix: stop the finish desk carrying one regu's entry to the next

### DIFF
--- a/tests/kedatangan_isian.test.mjs
+++ b/tests/kedatangan_isian.test.mjs
@@ -1,0 +1,59 @@
+// ============================================================================
+// hrcd-rekap : tests/kedatangan_isian.test.mjs
+//
+// ISIAN KOREKSI DI MEJA KEDATANGAN TIDAK BOLEH IKUT PINDAH KE REGU BERIKUTNYA.
+//
+// Dua kebutuhan memakai dua kotak yang sama. Regu yang sudah tercatat
+// ditampilkan jam lamanya supaya verifikasi terhadap kertas tinggal
+// membandingkan; petugas yang menyalin sederet catatan kertas sering mengetik
+// jamnya lebih dulu lalu membetulkan nomornya — itu sebabnya bersihkan()
+// sengaja tidak mengosongkan keduanya.
+//
+// Bedanya cuma siapa yang mengisi. Tanpa pembedaan itu, mengetik 042 yang
+// sudah tercatat 10:30 dengan 4 anggota lalu berpindah ke 043 yang baru masuk
+// pukul 11:05 menyimpan 043 sebagai datang 10:30 dengan 4 anggota — di kotak
+// yang tidak terlihat, karena panel koreksinya tertutup. Tidak ada galat, dan
+// penalti waktunya berubah dari 5 poin jadi 30.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+const layar = (() => {
+  const awal = app.indexOf("  async function cariDanTampilkan(dada) {");
+  const akhir = app.indexOf("  function gambarRiwayat() {", awal);
+  assert.notEqual(awal, -1, "cariDanTampilkan tidak ditemukan");
+  assert.notEqual(akhir, -1, "akhir layar Kedatangan tidak ditemukan");
+  return app.slice(awal, akhir);
+})();
+
+test("isian sistem milik satu regu, dan pergi bersama regu itu", () => {
+  assert.match(layar, /isianDariSistem = dada;/,
+    "prefill tidak menandai regu pemiliknya");
+  assert.match(layar,
+    /else if \(isianDariSistem !== null && isianDariSistem !== dada\)[\s\S]{0,220}inpJam\.setNilai\(""\)[\s\S]{0,80}inpHadir\.value = "5"/,
+    "berpindah ke regu yang belum tercatat tidak mengosongkan isian regu "
+    + "sebelumnya — jam dan jumlah anggota regu lain akan ikut tersimpan");
+});
+
+test("ketikan petugas tidak pernah dibuang", () => {
+  // Yang diketik petugas sendiri bukan milik satu regu; menghapusnya saat ia
+  // membetulkan nomor adalah kegagalan yang lain lagi, dan bersihkan() sudah
+  // menjelaskan kenapa.
+  assert.match(app, /inpJam\.dengar\(\(\) => \{ isianDariSistem = null;/,
+    "mengetik jam tidak membatalkan penanda isian sistem");
+  assert.match(app, /inpHadir\.addEventListener\("input", \(\) => \{ isianDariSistem = null;/,
+    "mengetik jumlah anggota tidak membatalkan penanda isian sistem");
+});
+
+test("isi yang punya akibat tidak boleh tersembunyi", () => {
+  // Kedua kotak duduk di dalam <details> yang tertutup, berikut lencana
+  // "penalti berubah" yang seharusnya memperingatkan.
+  assert.match(app, /const panelKoreksi = inpHadir\.closest\("details"\)/,
+    "panel koreksi tidak dikenali");
+  assert.match(app, /if \(berisi\) panelKoreksi\.open = true;/,
+    "panel koreksi tidak dibuka saat kotaknya berisi");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2147,6 +2147,23 @@ function layarFinish() {
   let regu = null;
   let jeda = null;
 
+  /* NOMOR DADA yang isian koreksinya diisi oleh SISTEM, atau null kalau
+     isinya diketik petugas sendiri.
+
+     Dua kebutuhan bertabrakan di dua kotak yang sama. Regu yang sudah tercatat
+     ditampilkan jam lamanya supaya verifikasi terhadap kertas tinggal
+     membandingkan; sementara petugas yang menyalin sederet catatan kertas
+     sering mengetik jamnya lebih dulu lalu membetulkan nomornya — itu sebabnya
+     bersihkan() sengaja tidak mengosongkan keduanya.
+
+     Bedanya cuma SIAPA yang mengisi. Isian sistem milik satu regu tertentu dan
+     harus pergi bersama regu itu; isian petugas miliknya sendiri dan tidak
+     boleh disentuh. Tanpa pembedaan ini, mengetik 042 yang sudah tercatat
+     10:30 lalu berpindah ke 043 yang baru masuk pukul 11:05 menyimpan 043
+     sebagai datang 10:30 — di kotak yang tidak terlihat, karena panelnya
+     tertutup. */
+  let isianDariSistem = null;
+
   inp.focus();
   gambarRiwayat();
 
@@ -2201,7 +2218,21 @@ function layarFinish() {
       ? html`<span class="badge badge-green">${arah} — penalti tetap ${tulis(pIsi)}</span>`
       : html`<span class="badge badge-yellow">${arah} — penalti berubah ${tulis(pDasar)} → ${tulis(pIsi)}</span>`;
   };
-  inpJam.dengar(perbaruiDampak);
+  /* Panel koreksi DIBUKA begitu salah satu kotaknya berisi. Isi yang tidak
+     terlihat tetap ikut tersimpan saat tombol ditekan, dan lencana "penalti
+     berubah" yang seharusnya memperingatkan justru ikut tersembunyi di
+     dalamnya. Yang punya akibat harus kelihatan. */
+  const panelKoreksi = inpHadir.closest("details");
+  const bukaKalauBerisi = () => {
+    if (!panelKoreksi) return;
+    const berisi = !inpJam.kosong() || inpHadir.value.trim() !== "5";
+    if (berisi) panelKoreksi.open = true;
+  };
+
+  // Ketikan petugas membatalkan penanda: sejak itu isinya miliknya, dan
+  // berpindah regu tidak boleh membuangnya.
+  inpJam.dengar(() => { isianDariSistem = null; bukaKalauBerisi(); perbaruiDampak(); });
+  inpHadir.addEventListener("input", () => { isianDariSistem = null; bukaKalauBerisi(); });
   // Bentuknya dirapikan saat kotak ditinggalkan, jadi lencana dampaknya ikut
   // dihitung ulang sesudah itu — tanpa ini "745" yang jadi "07:45" saat blur
   // meninggalkan lencana menampilkan hitungan dari teks yang sudah tidak ada.
@@ -2274,6 +2305,14 @@ function layarFinish() {
     if (r.sudah_finish && r.jam_datang) {
       inpJam.setNilai(jamMenit(r.jam_datang));
       inpHadir.value = r.anggota_hadir ?? 5;
+      isianDariSistem = dada;
+      bukaKalauBerisi();
+    } else if (isianDariSistem !== null && isianDariSistem !== dada) {
+      // Isian tadi milik regu LAIN yang sudah tercatat. Membawanya ke regu ini
+      // berarti menyimpan jam dan jumlah anggota regu sebelumnya atas namanya.
+      inpJam.setNilai("");
+      inpHadir.value = "5";
+      isianDariSistem = null;
     }
     perbaruiDampak();
   }
@@ -2318,6 +2357,7 @@ function layarFinish() {
       `${nama} — ${jamMenit(jam)}${hadir < 5 ? ` · ${hadir} anggota` : ""}`);
     tombol.dataset.jalan = "";
     inp.value = ""; inpJam.setNilai(""); inpHadir.value = "5";
+    isianDariSistem = null;
     bersihkan(); inp.focus();
     gambarRiwayat();
     notif(`${dada3(dada)} tercatat ${jamMenit(jam)}.`);


### PR DESCRIPTION
## What

The two correction boxes on Meja Kedatangan now remember **who filled them**. A
value the system prefilled belongs to one regu and is cleared when the officer
moves to a regu that has not been recorded; a value the officer typed is left
alone. The `<details>` panel also opens itself whenever either box is non-empty.

## Why

`cariDanTampilkan()` prefills jam and anggota when the regu looked up has
already finished, so verifying against paper is just a comparison. There was no
`else` branch, and `bersihkan()` deliberately leaves those boxes alone — so the
values stayed for whatever regu was typed next. Both boxes sit inside a closed
`<details>`, together with the "penalti berubah" badge that would have warned.

Type `042`, already recorded 10:30 with 4 members. Notice the wrong number, type
`043` which just crossed the line at 11:05, press Enter — the fast two-action
path the desk is designed around. `043` is stored as arriving **10:30 with 4
members**. Against an 11:00 target that is 30 penalty points instead of 5, plus
the missing-member penalty. Nothing errors, nothing turns red, and the history
line reads `10:30 · 4 anggota` as if it were right.

## Notes

Clearing the boxes unconditionally would have broken the case `bersihkan()`
protects and documents: an officer copying a row of paper records types the time
first and fixes the number afterwards. That is why the fix distinguishes owner
rather than just wiping — typing in either box hands ownership to the officer.

Opening the panel when it holds something is the second half. Content that
changes what gets saved must not be invisible.

Three tests, checked against the old behaviour before committing: removing the
clearing branch fails with `berpindah ke regu yang belum tercatat tidak
mengosongkan isian regu sebelumnya`.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)