### PR TITLE
fix: limit public account registration

### DIFF
--- a/tests/gateway_account_registration.test.mjs
+++ b/tests/gateway_account_registration.test.mjs
@@ -1,0 +1,77 @@
+// ============================================================================
+// hrcd-rekap : tests/gateway_account_registration.test.mjs
+// Pintu publik pembuat akun harus dibatasi sebelum menyentuh service role.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../workers/gateway/worker.js";
+
+const url = "https://gateway.example/akun/daftar";
+const isiSah = {
+  username: "petugas.uji", password: "rahasia123", peran: "gerbang", pos: null,
+};
+
+const request = (body, headers = {}) => new Request(url, {
+  method: "POST",
+  headers: { origin: "https://panitia-hrcd37.ciradyka.workers.dev",
+             "cf-connecting-ip": "203.0.113.7", ...headers },
+  body,
+});
+
+function lingkungan(hitung = 0) {
+  const put = [];
+  const get = [];
+  return {
+    env: {
+      RATE: {
+        get: async kunci => { get.push(kunci); return String(hitung); },
+        put: async (...arg) => { put.push(arg); },
+      },
+      SUPABASE_URL: "https://db.example",
+      SUPABASE_SERVICE_KEY: "service-key",
+    },
+    get, put,
+  };
+}
+
+test("body akun dibatasi walau Content-Length tidak dikirim", async () => {
+  const { env } = lingkungan();
+  const asliFetch = globalThis.fetch;
+  let menyentuhSupabase = false;
+  globalThis.fetch = async () => { menyentuhSupabase = true; throw new Error("tidak boleh"); };
+  try {
+    const r = await worker.fetch(request("x".repeat(2001)), env);
+    assert.equal(r.status, 413);
+    assert.equal(menyentuhSupabase, false);
+  } finally {
+    globalThis.fetch = asliFetch;
+  }
+});
+
+test("budget akun memakai kunci dan jendela terpisah", async () => {
+  const { env, get, put } = lingkungan(10);
+  const r = await worker.fetch(request(JSON.stringify(isiSah)), env);
+  assert.equal(r.status, 429);
+  assert.deepEqual(get, ["rl:akun:203.0.113.7"]);
+  assert.equal(put.length, 0);
+});
+
+test("akun yang benar-benar dibuat menghabiskan satu slot per jam", async () => {
+  const { env, put } = lingkungan(0);
+  const asliFetch = globalThis.fetch;
+  const jawaban = [
+    new Response(JSON.stringify({ id: "user-uji" }), { status: 200 }),
+    new Response(null, { status: 201 }),
+    new Response(JSON.stringify([]), { status: 200 }),
+  ];
+  globalThis.fetch = async () => jawaban.shift();
+  try {
+    const r = await worker.fetch(request(JSON.stringify(isiSah)), env);
+    assert.equal(r.status, 200);
+    assert.deepEqual(put, [["rl:akun:203.0.113.7", "1", { expirationTtl: 3600 }]]);
+  } finally {
+    globalThis.fetch = asliFetch;
+  }
+});

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -18,10 +18,12 @@
    ========================================================================== */
 
 const BATAS_BYTE = 32_000;      // payload wajar: 30 regu ~ 6 KB
+const BATAS_AKUN_BYTE = 2_000;  // satu akun hanya beberapa ratus byte
 // Longgar dengan sengaja: beberapa laptop meja mengisi pendaftaran offline
 // dari WiFi venue yang sama (satu IP) bisa memicu ini kalau terlalu ketat.
 // Angka ini cuma pagar terakhir untuk banjir skrip, bukan penghalang panitia.
 const BATAS_PER_MENIT = 30;     // pengiriman per IP per menit
+const BATAS_AKUN_PER_JAM = 10;  // pendaftaran mandiri akun per IP per jam
 
 // DUA asal, dan bedanya bukan kerapian. /daftar dipanggil form pendaftaran di
 // situs PESERTA; rute /akun dipanggil layar Akun di situs PANITIA. Keduanya
@@ -76,6 +78,34 @@ function jawab(status, isi, req) {
     status,
     headers: { "Content-Type": "application/json", ...cors(req) },
   });
+}
+
+/** Baca JSON sampai batas byte sungguhan, termasuk saat Content-Length tidak
+ * dikirim. Berhenti membaca segera setelah batas terlewati. */
+async function bacaJsonTerbatas(req, batas) {
+  const panjang = Number(req.headers.get("content-length") || 0);
+  if (panjang > batas) return { terlaluBesar: true };
+  if (!req.body) return { salah: true };
+
+  const reader = req.body.getReader();
+  const potongan = [];
+  let jumlah = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    jumlah += value.byteLength;
+    if (jumlah > batas) {
+      await reader.cancel();
+      return { terlaluBesar: true };
+    }
+    potongan.push(value);
+  }
+
+  const gabung = new Uint8Array(jumlah);
+  let posisi = 0;
+  for (const p of potongan) { gabung.set(p, posisi); posisi += p.byteLength; }
+  try { return { data: JSON.parse(new TextDecoder().decode(gabung)) }; }
+  catch { return { salah: true }; }
 }
 
 /** Header service_role. Kunci ini hidup HANYA di Worker (wrangler secret). */
@@ -398,9 +428,27 @@ export default {
        jadi akun menunggu tidak memegang satu fitur pun, dan layar login pun
        menolaknya sebelum sesi terbentuk. */
     if (req.method === "POST" && url.pathname === "/akun/daftar") {
-      let b;
-      try { b = await req.json(); } catch { return jawab(400, { message: "Format data salah." }, req); }
-      return daftarPanitia(req, env, b);
+      const panjang = Number(req.headers.get("content-length") || 0);
+      if (panjang > BATAS_AKUN_BYTE)
+        return jawab(413, { message: "Data terlalu besar." }, req);
+
+      const ip = req.headers.get("cf-connecting-ip") || "?";
+      const kunci = `rl:akun:${ip}`;
+      const hitung = Number((await env.RATE.get(kunci)) || 0);
+      if (hitung >= BATAS_AKUN_PER_JAM)
+        return jawab(429, {
+          message: "Terlalu sering mendaftar akun. Tunggu satu jam, lalu coba lagi.",
+        }, req);
+
+      const baca = await bacaJsonTerbatas(req, BATAS_AKUN_BYTE);
+      if (baca.terlaluBesar) return jawab(413, { message: "Data terlalu besar." }, req);
+      if (baca.salah) return jawab(400, { message: "Format data salah." }, req);
+
+      const hasil = await daftarPanitia(req, env, baca.data);
+      if (hasil.ok) {
+        await env.RATE.put(kunci, String(hitung + 1), { expirationTtl: 3600 });
+      }
+      return hasil;
     }
 
     // Rute akun: admin yang sedang login, bukan publik. Tidak kena rate limit


### PR DESCRIPTION
## What\n\n- cap self-registration request bodies at 2 KB, including requests without Content-Length\n- apply a separate 10-per-IP hourly account-creation budget\n- charge the budget only after an account is actually created\n- add executable Worker tests proving blocked requests never reach Supabase\n\n## Why\n\nThe only anonymous service-role identity writer was unbounded and unthrottled, allowing account floods and username squatting even though created accounts remained inactive.\n\nCloses #439\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)