### PR TITLE
feat: show final score per lomba on Live Score

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -136,10 +136,18 @@ jobs:
           # angka pun. Pemisahan itu satu-satunya jaminan bahwa nilai yang
           # belum diumumkan memang TIDAK ADA di CDN, bukan sekadar tidak
           # digambar.
+          #
+          # `poin` ikut dijaga, dan itu bukan kehati-hatian berlebihan: ia
+          # DITURUNKAN dari nilai lewat hitung_poin(), jadi menerbitkannya
+          # lebih awal membocorkan hasil lomba sama telanjangnya. Papan Live
+          # Score sekarang menggambar poin, bukan angka mentah — kalau pagar
+          # ini cuma menyebut `nilai`, yang bocor justru kolom yang dibaca
+          # orang.
           if d['fase'] != 'penuh':
               for baris in d['progres']:
-                  if baris.get('nilai'):
-                      sys.exit('BOCOR: nilai per komponen tertulis padahal fase belum penuh')
+                  for kunci in ('nilai', 'poin'):
+                      if baris.get(kunci):
+                          sys.exit(f'BOCOR: {kunci} per komponen tertulis padahal fase belum penuh')
 
           rekap = {'progres': d['progres'], 'klasemen': d['klasemen']}
           sidik = hashlib.sha256(json.dumps(

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **23 Agustus 2026**, sampai migrasi `0106`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0107`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-106 migrasi, `0001` sampai `0106`, dijalankan berurutan tanpa lubang penomoran.
+107 migrasi, `0001` sampai `0107`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/live.css
+++ b/live/live.css
@@ -111,13 +111,11 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 /* Kolom komponen: sempit, rata tengah, dan judulnya boleh membungkus.
    Bentuknya mengikuti tabel panitia — satu kolom per komponen, bukan per
    pos. */
-/* Rentang di bawah nama kolom: kecil, tidak tebal, tidak berteriak. Ia
-   keterangan, bukan judul — dan kalau setebal judulnya, mata membaca dua
-   judul untuk satu kolom. */
-.tabel .kolom-petunjuk {
-  display: block; font-size: .62rem; font-weight: 400; opacity: .75;
-  white-space: nowrap; letter-spacing: normal;
-}
+/* Rentang di bawah nama kolom SUDAH TIDAK ADA di papan ini, dan aturannya
+   ikut dibuang bersamanya: yang tergambar di bawah kepala kolom sekarang poin
+   akhir, sementara rentang menjelaskan apa yang boleh DIKETIK — dan di sini
+   tidak ada yang mengetik apa pun. Rentangnya tetap hidup di layar Input Pos
+   dan Rekapitulasi lewat `.kolom-petunjuk` di web/style.css. */
 .tabel th.kol-komponen { font-size: .72rem; font-weight: 600; white-space: normal;
   line-height: 1.15; }
 .tabel td.pos { text-align: center; }

--- a/live/live.js
+++ b/live/live.js
@@ -60,7 +60,7 @@
    ditunda sampai DOM siap, yang justru lebih aman daripada sebelumnya. */
 import {
   esc, dada3, jamMenit, tanggalJam, berapaLalu,
-  angkaRapi, petunjukKolom, nilaiBagian,
+  angkaRapi,
   GOLONGAN_LABEL, URUT_GOLONGAN,
 } from "./js/util.js";
 
@@ -363,15 +363,7 @@ function gambarPapan() {
     const milik = komponen.filter(w => w.pos === p.nomor);
     const nama = [];
     for (const w of milik) if (!nama.includes(w.name)) nama.push(w.name);
-    // Satu nama kolom bisa punya beberapa varian golongan dengan rentang
-    // berbeda (Tebak Simpul 0-5 untuk Penggalang, 0-10 untuk Penegak).
-    // Keduanya ditulis, dipisah garis miring — sama seperti blangko cetak.
-    const petunjuk = {};
-    for (const nm of nama) {
-      petunjuk[nm] = [...new Set(milik.filter(w => w.name === nm)
-        .map(petunjukKolom).filter(Boolean))].join(" / ");
-    }
-    return { pos: p, nama, milik, petunjuk };
+    return { pos: p, nama, milik };
   }).filter(x => x.nama.length);
 
   const kartu = URUT_GOLONGAN_PESERTA.map(g => {
@@ -423,15 +415,17 @@ function gambarPapan() {
                         : `Pos ${x.pos.nomor} · ${x.pos.name}`)}</th>`).join("")}
                 ${penuh ? `<th rowspan="2">Penalti</th><th rowspan="2">Total</th>` : ""}
               </tr>
