### PR TITLE
feat: biaya regu Intern Rp 100.000 dan tunai sebagai cara bayar utama

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0109`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0110`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-109 migrasi, `0001` sampai `0109`, dijalankan berurutan tanpa lubang penomoran.
+110 migrasi, `0001` sampai `0110`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -126,7 +126,7 @@ Postgres — layar tidak pernah menulis "setengah jadi":
 | RPC | Menjamin |
 | --- | --- |
 | `submit_pendaftaran` | Buat sekolah (bila baru) + batch + N baris regu + kode pembayaran unik, sekali jalan; validasi ulang rincian golongan = total di server |
-| `verifikasi_pembayaran` | Cek nominal = jumlah regu × `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
+| `verifikasi_pembayaran` | Cek nominal = `tagihan_pendaftaran()` = jumlah `biaya_regu(golongan)` seluruh regu yang belum dibatalkan — Intern memakai `biaya_per_regu_intern`, golongan lain `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
 | `batalkan_verifikasi` | Jalan mundur yang sah untuk salah verifikasi (meja di hari yang sama, admin kapan pun) — dengan alasan, terekam riwayat |
 | `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → terima pasangan regu→nomor dada **yang diketik petugas** (`p_nomor` jsonb; wajib lengkap satu batch, nomor divalidasi ada di stok / belum pensiun / belum dipakai, baris stoknya dikunci) → **satu gerbang `pg_advisory_xact_lock`** → tempatkan FIFO ke kloter paling awal yang belum berangkat dengan kuota 5 Eksternal + 3 Intern → tulis semuanya sekaligus. Regu `batal` dilewati. |
 | `tukar_nomor_dada` | Nomor dada rusak/salah pasang: tukar dengan stok tersedia, terekam riwayat |

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -17,7 +17,7 @@
 
 import { daftarSekolah, kirimPendaftaran, infoEdisi, namaReguDipakai, ErrorApi } from "./api.js";
 import { esc, h, html, rupiah, notif, kartuGagalMuat,
-         pemuat } from "./util.js";
+         pemuat, biayaRegu, totalBiaya } from "./util.js";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN = [
@@ -506,13 +506,21 @@ function sinkronRegu() {
 
 function perbaruiTotal() {
   const total = jawab.regu.length;
+  // Regu Intern berharga lain (migrasi 0110). Form ini tidak pernah mencampur
+  // keduanya — jenis peserta dipilih sekali di atas dan menentukan seluruh
+  // pilihan golongan — jadi "N × harga" masih benar dan harganya diambil dari
+  // regu pertama. Yang DIJUMLAHKAN tetap per regu, supaya angka besarnya tetap
+  // benar seandainya form suatu hari boleh mencampur; ia juga harus sama
+  // persis dengan hitungan Meja Pembayaran, atau pembayarannya akan ditolak.
+  const satuan = total ? biayaRegu(EDISI, jawab.regu[0].golongan) : 0;
+  const tagihan = totalBiaya(EDISI, jawab.regu);
   document.getElementById("kotak-total").innerHTML = total
     ? html`<strong>Total: ${total} regu</strong>
-           <div class="description">Biaya: ${total} × ${rupiah(EDISI.biaya_per_regu)}
-           = <strong>${rupiah(total * EDISI.biaya_per_regu)}</strong></div>`
+           <div class="description">Biaya: ${total} × ${rupiah(satuan)}
+           = <strong>${rupiah(tagihan)}</strong></div>`
     : `<span class="description">Belum ada regu yang ditambahkan.</span>`;
   document.getElementById("kirim-info").innerHTML = total
