### PR TITLE
feat: offer 3, 3.5, and 4 hour time contracts

### DIFF
--- a/docs/alur-hrcd.svg
+++ b/docs/alur-hrcd.svg
@@ -145,7 +145,7 @@
       <text x="348" y="465" font-size="15" font-weight="700" fill="#FFFFFF" text-anchor="middle">5</text>
       <text x="82" y="546" font-size="21" font-weight="700" fill="#1A1A1A">Garis Start</text>
       <text x="82" y="573" font-size="14.5" fill="#6B6B6B">Konfirmasi kontrak waktu</text>
-      <text x="82" y="595" font-size="14.5" fill="#6B6B6B">3,5 / 4 / 4,5 jam · antre 4 tahap</text>
+      <text x="82" y="595" font-size="14.5" fill="#6B6B6B">3 / 3,5 / 4 jam · antre 4 tahap</text>
     </g>
 
     <!-- Node 6 : Lima Pos — peserta mendaki dengan ransel -->

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -196,7 +196,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 8. **Satu kloter boleh berisi golongan campuran.** Penggalang dan Penegak, putra
    dan putri, dapat berangkat dalam kloter yang sama; hanya Intern dan Eksternal
    yang mempunyai kuota otomatis terpisah.
-9. Setiap regu memilih **kontrak waktu**: 3,5 / 4 / 4,5 jam. Kontrak dipilih per
+9. Setiap regu memilih **kontrak waktu**: 3 / 3,5 / 4 jam. Kontrak dipilih per
    regu, sehingga satu kloter bisa berisi regu dengan kontrak berbeda-beda.
    Kontrak baru dikonfirmasi **di garis start**, bukan saat daftar ulang —
    lihat bagian 6.

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0108`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0109`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-108 migrasi, `0001` sampai `0108`, dijalankan berurutan tanpa lubang penomoran.
+109 migrasi, `0001` sampai `0109`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -86,7 +86,7 @@ penyelesaiannya dicatat di bagian 11.
 | `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | Kuota otomatis 5 Eksternal + 3 Intern, perkiraan 300 Eksternal + 50 Intern, `kloter_maks=75`, jendela 07:00–10:00 |
 | `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
 | `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis`): bentuk konversi + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
