### PR TITLE
fix: align registration save action

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1640,9 +1640,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dari nama sekolah yang baru saja dibaca. */
   .table-daftar-ulang > tbody > tr > td:nth-child(3) { text-align: left; }
   .table-daftar-ulang > tbody > tr > td:nth-child(3) .pill-row { justify-content: flex-start; }
-  /* Kotak angka melebar sedikit — sasaran klik lebih besar, dan titik
-     tengahnya jatuh persis segaris dengan tombol Simpan di bawahnya. */
+  /* Kotak angka melebar sedikit supaya sasaran kliknya lebih besar. */
   .detail-table-dada input.small-input { width: 100%; max-width: 8rem; }
+
+  /* Tombol Simpan menempati pita kolom Nomor Dada (27%), bukan kolom Tukar
+     di tepi kanan. Margin 20% menyisakan pita kolom Tukar di sebelahnya. */
+  .action-row-simpan .button-small {
+    flex: 0 0 27%;
+    margin-right: 20%;
+  }
 }
 
 .detail-table-dada { width: 100%; margin: 0; }
@@ -2079,17 +2085,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Sejajar dengan teks di dalam tabel di atasnya, bukan dengan tepi kartu.
    Sel tabel punya padding sendiri, jadi keterangan yang tidak punya padding
    apa pun mulai lebih kiri daripada seluruh kolom di atasnya dan terbaca
-   seperti jatuh keluar dari tabelnya. Hanya KIRI yang diberi jarak: tombol
-   Simpan di kanan sengaja berbaris dengan kolom Nomor Dada, dan padding
-   kanan akan menggesernya keluar dari barisan itu. */
+   seperti jatuh keluar dari tabelnya. */
 .action-row-simpan .sub { flex: 1; min-width: 12rem; padding-left: .5rem; }
-/* Tombol Simpan selebar kolom Nomor Dada (28%) supaya titik tengahnya jatuh
-   segaris dengan kotak-kotak isian di atasnya — satu pita lurus dari tombol
-   "Isi N Nomor Dada", turun ke kotak isian, turun ke tombol Simpan. Dulu
-   tombol ini menempel ke tepi kanan kartu, jauh di kanan kotak isiannya. */
-@media (min-width: 561px) {
-  .action-row-simpan .button-small { flex: 0 0 28%; }
-}
 
 /* ============================================================================
    JENDELA SEMPIT TAPI MASIH TABEL (901px - 940px)

--- a/tests/registration_table_layout.test.mjs
+++ b/tests/registration_table_layout.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const webCss = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+const liveCss = await readFile(new URL("../live/style.css", import.meta.url), "utf8");
+
+
+test("tombol simpan menempati kolom nomor dada pada tabel lebar", () => {
+  const awal = webCss.indexOf("@media (min-width: 941px)");
+  const akhir = webCss.indexOf(".detail-table-dada { width: 100%", awal);
+  const layarLebar = webCss.slice(awal, akhir);
+
+  assert.match(
+    layarLebar,
+    /\.action-row-simpan \.button-small\s*\{\s*flex:\s*0 0 27%;\s*margin-right:\s*20%;\s*\}/,
+    "tombol Simpan harus mengisi kolom Nomor Dada dan menyisakan kolom Tukar",
+  );
+  assert.doesNotMatch(
+    webCss.slice(akhir),
+    /\.action-row-simpan \.button-small\s*\{[^}]*flex:/,
+    "aturan setelah breakpoint lebar menimpa kesejajaran tombol Simpan",
+  );
+});
+
+
+test("salinan CSS panitia dan peserta tetap sama", () => {
+  assert.equal(liveCss, webCss);
+});

--- a/web/style.css
+++ b/web/style.css
@@ -1640,9 +1640,15 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dari nama sekolah yang baru saja dibaca. */
   .table-daftar-ulang > tbody > tr > td:nth-child(3) { text-align: left; }
   .table-daftar-ulang > tbody > tr > td:nth-child(3) .pill-row { justify-content: flex-start; }
-  /* Kotak angka melebar sedikit — sasaran klik lebih besar, dan titik
-     tengahnya jatuh persis segaris dengan tombol Simpan di bawahnya. */
+  /* Kotak angka melebar sedikit supaya sasaran kliknya lebih besar. */
   .detail-table-dada input.small-input { width: 100%; max-width: 8rem; }
+
+  /* Tombol Simpan menempati pita kolom Nomor Dada (27%), bukan kolom Tukar
+     di tepi kanan. Margin 20% menyisakan pita kolom Tukar di sebelahnya. */
+  .action-row-simpan .button-small {
+    flex: 0 0 27%;
+    margin-right: 20%;
+  }
 }
 
 .detail-table-dada { width: 100%; margin: 0; }
@@ -2079,17 +2085,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Sejajar dengan teks di dalam tabel di atasnya, bukan dengan tepi kartu.
    Sel tabel punya padding sendiri, jadi keterangan yang tidak punya padding
    apa pun mulai lebih kiri daripada seluruh kolom di atasnya dan terbaca
-   seperti jatuh keluar dari tabelnya. Hanya KIRI yang diberi jarak: tombol
-   Simpan di kanan sengaja berbaris dengan kolom Nomor Dada, dan padding
-   kanan akan menggesernya keluar dari barisan itu. */
+   seperti jatuh keluar dari tabelnya. */
 .action-row-simpan .sub { flex: 1; min-width: 12rem; padding-left: .5rem; }
-/* Tombol Simpan selebar kolom Nomor Dada (28%) supaya titik tengahnya jatuh
-   segaris dengan kotak-kotak isian di atasnya — satu pita lurus dari tombol
-   "Isi N Nomor Dada", turun ke kotak isian, turun ke tombol Simpan. Dulu
-   tombol ini menempel ke tepi kanan kartu, jauh di kanan kotak isiannya. */
-@media (min-width: 561px) {
-  .action-row-simpan .button-small { flex: 0 0 28%; }
-}
 
 /* ============================================================================
    JENDELA SEMPIT TAPI MASIH TABEL (901px - 940px)


### PR DESCRIPTION
## What

- align the save action with the 27% Nomor Dada column on wide screens
- reserve the adjacent 20% Tukar column
- update the stale layout comments and add CSS regression coverage

## Why

The save button still used the old three-column geometry, so it appeared beneath Tukar after that action became its own column. Browser measurements now match the column edges at 941 px and 1200 px.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)