### PR TITLE
fix: ignore stale Input Pos refresh responses

### DIFF
--- a/tests/score_refresh.test.mjs
+++ b/tests/score_refresh.test.mjs
@@ -1,0 +1,36 @@
+// ============================================================================
+// hrcd-rekap : tests/score_refresh.test.mjs
+// Snapshot Input Pos yang basi tidak boleh menimpa nilai yang baru tersimpan.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+test("simpanan sukses membatalkan penyegaran yang sudah berjalan", () => {
+  const simpanAwal = app.indexOf("async function simpanBaris(");
+  const simpanAkhir = app.indexOf("/* ---------- perilaku isian", simpanAwal);
+  const simpan = app.slice(simpanAwal, simpanAkhir);
+  assert.match(simpan,
+    /await lembarPosSatu\(pos\.nomor, dada\);[\s\S]{0,300}versiLembar \+= 1;/,
+    "konfirmasi satu baris tidak membatalkan snapshot lembar yang lebih lama");
+});
+
+test("hanya respons penyegaran terbaru yang boleh menulis tabel", () => {
+  const awal = app.indexOf("const segarkanLembar = async () => {");
+  const akhir = app.indexOf("let denyut = null", awal);
+  assert.notEqual(awal, -1, "segarkanLembar tidak ditemukan");
+  assert.notEqual(akhir, -1, "akhir segarkanLembar tidak ditemukan");
+  const segarkan = app.slice(awal, akhir);
+
+  const versi = segarkan.indexOf("const versiPermintaan = ++versiLembar");
+  const tunggu = segarkan.indexOf("await lembarPos(pos.nomor)");
+  const pagar = segarkan.indexOf("versiPermintaan !== versiLembar");
+  const tulis = segarkan.indexOf("asli.set(");
+  assert.ok(versi >= 0 && versi < tunggu,
+    "versi request tidak diambil sebelum request dimulai");
+  assert.ok(pagar > tunggu && pagar < tulis,
+    "respons menulis cermin database sebelum memeriksa apakah ia masih terbaru");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3882,6 +3882,9 @@ async function layarInputPos() {
   // Jam terakhir kali sesuatu BENAR-BENAR masuk database. Diisi saat lembar
   // dimuat, karena saat itu angka di layar memang baru dibaca dari sana.
   let jamSinkron = new Date();
+  // Setiap request penyegaran dan setiap simpanan yang terkonfirmasi memajukan
+  // versi ini. Respons hanya boleh menulis DOM bila versinya masih terbaru.
+  let versiLembar = 0;
 
   function perbaruiRingkasan() {
     const baris = [...tbody.children];
@@ -4067,6 +4070,10 @@ async function layarInputPos() {
       for (const kode of dihapus) await hapusNilaiPos(dada, kode, pos.nomor);
 
       const segar = await lembarPosSatu(pos.nomor, dada);
+      // Membatalkan snapshot lembar penuh yang mulai diambil sebelum simpanan
+      // ini selesai. Tanpa ini respons lama bisa menimpa angka yang baru saja
+      // dikonfirmasi dari database.
+      versiLembar += 1;
       if (segar) {
         asli.set(dada, segar.nilai || {});
         tr.querySelector(".pos-nilai").textContent = angkaRapi(segar.nilai_pos);
@@ -4347,10 +4354,11 @@ async function layarInputPos() {
      tertinggal basi selamanya — yang ada hanya baris yang menunggu gilirannya.
      ========================================================================== */
   const segarkanLembar = async () => {
+    const versiPermintaan = ++versiLembar;
     let baru;
     try { baru = await lembarPos(pos.nomor); }
     catch { return; }   // pos sering kehilangan sinyal; percobaan berikutnya 20 detik lagi
-    if (location.hash !== layarIni) return;
+    if (location.hash !== layarIni || versiPermintaan !== versiLembar) return;
 
     const peta = new Map(baru.map(r => [Number(r.nomor_dada), r]));
     let berubah = false;


### PR DESCRIPTION
## What\n\n- assign a monotonic version to Input Pos refreshes\n- advance that version after each confirmed row save\n- discard stale and out-of-order full-sheet responses\n- add ordering regression tests\n\n## Why\n\nA slow refresh could return after a newer save, replace the visible value with its old snapshot, and roll back the client-side database mirror beside a green checkmark.\n\nCloses #491\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)