### PR TITLE
feat: show contract, kloter, and arrival columns on Live Score

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0107`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0108`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-107 migrasi, `0001` sampai `0107`, dijalankan berurutan tanpa lubang penomoran.
+108 migrasi, `0001` sampai `0108`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -928,6 +928,34 @@ export function dada3(n) {
     ? String(a).padStart(3, "0") : String(n);
 }
 
+/** KONTRAK WAKTU sebagai kata yang diucapkan panitia: "4 jam", "3,5 jam".
+ *
+ *  Yang tersimpan menit — 180, 210, 240 — dan menit adalah satuan yang tidak
+ *  pernah disebut siapa pun di lapangan. "Kontrak 210" menuntut pembagian di
+ *  kepala sebelum ia berarti apa-apa, dan yang membacanya di papan Live Score
+ *  adalah peserta dan pembina, bukan orang yang menyusun konfigurasinya.
+ *
+ *  KOMA, bukan titik: setengah jam ditulis "3,5 jam" karena begitulah angka
+ *  pecahan ditulis dalam bahasa Indonesia (aturan yang sama dengan ukuranRapi
+ *  di atas).
+ *
+ *  Menit yang bukan kelipatan 30 ditulis apa adanya di belakang koma —
+ *  "4,15 jam" jelek, tapi ia jujur, dan ia hanya muncul kalau ada yang
+ *  memasukkan kontrak ganjil ke kontrak_opsi. Membulatkannya diam-diam akan
+ *  menyembunyikan konfigurasi yang keliru justru dari orang yang bisa
+ *  membetulkannya.
+ *
+ *  Kosong jadi "—", bukan "0 jam": regu yang belum berkontrak belum memilih,
+ *  dan "0 jam" terbaca sebagai pilihan yang sudah dibuat. */
+export function kontrakTeks(menit) {
+  const n = Number(menit);
+  if (!menit || !Number.isFinite(n) || n <= 0) return "—";
+  const jam = Math.floor(n / 60);
+  const sisa = n % 60;
+  if (!sisa) return `${jam} jam`;
+  return `${jam},${sisa === 30 ? "5" : String(sisa).padStart(2, "0")} jam`;
+}
+
 /* ==========================================================================
    CARA MENULIS SATU KOMPONEN PENILAIAN — SATU SUMBER UNTUK SEMUA LAYAR
 

--- a/live/live.js
+++ b/live/live.js
@@ -60,7 +60,7 @@
    ditunda sampai DOM siap, yang justru lebih aman daripada sebelumnya. */
 import {
   esc, dada3, jamMenit, tanggalJam, berapaLalu,
-  angkaRapi,
+  angkaRapi, kontrakTeks,
   GOLONGAN_LABEL, URUT_GOLONGAN,
 } from "./js/util.js";
 
@@ -77,12 +77,6 @@ const golonganPeserta = g => URUT_GOLONGAN_PESERTA.includes(g);
 /** dada3() mengembalikan teks kosong untuk nomor yang tidak ada; di tabel ini
  *  yang dibutuhkan tanda pisah supaya barisnya tidak terlihat bolong. */
 const dada = (n) => n === null || n === undefined ? "—" : dada3(n);
-
-const kontrak = (menit) => {
-  if (!menit) return "—";
-  const j = Math.floor(menit / 60), m = menit % 60;
-  return m ? `${j},${m === 30 ? "5" : m} jam` : `${j} jam`;
-};
 
 let META = null;        // isi live.json
 let REKAP = null;       // isi rekap.json, kalau sudah diambil