-    ? html`${total} regu · ${rupiah(total * EDISI.biaya_per_regu)}`
+    ? html`${total} regu · ${rupiah(tagihan)}`
     : `<span class="description">Belum ada regu</span>`;
   if (sudahDiperiksa) periksa(false);
 }

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -788,11 +788,18 @@ function sukses(hasil) {
       <button class="button button-secondary" id="salin" type="button">📋 Salin kode</button>
     </div>
     <div class="card">
+      <!-- TUNAI yang disebut duluan, dan itu bukan urutan kalimat belaka:
+           mayoritas sekolah membayar langsung di meja, dan yang disebut lebih
+           dahulu itulah yang dianggap cara yang dimaksud panitia. Transfer
+           tetap ada di kalimat berikutnya, lengkap dengan satu hal yang tidak
+           bisa ditebak sendiri — kodenya harus ikut di berita transfer, kalau
+           tidak uangnya masuk tanpa nama. -->
       <h2 style="font-size:1.1rem">Cara membayar</h2>
-      <p style="margin-top:.4rem">Transfer <strong>${rupiah(hasil.total_tagihan)}</strong>
-         ke rekening panitia (tertera di poster/brosur), tulis kode
-         <strong>${hasil.kode_pembayaran}</strong> di berita transfer —
-         atau bayar tunai di meja pendaftaran.</p>
+      <p style="margin-top:.4rem">Bayar tunai <strong>${rupiah(hasil.total_tagihan)}</strong>
+         di meja pendaftaran.</p>
+      <p style="margin-top:.4rem">Kalau lebih mudah transfer: rekening panitia
+         tertera di poster/brosur, dan tulis kode
+         <strong>${hasil.kode_pembayaran}</strong> di berita transfer.</p>
       <p class="description" style="margin-top:.6rem">Setelah panitia memeriksa
          pembayaran, semua regumu (${hasil.jumlah_regu} regu) resmi terdaftar.</p>
     </div>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1107,3 +1107,33 @@ export const GOLONGAN_LABEL = {
 export const URUT_GOLONGAN =
   ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi",
    "intern_pa", "intern_pi"];
+
+/** Biaya pendaftaran SATU regu, menurut golongannya (migrasi 0110).
+ *
+ *  Pasangan sisi layar dari `biaya_regu()` di database, dan seperti fungsi itu
+ *  ia satu-satunya tempat di kedua situs yang tahu golongan mana yang berharga
+ *  intern. Tempatnya di util.js — berkas yang disalin utuh ke live/ dan dijaga
+ *  shared-files.yml — karena Meja Pembayaran dan form pendaftaran HARUS
+ *  menghitung angka yang sama: kalau keduanya berbeda satu rupiah,
+ *  `verifikasi_pembayaran` menolak pembayaran sekolah itu dan tidak ada tombol
+ *  di layar mana pun yang bisa memperbaikinya.
+ *
+ *  Tagihan satu batch adalah PENJUMLAHAN nilai ini per regu, bukan perkalian:
+ *  satu pendaftaran boleh memuat regu Eksternal dan Intern sekaligus.
+ *
+ *  HARGA INTERN YANG TIDAK ADA JATUH KE HARGA BIASA, dan itu yang membuat
+ *  urutan rilis tidak penting. Situs terbit tiap kali PR di-merge sedangkan
+ *  migrasi dijalankan terpisah sesudahnya (CLAUDE.md 7.6), jadi ada jeda
+ *  ketika layar baru ini membaca `v_edisi_publik` yang belum punya kolomnya.
+ *  Dengan jatuh ke `biaya_per_regu` layar menghitung persis seperti server
+ *  yang belum dimigrasi — angkanya cocok, pembayaran jalan. Kalau ia jatuh ke
+ *  nol, regu Intern akan tampil Rp 0 di Meja Pembayaran dan setiap
+ *  pembayarannya ditolak, tanpa satu pun galat yang menyebut sebabnya. */
+export const biayaRegu = (edisi, golongan) =>
+  golongan === "intern_pa" || golongan === "intern_pi"
+    ? Number(edisi?.biaya_per_regu_intern ?? edisi?.biaya_per_regu ?? 0)
+    : Number(edisi?.biaya_per_regu ?? 0);
+
+/** Tagihan satu daftar regu. Terima apa saja yang punya `golongan`. */
+export const totalBiaya = (edisi, daftarRegu) =>
+  (daftarRegu || []).reduce((n, r) => n + biayaRegu(edisi, r.golongan), 0);

--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -258,9 +258,13 @@ begin
     for v_kode in
       select kode_pembayaran from pendaftaran where status = 'menunggu_pembayaran'
     loop
+      -- tagihan_pendaftaran(), bukan jumlah_regu * biaya_per_regu: sejak
+      -- migrasi 0110 regu Intern berharga lain, jadi perkalian lama meleset
+      -- pada batch mana pun yang memuatnya dan simulasi berhenti di
+      -- "nominal tidak sama dengan tagihan".
       perform verifikasi_pembayaran(
         v_kode,
-        (select p.jumlah_regu * v_e.biaya_per_regu from pendaftaran p
+        (select tagihan_pendaftaran(p.id) from pendaftaran p
           where p.kode_pembayaran = v_kode),
         'tunai');
     end loop;

--- a/supabase/migrations/0110_biaya_intern_seratus_ribu.sql
+++ b/supabase/migrations/0110_biaya_intern_seratus_ribu.sql
@@ -1,0 +1,351 @@
+-- ============================================================================
+-- hrcd-rekap : 0110_biaya_intern_seratus_ribu.sql
+--
+-- REGU INTERN MEMBAYAR Rp 100.000; EKSTERNAL TETAP Rp 175.000.
+--
+-- Keputusan pemilik acara. Peserta internal berasal dari SMAN 1 Ciamis dan
+-- hanya dinilai dari lima Soal Tulis serta ketepatan waktu (migrasi 0091),
+-- jadi biayanya pun berdiri sendiri.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA TIDAK CUKUP MENGGANTI SATU ANGKA LAGI SEPERTI 0084
+--
+-- 0084 menulis bahwa "satu angka, dan itu memang cukup": tagihan tidak pernah
+-- disimpan, ia dihitung ulang sebagai `jumlah_regu * biaya_per_regu` di mana
+-- pun ia dibaca. Kalimat itu benar selama SELURUH regu berharga sama. Sejak
+-- hari ini tidak lagi, jadi yang berubah bukan angkanya melainkan
+-- PERKALIANNYA: tagihan sekarang adalah JUMLAH harga tiap regu, dan harga
+-- tiap regu ditentukan golongannya.
+--
+-- Perkaliannya hidup di empat tempat, dan semuanya harus ikut atau tidak sama
+-- sekali — kalau layar menghitung lain dari server, `verifikasi_pembayaran`
+-- menolak setiap pembayaran dengan "nominal X tidak sama dengan tagihan Y"
+-- dan Meja Pembayaran berhenti total:
+--
+--   1. `submit_pendaftaran`    -> `total_tagihan` yang dibaca pembina
+--   2. `verifikasi_pembayaran` -> pagar nominal di Meja Pembayaran
+--   3. `v_edisi_publik`        -> angka yang dipakai form pendaftaran
+--   4. layar (app.js, daftar.js) -> tagihan, rincian, dan kwitansi
+--
+-- Migrasi ini menutup 1-3 dan menyediakan kolom untuk 4.
+--
+-- ---------------------------------------------------------------------------
+-- SATU FUNGSI, BUKAN `case` YANG DISALIN
+--
+-- `biaya_regu(golongan)` adalah satu-satunya tempat di database yang tahu
+-- golongan mana yang berharga intern. Menyalin `case when golongan in (...)`
+-- ke tiap pemanggil berarti edisi berikutnya yang menambah golongan harus
+-- menemukan setiap salinannya — dan yang terlewat tidak menimbulkan galat apa
+-- pun, cuma tagihan yang salah di satu layar.
+--
+-- ---------------------------------------------------------------------------
+-- `not is_cancelled`, DAN INI SEKALIGUS MENUTUP SATU CACAT YANG TERPENDAM
+--
+-- Perkalian lama memakai `pendaftaran.jumlah_regu` — angka yang ditulis sekali
+-- saat pendaftaran dikirim dan tidak pernah turun. Layar Meja Pembayaran
+-- selalu menghitung dari regu yang MASIH AKTIF (`reguAktif` di app.js).
+-- Selama tidak ada regu yang dibatalkan keduanya sama, dan memang belum
+-- pernah ada: tidak satu pun RPC menyalakan `is_cancelled`. Tetapi pada hari
+-- pertama seseorang menyalakannya lewat admin untuk batch yang BELUM bayar,
+-- layar mengirim nominal untuk regu yang tersisa sementara server menagih
+-- regu yang sudah batal — pembayaran sekolah itu ditolak dan tidak ada jalan
+-- maju di layar. `tagihan_pendaftaran` menghitung dari regu aktif, sama
+-- dengan layarnya.
+--
+-- ---------------------------------------------------------------------------
+-- KONFIGURASI HARUS TIDAK TERKUNCI
+--
+-- Trigger `kunci_edisi` (0002) menolak setiap tulisan ke `edisi` selama
+-- `status_acara.konfigurasi_terkunci` menyala. Ditangkap di awal supaya yang
+-- menjalankan migrasi ini membaca nama saklarnya, bukan pesan trigger yang
+-- menyebut layar Konfigurasi.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Pagar: berhenti sebelum menyentuh apa pun.
+-- ---------------------------------------------------------------------------
+do $blok$
+begin
+  if (select konfigurasi_terkunci from status_acara) then
+    raise exception '0110: konfigurasi sedang terkunci — buka kuncinya di '
+      'status_acara dulu, lalu jalankan ulang migrasi ini.';
+  end if;
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Kolom harga kedua.
+--
+--    Ditambahkan kosong lalu diisi dari harga yang sedang berlaku, supaya
+--    edisi mana pun di database mana pun tetap menagih persis seperti
+--    sebelumnya. Yang benar-benar berganti harga cuma edisi 37, dan itu
+--    ditulis terpisah di bawah.
+--
+--    DEFAULT-nya WAJIB ADA, dan alasannya bukan kerapian. `supabase/seed.sql`
+--    menyisipkan edisi 37 dengan daftar kolom yang ditulis lengkap, dan daftar
+--    itu tidak menyebut kolom ini — tidak bisa menyebutnya, karena di
+--    `tests/run.sh` seed berjalan jauh SEBELUM berkas ini dan kolomnya belum
+--    lahir. `tests/dev_database.sh` berjalan terbalik: seluruh glob migrasi
+--    dulu, seed sesudahnya. Tanpa DEFAULT, insert itu menabrak not-null dan
+--    skrip yang dipakai maintainer menyiapkan database dev berhenti di sana —
+--    sesudah ia sempat men-drop `hrcd_dev`. CI tidak akan pernah melihatnya:
+--    sql-tests.yml cuma menjalankan run.sh, yang urutannya kebetulan aman.
+--
+--    Ketiga kolom `edisi` yang pernah ditambahkan sesudah 0001 memakai pola
+--    yang sama persis (0009 `jam_mulai_berangkat`, 0053 `jam_batas_berangkat`,
+--    0092) — ini yang pertama yang hampir tidak.
+--
+--    DEFAULT dipasang SESUDAH pengisian di bawah, dan urutan itu berarti:
+--    kalau ia ikut di `add column`, SELURUH edisi yang sudah ada di database
+--    langsung berharga 100.000, termasuk edisi lama yang biayanya cuma satu.
+-- ---------------------------------------------------------------------------
+alter table edisi add column if not exists biaya_per_regu_intern integer;
+
+update edisi set biaya_per_regu_intern = biaya_per_regu
+where biaya_per_regu_intern is null;
+
+alter table edisi alter column biaya_per_regu_intern set default 100000;
+
+alter table edisi alter column biaya_per_regu_intern set not null;
+
+alter table edisi drop constraint if exists edisi_biaya_per_regu_intern_check;
+alter table edisi add constraint edisi_biaya_per_regu_intern_check
+  check (biaya_per_regu_intern >= 0);
+
+comment on column edisi.biaya_per_regu_intern is
+  'Biaya pendaftaran per regu untuk golongan intern_pa dan intern_pi; golongan lain memakai biaya_per_regu.';
+
+update edisi set biaya_per_regu_intern = 100000 where nomor = 37;
+
+-- ---------------------------------------------------------------------------
+-- 3. Harga satu regu, dan tagihan satu pendaftaran.
+-- ---------------------------------------------------------------------------
+create or replace function biaya_regu(p_golongan text)
+returns integer
+language sql stable
+as $$
+  select case when p_golongan in ('intern_pa', 'intern_pi')
+              then biaya_per_regu_intern
+              else biaya_per_regu
+         end
+  from edisi where is_active
+$$;
+
+comment on function biaya_regu(text) is
+  'Biaya pendaftaran satu regu menurut golongannya, dari edisi yang aktif. Satu-satunya tempat yang tahu golongan mana yang berharga intern.';
+
+create or replace function tagihan_pendaftaran(p_pendaftaran uuid)
+returns integer
+language sql stable
+as $$
+  select coalesce(sum(biaya_regu(r.golongan)), 0)::integer
+  from regu r
+  where r.pendaftaran_id = p_pendaftaran
+    and not r.is_cancelled
+$$;
+
+comment on function tagihan_pendaftaran(uuid) is
+  'Total tagihan satu batch pendaftaran: jumlah biaya_regu() seluruh regu yang belum dibatalkan.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Form pendaftaran publik ikut melihat harga kedua.
+--
+--    Kolom baru DITARUH DI UJUNG. `create or replace view` menuntut kolom
+--    lama tetap pada nama dan urutan yang sama; menyelipkan harga intern di
+--    sebelah `biaya_per_regu` — yang terbaca lebih rapi — membuat perintah ini
+--    gagal seketika.
+-- ---------------------------------------------------------------------------
+create or replace view v_edisi_publik as
+select nomor, name, biaya_per_regu, tanggal_lomba, biaya_per_regu_intern
+from edisi where is_active;
+
+-- ---------------------------------------------------------------------------
+-- 5. Salinan terakhir submit_pendaftaran (0091); yang berubah hanya kedua
+--    perhitungan `total_tagihan`.
+-- ---------------------------------------------------------------------------
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', tagihan_pendaftaran(v_ada.id),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim, nama_kontak)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''))
+  returning id into v_batch;
+
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan'
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', tagihan_pendaftaran(v_batch),
+    'terkirim_ulang', false);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Salinan terakhir verifikasi_pembayaran (0064); yang berubah hanya baris
+--    yang menghitung tagihan.
+--
+--    Bunyi penolakannya DIPERTAHANKAN PERSIS. api.js mengenalinya lewat
+--    /nominal .* tidak sama dengan tagihan/i untuk mengganti galat Postgres
+--    dengan kalimat yang bisa ditindaklanjuti petugas; menyusun ulang
+--    kalimatnya mengembalikan pesan mentah ke layar tanpa satu pun tes
+--    berubah warna.
+-- ---------------------------------------------------------------------------
+create or replace function verifikasi_pembayaran(
+  p_kode    text,
+  p_nominal integer,
+  p_metode  text
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch     pendaftaran%rowtype;
+  v_tagihan   integer;
+  v_kwitansi  text;
+begin
+  if not boleh('pembayaran') then
+    raise exception 'tidak berhak: pembayaran';
+  end if;
+
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+  if v_batch.status <> 'menunggu_pembayaran' then
+    raise exception 'batch berstatus %, bukan menunggu_pembayaran', v_batch.status;
+  end if;
+
+  -- Semua-atau-tidak: nominal harus pas seluruh batch (alur 3.5).
+  v_tagihan := tagihan_pendaftaran(v_batch.id);
+  if p_nominal <> v_tagihan then
+    raise exception 'nominal % tidak sama dengan tagihan % — pembayaran sebagian tidak dilayani; sarankan daftar batch lebih kecil',
+      p_nominal, v_tagihan;
+  end if;
+
+  v_kwitansi := 'KW-HRCD' || edisi_aktif() || '-' ||
+                lpad(nextval('kwitansi_seq')::text, 4, '0');
+
+  insert into pembayaran (pendaftaran_id, amount, method, nomor_kwitansi, verified_by)
+  values (v_batch.id, p_nominal, p_metode, v_kwitansi, auth.uid());
+
+  update pendaftaran set status = 'lunas' where id = v_batch.id;
+
+  return jsonb_build_object('nomor_kwitansi', v_kwitansi);
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 7. Laporan penutup.
+--
+--    Sama seperti 0084: batch yang SUDAH lunas menyimpan nominal yang
+--    benar-benar dibayar di `pembayaran.amount`, jadi kwitansi lama tidak
+--    berubah. Yang belum bayar otomatis beralih ke harga baru.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_eksternal integer;
+  v_intern    integer;
+  v_lunas     integer;
+begin
+  select biaya_per_regu, biaya_per_regu_intern
+    into v_eksternal, v_intern
+  from edisi where nomor = 37;
+
+  if not found then
+    raise notice '0110: edisi 37 tidak ada di database ini — harganya dilewati.';
+    return;
+  end if;
+
+  assert v_intern = 100000, format('0110: biaya intern masih %s', v_intern);
+
+  select count(*) into v_lunas from pendaftaran where status = 'lunas';
+  -- Angkanya polos, tanpa pemisah ribuan — alasannya di 0084.
+  raise notice '0110: biaya per regu Eksternal Rp %, Intern Rp %. '
+               'Batch berstatus lunas: % (kwitansinya tetap menyebut nominal '
+               'yang dibayar).', v_eksternal, v_intern, v_lunas;
+end;
+$blok$;

--- a/tests/concurrency_test.py
+++ b/tests/concurrency_test.py
@@ -83,10 +83,12 @@ def siapkan():
              json.dumps(regu), 0, str(uuid.uuid4())),
             role="service_role", fetch="one")["h"]
         k = h["kode_pembayaran"]
