### PR TITLE
fix: close new database relations to anon

### DIFF
--- a/supabase/migrations/0099_anon_default_privileges.sql
+++ b/supabase/migrations/0099_anon_default_privileges.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- hrcd-rekap : 0099_anon_default_privileges.sql
+-- Semua relasi baru tertutup untuk anon kecuali sengaja dibuka.
+--
+-- Supabase memberi grant lewat default privileges role migrasi. Pencabutan
+-- `on all tables` di 0003 hanya mengenai relasi yang sudah ada saat itu, jadi
+-- tabel dan view yang dibuat sesudahnya lahir terbuka lagi. Bersihkan seluruh
+-- ACL sekarang, buka kembali lima relasi publik yang memang dirancang untuk
+-- peserta, lalu ubah default-nya agar migrasi berikutnya mulai dari tertutup.
+-- ============================================================================
+
+alter default privileges in schema public revoke all on tables from anon;
+
+revoke all on all tables in schema public from anon;
+
+grant select on sekolah, v_edisi_publik, v_fase_live, v_publik_ringkas,
+                v_kelengkapan_publik
+to anon;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -408,6 +408,10 @@ run tests/sql/58_kontrak_dari_gerbang.sql
 # `keberangkatan` harus bisa memakainya tanpa diam-diam menuntut cetak_kloter.
 run supabase/migrations/0098_pindah_kloter_dari_gerbang.sql
 run tests/sql/59_pindah_kloter_dari_gerbang.sql
+# Supabase memberi relasi baru kepada anon lewat default privileges. Tutup
+# default itu dan jaga daftar putih relasi publik secara menyeluruh.
+run supabase/migrations/0099_anon_default_privileges.sql
+run tests/sql/60_anon_default_privileges.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/00_harness.sql
+++ b/tests/sql/00_harness.sql
@@ -40,3 +40,8 @@ $$;
 grant usage on schema auth to anon, authenticated, service_role;
 grant select on auth.users to authenticated, service_role;
 grant anon, authenticated, service_role to current_user;
+
+-- Supabase memberi relasi baru buatan role migrasi kepada anon lewat default
+-- privileges. Tiruan ini wajib melakukan hal yang sama; tanpa itu tes lokal
+-- tidak bisa melihat grant publik yang lupa dicabut oleh sebuah migrasi.
+alter default privileges in schema public grant all on tables to anon;

--- a/tests/sql/60_anon_default_privileges.sql
+++ b/tests/sql/60_anon_default_privileges.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/60_anon_default_privileges.sql — migrasi 0099.
+-- Hak tabel/view anon harus persis daftar putih situs peserta.
+-- ============================================================================
+
+\echo '--- 60. relasi anon hanya yang sengaja dibuka'
+
+do $blok$
+declare
+  v_tidak_sengaja text;
+  v_daftar_putih integer;
+begin
+  select string_agg(x.table_name, ', ' order by x.table_name)
+    into v_tidak_sengaja
+  from (
+    select distinct table_name
+    from information_schema.role_table_grants
+    where table_schema = 'public'
+      and grantee = 'anon'
+      and table_name not in (
+        'sekolah', 'v_edisi_publik', 'v_fase_live', 'v_publik_ringkas',
+        'v_kelengkapan_publik'
+      )
+  ) x;
+
+  assert v_tidak_sengaja is null,
+    format('60 GAGAL: anon mendapat relasi yang tidak sengaja dibuka: %s',
+           v_tidak_sengaja);
+
+  select count(distinct table_name) into v_daftar_putih
+  from information_schema.role_table_grants
+  where table_schema = 'public' and grantee = 'anon'
+    and privilege_type = 'SELECT'
+    and table_name in (
+      'sekolah', 'v_edisi_publik', 'v_fase_live', 'v_publik_ringkas',
+      'v_kelengkapan_publik'
+    );
+
+  assert v_daftar_putih = 5,
+    format('60 GAGAL: hanya %s dari 5 relasi publik yang bisa dibaca anon',
+           v_daftar_putih);
+end;
+$blok$;
+
+\echo '60 default privileges anon: LULUS'


### PR DESCRIPTION
## What\n\n- revoke non access from every public table and view\n- explicitly reopen only the five participant-facing relations\n- change future default table privileges to start closed\n- mirror Supabase default privileges in the SQL harness and test the complete allowlist\n\n## Why\n\nThe earlier blanket revoke only covered relations that existed at that point. Supabase default privileges reopened later tables and definer views, exposing internal aggregate data without login and leaving future relations vulnerable.\n\nCloses #497\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)