### PR TITLE
fix: render the settings error card

### DIFF
--- a/tests/error_card_rendering.test.mjs
+++ b/tests/error_card_rendering.test.mjs
@@ -1,0 +1,16 @@
+// kartuGalat menghasilkan string HTML; replaceChildren memerlukan fragmen DOM.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("semua kartu galat langsung diparse sebelum replaceChildren", () => {
+  assert.doesNotMatch(app, /replaceChildren\(kartuGalat\(/,
+    "markup kartuGalat masih dikirim sebagai text node");
+  assert.match(app,
+    /LAYAR\.replaceChildren\(h\(kartuGalat\(\s*"Akun ini tidak berhak membuka Kalkulator Keberangkatan\."\)\)\);/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -532,7 +532,8 @@ async function layarHome() {
 async function layarPengaturanKloter() {
   pasangKepala("Kalkulator Keberangkatan");
   if (!bolehLihat("pengaturan")) {
-    LAYAR.replaceChildren(kartuGalat("Akun ini tidak berhak membuka Kalkulator Keberangkatan."));
+    LAYAR.replaceChildren(h(kartuGalat(
+      "Akun ini tidak berhak membuka Kalkulator Keberangkatan.")));
     return;
   }
   LAYAR.replaceChildren(h(pemuat()));


### PR DESCRIPTION
## What

- parse the settings permission error markup before passing it to `replaceChildren`
- add a regression that rejects every direct `replaceChildren(kartuGalat(...))` call

## Why

`kartuGalat` returns an HTML string, while `replaceChildren` treats strings as text nodes. Opening the departure calculator without permission therefore displayed literal HTML instead of the intended error card.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)