### PR TITLE
fix: explain duplicate registration resends

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -768,6 +768,12 @@ function sukses(hasil) {
   LAYAR.replaceChildren(h(html`
     <div class="card" style="border-color:var(--hijau);background:var(--hijau-muda)">
       <h2>✅ Pendaftaran diterima!</h2>
+      <p ${hasil.terkirim_ulang ? "" : "hidden"}>
+        <strong>Pendaftaran ini sudah tercatat dari kiriman sebelumnya.</strong>
+        Perubahan setelah kiriman pertama tidak ikut tersimpan. Data yang
+        tercatat berisi ${hasil.jumlah_regu} regu; hubungi panitia bila perlu
+        diperbaiki.
+      </p>
       <p>Ini <strong>kode pembayaran</strong>-mu. Simpan baik-baik — kode ini dipakai
          saat membayar dan saat daftar ulang.</p>
       <div class="giant-number" style="margin:1rem 0">${hasil.kode_pembayaran}</div>

--- a/tests/registration_resend_notice.test.mjs
+++ b/tests/registration_resend_notice.test.mjs
@@ -1,0 +1,19 @@
+// Kiriman ulang idempoten harus menjelaskan data mana yang sudah tersimpan.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const daftar = await readFile(new URL("../live/js/daftar.js", import.meta.url), "utf8");
+const awal = daftar.indexOf("function sukses(hasil)");
+const akhir = daftar.indexOf("/* ---------------- mulai", awal);
+const sukses = daftar.slice(awal, akhir);
+
+
+test("hasil kirim ulang menampilkan keadaan data yang sudah tercatat", () => {
+  assert.match(sukses, /hasil\.terkirim_ulang \? "" : "hidden"/);
+  assert.match(sukses, /sudah tercatat dari kiriman sebelumnya/);
+  assert.match(sukses, /Perubahan setelah kiriman pertama tidak ikut tersimpan/);
+  assert.match(sukses, /tercatat berisi \$\{hasil\.jumlah_regu\} regu/);
+});


### PR DESCRIPTION
## What

- show a warning when a registration response represents an earlier idempotent submission
- state the recorded team count and explain that later edits were not stored
- add a regression test for the duplicate-resend notice

## Why

After a successful request loses its response, a user can edit the form and retry with the same idempotency key. The server correctly returns the original registration, but the UI previously presented that response as a fresh submission and hid that the later edits were not recorded.

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)