### PR TITLE
fix: use stable photo contest keys

### DIFF
--- a/tests/photo_contest_key.test.mjs
+++ b/tests/photo_contest_key.test.mjs
@@ -1,0 +1,23 @@
+// Foto Jawaban harus memakai kode_lomba stabil, bukan slug dari labelnya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const awal = app.indexOf("async function layarFoto()");
+const akhir = app.indexOf("const RUTE = {", awal);
+const layarFoto = app.slice(awal, akhir);
+
+
+test("selector Foto Jawaban memakai kode dari kelompokLomba", () => {
+  assert.match(layarFoto, /<option value="\$\{esc\(l\.kode\)\}">\$\{esc\(l\.nama\)\}<\/option>/);
+  assert.match(layarFoto, /kodeLomba = lomba\.length \? lomba\[0\]\.kode : null/);
+});
+
+
+test("Foto Jawaban tidak mempunyai pembuat slug privat", () => {
+  assert.doesNotMatch(layarFoto, /const slug\s*=/);
+  assert.doesNotMatch(layarFoto, /slug\(l\.nama\)/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6071,9 +6071,6 @@ async function layarFoto() {
   const elBelum = document.getElementById("foto-belum");
   const elKuota = document.getElementById("foto-kuota");
 
-  const slug = (nama) => String(nama).toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
-
   /* ------------------------------------------------------------------------
      SATU PETAK, BUKAN DUA DAFTAR.
 
@@ -6228,8 +6225,8 @@ async function layarFoto() {
     }
     const lomba = kelompokLomba(kolomPos(komponen));
     elLomba.innerHTML = lomba.map(l =>
-      `<option value="${esc(slug(l.nama))}">${esc(l.nama)}</option>`).join("");
-    kodeLomba = lomba.length ? slug(lomba[0].nama) : null;
+      `<option value="${esc(l.kode)}">${esc(l.nama)}</option>`).join("");
+    kodeLomba = lomba.length ? lomba[0].kode : null;
     namaLomba = lomba.length ? lomba[0].nama : null;
     elAksi.hidden = !kodeLomba;
     elLomba.disabled = false;


### PR DESCRIPTION
## What
- populate the Foto Jawaban selector with stable kode_lomba values
- use the same key for the initial photo queue
- remove the screen-local slug helper
- add client regression coverage

## Why
Renaming a contest label could make bulk photo uploads send a derived key that the database rejects and hide photos stored under the stable key.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)