### PR TITLE
fix: decouple gate lookup from live score access

### DIFF
--- a/supabase/migrations/0100_gate_regu_lookup.sql
+++ b/supabase/migrations/0100_gate_regu_lookup.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- hrcd-rekap : 0100_gate_regu_lookup.sql
+-- Lookup regu di dua meja gerbang tidak bergantung pada hak Live Score.
+--
+-- `v_regu_ringkas` sebelumnya security_invoker dan ikut policy pendaftaran,
+-- yang tidak mengenal keberangkatan/kedatangan. Membuka tabel pendaftaran
+-- langsung kepada gerbang juga membuka nomor WA pembina yang tidak dipakai
+-- layar ini. Karena itu view ringkas menjadi definer dengan pagar haknya
+-- sendiri: gerbang mendapat data operasional yang diperlukan, bukan seluruh
+-- baris pendaftaran.
+-- ============================================================================
+
+create or replace view v_regu_ringkas with (security_invoker = off) as
+select
+  r.id                                   as regu_id,
+  r.nomor_dada,
+  r.nama_regu,
+  r.nama_ketua,
+  s.name                                 as nama_sekolah,
+  r.golongan,
+  r.kloter_nomor                         as kloter,
+  r.kontrak_menit,
+  k.jam_berangkat,
+  k.jam_berangkat is not null            as sudah_berangkat,
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                                           as sudah_ceklis,
+  c.jam_datang,
+  c.anggota_hadir,
+  c.regu_id is not null                  as sudah_finish,
+  r.disisipkan_pada is not null          as sisipan,
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+    then k.jam_berangkat + make_interval(mins => r.kontrak_menit)
+  end                                    as target_datang
+from regu r
+join pendaftaran d       on d.id = r.pendaftaran_id
+join sekolah s           on s.id = d.sekolah_id
+left join kloter k       on k.nomor = r.kloter_nomor
+left join closing_regu c on c.regu_id = r.id
+where not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and boleh_apa_saja('keberangkatan', 'kedatangan', 'daftar_ulang',
+                     'pengaturan');
+
+comment on view v_regu_ringkas is
+  'Lookup operasional untuk staging dan finish. Definer agar tidak membuka pendaftaran beserta nomor WA; badannya wajib menjaga keberangkatan/kedatangan/daftar_ulang/pengaturan.';
+
+grant select on v_regu_ringkas to authenticated;
+revoke all on v_regu_ringkas from anon;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -412,6 +412,10 @@ run tests/sql/59_pindah_kloter_dari_gerbang.sql
 # default itu dan jaga daftar putih relasi publik secara menyeluruh.
 run supabase/migrations/0099_anon_default_privileges.sql
 run tests/sql/60_anon_default_privileges.sql
+# Lookup staging/finish tidak boleh bergantung pada hak Live Score yang bisa
+# dicabut per akun, dan tidak perlu membuka nomor WA di tabel pendaftaran.
+run supabase/migrations/0100_gate_regu_lookup.sql
+run tests/sql/61_gate_regu_lookup.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/61_gate_regu_lookup.sql
+++ b/tests/sql/61_gate_regu_lookup.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/61_gate_regu_lookup.sql — migrasi 0100.
+-- Lookup staging/finish mengikuti hak gerbang, bukan centang Live Score.
+-- ============================================================================
+
+\echo '--- 61. lookup regu tetap hidup tanpa hak Live Score'
+
+do $blok$
+declare
+  v_gerbang uuid := '00000000-0000-0000-0000-0000000000c3';
+  v_jumlah integer;
+begin
+  insert into auth.users (id, email) values (v_gerbang, 'gerbang.lookup@uji.local')
+  on conflict (id) do nothing;
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_gerbang, 'gerbang.lookup', 'juri_pos', 1, true)
+  on conflict (user_id) do update set peran = 'juri_pos', pos = 1, is_active = true;
+  update akun_panitia set peran = 'gerbang', pos = null where user_id = v_gerbang;
+  delete from akun_hak where user_id = v_gerbang and fitur = 'live_score';
+
+  perform set_config('app.uid', v_gerbang::text, true);
+  set local role authenticated;
+
+  select count(*) into v_jumlah from v_regu_ringkas;
+  assert v_jumlah > 0,
+    '61.1 GAGAL: hak keberangkatan/kedatangan tidak membuka lookup regu';
+
+  -- View tidak boleh dibetulkan dengan membuka seluruh pendaftaran beserta
+  -- nomor WA kepada gerbang. Policy tabel tetap tertutup untuk akun ini.
+  select count(*) into v_jumlah from pendaftaran;
+  assert v_jumlah = 0,
+    '61.2 GAGAL: gerbang bisa membaca tabel pendaftaran secara langsung';
+
+  reset role;
+  delete from akun_hak
+  where user_id = v_gerbang and fitur in ('keberangkatan', 'kedatangan');
+  set local role authenticated;
+  perform set_config('app.uid', v_gerbang::text, true);
+  select count(*) into v_jumlah from v_regu_ringkas;
+  assert v_jumlah = 0,
+    '61.3 GAGAL: lookup tetap terbuka sesudah kedua hak gerbang dicabut';
+
+  reset role;
+  insert into akun_hak (user_id, fitur)
+  values (v_gerbang, 'keberangkatan'), (v_gerbang, 'kedatangan'),
+         (v_gerbang, 'live_score')
+  on conflict do nothing;
+  perform set_config('app.uid', '', true);
+end;
+$blok$;
+
+\echo '61 lookup regu gerbang: LULUS'


### PR DESCRIPTION
## What\n\n- guard _regu_ringkas directly with Keberangkatan, Kedatangan, Daftar Ulang, or Pengaturan\n- keep the underlying pendaftaran table closed to gate-only accounts\n- test a gate account after its unrelated Live Score permission is removed\n\n## Why\n\nBoth gate desks depended indirectly on the Live Score checkbox through registration RLS. Removing that unrelated checkbox made every nomor dada look unknown. A guarded definer view restores the operational lookup without exposing pembina contact data.\n\nCloses #493\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)