### PR TITLE
fix: add kloter capacity headroom

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -181,7 +181,9 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
 1. Penempatan otomatis memakai kuota **5 regu Eksternal + 3 regu Intern** per
    kloter. Kedua kuota dihitung terpisah.
-2. Perkiraan 300 Eksternal + 50 Intern membutuhkan **60 kloter**.
+2. Perkiraan 300 Eksternal + 50 Intern membutuhkan **60 kloter**, tetapi edisi
+   menyediakan **75 kloter** agar tempat kosong pada kloter yang sudah
+   berangkat tidak menggagalkan batch daftar ulang berikutnya.
 3. Kloter ditentukan otomatis begitu regu menerima nomor dada.
 4. **Urutannya FIFO:** siapa lebih dahulu menyelesaikan daftar ulang mendapat
    kloter lebih awal. Sekolah tidak memengaruhi penempatan.
@@ -189,8 +191,8 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    menutup kloter untuk tambahan.
 6. Set manual tidak memiliki batas kuota atau jumlah; ini sengaja agar petugas
    dapat mencatat keadaan lapangan apa adanya.
-7. Perkiraan waktu K1–K60 dibagi merata sepanjang 07:00–10:00, sekitar tiga
-   menit antar-kloter untuk jumlah tersebut.
+7. Perkiraan waktu K1–K75 dibagi merata sepanjang 07:00–10:00, sekitar dua
+   setengah menit antar-kloter untuk jumlah tersebut.
 8. **Satu kloter boleh berisi golongan campuran.** Penggalang dan Penegak, putra
    dan putri, dapat berangkat dalam kloter yang sama; hanya Intern dan Eksternal
    yang mempunyai kuota otomatis terpisah.

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -37,7 +37,7 @@ Ringkasan dari `alur-lomba.md` — setiap kandidat dipetakan ke daftar ini:
 | R1 | Form pendaftaran online (identitas regu, golongan, barak), link sama untuk online & offline |
 | R2 | Verifikasi pembayaran manual → kwitansi + kode pembayaran |
 | R3 | Daftar ulang 2–3 meja paralel: kode → nomor dada, diambil **per sekolah sekaligus**, tanpa nomor ganda |
-| R4 | Kloter otomatis FIFO saat itu juga: 5 Eksternal + 3 Intern, 60 kloter untuk perkiraan 300+50 regu; set manual tanpa batas |
+| R4 | Kloter otomatis FIFO saat itu juga: 5 Eksternal + 3 Intern, 75 kloter dengan headroom untuk perkiraan 300+50 regu; set manual tanpa batas |
 | R5 | Layar garis start: antrean 4 tahap, konfirmasi kontrak waktu, jam berangkat per kloter + ceklis per regu |
 | R6 | Input nilai per pos: link + akun/password sendiri per pos; input manual **dan** upload massal Excel/CSV dengan layar preview yang memvalidasi |
 | R7 | Mesin skor yang bisa dikonfigurasi panitia tanpa programmer: 5 bentuk konversi, bobot pos, rumus penalti, pengurangan lain |

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **23 Agustus 2026**, sampai migrasi `0104`.
+Terakhir diperiksa terhadap kode: **23 Agustus 2026**, sampai migrasi `0105`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-104 migrasi, `0001` sampai `0104`, dijalankan berurutan tanpa lubang penomoran.
+105 migrasi, `0001` sampai `0105`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -83,7 +83,7 @@ penyelesaiannya dicatat di bagian 11.
 
 | Tabel | Isi | Contoh edisi 37 |
 | --- | --- | --- |
