### PR TITLE
fix: allow gate staff to move kloter

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -117,7 +117,7 @@ export function pesanRamah(m) {
     return "Nama ketua tidak boleh memakai angka.";
   if (/nama_kontak_tanpa_angka/i.test(t))
     return "Nama contact person tidak boleh memakai angka.";
-  if (/permission denied|insufficient/i.test(t))
+  if (/permission denied|insufficient|tidak berhak:/i.test(t))
     return "Akun ini tidak berhak melakukan itu. Pakai akun yang sesuai.";
   if (/password.*(should be different|new password should be different)/i.test(t))
     return "Password baru harus beda dari password lama.";

--- a/supabase/migrations/0098_pindah_kloter_dari_gerbang.sql
+++ b/supabase/migrations/0098_pindah_kloter_dari_gerbang.sql
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- hrcd-rekap : 0098_pindah_kloter_dari_gerbang.sql
+-- Petugas gerbang boleh memindahkan regu dari layar Keberangkatan.
+--
+-- Layar Keberangkatan hanya dibuka oleh hak `keberangkatan`, tetapi definisi
+-- termuda `pindah_kloter` masih menuntut `cetak_kloter`. Hak lama tetap
+-- dipertahankan karena meja registrasi juga sudah memakai jalur manual ini.
+-- ============================================================================
+
+create or replace function pindah_kloter(
+  p_nomor_dada integer, p_alasan text, p_kloter smallint default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu regu%rowtype;
+  v_cfg edisi%rowtype;
+  v_tujuan smallint;
+  v_perlu_diumumkan boolean;
+  v_tercetak boolean;
+  v_lama smallint;
+  v_tujuan_berangkat boolean;
+begin
+  if not boleh_apa_saja('keberangkatan', 'cetak_kloter') then
+    raise exception 'tidak berhak: keberangkatan';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan pemindahan wajib diisi — tercatat di riwayat';
+  end if;
+  select * into v_cfg from edisi where is_active;
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+  select * into v_regu from regu where nomor_dada = p_nomor_dada for update;
+  if not found then raise exception 'nomor dada % tidak dikenal', p_nomor_dada; end if;
+  if v_regu.is_cancelled then raise exception 'regu % berstatus batal', p_nomor_dada; end if;
+  v_lama := v_regu.kloter_nomor;
+  if regu_sudah_berangkat(v_regu.id) then
+    raise exception 'regu % ikut berangkat bersama kloter % — kalau itu keliru, batalkan dulu keberangkatan kloter itu lewat admin', p_nomor_dada, v_lama;
+  end if;
+
+  if p_kloter is null then
+    select k.nomor into v_tujuan from kloter k
+    where k.jam_berangkat is null and k.nomor <= v_cfg.kloter_maks
+    order by k.nomor desc limit 1;
+  else
+    v_tujuan := p_kloter;
+    if not exists (select 1 from kloter where nomor = v_tujuan) then
+      raise exception 'kloter % tidak ada', v_tujuan;
+    end if;
+  end if;
+  if v_tujuan is null then raise exception 'tidak ada kloter tersisa yang belum berangkat'; end if;
+  if v_tujuan = v_lama then raise exception 'regu % sudah ada di kloter %', p_nomor_dada, v_tujuan; end if;
+
+  select dicetak_pada is not null or jam_berangkat is not null,
+         dicetak_pada is not null, jam_berangkat is not null
+    into v_perlu_diumumkan, v_tercetak, v_tujuan_berangkat
+  from kloter where nomor = v_tujuan;
+  perform set_config('hrcd.izin_pindah', '1', true);
+  update regu set
+    kloter_nomor = v_tujuan,
+    urutan_kloter = slot_kloter_berikutnya(v_tujuan),
+    disisipkan_pada = case when v_perlu_diumumkan then now() else disisipkan_pada end,
+    alasan_sisip = case when v_perlu_diumumkan then p_alasan else alasan_sisip end
+  where id = v_regu.id;
+  perform set_config('hrcd.izin_pindah', '0', true);
+
+  insert into history (table_name, row_id, regu_id, action, old_value, new_value, changed_by)
+  values ('regu', v_regu.id::text, v_regu.id, 'UPDATE',
+    jsonb_build_object('kloter_nomor', v_lama, 'urutan_kloter', v_regu.urutan_kloter),
+    jsonb_build_object('pindah_kloter', jsonb_build_object(
+      'nomor_dada', p_nomor_dada, 'dari', v_lama, 'ke', v_tujuan,
+      'alasan', p_alasan, 'kloter_tujuan_sudah_dicetak', v_tercetak,
+      'kloter_tujuan_sudah_berangkat', v_tujuan_berangkat)), auth.uid());
+
+  return jsonb_build_object(
+    'nomor_dada', p_nomor_dada, 'kloter_lama', v_lama, 'kloter_baru', v_tujuan,
+    'sisipan', v_perlu_diumumkan, 'tujuan_sudah_berangkat', v_tujuan_berangkat,
+    'peringatan', nullif(concat_ws(' ',
+      case when v_perlu_diumumkan then format(
+        'Nomor %s TIDAK ADA di kertas kloter %s. Beri tahu petugas staging.',
+        p_nomor_dada, v_tujuan) end,
+      case when v_tujuan_berangkat then format(
+        'Kloter %s sudah berangkat, jadi nomor %s dinilai dari jam berangkat kloter itu.',
+        v_tujuan, p_nomor_dada) end), ''));
+end;
+$$;
+
+comment on function pindah_kloter(integer, text, smallint) is
+  'Memindahkan regu secara manual dari meja registrasi atau garis start; hak cetak_kloter dan keberangkatan sama-sama membuka pintu.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -404,6 +404,10 @@ run tests/sql/57_kelengkapan_intern.sql
 # menduduki kursi gerbang dan mencabut centangnya di antara dua panggilan.
 run supabase/migrations/0097_kontrak_boleh_dari_gerbang.sql
 run tests/sql/58_kontrak_dari_gerbang.sql
+# Pemindahan regu dipanggil dari layar Keberangkatan, jadi pemegang hak
+# `keberangkatan` harus bisa memakainya tanpa diam-diam menuntut cetak_kloter.
+run supabase/migrations/0098_pindah_kloter_dari_gerbang.sql
+run tests/sql/59_pindah_kloter_dari_gerbang.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/59_pindah_kloter_dari_gerbang.sql
+++ b/tests/sql/59_pindah_kloter_dari_gerbang.sql
@@ -1,0 +1,73 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/59_pindah_kloter_dari_gerbang.sql — migrasi 0098.
+-- Panggilan yang sama harus mengikuti centang `keberangkatan` akun gerbang.
+-- ============================================================================
+
+\echo '--- 59. pindah kloter bisa dilakukan dari garis start'
+
+do $blok$
+declare
+  v_gerbang uuid := '00000000-0000-0000-0000-0000000000c2';
+  v_dada integer;
+  v_asal smallint;
+  v_tujuan smallint;
+  v_pesan text;
+begin
+  insert into auth.users (id, email) values (v_gerbang, 'gerbang.pindah@uji.local')
+  on conflict (id) do nothing;
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_gerbang, 'gerbang.pindah', 'juri_pos', 1, true)
+  on conflict (user_id) do update set peran = 'juri_pos', pos = 1, is_active = true;
+  update akun_panitia set peran = 'gerbang', pos = null where user_id = v_gerbang;
+
+  assert exists (select 1 from akun_hak
+                 where user_id = v_gerbang and fitur = 'keberangkatan'),
+    'akun gerbang tidak mendapat hak keberangkatan';
+  assert not exists (select 1 from akun_hak
+                     where user_id = v_gerbang and fitur = 'cetak_kloter'),
+    'akun gerbang mendapat cetak_kloter sehingga tes tidak membuktikan pagar baru';
+
+  select r.nomor_dada, r.kloter_nomor into v_dada, v_asal
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  join kloter k on k.nomor = r.kloter_nomor
+  where not r.is_cancelled and d.status = 'lunas'
+    and r.nomor_dada is not null and k.jam_berangkat is null
+    and not exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+  order by r.nomor_dada limit 1;
+  assert v_dada is not null, '59 GAGAL: tidak ada regu yang aman untuk diuji';
+
+  select nomor into v_tujuan from kloter
+  where nomor <> v_asal and jam_berangkat is null
+  order by nomor limit 1;
+  assert v_tujuan is not null, '59 GAGAL: tidak ada kloter tujuan';
+
+  perform set_config('app.uid', v_gerbang::text, true);
+  perform pindah_kloter(v_dada, 'uji hak keberangkatan', v_tujuan);
+  assert (select kloter_nomor = v_tujuan from regu where nomor_dada = v_dada),
+    '59.1 GAGAL: akun gerbang tidak berhasil memindahkan regu';
+
+  delete from akun_hak where user_id = v_gerbang and fitur = 'keberangkatan';
+  begin
+    perform pindah_kloter(v_dada, 'uji tanpa hak', v_asal);
+    assert false, '59.2 GAGAL: pindah kloter tetap terbuka tanpa hak';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%tidak berhak%',
+    format('59.2 GAGAL: ditolak dengan pesan lain — %s', v_pesan);
+
+  insert into akun_hak (user_id, fitur) values (v_gerbang, 'cetak_kloter')
+  on conflict do nothing;
+  perform pindah_kloter(v_dada, 'uji hak lama', v_asal);
+  assert (select kloter_nomor = v_asal from regu where nomor_dada = v_dada),
+    '59.3 GAGAL: hak cetak_kloter lama tidak lagi bisa memindahkan regu';
+
+  delete from akun_hak where user_id = v_gerbang and fitur = 'cetak_kloter';
+  insert into akun_hak (user_id, fitur) values (v_gerbang, 'keberangkatan')
+  on conflict do nothing;
+  perform set_config('app.uid', '', true);
+end;
+$blok$;
+
+\echo '59 pindah kloter dari garis start: LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -117,7 +117,7 @@ export function pesanRamah(m) {
     return "Nama ketua tidak boleh memakai angka.";
   if (/nama_kontak_tanpa_angka/i.test(t))
     return "Nama contact person tidak boleh memakai angka.";
-  if (/permission denied|insufficient/i.test(t))
+  if (/permission denied|insufficient|tidak berhak:/i.test(t))
     return "Akun ini tidak berhak melakukan itu. Pakai akun yang sesuai.";
   if (/password.*(should be different|new password should be different)/i.test(t))
     return "Password baru harus beda dari password lama.";


### PR DESCRIPTION
## What\n\n- allow holders of either keberangkatan or cetak_kloter to call pindah_kloter\n- add a seat-based SQL regression test for the gate role\n- translate database 	idak berhak errors into the standard friendly UI message\n\n## Why\n\nGate staff are the non-admin users of the Keberangkatan screen, but the RPC only accepted a registration-side permission. This prevented a race-day kloter correction and could attach the wrong departure time to a regu.\n\nCloses #489\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)