### PR TITLE
docs: correct printed kloter behavior

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -151,10 +151,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    golongan, dan nomor dada tiap regu.
 
    Ini bukan formalitas, melainkan pintu terakhir yang masih murah. Sesudah
-   lembar kloter dicetak, isinya dibekukan: menambah regu ke kloter tercetak
-   ditolak sistem, dan menukar nomor dada hanya boleh lewat admin — nomor
-   lamanya pun dipensiunkan permanen, karena kertas yang sudah beredar masih
-   menuliskannya (bagian 8.8).
+   lembar kloter dicetak, isinya belum dibekukan: regu tetap boleh ditambahkan
+   dan lembar itu dicetak ulang (bagian 5.5). Namun menukar nomor dada yang
+   sudah beredar hanya boleh lewat admin — nomor lamanya dipensiunkan permanen
+   karena salinan kertas lama masih menuliskannya (bagian 8.8).
 
    Harganya naik lagi sesudah lomba mulai. Slip penilaian per lomba hanya
    memuat NOMOR DADA tanpa nama regu, jadi nomor dada yang salah bukan

--- a/tests/docs_printed_kloter.test.mjs
+++ b/tests/docs_printed_kloter.test.mjs
@@ -1,0 +1,22 @@
+// Tanda cetak tidak boleh kembali didokumentasikan sebagai pagar kloter.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const alur = await readFile(new URL("../docs/alur-lomba.md", import.meta.url), "utf8");
+
+
+test("alur konsisten bahwa kloter tercetak tetap menerima regu", () => {
+  assert.doesNotMatch(alur, /menambah regu ke kloter tercetak\s+ditolak sistem/);
+  assert.match(alur, /regu tetap boleh ditambahkan\s+dan lembar itu dicetak ulang/);
+  assert.match(alur, /Tanda cetak tidak\s+menutup kloter untuk tambahan/);
+});
+
+
+test("aturan pensiun nomor yang sudah beredar tetap dipertahankan", () => {
+  assert.match(alur, /menukar nomor dada yang\s+sudah beredar hanya boleh lewat admin/);
+  assert.match(alur, /nomor lamanya dipensiunkan permanen/);
+});
+


### PR DESCRIPTION
## What
- state that a print mark does not close a kloter to additions
- direct officers to reprint the changed sheet
- preserve the admin-only retirement rule for circulated chest numbers
- add consistency coverage for both kloter sections

## Why
One paragraph said the system rejects additions to printed kloter while the current database and another section of the same document explicitly allow them.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)