### PR TITLE
fix: refuse simulation over operational data

### DIFF
--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -29,10 +29,14 @@
 -- panitia — situs peserta tetap seperti sebelumnya sampai ada yang
 -- menerbitkannya dengan sadar.
 --
--- AMAN DIULANG. Tiap langkah melewati baris yang sudah beres, jadi
--- menjalankannya dua kali tidak melahirkan pendaftaran kedua.
+-- DESTRUKTIF DAN BUKAN AMAN DIULANG. Langkah 0 menghapus seluruh data
+-- operasional edisi aktif sebelum membuat data simulasi. Berkas ini hanya
+-- boleh berjalan ketika pendaftaran, regu, nilai, perjalanan, dan tanda
+-- kloter memang masih kosong.
 --
--- MEMBERSIHKANNYA: lihat supabase/checks/hapus_simulasi.sql.
+-- MEMBERSIHKANNYA: jalankan supabase/checks/cleanup_data_uji.sql hanya bila
+-- memang bermaksud membuang seluruh data simulasi dan kembali ke keadaan
+-- operasional kosong.
 -- ============================================================================
 
 do $$
@@ -73,6 +77,23 @@ begin
   select count(distinct pos) into v_jml_pos from wahana where edisi = (select nomor from edisi where is_active);
   select * into v_e from edisi where is_active;
   raise notice 'edisi aktif: % (%)', v_e.name, v_e.nomor;
+
+  -- Tidak ada penanda yang bisa membedakan data simulasi lama dari data
+  -- sungguhan dengan pasti. Karena itu satu-satunya pagar yang jujur adalah
+  -- menuntut keadaan kosong. Untuk mengulang simulasi, bersihkan dengan
+  -- cleanup_data_uji.sql lebih dulu sebagai tindakan terpisah dan sadar.
+  if exists (select 1 from pendaftaran)
+     or exists (select 1 from regu)
+     or exists (select 1 from pembayaran)
+     or exists (select 1 from nilai_mentah)
+     or exists (select 1 from nilai_terkunci)
+     or exists (select 1 from keberangkatan_regu)
+     or exists (select 1 from closing_regu)
+     or exists (select 1 from foto_lembar)
+     or exists (select 1 from kloter
+                where jam_berangkat is not null or dicetak_pada is not null) then
+    raise exception 'DATA OPERASIONAL TIDAK KOSONG — simulasi dibatalkan sebelum penghapusan. Jalankan cleanup_data_uji.sql lebih dulu hanya jika seluruh data itu memang boleh dibuang.';
+  end if;
 
   -- ------------------------------------------------------ 0. bersihkan SEMUA
   -- "Bersihkan data" berarti kloter ikut kembali ke 1 (CLAUDE.md 12.4), dan

--- a/tests/dangerous_scripts.test.mjs
+++ b/tests/dangerous_scripts.test.mjs
@@ -10,6 +10,9 @@ import test from "node:test";
 const jadwal = await readFile(
   new URL("../supabase/checks/perbaiki_jadwal_uji.sql", import.meta.url), "utf8",
 );
+const simulasi = await readFile(
+  new URL("../supabase/checks/simulasi_end_to_end.sql", import.meta.url), "utf8",
+);
 
 test("perbaikan jadwal menolak sejak hari-H menurut tanggal Jakarta", () => {
   assert.match(jadwal,
@@ -24,4 +27,27 @@ test("perbaikan jadwal tidak menimpa jam berangkat yang sudah tercatat", () => {
   const langkah = jadwal.slice(awal, akhir);
   assert.match(langkah, /and k\.jam_berangkat is null/,
     "UPDATE kloter kembali menimpa catatan jam berangkat yang sudah ada");
+});
+
+test("simulasi menolak database operasional yang tidak kosong sebelum DELETE", () => {
+  const pagar = simulasi.indexOf("DATA OPERASIONAL TIDAK KOSONG");
+  const hapus = simulasi.indexOf("delete from closing_regu");
+  assert.ok(pagar >= 0 && pagar < hapus,
+    "simulasi mulai menghapus sebelum memastikan database kosong");
+  const blok = simulasi.slice(simulasi.lastIndexOf("if exists", pagar), pagar);
+  for (const tabel of [
+    "pendaftaran", "regu", "pembayaran", "nilai_mentah", "nilai_terkunci",
+    "keberangkatan_regu", "closing_regu", "foto_lembar", "kloter",
+  ]) {
+    assert.match(blok, new RegExp(`from ${tabel}\\b`),
+      `pagar simulasi tidak memeriksa ${tabel}`);
+  }
+});
+
+test("kepala simulasi memperingatkan penghapusan dan menunjuk cleanup nyata", () => {
+  const kepala = simulasi.slice(0, simulasi.indexOf("do $$"));
+  assert.match(kepala, /DESTRUKTIF DAN BUKAN AMAN DIULANG/);
+  assert.match(kepala, /supabase\/checks\/cleanup_data_uji\.sql/);
+  assert.doesNotMatch(kepala, /hapus_simulasi\.sql/,
+    "kepala masih menunjuk berkas pembersih yang tidak pernah ada");
 });


### PR DESCRIPTION
## What\n\n- abort the full simulation before deletion if any operational table or kloter marker is non-empty\n- state clearly that the script is destructive and not safely repeatable\n- point cleanup guidance to the existing cleanup_data_uji.sql\n- extend dangerous-script regression tests\n\n## Why\n\nThe script unconditionally deleted every registration, regu, score, trip record, and linked photo row while its header claimed it was safe to repeat and referenced a cleanup file that never existed.\n\nCloses #495\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)