### PR TITLE
fix: print range hints in black

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -935,7 +935,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      layar, supaya petugas tidak perlu mengingat skalanya. */
   .print-table th .kolom-petunjuk {
     display: block; max-width: none; font-size: 7pt; font-weight: 400;
-    text-transform: none; margin-top: 1pt;
+    text-transform: none; margin-top: 1pt; color: #000;
     /* Di layar petunjuk sengaja tidak dipatahkan, di kertas ia BOLEH:
        lebar kolom di sini dibagi habis oleh lebar kertas, dan satu keterangan
        yang menolak membungkus akan mendorong kolom sebelahnya keluar halaman. */

--- a/tests/print_range_hint_color.test.mjs
+++ b/tests/print_range_hint_color.test.mjs
@@ -1,0 +1,20 @@
+// Petunjuk rentang harus tetap hitam ketika master difotokopi berulang kali.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+const awalPrint = css.indexOf("@media print {");
+const awalAturan = css.indexOf(".print-table th .kolom-petunjuk", awalPrint);
+const akhirAturan = css.indexOf("}", awalAturan);
+const aturan = css.slice(awalAturan, akhirAturan);
+
+
+test("petunjuk rentang cetak berwarna hitam", () => {
+  assert.notEqual(awalPrint, -1);
+  assert.notEqual(awalAturan, -1);
+  assert.match(aturan, /color:\s*#000/);
+  assert.doesNotMatch(aturan, /var\(--tinta-lembut\)|#5c5c5c/);
+});

--- a/web/style.css
+++ b/web/style.css
@@ -935,7 +935,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      layar, supaya petugas tidak perlu mengingat skalanya. */
   .print-table th .kolom-petunjuk {
     display: block; max-width: none; font-size: 7pt; font-weight: 400;
-    text-transform: none; margin-top: 1pt;
+    text-transform: none; margin-top: 1pt; color: #000;
     /* Di layar petunjuk sengaja tidak dipatahkan, di kertas ia BOLEH:
        lebar kolom di sini dibagi habis oleh lebar kertas, dan satu keterangan
        yang menolak membungkus akan mendorong kolom sebelahnya keluar halaman. */


### PR DESCRIPTION
## What

- force printed score-range hints to solid black
- keep the panitia and participant stylesheets byte-identical
- add regression coverage for the print override

## Why

The screen rule colored range hints gray, and the print override did not reset that color. Seven-point gray text degrades rapidly when the master form is photocopied repeatedly, contrary to the repository's print rules.

Closes #449

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The 103-test local Node suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)