-| `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | Kuota otomatis 5 Eksternal + 3 Intern, perkiraan 300 Eksternal + 50 Intern, `kloter_maks=60`, jendela 07:00–10:00 |
+| `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | Kuota otomatis 5 Eksternal + 3 Intern, perkiraan 300 Eksternal + 50 Intern, `kloter_maks=75`, jendela 07:00–10:00 |
 | `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
 | `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis`): bentuk konversi + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
 | `kontrak_opsi` | Pilihan kontrak waktu | `('3,5 jam',210), ('4 jam',240), ('4,5 jam',270)` |

--- a/supabase/migrations/0105_expand_kloter_capacity.sql
+++ b/supabase/migrations/0105_expand_kloter_capacity.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- hrcd-rekap : 0105_expand_kloter_capacity.sql
+-- Sediakan 75 kloter agar kuota Eksternal tidak habis tepat di batas rencana.
+--
+-- Enam puluh kloter hanya memuat tepat 300 Eksternal. Setiap tempat kosong
+-- pada kloter yang telanjur berangkat tidak dapat dipakai lagi oleh pembagian
+-- otomatis, sehingga satu tempat yang hangus dapat menggagalkan seluruh batch
+-- daftar ulang terakhir. Lima belas kloter cadangan memberi 75 tempat
+-- Eksternal tambahan tanpa mengubah kuota 5 Eksternal + 3 Intern per kloter.
+--
+-- Seluruh 75 kloter tetap mempunyai perkiraan di dalam jendela edisi. Fungsi
+-- sebelumnya membagi waktu menurut jumlah regu perkiraan (60 kloter), sehingga
+-- K61 dan seterusnya jatuh sesudah batas pukul 10:00.
+-- ============================================================================
+
+update edisi
+set kloter_dasar = greatest(kloter_dasar, 75),
+    kloter_maks = greatest(kloter_maks, 75)
+where is_active;
+
+insert into kloter (nomor)
+select generate_series(
+  1,
+  (select kloter_maks from edisi where is_active)
+)::smallint
+on conflict (nomor) do nothing;
+
+create or replace function perkiraan_berangkat_kloter(p_kloter integer)
+returns timestamptz
+language sql stable
+set search_path = public
+as $$
+  with cfg as (
+    select e.*,
+      greatest(e.kloter_maks, 1)::int as jumlah_kloter
+    from edisi e
+    where e.is_active
+  )
+  select ((tanggal_lomba + jam_mulai_berangkat) at time zone 'Asia/Jakarta')
+    + case when jumlah_kloter = 1 then interval '0'
+           else (jam_batas_berangkat - jam_mulai_berangkat)
+             * ((p_kloter - 1)::double precision / (jumlah_kloter - 1))
+      end
+  from cfg
+$$;
+
+comment on function perkiraan_berangkat_kloter(integer) is
+  'Perkiraan FIFO yang membagi seluruh kloter edisi secara merata di dalam jendela keberangkatan.';

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -104,7 +104,8 @@ run supabase/migrations/0024_komponen_pos.sql
 #     itu benar-benar diperiksa. Tanpa 0054 ia melapor "Pembidaian tidak ada di
 #     database ini" dan penjaganya diam.
 #   * 0091 harus SESUDAH 0076 agar lima komponen Soal Tulis yang disalin untuk
-#     Intern sudah ada. 0093 lalu menyiapkan 60 kloter setelah edisi aktif lahir.
+#     Intern sudah ada. 0093 menyiapkan 60 kloter setelah edisi aktif lahir;
+#     0105 menambah headroom-nya menjadi 75.
 for m in $ULANG; do
   run "supabase/migrations/$m.sql"
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -443,6 +443,10 @@ run tests/sql/64_pos_last_entry.sql
 # publik harus memakai populasi yang sama. Papan panitia tetap menghitung Intern.
 run supabase/migrations/0104_public_completeness_external_only.sql
 run tests/sql/65_public_completeness_external.sql
+# Enam puluh kloter hanya memberi tepat 300 tempat Eksternal. Tambahkan 15
+# kloter cadangan dan tetap bagi seluruh perkiraannya di dalam 07:00-10:00.
+run supabase/migrations/0105_expand_kloter_capacity.sql
+run tests/sql/66_kloter_capacity_headroom.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/66_kloter_capacity_headroom.sql
+++ b/tests/sql/66_kloter_capacity_headroom.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/66_kloter_capacity_headroom.sql — migrasi 0105.
+-- Tujuh puluh lima kloter tersedia dan semuanya tetap dijadwalkan 07:00-10:00.
+-- ============================================================================
+
+\echo '--- 66. kapasitas cadangan 75 kloter'
+
+do $blok$
+declare
+  v_sekolah uuid;
+  v_daftar uuid;
+  v_regu uuid;
+  v_nomor int;
+  v_k1 timestamptz;
+  v_k2 timestamptz;
+  v_k60 timestamptz;
+  v_k75 timestamptz;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  assert (select kloter_dasar = 75 and kloter_maks = 75
+          from edisi where is_active),
+         '66.1 GAGAL: batas kloter edisi bukan 75';
+  assert (select count(*) from kloter where nomor between 1 and 75) = 75,
+         '66.2 GAGAL: baris kloter 1-75 belum lengkap';
+
+  select perkiraan_berangkat_kloter(1),
+         perkiraan_berangkat_kloter(2),
+         perkiraan_berangkat_kloter(60),
+         perkiraan_berangkat_kloter(75)
+  into v_k1, v_k2, v_k60, v_k75;
+
+  assert (v_k1 at time zone 'Asia/Jakarta')::time = time '07:00',
+         format('66.3 GAGAL: perkiraan K1 bukan 07:00: %s', v_k1);
+  assert (v_k75 at time zone 'Asia/Jakarta')::time = time '10:00',
+         format('66.4 GAGAL: perkiraan K75 bukan 10:00: %s', v_k75);
+  assert v_k60 < v_k75,
+         format('66.5 GAGAL: K60 (%s) tidak lebih awal dari K75 (%s)', v_k60, v_k75);
+  assert extract(epoch from (v_k2 - v_k1)) between 145 and 147,
+         format('66.6 GAGAL: jarak K1-K2 bukan sekitar 146 detik: %s',
+                extract(epoch from (v_k2 - v_k1)));
+
+  -- Buktikan kloter cadangan bukan sekadar baris mati. Setelah K1-K60 sudah
+  -- berangkat, pembagian otomatis berikutnya harus terus ke K61, bukan menolak
+  -- seluruh batch.
+  update kloter
+  set jam_berangkat = timestamptz '2026-08-29 07:00+07'
+  where nomor between 1 and 60;
+  update kloter
+  set jam_berangkat = null
+  where nomor between 61 and 75;
+
+  insert into sekolah (name, address)
+  values ('Sekolah Uji Headroom 0105', 'Ciamis')
+  returning id into v_sekolah;
+
+  insert into pendaftaran
+    (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa, status)
+  values (v_sekolah, 'UJI-HEADROOM-0105', 1, '081200000105', 'lunas')
+  returning id into v_daftar;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_daftar, 'Regu Uji Headroom', 'Ketua Uji', 'penggalang_pa')
+  returning id into v_regu;
+
+  select min(s.nomor) into v_nomor
+  from nomor_dada_stok s
+  where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+    and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+
+  perform * from daftar_ulang_batch(
+    'UJI-HEADROOM-0105',
+    jsonb_build_array(jsonb_build_object('regu_id', v_regu,
+                                         'nomor_dada', v_nomor))
+  );
+
+  assert (select kloter_nomor = 61 from regu where id = v_regu),
+         '66.7 GAGAL: pembagian otomatis tidak melanjutkan ke K61';
+
+  raise notice '66: K1-K75 terjadwal 07:00-10:00 dan K61 dapat dipakai otomatis.';
+end $blok$;
+
+\echo '66 kapasitas cadangan 75 kloter: LULUS'


### PR DESCRIPTION
## What

- expand the active edition from 60 to 75 kloter
- spread K1-K75 estimates across the configured 07:00-10:00 window
- add a SQL regression proving automatic allocation continues at K61
- update the current architecture and flow documentation

## Why

Sixty kloter provide exactly 300 External slots. A partially filled kloter that has already departed permanently removes its unused slots from automatic allocation, so the final registration batch can roll back despite remaining within the planned participant count.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)