-| `kontrak_opsi` | Pilihan kontrak waktu | `('3,5 jam',210), ('4 jam',240), ('4,5 jam',270)` |
+| `kontrak_opsi` | Pilihan kontrak waktu | `('3 jam',180), ('3,5 jam',210), ('4 jam',240)` |
 | `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=1, penalti_per_blok=1, penalti_tanpa_checkout=100, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
 
 1. `wahana.kode` dibatasi `CHECK` huruf-kecil/angka/underscore — kode ini

--- a/supabase/checks/seed_data_uji.sql
+++ b/supabase/checks/seed_data_uji.sql
@@ -174,7 +174,7 @@ begin
          d.nomor_dada,
          ((rn - 1) / 10 + 1)::smallint,
          ((rn - 1) % 10 + 1)::smallint,
-         (array[210, 240, 270])[(d.nomor_dada % 3) + 1]
+         (array[180, 210, 240])[(d.nomor_dada % 3) + 1]
   from (select *, row_number() over (order by nomor_dada) as rn
         from daftar_uji) d
   join sekolah s     on kunci_sekolah(s.name) = kunci_sekolah(d.sekolah)

--- a/supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
+++ b/supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
@@ -1,0 +1,108 @@
+-- ============================================================================
+-- hrcd-rekap : 0109_kontrak_waktu_tiga_pilihan.sql
+-- Pilihan kontrak waktu jadi 3 jam, 3,5 jam, dan 4 jam.
+--
+-- Sebelumnya 3,5 / 4 / 4,5 jam. Seluruh tangganya turun setengah jam:
+-- keputusan pemilik acara, bukan penyesuaian teknis.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA BUKAN SEKADAR UPDATE TIGA BARIS
+--
+-- `kontrak_opsi` berkunci PRIMARY KEY (edisi, menit), jadi yang berubah bukan
+-- label melainkan HIMPUNANNYA: 180 lahir, 270 pergi, 210 dan 240 bertahan
+-- dengan urutan baru. Menulisnya sebagai tiga UPDATE akan menabrak kunci itu
+-- di baris pertama.
+--
+-- ---------------------------------------------------------------------------
+-- PAGAR YANG MENAHAN KEHILANGAN DIAM-DIAM
+--
+-- Kalau ada regu yang kontraknya sudah tercatat 270 menit, membuang barisnya
+-- dari `kontrak_opsi` TIDAK menghapus kontrak regu itu — dan justru itu
+-- masalahnya. Layar Keberangkatan menggambar dropdown-nya dari
+-- `kontrak_opsi`, lalu menandai `selected` pada opsi yang cocok:
+--
+--     ${opsi.map(o => `<option ... ${r.kontrak_menit === o.menit ? "selected" : ""}>`)}
+--
+-- Tanpa baris 270, tidak ada yang cocok, dan dropdown-nya jatuh ke "Belum
+-- dipilih" — untuk regu yang SUDAH berkontrak. Petugas membaca "belum",
+-- sistem menyimpan 270, dan penaltinya dihitung dari angka yang tidak
+-- tertulis di mana pun di layar. Peringatan "sudah diceklis tapi belum punya
+-- kontrak" pun tidak menyalak, karena ia memeriksa `kontrak_menit === null`.
+--
+-- Karena itu migrasi ini BERHENTI kalau ada regu yang masih memegang menit
+-- yang akan hilang, dan menyebutkan nomor dadanya. Yang harus memutuskan apa
+-- yang terjadi pada regu itu adalah panitia, bukan berkas ini.
+-- ============================================================================
+
+do $blok$
+declare
+  v_edisi  smallint := edisi_aktif();
+  v_baru   smallint[] := array[180, 210, 240];
+  v_yatim  text;
+  v_lama   text;
+begin
+  if v_edisi is null then
+    raise notice '0109: belum ada edisi aktif — pilihan kontrak dilewati.';
+    return;
+  end if;
+
+  -- Trigger `kunci_kontrak_opsi` akan menolak setiap tulisan di bawah, tapi
+  -- pesannya menyebut layar Konfigurasi dan bukan berkas ini. Ditangkap lebih
+  -- dulu supaya yang menjalankannya tahu apa yang harus dibuka.
+  if (select konfigurasi_terkunci from status_acara) then
+    raise exception '0109: konfigurasi sedang terkunci — buka kuncinya di '
+      'status_acara dulu, lalu jalankan ulang migrasi ini.';
+  end if;
+
+  select string_agg(format('%s (%s menit)', dada3.nomor_dada, dada3.kontrak_menit),
+                    ', ' order by dada3.nomor_dada)
+    into v_yatim
+  from (select r.nomor_dada, r.kontrak_menit from regu r
+        where not r.is_cancelled
+          and r.kontrak_menit is not null
+          and not (r.kontrak_menit = any (v_baru))) dada3;
+
+  if v_yatim is not null then
+    raise exception '0109: regu berikut memegang kontrak yang akan dihapus: %. '
+      'Membuang pilihannya membuat dropdown Keberangkatan berbunyi "Belum '
+      'dipilih" untuk regu yang SUDAH berkontrak, sementara penaltinya tetap '
+      'dihitung dari angka lama. Betulkan kontrak regu itu dulu, baru '
+      'jalankan ulang migrasi ini.', v_yatim;
+  end if;
+
+  select string_agg(format('%s=%s', label, menit), ', ' order by sort_order)
+    into v_lama
+  from kontrak_opsi where edisi = v_edisi;
+
+  delete from kontrak_opsi
+  where edisi = v_edisi and not (menit = any (v_baru));
+
+  insert into kontrak_opsi (edisi, label, menit, sort_order) values
+    (v_edisi, '3 jam',   180, 1),
+    (v_edisi, '3,5 jam', 210, 2),
+    (v_edisi, '4 jam',   240, 3)
+  on conflict (edisi, menit) do update set
+    label      = excluded.label,
+    sort_order = excluded.sort_order;
+
+  raise notice '0109: kontrak edisi % — dari [%] jadi [3 jam=180, 3,5 jam=210, 4 jam=240].',
+               v_edisi, coalesce(v_lama, 'kosong');
+end;
+$blok$;
+
+do $blok$
+declare
+  v_edisi smallint := edisi_aktif();
+  v_isi   text;
+begin
+  if v_edisi is null then return; end if;
+
+  select string_agg(format('%s=%s', label, menit), ', ' order by sort_order)
+    into v_isi
+  from kontrak_opsi where edisi = v_edisi;
+
+  assert v_isi = '3 jam=180, 3,5 jam=210, 4 jam=240',
+    format('0109: pilihan kontrak edisi %s belum sesuai — sekarang [%s]',
+           v_edisi, coalesce(v_isi, 'kosong'));
+end;
+$blok$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -46,9 +46,9 @@ values
    null, null, 10, -5, null, 0, 20, 1);
 
 insert into kontrak_opsi (edisi, label, menit, sort_order) values
-  (37, '3,5 jam', 210, 1),
-  (37, '4 jam',   240, 2),
-  (37, '4,5 jam', 270, 3);
+  (37, '3 jam',   180, 1),
+  (37, '3,5 jam', 210, 2),
+  (37, '4 jam',   240, 3);
 
 insert into konfig_penalti (edisi, blok_menit, penalti_per_blok,
                             penalti_tanpa_checkout, penalti_per_anggota_hilang,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -465,6 +465,12 @@ run tests/sql/69_poin_per_komponen.sql
 # kolom perjalanan terbit sejak progres.
 run supabase/migrations/0108_anggota_hadir_publik.sql
 run tests/sql/70_anggota_hadir_publik.sql
+# 0109 menurunkan seluruh tangga kontrak setengah jam: 3 / 3,5 / 4 jam. Tes 71
+# memanggil berkas migrasinya dua kali lewat \ir — sekali dalam keadaan yang
+# harus ditolaknya (ada regu memegang kontrak yang akan hilang), sekali dalam
+# keadaan yang harus dikerjakannya.
+run supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
+run tests/sql/71_kontrak_waktu_tiga_pilihan.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/71_kontrak_waktu_tiga_pilihan.sql
+++ b/tests/sql/71_kontrak_waktu_tiga_pilihan.sql
@@ -1,0 +1,136 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/71_kontrak_waktu_tiga_pilihan.sql
+-- Tiga pilihan kontrak, pintu tulisnya mengikuti tabelnya, dan pagar 0109
+-- benar-benar menahan.
+--
+-- Bagian 71.3 memanggil berkas 0109 yang SAMA PERSIS dengan yang dijalankan
+-- ke produksi, dua kali: sekali dalam keadaan yang harus ditolaknya, sekali
+-- dalam keadaan yang harus dikerjakannya. Menyalin syarat penjaganya ke sini
+-- lalu memeriksa salinannya akan lulus selamanya — termasuk pada hari
+-- seseorang menghapus penjaga aslinya. Panggilan kedua yang berhasil menutup
+-- celah terakhir: berkas yang salah ketik juga gagal, dan juga tidak mengubah
+-- apa pun.
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+select set_config('app.uid', (select user_id::text from akun_panitia
+                              where peran = 'admin' and is_active limit 1), false);
+
+-- ---------------------------------------------------------------------------
+-- 71.1 dan 71.2 tidak menyentuh apa pun di luar dirinya.
+-- ---------------------------------------------------------------------------
+begin;
+
+-- 71.1 Ketiganya, berurutan, dan tidak ada yang keempat.
+do $$
+declare v_isi text;
+begin
+  select string_agg(format('%s=%s', label, menit), ', ' order by sort_order)
+    into v_isi
+  from kontrak_opsi where edisi = edisi_aktif();
+  assert v_isi = '3 jam=180, 3,5 jam=210, 4 jam=240',
+    format('71.1: pilihan kontrak [%s]', coalesce(v_isi, 'kosong'));
+end $$;
+
+-- 71.2 Jalur tulis mengikuti TABELNYA, bukan daftar yang ditulis di kode.
+--      Dropdown di layar bisa disunting dari devtools dalam sepuluh detik;
+--      yang menegakkan harus konfirmasi_kontrak().
+do $$
+declare
+  v_regu    uuid;
+  v_ditolak boolean := false;
+begin
+  select r.id into v_regu
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  where not r.is_cancelled and d.status = 'lunas'
+    and r.kloter_nomor is not null
+    and not exists (select 1 from keberangkatan_regu kb where kb.regu_id = r.id)
+  limit 1;
+
+  if v_regu is null then
+    raise notice '71.2 dilewati: tidak ada regu berkloter yang belum berangkat.';
+    return;
+  end if;
+
+  perform konfirmasi_kontrak(v_regu, 180::smallint);
+  assert (select kontrak_menit from regu where id = v_regu) = 180,
+    '71.2: kontrak 3 jam ditolak padahal ia salah satu dari tiga pilihan';
+
+  begin
+    perform konfirmasi_kontrak(v_regu, 270::smallint);
+  exception when others then
+    v_ditolak := true;
+  end;
+  assert v_ditolak,
+    '71.2: kontrak 4,5 jam masih diterima padahal sudah bukan pilihan edisi ini';
+  assert (select kontrak_menit from regu where id = v_regu) = 180,
+    '71.2: penolakan tetap mengubah kontrak yang sudah tersimpan';
+end $$;
+
+rollback;
+
+-- ---------------------------------------------------------------------------
+-- 71.3 PAGAR KONTRAK YATIM.
+--
+--      Sengaja TIDAK di dalam transaksi: berkas 0109 harus melihat keadaan
+--      ini sudah tersimpan, dan galatnya sendiri membatalkan transaksi apa
+--      pun yang sedang berjalan — jadi rollback bukan alat yang tersedia di
+--      sini. Dibersihkan dengan tangan di 71.5.
+--
+--      Pilihannya dikembalikan ke bentuk LAMA lebih dulu. Tanpa itu,
+--      "pilihannya tidak berubah" sesudah panggilan yang gagal tidak
+--      membuktikan apa-apa — ia sudah bernilai target sejak awal.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_regu uuid;
+begin
+  delete from kontrak_opsi where edisi = edisi_aktif();
+  insert into kontrak_opsi (edisi, label, menit, sort_order) values
+    (edisi_aktif(), '3,5 jam', 210, 1),
+    (edisi_aktif(), '4 jam',   240, 2),
+    (edisi_aktif(), '4,5 jam', 270, 3);
+
+  select r.id into v_regu from regu r where not r.is_cancelled limit 1;
+  update regu set kontrak_menit = 270 where id = v_regu;
+end $$;
+
+-- Galat yang DIHARAPKAN. run.sh memakai ON_ERROR_STOP, jadi ia dimatikan
+-- sebentar — persis pola tes 15 untuk 0036.
+\set ON_ERROR_STOP off
+\ir ../../supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
+\set ON_ERROR_STOP on
+
+-- 71.4 Yang gagal TIDAK boleh mengubah setengah-setengah.
+do $$
+declare v_isi text;
+begin
+  select string_agg(format('%s=%s', label, menit), ', ' order by sort_order)
+    into v_isi
+  from kontrak_opsi where edisi = edisi_aktif();
+  assert v_isi = '3,5 jam=210, 4 jam=240, 4,5 jam=270',
+    format('71.4: 0109 tetap mengubah pilihan padahal ada kontrak yatim — [%s]',
+           coalesce(v_isi, 'kosong'));
+end $$;
+
+-- 71.5 Kontraknya dibetulkan, lalu berkas yang SAMA harus berhasil.
+do $$
+begin
+  update regu set kontrak_menit = 240 where kontrak_menit = 270;
+end $$;
+
+\ir ../../supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
+
+do $$
+declare v_isi text;
+begin
+  select string_agg(format('%s=%s', label, menit), ', ' order by sort_order)
+    into v_isi
+  from kontrak_opsi where edisi = edisi_aktif();
+  assert v_isi = '3 jam=180, 3,5 jam=210, 4 jam=240',
+    format('71.5: 0109 tidak mengerjakan tugasnya sesudah kontrak yatim '
+           'dibetulkan — [%s]', coalesce(v_isi, 'kosong'));
+end $$;
+
+select '71_kontrak_waktu_tiga_pilihan OK' as hasil;


### PR DESCRIPTION
## What

Pilihan kontrak waktu turun setengah jam di seluruh tangganya:

| Sebelum | Sesudah |
|---|---|
| 3,5 jam · 4 jam · 4,5 jam | **3 jam · 3,5 jam · 4 jam** |

- **Migrasi 0109** mengganti isi `kontrak_opsi` edisi aktif.
- Ikut diperbarui: `supabase/seed.sql`, `supabase/checks/seed_data_uji.sql`,
  `docs/alur-lomba.md`, `docs/rancangan-b.md`, dan teks di
  `docs/alur-hrcd.svg`.

Layar Keberangkatan dan tabel Live Score tidak perlu disentuh — keduanya sudah
membaca daftarnya dari database.

## Why

Keputusan pemilik acara.

## Notes

- **Migrasi ini BERHENTI kalau ada regu yang kontraknya masih tercatat 270
  menit**, dan menyebutkan nomor dadanya. Membuang barisnya dari
  `kontrak_opsi` tidak menghapus kontrak regu itu — dan justru itu masalahnya.
  Dropdown di layar Keberangkatan digambar dari `kontrak_opsi` lalu menandai
  `selected` pada opsi yang cocok; tanpa baris 270 tidak ada yang cocok, dan
  ia jatuh ke **"Belum dipilih" untuk regu yang SUDAH berkontrak**. Petugas
  membaca "belum", sistem menyimpan 270, penaltinya dihitung dari angka yang
  tidak tertulis di layar mana pun — dan peringatan "sudah diceklis tapi belum
  punya kontrak" pun tidak menyalak, karena ia memeriksa `kontrak_menit is
  null`. Yang harus memutuskan nasib regu itu panitia, bukan berkas migrasi.
- Yang diganti **himpunannya**, bukan labelnya: `kontrak_opsi` berkunci
  `(edisi, menit)`, jadi menulisnya sebagai tiga `UPDATE` akan menabrak kunci
  itu di baris pertama.
- Migrasi juga berhenti lebih dulu kalau `konfigurasi_terkunci` menyala, dengan
  pesan yang menyebut apa yang harus dibuka — trigger `kunci_kontrak_opsi`
  akan menolaknya juga, tapi pesannya menunjuk layar Konfigurasi dan bukan
  berkas ini.
- `docs/alur-hrcd.png` **tidak** ikut diperbarui: ia biner dan tidak ada alat
  pembangkitnya di repo. SVG-nya yang jadi acuan.

## Dijalankan lokal (CLAUDE.md 16)

```
node --test tests/*.test.mjs        123 lolos, 0 gagal
bash tests/run.sh                   SEMUA TES LULUS, exit 0
python tests/concurrency_test.py    SEMUA PEMERIKSAAN LULUS, exit 0
```

`tests/sql/71_kontrak_waktu_tiga_pilihan.sql` memanggil berkas 0109 yang sama
persis dengan yang akan dijalankan ke produksi, **dua kali** — sekali dalam
keadaan yang harus ditolaknya, sekali dalam keadaan yang harus dikerjakannya.
Panggilan yang gagal saja tidak membuktikan apa-apa: berkas yang salah ketik
juga gagal. Pola yang sama dengan tes 15 untuk 0036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)