### PR TITLE
fix: validate attendance count at finish

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -32,6 +32,17 @@ export function html(potongan, ...nilai) {
 
 export const rupiah = n => "Rp " + Number(n || 0).toLocaleString("id-ID");
 
+/** Baca jumlah anggota di meja Kedatangan. Kotak kosong memakai default lima,
+ * tetapi ketikan yang tidak terbaca atau angka di luar 0–5 harus ditolak. */
+export function bacaAnggotaHadir(teks, badInput = false) {
+  if (badInput) return null;
+  const isi = String(teks ?? "").trim();
+  if (isi === "") return 5;
+  if (!/^\d+$/.test(isi)) return null;
+  const jumlah = Number(isi);
+  return jumlah >= 0 && jumlah <= 5 ? jumlah : null;
+}
+
 /** Cari kotak pada kolom tabel dan slot yang sama di baris berikutnya.
  *
  * Baris Input Pos tidak selalu punya kotak yang sama: komponen Eksternal

--- a/tests/kedatangan_isian.test.mjs
+++ b/tests/kedatangan_isian.test.mjs
@@ -20,6 +20,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+import { bacaAnggotaHadir } from "../web/js/util.js";
+
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
 
 const layar = (() => {
@@ -45,7 +47,8 @@ test("ketikan petugas tidak pernah dibuang", () => {
   // menjelaskan kenapa.
   assert.match(app, /inpJam\.dengar\(\(\) => \{ isianDariSistem = null;/,
     "mengetik jam tidak membatalkan penanda isian sistem");
-  assert.match(app, /inpHadir\.addEventListener\("input", \(\) => \{ isianDariSistem = null;/,
+  assert.match(app,
+    /inpHadir\.addEventListener\("input", \(\) => \{\s*isianDariSistem = null;/,
     "mengetik jumlah anggota tidak membatalkan penanda isian sistem");
 });
 
@@ -56,4 +59,24 @@ test("isi yang punya akibat tidak boleh tersembunyi", () => {
     "panel koreksi tidak dikenali");
   assert.match(app, /if \(berisi\) panelKoreksi\.open = true;/,
     "panel koreksi tidak dibuka saat kotaknya berisi");
+});
+
+test("kotak anggota kosong memakai default lima, bukan nol", () => {
+  assert.equal(bacaAnggotaHadir(""), 5);
+  assert.equal(bacaAnggotaHadir("   "), 5);
+  assert.equal(bacaAnggotaHadir("0"), 0, "nol yang benar-benar diketik tetap sah");
+  assert.equal(bacaAnggotaHadir("5"), 5);
+});
+
+test("jumlah anggota yang tidak sah menghentikan penyimpanan", () => {
+  for (const isi of ["-1", "6", "1.5", "abc"]) {
+    assert.equal(bacaAnggotaHadir(isi), null, `${isi} seharusnya ditolak`);
+  }
+  assert.equal(bacaAnggotaHadir("", true), null,
+    "ketikan tak terbaca dari input number bukan kotak kosong biasa");
+  assert.match(layar,
+    /const hadir = bacaAnggotaHadir\([\s\S]{0,180}if \(hadir === null\)/,
+    "layar tidak menghentikan penyimpanan saat jumlah anggota tidak sah");
+  assert.doesNotMatch(layar, /Math\.max\(0, Math\.min\(5,/,
+    "layar kembali menjepit isian salah menjadi angka yang tampak sah");
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -35,7 +35,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
          angkaRapi, nilaiTeks, petunjukKolom, nilaiBagian,
-         jamPadaHari, kotakBerikutnyaDalamKolom,
+         jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
          GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
 
@@ -2233,7 +2233,13 @@ function layarFinish() {
   // Ketikan petugas membatalkan penanda: sejak itu isinya miliknya, dan
   // berpindah regu tidak boleh membuangnya.
   inpJam.dengar(() => { isianDariSistem = null; bukaKalauBerisi(); perbaruiDampak(); });
-  inpHadir.addEventListener("input", () => { isianDariSistem = null; bukaKalauBerisi(); });
+  inpHadir.addEventListener("input", () => {
+    isianDariSistem = null;
+    if (bacaAnggotaHadir(inpHadir.value, inpHadir.validity?.badInput) !== null) {
+      inpHadir.removeAttribute("aria-invalid");
+    }
+    bukaKalauBerisi();
+  });
   // Bentuknya dirapikan saat kotak ditinggalkan, jadi lencana dampaknya ikut
   // dihitung ulang sesudah itu — tanpa ini "745" yang jadi "07:45" saat blur
   // meninggalkan lencana menampilkan hitungan dari teks yang sudah tidak ada.
@@ -2339,12 +2345,18 @@ function layarFinish() {
             + "Kosongkan untuk memakai jam saat tombol ditekan.", true);
       return;
     }
+    const hadir = bacaAnggotaHadir(inpHadir.value, inpHadir.validity?.badInput);
+    if (hadir === null) {
+      inpHadir.setAttribute("aria-invalid", "true");
+      inpHadir.focus();
+      notif("Anggota hadir harus angka 0–5. Kosongkan untuk memakai 5.", true);
+      return;
+    }
     tombol.dataset.jalan = "1"; tombol.disabled = true;
 
     // Jam dikunci DI SINI — saat tombol ditekan, dari jam laptop panitia.
     // Kolom jam hanya dipakai bila memang diisi (koreksi hasil verifikasi).
     const jam = jamIsi ? jamPadaHari(jamIsi, regu.target_datang) : new Date();
-    const hadir = Math.max(0, Math.min(5, Number(inpHadir.value) || 0));
     const dada = regu.nomor_dada;
     const nama = regu.nama_regu;
     try {

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -32,6 +32,17 @@ export function html(potongan, ...nilai) {
 
 export const rupiah = n => "Rp " + Number(n || 0).toLocaleString("id-ID");
 
+/** Baca jumlah anggota di meja Kedatangan. Kotak kosong memakai default lima,
+ * tetapi ketikan yang tidak terbaca atau angka di luar 0–5 harus ditolak. */
+export function bacaAnggotaHadir(teks, badInput = false) {
+  if (badInput) return null;
+  const isi = String(teks ?? "").trim();
+  if (isi === "") return 5;
+  if (!/^\d+$/.test(isi)) return null;
+  const jumlah = Number(isi);
+  return jumlah >= 0 && jumlah <= 5 ? jumlah : null;
+}
+
 /** Cari kotak pada kolom tabel dan slot yang sama di baris berikutnya.
  *
  * Baris Input Pos tidak selalu punya kotak yang sama: komponen Eksternal


### PR DESCRIPTION
## What\n\n- interpret an empty Anggota hadir field as the documented default of five\n- reject unreadable, fractional, negative, and above-five values\n- keep an explicitly entered zero valid\n- add regression tests for the parser and save guard\n\n## Why\n\nThe previous coercion converted an empty or invalid field to zero, silently applying a 100-point missing-member penalty.\n\nCloses #492\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)