### PR TITLE
chore: run CI once per change instead of twice

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -66,6 +66,16 @@ on:
       - '.github/workflows/publish-live.yml'
   # schedule:
   #   - cron: '*/5 * * * *'   # nyalakan pada minggu lomba
+  #
+  # SEBELUM MENYALAKANNYA, HITUNG DULU. Tiap lima menit = 288 run sehari, dan
+  # GitHub membulatkan tiap job ke atas ke menit penuh — jadi 288 menit sehari
+  # walaupun run-nya cuma 30 detik. Jatah repo privat 2.000 menit sebulan habis
+  # dalam SEMINGGU, dan yang ikut mati bukan cuma penerbitan ini melainkan
+  # seluruh Actions: tes PR, apply-migration, ganti password panitia.
+  #
+  # Kalau memang dibutuhkan pada hari-H, `*/15` sudah memberi papan yang
+  # terbarui empat kali sejam dengan sepertiga biayanya, dan matikan lagi
+  # begitu acaranya usai.
 
 # Dua jalan yang bertumpuk akan saling menimpa live.json di Cloudflare, dan
 # yang menang belum tentu yang terbaru. Satu jalan saja pada satu waktu.

--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -29,11 +29,16 @@
 
 name: Shared files
 
+# Pull request saja — alasan lengkapnya di sql-tests.yml. Singkatnya: event
+# `pull_request` sudah menguji hasil merge-nya, jadi run kedua saat merge
+# mendarat di `main` memeriksa pohon yang sama persis dan tetap menagih.
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   periksa:

--- a/.github/workflows/sql-tests.yml
+++ b/.github/workflows/sql-tests.yml
@@ -18,11 +18,28 @@
 
 name: SQL Tests
 
+# ---------------------------------------------------------------------------
+# BERJALAN DI PULL REQUEST SAJA, TIDAK LAGI DI `main`.
+#
+# Dulu keduanya. Untuk satu perubahan itu berarti dua run yang memeriksa POHON
+# YANG SAMA PERSIS: event `pull_request` menguji HASIL MERGE-nya — PR digabung
+# ke `main` yang sedang berlaku — bukan cabangnya sendiri. Jadi run kedua saat
+# merge-nya mendarat tidak pernah menemukan apa pun yang tidak ditemukan run
+# pertama, dan tetap menagih.
+#
+# Yang hilang: push LANGSUNG ke `main` tidak lagi diperiksa mesin. Itu memang
+# sudah dilarang CLAUDE.md pasal 1.1, dan pernah terjadi sekali (5502a5a). Yang
+# menggantikannya adalah pasal 16: verifikasi lokal, bukan opsional.
+# ---------------------------------------------------------------------------
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
+
+# Dorong dua kali beruntun ke satu PR, dan run yang lama dibatalkan. Tanpa ini
+# ia berjalan sampai selesai untuk memeriksa kode yang sudah tidak ada.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -618,3 +618,21 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    produced locally. This preserves the repository owner's Actions billing.
 4. **Report the local command and result.** If local execution is genuinely
    unavailable, say what is missing before falling back to GitHub Actions.
+5. **CI runs once, on the pull request. `main` is not checked again.** The
+   same two workflows used to run twice per change — once on the PR, once when
+   the merge landed — and they checked the identical tree, because the
+   `pull_request` event tests the MERGE RESULT and not the branch. The second
+   run never found anything the first had not, and it billed anyway. Both now
+   trigger on `pull_request` and `workflow_dispatch` only.
+6. **What costs money is the NUMBER of runs, not their length.** GitHub rounds
+   every JOB up to a whole minute, so a 7-second check and a 50-second check
+   bill exactly the same. Adding one more automatically-triggered workflow
+   costs more than adding ten steps to a workflow that already runs.
+7. **Because of rule 5, rule 1 is not advice.** There is no second net on
+   `main` any more. A change that was never run locally, and that PR review
+   did not catch, lands without any machine having executed it.
+8. **A cron trigger is a standing bill.** `*/5 * * * *` is 288 billed minutes
+   a day, which empties a private repo's monthly allowance in a week. Multiply
+   it out before enabling one, and remember that an exhausted allowance stops
+   EVERY workflow — including `apply-migration.yml` and the ones the panitia
+   run from their phones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,3 +616,21 @@ Guidance for Claude Code when working in this repository.
    produced locally. This preserves the repository owner's Actions billing.
 4. **Report the local command and result.** If local execution is genuinely
    unavailable, say what is missing before falling back to GitHub Actions.
