### PR TITLE
fix: route live phase through dev RPC

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -469,7 +469,6 @@ export async function cariRegu(nomorDada) {
  *  padahal belum adalah cara tercepat membuat panitia mengumumkan juara yang
  *  tidak ada di layar peserta. */
 export async function aturFaseLive(fase) {
-  if (K.mode === "dev") return kirim("/atur-fase-live", { method: "POST", body: JSON.stringify({ fase }) });
   return rpc("atur_fase_live", { p_fase: fase });
 }
 

--- a/tests/dev_live_phase_route.test.mjs
+++ b/tests/dev_live_phase_route.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const webApi = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const liveApi = await readFile(new URL("../live/js/api.js", import.meta.url), "utf8");
+const devServer = await readFile(new URL("dev_server.py", import.meta.url), "utf8");
+
+
+test("aturFaseLive memakai pembungkus RPC yang sama di dev dan produksi", () => {
+  const awal = webApi.indexOf("export async function aturFaseLive");
+  const akhir = webApi.indexOf("export async function statusAcara", awal);
+  const fungsi = webApi.slice(awal, akhir);
+
+  assert.match(fungsi, /return rpc\("atur_fase_live", \{ p_fase: fase \}\);/);
+  assert.doesNotMatch(fungsi, /K\.mode|\/atur-fase-live|\bfetch\b|\bkirim\b/);
+  assert.match(devServer, /"atur_fase_live":\s*\["p_fase"\]/);
+});
+
+
+test("salinan API panitia dan peserta tetap sama", () => {
+  assert.equal(liveApi, webApi);
+});

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -53,6 +53,7 @@ RPC = {
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
     "hapus_nilai_pos":       ["p_nomor_dada", "p_kode", "p_pos"],
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
+    "atur_fase_live":        ["p_fase"],
     "susun_barak":           [],
     "tandai_kloter_dicetak": ["p_kloter"],
     "pindah_kloter":         ["p_nomor_dada", "p_alasan", "p_kloter"],

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -469,7 +469,6 @@ export async function cariRegu(nomorDada) {
  *  padahal belum adalah cara tercepat membuat panitia mengumumkan juara yang
  *  tidak ada di layar peserta. */
 export async function aturFaseLive(fase) {
-  if (K.mode === "dev") return kirim("/atur-fase-live", { method: "POST", body: JSON.stringify({ fase }) });
   return rpc("atur_fase_live", { p_fase: fase });
 }
 


### PR DESCRIPTION
## What

- route aturFaseLive through the shared RPC wrapper in every mode
- add atur_fase_live to the development server allowlist
- add regression coverage and keep both API copies identical

## Why

The local branch posted to the static page origin without JSON headers or a matching route, so maintainers could not rehearse the participant live-phase switch outside production.

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)