### PR TITLE
docs: update penalty preview comment

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2185,8 +2185,9 @@ function layarFinish() {
 
   // Angka penalti dipakai untuk menjawab pertanyaan yang sebenarnya saat
   // membandingkan catatan kertas dengan jam tombol: bukan "beda berapa menit",
-  // melainkan "apakah bedanya MENGUBAH penalti". Karena penalti dibulatkan per
-  // 10 menit, selisih semenit dua menit hampir selalu tidak berpengaruh.
+  // melainkan "apakah bedanya MENGUBAH penalti". Sejak migrasi 0089 setiap
+  // selisih satu menit mengubah penalti satu poin; badge yang ikut berubah pada
+  // tiap menit adalah perilaku yang disengaja, bukan noise.
   let PENALTI = null;
   infoPenalti().then(p => { PENALTI = p; }).catch(() => {});
 


### PR DESCRIPTION
## What

- replace the stale ten-minute penalty explanation
- document that every minute changes the penalty by one point
- clarify that minute-by-minute badge changes are intentional

## Why

The comment contradicted migration 0089 and could lead a maintainer to restore a tolerance that the active scoring rule explicitly removed.

Closes #472

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes (107/107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)