### PR TITLE
fix: block score locking before save completes

### DIFF
--- a/tests/score_lock.test.mjs
+++ b/tests/score_lock.test.mjs
@@ -1,0 +1,40 @@
+// ============================================================================
+// hrcd-rekap : tests/score_lock.test.mjs
+// Gembok tidak boleh mendahului penyimpanan nilai Input Pos.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+test("gembok hanya dipasang setelah nilai terkonfirmasi di database", () => {
+  const awal = app.indexOf("async function ubahGembok(tr) {");
+  const akhir = app.indexOf("const jawab = await dialog", awal);
+  assert.notEqual(awal, -1, "ubahGembok tidak ditemukan");
+  assert.notEqual(akhir, -1, "cabang mengunci tidak ditemukan");
+  const kunci = app.slice(awal, akhir);
+
+  const pagar = kunci.indexOf('tr.dataset.keadaan !== "tersimpan"');
+  const panggil = kunci.indexOf("await kunciNilaiPos");
+  assert.ok(pagar >= 0 && pagar < panggil,
+    "kunciNilaiPos dipanggil sebelum keadaan tersimpan diperiksa");
+  assert.match(kunci, /Number\(tr\.dataset\.terisi\) === 0/,
+    "baris tanpa satu nilai pun masih bisa digembok");
+});
+
+test("Ulangi pada baris terkunci memberi alasan, bukan diam", () => {
+  assert.match(app,
+    /\[data-ulang\][\s\S]{0,100}simpanBaris\(tr, true\)/,
+    "tombol Ulangi tidak menandai pemanggilan manual");
+
+  const awal = app.indexOf("async function simpanBaris(tr, beriTahu = false) {");
+  const akhir = app.indexOf("const lama = asli.get(dada)", awal);
+  assert.notEqual(awal, -1, "simpanBaris dengan penanda manual tidak ditemukan");
+  const pagar = app.slice(awal, akhir);
+  assert.match(pagar, /dataset\.terkunci === "1"[\s\S]*statusBaris\(tr, "gagal", pesan\)/,
+    "baris terkunci kembali keluar tanpa status yang menjelaskan");
+  assert.match(pagar, /if \(beriTahu\) notif\(/,
+    "tombol Ulangi tidak memberi tahu kenapa retry ditolak");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3403,7 +3403,7 @@ async function layarInputPos() {
     } else if (keadaan === "gagal") {
       sel.replaceChildren(h(html`<button class="button button-danger button-mini"
         type="button" data-ulang title="${pesan}">Ulangi</button>`));
-      sel.querySelector("[data-ulang]").addEventListener("click", () => simpanBaris(tr));
+      sel.querySelector("[data-ulang]").addEventListener("click", () => simpanBaris(tr, true));
     } else {
       sel.replaceChildren();
     }
@@ -3450,6 +3450,14 @@ async function layarInputPos() {
     // berubah sesudah gemboknya terbuka. Yang mahal memang arah itu, bukan
     // arah sebaliknya.
     if (!kunci) {
+      // Gembok hanya boleh mengesahkan angka yang SUDAH dibaca kembali dari
+      // database. Tanpa pagar ini request kunci bisa mendahului request simpan,
+      // lalu server menolak simpanan itu karena baris telanjur terkunci.
+      if (tr.dataset.keadaan !== "tersimpan"
+          || Number(tr.dataset.terisi) === 0) {
+        notif(`Nilai ${tiga} belum tersimpan. Tunggu tanda ✓, lalu kunci.`, true);
+        return;
+      }
       try { await kunciNilaiPos(dada, pos.nomor); }
       catch (err) { notif(`Gagal mengunci: ${err.message}`, true); return; }
       tr.dataset.terkunci = "1";
@@ -3969,7 +3977,7 @@ async function layarInputPos() {
   });
   perbaruiRingkasan();
 
-  async function simpanBaris(tr) {
+  async function simpanBaris(tr, beriTahu = false) {
     // Satu baris punya banyak kotak, dan tiap kotak yang ditinggalkan memicu
     // simpanan sendiri. Petugas yang mengetik cepat menghasilkan lima
     // panggilan beruntun, dan yang kedua sampai kelima datang selagi yang
@@ -3983,10 +3991,17 @@ async function layarInputPos() {
     // seluruh baris, sehingga berapa pun ketukan yang menumpuk cukup
     // diselesaikan satu kali.
     if (tr.dataset.jalan === "1") { tr.dataset.antre = "1"; return; }
-    // Baris tergembok tidak pernah dikirim. Kotaknya memang sudah mati, tapi
-    // simpanBaris juga dipanggil dari antrean dan dari tombol Ulangi.
-    if (tr.dataset.terkunci === "1") return;
     const dada = Number(tr.dataset.dada);
+    // Baris tergembok tidak pernah dikirim. Kotaknya memang sudah mati, tapi
+    // simpanBaris juga dipanggil dari antrean dan dari tombol Ulangi. Tombol
+    // itu harus menjelaskan jalan keluarnya; putaran otomatis tetap diam agar
+    // tidak menyemburkan notifikasi setiap 15 detik.
+    if (tr.dataset.terkunci === "1") {
+      const pesan = "Nilai sudah digembok. Buka gembok sebelum mengirim ulang.";
+      statusBaris(tr, "gagal", pesan);
+      if (beriTahu) notif(pesanBaris(dada, pesan), true);
+      return;
+    }
     const lama = asli.get(dada) || {};
     const baris = [], dihapus = [], takTerbaca = [];
 


### PR DESCRIPTION
## What\n\n- allow locking only for rows confirmed as stored with at least one value\n- keep pending, saving, and failed rows unlocked\n- explain why a manual retry cannot run on an already locked row\n- add regression coverage for both guards\n\n## Why\n\nA lock request could commit before a failed or in-flight score save. The server would then reject the save, disable the inputs, and leave Retry ineffective while showing a successful lock notification.\n\nCloses #483\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)