### PR TITLE
fix: align print table utilities

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -900,6 +900,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     text-align: left;
     font-size: 11pt;
   }
+  .print-table th.text-center, .print-table td.text-center { text-align: center; }
+  .print-table th.text-right, .print-table td.text-right { text-align: right; }
   /* Kepala tabel TANPA raster abu-abu. #eee terlihat rapi di layar dan di
      printer laser, tapi kertas ini digandakan dengan fotokopi: raster halus
      itu keluar belang, atau menghitam sampai judul kolomnya sulit dibaca.

--- a/tests/print_table_alignment.test.mjs
+++ b/tests/print_table_alignment.test.mjs
@@ -1,0 +1,19 @@
+// Utility alignment harus mengalahkan text-align dasar sel tabel cetak.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+const awal = css.indexOf("@media print {");
+const akhir = css.indexOf("/* ---------- RESPONSIVE", awal);
+const cetak = css.slice(awal, akhir);
+
+
+test("utility alignment tabel cetak menargetkan th dan td", () => {
+  assert.match(cetak,
+    /\.print-table th\.text-right, \.print-table td\.text-right \{ text-align: right; \}/);
+  assert.match(cetak,
+    /\.print-table th\.text-center, \.print-table td\.text-center \{ text-align: center; \}/);
+});

--- a/web/style.css
+++ b/web/style.css
@@ -900,6 +900,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     text-align: left;
     font-size: 11pt;
   }
+  .print-table th.text-center, .print-table td.text-center { text-align: center; }
+  .print-table th.text-right, .print-table td.text-right { text-align: right; }
   /* Kepala tabel TANPA raster abu-abu. #eee terlihat rapi di layar dan di
      printer laser, tapi kertas ini digandakan dengan fotokopi: raster halus
      itu keluar belang, atau menghitam sampai judul kolomnya sulit dibaca.


### PR DESCRIPTION
## What

- add print-table-specific right and center alignment utilities
- keep both shared stylesheets identical
- add regression coverage for the required selector specificity

## Why

The base print cell rule was more specific than `.text-right`, so receipt amounts and the TOTAL row printed left-aligned even though their markup requested right alignment.

Closes #450

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The 104-test local Node suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)