### PR TITLE
fix: refresh operational session on boot

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -27,27 +27,44 @@ export function bolehLihat(fitur) {
   return !!s && Array.isArray(s.hak) && s.hak.includes(fitur);
 }
 
-/** Isi `hak` ke sesi yang belum punya.
+/** Segarkan profil operasional dan `hak` saat aplikasi dibuka.
  *
- *  Sesi disimpan di localStorage dan hanya ditulis ulang saat login. Waktu
- *  `hak` mulai dibawa ke dalamnya, SETIAP orang yang sudah login memegang
- *  sesi tanpa field itu — dan bolehLihat() menjawab false untuk semuanya:
- *  papan Home kosong, tombol Akun hilang, dan orangnya wajar mengira
- *  aksesnya dicabut. Memaksa mereka keluar-masuk bukan jawaban; di hari
- *  lomba itu berarti belasan orang mengetik password di tengah antrean.
+ *  Admin dapat mengubah peran, pos, status aktif, dan centang hak ketika
+ *  petugas masih login. Semuanya disimpan di localStorage untuk menggambar
+ *  layar, jadi tanpa refresh petugas tetap melihat penempatan lama sampai
+ *  keluar-masuk. Database tetap menjadi pagar; refresh ini menyamakan UI.
  *
- *  Jadi diisi sekali di sini, diam-diam, lalu tidak pernah dipanggil lagi. */
+ *  Kalau jaringan gagal, sesi lama dipertahankan. Mengosongkan hak hanya
+ *  karena satu request putus akan mematikan seluruh papan di tengah shift. */
+let sesiOperasionalSegar = false;
 export async function lengkapiHakSesi() {
   const s = sesi();
-  if (!s || Array.isArray(s.hak)) return;
+  if (!s || sesiOperasionalSegar) return;
   try {
-    const hak = K.mode === "dev"
-      ? await baca(`/hak-saya?uid=${s.uid}`)
-      : (await baca(null, `akun_hak?user_id=eq.${s.uid}&select=fitur`));
-    simpanSesi({ ...s, hak: (hak || []).map(x => x.fitur) });
+    let akun, hak;
+    if (K.mode === "dev") {
+      akun = await baca("/akun-saya");
+      hak = await baca("/hak-saya");
+    } else {
+      const baris = await baca(null,
+        `akun_panitia?user_id=eq.${s.uid}&select=username,peran,pos,is_active`);
+      akun = baris && baris[0];
+      hak = await baca(null, `akun_hak?user_id=eq.${s.uid}&select=fitur`);
+    }
+    if (!akun) return;
+    // baca() mungkin sekaligus menyegarkan token. Ambil sesi terbaru agar
+    // profil yang baru tidak menimpa token hasil refresh dengan salinan lama.
+    const terbaru = sesi() || s;
+    simpanSesi({ ...terbaru,
+      username: akun.username,
+      peran: akun.peran,
+      pos: akun.pos,
+      is_active: akun.is_active,
+      hak: (hak || []).map(x => x.fitur),
+    });
+    sesiOperasionalSegar = true;
   } catch {
-    // Dibiarkan gagal: panggilan berikutnya mencoba lagi, dan sampai berhasil
-    // layarnya menunjukkan papan kosong — bukan papan yang salah.
+    // Sesi lama tetap dipakai; navigasi atau boot berikutnya mencoba lagi.
   }
 }
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -220,6 +220,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q(
                     "select fitur from akun_hak where user_id = %s::uuid",
                     (p.get("uid"),), role="service_role"))
+            elif u.path == "/akun-saya":
+                self._kirim(200, q(
+                    "select username, peran, pos, is_active from akun_panitia "
+                    "where user_id = %s::uuid",
+                    (p.get("uid"),), role="service_role", fetch="one"))
             elif u.path == "/hak":
                 self._kirim(200, q(
                     "select user_id::text, fitur from akun_hak", uid=p.get("uid")))

