### PR TITLE
fix: merge Intern score variants into one column

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1008,6 +1008,31 @@ export function petunjukKolom(k) {
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
 }
 
+/** Gabungkan varian `wahana` menjadi satu kolom penilaian di layar.
+ *
+ * Kalau minimal satu baris bernama sama dibatasi golongan, SEMUA baris dengan
+ * nama itu adalah varian satu kolom — termasuk baris asal yang golongannya
+ * null. Ini menyatukan pasangan umum + Intern tanpa menurunkan hubungan dari
+ * akhiran `kode`, yang hanya kebiasaan penamaan dan bukan kontrak data. */
+export function kolomPos(komponen) {
+  const namaBervarian = new Set(
+    komponen.filter(k => k.golongan).map(k => k.name),
+  );
+  const urut = [], peta = new Map();
+  for (const k of komponen) {
+    const kunci = namaBervarian.has(k.name) ? `nama:${k.name}` : `kode:${k.kode}`;
+    if (!peta.has(kunci)) {
+      peta.set(kunci, { nama: k.name, varian: [] });
+      urut.push(peta.get(kunci));
+    }
+    peta.get(kunci).varian.push(k);
+  }
+  for (const kol of urut) {
+    kol.petunjuk = [...new Set(kol.varian.map(petunjukKolom))].join(" / ");
+  }
+  return urut;
+}
+
 /** Angka nilai sebagai TEKS, satu bagian atau dua.
  *
  *  Mengembalikan bagian-bagiannya, bukan HTML jadi, dan itu yang membuatnya

--- a/tests/score_columns.test.mjs
+++ b/tests/score_columns.test.mjs
@@ -1,0 +1,40 @@
+// ============================================================================
+// hrcd-rekap : tests/score_columns.test.mjs
+// Varian umum dan Intern dari satu penilaian tetap satu kolom layar.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { kolomPos } from "../web/js/util.js";
+
+const komponen = (kode, name, golongan = null) => ({
+  kode, name, golongan, form: "benar_per_total", total_soal: 10,
+  rentang_mentah_min: 0, rentang_mentah_maks: 10,
+});
+
+test("pasangan umum dan Intern bergabung berdasarkan nama", () => {
+  const kolom = kolomPos([
+    komponen("semaphore", "Semaphore"),
+    komponen("menaksir", "Menaksir"),
+    komponen("keagamaan", "Keagamaan"),
+    komponen("keagamaan_intern", "Keagamaan", "intern"),
+    komponen("kepramukaan", "Kepramukaan"),
+    komponen("kepramukaan_intern", "Kepramukaan", "intern"),
+  ]);
+
+  assert.deepEqual(kolom.map(k => k.nama),
+    ["Semaphore", "Menaksir", "Keagamaan", "Kepramukaan"]);
+  assert.deepEqual(kolom[2].varian.map(k => k.kode),
+    ["keagamaan", "keagamaan_intern"]);
+  assert.deepEqual(kolom[3].varian.map(k => k.kode),
+    ["kepramukaan", "kepramukaan_intern"]);
+});
+
+test("komponen umum bernama berbeda tetap berdiri sendiri", () => {
+  const kolom = kolomPos([
+    komponen("a", "Nama A"),
+    komponen("b", "Nama B"),
+  ]);
+  assert.equal(kolom.length, 2);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -34,7 +34,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
-         angkaRapi, nilaiTeks, petunjukKolom, nilaiBagian,
+         angkaRapi, nilaiTeks, nilaiBagian, kolomPos,
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
          GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
@@ -2563,42 +2563,6 @@ function bacaSel(tr, k) {
   if (takTerbaca(kotak[0])) return TIDAK_SAH;
   const v = kotak[0].value.trim();
   return v === "" ? null : { nilai_1: Number(v), nilai_2: null };
-}
-
-/** SATU LOMBA BISA PUNYA BEBERAPA BARIS `wahana`, DAN TETAP SATU KOLOM.
- *
- *  Tebak Simpul punya empat baris — satu per golongan — karena skalanya
- *  berbeda: Penggalang menebak 5 simpul, Penegak 10 (0030). Di layar itu tetap
- *  satu kolom, karena tiap regu hanya berhak mengisi variannya sendiri.
- *
- *  Sebelum ini layar menggambar satu kolom per BARIS wahana, jadi Pos 1 punya
- *  empat kolom bernama "Tebak Simpul" tanpa satu pun penanda golongan.
- *  Akibatnya dua-duanya buruk sekaligus: petugas mengetik di kolom yang salah
- *  lalu ditolak server, dan tidak ada regu yang bisa dihitung "lengkap" —
- *  siapa pun hanya bisa mengisi tiga dari enam kotak, jadi angka di atas tabel
- *  membeku di "0/46 lengkap" selamanya.
- *
- *  Aturan pengelompokannya dibuat sesederhana mungkin: komponen BERGOLONGAN
- *  dengan nama sama jadi satu kolom, komponen tanpa golongan berdiri sendiri.
- *  Tidak ada kolom penanda grup di database yang harus diisi benar — dua baris
- *  yang panitia beri nama sama memang dimaksudkan sebagai satu lomba. */
-function kolomPos(komponen) {
-  const urut = [], peta = new Map();
-  for (const k of komponen) {
-    const kunci = k.golongan ? `nama:${k.name}` : `kode:${k.kode}`;
-    if (!peta.has(kunci)) {
-      peta.set(kunci, { nama: k.name, varian: [] });
-      urut.push(peta.get(kunci));
-    }
-    peta.get(kunci).varian.push(k);
-  }
-  for (const kol of urut) {
-    // Rentang yang berbeda digabung jadi "0 – 5 / 0 – 10". Kotak di tiap baris
-    // tetap dibatasi min/max variannya sendiri, jadi baris ini keterangan —
-    // bukan aturan yang bisa berbeda pendapat dengan server.
-    kol.petunjuk = [...new Set(kol.varian.map(petunjukKolom))].join(" / ");
-  }
-  return urut;
 }
 
 /** Varian yang berhak diisi regu bergolongan ini — cerminan persis

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1008,6 +1008,31 @@ export function petunjukKolom(k) {
   return `${angkaRapi(k.rentang_mentah_min)} – ${angkaRapi(k.rentang_mentah_maks)}`;
 }
 
+/** Gabungkan varian `wahana` menjadi satu kolom penilaian di layar.
+ *
+ * Kalau minimal satu baris bernama sama dibatasi golongan, SEMUA baris dengan
+ * nama itu adalah varian satu kolom — termasuk baris asal yang golongannya
+ * null. Ini menyatukan pasangan umum + Intern tanpa menurunkan hubungan dari
+ * akhiran `kode`, yang hanya kebiasaan penamaan dan bukan kontrak data. */
+export function kolomPos(komponen) {
+  const namaBervarian = new Set(
+    komponen.filter(k => k.golongan).map(k => k.name),
+  );
+  const urut = [], peta = new Map();
+  for (const k of komponen) {
+    const kunci = namaBervarian.has(k.name) ? `nama:${k.name}` : `kode:${k.kode}`;
+    if (!peta.has(kunci)) {
+      peta.set(kunci, { nama: k.name, varian: [] });
+      urut.push(peta.get(kunci));
+    }
+    peta.get(kunci).varian.push(k);
+  }
+  for (const kol of urut) {
+    kol.petunjuk = [...new Set(kol.varian.map(petunjukKolom))].join(" / ");
+  }
+  return urut;
+}
+
 /** Angka nilai sebagai TEKS, satu bagian atau dua.
  *
  *  Mengembalikan bagian-bagiannya, bukan HTML jadi, dan itu yang membuatnya


### PR DESCRIPTION
## What\n\n- merge a null-golongan component with same-named Intern variants\n- keep unrelated general components separate\n- share and unit-test the pure column grouping rule\n\n## Why\n\nThe previous key used kode for the general row and 
ame for its Intern copy, producing duplicate, indistinguishable columns across Input Pos, Rekap, Live Score, and the backup form.\n\nCloses #490\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)