### PR TITLE
test: execute live JSON query

### DIFF
--- a/tests/live_json_check.test.mjs
+++ b/tests/live_json_check.test.mjs
@@ -1,0 +1,17 @@
+// Query penerbitan peserta harus diparse oleh PostgreSQL pada setiap suite.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const runner = await readFile(new URL("run.sh", import.meta.url), "utf8");
+const publish = await readFile(
+  new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
+
+
+test("suite dan workflow menjalankan query live.json yang sama", () => {
+  const perintah = "supabase/checks/live_json.sql";
+  assert.match(runner, new RegExp(`^run ${perintah.replaceAll("/", "\\/")}$`, "m"));
+  assert.match(publish, new RegExp(perintah.replaceAll("/", "\\/")));
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -454,6 +454,9 @@ run tests/sql/66_kloter_capacity_headroom.sql
 # harus menyebut rentang yang dilihat petugas di kotak, bukan angka penyimpanan.
 run supabase/migrations/0106_format_input_range_units.sql
 run tests/sql/67_input_range_units.sql
+# Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
+# migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
+run supabase/checks/live_json.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.

--- a/tests/sql/09_rekap_publik.sql
+++ b/tests/sql/09_rekap_publik.sql
@@ -120,8 +120,9 @@ end;
 $$;
 
 -- ---------------------------------------------------------------------------
--- 9.4 Berkas yang benar-benar diterbitkan.
---     Query yang sama persis dengan yang dipakai publish-live.yml.
+-- 9.4 Bentuk terbitan historis pada titik migrasi ini.
+--     Query produksi lengkap dijalankan langsung dari live_json.sql di ujung
+--     run.sh setelah seluruh migrasi; subset ini hanya menjaga pagar fase lama.
 -- ---------------------------------------------------------------------------
 
 reset role;


### PR DESCRIPTION
## What

- execute supabase/checks/live_json.sql after the final migration
- add a structural test that keeps CI and publish on the same query file
- relabel test 09's partial JSON as its historical migration-point shape

## Why

The production participant-data query was never parsed by the SQL suite, so its complete view and column contract could drift until publish time.

Closes #454

## Notes

The complete local PostgreSQL suite and Node suite pass (110/110 Node tests). GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)