### PR TITLE
test: enforce SQL suite coverage

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -16,6 +16,18 @@ export PGHOST="${PGHOST:-127.0.0.1}" PGPORT="${PGPORT:-55432}" PGUSER="${PGUSER:
 DB=hrcd_test
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Urutannya sengaja ditulis manual di bawah, tetapi setiap berkas WAJIB muncul
+# pada sebuah baris `run`. Tanpa pagar ini migrasi baru dapat dilewati CI
+# secara diam-diam dan baru pertama kali dijalankan di database produksi.
+for file in "$ROOT"/supabase/migrations/*.sql "$ROOT"/tests/sql/*.sql; do
+  relative="${file#"$ROOT"/}"
+  if ! awk -v target="$relative" \
+      '$1 == "run" && $2 == target { found = 1 } END { exit !found }' "$0"; then
+    echo "run.sh: $relative tidak pernah dijalankan — tambahkan baris run" >&2
+    exit 1
+  fi
+done
+
 "$PSQL" -d postgres -v ON_ERROR_STOP=1 -q \
   -c "drop database if exists $DB;" \
   -c "create database $DB;"

--- a/tests/sql_coverage.test.mjs
+++ b/tests/sql_coverage.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const root = new URL("../", import.meta.url);
+const script = await readFile(new URL("run.sh", import.meta.url), "utf8");
+
+
+async function sqlFiles(directory, prefix) {
+  return (await readdir(new URL(directory, root)))
+    .filter((name) => name.endsWith(".sql"))
+    .map((name) => `${prefix}/${name}`);
+}
+
+
+test("run.sh menyebut setiap migrasi dan tes SQL pada baris run", async () => {
+  const listed = new Set(
+    [...script.matchAll(/^run\s+(\S+\.sql)\s*$/gm)].map((match) => match[1]),
+  );
+  const files = [
+    ...await sqlFiles("supabase/migrations/", "supabase/migrations"),
+    ...await sqlFiles("tests/sql/", "tests/sql"),
+  ];
+  const missing = files.filter((file) => !listed.has(file));
+
+  assert.deepEqual(
+    missing,
+    [],
+    `berkas SQL tidak pernah dijalankan oleh run.sh: ${missing.join(", ")}`,
+  );
+});
+
+
+test("run.sh memeriksa kelengkapan sebelum membuat database uji", () => {
+  const guard = script.indexOf('for file in "$ROOT"/supabase/migrations/*.sql');
+  const database = script.indexOf('"$PSQL" -d postgres');
+
+  assert.notEqual(guard, -1, "pemeriksa kelengkapan SQL tidak ditemukan");
+  assert.ok(guard < database, "pemeriksa baru berjalan setelah database dibuat");
+});


### PR DESCRIPTION
## What

- make run.sh fail before database setup when any SQL file lacks a run entry
- preserve the deliberately hand-ordered migration sequence
- add an independent JavaScript regression test for suite coverage

## Why

A newly added migration or SQL test could otherwise be omitted while CI stayed green, leaving production as the first database to execute it.

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)