### PR TITLE
fix: focus the invalid chest number

### DIFF
--- a/tests/registration_invalid_focus.test.mjs
+++ b/tests/registration_invalid_focus.test.mjs
@@ -1,0 +1,16 @@
+// Daftar ulang harus memfokuskan kotak nomor dada yang baru ditandai salah.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("fokus daftar ulang mengikuti class error yang benar-benar dipasang", () => {
+  assert.match(app, /classList\.add\("input-error"\)/);
+  assert.match(app,
+    /isian\.find\(i => i\.classList\.contains\("input-error"\)\)\?\.focus\(\)/);
+  assert.doesNotMatch(app, /galat-isian/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1439,7 +1439,7 @@ async function layarDaftarUlang() {
         }
         if (keluhan) {
           notif(keluhan, true);
-          isian.find(i => i.classList.contains("galat-isian"))?.focus();
+          isian.find(i => i.classList.contains("input-error"))?.focus();
           return;
         }
 


### PR DESCRIPTION
## What

- focus the first nomor dada input carrying the actual `input-error` marker
- add regression coverage that removes the unused `galat-isian` class name

## Why

The validation loop marked invalid fields with `input-error`, but the recovery path searched for a class that was never added. On phones, officers had to scroll through a large batch to find the red field manually.

Closes #473

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)