### PR TITLE
fix: clear stale print documents

### DIFF
--- a/tests/print_cleanup.test.mjs
+++ b/tests/print_cleanup.test.mjs
@@ -1,0 +1,32 @@
+// Dokumen cetak sementara tidak boleh hidup lebih lama dari satu operasi print.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("printout dibersihkan setelah dialog print dan saat navigasi", () => {
+  assert.match(app, /window\.addEventListener\("afterprint", \(\) => \{\s*document\.getElementById\("cetakan"\)\?\.remove\(\);/);
+
+  const awal = app.indexOf("async function arahkan()");
+  const akhir = app.indexOf("// Tiga aksi yang sama", awal);
+  const arahkan = app.slice(awal, akhir);
+  assert.match(arahkan, /document\.getElementById\("cetakan"\)\?\.remove\(\);/);
+});
+
+
+test("pos tanpa blangko tidak meninggalkan printout kosong", () => {
+  const awal = app.indexOf("function siapkanCetakBlangko(");
+  const akhir = app.indexOf("/** Layar Input Pos", awal);
+  const siapkan = app.slice(awal, akhir);
+  const posisiKosong = siapkan.indexOf("if (!daftarLomba.length) return 0;");
+  const posisiPasang = siapkan.lastIndexOf("document.body.appendChild");
+
+  assert.notEqual(posisiKosong, -1);
+  assert.notEqual(posisiPasang, -1);
+  assert.ok(posisiKosong < posisiPasang,
+    "printout dipasang sebelum diketahui bahwa tidak ada blangko");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3115,6 +3115,8 @@ function siapkanCetakBlangko(pos, kolomLayar) {
      berarti lomba soal tahun depan tercetak lagi tanpa ada yang tahu kenapa. */
   const lombaSoal = (l) => l.kolom.every(kol => kol.varian[0].type === "soal");
   const daftarLomba = kelompokLomba(kolomLayar).filter(l => !lombaSoal(l));
+  if (!daftarLomba.length) return 0;
+
   const cetakan = daftarLomba.map(l => `
     <section class="print-page blangko-halaman">${satuBlangko(l)}</section>`).join("");
 
@@ -6473,6 +6475,7 @@ async function arahkan() {
     history.replaceState(null, "", hashLayar || "#/home");
     return;
   }
+  document.getElementById("cetakan")?.remove();
   hashLayar = tujuan;
   segarkanDiTempat = null;
   if (!sesi()) { layarLogin(); return; }
@@ -6525,6 +6528,9 @@ document.getElementById("nav-akun").addEventListener("click", keAkun);
 document.getElementById("nav-keluar").addEventListener("click", keluarSekarang);
 document.getElementById("ganti-password").addEventListener("click", keSetelan);
 window.addEventListener("hashchange", arahkan);
+window.addEventListener("afterprint", () => {
+  document.getElementById("cetakan")?.remove();
+});
 
 /* TIDAK ADA yang menyegarkan sendiri saat tab kembali terlihat.
 


### PR DESCRIPTION
## What

- remove temporary print output after the browser print dialog closes
- clear any remaining print output when an accepted navigation starts
- avoid installing an empty printout for a pos containing only written tests
- add regression coverage for all cleanup paths

## Why

Print documents live outside the routed screen container. Without cleanup, a later browser-initiated print can render the previous receipt, kloter sheet, or score form instead of the normal blank print state.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)