### PR TITLE
fix: pause hidden participant polling

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -699,6 +699,12 @@ muat();
    tertinggal terbuka di saku adalah beban yang tidak menghasilkan apa pun —
    dan mereka tetap mendapat data segar begitu layarnya dibuka lagi. */
 let denyut = null;
+const segarkanFase = async () => {
+  if (document.hidden) return;
+  const sebelum = FASE_DB;
+  await ambilFaseDb();
+  if (FASE_DB !== sebelum) gambar();
+};
 const nyalakan = () => {
   if (denyut === null) denyut = setInterval(muat, 60000);
   /* FASE dipantau TERPISAH dan jauh lebih sering.
@@ -713,29 +719,19 @@ const nyalakan = () => {
    *  Dan yang paling menentukan di lapangan: BEGITU HP DIBUKA LAGI. Peserta
    *  mengunci layarnya lalu membukanya menit berikutnya; tanpa baris ini ia
    *  melihat papan basi sampai denyut berikutnya tiba. */
-  if (denyutFase === null) {
-    denyutFase = setInterval(async () => {
-      const sebelum = FASE_DB;
-      await ambilFaseDb();
-      if (FASE_DB !== sebelum) gambar();
-    }, 15000);
-    const segera = async () => {
-      if (document.visibilityState !== "visible") return;
-      const sebelum = FASE_DB;
-      await ambilFaseDb();
-      if (FASE_DB !== sebelum) gambar();
-    };
-    document.addEventListener("visibilitychange", segera);
-    window.addEventListener("focus", segera);
-  }
+  if (denyutFase === null) denyutFase = setInterval(segarkanFase, 15000);
 };
 const matikan = () => {
   if (denyut !== null) { clearInterval(denyut); denyut = null; }
+  if (denyutFase !== null) { clearInterval(denyutFase); denyutFase = null; }
 };
 document.addEventListener("visibilitychange", () => {
   if (document.hidden) matikan();
   else { nyalakan(); muat(); }
 });
+// Fokus bisa kembali tanpa visibilitychange (misalnya berpindah jendela).
+// Pendengarnya dipasang sekali; nyalakan() hanya mengelola kedua interval.
+window.addEventListener("focus", segarkanFase);
 if (!document.hidden) nyalakan();
 
 // Cap "berapa menit lalu" ikut berjalan meski datanya belum berubah.

--- a/tests/live_poll_lifecycle.test.mjs
+++ b/tests/live_poll_lifecycle.test.mjs
@@ -1,0 +1,38 @@
+// ============================================================================
+// hrcd-rekap : tests/live_poll_lifecycle.test.mjs
+// Poll database peserta berhenti bersama poll CDN saat halaman tersembunyi.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+const awal = live.indexOf("let denyut = null;");
+const akhir = live.indexOf('// Cap "berapa menit lalu"', awal);
+const siklus = live.slice(awal, akhir);
+
+
+test("halaman tersembunyi mematikan poll CDN dan database", () => {
+  const awalMatikan = siklus.indexOf("const matikan = () => {");
+  const akhirMatikan = siklus.indexOf("document.addEventListener", awalMatikan);
+  const matikan = siklus.slice(awalMatikan, akhirMatikan);
+
+  assert.match(matikan, /clearInterval\(denyut\); denyut = null/);
+  assert.match(matikan, /clearInterval\(denyutFase\); denyutFase = null/);
+});
+
+
+test("poll fase hidup kembali tanpa menggandakan listener", () => {
+  const awalNyalakan = siklus.indexOf("const nyalakan = () => {");
+  const akhirNyalakan = siklus.indexOf("const matikan", awalNyalakan);
+  const nyalakan = siklus.slice(awalNyalakan, akhirNyalakan);
+
+  assert.match(nyalakan, /denyutFase = setInterval\(segarkanFase, 15000\)/);
+  assert.doesNotMatch(nyalakan, /addEventListener/);
+  assert.equal(
+    [...siklus.matchAll(/window\.addEventListener\("focus", segarkanFase\)/g)].length,
+    1,
+  );
+});


### PR DESCRIPTION
## What
- stop both participant polling intervals while the page is hidden
- rearm phase polling without accumulating focus listeners
- add lifecycle regression coverage

## Why
Hidden participant tabs should not keep polling the database every 15 seconds.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)