### PR TITLE
fix: show live phase switch before rankings exist

### DIFF
--- a/tests/live_score_phase_switch.test.mjs
+++ b/tests/live_score_phase_switch.test.mjs
@@ -1,0 +1,23 @@
+// ============================================================================
+// hrcd-rekap : tests/live_score_phase_switch.test.mjs
+// Saklar fase tetap tersedia sebelum klasemen mempunyai satu baris pun.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+test("cabang klasemen kosong tetap menggambar saklar fase", () => {
+  const awal = app.indexOf("const papan = !klasemen.length");
+  const akhir = app.indexOf(": GOL.map", awal);
+  assert.notEqual(awal, -1, "cabang papan kosong tidak ditemukan");
+  assert.notEqual(akhir, -1, "akhir cabang papan kosong tidak ditemukan");
+  const kosong = app.slice(awal, akhir);
+
+  assert.match(kosong, /\$\{saklar\}/,
+    "fase tidak terlihat atau tidak bisa diubah ketika klasemen kosong");
+  assert.match(kosong, /Klasemen sementara/,
+    "saklar kehilangan kepala kartu yang menjelaskan konteksnya");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5386,8 +5386,15 @@ async function layarLiveScore() {
     </div>`;
 
   const papan = !klasemen.length
-    ? `<div class="card"><p class="description">Belum ada regu yang bisa
-         diperingkat di golongan mana pun.</p></div>`
+    ? `<div class="card">
+         <div class="kepala-klasemen">
+           <div class="sisi"></div>
+           <h2>Klasemen sementara</h2>
+           <div class="sisi kanan">${saklar}</div>
+         </div>
+         <p class="description">Belum ada regu yang bisa diperingkat di
+           golongan mana pun.</p>
+       </div>`
     : GOL.map(g => `<div class="panel-gol" data-gol="${esc(g)}"${
         g === golAktif ? "" : " hidden"}>${kartuGolongan(g)}</div>`).join("");
 


### PR DESCRIPTION
## What\n\n- give the empty Live Score state the same ranking header as populated panels\n- keep the current phase visible and editable before any ranking rows exist\n- add a regression test for the empty branch\n\n## Why\n\nThe only phase control lived inside ranking panels. Before the first departed kloter, an administrator could neither see nor tighten the participant phase.\n\nCloses #498\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)