--- a/tests/session_refresh.test.mjs
+++ b/tests/session_refresh.test.mjs
@@ -1,0 +1,37 @@
+// Profil dan hak sesi harus mengikuti perubahan admin pada boot berikutnya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const awal = api.indexOf("export async function lengkapiHakSesi()");
+const akhir = api.indexOf("export function sesi()", awal);
+const refresh = api.slice(awal, akhir);
+
+
+test("sesi berisi hak tetap disegarkan dari profil dan matriks server", () => {
+  assert.doesNotMatch(refresh, /Array\.isArray\(s\.hak\).*return/);
+  assert.match(refresh, /akun_panitia\?user_id=eq\.\$\{s\.uid\}/);
+  assert.match(refresh, /akun_hak\?user_id=eq\.\$\{s\.uid\}/);
+  assert.match(refresh, /username: akun\.username/);
+  assert.match(refresh, /peran: akun\.peran/);
+  assert.match(refresh, /pos: akun\.pos/);
+  assert.match(refresh, /is_active: akun\.is_active/);
+  assert.match(refresh, /hak: \(hak \|\| \[\]\)\.map/);
+  assert.match(refresh, /sesiOperasionalSegar = true/);
+});
+
+
+test("dev server menyediakan profil akun sendiri", async () => {
+  const server = await readFile(new URL("./dev_server.py", import.meta.url), "utf8");
+  assert.match(server, /u\.path == "\/akun-saya"/);
+  assert.match(server, /select username, peran, pos, is_active from akun_panitia/);
+});
+
+
+test("profil baru tidak menimpa token yang baru disegarkan", () => {
+  assert.match(refresh, /const terbaru = sesi\(\) \|\| s;/);
+  assert.match(refresh, /simpanSesi\(\{ \.\.\.terbaru,/);
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -27,27 +27,44 @@ export function bolehLihat(fitur) {
   return !!s && Array.isArray(s.hak) && s.hak.includes(fitur);
 }
 
-/** Isi `hak` ke sesi yang belum punya.
+/** Segarkan profil operasional dan `hak` saat aplikasi dibuka.
  *
- *  Sesi disimpan di localStorage dan hanya ditulis ulang saat login. Waktu
- *  `hak` mulai dibawa ke dalamnya, SETIAP orang yang sudah login memegang
- *  sesi tanpa field itu — dan bolehLihat() menjawab false untuk semuanya:
- *  papan Home kosong, tombol Akun hilang, dan orangnya wajar mengira
- *  aksesnya dicabut. Memaksa mereka keluar-masuk bukan jawaban; di hari
- *  lomba itu berarti belasan orang mengetik password di tengah antrean.
+ *  Admin dapat mengubah peran, pos, status aktif, dan centang hak ketika
+ *  petugas masih login. Semuanya disimpan di localStorage untuk menggambar
+ *  layar, jadi tanpa refresh petugas tetap melihat penempatan lama sampai
+ *  keluar-masuk. Database tetap menjadi pagar; refresh ini menyamakan UI.
  *
- *  Jadi diisi sekali di sini, diam-diam, lalu tidak pernah dipanggil lagi. */
+ *  Kalau jaringan gagal, sesi lama dipertahankan. Mengosongkan hak hanya
+ *  karena satu request putus akan mematikan seluruh papan di tengah shift. */
+let sesiOperasionalSegar = false;
 export async function lengkapiHakSesi() {
   const s = sesi();
-  if (!s || Array.isArray(s.hak)) return;
+  if (!s || sesiOperasionalSegar) return;
   try {
-    const hak = K.mode === "dev"
-      ? await baca(`/hak-saya?uid=${s.uid}`)
-      : (await baca(null, `akun_hak?user_id=eq.${s.uid}&select=fitur`));
-    simpanSesi({ ...s, hak: (hak || []).map(x => x.fitur) });
+    let akun, hak;
+    if (K.mode === "dev") {
+      akun = await baca("/akun-saya");
+      hak = await baca("/hak-saya");
+    } else {
+      const baris = await baca(null,
+        `akun_panitia?user_id=eq.${s.uid}&select=username,peran,pos,is_active`);
+      akun = baris && baris[0];
+      hak = await baca(null, `akun_hak?user_id=eq.${s.uid}&select=fitur`);
+    }
+    if (!akun) return;
+    // baca() mungkin sekaligus menyegarkan token. Ambil sesi terbaru agar
+    // profil yang baru tidak menimpa token hasil refresh dengan salinan lama.
+    const terbaru = sesi() || s;
+    simpanSesi({ ...terbaru,
+      username: akun.username,
+      peran: akun.peran,
+      pos: akun.pos,
+      is_active: akun.is_active,
+      hak: (hak || []).map(x => x.fitur),
+    });
+    sesiOperasionalSegar = true;
   } catch {
-    // Dibiarkan gagal: panggilan berikutnya mencoba lagi, dan sampai berhasil
-    // layarnya menunjukkan papan kosong — bukan papan yang salah.
+    // Sesi lama tetap dipakai; navigasi atau boot berikutnya mencoba lagi.
   }
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6485,9 +6485,9 @@ async function arahkan() {
   hashLayar = tujuan;
   segarkanDiTempat = null;
   if (!sesi()) { layarLogin(); return; }
-  // Sesi yang dibuat sebelum `hak` dibawa ke dalamnya tidak punya field itu,
-  // dan papan Home lalu kosong untuk semua orang yang sudah login. Diisi
-  // sekali; sesudah itu panggilan ini langsung kembali.
+  // Profil operasional dan centang hak bisa diubah admin saat petugas masih
+  // login. Segarkan sekali per boot agar UI tidak memakai peran/pos lama;
+  // panggilan navigasi berikutnya langsung kembali.
   await lengkapiHakSesi();
   if (!EDISI) {
     try { EDISI = await infoEdisi(); }


### PR DESCRIPTION
## What
- refresh role, pos, active status, and feature rights once per app boot
- preserve a token refreshed during those reads
- retain the cached session if the network refresh fails
- add the matching development self-profile route
- keep both API copies byte-identical and add regression coverage

## Why
Admin changes to a logged-in organizer's assignment or rights were never reflected by a reopened app because the UI trusted login-time localStorage forever.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)