### PR TITLE
docs: describe blank form identity fields

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1031,10 +1031,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     border-top: 1.5pt solid #000; padding-top: 1.4mm;
   }
 
-  /* Identitas: SATU kotak besar untuk nomor dada, dan satu kotak catatan di
-     sebelahnya. Tidak ada kolom nama regu, sekolah, atau golongan — alasannya
-     di siapkanCetakBlangko(): ketiganya sudah ditentukan nomor dada, dan
-     menyalinnya ribuan kali adalah pekerjaan tanpa informasi baru.
+  /* Identitas: satu kotak besar untuk nomor dada, lalu kotak nama regu dan
+     pangkalan/sekolah, dengan baris kategori yang dilingkari. Nilainya tidak
+     dicetak per regu: seluruh blangko tetap master kosong yang sama karena
+     urutan kedatangan regu tidak bisa ditebak.
 
      Kotak nomor dada dibuat tinggi supaya angkanya bisa ditulis BESAR. Ia
      dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2841,31 +2841,17 @@ function contohIsian(kol) {
  *  kali satu regu masuk — pekerjaan yang lebih lama daripada lombanya sendiri,
  *  dilakukan sambil regu menunggu.
  *
- *  Jadi semua kertas identik, dan petugas menulis "005" di kotak paling kiri
- *  atas. Yang dicetak sistem bukan datanya, melainkan BENTUKNYA: nama lomba,
- *  satuan yang benar, contoh angkanya, dan tempat tanda tangan.
+ *  Jadi semua kertas identik; sistem mencetak BENTUKNYA, bukan satu lembar
+ *  yang sudah diisi untuk tiap regu. Petugas menulis nomor dada, nama regu,
+ *  dan pangkalan/sekolah, lalu melingkari satu kategori. Identitas yang tetap
+ *  menempel pada lembar lepas itu menjadi pemeriksaan kedua bila nomor dada
+ *  salah tulis atau sulit dibaca.
  *
- *  YANG DITULIS TANGAN HANYA NOMOR DADA.
- *
- *  Tidak ada kolom nama regu, sekolah, atau golongan — dan itu keputusan,
- *  bukan kelalaian. Ketiganya sudah ditentukan oleh nomor dada, jadi
- *  menuliskannya berarti menyalin ~30 huruf sebanyak 1.500 kali untuk
- *  informasi yang sudah dimiliki sistem. Di pos yang sedang mengantre, itu
- *  pekerjaan yang memakan waktu lomba itu sendiri.
- *
- *  Lebih buruk lagi: kolom yang terlalu mahal untuk diisi AKAN dikosongkan,
- *  dan kolom kosong yang bernama "konfirmasi" adalah pengaman palsu — ia
- *  membuat orang merasa ada pengecekan padahal tidak ada.
- *
- *  Pengecekannya memang ada, tapi bukan di kertas. Saat tim IT mengetik 005,
- *  baris di layar Input Pos langsung menampilkan nama regu, sekolahnya, dan
- *  golongannya. Salah ketik ketahuan di sana — tanpa satu huruf pun ditulis
- *  di lapangan.
- *
- *  Satu baris kecil tetap disediakan untuk keadaan yang benar-benar
- *  membutuhkan tulisan: nomor dadanya TIDAK TERBACA — robek, tertutup jaket,
- *  atau petugas ragu antara 6 dan 8. Tanpa tempatnya, catatan itu tetap
- *  ditulis, hanya saja di pinggir kertas tempat tidak ada yang mencarinya.
+ *  Nomor dada mendapat kotak terbesar karena itulah kunci utama saat tim IT
+ *  mengurutkan dan mengetik ratusan lembar. Kategori tidak ditulis ulang:
+ *  pilihannya sudah tercetak agar satu lingkaran cukup dan tidak bisa salah
+ *  eja. Nama lomba, satuan, tempat nilai, dan tanda tangan juga sudah menjadi
+ *  bagian bentuk yang sama pada setiap master.
  */
 function siapkanCetakBlangko(pos, kolomLayar) {
   document.getElementById("cetakan")?.remove();

--- a/web/style.css
+++ b/web/style.css
@@ -1031,10 +1031,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     border-top: 1.5pt solid #000; padding-top: 1.4mm;
   }
 
-  /* Identitas: SATU kotak besar untuk nomor dada, dan satu kotak catatan di
-     sebelahnya. Tidak ada kolom nama regu, sekolah, atau golongan — alasannya
-     di siapkanCetakBlangko(): ketiganya sudah ditentukan nomor dada, dan
-     menyalinnya ribuan kali adalah pekerjaan tanpa informasi baru.
+  /* Identitas: satu kotak besar untuk nomor dada, lalu kotak nama regu dan
+     pangkalan/sekolah, dengan baris kategori yang dilingkari. Nilainya tidak
+     dicetak per regu: seluruh blangko tetap master kosong yang sama karena
+     urutan kedatangan regu tidak bisa ditebak.
 
      Kotak nomor dada dibuat tinggi supaya angkanya bisa ditulis BESAR. Ia
      dibaca dua kali dalam keadaan yang sama-sama tergesa: saat petugas


### PR DESCRIPTION
## What

- document the handwritten team, school, and category fields on blank forms
- remove references to a nonexistent unreadable-number note line
- align both shared CSS comments with the rendered identity table

## Why

The existing comments emphatically denied fields that the same function deliberately prints, creating a trap for future form maintenance.

Closes #452

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes (107/107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)