### PR TITLE
fix: preserve pasted time minutes

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -385,7 +385,7 @@ export function kotakJamHtml(id, nilai = "") {
   const [hh = "", mm = ""] = String(nilai || "").split(":");
   return `<span class="jam-pasang" id="${id}">
     <input type="text" class="jam-ketik jam-hh" id="${id}-hh" value="${hh}"
-           inputmode="numeric" maxlength="2" autocomplete="off"
+           inputmode="numeric" autocomplete="off"
            spellcheck="false" placeholder="HH" aria-label="Jam">
     <span class="jam-titik" aria-hidden="true">:</span>
     <input type="text" class="jam-ketik jam-mm" id="${id}-mm" value="${mm}"

--- a/tests/time_input_paste.test.mjs
+++ b/tests/time_input_paste.test.mjs
@@ -1,0 +1,24 @@
+// Kotak HH harus menerima empat digit agar handler dapat memindahkan MM.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const util = await readFile(new URL("../web/js/util.js", import.meta.url), "utf8");
+const awal = util.indexOf("export function kotakJamHtml(");
+const akhir = util.indexOf("export function pasangKotakJam(", awal);
+const markup = util.slice(awal, akhir);
+
+
+test("kotak jam tidak memotong menit sebelum event paste", () => {
+  const hh = markup.match(/<input[^>]+class="jam-ketik jam-hh"[^>]+>/)?.[0] || "";
+  const mm = markup.match(/<input[^>]+class="jam-ketik jam-mm"[^>]+>/)?.[0] || "";
+
+  assert.doesNotMatch(hh, /maxlength=/,
+    "maxlength HH membuat browser membuang digit menit sebelum handler input");
+  assert.match(mm, /maxlength="2"/,
+    "kotak MM tetap harus membatasi isi langsung menjadi dua digit");
+  assert.match(util, /if \(angka\.length > 2\)[\s\S]*mm\.value = angka\.slice\(2, 4\)/,
+    "handler tidak lagi memindahkan digit ketiga dan keempat ke menit");
+});

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -385,7 +385,7 @@ export function kotakJamHtml(id, nilai = "") {
   const [hh = "", mm = ""] = String(nilai || "").split(":");
   return `<span class="jam-pasang" id="${id}">
     <input type="text" class="jam-ketik jam-hh" id="${id}-hh" value="${hh}"
-           inputmode="numeric" maxlength="2" autocomplete="off"
+           inputmode="numeric" autocomplete="off"
            spellcheck="false" placeholder="HH" aria-label="Jam">
     <span class="jam-titik" aria-hidden="true">:</span>
     <input type="text" class="jam-ketik jam-mm" id="${id}-mm" value="${mm}"


### PR DESCRIPTION
## What

- allow the hour field to receive all pasted digits before normalization
- keep the minute field limited to two direct digits
- preserve byte-identical shared utility files
- add regression coverage for the paste path

## Why

The browser enforced `maxlength=2` before the input handler ran, so pasting `1503` into the hour field discarded `03` instead of moving it into the minute field as designed.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)