### PR TITLE
test: check all shared imports

### DIFF
--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -83,7 +83,7 @@ jobs:
       # itu dijalankan: `node --check` lulus, halaman terbuka normal, dan
       # galatnya baru muncul saat petugas menekan tombolnya di lapangan.
       # `kunciNilaiPos` pernah lolos sampai produksi persis begitu.
-      - name: Setiap fungsi api.js yang dipanggil app.js benar-benar diimpor
+      - name: Setiap fungsi shared module yang dipanggil benar-benar diimpor
         run: python tools/periksa_impor.py
 
       # Golongan kini tinggal di web/js/util.js — berkas yang sudah dibandingkan

--- a/tests/import_checker_scope.test.mjs
+++ b/tests/import_checker_scope.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const alat = await readFile(new URL("../tools/periksa_impor.py", import.meta.url), "utf8");
+
+
+test("checker mencakup seluruh pemakai shared module", () => {
+  for (const berkas of ["web/js/app.js", "live/js/daftar.js", "live/live.js"]) {
+    assert.match(alat, new RegExp(berkas.replaceAll("/", "\\/")));
+  }
+  assert.match(alat, /"\.\/api\.js"/);
+  assert.match(alat, /"\.\/util\.js"/);
+  assert.match(alat, /"\.\/js\/util\.js"/);
+});

--- a/tools/periksa_impor.py
+++ b/tools/periksa_impor.py
@@ -1,4 +1,4 @@
-r"""Pastikan setiap fungsi api.js yang DIPANGGIL app.js benar-benar diimpor.
+r"""Pastikan fungsi shared module yang DIPANGGIL benar-benar diimpor.
 
 KENAPA BERKAS INI ADA
 
@@ -22,15 +22,17 @@ from pathlib import Path
 AKAR = Path(__file__).resolve().parent.parent
 
 
-def periksa(app_path: Path, api_path: Path) -> list[str]:
+def periksa(app_path: Path, sumber_path: Path, modul: str) -> list[str]:
     app = app_path.read_text(encoding="utf-8")
-    api = api_path.read_text(encoding="utf-8")
+    sumber = sumber_path.read_text(encoding="utf-8")
 
     ekspor = set(re.findall(
-        r"export\s+(?:async\s+function|function|const)\s+(\w+)", api))
-    m = re.search(r'import\s*\{([^}]*)\}\s*from\s*"\./api\.js"', app, re.S)
+        r"export\s+(?:async\s+function|function|const)\s+(\w+)", sumber))
+    m = re.search(
+        r'import\s*\{([^}]*)\}\s*from\s*["\']' + re.escape(modul) + r'["\']',
+        app, re.S)
     if not m:
-        raise SystemExit(f"{app_path}: pernyataan import api.js tidak ditemukan")
+        raise SystemExit(f"{app_path}: pernyataan import {modul} tidak ditemukan")
     diimpor = {x.strip() for x in m.group(1).replace("\n", " ").split(",") if x.strip()}
 
     # Hanya badan SESUDAH importnya — kalau tidak, daftar impor itu sendiri
@@ -62,10 +64,20 @@ def tanpa_komentar(kode: str) -> str:
 
 
 if __name__ == "__main__":
-    kurang = periksa(AKAR / "web" / "js" / "app.js", AKAR / "web" / "js" / "api.js")
-    if kurang:
-        print("Dipanggil app.js tapi TIDAK diimpor dari api.js:")
-        for n in kurang:
-            print(f"  {n}")
+    pasangan = [
+        ("web/js/app.js", "web/js/api.js", "./api.js"),
+        ("web/js/app.js", "web/js/util.js", "./util.js"),
+        ("live/js/daftar.js", "live/js/api.js", "./api.js"),
+        ("live/js/daftar.js", "live/js/util.js", "./util.js"),
+        ("live/live.js", "live/js/util.js", "./js/util.js"),
+    ]
+    gagal = []
+    for pemakai, sumber, modul in pasangan:
+        for nama in periksa(AKAR / pemakai, AKAR / sumber, modul):
+            gagal.append((pemakai, modul, nama))
+    if gagal:
+        print("Dipanggil tetapi TIDAK diimpor dari shared module:")
+        for pemakai, modul, nama in gagal:
+            print(f"  {pemakai}: {nama} dari {modul}")
         sys.exit(1)
-    print("Semua fungsi api.js yang dipanggil app.js sudah diimpor.")
+    print("Semua fungsi shared module yang dipanggil sudah diimpor.")


### PR DESCRIPTION
## What

- parameterize the shared-module import checker
- cover app.js, the registration form, and participant Live Score
- check both api.js and util.js imports
- add a structural scope regression test

## Why

The checker only covered app.js calls into api.js, leaving the public registration and Live Score consumers unchecked.

Closes #456

## Notes

The complete local Node suite passes (111/111). Python is not installed in this Windows environment, and GitHub-hosted jobs remain blocked by the repository owner's billing/spending limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)