### PR TITLE
fix: remove duplicate icon sizing

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3174,10 +3174,6 @@ input.small-input { text-align: center; }
   .icon-button.berputar { animation-duration: 1.8s; }
 }
 
-/* Ikon SVG di dalam tombol: mengikuti font-size tombolnya, bukan ukuran
-   tetap, supaya satu ikon melayani tombol besar dan kecil sekaligus. */
-.icon-button .ikon { width: 1em; height: 1em; display: block; }
-
 /* Jumlah baris, cap refresh, dan tombolnya berjalan bersama. Sebagai anak
    lepas dari .table-toolbar, tombol itu jatuh sendirian ke baris baru begitu
    deretan saringan penuh — terpisah dari jam yang menerangkannya. */
@@ -3407,7 +3403,9 @@ input.small-input { text-align: center; }
    warna di papan rujukan. */
 /* Di dalam kotak bertint, ukuran dan warnanya diatur .ikon-kotak. */
 .function-name > .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
-.icon-button .ikon { width: 1.4em; height: 1.4em; }
+/* Ikon tombol mengikuti font-size tombolnya supaya satu aturan melayani
+   tombol besar dan kecil sekaligus. */
+.icon-button .ikon { width: 1.4em; height: 1.4em; display: block; }
 .bottom-nav-icon .ikon { width: 1.5em; height: 1.5em; }
 
 /* ============================================================================

--- a/tests/icon_styles.test.mjs
+++ b/tests/icon_styles.test.mjs
@@ -1,0 +1,15 @@
+// Ukuran ikon tombol tidak boleh diam-diam ditimpa selector duplikat.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+
+test("ikon tombol mempunyai satu deklarasi ukuran", () => {
+  const aturan = css.match(/\.icon-button \.ikon\s*\{[^}]+\}/g) || [];
+  assert.equal(aturan.length, 1);
+  assert.match(aturan[0], /width: 1\.4em; height: 1\.4em; display: block/);
+});

--- a/web/style.css
+++ b/web/style.css
@@ -3174,10 +3174,6 @@ input.small-input { text-align: center; }
   .icon-button.berputar { animation-duration: 1.8s; }
 }
 
-/* Ikon SVG di dalam tombol: mengikuti font-size tombolnya, bukan ukuran
-   tetap, supaya satu ikon melayani tombol besar dan kecil sekaligus. */
-.icon-button .ikon { width: 1em; height: 1em; display: block; }
-
 /* Jumlah baris, cap refresh, dan tombolnya berjalan bersama. Sebagai anak
    lepas dari .table-toolbar, tombol itu jatuh sendirian ke baris baru begitu
    deretan saringan penuh — terpisah dari jam yang menerangkannya. */
@@ -3407,7 +3403,9 @@ input.small-input { text-align: center; }
    warna di papan rujukan. */
 /* Di dalam kotak bertint, ukuran dan warnanya diatur .ikon-kotak. */
 .function-name > .ikon { width: 1.35em; height: 1.35em; color: var(--utama); }
-.icon-button .ikon { width: 1.4em; height: 1.4em; }
+/* Ikon tombol mengikuti font-size tombolnya supaya satu aturan melayani
+   tombol besar dan kecil sekaligus. */
+.icon-button .ikon { width: 1.4em; height: 1.4em; display: block; }
 .bottom-nav-icon .ikon { width: 1.5em; height: 1.5em; }
 
 /* ============================================================================


### PR DESCRIPTION
## What

- consolidate icon-button sizing into one CSS declaration
- preserve the existing rendered 1.4em size
- add a regression test that rejects duplicate sizing rules

## Why

Two identical selectors declared conflicting sizes, so the earlier documented 1em value was dead and edits to it had no visible effect.

Closes #461

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes (106/106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)