### PR TITLE
fix: avoid double-escaping school labels

### DIFF
--- a/tests/payment_school_label.test.mjs
+++ b/tests/payment_school_label.test.mjs
@@ -1,0 +1,18 @@
+// Nama sekolah yang sudah aman tidak boleh di-escape lagi di accessible name.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const awal = app.indexOf("async function layarPembayaran()");
+const akhir = app.indexOf("/* ============================ DAFTAR ULANG", awal);
+const pembayaran = app.slice(awal, akhir);
+
+
+test("label rincian pembayaran tidak meng-escape nama sekolah dua kali", () => {
+  assert.match(pembayaran, /const sekolah = esc\(b\.sekolah\?\.name \|\| "—"\)/);
+  assert.match(pembayaran, /aria-label="Lihat \$\{aktif\.length\} regu \$\{sekolah\}"/);
+  assert.doesNotMatch(pembayaran, /esc\(sekolah\)/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -941,7 +941,7 @@ async function layarPembayaran() {
             ${aktif.length
               ? `<button class="button-detail" type="button" data-detail="${kode}"
                          data-jumlah="${aktif.length}" aria-expanded="${terbuka}"
-                         aria-label="Lihat ${aktif.length} regu ${esc(sekolah)}">${
+                         aria-label="Lihat ${aktif.length} regu ${sekolah}">${
                    terbuka ? "▾" : "▸"} ${aktif.length}<span class="satuan-regu"> regu</span></button>`
               : aktif.length}
           </td>


### PR DESCRIPTION
## What

- reuse the already escaped school name in the payment-detail accessible label
- add a regression preventing a second `esc` call on that value

## Why

School names containing apostrophes or ampersands were escaped twice in the button's `aria-label`, causing screen readers to announce literal HTML entity text while the visible name remained correct.

Closes #467

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)