### PR TITLE
test: compare agent instructions

### DIFF
--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -59,6 +59,16 @@ jobs:
           banding web/js/api.js   live/js/api.js
           banding web/js/util.js  live/js/util.js
 
+          # Kedua berkas punya preamble berbeda panjang, lalu isi aturan yang
+          # wajib sama. Drift pasangan ini pernah menghilangkan 21 baris.
+          if ! diff -q <(tail -n +5 CLAUDE.md) <(tail -n +7 AGENTS.md) >/dev/null; then
+            echo "MENYIMPANG: isi AGENTS.md tidak sama dengan CLAUDE.md"
+            diff -u <(tail -n +5 CLAUDE.md) <(tail -n +7 AGENTS.md) | head -40 || true
+            gagal=1
+          else
+            echo "sama: isi CLAUDE.md dan AGENTS.md"
+          fi
+
           if [ "$gagal" -ne 0 ]; then
             echo ""
             echo "Salin ulang dari web/ (acuan), jangan sunting salinannya:"


### PR DESCRIPTION
## What

- compare the shared rule bodies in CLAUDE.md and AGENTS.md
- account for their intentionally different preamble lengths
- report the first diff when they diverge

## Why

The pair previously drifted by 21 lines, while the shared-files workflow only protected web/live copies.

Closes #455

## Notes

The local comparison and complete Node suite pass (110/110). GitHub-hosted jobs remain blocked by the repository owner's billing/spending limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)