### PR TITLE
fix: read registrant count straight from the database

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -5,12 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Live Score — Hiking Rally Ciradyka</title>
   <meta name="description" content="Rekap live Hiking Rally Ciradyka — periksa nilai regu sudah masuk atau belum.">
-  <!-- Halaman ini TIDAK memuat kunci apa pun: tidak ada anon key, tidak ada
-       alamat Supabase, tidak ada kotak login. Seluruh isinya datang dari dua
-       berkas statis yang ditulis GitHub Actions — live.json (kecil, di-poll)
-       dan rekap.json (besar, diambil sekali per versi). Itu sebabnya ia
-       berdiri di Worker sendiri, terpisah dari layar panitia — lihat
-       live/wrangler.toml dan kepala live.js. -->
+  <!-- Isi papannya datang dari dua berkas statis yang ditulis GitHub Actions
+       — live.json (kecil, di-poll) dan rekap.json (besar, diambil sekali per
+       versi). Itu sebabnya ia berdiri di Worker sendiri, terpisah dari layar
+       panitia — lihat live/wrangler.toml dan kepala live.js.
+
+       Halaman ini MEMUAT anon key, lewat config.js di kaki berkas. Kalimat di
+       sini dulu berbunyi "tidak memuat kunci apa pun", dan itu berhenti benar
+       sejak 0070: dua hal dibaca langsung dari Supabase — fase live, supaya
+       saklar panitia berlaku dalam hitungan detik alih-alih menunggu
+       penerbitan, dan jumlah pendaftar selama fase `pra`. Keduanya view
+       publik yang memang di-grant ke `anon` dan tidak memuat satu pun nama,
+       nomor, atau nilai. Kotak login tetap tidak ada di sini. -->
   <!-- SATU SUMBER TAMPILAN untuk dua situs. style.css inilah yang dipakai layar
        panitia, dan berkas ini disalin byte-identik ke live/ serta ditegakkan
        shared-files.yml — jadi komponen yang sama tampil sama di kedua papan
@@ -57,6 +63,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=12"></script>
+  <script type="module" src="live.js?v=13"></script>
 </body>
 </html>

--- a/live/live.js
+++ b/live/live.js
@@ -42,7 +42,11 @@
    dibaca di layar HP, ini juga yang membuat pengambilan `rekap.json` bisa
    ditunda sampai orangnya benar-benar mencari sesuatu.
 
