### PR TITLE
fix: retry a rekap that failed, and stop the clock lying about it

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -633,16 +633,34 @@ async function muat() {
     const r = await fetch(`live.json?t=${Date.now()}`, { cache: "no-store" });
     if (!r.ok) throw new Error(String(r.status));
     const baru = await r.json();
-    const versiBerubah = !META || META.versi !== baru.versi;
+    const metaLama = META;
     META = baru;
 
-    // Rekap diambil ulang hanya kalau memang sudah dipegang (peserta sedang
-    // melihatnya) atau memang harus tampil tanpa dicari (fase 'penuh').
-    // Papan sekarang menggambar SELURUH regu begitu lomba mulai, bukan hanya
-    // hasil pencarian — jadi rekap.json memang harus ada di tangan. Yang
-    // menahan bebannya tetap alamat ber-versi: selama isinya tidak berubah,
-    // tidak satu HP pun mengunduhnya dua kali.
-    if (mulai() && (versiBerubah || !REKAP)) await muatRekap();
+    /* Rekap diambil selama yang dipegang belum sesuai versi live.json.
+       Syaratnya SAMA PERSIS dengan penjaga di dalam muatRekap() — dan itu
+       yang dulu salah. Dulu di sini berbunyi `versiBerubah || !REKAP`, yaitu
+       perbandingan META LAMA dengan live.json BARU, jadi ia benar hanya pada
+       satu poll: poll pertama sesudah versi berganti. Kalau justru pada poll
+       itu unduhannya gagal — jaringan seluler padat di lapangan —
+       `muatRekap()` mendiamkan galatnya, REKAP tetap memegang versi lama, dan
+       poll-poll berikutnya melihat `META.versi === baru.versi` sehingga tidak
+       pernah mencoba lagi. Papan berhenti di penerbitan sebelumnya sampai
+       halamannya dimuat ulang dengan tangan.
+
+       Papan menggambar SELURUH regu begitu lomba mulai, jadi rekap.json memang
+       harus ada di tangan. Bebannya tetap ditahan alamat ber-versi: selama
+       isinya tidak berubah, tidak satu HP pun mengunduhnya dua kali. */
+    if (mulai() && (!REKAP || versiRekap !== META.versi)) await muatRekap();
+
+    /* DAN KALAU REKAPNYA TIDAK SAMPAI, META-nya DIKEMBALIKAN.
+       Cap waktu "Update terakhir" dibaca dari META. Membiarkan META maju
+       sementara tabelnya masih terbitan sebelumnya membuat baris itu berbohong
+       dengan meyakinkan: podium pukul 14:00 di bawah tulisan "baru saja".
+       Lebih baik halaman menyebut terbitan yang memang sedang ia tampilkan —
+       dan poll berikutnya otomatis mencoba lagi karena versinya kembali
+       berbeda. Fase tetap bisa MENGETAT seketika: pengetatan datang dari
+       denyut database (FASE_DB), bukan dari berkas ini. */
+    if (mulai() && metaLama && versiRekap !== META.versi) META = metaLama;
 
     /* DIGAMBAR ULANG HANYA KALAU ADA YANG BERUBAH.
        Denyut 60 detik yang selalu menggambar ulang membuang tiga hal

--- a/tests/filter_sekolah.test.mjs
+++ b/tests/filter_sekolah.test.mjs
@@ -55,3 +55,26 @@ test("papan peserta tidak digambar ulang kalau tidak ada yang berubah", () => {
   assert.match(live, /const kunciGambar = \(\) =>[\s\S]{0,120}META && META\.versi[\s\S]{0,80}fase\(\)[\s\S]{0,80}REKAP && REKAP\.versi/,
     "kunci penggambaran tidak memuat ketiga hal yang menentukan isi papan");
 });
+
+test("rekap yang gagal diambil dicoba lagi pada poll berikutnya", () => {
+  // Syarat di luar harus SAMA dengan penjaga di dalam muatRekap(). Dulu di
+  // luar berbunyi `versiBerubah || !REKAP` — perbandingan META lama dengan
+  // live.json baru — sehingga ia benar hanya pada satu poll. Satu kegagalan
+  // unduh tepat pada poll itu membekukan papan di penerbitan sebelumnya
+  // sampai halamannya dimuat ulang dengan tangan.
+  assert.match(live,
+    /if \(mulai\(\) && \(!REKAP \|\| versiRekap !== META\.versi\)\) await muatRekap\(\);/,
+    "syarat pengambilan rekap tidak sama dengan penjaga di dalam muatRekap()");
+  // Bentuk lamanya masih DIKUTIP di komentar sebagai catatan sejarah, jadi
+  // yang dicari pernyataannya, bukan teksnya.
+  assert.doesNotMatch(live, /if \(mulai\(\) && \(versiBerubah \|\| !REKAP\)\)/,
+    "syarat lama yang hanya benar satu kali masih terpasang");
+});
+
+test("cap waktu tidak maju mendahului tabel yang ditampilkannya", () => {
+  // "Update terakhir" dibaca dari META. Membiarkannya maju sementara tabelnya
+  // masih terbitan sebelumnya membuat baris itu berbohong dengan meyakinkan.
+  assert.match(live,
+    /if \(mulai\(\) && metaLama && versiRekap !== META\.versi\) META = metaLama;/,
+    "META tetap maju walau rekap terbitan itu tidak sampai");
+});


### PR DESCRIPTION
## What

`muat()` keeps trying to fetch `rekap.json` while the copy in hand does not
match `live.json`, and rolls `META` back to the publication whose rekap it
actually holds when the fetch still fails.

## Why

The outer condition was `versiBerubah || !REKAP` — old `META` compared against
the new `live.json` — so it was true on exactly **one** poll: the first after a
new version is published. `muatRekap()` swallows a failed download on purpose
(the old data stays usable), so if the network dropped on that one poll, `REKAP`
kept the old version and every later poll saw `META.versi === baru.versi` and
never tried again. The board stayed on the previous publication until someone
reloaded the page by hand.

The correct test already existed inside `muatRekap()` (`versiRekap === META.versi`).
The outer one used a different comparison and shadowed it.

Race-day shape: at 14:30 the final klasemen is published, one phone's fetch
fails in the crowd, and that phone shows the 14:00 podium — a different Juara 1
— for the rest of the afternoon.

## Notes

The rollback is the second half. "Update terakhir" is read from `META`, so
letting it advance past the table turns that line into a convincing lie: the
14:00 podium under the words "baru saja". Showing the publication the page is
actually displaying is both honest and self-healing — the next poll retries
because the version differs again.

Phase tightening is unaffected: it arrives through the 15-second database
heartbeat, not through this file, so `penuh → progres` still reaches phones
immediately. Loosening waits for the matching rekap, which is the rule anyway —
the page may never show more than the file it holds (CLAUDE.md 14.3).

Both assertions were checked against the old code before committing: restoring
the old condition fails with `syarat pengambilan rekap tidak sama dengan
penjaga di dalam muatRekap()`, and deleting the rollback fails with `META tetap
maju walau rekap terbitan itu tidak sampai`.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)