+5. **CI runs once, on the pull request. `main` is not checked again.** The
+   same two workflows used to run twice per change — once on the PR, once when
+   the merge landed — and they checked the identical tree, because the
+   `pull_request` event tests the MERGE RESULT and not the branch. The second
+   run never found anything the first had not, and it billed anyway. Both now
+   trigger on `pull_request` and `workflow_dispatch` only.
+6. **What costs money is the NUMBER of runs, not their length.** GitHub rounds
+   every JOB up to a whole minute, so a 7-second check and a 50-second check
+   bill exactly the same. Adding one more automatically-triggered workflow
+   costs more than adding ten steps to a workflow that already runs.
+7. **Because of rule 5, rule 1 is not advice.** There is no second net on
+   `main` any more. A change that was never run locally, and that PR review
+   did not catch, lands without any machine having executed it.
+8. **A cron trigger is a standing bill.** `*/5 * * * *` is 288 billed minutes
+   a day, which empties a private repo's monthly allowance in a week. Multiply
+   it out before enabling one, and remember that an exhausted allowance stops
+   EVERY workflow — including `apply-migration.yml` and the ones the panitia
+   run from their phones.


### PR DESCRIPTION
## What

- `sql-tests.yml` dan `shared-files.yml` tidak lagi berjalan pada `push: branches: [main]`. Tersisa `pull_request` + `workflow_dispatch`.
- Keduanya dapat `concurrency` dengan `cancel-in-progress: true`.
- `publish-live.yml`: catatan biaya di sebelah `cron` yang masih dikomentari.
- CLAUDE.md / AGENTS.md pasal 16 bertambah aturan 5-8.

## Why

Diukur dari 60 run sukses dalam 20 jam terakhir:

| workflow | event | run | ditagih |
| --- | --- | ---: | ---: |
| SQL Tests | pull_request | 12 | 12 mnt |
| SQL Tests | **push** | **12** | **12 mnt** |
| Shared files | pull_request | 14 | 14 mnt |
| Shared files | **push** | **12** | **12 mnt** |
| Publish rekap live | push + dispatch | 6 | 6 mnt |
| Apply migration | dispatch | 4 | 4 mnt |
| | | **60** | **60 mnt** |

Yang tebal adalah pemeriksaan yang **memeriksa pohon yang sama persis** dengan pasangannya di baris atas — event `pull_request` menguji hasil merge PR ke `main` yang sedang berlaku, bukan cabangnya. Run kedua saat merge mendarat tidak pernah menemukan apa pun yang baru. **24 dari 60 run, 40% pemakaian.**

Yang membuat ini mahal bukan lamanya: GitHub membulatkan tiap **job** ke atas ke menit penuh, jadi Shared files yang 7 detik menagih sama dengan SQL Tests yang 50 detik. Jumlah run-lah yang menagih.

## Notes

**Yang hilang:** push LANGSUNG ke `main` tidak lagi diperiksa mesin. Itu sudah dilarang pasal 1.1 dan pernah terjadi sekali (`5502a5a`). Penggantinya pasal 16 — verifikasi lokal — yang sekarang ditulis sebagai kewajiban, bukan anjuran.

**Belum dikerjakan, menunggu keputusan:** menggabungkan `shared-files.yml` ke dalam job `sql-tests.yml` akan memotong 13 menit lagi (dua job → satu job, dan pembulatannya cuma sekali). Tidak dilakukan di PR ini karena `shared-files.yml` disebut namanya di CLAUDE.md pasal 7.7 dan 8.8.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 124 pass, 0 fail |
| `python -c "yaml.safe_load(...)"` atas ketiga workflow | trigger sesuai maksud |
| `diff` empat berkas bersama `web/` vs `live/` | sama |
| `periksa_impor` / `periksa_urutan_golongan` / `periksa_sekolah` / `pratinjau_cetak` | bersih |
| `diff` CLAUDE.md vs AGENTS.md | byte-identical |

`tests/run.sh` tidak dijalankan ulang: PR ini tidak menyentuh satu berkas SQL pun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