-   Tanpa framework, tanpa build step, tanpa kunci apa pun.
+   Tanpa framework dan tanpa build step. Kuncinya ada satu — anon key lewat
+   config.js — dan ia dipakai untuk DUA bacaan kecil yang sengaja tidak
+   menunggu penerbitan: fase live (0070) dan jumlah pendaftar selama fase
+   `pra`. Keduanya view publik yang memang di-grant ke `anon`, dan tidak satu
+   pun memuat nama, nomor, atau nilai.
    ========================================================================== */
 
 /* Aturan bersama diimpor, tidak lagi disalin tangan.
@@ -112,27 +116,78 @@ const fase = () => {
   return URUT_FASE[FASE_DB] < URUT_FASE[berkas] ? FASE_DB : berkas;
 };
 
-async function ambilFaseDb() {
+/** Satu baris dari sebuah view publik Supabase, atau null.
+ *
+ *  Dipakai dua tempat, dan keduanya punya sifat yang sama: kecil, boleh
+ *  gagal, dan tidak boleh menahan papan CDN lebih dari beberapa detik ketika
+ *  origin Supabase sedang sulit dijangkau. Gagalnya SELALU diam — yang
+ *  memanggil sudah punya jawaban cadangan dari berkas statis. */
+async function bacaViewPublik(jalur) {
   const K = window.HRCD || {};
-  if (!K.supabaseUrl || !K.anonKey) return;
+  if (!K.supabaseUrl || !K.anonKey) return null;
   const ac = new AbortController();
   const batas = setTimeout(() => ac.abort(), BATAS_FASE_MS);
   try {
-    const r = await fetch(`${K.supabaseUrl}/rest/v1/v_fase_live?select=fase_live`,
+    const r = await fetch(`${K.supabaseUrl}/rest/v1/${jalur}`,
       { headers: { apikey: K.anonKey, Authorization: `Bearer ${K.anonKey}` },
         cache: "no-store", signal: ac.signal });
-    if (!r.ok) return;                       // diamkan: berkas tetap dipakai
+    if (!r.ok) return null;
     const d = await r.json();
-    if (Array.isArray(d) && d[0] && URUT_FASE[d[0].fase_live] !== undefined) {
-      FASE_DB = d[0].fase_live;
-    }
+    return Array.isArray(d) && d[0] ? d[0] : null;
   } catch {
-    // Sambungan ke Supabase mati bukan alasan mengosongkan papan: tanpa
-    // FASE_DB, yang berlaku fase di berkas — keadaan sebelum berkas ini ada.
+    return null;
   } finally {
     clearTimeout(batas);
   }
 }
+
+async function ambilFaseDb() {
+  const d = await bacaViewPublik("v_fase_live?select=fase_live");
+  // Sambungan ke Supabase mati bukan alasan mengosongkan papan: tanpa
+  // FASE_DB, yang berlaku fase di berkas — keadaan sebelum berkas ini ada.
+  if (d && URUT_FASE[d.fase_live] !== undefined) FASE_DB = d.fase_live;
+}
+
+/* JUMLAH PENDAFTAR DIBACA LANGSUNG DARI DATABASE, dan hanya selama fase `pra`.
+ *
+ * Angka "N regu sudah mendaftar" adalah satu-satunya angka di halaman ini yang
+ * berubah karena perbuatan PEMBACANYA sendiri: ia mendaftar lewat daftar.html
+ * di situs yang sama, lalu kembali ke sini dan melihat angka yang belum
+ * bergerak. Sampai sekarang ia hanya ikut `live.json`, dan berkas itu cuma
+ * ditulis ulang kalau ada yang menjalankan publish-live.yml — cron-nya sengaja
+ * dimatikan di luar minggu lomba. Akibatnya angkanya berhenti di penerbitan
+ * terakhir: empat regu terdaftar, papan tetap menyebut nol, dan yang membaca
+ * menyimpulkan pendaftarannya tidak masuk.
+ *
+ * `v_publik_ringkas` memang sudah di-grant ke `anon` (migrasi 0099) dan isinya
+ * cuma hitungan — tidak satu pun nama, nomor, atau nilai. Membacanya di sini
+ * mengikuti pola yang SUDAH ada untuk fase (0070), termasuk batas waktunya.
+ *
+ * HANYA di fase `pra`: sesudah lomba mulai, yang tergambar papan klasemen dan
+ * angka ini tidak muncul di mana pun. Beban tambahannya karena itu nol persis
+ * pada jam ketika 3.000 HP membuka halaman ini bersamaan. */
+let RINGKAS_DB = null;
+
+async function ambilRingkasDb() {
+  const d = await bacaViewPublik("v_publik_ringkas?select=*");
+  if (d) RINGKAS_DB = d;
+}
+
+/** Ringkasan yang berlaku: database kalau terbaca, berkas kalau tidak. */
+const ringkasBerlaku = () => RINGKAS_DB || (META && META.ringkas) || {};
+
+/** Regu yang sudah mendaftar, EKSTERNAL saja — sama dengan yang diumumkan
+ *  pil golongan di bawahnya. Ringkasan sumber juga memuat Intern untuk
+ *  kebutuhan panitia; halaman ini sengaja tidak. Cadangan `jumlah_regu_daftar`
+ *  menjaga live.json lama yang belum punya `per_golongan` tetap tergambar. */
+const jumlahPesertaPra = () => {
+  const r = ringkasBerlaku();
+  const per = r.per_golongan || {};
+  return r.per_golongan && typeof r.per_golongan === "object"
+    ? URUT_GOLONGAN_PESERTA.reduce((n, g) => n + Number(per[g] || 0), 0)
+    : Number(r.jumlah_regu_daftar ?? r.jumlah_regu_lunas ?? 0);
+};
+
 const mulai = () => fase() !== "pra";
 
 /* ---------------------------------------------------------------------------
@@ -164,15 +219,10 @@ function gambarSinkron() {
    paling banyak datang saat itu.
    ------------------------------------------------------------------------- */
 function gambarPra() {
-  const r = META.ringkas || {};
-  const per = r.per_golongan || {};
-  // Headline dan pill harus menghitung populasi yang sama. Ringkasan sumber
-  // juga memuat Intern untuk kebutuhan panitia, tetapi halaman ini sengaja
-  // hanya mengumumkan Eksternal. Fallback menjaga live.json lama yang belum
-  // memiliki per_golongan tetap bisa digambar sampai penerbitan berikutnya.
-  const jumlahPeserta = r.per_golongan && typeof r.per_golongan === "object"
-    ? URUT_GOLONGAN_PESERTA.reduce((n, g) => n + Number(per[g] || 0), 0)
-    : (r.jumlah_regu_daftar ?? r.jumlah_regu_lunas ?? 0);
+  // Headline dan pil menghitung populasi yang SAMA, dari sumber yang sama —
+  // database kalau terbaca, live.json kalau tidak (lihat ringkasBerlaku).
+  const per = ringkasBerlaku().per_golongan || {};
+  const jumlahPeserta = jumlahPesertaPra();
   const t = META.edisi && META.edisi.tanggal_lomba
     ? new Date(META.edisi.tanggal_lomba) : null;
   return `
@@ -603,7 +653,11 @@ function pasangPapan() {
    barusan digambar, menggambar ulang tidak mengubah satu angka pun — ia hanya
    merusak yang sedang dipegang peserta. */
 const kunciGambar = () =>
-  [META && META.versi, fase(), REKAP && REKAP.versi].join("|");
+  [META && META.versi, fase(), REKAP && REKAP.versi,
+   // Angka pendaftar ikut, kalau tidak papan `pra` tidak pernah digambar ulang
+   // ketika satu-satunya yang berubah justru angka itu — dan itulah yang
+   // berubah paling sering sebelum lomba.
+   jumlahPesertaPra()].join("|");
 let kunciTergambar = null;
 
 function gambar() {
@@ -689,6 +743,13 @@ async function muat() {
        berbeda. Fase tetap bisa MENGETAT seketika: pengetatan datang dari
        denyut database (FASE_DB), bukan dari berkas ini. */
     if (mulai() && metaLama && versiRekap !== META.versi) META = metaLama;
+
+    /* Jumlah pendaftar disegarkan dari database SELAMA FASE `pra` saja — di
+       fase lain angka ini tidak tergambar di mana pun, jadi permintaannya
+       tidak dikirim sama sekali. Ditunggu, bukan dilepas: ia menentukan apa
+       yang digambar beberapa baris di bawah, dan batas waktunya sudah pendek
+       (BATAS_FASE_MS). */
+    if (!mulai()) await ambilRingkasDb();
 
     /* DIGAMBAR ULANG HANYA KALAU ADA YANG BERUBAH.
        Denyut 60 detik yang selalu menggambar ulang membuang tiga hal

--- a/tests/live_phase_timeout.test.mjs
+++ b/tests/live_phase_timeout.test.mjs
@@ -9,20 +9,37 @@ import test from "node:test";
 
 const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
 
-test("ambilFaseDb membatalkan request Supabase yang terlalu lama", () => {
-  const awal = live.indexOf("async function ambilFaseDb() {");
-  const akhir = live.indexOf("const mulai =", awal);
-  assert.notEqual(awal, -1, "ambilFaseDb tidak ditemukan");
+test("bacaViewPublik membatalkan request Supabase yang terlalu lama", () => {
+  // Batas waktunya tinggal di SATU tempat sejak halaman ini membaca dua view
+  // (fase dan jumlah pendaftar). Menuliskannya per pemanggil berarti bacaan
+  // berikutnya lahir tanpa batas waktu sama sekali, dan yang terlihat cuma
+  // papan yang menggantung di "Memuat rekap…" ketika origin sulit dijangkau.
+  const awal = live.indexOf("async function bacaViewPublik(jalur) {");
+  const akhir = live.indexOf("async function ambilFaseDb()", awal);
+  assert.notEqual(awal, -1, "bacaViewPublik tidak ditemukan");
   const fungsi = live.slice(awal, akhir);
 
   assert.match(fungsi, /const ac = new AbortController\(\)/,
-    "request fase tidak memiliki AbortController");
+    "request view publik tidak memiliki AbortController");
   assert.match(fungsi, /setTimeout\(\(\) => ac\.abort\(\), BATAS_FASE_MS\)/,
     "AbortController tidak punya batas waktu");
   assert.match(fungsi, /signal: ac\.signal/,
     "signal pembatalan tidak dikirim ke fetch");
   assert.match(fungsi, /finally\s*\{\s*clearTimeout\(batas\)/,
-    "timer fase tidak dibersihkan setelah request selesai");
+    "timer tidak dibersihkan setelah request selesai");
+});
+
+test("kedua bacaan Supabase lewat pembungkus berbatas waktu itu", () => {
+  for (const [nama, jalur] of [["fase", "v_fase_live"],
+                               ["jumlah pendaftar", "v_publik_ringkas"]]) {
+    assert.match(live, new RegExp(`bacaViewPublik\\("${jalur}`),
+      `bacaan ${nama} tidak lewat bacaViewPublik()`);
+  }
+  // Satu-satunya fetch ke Supabase yang boleh ada di berkas ini yang di dalam
+  // pembungkus itu. Yang lain mengambil berkas statis dari origin yang sama.
+  const langsung = [...live.matchAll(/fetch\(`\$\{K\.supabaseUrl\}/g)];
+  assert.equal(langsung.length, 1,
+    "ada fetch ke Supabase di luar bacaViewPublik() — ia lahir tanpa batas waktu");
 });
 
 test("fase tetap selesai sebelum live.json boleh digambar", () => {

--- a/tests/public_registration_headline.test.mjs
+++ b/tests/public_registration_headline.test.mjs
@@ -1,4 +1,5 @@
-// Headline pendaftaran peserta harus menjumlahkan golongan yang ditampilkan.
+// Headline pendaftaran peserta: menjumlahkan golongan yang ditampilkan, dan
+// membaca angkanya dari database selama fase `pra`.
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
@@ -6,28 +7,78 @@ import test from "node:test";
 
 
 const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
-const awal = live.indexOf("function gambarPra() {");
-const akhir = live.indexOf("function gambarKelengkapan()", awal);
-const gambarPra = live.slice(awal, akhir);
+
+const potong = (dari, sampai) => {
+  const awal = live.indexOf(dari);
+  const akhir = live.indexOf(sampai, awal);
+  assert.ok(awal >= 0 && akhir > awal, `tidak ketemu: ${dari}`);
+  return live.slice(awal, akhir);
+};
+
+const gambarPra = potong("function gambarPra() {", "function gambarKelengkapan()");
+const jumlahHelper = potong("const jumlahPesertaPra = () => {", "const mulai =");
+const muat = potong("async function muat() {", "muat();");
 
 
 test("headline pra menjumlahkan golongan peserta yang sama dengan pill", () => {
+  // Aturannya pindah ke jumlahPesertaPra() supaya kunci penggambaran ulang
+  // bisa memakai angka yang SAMA — tapi ia tetap satu aturan, bukan dua.
   assert.match(
-    gambarPra,
+    jumlahHelper,
     /URUT_GOLONGAN_PESERTA\.reduce\(\(n, g\) => n \+ Number\(per\[g\] \|\| 0\), 0\)/,
   );
+  assert.match(gambarPra, /jumlahPesertaPra\(\)/);
   assert.match(gambarPra, /String\(jumlahPeserta\)/);
-  assert.doesNotMatch(
-    gambarPra,
-    /angka-besar[^\n]+jumlah_regu_daftar/,
-  );
+  assert.doesNotMatch(gambarPra, /angka-besar[^\n]+jumlah_regu_daftar/);
 });
 
 
 test("live.json lama tanpa rincian golongan tetap punya fallback", () => {
   assert.match(
-    gambarPra,
+    jumlahHelper,
     /r\.jumlah_regu_daftar \?\? r\.jumlah_regu_lunas \?\? 0/,
   );
 });
 
+
+test("headline dan pill membaca ringkasan yang sama", () => {
+  // Dua sumber untuk satu populasi adalah dua sumber yang suatu hari tidak
+  // sepakat — dan yang terlihat cuma angka besar membantah pil di bawahnya.
+  assert.match(gambarPra, /ringkasBerlaku\(\)\.per_golongan/);
+  assert.match(jumlahHelper, /ringkasBerlaku\(\)/);
+});
+
+
+test("jumlah pendaftar disegarkan dari database, hanya selama fase pra", () => {
+  assert.match(muat, /if \(!mulai\(\)\) await ambilRingkasDb\(\)/,
+    "muat() tidak menyegarkan jumlah pendaftar dari database");
+  assert.match(live, /v_publik_ringkas\?select=\*/,
+    "ringkasan tidak dibaca dari view publik yang di-grant ke anon (0099)");
+  // Sesudah lomba mulai angka ini tidak tergambar di mana pun, jadi
+  // permintaannya tidak boleh dikirim sama sekali — di situlah 3.000 HP
+  // membuka halaman ini bersamaan.
+  assert.doesNotMatch(muat, /await ambilRingkasDb\(\);\s*\n\s*if/,
+    "ambilRingkasDb dipanggil tanpa pagar fase");
+});
+
+
+test("angka pendaftar ikut menentukan penggambaran ulang", () => {
+  const kunci = potong("const kunciGambar = () =>", "let kunciTergambar");
+  assert.match(kunci, /jumlahPesertaPra\(\)/,
+    "papan pra tidak digambar ulang saat satu-satunya yang berubah justru "
+    + "angka pendaftar");
+});
+
+
+test("halaman peserta tidak lagi mengaku tanpa kunci", async () => {
+  // Ia memuat anon key lewat config.js, dan sudah begitu sejak 0070. Kalimat
+  // yang membantahnya membuat pembaca berikutnya menyimpulkan hal yang salah
+  // tentang apa yang boleh ditaruh di halaman ini.
+  const indeks = await readFile(
+    new URL("../live/index.html", import.meta.url), "utf8");
+  assert.match(indeks, /<script src="config\.js"><\/script>/);
+  for (const [nama, isi] of [["live/index.html", indeks], ["live/live.js", live]]) {
+    assert.doesNotMatch(isi, /tanpa kunci apa pun|TIDAK memuat kunci apa pun/,
+      `${nama} masih mengaku tidak memuat kunci apa pun`);
+  }
+});


### PR DESCRIPTION
## What

Angka **"N regu sudah mendaftar"** di halaman peserta dibaca langsung dari
`v_publik_ringkas`, bukan lagi hanya dari `live.json`.

Berlaku **hanya selama fase `pra`** — sesudah lomba mulai angka itu tidak
tergambar di mana pun, jadi permintaannya tidak dikirim sama sekali.

## Why

Halaman menyebut **0 regu** padahal database punya **4**. Angkanya tidak salah
hitung, ia basi:

```
$ curl -s https://hrcd37.ciradyka.workers.dev/live.json
  "dibuat_pada": "2026-08-23T16:39:31+00:00",
  "ringkas": { "per_golongan": null, "jumlah_regu_daftar": 0 }

$ curl -s .../rest/v1/v_publik_ringkas   (anon)
  [{"jumlah_regu_daftar":4,"per_golongan":{"penggalang_pa":2,"penggalang_pi":2}}]
```

`live.json` hanya ditulis ulang kalau ada yang menjalankan `publish-live.yml`,
dan cron-nya sengaja dimatikan di luar minggu lomba. Berkas yang sedang tayang
dibuat 23 Agustus — sebelum keempat regu itu mendaftar.

Ini angka yang paling buruk untuk dibiarkan basi: **ia satu-satunya di halaman
ini yang berubah karena perbuatan pembacanya sendiri.** Pembina mendaftar lewat
`daftar.html` di situs yang sama, kembali ke sini, melihat nol, dan
menyimpulkan pendaftarannya tidak masuk.

## Notes

- `v_publik_ringkas` **sudah** di-grant ke `anon` sejak migrasi 0099, dan
  isinya cuma hitungan — tidak satu pun nama, nomor, atau nilai. Tidak ada
  migrasi baru di PR ini.
- Polanya mengikuti yang sudah ada untuk fase live (0070). Batas waktunya kini
  tinggal di satu pembungkus, `bacaViewPublik()`, yang dipakai kedua bacaan —
  dan sebuah tes menjaga agar tidak ada `fetch` ke Supabase yang lahir di luar
  pembungkus itu tanpa batas waktu.
- **Ini tidak melonggarkan apa pun soal nilai.** Yang dibaca hitungan
  pendaftar, bukan skor. Aturan "mematikan seketika, menyalakan tetap lewat
  penerbitan" (CLAUDE.md 14.3) tidak tersentuh: `fase()` tetap hanya boleh
  MEMPERKETAT isi berkas.
- Kalimat **"tidak memuat kunci apa pun"** di `live.js` dan `live/index.html`
  ikut dibetulkan. Ia berhenti benar sejak 0070 menaruh `config.js` di halaman
  ini; membiarkannya membuat pembaca berikutnya menyimpulkan hal yang salah
  tentang apa yang boleh ada di sini. `live.js?v=12` naik ke `v=13`.

## Dijalankan lokal (CLAUDE.md 16)

```
node --test tests/*.test.mjs   124 lolos, 0 gagal
bash tests/run.sh              SEMUA TES LULUS, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)