### PR TITLE
fix: exclude Intern from public completeness

### DIFF
--- a/supabase/migrations/0104_public_completeness_external_only.sql
+++ b/supabase/migrations/0104_public_completeness_external_only.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- hrcd-rekap : 0104_public_completeness_external_only.sql
+-- Kelengkapan halaman peserta menghitung regu Eksternal saja.
+--
+-- Halaman peserta sengaja tidak menerbitkan regu Intern. publish-live.yml
+-- membuang baris Intern dari progres, klasemen, dan daftar komponen, tetapi
+-- `v_kelengkapan_publik` sudah telanjur mengagregasi seluruh golongan sehingga
+-- hasilnya tidak bisa disaring lagi saat penerbitan.
+--
+-- Migrasi 0096 sudah membetulkan penyebut tiap golongan dan mengeluarkan regu
+-- dari pos yang memang tidak mereka ikuti. Namun Intern tetap mengikuti Soal
+-- Tulis di Pos 1--3, jadi penghitung publik ketiga pos itu masih lebih besar
+-- daripada jumlah regu yang ditampilkan di bawahnya.
+--
+-- Papan panitia `v_kelengkapan_pos` tidak diubah: Intern adalah peserta nyata
+-- yang kemajuannya memang perlu dipantau di sana. Hanya view publik yang
+-- mengikuti boundary Eksternal milik halaman peserta.
+-- ============================================================================
+
+create or replace view v_kelengkapan_publik as
+with regu_ikut as (
+  select r.id, r.golongan
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+    and r.golongan not in ('intern_pa', 'intern_pi')
+),
+terisi as (
+  select n.regu_id, w.pos, count(*)::int as jumlah
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id, w.pos
+)
+select
+  p.nomor          as pos,
+  p.name           as nama_pos,
+  p.jumlah_komponen,
+  count(ri.id)::int as regu_total,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0)
+          = komponen_pos_golongan(p.nomor, ri.golongan))::int as lengkap,
+  count(ri.id) filter (
+    where coalesce(t.jumlah, 0) > 0
+      and coalesce(t.jumlah, 0)
+          < komponen_pos_golongan(p.nomor, ri.golongan))::int as sebagian,
+  case when count(ri.id) = 0 then 0 else
+    floor(100.0 * count(ri.id) filter (
+      where coalesce(t.jumlah, 0)
+            = komponen_pos_golongan(p.nomor, ri.golongan)) / count(ri.id))::int
+  end              as persen
+from v_pos p
+left join regu_ikut ri on komponen_pos_golongan(p.nomor, ri.golongan) > 0
+left join terisi t     on t.regu_id = ri.id and t.pos = p.nomor
+where p.jumlah_komponen > 0
+  and (select fase_live from status_acara) in ('progres', 'penuh')
+group by p.nomor, p.name, p.jumlah_komponen;
+
+grant select on v_kelengkapan_publik to anon, authenticated, service_role;
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -439,6 +439,10 @@ run tests/sql/63_daftar_ulang_after_print.sql
 # Panel kelengkapan memakai waktu nilai terakhir untuk menandai pos yang diam.
 run supabase/migrations/0103_restore_pos_last_entry.sql
 run tests/sql/64_pos_last_entry.sql
+# Halaman peserta hanya menerbitkan regu Eksternal, jadi penghitung kelengkapan
+# publik harus memakai populasi yang sama. Papan panitia tetap menghitung Intern.
+run supabase/migrations/0104_public_completeness_external_only.sql
+run tests/sql/65_public_completeness_external.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/65_public_completeness_external.sql
+++ b/tests/sql/65_public_completeness_external.sql
@@ -14,6 +14,10 @@ declare
   v_semua           int;
   v_fase_sebelumnya text;
 begin
+  -- v_kelengkapan_pos sengaja dipagari untuk panitia aktif (0101). Duduki
+  -- akun admin fikstur supaya perbandingan menguji populasinya, bukan pagarnya.
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
   select fase_live into v_fase_sebelumnya from status_acara;
   update status_acara set fase_live = 'progres' where id = true;
 
@@ -71,4 +75,3 @@ end;
 $blok$;
 
 \echo '65 kelengkapan publik Eksternal: LULUS'
-

--- a/tests/sql/65_public_completeness_external.sql
+++ b/tests/sql/65_public_completeness_external.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/65_public_completeness_external.sql — migrasi 0104.
+-- Kelengkapan publik harus memakai populasi yang sama dengan tabel peserta.
+-- ============================================================================
+
+\echo '--- 65. kelengkapan publik hanya menghitung Eksternal'
+
+do $blok$
+declare
+  v_pos             smallint;
+  v_publik          int;
+  v_panitia         int;
+  v_eksternal       int;
+  v_semua           int;
+  v_fase_sebelumnya text;
+begin
+  select fase_live into v_fase_sebelumnya from status_acara;
+  update status_acara set fase_live = 'progres' where id = true;
+
+  -- Pilih pos yang benar-benar diikuti Intern agar tes tidak bisa lulus hanya
+  -- karena 0096 memang sudah mengeluarkan mereka dari Pos 4/5.
+  select p.nomor into v_pos
+  from v_pos p
+  where p.jumlah_komponen > 0
+    and exists (
+      select 1 from regu r
+      where r.golongan in ('intern_pa', 'intern_pi')
+        and komponen_pos_golongan(p.nomor, r.golongan) > 0
+    )
+  order by p.nomor
+  limit 1;
+
+  assert v_pos is not null,
+    '65 GAGAL: tidak ada pos yang diikuti Intern; fikstur tidak menguji boundary publik';
+
+  select regu_total into v_publik
+  from v_kelengkapan_publik where pos = v_pos;
+  select regu_total into v_panitia
+  from v_kelengkapan_pos where pos = v_pos;
+
+  select count(*)::int into v_eksternal
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+    and r.golongan not in ('intern_pa', 'intern_pi')
+    and komponen_pos_golongan(v_pos, r.golongan) > 0;
+
+  select count(*)::int into v_semua
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled
+    and d.status = 'lunas'
+    and r.nomor_dada is not null
+    and komponen_pos_golongan(v_pos, r.golongan) > 0;
+
+  assert v_semua > v_eksternal,
+    '65 GAGAL: tidak ada regu Intern yang membedakan hitungan publik dan panitia';
+  assert v_publik = v_eksternal,
+    format('65 GAGAL: publik menghitung %s regu di Pos %s, seharusnya %s Eksternal',
+           v_publik, v_pos, v_eksternal);
+  assert v_panitia = v_semua,
+    format('65 GAGAL: papan panitia berubah menjadi %s regu, seharusnya tetap %s',
+           v_panitia, v_semua);
+
+  update status_acara set fase_live = v_fase_sebelumnya where id = true;
+  raise notice '65 OK — Pos %: publik % Eksternal, panitia % seluruh regu.',
+    v_pos, v_publik, v_panitia;
+end;
+$blok$;
+
+\echo '65 kelengkapan publik Eksternal: LULUS'
+


### PR DESCRIPTION
## What
- make public completeness count only External teams
- preserve the organizer completeness count across all applicable groups
- add SQL regression coverage for both views

## Why
The participant page publishes only External teams, but its Pos 1–3 completeness counters still included Intern teams and could disagree with the visible table.

## Notes
Migration 0096 had already fixed the per-group denominator and non-applicable Pos 4/5 rows. This PR fixes the remaining public-boundary mismatch.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)