### PR TITLE
fix: restore pos last-entry signal

### DIFF
--- a/supabase/migrations/0103_restore_pos_last_entry.sql
+++ b/supabase/migrations/0103_restore_pos_last_entry.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- hrcd-rekap : 0103_restore_pos_last_entry.sql
+-- Kembalikan waktu nilai terakhir ke panel kelengkapan pos.
+--
+-- Rebuild view di 0060 menghilangkan `terakhir_masuk`, padahal layar Rekap
+-- masih memakainya untuk menandai pos yang diam lebih dari 30 menit. Kolom
+-- ditambahkan di akhir agar kontrak kolom view yang sudah ada tidak berubah.
+-- ============================================================================
+
+create or replace view v_kelengkapan_pos as
+with regu_ikut as (
+  select
+    r.id,
+    r.golongan,
+    (k.jam_berangkat is not null)                                as sudah_berangkat,
+    exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  left join kloter k on k.nomor = r.kloter_nomor
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor                       as pos,
+  p.name                        as nama_pos,
+  p.bayangan,
+  p.jumlah_komponen,
+  count(ri.id)::int                                      as regu_total,
+  count(ri.id) filter (where ri.sudah_berangkat)::int    as regu_berangkat,
+  count(ri.id) filter (where ri.sudah_closing)::int      as regu_closing,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0)
+          = komponen_pos_golongan(p.nomor, ri.golongan))::int as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as sebagian,
+  count(ri.id) filter (where coalesce(t.jumlah, 0) = 0)::int  as kosong,
+  count(ri.id) filter (
+    where ri.sudah_closing
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as hilang,
+  (select max(n.created_at)
+   from nilai_mentah n
+   join wahana w on w.id = n.wahana_id
+   where w.edisi = edisi_aktif() and w.pos = p.nomor)    as terakhir_masuk
+from v_pos p
+left join regu_ikut ri on komponen_pos_golongan(p.nomor, ri.golongan) > 0
+left join terisi t     on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and peran() is not null
+group by p.nomor, p.name, p.bayangan, p.jumlah_komponen;
+
+comment on view v_kelengkapan_pos is
+  'Agregat kelengkapan dan waktu nilai terakhir seluruh pos untuk panitia aktif. Definer agar agregat lintas pos tidak menuntut hak baca nilai mentah; badan view wajib menjaga peran() is not null.';
+
+grant select on v_kelengkapan_pos to authenticated, service_role;
+revoke all on v_kelengkapan_pos from anon;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -424,6 +424,9 @@ run tests/sql/62_guard_pos_completeness.sql
 # berangkat; tandai regunya agar petugas tahu kertas staging perlu diperbarui.
 run supabase/migrations/0102_mark_printed_kloter_insertion.sql
 run tests/sql/63_daftar_ulang_after_print.sql
+# Panel kelengkapan memakai waktu nilai terakhir untuk menandai pos yang diam.
+run supabase/migrations/0103_restore_pos_last_entry.sql
+run tests/sql/64_pos_last_entry.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/64_pos_last_entry.sql
+++ b/tests/sql/64_pos_last_entry.sql
@@ -1,0 +1,36 @@
+-- Panel kelengkapan harus membawa waktu nilai terakhir pada setiap pos.
+
+do $blok$
+declare
+  v_pos smallint;
+  v_terakhir timestamptz;
+  v_dari_view timestamptz;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  assert exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'v_kelengkapan_pos'
+      and column_name = 'terakhir_masuk'
+  ), 'v_kelengkapan_pos tidak mengekspos terakhir_masuk';
+
+  select w.pos, max(n.created_at)
+    into v_pos, v_terakhir
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by w.pos
+  order by w.pos
+  limit 1;
+
+  assert v_pos is not null, 'fixture tidak punya nilai untuk menguji terakhir_masuk';
+  select terakhir_masuk into v_dari_view
+  from v_kelengkapan_pos where pos = v_pos;
+  assert v_dari_view = v_terakhir,
+         format('terakhir_masuk view %s, seharusnya %s', v_dari_view, v_terakhir);
+
+  raise notice '64: waktu nilai terakhir Pos % terbaca di panel kelengkapan.', v_pos;
+end $blok$;
+
+\echo '64 waktu nilai terakhir per pos: LULUS'


### PR DESCRIPTION
## What

- restore the latest score-entry timestamp to each pos completeness row
- retain the active-panitia access guard and existing grants
- add SQL coverage for the column and its value

## Why

The Rekap screen uses this timestamp to identify a pos that has stopped submitting. The view dropped the column, so the warning and last-entry caption could never work.

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)