### PR TITLE
fix: guard navigation with unsaved scores

### DIFF
--- a/tests/navigation_guard.test.mjs
+++ b/tests/navigation_guard.test.mjs
@@ -1,0 +1,38 @@
+// ============================================================================
+// hrcd-rekap : tests/navigation_guard.test.mjs
+// Navigasi hash tidak boleh membuang nilai Input Pos tanpa jeda keputusan.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+test("router memeriksa nilai belum tersimpan sebelum mengganti layar", () => {
+  const awal = app.indexOf("async function arahkan() {");
+  const akhir = app.indexOf("// Tiga aksi yang sama", awal);
+  assert.notEqual(awal, -1, "router arahkan tidak ditemukan");
+  const router = app.slice(awal, akhir);
+
+  const pagar = router.indexOf("!bolehMeninggalkanNilai()");
+  const batal = router.indexOf("history.replaceState");
+  const bongkar = router.indexOf("segarkanDiTempat = null");
+  const gambar = router.indexOf("RUTE[location.hash]");
+  assert.ok(pagar >= 0 && pagar < bongkar && pagar < gambar,
+    "router membongkar layar sebelum meminta keputusan");
+  assert.ok(batal > pagar && batal < bongkar,
+    "navigasi yang dibatalkan tidak memulihkan hash sebelum layar dibongkar");
+});
+
+test("keluar memakai pagar yang sama dengan navigasi dan penutupan tab", () => {
+  const awal = app.indexOf("const keluarSekarang = () => {");
+  const akhir = app.indexOf("document.getElementById", awal);
+  const keluar = app.slice(awal, akhir);
+  assert.match(keluar, /if \(!bolehMeninggalkanNilai\(\)\) return;/,
+    "logout masih bisa membuang nilai tanpa peringatan");
+
+  assert.match(app,
+    /const bolehMeninggalkanNilai = \(\) => !adaYangBelumTersimpan\(\)/,
+    "pagar hash tidak memakai pemeriksaan yang sama dengan beforeunload");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6462,7 +6462,20 @@ const RUTE = {
   "#/account": layarAkun,
 };
 
+// Hash yang benar-benar sedang tergambar. `location.hash` sudah berisi tujuan
+// baru ketika hashchange tiba, jadi nilai lama harus disimpan terpisah agar
+// perpindahan yang dibatalkan dapat dikembalikan tanpa membuang tabel.
+let hashLayar = location.hash;
+
 async function arahkan() {
+  const tujuan = location.hash;
+  if (tujuan !== hashLayar && !bolehMeninggalkanNilai()) {
+    // replaceState tidak memicu hashchange kedua dan tidak menambah entri Back
+    // palsu. DOM layar lama belum disentuh pada titik ini.
+    history.replaceState(null, "", hashLayar || "#/home");
+    return;
+  }
+  hashLayar = tujuan;
   segarkanDiTempat = null;
   if (!sesi()) { layarLogin(); return; }
   // Sesi yang dibuat sebelum `hak` dibawa ke dalamnya tidak punya field itu,
@@ -6497,7 +6510,13 @@ const keSetelan = () => {
 const keAkun = () => {
   if (location.hash === "#/account") arahkan(); else location.hash = "#/account";
 };
-const keluarSekarang = () => { keluar(); EDISI = null; location.hash = ""; arahkan(); };
+const keluarSekarang = () => {
+  if (!bolehMeninggalkanNilai()) return;
+  // Peringatan sudah dijawab di atas; samakan penanda agar arahkan() tidak
+  // menanyakan hal yang sama untuk kedua kali setelah sesi dibuang.
+  hashLayar = "";
+  keluar(); EDISI = null; location.hash = ""; arahkan();
+};
 
 document.getElementById("btn-keluar").addEventListener("click", keluarSekarang);
 document.getElementById("btn-home").addEventListener("click", keHome);
@@ -6538,6 +6557,9 @@ document.addEventListener("visibilitychange", () => {
 /** Baris lembar pos yang isinya belum sampai ke database. */
 const adaYangBelumTersimpan = () => !!document.querySelector(
   '#isi-tabel tr[data-keadaan="belum"], #isi-tabel tr[data-keadaan="gagal"]');
+
+const bolehMeninggalkanNilai = () => !adaYangBelumTersimpan()
+  || window.confirm("Ada nilai yang belum tersimpan. Tetap pindah layar?");
 
 // Menutup tab dengan nilai yang belum terkirim = nilai itu hilang tanpa
 // jejak. Browser hanya mengizinkan peringatan bawaannya, dan itu sudah cukup:


### PR DESCRIPTION
## What\n\n- ask before hash navigation when Input Pos contains unsaved or failed rows\n- restore a cancelled route without rebuilding the current screen\n- apply the same guard to logout\n- keep the existing beforeunload check as the single source of unsaved state\n\n## Why\n\nThe browser warning only protected tab close and reload. Home, Back, settings, account, or logout could detach the table and permanently discard failed score inputs without warning.\n\nCloses #484\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)