### PR TITLE
fix: bound participant phase lookup time

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -105,6 +105,10 @@ let mengambil = false;  // penjaga supaya tidak dua permintaan sekaligus
  *
  *  Jadi: mematikan seketika, menyalakan tetap lewat penerbitan. */
 const URUT_FASE = { pra: 0, progres: 1, penuh: 2 };
+// Fase database hanya memperketat isi berkas. Ia harus sempat menjawab sebelum
+// gambar pertama, tetapi tidak boleh menahan papan CDN lebih dari beberapa
+// detik ketika origin Supabase sedang sulit dijangkau.
+const BATAS_FASE_MS = 5000;
 let FASE_DB = null;
 let denyutFase = null;
 
@@ -117,10 +121,12 @@ const fase = () => {
 async function ambilFaseDb() {
   const K = window.HRCD || {};
   if (!K.supabaseUrl || !K.anonKey) return;
+  const ac = new AbortController();
+  const batas = setTimeout(() => ac.abort(), BATAS_FASE_MS);
   try {
     const r = await fetch(`${K.supabaseUrl}/rest/v1/v_fase_live?select=fase_live`,
       { headers: { apikey: K.anonKey, Authorization: `Bearer ${K.anonKey}` },
-        cache: "no-store" });
+        cache: "no-store", signal: ac.signal });
     if (!r.ok) return;                       // diamkan: berkas tetap dipakai
     const d = await r.json();
     if (Array.isArray(d) && d[0] && URUT_FASE[d[0].fase_live] !== undefined) {
@@ -129,6 +135,8 @@ async function ambilFaseDb() {
   } catch {
     // Sambungan ke Supabase mati bukan alasan mengosongkan papan: tanpa
     // FASE_DB, yang berlaku fase di berkas — keadaan sebelum berkas ini ada.
+  } finally {
+    clearTimeout(batas);
   }
 }
 const mulai = () => fase() !== "pra";
@@ -627,8 +635,9 @@ async function muatRekap() {
 
 async function muat() {
   try {
-    // Diambil bersamaan, bukan berurutan: keduanya kecil dan salah satunya
-    // boleh gagal tanpa menjatuhkan yang lain.
+    // Fase diambil lebih dulu karena ia boleh MEMPERKETAT data yang akan
+    // digambar. Batas waktu pendek di ambilFaseDb() menjaga urutan aman ini
+    // tanpa menggantungkan papan CDN pada origin Supabase.
     await ambilFaseDb();
     const r = await fetch(`live.json?t=${Date.now()}`, { cache: "no-store" });
     if (!r.ok) throw new Error(String(r.status));

--- a/tests/live_phase_timeout.test.mjs
+++ b/tests/live_phase_timeout.test.mjs
@@ -1,0 +1,34 @@
+// ============================================================================
+// hrcd-rekap : tests/live_phase_timeout.test.mjs
+// Pemeriksaan fase peserta tidak boleh menggantungkan gambar pertama.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+
+test("ambilFaseDb membatalkan request Supabase yang terlalu lama", () => {
+  const awal = live.indexOf("async function ambilFaseDb() {");
+  const akhir = live.indexOf("const mulai =", awal);
+  assert.notEqual(awal, -1, "ambilFaseDb tidak ditemukan");
+  const fungsi = live.slice(awal, akhir);
+
+  assert.match(fungsi, /const ac = new AbortController\(\)/,
+    "request fase tidak memiliki AbortController");
+  assert.match(fungsi, /setTimeout\(\(\) => ac\.abort\(\), BATAS_FASE_MS\)/,
+    "AbortController tidak punya batas waktu");
+  assert.match(fungsi, /signal: ac\.signal/,
+    "signal pembatalan tidak dikirim ke fetch");
+  assert.match(fungsi, /finally\s*\{\s*clearTimeout\(batas\)/,
+    "timer fase tidak dibersihkan setelah request selesai");
+});
+
+test("fase tetap selesai sebelum live.json boleh digambar", () => {
+  const awal = live.indexOf("async function muat() {");
+  const akhir = live.indexOf("\nmuat();", awal);
+  const muat = live.slice(awal, akhir);
+  assert.ok(muat.indexOf("await ambilFaseDb()") < muat.indexOf("fetch(`live.json"),
+    "live.json kembali digambar sebelum fase database sempat memperketatnya");
+});


### PR DESCRIPTION
## What\n\n- abort the participant phase lookup after five seconds\n- clear its timer on every outcome\n- keep phase tightening ahead of rendering published data\n- correct the misleading parallel-fetch comment and add regression tests\n\n## Why\n\nA hanging Supabase request could hold the participant page on Memuat rekap indefinitely even while the small CDN-hosted live files were immediately available.\n\nCloses #499\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)