### PR TITLE
test: verify cleanup resets event state

### DIFF
--- a/tests/sql/55_cleanup_preserves_schools.sql
+++ b/tests/sql/55_cleanup_preserves_schools.sql
@@ -8,6 +8,31 @@
 
 create temporary table sekolah_sebelum_cleanup as table sekolah;
 
+-- Bentuk sendiri seluruh state yang wajib dipulihkan. Test tidak boleh
+-- bergantung pada kebetulan test sebelumnya meninggalkan state ini.
+update kloter set
+  jam_berangkat = timestamptz '2026-08-29 07:00+07',
+  dicetak_pada = timestamptz '2026-08-28 20:00+07'
+where nomor = (select min(nomor) from kloter);
+update status_acara set
+  daftar_ulang_ditutup = true,
+  fase_live = 'penuh',
+  konfigurasi_terkunci = true
+where id = true;
+
+do $$
+begin
+  assert exists (select 1 from kloter where jam_berangkat is not null),
+         'fixture cleanup tidak punya jam berangkat';
+  assert exists (select 1 from kloter where dicetak_pada is not null),
+         'fixture cleanup tidak punya tanda cetak';
+  assert (select daftar_ulang_ditutup and fase_live = 'penuh'
+                 and konfigurasi_terkunci
+          from status_acara where id = true),
+         'fixture cleanup tidak memasang saklar hari-H';
+end;
+$$;
+
 \ir ../../supabase/checks/cleanup_data_uji.sql
 
 do $$
@@ -22,5 +47,13 @@ begin
          'cleanup tidak menghapus seluruh pendaftaran';
   assert (select count(*) from regu) = 0,
          'cleanup tidak menghapus seluruh regu';
+  assert not exists (select 1 from kloter where jam_berangkat is not null),
+         'cleanup meninggalkan jam berangkat di kloter';
+  assert not exists (select 1 from kloter where dicetak_pada is not null),
+         'cleanup meninggalkan tanda cetak di kloter';
+  assert (select not daftar_ulang_ditutup and fase_live = 'pra'
+                 and not konfigurasi_terkunci
+          from status_acara where id = true),
+         'cleanup tidak mengembalikan saklar hari-H';
 end;
 $$;


### PR DESCRIPTION
## What

- create explicit departure, print, and event-switch cleanup fixtures
- assert the fixtures are meaningful before cleanup runs
- assert cleanup clears kloter timestamps and restores all day-of-event switches

## Why

The cleanup test only checked schools and team data, so removal of the kloter and status reset statements would still leave the suite green.

Closes #458

## Notes

The complete local PostgreSQL suite and Node suite pass (110/110 Node tests). GitHub-hosted jobs are currently blocked by the repository owner's billing/spending limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)