@@ -413,6 +407,21 @@ function gambarPapan() {
                 ${perPos.map(x => `<th class="pos" colspan="${x.nama.length}"
                   >${esc(x.pos.bayangan ? x.pos.name
                         : `Pos ${x.pos.nomor} · ${x.pos.name}`)}</th>`).join("")}
+                <!-- Lima kolom perjalanan berdiri SEBELUM Penalti: Penalti
+                     selalu dibaca dengan pertanyaan "dari mana", dan
+                     jawabannya persis kelima kolom ini. Keempat yang
+                     pertama sudah terbit sejak fase progres, jadi mereka
+                     ikut tergambar di fase itu juga -- yang menunggu fase
+                     penuh cuma Penalti dan Total.
+
+                     TANPA BACKTICK DI KOMENTAR INI: ia duduk di dalam
+                     template literal, dan satu backtick menutup string itu
+                     sehingga sisa kalimatnya dibaca sebagai KODE. -->
+                <th rowspan="2">Kontrak</th>
+                <th rowspan="2">Kloter</th>
+                <th rowspan="2">Berangkat</th>
+                <th rowspan="2">Datang</th>
+                <th rowspan="2">Anggota</th>
                 ${penuh ? `<th rowspan="2">Penalti</th><th rowspan="2">Total</th>` : ""}
               </tr>
               <!-- Nama lomba saja, TANPA rentang. Yang tergambar di bawahnya
@@ -461,6 +470,11 @@ function gambarPapan() {
                   <td class="regu">${esc(b.nama_regu)}</td>
                   <td class="sekolah-sel">${esc(b.nama_sekolah || "—")}</td>
                   ${sel}
+                  <td>${esc(kontrakTeks(b.kontrak_menit))}</td>
+                  <td>${esc(b.kloter ?? "—")}</td>
+                  <td>${esc(b.jam_berangkat ? jamMenit(b.jam_berangkat) : "—")}</td>
+                  <td>${esc(b.jam_datang ? jamMenit(b.jam_datang) : "—")}</td>
+                  <td>${esc(b.anggota_hadir ?? "—")}</td>
                   ${penuh ? `<td>${esc(String(penalti))}</td>
                      <td class="total">${b.total === null || b.total === undefined
                        ? "—" : esc(angkaRapi(b.total))}</td>` : ""}

--- a/supabase/migrations/0108_anggota_hadir_publik.sql
+++ b/supabase/migrations/0108_anggota_hadir_publik.sql
@@ -1,0 +1,126 @@
+-- ============================================================================
+-- hrcd-rekap : 0108_anggota_hadir_publik.sql
+-- `anggota_hadir` ikut terbit ke halaman peserta.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Papan Live Score menampilkan Penalti dan Total, dan Penalti selalu dibaca
+-- dengan satu pertanyaan: "−12 dari mana?". Jawabannya empat hal — kontrak
+-- waktu, jam berangkat, jam datang, dan berapa anggota yang tiba — dan tanpa
+-- keempatnya angka itu tinggal tuduhan yang tidak bisa ditelusuri pembina
+-- mana pun tanpa bertanya ke meja panitia.
+--
+-- Tiga yang pertama sudah lama ada di `v_progres_publik` (`kontrak_menit`,
+-- `jam_berangkat`, `jam_datang`) — mereka cuma belum pernah digambar. Yang
+-- keempat memang belum ada, dan itulah satu-satunya isi migrasi ini.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TIDAK DIPAGARI FASE
+--
+-- `nilai` dan `poin` (0107) dipagari `fase_live = 'penuh'` karena keduanya
+-- HASIL LOMBA. `anggota_hadir` bukan: ia catatan perjalanan, sekelas
+-- `jam_datang` yang sudah terbit sejak fase `progres` di view yang sama.
+-- Memagarinya akan membuat kolom Anggota kosong justru pada fase ketika
+-- peserta paling sering memeriksa apakah regunya sudah tercatat sampai.
+--
+-- Yang ikut penalti memang angkanya, tetapi penaltinya sendiri baru terbit di
+-- fase penuh lewat `v_klasemen_publik` — dan itu pagar yang benar untuk
+-- penalti, bukan untuk jumlah orang yang tiba di garis finish.
+--
+-- ---------------------------------------------------------------------------
+-- Kolomnya ditambah DI UJUNG, sesudah `poin` milik 0107 — alasannya sama:
+-- `create or replace view` hanya mengizinkan penambahan di belakang, dan drop
+-- + create akan membuang `grant select ... to anon` yang menghidupkan halaman
+-- peserta.
+-- ============================================================================
+
+create or replace view v_progres_publik as
+select
+  r.nomor_dada,
+  r.nama_regu,
+  s.name as nama_sekolah,
+  r.golongan,
+  (select jsonb_object_agg(p.nomor::text,
+            exists (select 1 from nilai_mentah n
+                    join wahana w on w.id = n.wahana_id
+                    where n.regu_id = r.id and w.pos = p.nomor))
+   from pos p
+   where p.edisi = edisi_aktif()
+     and exists (select 1 from wahana w
+                 where w.edisi = p.edisi and w.pos = p.nomor)) as pos_terlewati,
+  exists (select 1 from closing_regu c where c.regu_id = r.id) as sudah_closing,
+  r.kloter_nomor                              as kloter,
+  r.kontrak_menit,
+  k.jam_berangkat,
+  case when k.jam_berangkat is not null and r.kontrak_menit is not null
+    then k.jam_berangkat + make_interval(mins => r.kontrak_menit)
+  end                                         as target_datang,
+  c.jam_datang,
+  exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+                                              as sudah_berangkat,
+
+  (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+            exists (select 1 from nilai_mentah n
+                     where n.regu_id = r.id and n.wahana_id = w.id)), '{}'::jsonb)
+   from wahana w
+   where w.edisi = edisi_aktif()
+     and (w.golongan is null or w.golongan = r.golongan))    as komponen_terisi,
+
+  case when (select fase_live from status_acara) = 'penuh' then
+    (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+              jsonb_build_object('nilai_1', n.nilai_1, 'nilai_2', n.nilai_2)), '{}'::jsonb)
+     from nilai_mentah n join wahana w on w.id = n.wahana_id
+     where n.regu_id = r.id and w.edisi = edisi_aktif())
+  else '{}'::jsonb end                                        as nilai,
+
+  case when (select fase_live from status_acara) = 'penuh' then
+    (select coalesce(jsonb_object_agg(w.pos || '.' || w.kode,
+              hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks,
+                          w.raw_terbaik, w.raw_terburuk, w.poin_benar,
+                          w.poin_salah, w.total_soal, w.tingkat,
+                          w.jawaban_benar)), '{}'::jsonb)
+     from nilai_mentah n join wahana w on w.id = n.wahana_id
+     where n.regu_id = r.id and w.edisi = edisi_aktif())
+  else '{}'::jsonb end                                        as poin,
+
+  -- Kolom BARU, di ujung, TANPA pagar fase. Lihat kepala berkas.
+  c.anggota_hadir
+
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+left join kloter k        on k.nomor = r.kloter_nomor
+left join closing_regu c  on c.regu_id = r.id
+where not r.is_cancelled
+  and d.status = 'lunas'
+  and r.nomor_dada is not null
+  and (select fase_live from status_acara) in ('progres', 'penuh');
+
+comment on view v_progres_publik is
+  'Baris regu untuk halaman peserta. `komponen_terisi` centang (boleh sejak fase progres); `nilai` dan `poin` hasil lomba, hanya di fase penuh; `kloter`, `kontrak_menit`, `jam_berangkat`, `jam_datang`, dan `anggota_hadir` catatan perjalanan, terbit sejak progres.';
+
+do $blok$
+declare
+  v_kolom int;
+begin
+  select count(*) into v_kolom
+  from information_schema.columns
+  where table_schema = 'public' and table_name = 'v_progres_publik'
+    and column_name in ('kloter', 'kontrak_menit', 'jam_berangkat',
+                        'jam_datang', 'anggota_hadir');
+  assert v_kolom = 5,
+    format('0108: kelima kolom perjalanan belum lengkap (ketemu %s dari 5)', v_kolom);
+
+  -- Kolom yang lahir 0107 tidak boleh ikut hilang saat view ditulis ulang.
+  -- `create or replace` mengganti SELURUH badannya, jadi kolom yang lupa
+  -- disalin lenyap tanpa satu galat pun — pelajaran yang sama dengan
+  -- paket_peran() di 0075.
+  assert (select count(*) from information_schema.columns
+          where table_schema = 'public' and table_name = 'v_progres_publik'
+            and column_name in ('nilai', 'poin')) = 2,
+    '0108: kolom nilai/poin dari 0107 ikut hilang saat view ditulis ulang';
+
+  raise notice '0108: anggota_hadir ikut terbit ke halaman peserta.';
+end;
+$blok$;

