### PR TITLE
fix: seed intern teams

### DIFF
--- a/tests/seed_team_categories.test.mjs
+++ b/tests/seed_team_categories.test.mjs
@@ -1,0 +1,16 @@
+// Alat seed rehearsal harus menerima seluruh golongan edisi aktif.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const alat = await readFile(
+  new URL("../tools/seed_regu_uji.py", import.meta.url), "utf8");
+
+
+test("alat seed memetakan dua golongan Intern", () => {
+  assert.match(alat, /"Intern PA": "intern_pa"/);
+  assert.match(alat, /"Intern PI": "intern_pi"/);
+  assert.doesNotMatch(alat, /Intern PA\/PI` juga dibuang/);
+});

--- a/tools/seed_regu_uji.py
+++ b/tools/seed_regu_uji.py
@@ -30,7 +30,8 @@ yang mengira nama-nama itu asli.
 
 Baris yang dibuang, dengan aturan yang sama seperti normalize_sekolah.py:
 nama kelas, organisasi, dan lelucon (`SMA 7 MARS`, `SMKN 1 Hogwarts`).
-Golongan `Intern PA/PI` juga dibuang — golongan itu tidak ada di edisi 37.
+Golongan `Intern PA/PI` tetap dimuat karena edisi 37 menerima keduanya dan
+memberi kuota kloter tersendiri (migrasi 0091–0093).
 
 PAKAI (database dev, JANGAN produksi):
 
@@ -57,6 +58,7 @@ DSN = " ".join([
 GOLONGAN = {
     "Penegak PA": "penegak_pa", "Penegak PI": "penegak_pi",
     "Penggalang PA": "penggalang_pa", "Penggalang PI": "penggalang_pi",
+    "Intern PA": "intern_pa", "Intern PI": "intern_pi",
 }
 # Sama dengan bukan_sekolah() di normalize_sekolah.py — dijaga tetap sama
 # supaya "sekolah" di sini berarti hal yang sama dengan di daftar sekolah.


### PR DESCRIPTION
## What

- accept Intern PA and Intern PI in the rehearsal seed tool
- document the active-edition behavior
- add a regression test for both mappings

## Why

The tool still dropped Intern teams using an obsolete four-category assumption, so a development rehearsal could omit the active Intern standings and quota paths.

Closes #459

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes (105/105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)