+              <!-- Nama lomba saja, TANPA rentang. Yang tergambar di bawahnya
+                   sudah poin akhir, dan "0 – 5" di kepala kolom berisi 80
+                   membantahnya. Rentang menjelaskan apa yang boleh DIKETIK,
+                   dan di papan ini tidak ada yang mengetik apa pun. -->
               <tr>${perPos.map(x => x.nama.map(nm =>
-                `<th class="pos kol-komponen">${esc(nm)}${x.petunjuk[nm]
-                  ? `<span class="kolom-petunjuk">${esc(x.petunjuk[nm])}</span>`
-                  : ""}</th>`).join("")).join("")}</tr>
+                `<th class="pos kol-komponen">${esc(nm)}</th>`).join("")).join("")}</tr>
             </thead>
             <tbody>
               ${baris.map(b => {
                 const terisi = b.komponen_terisi || {};
-                const angka = b.nilai || {};
+                const poin = b.poin || {};
                 const sel = perPos.map(x => x.nama.map(nm => {
                   const w = x.milik.find(k =>
                     k.name === nm && (!k.golongan || k.golongan === b.golongan));
@@ -441,16 +435,18 @@ function gambarPapan() {
                     const ada = terisi[kunci];
                     return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : ""}</td>`;
                   }
-                  const v = angka[kunci];
-                  if (!v || v.nilai_1 === null || v.nilai_1 === undefined) {
+                  // POIN AKHIR, bukan angka mentah. "4" di Semaphore, "8.55"
+                  // di Menaksir, dan "01:14" di Bakiak adalah tiga satuan yang
+                  // berbeda dan tidak satu pun menyebut sumbangannya ke Total
+                  // di ujung baris — sementara yang membaca papan ini persis
+                  // orang yang tidak memegang tangga poin tiap lomba.
+                  // Angkanya datang JADI dari rekap.json (migrasi 0107);
+                  // halaman ini tidak menghitung apa pun.
+                  const p = poin[kunci];
+                  if (p === null || p === undefined) {
                     return `<td class="pos belum">–</td>`;
                   }
-                  // Dieja nilaiBagian() — fungsi yang sama dengan papan
-                  // panitia. Sebelumnya String() mentah: 74 detik tergambar
-                  // "74" di sini dan "01:14" di sana, untuk angka yang sama,
-                  // di fase `penuh` yang justru pengumuman juaranya.
-                  const bagian = nilaiBagian(w, v.nilai_1, v.nilai_2);
-                  return `<td class="pos ada">${bagian.map(esc).join(" / ")}</td>`;
+                  return `<td class="pos ada">${esc(angkaRapi(p))}</td>`;
                 }).join("")).join("");
                 const penalti = penuh
                   ? Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)

--- a/supabase/migrations/0107_poin_per_komponen.sql
+++ b/supabase/migrations/0107_poin_per_komponen.sql
@@ -1,0 +1,243 @@
+-- ============================================================================
+-- hrcd-rekap : 0107_poin_per_komponen.sql
+-- Poin akhir TIAP KOMPONEN, supaya Live Score bisa menampilkan nilai — bukan
+-- angka mentahnya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Live Score dibaca orang yang ingin tahu SIAPA UNGGUL, bukan berapa detik
+-- larinya. Sampai sekarang tabel rinciannya menampilkan angka mentah, dan
+-- angka mentah tidak bisa dibandingkan antar kolom:
+--
+--   Semaphore   "4"      lima huruf benar -> sebenarnya 80 poin
+--   Menaksir    "8.55"   meter            -> sebenarnya 100 poin
+--   Bakiak      "01:14"  waktu tempuh     -> sebenarnya 60 poin
+--
+-- Tiga kolom bersebelahan, tiga satuan berbeda, dan tidak satu pun menyebut
+-- sumbangannya ke Total di ujung baris. Pembaca harus tahu tangga poin tiap
+-- lomba di kepalanya sebelum baris itu berarti apa-apa — dan yang membaca
+-- papan ini justru orang yang paling tidak punya tangga itu: pembina, peserta,
+-- dan panitia yang bukan juri lomba tersebut.
+--
+-- Rekapitulasi panitia (#/rekap) TIDAK ikut berubah. Di sana angka mentah
+-- justru yang dicari: ia lembar kerja untuk mencocokkan layar dengan kertas.
+
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KOLOM BARU, BUKAN DIHITUNG DI BROWSER
+--
+-- "Layar tidak pernah menghitung skor sendiri, supaya tidak ada mesin skor
+-- kedua yang bisa berbeda pendapat dengan v_poin_pos" — komentar itu sudah
+-- ada di kepala layar Input Pos dan Rekapitulasi, dan berlaku sama di sini.
+-- Menyalin `hitung_poin` ke JavaScript berarti tangga Menaksir hidup di dua
+-- tempat, dan yang di browser akan basi pada edisi pertama yang mengubahnya.
+--
+-- ---------------------------------------------------------------------------
+-- DUA VIEW, DUA CARA MENGAMBILNYA — DAN ITU BUKAN KELALAIAN
+--
+-- `v_rekap_penuh` security_invoker, jadi ia boleh memakai `v_poin_wahana`
+-- (yang juga invoker): keduanya diperiksa terhadap hak pemanggil yang sama.
+--
+-- `v_progres_publik` DEFINER — itulah yang membuat anon boleh membacanya.
+-- View invoker yang dipanggil dari dalam view definer tetap diperiksa
+-- terhadap hak PEMANGGIL, jadi `v_poin_wahana` di dalamnya akan mengembalikan
+-- nol baris untuk anon, tanpa satu pun galat. Karena itu yang di sana
+-- memanggil `hitung_poin()` langsung atas tabel dasarnya — pola yang sama
+-- persis dengan kolom `nilai` yang sudah ada di view itu, dan dengan
+-- `v_lembar_pos` (lihat 0085 bagian 3b).
+--
+-- ---------------------------------------------------------------------------
+-- KOLOMNYA DITAMBAH DI UJUNG, dan itu keharusan, bukan selera.
+-- `create or replace view` menolak daftar kolom yang berubah urutan atau
+-- tipenya; hanya penambahan di belakang yang diizinkan. Menyisipkan `poin` di
+-- sebelah `nilai` akan menuntut drop + create, dan drop membuang GRANT-nya —
+-- termasuk `grant select ... to anon` yang menghidupkan halaman peserta.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. v_rekap_penuh — badannya disalin utuh dari definisi termuda (0065, lalu
+--    saringannya dilebarkan 0069). Yang bertambah: satu CTE dan satu kolom.
+-- ---------------------------------------------------------------------------
+create or replace view v_rekap_penuh with (security_invoker = on) as
+with nilai_per_regu as (
+  select
+    n.regu_id,
+    jsonb_object_agg(w.pos || '.' || w.kode, jsonb_build_object(
+      'nilai_1', n.nilai_1, 'nilai_2', n.nilai_2)) as nilai
+  from nilai_mentah n
+  join wahana w on w.id = n.wahana_id
+  where w.edisi = edisi_aktif()
+  group by n.regu_id
+),
+poin_per_regu as (
+  select pp.regu_id, jsonb_object_agg(pp.pos::text, pp.poin_pos) as poin_pos
+  from v_poin_pos pp
+  group by pp.regu_id
+),
+-- BARU. Kuncinya `pos.kode`, sama persis dengan `nilai` di atas, supaya layar
+-- membaca keduanya dengan kunci yang sama dan tidak perlu memetakan apa pun.
+poin_per_komponen as (
+  select pk.regu_id,
+         jsonb_object_agg(pk.pos || '.' || pk.kode, pk.poin) as poin
+  from v_poin_wahana pk
+  group by pk.regu_id
+),
+berangkat as (
+  select distinct kb.regu_id from keberangkatan_regu kb
+)
+select
+  r.id            as regu_id,
+  kl.peringkat,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name          as nama_sekolah,
+  r.golongan,
+
+  coalesce(npr.nilai,    '{}'::jsonb) as nilai,
+  coalesce(ppr.poin_pos, '{}'::jsonb) as poin_pos,
+
+  r.kloter_nomor  as kloter,
+  k.jam_berangkat,
+  c.jam_datang,
+  r.kontrak_menit,
+  pw.selisih_menit,
+  case when k.jam_berangkat is not null and c.jam_datang is not null
+    then round(extract(epoch from (c.jam_datang - k.jam_berangkat)) / 60)::int
+  end             as tempuh_menit,
+  c.anggota_hadir,
+
+  t.total_pos,
+  pw.penalti_waktu,
+  t.penalti_checkout,
+  t.penalti_anggota,
+  t.total,
+
+  (b.regu_id is not null) as sudah_berangkat,
+  (c.regu_id is not null) as sudah_closing,
+
+  -- Kolom BARU, di ujung. Lihat kepala berkas.
+  coalesce(pkm.poin, '{}'::jsonb) as poin
+
+from regu r
+join pendaftaran d       on d.id = r.pendaftaran_id
+join sekolah s           on s.id = d.sekolah_id
+join v_total_skor t      on t.regu_id = r.id
+join v_penalti_waktu pw  on pw.regu_id = r.id
+left join v_klasemen kl  on kl.regu_id = r.id
+left join kloter k       on k.nomor = r.kloter_nomor
+left join closing_regu c on c.regu_id = r.id
+left join nilai_per_regu npr on npr.regu_id = r.id
+left join poin_per_regu ppr  on ppr.regu_id = r.id
+left join poin_per_komponen pkm on pkm.regu_id = r.id
+left join berangkat b        on b.regu_id = r.id
+where boleh_apa_saja('rekap', 'live_score');
+
+comment on view v_rekap_penuh is
+  'Rekap lengkap panitia. `nilai` angka mentah per komponen, `poin` poin akhir per komponen, `poin_pos` totalnya per pos. Haknya lewat boleh(rekap) atau boleh(live_score).';
+
+-- ---------------------------------------------------------------------------
+-- 2. v_progres_publik — badannya disalin utuh dari 0072. Yang bertambah satu
+--    kolom, dengan pagar fase yang SAMA PERSIS dengan `nilai` di atasnya.
+--
+--    Pagar itu bukan hiasan: poin diturunkan dari nilai, jadi menerbitkannya
+--    lebih awal membocorkan hasil lomba sama telanjangnya dengan menerbitkan
+--    angka mentahnya. publish-live.yml memeriksa keduanya (CLAUDE.md 14.4).
+-- ---------------------------------------------------------------------------
+create or replace view v_progres_publik as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.name as nama_sekolah,
+  r.golongan,
+  (select jsonb_object_agg(p.nomor::text,
+            exists (select 1 from nilai_mentah n
+                    join wahana w on w.id = n.wahana_id
+                    where n.regu_id = r.id and w.pos = p.nomor))
+   from pos p
+   where p.edisi = edisi_aktif()
+     and exists (select 1 from wahana w
+                 where w.edisi = p.edisi and w.pos = p.nomor)) as pos_terlewati,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing,
+  r.kloter_nomor                              as kloter,
+  r.kontrak_menit,
+  k.jam_berangkat,
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+    then k.jam_berangkat + make_interval(mins => r.kontrak_menit)
+  end                                         as target_datang,
+  c.jam_datang,
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                                              as sudah_berangkat,
+
+  (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+            exists (select 1 from nilai_mentah n
+                     where n.regu_id = r.id and n.wahana_id = w.id)), '{}'::jsonb)
+   from wahana w
+   where w.edisi = edisi_aktif()
+     and (w.golongan is null or w.golongan = r.golongan))    as komponen_terisi,
+
+  case when (select fase_live from status_acara) = 'penuh' then
+    (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+              jsonb_build_object('nilai_1', n.nilai_1, 'nilai_2', n.nilai_2)), '{}'::jsonb)
+     from nilai_mentah n join wahana w on w.id = n.wahana_id
+     where n.regu_id = r.id and w.edisi = edisi_aktif())
+  else '{}'::jsonb end                                        as nilai,
+
+  -- Kolom BARU, di ujung. `hitung_poin()` dipanggil langsung, BUKAN lewat
+  -- v_poin_wahana — alasannya di kepala berkas: view invoker di dalam view
+  -- definer akan kosong untuk anon.
+  case when (select fase_live from status_acara) = 'penuh' then
+    (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+              hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                          w.raw_terbaik, w.raw_terburuk, w.poin_benar,
+                          w.poin_salah, w.total_soal, w.tingkat,
+                          w.jawaban_benar)), '{}'::jsonb)
+     from nilai_mentah n join wahana w on w.id = n.wahana_id
+     where n.regu_id = r.id and w.edisi = edisi_aktif())
+  else '{}'::jsonb end                                        as poin
+
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join kloter k        on k.nomor = r.kloter_nomor
+left join closing_regu c  on c.regu_id = r.id
+where not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and (select fase_live from status_acara) in ('progres', 'penuh');
+
+comment on view v_progres_publik is
+  'Baris regu untuk halaman peserta. `komponen_terisi` centang (boleh sejak fase progres); `nilai` dan `poin` hanya terisi di fase penuh.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Laporan, dan dua pagar yang harus tetap berdiri.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_fase   text;
+  v_kolom  int;
+begin
+  -- Kedua kolom `poin` benar-benar ada, dan namanya persis itu. Layar membaca
+  -- `rk.poin` dan `b.poin`; kolom yang salah nama tidak menggagalkan apa pun,
+  -- ia cuma membuat seluruh sel tergambar kosong.
+  select count(*) into v_kolom
+  from information_schema.columns
+  where table_schema = 'public'
+    and (table_name, column_name) in (
+      ('v_rekap_penuh', 'poin'), ('v_progres_publik', 'poin'));
+  assert v_kolom = 2,
+    format('0107: kolom `poin` belum ada di kedua view (ketemu %s dari 2)', v_kolom);
+
+  -- Pagar fase di v_progres_publik dibaca dari definisinya, bukan diandaikan.
+  assert (select count(*) from pg_views
+          where schemaname = 'public' and viewname = 'v_progres_publik'
+            and definition like '%hitung_poin%'
+            and definition like '%fase_live%') = 1,
+    '0107: v_progres_publik menghitung poin tanpa menyebut fase_live — '
+    'poin akan terbit sebelum hasil diumumkan.';
+
+  select fase_live into v_fase from status_acara;
+  raise notice '0107: poin per komponen terpasang. Fase sekarang %; kolom `poin` '
+               'di halaman peserta terisi hanya saat fase penuh.', v_fase;
+end;
+$blok$;

--- a/tests/live_score_poin.test.mjs
+++ b/tests/live_score_poin.test.mjs
@@ -1,0 +1,71 @@
+// ============================================================================
+// hrcd-rekap : tests/live_score_poin.test.mjs
+// Papan Live Score menggambar POIN AKHIR, bukan angka mentah — dan kepala
+// kolomnya tidak lagi menyebut rentang.
+//
+// Diuji atas SUMBER kedua papan, bukan atas DOM: keduanya merakit tabelnya
+// sebagai satu template literal panjang di dalam fungsi yang menuntut enam
+// permintaan jaringan lebih dulu, dan yang perlu dijaga di sini bentuk yang
+// dipilih — sel membaca `poin`, bukan `nilai`; kepala kolom tidak membawa
+// `kolom-petunjuk`.
+//
+// Kalau suatu hari tabelnya dipindah ke fungsi tersendiri yang bisa dipanggil
+// langsung, tes ini yang pertama harus ditulis ulang — dan itu perbaikan,
+// bukan kerusakan.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+
+/** Badan `kartuGolongan` di app.js — tabel Live Score panitia. Dipotong dari
+ *  sumbernya supaya aturan di sini tidak salah mengenai layar Rekapitulasi,
+ *  yang memang MASIH menggambar angka mentah dan memang harus begitu. */
+const papanPanitia = (() => {
+  const awal = app.indexOf("const kartuGolongan = (g) => {");
+  const akhir = app.indexOf("const GOL = URUT_GOLONGAN;", awal);
+  assert.ok(awal >= 0 && akhir > awal, "kartuGolongan tidak ditemukan di app.js");
+  return app.slice(awal, akhir);
+})();
+
+/** Badan `gambarPapan` di live.js — tabel Live Score peserta. */
+const papanPeserta = (() => {
+  const awal = live.indexOf("function gambarPapan()");
+  const akhir = live.indexOf("let pengendaliFilter = null;", awal);
+  assert.ok(awal >= 0 && akhir > awal, "gambarPapan tidak ditemukan di live.js");
+  return live.slice(awal, akhir);
+})();
+
+test("sel lomba panitia membaca poin per komponen, bukan nilai mentah", () => {
+  assert.match(papanPanitia, /selPoin\(poinKomponen\[/,
+    "sel Live Score panitia tidak lagi membaca poin per komponen");
+  assert.doesNotMatch(papanPanitia, /selRekap\(/,
+    "sel Live Score panitia kembali menggambar angka mentah lewat selRekap()");
+});
+
+test("sel lomba peserta membaca poin per komponen, bukan nilai mentah", () => {
+  assert.match(papanPeserta, /const poin = b\.poin \|\| \{\}/,
+    "papan peserta tidak lagi mengambil poin per komponen dari rekap.json");
+  assert.doesNotMatch(papanPeserta, /nilaiBagian\(/,
+    "papan peserta kembali mengeja angka mentah lewat nilaiBagian()");
+});
+
+test("kepala kolom lomba tidak menyebut rentang di kedua papan", () => {
+  for (const [nama, sumber] of [["panitia", papanPanitia], ["peserta", papanPeserta]]) {
+    assert.doesNotMatch(sumber, /kolom-petunjuk/,
+      `kepala kolom Live Score ${nama} kembali membawa rentang — `
+      + `"0 – 5" di atas sel berisi 80 membantah selnya sendiri`);
+  }
+});
+
+test("pagar BOCOR di publish-live.yml ikut menjaga poin", async () => {
+  const publish = await readFile(
+    new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
+  const pagar = publish.slice(publish.indexOf("if d['fase'] != 'penuh':"));
+  assert.match(pagar, /for kunci in \('nilai', 'poin'\)/,
+    "poin diturunkan dari nilai, jadi ia bocor sama telanjangnya — "
+    + "pagar BOCOR harus menyebut keduanya");
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -454,6 +454,12 @@ run tests/sql/66_kloter_capacity_headroom.sql
 # harus menyebut rentang yang dilihat petugas di kotak, bukan angka penyimpanan.
 run supabase/migrations/0106_format_input_range_units.sql
 run tests/sql/67_input_range_units.sql
+# 0107 menambah poin akhir per komponen ke kedua papan Live Score, dan
+# `anggota_hadir` ke view peserta. Tes 69 membandingkan angkanya baris per
+# baris dengan hitung_poin() dan menempati kursi untuk membuktikan pagar
+# fasenya — poin diturunkan dari nilai, jadi ia bocor sama telanjangnya.
+run supabase/migrations/0107_poin_per_komponen.sql
+run tests/sql/69_poin_per_komponen.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/69_poin_per_komponen.sql
+++ b/tests/sql/69_poin_per_komponen.sql
@@ -1,0 +1,175 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/69_poin_per_komponen.sql
+-- Poin per komponen terbit ke kedua papan, dan TIDAK terbit sebelum waktunya.
+--
+-- Yang diuji bukan "kolomnya ada" — itu sudah diperiksa assert di dalam 0107.
+-- Yang diuji di sini ANGKANYA: poin yang keluar dari view harus sama persis
+-- dengan yang dihitung hitung_poin(), dan pagar fase pada view publik harus
+-- benar-benar menahan.
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Kursi admin: v_rekap_penuh dipagari boleh('rekap') / boleh('live_score').
+-- ---------------------------------------------------------------------------
+select set_config('app.uid', (select user_id::text from akun_panitia
+                              where peran = 'admin' and is_active limit 1), true);
+
+-- 69.1 poin per komponen = hitung_poin() atas baris nilai_mentah yang sama.
+--
+-- Dibandingkan baris per baris, bukan cuma jumlahnya: dua komponen yang
+-- poinnya tertukar menghasilkan total yang sama dan tabel yang salah.
+do $$
+declare
+  v_beda int;
+begin
+  select count(*) into v_beda
+  from v_rekap_penuh rp
+  join regu r on r.id = rp.regu_id
+  join nilai_mentah n on n.regu_id = r.id
+  join wahana w on w.id = n.wahana_id and w.edisi = edisi_aktif()
+  where (rp.poin ->> (w.pos || '.' || w.kode))::numeric is distinct from
+        hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                    w.raw_terbaik, w.raw_terburuk, w.poin_benar,
+                    w.poin_salah, w.total_soal, w.tingkat, w.jawaban_benar);
+  assert v_beda = 0,
+    format('69.1: %s komponen di v_rekap_penuh berbeda dengan hitung_poin()', v_beda);
+end $$;
+
+-- 69.2 Kunci `poin` sama persis dengan kunci `nilai`.
+--
+-- Layar membaca keduanya dengan kunci yang sama (`pos.kode`). Kunci yang
+-- bergeser tidak menggagalkan apa pun — ia cuma membuat setiap sel kosong.
+do $$
+declare
+  v_beda int;
+begin
+  select count(*) into v_beda
+  from v_rekap_penuh
+  where (select coalesce(array_agg(k order by k), '{}')
+         from jsonb_object_keys(nilai) k)
+     is distinct from
+        (select coalesce(array_agg(k order by k), '{}')
+         from jsonb_object_keys(poin) k);
+  assert v_beda = 0,
+    format('69.2: %s regu punya kunci `poin` yang berbeda dari kunci `nilai`', v_beda);
+end $$;
+
+-- 69.3 Angkanya memang POIN, bukan angka mentah yang menyamar.
+--
+-- Rumusnya sengaja TIDAK diturunkan ulang di sini. 69.1 sudah membandingkan
+-- setiap baris dengan hitung_poin(), dan menuliskan rumusnya lagi di tes
+-- berarti membangun mesin skor kedua di tempat yang justru ditugasi menjaga
+-- agar mesin skor cuma ada satu. Versi pertama tes ini melakukannya dan
+-- langsung terjatuh: ia memakai `rentang_mentah_maks` sebagai penyebut,
+-- sementara `besar_baik` menskala dari `raw_terbaik` — dan pada
+-- `kepramukaan_keagamaan` keduanya berbeda jauh (20 lawan 10000, karena 0037
+-- melebarkan rentang isiannya). Yang salah tesnya, bukan view-nya.
+--
+-- Yang diuji di sini tinggal KLAIMNYA: angka yang keluar berskala poin, bukan
+-- skala isian. Diambil dari komponen `besar_baik` yang poin_maks-nya memang
+-- berbeda dari raw_terbaik — persis bentuk Semaphore (mentah 0-5, poin 0-100).
+do $$
+declare
+  v_kode    text;
+  v_mentah  numeric;
+  v_poin    numeric;
+  v_terbaik numeric;
+  v_maks    numeric;
+begin
+  select w.kode, n.nilai_1, w.raw_terbaik, w.poin_maks,
+         (rp.poin ->> (w.pos || '.' || w.kode))::numeric
+    into v_kode, v_mentah, v_terbaik, v_maks, v_poin
+  from v_rekap_penuh rp
+  join nilai_mentah n on n.regu_id = rp.regu_id
+  join wahana w on w.id = n.wahana_id and w.edisi = edisi_aktif()
+  where w.form = 'besar_baik'
+    and w.poin_maks is distinct from w.raw_terbaik
+    and n.nilai_1 > 0
+  limit 1;
+
+  if v_kode is null then
+    raise notice '69.3 dilewati: tidak ada komponen besar_baik berskala tidak 1:1 yang sudah dinilai.';
+    return;
+  end if;
+
+  assert v_poin is distinct from v_mentah,
+    format('69.3: %s memberi angka mentah (%s), bukan poin', v_kode, v_mentah);
+  assert v_poin > 0 and v_poin <= v_maks,
+    format('69.3: %s memberi %s, di luar skala poin 0-%s', v_kode, v_poin, v_maks);
+  raise notice '69.3: % mentah % (skala 0-%) -> % poin (skala 0-%).',
+               v_kode, v_mentah, v_terbaik, v_poin, v_maks;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 69.4 PAGAR FASE — poin peserta kosong sebelum hasil diumumkan.
+--
+-- Bentuknya menempati kursi, bukan memindai nama (CLAUDE.md 13.8): fase
+-- diubah di antara dua pembacaan view yang SAMA.
+--
+-- Barisnya disiapkan sendiri, dan itu perlu. Di titik ini dalam suite, regu
+-- yang punya nilai_mentah kebetulan belum bernomor dada — dan `v_progres_publik`
+-- memang menuntut `nomor_dada is not null`. Tanpa langkah persiapan ini,
+-- "fase penuh memberi poin" akan LULUS PALSU atas nol baris, yang berarti
+-- pagar fasenya tidak pernah benar-benar diuji.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_asal   text;
+  v_regu   uuid;
+  v_isi    int;
+begin
+  select fase_live into v_asal from status_acara;
+
+  -- Satu regu yang sudah dinilai, lunas, dan tidak batal — diberi nomor dada
+  -- dari stok supaya ia masuk ke papan peserta. Seluruhnya di-rollback.
+  select r.id into v_regu
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is null
+    and exists (select 1 from nilai_mentah n
+                join wahana w on w.id = n.wahana_id
+                where n.regu_id = r.id and w.edisi = edisi_aktif())
+  limit 1;
+  assert v_regu is not null,
+    '69.4: tidak ada regu bernilai yang bisa dipakai — periksa urutan tes di run.sh';
+
+  -- Ketiganya dipasang BERSAMA: `regu_check` menuntut nomor_dada dan
+  -- kloter_nomor sama-sama terisi atau sama-sama kosong, dan `regu_check1`
+  -- menuntut hal yang sama untuk urutan_kloter. Mengisi satu saja ditolak
+  -- constraint, bukan diterima diam-diam.
+  update regu set
+    nomor_dada = (select max(s.nomor) from nomor_dada_stok s
+                  where not exists (select 1 from regu r2
+                                    where r2.nomor_dada = s.nomor)),
+    kloter_nomor = 1,
+    urutan_kloter = slot_kloter_berikutnya(1::smallint)
+  where id = v_regu;
+
+  update status_acara set fase_live = 'progres' where fase_live is not null;
+  select count(*) into v_isi from v_progres_publik where poin <> '{}'::jsonb;
+  assert v_isi = 0,
+    format('69.4: %s baris membawa poin di fase progres — hasil bocor sebelum diumumkan', v_isi);
+
+  update status_acara set fase_live = 'penuh' where fase_live is not null;
+  select count(*) into v_isi from v_progres_publik where poin <> '{}'::jsonb;
+  assert v_isi > 0,
+    '69.4: fase penuh tetap tidak memberi satu pun poin — papan peserta akan kosong';
+
+  -- Kunci `poin` dan `nilai` bergerak bersama: keduanya lahir dari baris
+  -- nilai_mentah yang sama, jadi satu yang terisi sementara satunya kosong
+  -- berarti salah satu subquery-nya menyimpang.
+  select count(*) into v_isi from v_progres_publik
+  where (poin <> '{}'::jsonb) is distinct from (nilai <> '{}'::jsonb);
+  assert v_isi = 0,
+    format('69.4: %s baris punya poin tanpa nilai (atau sebaliknya)', v_isi);
+
+  update status_acara set fase_live = v_asal where fase_live is not null;
+end $$;
+
+select '69_poin_per_komponen OK' as hasil;
+
+rollback;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4657,6 +4657,23 @@ function selRekap(w, isi) {
 const angka = (n) => n === null || n === undefined ? "—"
   : String(Math.round(Number(n) * 100) / 100);
 
+/** Satu sel Live Score: POIN AKHIR komponen itu, bukan angka mentahnya.
+ *
+ *  Angka mentah tidak bisa dibandingkan antar kolom — "4" di Semaphore, "8.55"
+ *  di Menaksir, dan "01:14" di Bakiak adalah tiga satuan yang berbeda, dan
+ *  tidak satu pun menyebut sumbangannya ke Total di ujung baris. Papan ini
+ *  dibaca justru oleh orang yang tidak memegang tangga poin tiap lomba:
+ *  pembina, peserta, dan panitia yang bukan juri lomba itu.
+ *
+ *  Angkanya datang JADI dari `v_rekap_penuh.poin` (migrasi 0107). Layar tidak
+ *  menghitungnya sendiri — alasannya sama dengan Nilai Pos di layar Input Pos:
+ *  mesin skor kedua adalah mesin skor yang suatu hari berbeda pendapat dengan
+ *  yang pertama.
+ *
+ *  Kosong berarti komponennya belum dinilai. Nol yang SUDAH dinilai tetap
+ *  tergambar "0" — itu angka, bukan ketiadaan. */
+const selPoin = (v) => esc(angkaRapi(v));
+
 async function layarRekap() {
   const s = sesi();
   if (!bolehLihat("rekap")) {
@@ -5317,17 +5334,24 @@ async function layarLiveScore() {
                   <th rowspan="2">Total</th>
                 </tr>
                 <tr>
+                  <!-- Nama lomba saja, TANPA rentang. Rentang menjelaskan apa
+                       yang boleh DIKETIK, dan di papan ini tidak ada yang
+                       mengetik apa pun — yang tergambar sudah poin akhir, dan
+                       "0 – 5" di bawah kolom berisi 80 justru membantahnya.
+                       Rentangnya tetap ada di layar Input Pos dan di
+                       Rekapitulasi, tempat ia memang menjawab pertanyaan. -->
                   ${posKolom.map(p => p.kolom.map(kol =>
-                      `<th class="pos-kol">${esc(kol.nama)}${kol.petunjuk
-                        ? `<span class="kolom-petunjuk">${esc(kol.petunjuk)}</span>`
-                        : ""}</th>`).join("")
+                      `<th class="pos-kol">${esc(kol.nama)}</th>`).join("")
                     + `<th class="pos-kol rekap-batas">Nilai</th>`).join("")}
                 </tr>
               </thead>
               <tbody>
                 ${baris.map(k => {
                   const rk = rekapDada.get(k.nomor_dada) || {};
-                  const nilai = rk.nilai || {};
+                  // Poin per KOMPONEN (0107) untuk sel lomba, poin per POS
+                  // untuk kolom Nilai di ujung tiap kelompok. Dua hal berbeda,
+                  // dua kunci berbeda — `pos.kode` lawan `pos`.
+                  const poinKomponen = rk.poin || {};
                   const poin = k.poin_per_pos || {};
                   return `
                   <tr data-sekolah="${esc(k.nama_sekolah || "")}">
@@ -5340,7 +5364,7 @@ async function layarLiveScore() {
                         // golongan; yang berlaku untuk regu INI yang dibaca.
                         const w = varianUntuk(kol, k.golongan);
                         return `<td class="text-center">${w
-                          ? selRekap(w, nilai[`${p.nomor}.${w.kode}`])
+                          ? selPoin(poinKomponen[`${p.nomor}.${w.kode}`])
                           : `<span class="sel-mati">–</span>`}</td>`;
                       }).join("")
                       + `<td class="text-center pos-nilai rekap-batas">${


### PR DESCRIPTION
## What

Papan Live Score — panitia (`#/live-score`) dan peserta — menampilkan **poin
akhir tiap lomba**, bukan angka mentahnya. Kepala kolomnya tinggal nama lomba,
tanpa rentang.

| Lomba | Sebelum | Sesudah |
|---|---|---|
| Semaphore | `4` (0 – 5) | `80` |
| Menaksir | `8.55` (meter) | `100` |
| Bakiak | `01:14` (menit:detik) | `60` |

- **Migrasi 0107** menambah kolom `poin` — poin akhir per komponen, kunci
  `pos.kode`, sama persis dengan kunci `nilai` yang sudah ada — ke
  `v_rekap_penuh` dan `v_progres_publik`.
- Kedua papan membaca angka itu apa adanya. Tidak ada perhitungan di browser:
  alasan yang sama dengan Nilai Pos di layar Input Pos — mesin skor kedua
  adalah mesin skor yang suatu hari berbeda pendapat dengan yang pertama.
- Kepala kolom tidak lagi membawa `kolom-petunjuk`.

## Why

Angka mentah tidak bisa dibandingkan antar kolom, dan tidak satu pun menyebut
sumbangannya ke Total di ujung baris. Pembaca harus memegang tangga poin tiap
lomba di kepalanya sebelum baris itu berarti apa-apa — sementara yang membaca
papan ini justru orang yang paling tidak punya tangga itu: pembina, peserta,
dan panitia yang bukan juri lomba tersebut.

Rentang menjelaskan apa yang boleh DIKETIK, dan di papan ini tidak ada yang
mengetik apa pun. "0 – 5" di atas sel berisi 80 membantah selnya sendiri.

## Notes

- **Rekapitulasi panitia (`#/rekap`) sengaja tidak berubah.** Di sana angka
  mentah justru yang dicari: ia lembar kerja untuk mencocokkan layar dengan
  kertas.
- **Pagar "BOCOR" di `publish-live.yml` ikut menjaga `poin`.** Ia diturunkan
  dari `nilai`, jadi menerbitkannya sebelum fase `penuh` membocorkan hasil
  lomba sama telanjangnya (CLAUDE.md 14.4–14.5).
- Dua view, dua cara mengambilnya, dan itu bukan kelalaian: `v_rekap_penuh`
  invoker boleh memakai `v_poin_wahana`, sedangkan `v_progres_publik` DEFINER
  harus memanggil `hitung_poin()` langsung — view invoker di dalam view definer
  tetap diperiksa terhadap hak PEMANGGIL, jadi ia akan kosong untuk anon.
- Kolomnya ditambah di UJUNG. `create or replace view` menolak urutan kolom
  yang berubah, dan drop + create membuang GRANT-nya — termasuk
  `grant select ... to anon` yang menghidupkan halaman peserta.

## Dijalankan lokal (CLAUDE.md 16)

```
node --test tests/*.test.mjs        115 lolos, 0 gagal
bash tests/run.sh                   SEMUA TES LULUS, exit 0
python tests/concurrency_test.py    SEMUA PEMERIKSAAN LULUS, exit 0
```

Tes baru: `tests/sql/69_poin_per_komponen.sql` (angkanya dibandingkan baris per
baris dengan `hitung_poin()`, plus pagar fase yang diuji dengan menempati kursi)
dan `tests/live_score_poin.test.mjs`.

Sesudah merge, `publish-live.yml` berjalan sendiri karena `live/**` ikut
berubah — angkanya baru terlihat peserta setelah penerbitan itu selesai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)