### PR TITLE
docs: replace retired event roles

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -640,14 +640,18 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    | `pos2hrcd37` | Hanya input nilai Pos 2 |
    | `admin.ciradyka` | Semua bagian sistem |
 
-   Ada tiga peran: `admin`, `meja` (petugas pembayaran / daftar ulang /
-   keberangkatan), dan `operator_pos`. Akun hanya diberikan kepada admin tiap
-   pos, petugas meja, dan tim IT. Operator sebuah pos tidak dapat menyentuh
-   nilai pos lain, dan akun meja ditolak masuk ke layar input pos dengan pesan
-   "Akun meja, bukan akun pos" — ditegakkan oleh sistem, bukan sekadar
-   disembunyikan dari layar. Sebaliknya akun pos tidak diberi jalan ke layar
-   meja: Home-nya hanya memuat satu kartu, "Input Nilai Pos N", dan RLS
-   mengosongkan data meja seandainya alamatnya diketik langsung.
+   Ada lima preset peran: `admin`, `registrasi`, `gerbang`, `juri_pos`, dan
+   `koordinator_pos`. Peran memilih centang awal melalui `paket_peran()`;
+   keputusan boleh-tidaknya datang dari matriks `akun_hak` melalui
+   `boleh(fitur)`. Koordinator dapat menambah atau mencabut centang per akun
+   tanpa menciptakan peran baru.
+
+   `juri_pos` membawa satu nomor pos dan hanya boleh menulis nilai pos itu.
+   `koordinator_pos` membawa hak penilaian yang sama tetapi kolom posnya
+   kosong, sehingga dapat menangani seluruh pos. Paket `registrasi` memuat
+   pekerjaan pendaftaran sampai cetak kloter; paket `gerbang` memuat
+   keberangkatan dan kedatangan. Seluruhnya tetap ditegakkan database, bukan
+   sekadar disembunyikan dari Home.
 11. Pola nama akun mengikuti edisi (`hrcd37` = edisi ke-37), sehingga akun dan
    password dapat diganti bersih setiap tahun tanpa membongkar sistem.
 12. Panitia bekerja atas dasar saling percaya, tetapi **riwayat perubahan tetap

--- a/tests/docs_access_roles.test.mjs
+++ b/tests/docs_access_roles.test.mjs
@@ -1,0 +1,25 @@
+// Dokumen operasional tidak boleh menghidupkan kembali model role lama.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const alur = await readFile(new URL("../docs/alur-lomba.md", import.meta.url), "utf8");
+
+
+test("alur lomba menyebut lima preset role yang berlaku", () => {
+  for (const peran of ["admin", "registrasi", "gerbang", "juri_pos", "koordinator_pos"])
+    assert.ok(alur.includes(`\`${peran}\``));
+  assert.doesNotMatch(alur, /Ada tiga peran/);
+  assert.doesNotMatch(alur, /`operator_pos`/);
+  assert.doesNotMatch(alur, /`meja` \(petugas/);
+});
+
+
+test("alur lomba menjelaskan hak per fitur sebagai pintu", () => {
+  assert.match(alur, /matriks `akun_hak`/);
+  assert.match(alur, /`boleh\(fitur\)`/);
+  assert.match(alur, /Peran memilih centang awal melalui `paket_peran\(\)`/);
+});
+


### PR DESCRIPTION
## What
- replace meja and operator_pos with the five current role presets
- explain that peran seeds initial rights through paket_peran()
- document akun_hak and boleh(fitur) as the real enforcement path
- clarify the juri_pos and koordinator_pos scope difference
- add regression coverage for the operational document

## Why
The event flow still taught maintainers to provision roles removed by migration 0058 and described a gate replaced by feature rights in migration 0064.

## Notes
The matching final-architecture passage was corrected separately in PR #536.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)