### PR TITLE
test: cover live phase value gate

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -100,6 +100,8 @@ run tests/sql/07_pindah_setelah_berangkat.sql
 # ditekan dua kali dari HP.
 run supabase/migrations/0024_komponen_pos.sql
 run tests/sql/08_lembar_pos.sql
+# Tes 09 menjaga bentuk historis view pada titik ini. Migrasi 0071/0072 nanti
+# mengganti kontraknya; tes 68 di bawah menjaga gerbang fase bentuk terbaru.
 run tests/sql/09_rekap_publik.sql
 # 10 dijalankan di ujung, dan itu perlu: ia membandingkan rekap panitia
 # dengan v_poin_pos, v_total_skor, dan v_klasemen, jadi ia butuh database yang
@@ -272,6 +274,7 @@ run supabase/migrations/0071_ringkas_publik_terdaftar.sql
 # v_progres_publik, supaya halaman peserta bisa menggambar tabel yang sama
 # bentuknya dengan layar panitia.
 run supabase/migrations/0072_progres_komponen_publik.sql
+run tests/sql/68_live_phase_value_gate.sql
 # 0073 mengganti nama satu sekolah. Ikut dijalankan supaya berkasnya tetap
 # teruji; di database uji ia memang tidak menemukan apa pun.
 run supabase/migrations/0073_nama_al_azhar_citangkolo.sql

--- a/tests/sql/68_live_phase_value_gate.sql
+++ b/tests/sql/68_live_phase_value_gate.sql
@@ -1,0 +1,57 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/68_live_phase_value_gate.sql
+-- Gerbang nilai pada bentuk TERBARU v_progres_publik (migrasi 0072).
+--
+-- komponen_terisi memang boleh terbit sejak fase progres karena hanya membawa
+-- centang. Nilai mentah tidak boleh ikut sampai fase penuh; menyembunyikannya
+-- di tampilan tidak cukup karena rekap.json dapat diminta langsung dari CDN.
+-- ============================================================================
+
+reset role;
+
+do $$
+declare
+  v_fase_asli text;
+  v_dada smallint;
+  v_komponen jsonb;
+begin
+  select fase_live into strict v_fase_asli from status_acara where id = true;
+
+  update status_acara set fase_live = 'progres' where id = true;
+
+  assert (select count(*) from v_progres_publik) > 0,
+         'fase progres kosong; gerbang nilai tidak benar-benar diuji';
+  assert not exists (
+    select 1 from v_progres_publik where nilai <> '{}'::jsonb
+  ), 'BOCOR: nilai keluar sebelum fase penuh';
+
+  -- Pilih regu yang sudah punya nilai. Centangnya harus terlihat sekarang,
+  -- lalu tetap sama setelah fase dibuka penuh.
+  select p.nomor_dada, p.komponen_terisi
+    into v_dada, v_komponen
+  from v_progres_publik p
+  where exists (
+    select 1
+    from jsonb_each_text(p.komponen_terisi) as isi(kode, terisi)
+    where isi.terisi::boolean
+  )
+  order by p.nomor_dada
+  limit 1;
+
+  assert v_dada is not null,
+         'tidak ada komponen terisi; gerbang nilai tidak benar-benar diuji';
+
+  update status_acara set fase_live = 'penuh' where id = true;
+
+  assert (select komponen_terisi = v_komponen
+          from v_progres_publik where nomor_dada = v_dada),
+         'centang komponen berubah ketika fase dibuka penuh';
+  assert (select nilai <> '{}'::jsonb
+          from v_progres_publik where nomor_dada = v_dada),
+         'nilai tetap kosong di fase penuh';
+
+  update status_acara set fase_live = v_fase_asli where id = true;
+end;
+$$;
+
+select '68_live_phase_value_gate OK' as hasil;


### PR DESCRIPTION
## What

- add a post-0072 SQL test for the live value gate
- assert progress publishes component checks but no raw values
- assert full phase preserves those checks and publishes values
- document why historical test 09 remains at its original migration point

## Why

The only existing public-recap test ran before migrations 0071 and 0072, so it never exercised the current nilai column or its phase gate.

Closes #502

## Notes

GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit, and PostgreSQL is not available locally. The structural runner checks and complete local Node suite pass (109/109); the new SQL assertion could not be executed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)