-        biaya = jalankan("select biaya_per_regu from edisi where is_active",
-                         role="service_role", fetch="one")["biaya_per_regu"]
+        # Nominalnya diambil dari yang sudah dihitung submit_pendaftaran, bukan
+        # dari REGU_PER_SEKOLAH * biaya_per_regu. Batch ini CAMPURAN Eksternal
+        # dan Intern, dan sejak migrasi 0110 keduanya berharga lain — perkalian
+        # itu meleset dan verifikasi_pembayaran menolak seluruh fixture.
         jalankan("select verifikasi_pembayaran(%s,%s,%s)",
-                 (k, REGU_PER_SEKOLAH * biaya, "tunai"),
+                 (k, h["total_tagihan"], "tunai"),
                  uid=MEJA[0], fetch="one")
         kode.append(k)
     return kode
@@ -242,8 +244,6 @@ def uji_nomor_kembar():
     sama untuk dua regu berbeda, pada detik yang sama. Tepat satu boleh
     menang; yang kalah harus DITOLAK dengan pesan, bukan menimpa regu lain
     atau lolos jadi nomor ganda."""
-    biaya = jalankan("select biaya_per_regu from edisi where is_active",
-                     role="service_role", fetch="one")["biaya_per_regu"]
     kode = []
     for i in range(2):
         h = jalankan(
@@ -253,7 +253,8 @@ def uji_nomor_kembar():
                           "golongan": "penegak_pa"}]), 0, str(uuid.uuid4())),
             role="service_role", fetch="one")["h"]
         k = h["kode_pembayaran"]
-        jalankan("select verifikasi_pembayaran(%s,%s,%s)", (k, biaya, "tunai"),
+        jalankan("select verifikasi_pembayaran(%s,%s,%s)",
+                 (k, h["total_tagihan"], "tunai"),
                  uid=MEJA[0], fetch="one")
         kode.append(k)
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -471,6 +471,12 @@ run tests/sql/70_anggota_hadir_publik.sql
 # keadaan yang harus dikerjakannya.
 run supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
 run tests/sql/71_kontrak_waktu_tiga_pilihan.sql
+# 0110 memberi regu Intern harganya sendiri, jadi tagihan berhenti jadi
+# perkalian dan menjadi penjumlahan per regu. Tes 72 memakai batch CAMPURAN —
+# satu-satunya bentuk yang membedakan kedua rumus — dan menempati kursi Meja
+# Pembayaran untuk membuktikan server menolak nominal rumus lama.
+run supabase/migrations/0110_biaya_intern_seratus_ribu.sql
+run tests/sql/72_biaya_intern.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/72_biaya_intern.sql
+++ b/tests/sql/72_biaya_intern.sql
@@ -1,0 +1,271 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/72_biaya_intern.sql
+-- Regu Intern ditagih Rp 100.000, Eksternal Rp 175.000, dan yang menghitung
+-- tagihan adalah PENJUMLAHAN — bukan lagi perkalian.
+--
+-- Kenapa penjumlahan itu yang diuji, bukan angkanya: harga berganti tiap
+-- edisi, jadi tes yang memaku 100000 adalah pekerjaan tahunan (0084 menulis
+-- alasan yang sama). Yang TIDAK boleh berganti diam-diam adalah bentuk
+-- hitungannya. Selama seluruh regu berharga sama, `jumlah_regu * harga` dan
+-- `sum(harga tiap regu)` memberi angka yang sama persis — jadi satu batch
+-- CAMPURAN adalah satu-satunya bentuk yang bisa membedakan keduanya, dan
+-- itulah yang dipakai di 72.3 dan 72.4.
+--
+-- Angka edisi 37 tetap ikut diperiksa sekali di 72.1: kalau harganya memang
+-- diganti tahun depan, tes ini gagal di satu baris yang menyebutkan angkanya
+-- — bukan di lima baris yang tersebar.
+-- ============================================================================
+
+\echo '== 72: biaya intern =='
+\set ON_ERROR_STOP on
+
+select set_config('app.uid', (select user_id::text from akun_panitia
+                              where peran = 'admin' and is_active limit 1), false);
+
+-- Seluruh isi tes membuat pendaftaran, sekolah, dan kwitansi sendiri, lalu
+-- dibatalkan di akhir. Tes sesudahnya membaca database yang sama.
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 72.1 Dua harga, dan biaya_regu() memilih yang benar untuk keenam golongan.
+--
+--      Keenamnya disebut satu per satu dengan sengaja. Menuliskannya sebagai
+--      "yang bukan intern" akan tetap lulus pada hari seseorang menambahkan
+--      golongan ketujuh yang harganya belum diputuskan.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_eksternal integer;
+  v_intern    integer;
+  v_g         text;
+begin
+  select biaya_per_regu, biaya_per_regu_intern into v_eksternal, v_intern
+  from edisi where is_active;
+
+  assert v_eksternal = 175000,
+    format('72.1: biaya Eksternal %s, harusnya 175000', v_eksternal);
+  assert v_intern = 100000,
+    format('72.1: biaya Intern %s, harusnya 100000', v_intern);
+
+  foreach v_g in array array['penegak_pa', 'penegak_pi',
+                             'penggalang_pa', 'penggalang_pi'] loop
+    assert biaya_regu(v_g) = v_eksternal,
+      format('72.1: biaya_regu(%s) = %s, harusnya harga Eksternal %s',
+             v_g, biaya_regu(v_g), v_eksternal);
+  end loop;
+
+  foreach v_g in array array['intern_pa', 'intern_pi'] loop
+    assert biaya_regu(v_g) = v_intern,
+      format('72.1: biaya_regu(%s) = %s, harusnya harga Intern %s',
+             v_g, biaya_regu(v_g), v_intern);
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 72.2 Batch seragam: angka yang dibaca pembina tetap seperti dulu.
+-- ---------------------------------------------------------------------------
+create temp table uji72 (label text primary key, hasil jsonb);
+
+insert into uji72 values ('eks', submit_pendaftaran(
+  'SMPN Uji Biaya Eksternal', 'Jl. Uji Biaya', false, '081200007201',
+  '[{"nama_regu":"Ujibiaya Eksalfa","nama_ketua":"Ketua Eksalfa","golongan":"penggalang_pa"},
+    {"nama_regu":"Ujibiaya Eksbeta","nama_ketua":"Ketua Eksbeta","golongan":"penggalang_pa"},
+    {"nama_regu":"Ujibiaya Eksgama","nama_ketua":"Ketua Eksgama","golongan":"penegak_pi"}]'));
+
+insert into uji72 values ('int', submit_pendaftaran(
+  'SMAN 1 Ciamis', 'Jl. Gunung Galuh 37', false, '081200007202',
+  '[{"nama_regu":"Ujibiaya Intalfa","nama_ketua":"Ketua Intalfa","golongan":"intern_pa"},
+    {"nama_regu":"Ujibiaya Intbeta","nama_ketua":"Ketua Intbeta","golongan":"intern_pa"},
+    {"nama_regu":"Ujibiaya Intgama","nama_ketua":"Ketua Intgama","golongan":"intern_pi"}]'));
+
+do $$
+declare
+  v_eksternal integer := biaya_regu('penegak_pa');
+  v_intern    integer := biaya_regu('intern_pa');
+  v           jsonb;
+begin
+  select hasil into strict v from uji72 where label = 'eks';
+  assert (v ->> 'total_tagihan')::int = 3 * v_eksternal,
+    format('72.2: tagihan 3 regu Eksternal %s, harusnya %s',
+           v ->> 'total_tagihan', 3 * v_eksternal);
+
+  select hasil into strict v from uji72 where label = 'int';
+  assert (v ->> 'total_tagihan')::int = 3 * v_intern,
+    format('72.2: tagihan 3 regu Intern %s, harusnya %s',
+           v ->> 'total_tagihan', 3 * v_intern);
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 72.3 Batch campuran: di sinilah perkalian lama dan penjumlahan baru berbeda.
+--
+--      Dua Eksternal + dua Intern. Perkalian lama memberi 4 x Eksternal, dan
+--      pesan gagalnya menyebutkan angka itu supaya siapa pun yang membuat tes
+--      ini merah tahu persis apa yang kembali.
+-- ---------------------------------------------------------------------------
+insert into uji72 values ('campur', submit_pendaftaran(
+  'SMPN Uji Biaya Campuran', 'Jl. Uji Campur', false, '081200007203',
+  '[{"nama_regu":"Ujibiaya Campeksa","nama_ketua":"Ketua Campeksa","golongan":"penegak_pa"},
+    {"nama_regu":"Ujibiaya Campeksb","nama_ketua":"Ketua Campeksb","golongan":"penegak_pa"},
+    {"nama_regu":"Ujibiaya Campinta","nama_ketua":"Ketua Campinta","golongan":"intern_pa"},
+    {"nama_regu":"Ujibiaya Campintb","nama_ketua":"Ketua Campintb","golongan":"intern_pi"}]'));
+
+do $$
+declare
+  v_eksternal integer := biaya_regu('penegak_pa');
+  v_intern    integer := biaya_regu('intern_pa');
+  v_benar     integer := 2 * v_eksternal + 2 * v_intern;
+  v_lama      integer := 4 * v_eksternal;
+  v           jsonb;
+  v_id        uuid;
+begin
+  select hasil into strict v from uji72 where label = 'campur';
+  assert (v ->> 'total_tagihan')::int = v_benar,
+    format('72.3: tagihan campuran %s, harusnya %s (perkalian lama memberi %s)',
+           v ->> 'total_tagihan', v_benar, v_lama);
+
+  select id into strict v_id from pendaftaran
+  where kode_pembayaran = v ->> 'kode_pembayaran';
+  assert tagihan_pendaftaran(v_id) = v_benar,
+    format('72.3: tagihan_pendaftaran %s, harusnya %s',
+           tagihan_pendaftaran(v_id), v_benar);
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 72.4 Meja Pembayaran: yang diterima hanya jumlah yang sama persis.
+--
+--      Nominal perkalian lama harus DITOLAK. Kalau ia diterima, artinya
+--      server masih menagih dengan rumus lama dan setiap sekolah campuran
+--      membayar kelebihan yang tidak pernah muncul di layar mana pun.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_eksternal integer := biaya_regu('penegak_pa');
+  v_intern    integer := biaya_regu('intern_pa');
+  v_benar     integer := 2 * v_eksternal + 2 * v_intern;
+  v_lama      integer := 4 * v_eksternal;
+  v_kode      text;
+  v_tolak     boolean := false;
+begin
+  select hasil ->> 'kode_pembayaran' into strict v_kode
+  from uji72 where label = 'campur';
+
+  begin
+    perform verifikasi_pembayaran(v_kode, v_lama, 'tunai');
+  exception when others then
+    v_tolak := true;
+  end;
+  assert v_tolak,
+    format('72.4: nominal perkalian lama (%s) masih diterima', v_lama);
+
+  assert (select status from pendaftaran where kode_pembayaran = v_kode)
+         = 'menunggu_pembayaran',
+    '72.4: penolakan tetap melunasi batch';
+
+  assert verifikasi_pembayaran(v_kode, v_benar, 'tunai') ->> 'nomor_kwitansi'
+         like 'KW-HRCD37-%',
+    format('72.4: nominal yang benar (%s) tidak menerbitkan kwitansi', v_benar);
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 72.5 Regu yang dibatalkan tidak ditagih.
+--
+--      Layar Meja Pembayaran selalu menghitung dari regu yang masih aktif
+--      (`reguAktif` di app.js). Sebelum 0110 server memakai
+--      `pendaftaran.jumlah_regu`, yang tidak pernah turun — jadi batch yang
+--      salah satu regunya dibatalkan sebelum bayar tidak bisa dilunasi sama
+--      sekali: nominal dari layar selalu kurang dari tagihan server, dan
+--      tidak ada tombol yang bisa memperbaikinya.
+-- ---------------------------------------------------------------------------
+insert into uji72 values ('batal', submit_pendaftaran(
+  'SMPN Uji Biaya Batal', 'Jl. Uji Batal', false, '081200007204',
+  '[{"nama_regu":"Ujibiaya Batalsatu","nama_ketua":"Ketua Batalsatu","golongan":"penegak_pa"},
+    {"nama_regu":"Ujibiaya Bataldua","nama_ketua":"Ketua Bataldua","golongan":"penegak_pa"},
+    {"nama_regu":"Ujibiaya Bataltiga","nama_ketua":"Ketua Bataltiga","golongan":"intern_pa"}]'));
+
+do $$
+declare
+  v_eksternal integer := biaya_regu('penegak_pa');
+  v_intern    integer := biaya_regu('intern_pa');
+  v_kode      text;
+  v_id        uuid;
+begin
+  select hasil ->> 'kode_pembayaran' into strict v_kode
+  from uji72 where label = 'batal';
+  select id into strict v_id from pendaftaran where kode_pembayaran = v_kode;
+
+  assert tagihan_pendaftaran(v_id) = 2 * v_eksternal + v_intern,
+    format('72.5: tagihan awal %s, harusnya %s',
+           tagihan_pendaftaran(v_id), 2 * v_eksternal + v_intern);
+
+  update regu set is_cancelled = true
+  where pendaftaran_id = v_id and nama_regu = 'Ujibiaya Bataltiga';
+
+  assert tagihan_pendaftaran(v_id) = 2 * v_eksternal,
+    format('72.5: regu Intern yang dibatalkan masih ditagih — %s, harusnya %s',
+           tagihan_pendaftaran(v_id), 2 * v_eksternal);
+
+  assert verifikasi_pembayaran(v_kode, 2 * v_eksternal, 'tunai')
+         ->> 'nomor_kwitansi' like 'KW-HRCD37-%',
+    '72.5: batch dengan satu regu batal tidak bisa dilunasi';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 72.6 Form pendaftaran publik melihat KEDUA harga tanpa login.
+--
+--      daftar.js memilih harganya sendiri dari jenis peserta yang dipilih
+--      pembina, jadi angka yang hilang di sini berarti "Rp 0" di layar
+--      pendaftaran — dan sekolah membawa uang sejumlah itu.
+-- ---------------------------------------------------------------------------
+set local role anon;
+
+do $$
+declare v record;
+begin
+  select * into strict v from v_edisi_publik;
+  assert v.biaya_per_regu = 175000,
+    format('72.6: anon membaca biaya Eksternal %s', v.biaya_per_regu);
+  assert v.biaya_per_regu_intern = 100000,
+    format('72.6: anon membaca biaya Intern %s', v.biaya_per_regu_intern);
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- 72.7 Edisi masih bisa disisipkan TANPA menyebut kolom harga intern.
+--
+--      `supabase/seed.sql` menyisipkan edisi dengan daftar kolom yang ditulis
+--      lengkap, dan daftar itu tidak menyebut `biaya_per_regu_intern` — tidak
+--      bisa menyebutnya, karena di berkas run.sh ini seed berjalan jauh
+--      sebelum 0110 dan kolomnya belum ada. `tests/dev_database.sh` berjalan
+--      TERBALIK: seluruh glob migrasi dulu, seed sesudahnya. Tanpa DEFAULT,
+--      insert itu menabrak not-null dan skrip penyiapan database dev berhenti
+--      di sana — sesudah ia sempat men-drop hrcd_dev.
+--
+--      Kursi yang diduduki di sini persis kursi seed.sql: daftar kolom yang
+--      sama, hanya nomor dan is_active yang diganti supaya tidak menabrak
+--      edisi yang sedang aktif. Kalau seed.sql menambah kolom, samakan juga
+--      daftar di bawah.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_biaya integer;
+begin
+  -- Trigger kunci_edisi menolak tulisan ke `edisi` saat konfigurasi terkunci,
+  -- dan tes sebelumnya boleh saja meninggalkannya menyala. Seluruh blok ini
+  -- ada di dalam transaksi yang dibatalkan di akhir berkas.
+  update status_acara set konfigurasi_terkunci = false where id = true;
+
+  insert into edisi (nomor, name, tahun, tanggal_lomba, biaya_per_regu,
+                     maks_regu_per_kloter, kloter_dasar, kloter_maks,
+                     lompatan_kloter, interval_berangkat_menit, is_active)
+  values (99, 'HRCD UJI BIAYA', 2099, date '2099-01-01', 250000,
+          10, 30, 40, 2, 4, false);
+
+  select biaya_per_regu_intern into v_biaya from edisi where nomor = 99;
+  assert v_biaya = 100000,
+    format('72.7: edisi baru tanpa harga intern mendapat %s, harusnya 100000',
+           coalesce(v_biaya::text, 'null'));
+end $$;
+
+rollback;
+
+select '72_biaya_intern OK' as hasil;

--- a/tools/seed_regu_uji.py
+++ b/tools/seed_regu_uji.py
@@ -182,9 +182,9 @@ def main():
     lunas = 0
     for kode in kode_semua:
         try:
-            t = jalan("select p.jumlah_regu * e.biaya_per_regu tagihan"
-                      " from pendaftaran p, edisi e"
-                      " where p.kode_pembayaran = %s and e.is_active", (kode,))
+            t = jalan("select tagihan_pendaftaran(p.id) tagihan"
+                      " from pendaftaran p"
+                      " where p.kode_pembayaran = %s", (kode,))
             jalan("select verifikasi_pembayaran(%s, %s, %s)",
                   (kode, t[0]["tagihan"], "tunai"))
             lunas += 1

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -36,7 +36,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
          angkaRapi, nilaiTeks, nilaiBagian, kolomPos, kontrakTeks,
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
-         GOLONGAN_LABEL, URUT_GOLONGAN } from "./util.js";
+         GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
 
 const LAYAR = document.getElementById("layar");
@@ -867,7 +867,12 @@ async function layarPembayaran() {
 
     tbody.replaceChildren(h(baris.map(b => {
       const aktif = reguAktif(b);
-      const tagihan = aktif.length * EDISI.biaya_per_regu;
+      // PENJUMLAHAN per regu, bukan perkalian: regu Intern berharga lain
+      // (migrasi 0110), dan satu pendaftaran boleh memuat kedua jenis.
+      // Angka ini dikirim apa adanya sebagai nominal ke verifikasi_pembayaran,
+      // yang menghitung ulang dengan rumus yang sama di server dan menolak
+      // kalau berbeda — jadi kedua sisi wajib memakai biayaRegu() yang sama.
+      const tagihan = totalBiaya(EDISI, aktif);
       // Cara bayar default TUNAI — mayoritas sekolah membayar langsung di
       // meja, jadi jalur tersibuk cukup satu ketukan. Yang transfer memilih
       // "Transfer" dulu. Salah tandai dibereskan lewat "Batalkan", bukan
@@ -971,7 +976,7 @@ async function layarPembayaran() {
                     <td>${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}</td>
                     <td>${esc(r.nama_ketua)}</td>
                     <td>${sekolah}</td>
-                    <td class="text-right">${esc(rupiah(EDISI.biaya_per_regu))}</td>
+                    <td class="text-right">${esc(rupiah(biayaRegu(EDISI, r.golongan)))}</td>
                   </tr>`).join("")}
               </tbody>
             </table>
@@ -1056,7 +1061,7 @@ async function layarPembayaran() {
         const b = semua.find(x => x.kode_pembayaran === kode);
         const metode = tbody.querySelector(`[data-metode="${CSS.escape(kode)}"]`).value;
         const aktif = reguAktif(b);
-        const tagihan = aktif.length * EDISI.biaya_per_regu;
+        const tagihan = totalBiaya(EDISI, aktif);
 
         if (btn.dataset.jalan === "1") return;
         btn.dataset.jalan = "1"; btn.disabled = true; btn.textContent = "Menyimpan…";
@@ -1127,13 +1132,13 @@ function cetakKwitansi(daftar) {
   const halaman = daftar.map(b => {
     const aktif = reguAktif(b);
     const bayar = b.pembayaran || {};
-    const total = bayar.amount ?? aktif.length * EDISI.biaya_per_regu;
+    const total = bayar.amount ?? totalBiaya(EDISI, aktif);
     const baris = aktif.map((r, i) => html`
       <tr><td>${String(i + 1)}</td>
           <td>${r.nama_regu}</td>
           <td>${GOLONGAN_LABEL[r.golongan] || r.golongan}</td>
           <td>${r.nama_ketua}</td>
-          <td class="text-right">${rupiah(EDISI.biaya_per_regu)}</td></tr>`).join("");
+          <td class="text-right">${rupiah(biayaRegu(EDISI, r.golongan))}</td></tr>`).join("");
 
     return `
       <section class="print-page">
@@ -1144,8 +1149,13 @@ function cetakKwitansi(daftar) {
            · <strong>Cara bayar:</strong> ${esc(bayar.method || "—")}<br>
            <span class="receipt-date"><strong>Tanggal:</strong>
              ${esc(tanggal(bayar.verified_at))}</span></p>
-        <p><strong>Untuk pembayaran:</strong> pendaftaran ${aktif.length} regu
-           @ ${esc(rupiah(EDISI.biaya_per_regu))}</p>
+        <!-- Dulu baris ini berbunyi "N regu @ Rp X". Sejak regu Intern punya
+             harganya sendiri (migrasi 0110) tidak ada lagi SATU harga satuan
+             yang benar untuk setiap batch, dan menuliskan salah satunya di
+             kwitansi yang dipegang pembina lebih buruk daripada tidak
+             menuliskannya. Angkanya tidak hilang: tabel di bawah menyebut
+             biaya tiap regu satu per satu, lalu TOTAL-nya. -->
+        <p><strong>Untuk pembayaran:</strong> pendaftaran ${aktif.length} regu</p>
         <table class="print-table">
           <thead>
             <tr><th>No</th><th>Nama Regu</th><th>Kategori</th><th>Ketua</th>

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1107,3 +1107,33 @@ export const GOLONGAN_LABEL = {
 export const URUT_GOLONGAN =
   ["penegak_pa", "penegak_pi", "penggalang_pa", "penggalang_pi",
    "intern_pa", "intern_pi"];
+
+/** Biaya pendaftaran SATU regu, menurut golongannya (migrasi 0110).
+ *
+ *  Pasangan sisi layar dari `biaya_regu()` di database, dan seperti fungsi itu
+ *  ia satu-satunya tempat di kedua situs yang tahu golongan mana yang berharga
+ *  intern. Tempatnya di util.js — berkas yang disalin utuh ke live/ dan dijaga
+ *  shared-files.yml — karena Meja Pembayaran dan form pendaftaran HARUS
+ *  menghitung angka yang sama: kalau keduanya berbeda satu rupiah,
+ *  `verifikasi_pembayaran` menolak pembayaran sekolah itu dan tidak ada tombol
+ *  di layar mana pun yang bisa memperbaikinya.
+ *
+ *  Tagihan satu batch adalah PENJUMLAHAN nilai ini per regu, bukan perkalian:
+ *  satu pendaftaran boleh memuat regu Eksternal dan Intern sekaligus.
+ *
+ *  HARGA INTERN YANG TIDAK ADA JATUH KE HARGA BIASA, dan itu yang membuat
+ *  urutan rilis tidak penting. Situs terbit tiap kali PR di-merge sedangkan
+ *  migrasi dijalankan terpisah sesudahnya (CLAUDE.md 7.6), jadi ada jeda
+ *  ketika layar baru ini membaca `v_edisi_publik` yang belum punya kolomnya.
+ *  Dengan jatuh ke `biaya_per_regu` layar menghitung persis seperti server
+ *  yang belum dimigrasi — angkanya cocok, pembayaran jalan. Kalau ia jatuh ke
+ *  nol, regu Intern akan tampil Rp 0 di Meja Pembayaran dan setiap
+ *  pembayarannya ditolak, tanpa satu pun galat yang menyebut sebabnya. */
+export const biayaRegu = (edisi, golongan) =>
+  golongan === "intern_pa" || golongan === "intern_pi"
+    ? Number(edisi?.biaya_per_regu_intern ?? edisi?.biaya_per_regu ?? 0)
+    : Number(edisi?.biaya_per_regu ?? 0);
+
+/** Tagihan satu daftar regu. Terima apa saja yang punya `golongan`. */
+export const totalBiaya = (edisi, daftarRegu) =>
+  (daftarRegu || []).reduce((n, r) => n + biayaRegu(edisi, r.golongan), 0);


### PR DESCRIPTION
## What

**Biaya Intern Rp 100.000; Eksternal tetap Rp 175.000.** Karena harga tidak lagi seragam, tagihan berhenti menjadi `jumlah_regu × biaya_per_regu` dan menjadi penjumlahan harga tiap regu.

- `0110_biaya_intern_seratus_ribu.sql` — kolom `edisi.biaya_per_regu_intern`, fungsi `biaya_regu(golongan)` dan `tagihan_pendaftaran(id)`, lalu `v_edisi_publik`, `submit_pendaftaran`, dan `verifikasi_pembayaran` memakainya. Salinan kedua RPC didiff terhadap versi terakhirnya (0091 dan 0064): hanya baris tagihan yang berubah.
- `biayaRegu()` / `totalBiaya()` di `web/js/util.js` (disalin ke `live/`) — dipakai Meja Pembayaran, tabel rincian, kwitansi, dan form pendaftaran.
- Baris kwitansi "N regu @ Rp X" dihapus: tidak ada lagi satu harga satuan yang benar untuk setiap batch, dan tabel di bawahnya sudah menyebut biaya tiap regu beserta TOTAL.
- Ikut dibetulkan karena memakai rumus lama: `tests/concurrency_test.py`, `supabase/checks/simulasi_end_to_end.sql`, `tools/seed_regu_uji.py`.

**Tunai disebut lebih dulu di layar "Cara membayar"**, untuk pendaftar Internal maupun Eksternal. Dropdown cara bayar di Meja Pembayaran sudah default Tunai sejak b292993.

## Why

Keputusan pemilik acara. Peserta internal berasal dari SMAN 1 Ciamis dan hanya dinilai dari lima Soal Tulis serta ketepatan waktu (0091), jadi biayanya berdiri sendiri.

Tunai: mayoritas sekolah membayar langsung di meja, dan cara yang disebut lebih dahulu itulah yang dibaca sebagai cara yang dimaksud panitia.

## Notes

- **Migrasi berhenti kalau `status_acara.konfigurasi_terkunci` menyala** — trigger `kunci_edisi` menolak setiap tulisan ke `edisi`. Pesannya menyebut saklarnya.
- **Kolom barunya punya DEFAULT, dan itu perlu.** `supabase/seed.sql` menyisipkan edisi dengan daftar kolom lengkap yang tidak menyebut kolom ini — tidak bisa menyebutnya, karena di `tests/run.sh` seed berjalan sebelum 0110. `tests/dev_database.sh` berjalan terbalik, jadi tanpa DEFAULT ia berhenti di seed sesudah men-drop `hrcd_dev`. Tes 72.7 menduduki kursi itu.
- **Urutan rilis tidak mengikat.** `biayaRegu()` jatuh ke `biaya_per_regu` kalau kolom intern belum ada di `v_edisi_publik`, jadi selama jeda antara merge dan `apply-migration.yml` layar menghitung persis seperti server yang belum dimigrasi.
- Batch yang sudah lunas tidak berubah: `pembayaran.amount` menyimpan nominal yang benar-benar dibayar.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `bash tests/run.sh` | `SEMUA TES LULUS` (tes 72 baru) |
| `node --test tests/*.test.mjs` | 124 pass, 0 fail |
| `python tests/concurrency_test.py` | `SEMUA PEMERIKSAAN LULUS` |
| `bash tests/dev_database.sh` | `hrcd_dev siap`, intern 100000 |
| `python tools/simulasi_end_to_end.py` | 301 regu, 55 kloter |
| 0110 dijalankan dua kali | aman diulang |
| 0110 saat konfigurasi terkunci | berhenti dengan pesan yang benar |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
