### PR TITLE
fix: complete development RPC routes

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -832,15 +832,8 @@ export async function tautanFotoBanyak(paths) {
  *  fotonya sudah lenyap dari layar, dan memberi tahu petugas bahwa "hapus
  *  gagal" padahal fotonya memang sudah hilang cuma membuatnya menekan lagi. */
 export async function hapusFotoLembar(id, alasan) {
-  if (K.mode === "dev") {
-    return kirim(`${K.devUrl}/rpc/hapus_foto_lembar`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ uid: sesi() ? sesi().uid : null,
-                             args: { p_id: id, p_alasan: alasan } }),
-    });
-  }
   const path = await rpc("hapus_foto_lembar", { p_id: id, p_alasan: alasan });
+  if (K.mode === "dev") return path;
   if (path) {
     try {
       await pastikanSesiSegar();

--- a/tests/dev_rpc_parity.test.mjs
+++ b/tests/dev_rpc_parity.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const devServer = await readFile(new URL("dev_server.py", import.meta.url), "utf8");
+
+
+test("setiap RPC API tersedia di dev server", () => {
+  const apiNames = new Set(
+    [...api.matchAll(/\brpc\(\s*"([^"]+)"/g)].map((match) => match[1]),
+  );
+  const awal = devServer.indexOf("RPC = {");
+  const akhir = devServer.indexOf("RPC_TABEL", awal);
+  const rpcBlock = devServer.slice(awal, akhir);
+  const devNames = new Set(
+    [...rpcBlock.matchAll(/^\s*"([^"]+)"\s*:/gm)].map((match) => match[1]),
+  );
+  const missing = [...apiNames].filter((name) => !devNames.has(name)).sort();
+
+  assert.deepEqual(missing, [], `RPC tanpa rute dev: ${missing.join(", ")}`);
+});
+
+
+test("hapus foto memakai wrapper RPC dan cast UUID di dev", () => {
+  const awal = api.indexOf("export async function hapusFotoLembar");
+  const akhir = api.indexOf("export async function kuotaFoto", awal);
+  const fungsi = api.slice(awal, akhir);
+
+  assert.match(fungsi, /await rpc\("hapus_foto_lembar", \{ p_id: id, p_alasan: alasan \}\)/);
+  assert.doesNotMatch(fungsi, /K\.devUrl\/rpc|JSON\.stringify/);
+  assert.match(devServer, /"p_id":\s*"::uuid"/);
+});

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -50,8 +50,11 @@ RPC = {
     "berangkatkan_kloter":   ["p_kloter", "p_jam"],
     "ceklis_berangkat":      ["p_nomor_dada"],
     "batal_ceklis_berangkat":["p_nomor_dada"],
+    "koreksi_jam_berangkat": ["p_kloter", "p_jam", "p_alasan"],
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
     "hapus_nilai_pos":       ["p_nomor_dada", "p_kode", "p_pos"],
+    "kunci_nilai_pos":       ["p_nomor_dada", "p_pos"],
+    "buka_kunci_nilai_pos":  ["p_nomor_dada", "p_pos", "p_alasan"],
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
     "atur_fase_live":        ["p_fase"],
     "susun_barak":           [],
@@ -61,6 +64,8 @@ RPC = {
     # Foto jawaban (0074). Gambarnya sendiri TIDAK lewat sini — dev server
     # tidak punya Storage — tapi barisnya tetap dicatat supaya alur layarnya
     # bisa dicoba tanpa Supabase.
+    "catat_foto_lembar":     ["p_nomor_dada", "p_pos", "p_kode_lomba", "p_nama_lomba", "p_path", "p_ukuran"],
+    "hapus_foto_lembar":     ["p_id", "p_alasan"],
     "catat_foto_masuk":      ["p_pos", "p_kode_lomba", "p_nama_lomba", "p_path", "p_ukuran"],
     "tautkan_foto":          ["p_foto_id", "p_nomor_dada", "p_cara"],
 }
@@ -433,7 +438,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         "p_menit": "::smallint", "p_kloter": "::smallint",
                         "p_anggota_hadir": "::smallint", "p_jumlah": "::smallint",
                         "p_regu": "::uuid", "p_jam": "::timestamptz",
-                        "p_jam_datang": "::timestamptz"}
+                        "p_jam_datang": "::timestamptz", "p_id": "::uuid"}
                 if nama == "tandai_kloter_dicetak":
                     CAST = {**CAST, "p_kloter": "::smallint[]"}
                 tanda = ", ".join("%s" + CAST.get(k, "") for k in urutan)

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -832,15 +832,8 @@ export async function tautanFotoBanyak(paths) {
  *  fotonya sudah lenyap dari layar, dan memberi tahu petugas bahwa "hapus
  *  gagal" padahal fotonya memang sudah hilang cuma membuatnya menekan lagi. */
 export async function hapusFotoLembar(id, alasan) {
-  if (K.mode === "dev") {
-    return kirim(`${K.devUrl}/rpc/hapus_foto_lembar`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ uid: sesi() ? sesi().uid : null,
-                             args: { p_id: id, p_alasan: alasan } }),
-    });
-  }
   const path = await rpc("hapus_foto_lembar", { p_id: id, p_alasan: alasan });
+  if (K.mode === "dev") return path;
   if (path) {
     try {
       await pastikanSesiSegar();


### PR DESCRIPTION
## What

- add the five remaining API RPCs to the development server
- cast hapus_foto_lembar IDs as UUID
- route dev photo deletion through the shared RPC wrapper
- add an API-to-dev-server parity test

## Why

Local gembok, departure correction, and photo flows called RPC names that the development server rejected, forcing maintainers to exercise those paths against production.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)