### PR TITLE
fix: align public registration headline

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -172,6 +172,13 @@ function gambarSinkron() {
 function gambarPra() {
   const r = META.ringkas || {};
   const per = r.per_golongan || {};
+  // Headline dan pill harus menghitung populasi yang sama. Ringkasan sumber
+  // juga memuat Intern untuk kebutuhan panitia, tetapi halaman ini sengaja
+  // hanya mengumumkan Eksternal. Fallback menjaga live.json lama yang belum
+  // memiliki per_golongan tetap bisa digambar sampai penerbitan berikutnya.
+  const jumlahPeserta = r.per_golongan && typeof r.per_golongan === "object"
+    ? URUT_GOLONGAN_PESERTA.reduce((n, g) => n + Number(per[g] || 0), 0)
+    : (r.jumlah_regu_daftar ?? r.jumlah_regu_lunas ?? 0);
   const t = META.edisi && META.edisi.tanggal_lomba
     ? new Date(META.edisi.tanggal_lomba) : null;
   return `
@@ -182,7 +189,7 @@ function gambarPra() {
            yang mereka punya. Tanggal lombanya ikut hilang: ia ada di
            halaman pendaftaran, dan di sini cuma memberi alasan menunda. -->
       <h2>Segera daftarkan dirimu di<br>Hiking Rally Ciradyka XXXVII</h2>
-      <p class="angka-besar">${esc(String(r.jumlah_regu_daftar ?? r.jumlah_regu_lunas ?? 0))}</p>
+      <p class="angka-besar">${esc(String(jumlahPeserta))}</p>
       <p>regu sudah mendaftar</p>
       <p><a class="tombol" href="daftar.html">Daftar Sekarang</a></p>
       <div class="pil-baris">

--- a/tests/public_registration_headline.test.mjs
+++ b/tests/public_registration_headline.test.mjs
@@ -1,0 +1,33 @@
+// Headline pendaftaran peserta harus menjumlahkan golongan yang ditampilkan.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+const awal = live.indexOf("function gambarPra() {");
+const akhir = live.indexOf("function gambarKelengkapan()", awal);
+const gambarPra = live.slice(awal, akhir);
+
+
+test("headline pra menjumlahkan golongan peserta yang sama dengan pill", () => {
+  assert.match(
+    gambarPra,
+    /URUT_GOLONGAN_PESERTA\.reduce\(\(n, g\) => n \+ Number\(per\[g\] \|\| 0\), 0\)/,
+  );
+  assert.match(gambarPra, /String\(jumlahPeserta\)/);
+  assert.doesNotMatch(
+    gambarPra,
+    /angka-besar[^\n]+jumlah_regu_daftar/,
+  );
+});
+
+
+test("live.json lama tanpa rincian golongan tetap punya fallback", () => {
+  assert.match(
+    gambarPra,
+    /r\.jumlah_regu_daftar \?\? r\.jumlah_regu_lunas \?\? 0/,
+  );
+});
+


### PR DESCRIPTION
## What
- sum the pre-event registration headline from External group counts
- keep compatibility with older live metadata
- add regression coverage for the headline and fallback

## Why
The participant page hides Intern groups but its headline still included them, so the total disagreed with the visible group pills.

## Notes
The completeness-counter portion of this report was resolved by migration 0096 and PR #528. This PR fixes the remaining pre-event headline mismatch.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)