### PR TITLE
fix: close race-day test schedule guard

### DIFF
--- a/supabase/checks/perbaiki_jadwal_uji.sql
+++ b/supabase/checks/perbaiki_jadwal_uji.sql
@@ -74,7 +74,7 @@
 -- jaring itu.
 
 -- ---------------------------------------------------------------------------
--- 0. Pagar. Kalau edisi aktifnya sudah lewat, berhenti.
+-- 0. Pagar. Begitu hari-H dimulai di WIB, berhenti.
 -- ---------------------------------------------------------------------------
 do $$
 declare v_tanggal date;
@@ -83,9 +83,9 @@ begin
   if v_tanggal is null then
     raise exception 'tidak ada edisi aktif';
   end if;
-  if v_tanggal < current_date then
-    raise exception 'edisi aktif (%) sudah lewat — skrip ini menimpa jam '
-      'yang diketik petugas dan tidak boleh dijalankan sesudah hari-H',
+  if v_tanggal <= (now() at time zone 'Asia/Jakarta')::date then
+    raise exception 'edisi aktif (%) sudah dimulai atau lewat — skrip ini menimpa jam '
+      'yang diketik petugas dan tidak boleh dijalankan sejak hari-H',
       v_tanggal;
   end if;
   raise notice 'edisi aktif: %', v_tanggal;
@@ -122,6 +122,7 @@ set jam_berangkat =
                               + (k.nomor * 3) % 7)
 from edisi e
 where e.is_active
+  and k.jam_berangkat is null
   and exists (select 1 from regu r
               where r.kloter_nomor = k.nomor and not r.is_cancelled);
 

--- a/tests/dangerous_scripts.test.mjs
+++ b/tests/dangerous_scripts.test.mjs
@@ -1,0 +1,27 @@
+// ============================================================================
+// hrcd-rekap : tests/dangerous_scripts.test.mjs
+// Skrip data uji yang bisa mengubah catatan waktu wajib menolak hari-H.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const jadwal = await readFile(
+  new URL("../supabase/checks/perbaiki_jadwal_uji.sql", import.meta.url), "utf8",
+);
+
+test("perbaikan jadwal menolak sejak hari-H menurut tanggal Jakarta", () => {
+  assert.match(jadwal,
+    /v_tanggal\s*<=\s*\(now\(\) at time zone 'Asia\/Jakarta'\)::date/,
+    "pagar masih terbuka pada hari-H atau masih memakai tanggal sesi UTC");
+});
+
+test("perbaikan jadwal tidak menimpa jam berangkat yang sudah tercatat", () => {
+  const awal = jadwal.indexOf("update kloter k");
+  const akhir = jadwal.indexOf("-- 3. Centang berangkat", awal);
+  assert.notEqual(awal, -1, "UPDATE kloter tidak ditemukan");
+  const langkah = jadwal.slice(awal, akhir);
+  assert.match(langkah, /and k\.jam_berangkat is null/,
+    "UPDATE kloter kembali menimpa catatan jam berangkat yang sudah ada");
+});


### PR DESCRIPTION
## What\n\n- reject the test schedule script on and after event day in Jakarta time\n- preserve any kloter departure time that is already recorded\n- add regression tests for both independent safeguards\n\n## Why\n\nThe old < current_date check remained open throughout event day—and into the next Jakarta morning under UTC—allowing a test-data script to overwrite real departure and arrival records.\n\nCloses #496\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)