### PR TITLE
fix: associate time field labels

### DIFF
--- a/tests/time_input_labels.test.mjs
+++ b/tests/time_input_labels.test.mjs
@@ -1,0 +1,23 @@
+// Label kotak jam harus menunjuk input HH, bukan span pembungkusnya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("semua label kotak jam manual menunjuk input HH", () => {
+  const pasangan = [
+    ["kloter-pertama", "Waktu Berangkat Pertama"],
+    ["kloter-terakhir", "Waktu Berangkat Terakhir"],
+    ["jam-berangkat", "Jam berangkat"],
+    ["jam", "Jam datang"],
+  ];
+
+  for (const [id, label] of pasangan) {
+    assert.match(app, new RegExp(
+      `<label for="${id}-hh">${label}</label>[\\s\\S]{0,400}kotakJamHtml\\("${id}"`));
+  }
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -561,11 +561,11 @@ async function layarPengaturanKloter() {
     <div class="card">
       <div class="two-column">
         <div class="field">
-          <label>Waktu Berangkat Pertama</label>
+          <label for="kloter-pertama-hh">Waktu Berangkat Pertama</label>
           ${kotakJamHtml("kloter-pertama", pertamaAwal)}
         </div>
         <div class="field">
-          <label>Waktu Berangkat Terakhir</label>
+          <label for="kloter-terakhir-hh">Waktu Berangkat Terakhir</label>
           ${kotakJamHtml("kloter-terakhir", terakhirAwal)}
         </div>
       </div>
@@ -1674,7 +1674,7 @@ async function layarKeberangkatan() {
         ${sudahBerangkat ? "" : `
           <div class="departure-bar">
             <div class="field" style="margin:0">
-              <label for="jam-berangkat">Jam berangkat</label>
+              <label for="jam-berangkat-hh">Jam berangkat</label>
               <!-- Kotak ketik, bukan <input type="time">: pemilih bawaan
                    browser merender AM/PM kalau locale browsernya Inggris, dan
                    tidak ada atribut yang bisa memaksanya 24 jam. Lihat
@@ -2133,7 +2133,7 @@ function layarFinish() {
         </summary>
         <div class="two-column pasangan-sempit" style="margin-top:.5rem">
           <div class="field" style="margin:0">
-            <label for="jam">Jam datang</label>
+            <label for="jam-hh">Jam datang</label>
             <!-- Kotak ketik, alasan sama dengan jam berangkat: pemilih bawaan
                  browser bisa muncul sebagai AM/PM. Lihat jamSah() di util.js. -->
             ${kotakJamHtml("jam")}


### PR DESCRIPTION
## What

- point all hand-written time labels at their HH input
- cover the calculator, departure, and finish time fields
- add regression coverage for the label/input pairs

## Why

The time widget places its public id on a wrapper span and the actual inputs at `-hh` and `-mm`. Labels targeting the wrapper, or lacking a target, did not focus a field when tapped.

Closes #469

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)