--- a/tests/live_score_kolom_perjalanan.test.mjs
+++ b/tests/live_score_kolom_perjalanan.test.mjs
@@ -1,0 +1,88 @@
+// ============================================================================
+// hrcd-rekap : tests/live_score_kolom_perjalanan.test.mjs
+// Lima kolom yang menjelaskan Penalti berdiri di kedua papan Live Score,
+// dalam urutan yang membuatnya bisa dibaca.
+//
+// Penalti selalu dibaca dengan pertanyaan "dari mana", dan jawabannya kontrak
+// waktu, kloter, jam berangkat, jam datang, dan berapa anggota yang tiba.
+// Kelimanya SESUDAH Penalti berarti mata harus melompat balik melewati
+// seluruh kolom lomba — jadi urutannya ikut dijaga di sini, bukan cuma
+// keberadaannya.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { kontrakTeks } from "../web/js/util.js";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+
+const papanPanitia = (() => {
+  const awal = app.indexOf("const kartuGolongan = (g) => {");
+  const akhir = app.indexOf("const GOL = URUT_GOLONGAN;", awal);
+  assert.ok(awal >= 0 && akhir > awal, "kartuGolongan tidak ditemukan di app.js");
+  return app.slice(awal, akhir);
+})();
+
+const papanPeserta = (() => {
+  const awal = live.indexOf("function gambarPapan()");
+  const akhir = live.indexOf("let pengendaliFilter = null;", awal);
+  assert.ok(awal >= 0 && akhir > awal, "gambarPapan tidak ditemukan di live.js");
+  return live.slice(awal, akhir);
+})();
+
+const PAPAN = [["panitia", papanPanitia], ["peserta", papanPeserta]];
+const URUTAN = ["Kontrak", "Kloter", "Berangkat", "Datang", "Anggota", "Penalti"];
+
+test("kelima kolom perjalanan ada di kedua papan, berurutan sebelum Penalti", () => {
+  for (const [nama, sumber] of PAPAN) {
+    const posisi = URUTAN.map(judul => {
+      const at = sumber.indexOf(`>${judul}</th>`);
+      assert.notEqual(at, -1, `kolom ${judul} hilang dari papan ${nama}`);
+      return at;
+    });
+    for (let i = 1; i < posisi.length; i++) {
+      assert.ok(posisi[i] > posisi[i - 1],
+        `di papan ${nama}, ${URUTAN[i]} berdiri sebelum ${URUTAN[i - 1]}`);
+    }
+  }
+});
+
+test("jam di kedua papan lewat jamMenit, bukan zona waktu alat", () => {
+  for (const [nama, sumber] of PAPAN) {
+    assert.match(sumber, /jamMenit\((?:rk|b)\.jam_berangkat\)/,
+      `jam berangkat papan ${nama} tidak lewat jamMenit()`);
+    assert.match(sumber, /jamMenit\((?:rk|b)\.jam_datang\)/,
+      `jam datang papan ${nama} tidak lewat jamMenit()`);
+    assert.doesNotMatch(sumber, /toTimeString|toLocaleTimeString/,
+      `papan ${nama} membaca jam dari zona waktu alat`);
+  }
+});
+
+test("kontrak waktu dieja lewat aturan bersama, bukan disalin tangan", () => {
+  for (const [nama, sumber] of PAPAN) {
+    assert.match(sumber, /kontrakTeks\((?:rk|b)\.kontrak_menit\)/,
+      `papan ${nama} tidak memakai kontrakTeks() dari util.js`);
+  }
+  // Salinan tangan yang dulu tinggal di live.js — dan tidak pernah dipanggil
+  // sekali pun. Kalau ia lahir lagi, dua papan akan mengeja satu angka dengan
+  // dua cara pada edisi pertama yang mengubah aturannya.
+  assert.doesNotMatch(live, /const kontrak = \(menit\)/,
+    "live.js kembali menuliskan aturan kontrak waktunya sendiri");
+});
+
+test("kontrakTeks mengeja menit sebagai kata yang diucapkan panitia", () => {
+  assert.equal(kontrakTeks(180), "3 jam");
+  assert.equal(kontrakTeks(210), "3,5 jam");
+  assert.equal(kontrakTeks(240), "4 jam");
+  // Belum berkontrak bukan "0 jam": itu terbaca sebagai pilihan yang sudah
+  // dibuat, padahal justru belum.
+  for (const kosong of [null, undefined, 0, ""]) {
+    assert.equal(kontrakTeks(kosong), "—", `kontrakTeks(${kosong})`);
+  }
+  // Menit ganjil ditulis apa adanya — jelek, tapi jujur. Membulatkannya
+  // diam-diam menyembunyikan konfigurasi keliru dari yang bisa membetulkannya.
+  assert.equal(kontrakTeks(255), "4,15 jam");
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -460,6 +460,11 @@ run tests/sql/67_input_range_units.sql
 # fasenya — poin diturunkan dari nilai, jadi ia bocor sama telanjangnya.
 run supabase/migrations/0107_poin_per_komponen.sql
 run tests/sql/69_poin_per_komponen.sql
+# 0108 menerbitkan `anggota_hadir` ke halaman peserta. Tes 70 menjaga
+# pembagian yang gampang tertukar: nilai dan poin menunggu fase penuh, kelima
+# kolom perjalanan terbit sejak progres.
+run supabase/migrations/0108_anggota_hadir_publik.sql
+run tests/sql/70_anggota_hadir_publik.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/70_anggota_hadir_publik.sql
+++ b/tests/sql/70_anggota_hadir_publik.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/70_anggota_hadir_publik.sql
+-- Kolom perjalanan halaman peserta: lengkap, dan TIDAK ikut dipagari fase.
+--
+-- Yang dijaga di sini pembagian yang gampang tertukar: `nilai` dan `poin`
+-- adalah HASIL LOMBA dan menunggu fase `penuh`; kelima kolom perjalanan
+-- adalah CATATAN dan terbit sejak `progres`. Memagari yang kedua akan
+-- mengosongkan kolom Anggota justru pada fase ketika peserta paling sering
+-- memeriksa apakah regunya sudah tercatat sampai.
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+select set_config('app.uid', (select user_id::text from akun_panitia
+                              where peran = 'admin' and is_active limit 1), true);
+
+do $$
+declare
+  v_asal   text;
+  v_regu   uuid;
+  v_isi    int;
+  v_poin   int;
+begin
+  select fase_live into v_asal from status_acara;
+
+  -- Satu regu yang sudah dinilai DAN sudah closing, diberi nomor dada supaya
+  -- ia masuk papan peserta. Ketiga kolom kloter dipasang bersama: `regu_check`
+  -- menuntut nomor_dada dan kloter_nomor sama-sama terisi, `regu_check1`
+  -- menuntut hal yang sama untuk urutan_kloter.
+  select r.id into v_regu
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  join closing_regu c on c.regu_id = r.id
+  where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is null
+  limit 1;
+
+  if v_regu is null then
+    raise notice '70 dilewati: tidak ada regu closing tanpa nomor dada di titik ini.';
+    return;
+  end if;
+
+  update regu set
+    nomor_dada = (select max(s.nomor) from nomor_dada_stok s
+                  where not exists (select 1 from regu r2
+                                    where r2.nomor_dada = s.nomor)),
+    kloter_nomor = 1,
+    urutan_kloter = slot_kloter_berikutnya(1::smallint)
+  where id = v_regu;
+
+  -- 70.1 Di fase `progres`, catatan perjalanan ADA sementara hasil lomba TIDAK.
+  update status_acara set fase_live = 'progres' where fase_live is not null;
+
+  select count(*) into v_isi from v_progres_publik
+  where nomor_dada = (select nomor_dada from regu where id = v_regu)
+    and anggota_hadir is not null;
+  assert v_isi = 1,
+    '70.1: anggota_hadir kosong di fase progres — kolom Anggota akan kosong '
+    'justru saat peserta paling sering memeriksanya';
+
+  select count(*) into v_poin from v_progres_publik where poin <> '{}'::jsonb;
+  assert v_poin = 0,
+    format('70.1: %s baris membawa poin di fase progres — hasil bocor', v_poin);
+
+  -- 70.2 Kelima kolom perjalanan terisi untuk regu yang memang sudah menjalaninya.
+  select count(*) into v_isi from v_progres_publik
+  where nomor_dada = (select nomor_dada from regu where id = v_regu)
+    and kloter is not null;
+  assert v_isi = 1, '70.2: kloter tidak ikut terbit ke halaman peserta';
+
+  update status_acara set fase_live = v_asal where fase_live is not null;
+end $$;
+
+-- 70.3 Bentuk kolomnya, dibaca dari katalog — supaya penulisan ulang view
+--      berikutnya tidak diam-diam menjatuhkan salah satunya.
+do $$
+declare v_kurang text;
+begin
+  select string_agg(k, ', ' order by k) into v_kurang
+  from unnest(array['kloter', 'kontrak_menit', 'jam_berangkat', 'jam_datang',
+                    'anggota_hadir', 'nilai', 'poin']) k
+  where not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'v_progres_publik'
+      and column_name = k);
+  assert v_kurang is null,
+    format('70.3: v_progres_publik kehilangan kolom: %s', v_kurang);
+end $$;
+
+select '70_anggota_hadir_publik OK' as hasil;
+
+rollback;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -34,7 +34,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          dialog, kartuGagalMuat, jamSah, pasangKotakJam,
          berapaLalu, pemuat, ikonRefresh, detikSah, detikTeks,
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
-         angkaRapi, nilaiTeks, nilaiBagian, kolomPos,
+         angkaRapi, nilaiTeks, nilaiBagian, kolomPos, kontrakTeks,
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
          GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
@@ -5330,6 +5330,18 @@ async function layarLiveScore() {
                     <span class="hitung-filter"></span> <span aria-hidden="true">▾</span></th>
                   ${posKolom.map(p => `<th colspan="${p.kolom.length + 1}"
                     class="rekap-batas">Pos ${esc(String(p.nomor))} · ${esc(p.name)}</th>`).join("")}
+                  <!-- Lima kolom perjalanan mendahului Penalti, dan urutan
+                       itu yang membuatnya berguna: Penalti selalu dibaca
+                       dengan pertanyaan "dari mana", dan jawabannya persis
+                       kelima kolom ini -- kontrak yang dijanjikan, jam
+                       berangkat, jam datang, dan berapa anggota yang tiba.
+                       Menaruhnya SESUDAH Penalti memaksa mata melompat balik
+                       melewati seluruh kolom lomba. -->
+                  <th rowspan="2">Kontrak</th>
+                  <th rowspan="2">Kloter</th>
+                  <th rowspan="2">Berangkat</th>
+                  <th rowspan="2">Datang</th>
+                  <th rowspan="2">Anggota</th>
                   <th rowspan="2">Penalti</th>
                   <th rowspan="2">Total</th>
                 </tr>
@@ -5370,6 +5382,13 @@ async function layarLiveScore() {
                       + `<td class="text-center pos-nilai rekap-batas">${
                           poin[String(p.nomor)] === undefined
                             ? "–" : esc(angkaRapi(poin[String(p.nomor)]))}</td>`).join("")}
+                    <td class="text-center">${esc(kontrakTeks(rk.kontrak_menit))}</td>
+                    <td class="text-center">${esc(rk.kloter ?? "—")}</td>
+                    <td class="text-center">${esc(rk.jam_berangkat
+                      ? jamMenit(rk.jam_berangkat) : "—")}</td>
+                    <td class="text-center">${esc(rk.jam_datang
+                      ? jamMenit(rk.jam_datang) : "—")}</td>
+                    <td class="text-center">${esc(rk.anggota_hadir ?? "—")}</td>
                     <td class="text-center">${esc(angkaRapi(
                       Number(k.penalti_waktu) + Number(k.penalti_checkout)
                       + Number(k.penalti_anggota)))}</td>

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -928,6 +928,34 @@ export function dada3(n) {
     ? String(a).padStart(3, "0") : String(n);
 }
 
+/** KONTRAK WAKTU sebagai kata yang diucapkan panitia: "4 jam", "3,5 jam".
+ *
+ *  Yang tersimpan menit — 180, 210, 240 — dan menit adalah satuan yang tidak
+ *  pernah disebut siapa pun di lapangan. "Kontrak 210" menuntut pembagian di
+ *  kepala sebelum ia berarti apa-apa, dan yang membacanya di papan Live Score
+ *  adalah peserta dan pembina, bukan orang yang menyusun konfigurasinya.
+ *
+ *  KOMA, bukan titik: setengah jam ditulis "3,5 jam" karena begitulah angka
+ *  pecahan ditulis dalam bahasa Indonesia (aturan yang sama dengan ukuranRapi
+ *  di atas).
+ *
+ *  Menit yang bukan kelipatan 30 ditulis apa adanya di belakang koma —
+ *  "4,15 jam" jelek, tapi ia jujur, dan ia hanya muncul kalau ada yang
+ *  memasukkan kontrak ganjil ke kontrak_opsi. Membulatkannya diam-diam akan
+ *  menyembunyikan konfigurasi yang keliru justru dari orang yang bisa
+ *  membetulkannya.
+ *
+ *  Kosong jadi "—", bukan "0 jam": regu yang belum berkontrak belum memilih,
+ *  dan "0 jam" terbaca sebagai pilihan yang sudah dibuat. */
+export function kontrakTeks(menit) {
+  const n = Number(menit);
+  if (!menit || !Number.isFinite(n) || n <= 0) return "—";
+  const jam = Math.floor(n / 60);
+  const sisa = n % 60;
+  if (!sisa) return `${jam} jam`;
+  return `${jam},${sisa === 30 ? "5" : String(sisa).padStart(2, "0")} jam`;
+}
+
 /* ==========================================================================
    CARA MENULIS SATU KOMPONEN PENILAIAN — SATU SUMBER UNTUK SEMUA LAYAR
 


### PR DESCRIPTION
## What

Papan Live Score — panitia (`#/live-score`) dan peserta — menambah lima kolom
di antara kolom lomba dan Penalti:

**Kontrak · Kloter · Berangkat · Datang · Anggota** · Penalti · Total

- Empat dari lima sudah ada di `v_progres_publik` dan `v_rekap_penuh`; mereka
  cuma belum pernah digambar.
- **Migrasi 0108** menambah yang kelima, `anggota_hadir`, ke
  `v_progres_publik`.
- Kontrak waktu dieja **"3,5 jam"**, bukan `210`. Aturannya pindah ke
  `util.js` sebagai `kontrakTeks()`.

## Why

Penalti selalu dibaca dengan satu pertanyaan: "−12 dari mana?" Jawabannya
persis kelima kolom itu. Tanpa mereka angka penalti tinggal tuduhan yang tidak
bisa ditelusuri pembina mana pun tanpa bertanya ke meja panitia.

Urutannya ikut dijaga tes: kelimanya **sebelum** Penalti. Sesudahnya, mata
harus melompat balik melewati seluruh kolom lomba untuk mencari jawabannya.

Menit adalah satuan yang tidak pernah disebut siapa pun di lapangan — "kontrak
210" menuntut pembagian di kepala sebelum berarti apa-apa, dan yang membacanya
di papan ini peserta dan pembina, bukan orang yang menyusun konfigurasinya.

## Notes

- **`anggota_hadir` sengaja TIDAK dipagari fase.** `nilai` dan `poin` menunggu
  fase `penuh` karena keduanya hasil lomba; `anggota_hadir` catatan perjalanan,
  sekelas `jam_datang` yang sudah terbit sejak `progres`. Memagarinya akan
  mengosongkan kolom Anggota justru pada fase ketika peserta paling sering
  memeriksa apakah regunya sudah tercatat sampai. Tes 70 menjaga pembagian itu
  dari kedua arah.
- **`kontrak()` di `live.js` ternyata kode mati** — dideklarasikan, tidak
  pernah dipanggil. Ia tidak dihidupkan di tempatnya; ia dipindahkan ke
  `util.js` supaya dua papan tidak mengeja satu angka dengan dua cara pada
  edisi pertama yang mengubah aturannya.
- Assertion di 0108 memeriksa bahwa `nilai` dan `poin` dari 0107 tidak ikut
  hilang: `create or replace view` mengganti SELURUH badannya, jadi kolom yang
  lupa disalin lenyap tanpa satu galat pun (pelajaran yang sama dengan
  `paket_peran()` di 0075).

## Dijalankan lokal (CLAUDE.md 16)

```
node --test tests/*.test.mjs   119 lolos, 0 gagal
bash tests/run.sh              SEMUA TES LULUS, exit 0
```

Tes baru: `tests/sql/70_anggota_hadir_publik.sql` dan
`tests/live_score_kolom_perjalanan.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)