### PR TITLE
fix: confirm destructive participant switch

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -225,6 +225,12 @@ function halaman() {
 
   const pilihJenis = (jenis) => {
     if (jawab.jenis_peserta === jenis) return;
+    const adaIsianJenis = jawab.regu.length > 0
+      || (jawab.jenis_peserta === "eksternal"
+          && (jawab.sekolah || jawab.butuh_barak !== null));
+    if (adaIsianJenis && !window.confirm(
+      "Ganti jenis peserta? Isian asal sekolah, menginap, dan regu akan dihapus.",
+    )) return;
     jawab.jenis_peserta = jenis;
     jawab.sekolah = jenis === "internal" ? sekolahInternal() : null;
     jawab.butuh_barak = jenis === "internal" ? false : null;

--- a/tests/registration_participant_type.test.mjs
+++ b/tests/registration_participant_type.test.mjs
@@ -1,0 +1,30 @@
+// Pergantian jenis peserta tidak boleh diam-diam menimpa draf pendaftaran.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const daftar = await readFile(new URL("../live/js/daftar.js", import.meta.url), "utf8");
+const awal = daftar.indexOf("const pilihJenis = (jenis) => {");
+const akhir = daftar.indexOf("document.getElementById(\"p-eksternal\")", awal);
+const pilihJenis = daftar.slice(awal, akhir);
+
+
+test("pergantian jenis meminta konfirmasi sebelum menghapus draf", () => {
+  const posisiKonfirmasi = pilihJenis.indexOf("window.confirm(");
+  const posisiHapusRegu = pilihJenis.indexOf("jawab.regu = [];");
+  const posisiSimpan = pilihJenis.indexOf("simpanDraf();");
+
+  assert.match(pilihJenis, /jawab\.regu\.length > 0/);
+  assert.match(pilihJenis, /jawab\.sekolah \|\| jawab\.butuh_barak !== null/);
+  assert.match(pilihJenis, /if \(adaIsianJenis && !window\.confirm\(/);
+  assert.ok(posisiKonfirmasi < posisiHapusRegu);
+  assert.ok(posisiKonfirmasi < posisiSimpan);
+});
+
+
+test("membatalkan konfirmasi keluar sebelum mutasi", () => {
+  assert.match(pilihJenis, /\)\) return;\s+jawab\.jenis_peserta = jenis;/);
+});
+


### PR DESCRIPTION
## What
- detect participant-type data that would be discarded
- confirm before replacing the saved registration draft
- keep the initial type choice and empty switches frictionless
- add regression coverage for confirmation ordering and cancellation

## Why
A stray tap on Internal or External could silently erase school, lodging, team-count, and team-name data and immediately overwrite the local draft.

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)