### PR TITLE
fix: require active staff for pos completeness

### DIFF
--- a/supabase/migrations/0101_guard_pos_completeness.sql
+++ b/supabase/migrations/0101_guard_pos_completeness.sql
@@ -1,0 +1,64 @@
+-- ============================================================================
+-- hrcd-rekap : 0101_guard_pos_completeness.sql
+-- Kelengkapan pos hanya terbuka untuk akun panitia aktif.
+--
+-- Rebuild di 0060, lalu salinannya di 0096, kehilangan `peran() is not null`.
+-- View ini definer agar dapat menghitung agregat lintas pos, jadi RLS tabel
+-- dasarnya tidak menjadi pagar. Isolasi pos tidak dikembalikan: sejak 0069
+-- membaca rincian lintas pos memang dibuka untuk panitia; yang hilang hanya
+-- syarat bahwa pembacanya benar-benar panitia aktif.
+-- ============================================================================
+
+create or replace view v_kelengkapan_pos as
+with regu_ikut as (
+  select
+    r.id,
+    r.golongan,
+    (k.jam_berangkat is not null)                                as sudah_berangkat,
+    exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  left join kloter k on k.nomor = r.kloter_nomor
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor                       as pos,
+  p.name                        as nama_pos,
+  p.bayangan,
+  p.jumlah_komponen,
+  count(ri.id)::int                                      as regu_total,
+  count(ri.id) filter (where ri.sudah_berangkat)::int    as regu_berangkat,
+  count(ri.id) filter (where ri.sudah_closing)::int      as regu_closing,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0)
+          = komponen_pos_golongan(p.nomor, ri.golongan))::int as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as sebagian,
+  count(ri.id) filter (where coalesce(t.jumlah, 0) = 0)::int  as kosong,
+  count(ri.id) filter (
+    where ri.sudah_closing
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as hilang
+from v_pos p
+left join regu_ikut ri on komponen_pos_golongan(p.nomor, ri.golongan) > 0
+left join terisi t     on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and peran() is not null
+group by p.nomor, p.name, p.bayangan, p.jumlah_komponen;
+
+comment on view v_kelengkapan_pos is
+  'Agregat kelengkapan seluruh pos untuk panitia aktif. Definer agar agregat lintas pos tidak menuntut hak baca nilai mentah; badan view wajib menjaga peran() is not null.';
+
+grant select on v_kelengkapan_pos to authenticated, service_role;
+revoke all on v_kelengkapan_pos from anon;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -416,6 +416,10 @@ run tests/sql/60_anon_default_privileges.sql
 # dicabut per akun, dan tidak perlu membuka nomor WA di tabel pendaftaran.
 run supabase/migrations/0100_gate_regu_lookup.sql
 run tests/sql/61_gate_regu_lookup.sql
+# View agregat kelengkapan bersifat definer, jadi pagarnya harus tinggal di
+# badan view dan harus menolak akun yang belum aktif atau sudah dinonaktifkan.
+run supabase/migrations/0101_guard_pos_completeness.sql
+run tests/sql/62_guard_pos_completeness.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/62_guard_pos_completeness.sql
+++ b/tests/sql/62_guard_pos_completeness.sql
@@ -1,0 +1,40 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/62_guard_pos_completeness.sql — migrasi 0101.
+-- View definer harus berubah hasil saat akun yang sama diaktifkan.
+-- ============================================================================
+
+\echo '--- 62. kelengkapan pos hanya untuk panitia aktif'
+
+do $blok$
+declare
+  v_user uuid := '00000000-0000-0000-0000-0000000000c4';
+  v_jumlah integer;
+begin
+  insert into auth.users (id, email) values (v_user, 'kelengkapan@uji.local')
+  on conflict (id) do nothing;
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_user, 'kelengkapan.uji', 'registrasi', null, false)
+  on conflict (user_id) do update
+    set peran = 'registrasi', pos = null, is_active = false;
+
+  perform set_config('app.uid', v_user::text, true);
+  set local role authenticated;
+  select count(*) into v_jumlah from v_kelengkapan_pos;
+  assert v_jumlah = 0,
+    format('62.1 GAGAL: akun nonaktif melihat %s baris kelengkapan', v_jumlah);
+
+  reset role;
+  update akun_panitia set is_active = true where user_id = v_user;
+  set local role authenticated;
+  perform set_config('app.uid', v_user::text, true);
+  select count(*) into v_jumlah from v_kelengkapan_pos;
+  assert v_jumlah > 0,
+    '62.2 GAGAL: panitia aktif tidak bisa membaca kelengkapan lintas pos';
+
+  reset role;
+  update akun_panitia set is_active = false where user_id = v_user;
+  perform set_config('app.uid', '', true);
+end;
+$blok$;
+
+\echo '62 pagar kelengkapan pos: LULUS'


### PR DESCRIPTION
## What\n\n- restore peran() is not null inside _kelengkapan_pos\n- retain deliberate cross-pos aggregate visibility for active panitia\n- explicitly keep the definer view closed to non\n- add a seat-based active/inactive regression test\n\n## Why\n\nThe latest definer-view rebuild had no caller predicate, so any authenticated identity—including pending or deactivated accounts—could read operational completeness counts despite underlying RLS.\n\nCloses #433\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)