### PR TITLE
fix: verify the print preview extractor

### DIFF
--- a/.github/workflows/sql-tests.yml
+++ b/.github/workflows/sql-tests.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Test JavaScript
         run: node --test tests/*.test.mjs
 
+      - name: Verify print preview extractor
+        run: python tools/pratinjau_cetak.py > /dev/null
+
       - name: Jalankan seluruh tes
         env:
           PGPASSWORD: hrcd

--- a/tests/print_preview_tool.test.mjs
+++ b/tests/print_preview_tool.test.mjs
@@ -1,0 +1,24 @@
+// Extractor cetak harus mengikuti aturan penyembunyi layar yang sebenarnya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const alat = await readFile(new URL("../tools/pratinjau_cetak.py", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+
+test("extractor mengenali seluruh selector layar yang disembunyikan", () => {
+  assert.match(css,
+    /\.header, \.isi, \.notification, \.overlay,\s*\.bottom-nav \{ display: none !important; \}/);
+  assert.match(alat,
+    /SEMBUNYI = \("\.header, \.isi, \.notification, \.overlay,\\n"\s*"  \.bottom-nav \{ display: none !important; \}"\)/);
+});
+
+
+test("workflow menjalankan extractor Python", async () => {
+  const workflow = await readFile(
+    new URL("../.github/workflows/sql-tests.yml", import.meta.url), "utf8");
+  assert.match(workflow, /python tools\/pratinjau_cetak\.py > \/dev\/null/);
+});

--- a/tools/pratinjau_cetak.py
+++ b/tools/pratinjau_cetak.py
@@ -24,7 +24,8 @@ from pathlib import Path
 
 AKAR = Path(__file__).resolve().parent.parent
 # Satu-satunya aturan yang memang tidak boleh ikut: penyembunyi layar.
-SEMBUNYI = ".header, .isi, .notification, .overlay { display: none !important; }"
+SEMBUNYI = (".header, .isi, .notification, .overlay,\n"
+            "  .bottom-nav { display: none !important; }")
 
 
 def css_cetak() -> str:


### PR DESCRIPTION
## What

- update the exact print-screen hiding rule used by the preview extractor
- add a workflow step that executes the Python extractor
- add local structural regression coverage for the CSS rule and workflow guard

## Why

Adding the bottom navigation to the print-only hiding selector made the extractor's exact-match safety check fail on every invocation. Nothing in CI ran the tool, so the breakage remained unnoticed.

Closes #501

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The 102-test local Node suite passes; Python is unavailable in this Windows environment, so direct Python execution remains delegated to the added CI step once runners are restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)