### PR TITLE
fix: mark printed kloter insertions

### DIFF
--- a/supabase/migrations/0102_mark_printed_kloter_insertion.sql
+++ b/supabase/migrations/0102_mark_printed_kloter_insertion.sql
@@ -1,0 +1,136 @@
+-- ============================================================================
+-- hrcd-rekap : 0102_mark_printed_kloter_insertion.sql
+-- Tandai regu yang masuk otomatis setelah daftar kloternya dicetak.
+--
+-- Daftar ulang otomatis tetap memilih kloter paling awal yang belum berangkat,
+-- termasuk kloter yang kertasnya sudah dicetak. Penempatan itu benar, tetapi
+-- petugas staging harus diberi tahu bahwa kertas lama belum memuat regu baru.
+-- ============================================================================
+
+create or replace function daftar_ulang_batch(p_kode text, p_nomor jsonb)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch pendaftaran%rowtype;
+  v_berhak uuid[];
+  v_regu uuid[];
+  v_nomor integer[];
+  v_n int;
+  v_cfg edisi%rowtype;
+  v_kandidat smallint;
+  v_i int;
+  v_salah text;
+  v_intern boolean;
+begin
+  if not boleh('daftar_ulang') then raise exception 'tidak berhak: daftar_ulang'; end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then raise exception 'kode pembayaran tidak dikenal: %', p_kode; end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.is_cancelled and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+       as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) t(g) where not (t.g = any(v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+  if exists (select 1 from unnest(v_nomor) t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct nomor) from unnest(v_nomor) t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any(v_nomor) order by s.nomor for update;
+
+  select string_agg(distinct nomor::text, ', ' order by nomor::text) into v_salah
+  from unnest(v_nomor) t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+  select string_agg(distinct nomor::text, ', ' order by nomor::text) into v_salah
+  from unnest(v_nomor) t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+  select string_agg(distinct nomor::text, ', ' order by nomor::text) into v_salah
+  from unnest(v_nomor) t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- Gerbang ini membuat urutan transaksi daftar ulang sekaligus urutan kloter.
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  for v_i in 1..v_n loop
+    select r.golongan in ('intern_pa', 'intern_pi') into v_intern
+    from regu r where r.id = v_regu[v_i];
+
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.jam_berangkat is null
+      and k.nomor <= v_cfg.kloter_maks
+      and (select count(*) from regu r
+           where r.kloter_nomor = k.nomor and not r.is_cancelled
+             and (r.golongan in ('intern_pa', 'intern_pi')) = v_intern)
+          < case when v_intern then v_cfg.maks_intern_per_kloter
+                 else v_cfg.maks_eksternal_per_kloter end
+    order by k.nomor
+    limit 1;
+
+    if v_kandidat is null then
+      raise exception 'semua kuota kloter yang belum berangkat penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu set
+      nomor_dada = v_nomor[v_i],
+      kloter_nomor = v_kandidat,
+      urutan_kloter = slot_kloter_berikutnya(v_kandidat),
+      disisipkan_pada = case
+        when exists (select 1 from kloter k
+                     where k.nomor = v_kandidat and k.dicetak_pada is not null)
+        then now() else disisipkan_pada end,
+      alasan_sisip = case
+        when exists (select 1 from kloter k
+                     where k.nomor = v_kandidat and k.dicetak_pada is not null)
+        then 'daftar ulang otomatis setelah daftar kloter dicetak'
+        else alasan_sisip end
+    where id = v_regu[v_i];
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r where r.id = any(v_regu) order by r.nomor_dada;
+end;
+$$;
+
+comment on function daftar_ulang_batch(text, jsonb) is
+  'Memberi nomor dada dan kloter FIFO; penempatan setelah daftar kloter dicetak ditandai sebagai sisipan.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -420,6 +420,10 @@ run tests/sql/61_gate_regu_lookup.sql
 # badan view dan harus menolak akun yang belum aktif atau sudah dinonaktifkan.
 run supabase/migrations/0101_guard_pos_completeness.sql
 run tests/sql/62_guard_pos_completeness.sql
+# Daftar ulang otomatis boleh mengisi kloter yang sudah dicetak tetapi belum
+# berangkat; tandai regunya agar petugas tahu kertas staging perlu diperbarui.
+run supabase/migrations/0102_mark_printed_kloter_insertion.sql
+run tests/sql/63_daftar_ulang_after_print.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/63_daftar_ulang_after_print.sql
+++ b/tests/sql/63_daftar_ulang_after_print.sql
@@ -1,0 +1,70 @@
+-- Daftar ulang otomatis ke kloter tercetak harus muncul sebagai sisipan.
+
+do $blok$
+declare
+  v_sekolah uuid;
+  v_daftar uuid;
+  v_regu uuid;
+  v_nomor integer;
+  v_kandidat smallint;
+  v_dicetak_lama timestamptz;
+  v_maks_eksternal smallint;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  select maks_eksternal_per_kloter into v_maks_eksternal
+  from edisi where is_active;
+
+  select k.nomor, k.dicetak_pada
+    into v_kandidat, v_dicetak_lama
+  from kloter k
+  where k.jam_berangkat is null
+    and (select count(*) from regu r
+         where r.kloter_nomor = k.nomor and not r.is_cancelled
+           and r.golongan not in ('intern_pa', 'intern_pi')) < v_maks_eksternal
+  order by k.nomor
+  limit 1;
+  assert v_kandidat is not null, 'tidak ada kloter calon untuk menguji sisipan otomatis';
+
+  update kloter set dicetak_pada = now() where nomor = v_kandidat;
+
+  insert into sekolah (name, address)
+  values ('Sekolah Uji Sisipan Otomatis 0102', 'Ciamis')
+  returning id into v_sekolah;
+  insert into pendaftaran
+    (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa, status)
+  values (v_sekolah, 'UJI-SISIPAN-0102', 1, '081200000102', 'lunas')
+  returning id into v_daftar;
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_daftar, 'Sisip Baru', 'Ketua Uji', 'penggalang_pa')
+  returning id into v_regu;
+
+  select min(s.nomor) into v_nomor
+  from nomor_dada_stok s
+  where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+    and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+
+  perform * from daftar_ulang_batch(
+    'UJI-SISIPAN-0102',
+    jsonb_build_array(jsonb_build_object('regu_id', v_regu, 'nomor_dada', v_nomor))
+  );
+
+  assert (select kloter_nomor = v_kandidat from regu where id = v_regu),
+         'daftar ulang tidak memilih kloter tercetak yang paling awal';
+  assert (select disisipkan_pada is not null from regu where id = v_regu),
+         'regu yang masuk setelah cetak tidak ditandai sebagai sisipan';
+  assert (select alasan_sisip = 'daftar ulang otomatis setelah daftar kloter dicetak'
+          from regu where id = v_regu),
+         'alasan sisipan otomatis tidak tercatat';
+  assert exists (select 1 from v_sisipan_kloter where nomor_dada = v_nomor),
+         'regu baru tidak muncul di daftar sisipan untuk petugas staging';
+
+  delete from regu where id = v_regu;
+  delete from pendaftaran where id = v_daftar;
+  delete from sekolah where id = v_sekolah;
+  update kloter set dicetak_pada = v_dicetak_lama where nomor = v_kandidat;
+
+  raise notice '63: daftar ulang setelah cetak ditandai sebagai sisipan.';
+end $blok$;
+
+\echo '63 daftar ulang setelah cetak: LULUS'


### PR DESCRIPTION
## What

- mark automatic daftar ulang placements into printed kloter as insertions
- record a clear insertion reason for staging staff
- add SQL regression coverage and run the migration in CI

## Why

Printed kloter remain valid automatic FIFO targets until departure. Without an insertion marker, a newly assigned regu is absent from the already-printed staging list with no warning.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)