### PR TITLE
fix: expose contest slug fallback

### DIFF
--- a/tests/contest_group_fallback.test.mjs
+++ b/tests/contest_group_fallback.test.mjs
@@ -1,0 +1,37 @@
+// Fallback kode lomba harus bisa dipanggil dari kelompokLomba di module scope.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const awal = app.indexOf("const slugLomba =");
+const akhir = app.indexOf("const varianUntuk", awal);
+const sumber = app.slice(awal, akhir);
+const { kelompokLomba } = new Function(
+  `${sumber}; return { kelompokLomba };`,
+)();
+
+
+test("kelompokLomba membuat fallback saat kode_lomba kosong", () => {
+  const hasil = kelompokLomba([{
+    nama: "Pembidaian & PPPK",
+    varian: [{ lomba: "Pembidaian & PPPK", kode_lomba: null }],
+  }]);
+
+  assert.equal(hasil.length, 1);
+  assert.equal(hasil[0].nama, "Pembidaian & PPPK");
+  assert.equal(hasil[0].kode, "pembidaian-pppk");
+});
+
+
+test("kode_lomba database tetap menang atas fallback nama", () => {
+  const hasil = kelompokLomba([{
+    nama: "Pembidaian & PPPK",
+    varian: [{ lomba: "Pembidaian & PPPK", kode_lomba: "pembidaian" }],
+  }]);
+
+  assert.equal(hasil[0].kode, "pembidaian");
+});
+

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2581,6 +2581,9 @@ function bacaSel(tr, k) {
  *
  *  `lomba` kosong berarti komponen itu lomba tersendiri, keadaan yang benar
  *  untuk sebagian besar baris. */
+const slugLomba = (nama) => String(nama).toLowerCase()
+  .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
+
 function kelompokLomba(kolom) {
   const urut = [], peta = new Map();
   for (const kol of kolom) {
@@ -3586,15 +3589,6 @@ async function layarInputPos() {
 
     await janji;
   }
-
-  /** Slug lomba dari NAMANYA, bukan dari kode wahana.
-   *
-   *  Satu slip = satu lomba, tapi satu lomba bisa punya beberapa baris wahana:
-   *  Bidai lima kriteria di satu kertas, Tebak Simpul satu baris per golongan.
-   *  Kode wahana karena itu bukan penanda selembar kertas — namanya yang
-   *  justru satu, dan itulah yang sudah dipakai kolomPos() mengelompokkan. */
-  const slugLomba = (nama) => String(nama).toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
 
   /** Foto slip penilaian satu regu — satu foto per lomba (migrasi 0047).
    *


### PR DESCRIPTION
## What
- move slugLomba to the module scope used by kelompokLomba
- remove the unreachable function-local duplicate
- execute regression tests for missing and present kode_lomba values

## Why
The fallback for an absent contest key called a helper outside its scope and crashed instead of producing the documented slug.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)