### PR TITLE
refactor: remove unused batch API

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -383,22 +383,6 @@ export async function kirimPendaftaran(payload, tokenTurnstile) {
 
 /* ============================ MEJA ====================================== */
 
-export async function lihatBatch(kode) {
-  if (K.mode === "dev") return baca(`/batch?kode=${encodeURIComponent(kode)}`);
-  // order pada embed regu: urutan bacaan meja harus sama dengan urutan
-  // pemberian nomor oleh RPC (temuan review).
-  const d = await baca(null,
-    `pendaftaran?kode_pembayaran=eq.${encodeURIComponent(kode)}` +
-    `&select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping,butuh_barak,kontak_wa,` +
-    `sekolah(name,address),` +
-    `regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled),` +
-    `pembayaran(amount,method,nomor_kwitansi,verified_at)` +
-    `&regu.order=nama_regu.asc`);
-  if (!d.length)
-    throw new ErrorApi(`Kode ${kode} tidak ditemukan. Periksa lagi hurufnya.`);
-  return d[0];
-}
-
 export async function ringkasanMeja() {
   if (K.mode === "dev") return baca("/ringkasan");
   // Dihitung dari sisi regu supaya angkanya benar-benar "batch lunas yang
@@ -449,9 +433,6 @@ export const daftarUlang = (kode, pasangan) =>
 
 export const tukarNomor = (reguId, nomorBaru, alasan) =>
   rpc("tukar_nomor_dada", { p_regu: reguId, p_nomor_baru: nomorBaru, p_alasan: alasan });
-
-export const ubahPendamping = (kode, jumlah) =>
-  rpc("ubah_pendamping", { p_kode: kode, p_jumlah: jumlah });
 
 /* ============================ CETAK KLOTER ============================== */
 

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -290,31 +290,6 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         as regu_berangkat,
                       (select count(*) from closing_regu)::int as regu_datang
                     """, uid=p.get("uid"), fetch="one"))
-            elif u.path == "/batch":
-                b = q("""
-                    select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
-                           d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
-                           jsonb_build_object('name', s.name, 'address', s.address) as sekolah,
-                           (select jsonb_agg(jsonb_build_object(
-                              'id', r.id, 'nama_regu', r.nama_regu,
-                              'nama_ketua', r.nama_ketua, 'golongan', r.golongan,
-                              'nomor_dada', r.nomor_dada, 'kloter_nomor', r.kloter_nomor,
-                              'is_cancelled', r.is_cancelled)
-                              order by r.nama_regu)
-                            from regu r where r.pendaftaran_id = d.id) as regu,
-                           (select jsonb_build_object(
-                              'amount', b.amount, 'method', b.method,
-                              'nomor_kwitansi', b.nomor_kwitansi,
-                              'verified_at', b.verified_at)
-                            from pembayaran b where b.pendaftaran_id = d.id) as pembayaran
-                    from pendaftaran d join sekolah s on s.id = d.sekolah_id
-                    where d.kode_pembayaran = %s
-                    """, (p.get("kode", ""),), uid=p.get("uid"), fetch="one")
-                if b is None:
-                    self._kirim(404, {"message":
-                        f"Kode {p.get('kode')} tidak ditemukan. Periksa lagi hurufnya."})
-                else:
-                    self._kirim(200, b)
             else:
                 self._kirim(404, {"message": "tidak ada"})
         except psycopg2.Error as e:

--- a/tests/unused_batch_api.test.mjs
+++ b/tests/unused_batch_api.test.mjs
@@ -1,0 +1,18 @@
+// Jalur client yang tidak punya layar tidak boleh terlihat seperti fitur aktif.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const dev = await readFile(new URL("dev_server.py", import.meta.url), "utf8");
+
+
+test("wrapper batch tanpa pemanggil tidak dipublikasikan", () => {
+  assert.doesNotMatch(api, /\blihatBatch\b/);
+  assert.doesNotMatch(api, /\bubahPendamping\b/);
+  assert.doesNotMatch(dev, /u\.path == "\/batch"/);
+  // RPC tetap tersedia bila kelak layar koreksi pendamping benar-benar dibuat.
+  assert.match(dev, /"ubah_pendamping":\s*\["p_kode", "p_jumlah"\]/);
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -383,22 +383,6 @@ export async function kirimPendaftaran(payload, tokenTurnstile) {
 
 /* ============================ MEJA ====================================== */
 
-export async function lihatBatch(kode) {
-  if (K.mode === "dev") return baca(`/batch?kode=${encodeURIComponent(kode)}`);
-  // order pada embed regu: urutan bacaan meja harus sama dengan urutan
-  // pemberian nomor oleh RPC (temuan review).
-  const d = await baca(null,
-    `pendaftaran?kode_pembayaran=eq.${encodeURIComponent(kode)}` +
-    `&select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping,butuh_barak,kontak_wa,` +
-    `sekolah(name,address),` +
-    `regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled),` +
-    `pembayaran(amount,method,nomor_kwitansi,verified_at)` +
-    `&regu.order=nama_regu.asc`);
-  if (!d.length)
-    throw new ErrorApi(`Kode ${kode} tidak ditemukan. Periksa lagi hurufnya.`);
-  return d[0];
-}
-
 export async function ringkasanMeja() {
   if (K.mode === "dev") return baca("/ringkasan");
   // Dihitung dari sisi regu supaya angkanya benar-benar "batch lunas yang
@@ -449,9 +433,6 @@ export const daftarUlang = (kode, pasangan) =>
 
 export const tukarNomor = (reguId, nomorBaru, alasan) =>
   rpc("tukar_nomor_dada", { p_regu: reguId, p_nomor_baru: nomorBaru, p_alasan: alasan });
-
-export const ubahPendamping = (kode, jumlah) =>
-  rpc("ubah_pendamping", { p_kode: kode, p_jumlah: jumlah });
 
 /* ============================ CETAK KLOTER ============================== */
 


### PR DESCRIPTION
## What

- remove the unused lihatBatch and ubahPendamping client wrappers
- remove the orphaned development /batch GET route
- retain the ubah_pendamping RPC route for a future real correction screen
- add a regression test for the intended boundary

## Why

The exported wrappers had no caller but made unsupported client features look active; lihatBatch also kept an otherwise unused development route alive.

Closes #468

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit. The complete local Node suite passes (109/109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)