### PR TITLE
fix: keep Enter navigation in the same score column

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -32,6 +32,30 @@ export function html(potongan, ...nilai) {
 
 export const rupiah = n => "Rp " + Number(n || 0).toLocaleString("id-ID");
 
+/** Cari kotak pada kolom tabel dan slot yang sama di baris berikutnya.
+ *
+ * Baris Input Pos tidak selalu punya kotak yang sama: komponen Eksternal
+ * digambar sebagai tanda mati pada baris Intern, dan sebaliknya. Karena itu
+ * indeks di antara seluruh input satu baris tidak menunjukkan kolom tabel.
+ * `data-slot` membedakan pasangan Benar/Salah di dalam satu sel. */
+export function kotakBerikutnyaDalamKolom(baris, kotak) {
+  const selAsal = kotak?.closest?.("td");
+  const kolom = selAsal?.cellIndex;
+  if (!Number.isInteger(kolom) || kolom < 0) return null;
+
+  const slot = kotak.dataset?.slot || "";
+  for (let lanjut = baris?.nextElementSibling; lanjut;
+       lanjut = lanjut.nextElementSibling) {
+    if (lanjut.hidden) continue;
+    const selTujuan = lanjut.cells?.[kolom];
+    if (!selTujuan) continue;
+    const tujuan = [...selTujuan.querySelectorAll("input")]
+      .find(el => (el.dataset?.slot || "") === slot);
+    if (tujuan) return tujuan;
+  }
+  return null;
+}
+
 /* ---------------------------------------------------------------------------
    WAKTU — tiga bentuk, dan hanya tiga. Semua layar memakai yang ini.
 

--- a/tests/input_pos_navigation.test.mjs
+++ b/tests/input_pos_navigation.test.mjs
@@ -1,0 +1,63 @@
+// ============================================================================
+// hrcd-rekap : tests/input_pos_navigation.test.mjs
+// Enter di Input Pos harus turun dalam kolom lomba yang sama.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { kotakBerikutnyaDalamKolom } from "../web/js/util.js";
+
+const kotak = (slot = "") => ({ dataset: slot ? { slot } : {} });
+const sel = (...kotakIsian) => ({ querySelectorAll: () => kotakIsian });
+const baris = (cells, hidden = false) => ({ cells, hidden, nextElementSibling: null });
+
+function rangkai(...barisDaftar) {
+  for (let i = 0; i < barisDaftar.length - 1; i += 1) {
+    barisDaftar[i].nextElementSibling = barisDaftar[i + 1];
+  }
+}
+
+test("Enter mengikuti kolom tabel melewati batas Intern dan Eksternal", () => {
+  const asal = kotak();
+  asal.closest = () => ({ cellIndex: 3 });
+
+  const tersembunyi = kotak();
+  const salahKolom = kotak();
+  const tujuan = kotak();
+  const pertama = baris([]);
+  const disaring = baris([sel(), sel(), sel(), sel(tersembunyi)], true);
+  // Baris Intern tidak punya lomba pada kolom 3. Ia punya input pada kolom 0,
+  // tetapi input itu tidak boleh dianggap sebagai kolom yang sama.
+  const intern = baris([sel(salahKolom), sel(), sel(), sel()]);
+  const eksternal = baris([sel(), sel(), sel(), sel(tujuan)]);
+  rangkai(pertama, disaring, intern, eksternal);
+
+  assert.equal(kotakBerikutnyaDalamKolom(pertama, asal), tujuan);
+});
+
+test("Enter mempertahankan slot benar atau salah di dalam satu sel", () => {
+  const asal = kotak("salah");
+  asal.closest = () => ({ cellIndex: 4 });
+  const benar = kotak("benar");
+  const salah = kotak("salah");
+  const pertama = baris([]);
+  const berikutnya = baris([sel(), sel(), sel(), sel(), sel(benar, salah)]);
+  rangkai(pertama, berikutnya);
+
+  assert.equal(kotakBerikutnyaDalamKolom(pertama, asal), salah);
+});
+
+test("kotak biasa tidak mendarat di salah satu slot pasangan", () => {
+  const asal = kotak();
+  asal.closest = () => ({ cellIndex: 2 });
+  const benar = kotak("benar");
+  const salah = kotak("salah");
+  const tujuan = kotak();
+  const pertama = baris([]);
+  const pasangan = baris([sel(), sel(), sel(benar, salah)]);
+  const biasa = baris([sel(), sel(), sel(tujuan)]);
+  rangkai(pertama, pasangan, biasa);
+
+  assert.equal(kotakBerikutnyaDalamKolom(pertama, asal), tujuan);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -35,7 +35,8 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
          angkaRapi, nilaiTeks, petunjukKolom, nilaiBagian,
-         jamPadaHari, GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
+         jamPadaHari, kotakBerikutnyaDalamKolom,
+         GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
 
 const LAYAR = document.getElementById("layar");
@@ -4204,11 +4205,7 @@ async function layarInputPos() {
     if (e.key !== "Enter" || e.target.tagName !== "INPUT") return;
     e.preventDefault();
     const tr = e.target.closest("tr");
-    const kotak = [...tr.querySelectorAll("input")];
-    const kolom = kotak.indexOf(e.target);
-    let lanjut = tr.nextElementSibling;
-    while (lanjut && lanjut.hidden) lanjut = lanjut.nextElementSibling;
-    const tujuan = lanjut && lanjut.querySelectorAll("input")[kolom];
+    const tujuan = kotakBerikutnyaDalamKolom(tr, e.target);
     if (tujuan) { tujuan.focus(); if (tujuan.select) tujuan.select(); }
     else e.target.blur();
   });

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -32,6 +32,30 @@ export function html(potongan, ...nilai) {
 
 export const rupiah = n => "Rp " + Number(n || 0).toLocaleString("id-ID");
 
+/** Cari kotak pada kolom tabel dan slot yang sama di baris berikutnya.
+ *
+ * Baris Input Pos tidak selalu punya kotak yang sama: komponen Eksternal
+ * digambar sebagai tanda mati pada baris Intern, dan sebaliknya. Karena itu
+ * indeks di antara seluruh input satu baris tidak menunjukkan kolom tabel.
+ * `data-slot` membedakan pasangan Benar/Salah di dalam satu sel. */
+export function kotakBerikutnyaDalamKolom(baris, kotak) {
+  const selAsal = kotak?.closest?.("td");
+  const kolom = selAsal?.cellIndex;
+  if (!Number.isInteger(kolom) || kolom < 0) return null;
+
+  const slot = kotak.dataset?.slot || "";
+  for (let lanjut = baris?.nextElementSibling; lanjut;
+       lanjut = lanjut.nextElementSibling) {
+    if (lanjut.hidden) continue;
+    const selTujuan = lanjut.cells?.[kolom];
+    if (!selTujuan) continue;
+    const tujuan = [...selTujuan.querySelectorAll("input")]
+      .find(el => (el.dataset?.slot || "") === slot);
+    if (tujuan) return tujuan;
+  }
+  return null;
+}
+
 /* ---------------------------------------------------------------------------
    WAKTU — tiga bentuk, dan hanya tiga. Semua layar memakai yang ini.
 


### PR DESCRIPTION
## What\n\n- navigate Input Pos vertically by table column instead of per-row input index\n- skip rows where the lomba does not apply\n- preserve the Benar/Salah sub-slot for paired inputs\n- add focused navigation regression tests\n\n## Why\n\nIntern and Eksternal rows contain different input counts. Enter could therefore focus an unrelated lomba in the next row and cause a valid-looking score to be saved under the wrong component.\n\nCloses #488\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)