### PR TITLE
chore: jalankan CI saat diminta, bukan tiap PR dan merge

### DIFF
--- a/.github/workflows/shared-files.yml
+++ b/.github/workflows/shared-files.yml
@@ -29,16 +29,18 @@
 
 name: Shared files
 
-# Pull request saja — alasan lengkapnya di sql-tests.yml. Singkatnya: event
-# `pull_request` sudah menguji hasil merge-nya, jadi run kedua saat merge
-# mendarat di `main` memeriksa pohon yang sama persis dan tetap menagih.
+# Saat diminta saja — alasan lengkapnya di sql-tests.yml. Keempat pemeriksaan
+# di bawah semuanya jalan di laptop dalam hitungan detik:
+#
+#   diff web/style.css live/style.css   (dan tiga pasangan lainnya)
+#   python tools/periksa_impor.py
+#   python tools/periksa_urutan_golongan.py
+#   python tools/periksa_sekolah.py
+#
+# Jalankan keempatnya sebelum membuka PR. Yang dibayar di sini bukan lamanya —
+# run tujuh detik pun ditagih satu menit penuh, sama dengan SQL Tests.
 on:
-  pull_request:
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   periksa:

--- a/.github/workflows/sql-tests.yml
+++ b/.github/workflows/sql-tests.yml
@@ -19,27 +19,35 @@
 name: SQL Tests
 
 # ---------------------------------------------------------------------------
-# BERJALAN DI PULL REQUEST SAJA, TIDAK LAGI DI `main`.
+# DIJALANKAN SAAT DIMINTA, TIDAK OTOMATIS.
 #
-# Dulu keduanya. Untuk satu perubahan itu berarti dua run yang memeriksa POHON
-# YANG SAMA PERSIS: event `pull_request` menguji HASIL MERGE-nya — PR digabung
-# ke `main` yang sedang berlaku — bukan cabangnya sendiri. Jadi run kedua saat
-# merge-nya mendarat tidak pernah menemukan apa pun yang tidak ditemukan run
-# pertama, dan tetap menagih.
+# Tidak ada trigger `push` maupun `pull_request`. Seluruh isi berkas ini bisa
+# dijalankan di laptop dengan satu perintah — `bash tests/run.sh` — dan itulah
+# yang dituntut CLAUDE.md pasal 16.1 sebelum PR dibuka. Menjalankannya lagi di
+# jam GitHub tidak menambah bukti apa pun, tetapi menambah tagihan: pemakaian
+# dibulatkan ke atas per JOB ke menit penuh, jadi tiap run menagih satu menit
+# penuh walau isinya lima puluh detik.
 #
-# Yang hilang: push LANGSUNG ke `main` tidak lagi diperiksa mesin. Itu memang
-# sudah dilarang CLAUDE.md pasal 1.1, dan pernah terjadi sekali (5502a5a). Yang
-# menggantikannya adalah pasal 16: verifikasi lokal, bukan opsional.
+# Diukur sekali: dalam 20 jam, 24 dari 60 run adalah salinan kedua dari
+# pemeriksaan yang sudah hijau — sekali di PR, sekali lagi saat merge-nya
+# mendarat di `main`, atas pohon yang sama persis.
+#
+# KAPAN TETAP DIJALANKAN. Bukan "kalau sempat", melainkan saat salah itu mahal:
+#
+#   * ada migrasi baru — ia akan menyentuh database produksi
+#   * perubahan yang tidak bisa dijalankan lokal (butuh secret repo)
+#   * laptop yang dipakai tidak punya PostgreSQL, atau hasil lokalnya meragukan
+#   * minggu menjelang hari lomba
+#
+#   gh workflow run "SQL Tests" --ref <cabang>
+#
+# Atau dari HP: Actions -> SQL Tests -> Run workflow -> pilih cabangnya.
+#
+# YANG HILANG, dan ini disengaja: tidak ada lagi apa pun di GitHub yang
+# memeriksa satu cabang pun dengan sendirinya. Pasal 16 bukan anjuran lagi.
 # ---------------------------------------------------------------------------
 on:
-  pull_request:
   workflow_dispatch:
-
-# Dorong dua kali beruntun ke satu PR, dan run yang lama dibatalkan. Tanpa ini
-# ia berjalan sampai selesai untuk memeriksa kode yang sudah tidak ada.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   tes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -618,20 +618,27 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    produced locally. This preserves the repository owner's Actions billing.
 4. **Report the local command and result.** If local execution is genuinely
    unavailable, say what is missing before falling back to GitHub Actions.
-5. **CI runs once, on the pull request. `main` is not checked again.** The
-   same two workflows used to run twice per change — once on the PR, once when
-   the merge landed — and they checked the identical tree, because the
-   `pull_request` event tests the MERGE RESULT and not the branch. The second
-   run never found anything the first had not, and it billed anyway. Both now
-   trigger on `pull_request` and `workflow_dispatch` only.
+5. **No check runs by itself any more — CI is dispatched deliberately.**
+   `sql-tests.yml` and `shared-files.yml` carry `workflow_dispatch` and nothing
+   else: no `push`, no `pull_request`. Every check they perform runs on a
+   laptop in well under a minute, and rule 1 already requires it there. The one
+   workflow still triggered automatically is `publish-live.yml`, and that is a
+   deploy, not a check.
 6. **What costs money is the NUMBER of runs, not their length.** GitHub rounds
    every JOB up to a whole minute, so a 7-second check and a 50-second check
-   bill exactly the same. Adding one more automatically-triggered workflow
-   costs more than adding ten steps to a workflow that already runs.
-7. **Because of rule 5, rule 1 is not advice.** There is no second net on
-   `main` any more. A change that was never run locally, and that PR review
-   did not catch, lands without any machine having executed it.
-8. **A cron trigger is a standing bill.** `*/5 * * * *` is 288 billed minutes
+   bill exactly the same. One measured day: 24 of 60 runs were a second copy of
+   a check that had already passed — once on the PR, once when the merge landed
+   on `main`, over the identical tree.
+7. **Dispatch CI when being wrong would be expensive.** Not "when there is
+   time". Concretely: there is a new migration, the change could not be run
+   locally, the machine at hand has no PostgreSQL or its result looks doubtful,
+   or the event is less than a week away. `gh workflow run "SQL Tests" --ref
+   <branch>` — or Actions -> SQL Tests -> Run workflow, which works from a
+   phone.
+8. **Because of rule 5, rule 1 is not advice.** Nothing on GitHub inspects a
+   branch on its own now. A change nobody ran locally lands with no machine
+   having executed it, and the first place it fails is a panitia's screen.
+9. **A cron trigger is a standing bill.** `*/5 * * * *` is 288 billed minutes
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,20 +616,27 @@ Guidance for Claude Code when working in this repository.
    produced locally. This preserves the repository owner's Actions billing.
 4. **Report the local command and result.** If local execution is genuinely
    unavailable, say what is missing before falling back to GitHub Actions.
-5. **CI runs once, on the pull request. `main` is not checked again.** The
-   same two workflows used to run twice per change — once on the PR, once when
-   the merge landed — and they checked the identical tree, because the
-   `pull_request` event tests the MERGE RESULT and not the branch. The second
-   run never found anything the first had not, and it billed anyway. Both now
-   trigger on `pull_request` and `workflow_dispatch` only.
+5. **No check runs by itself any more — CI is dispatched deliberately.**
+   `sql-tests.yml` and `shared-files.yml` carry `workflow_dispatch` and nothing
+   else: no `push`, no `pull_request`. Every check they perform runs on a
+   laptop in well under a minute, and rule 1 already requires it there. The one
+   workflow still triggered automatically is `publish-live.yml`, and that is a
+   deploy, not a check.
 6. **What costs money is the NUMBER of runs, not their length.** GitHub rounds
    every JOB up to a whole minute, so a 7-second check and a 50-second check
-   bill exactly the same. Adding one more automatically-triggered workflow
-   costs more than adding ten steps to a workflow that already runs.
-7. **Because of rule 5, rule 1 is not advice.** There is no second net on
-   `main` any more. A change that was never run locally, and that PR review
-   did not catch, lands without any machine having executed it.
-8. **A cron trigger is a standing bill.** `*/5 * * * *` is 288 billed minutes
+   bill exactly the same. One measured day: 24 of 60 runs were a second copy of
+   a check that had already passed — once on the PR, once when the merge landed
+   on `main`, over the identical tree.
+7. **Dispatch CI when being wrong would be expensive.** Not "when there is
+   time". Concretely: there is a new migration, the change could not be run
+   locally, the machine at hand has no PostgreSQL or its result looks doubtful,
+   or the event is less than a week away. `gh workflow run "SQL Tests" --ref
+   <branch>` — or Actions -> SQL Tests -> Run workflow, which works from a
+   phone.
+8. **Because of rule 5, rule 1 is not advice.** Nothing on GitHub inspects a
+   branch on its own now. A change nobody ran locally lands with no machine
+   having executed it, and the first place it fails is a panitia's screen.
+9. **A cron trigger is a standing bill.** `*/5 * * * *` is 288 billed minutes
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia

--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ Butuh PostgreSQL 16 (lokal atau portable, tanpa Supabase):
 PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
 ```
 
+`PGPORT=55432` itu port container Postgres di CI. Instalasi PostgreSQL biasa
+memakai **5432** — sesuaikan, jangan tambahkan container hanya supaya angkanya
+cocok.
+
+Tes JavaScript dan pemeriksaan sumber tidak butuh database sama sekali:
+
+```bash
+node --test tests/*.test.mjs
+python tools/periksa_impor.py
+python tools/periksa_urutan_golongan.py
+python tools/periksa_sekolah.py
+```
+
+**Tes ini TIDAK berjalan sendiri di GitHub.** Workflow `SQL Tests` dan
+`Shared files` hanya jalan kalau diminta — Actions → pilih workflow → Run
+workflow, atau `gh workflow run "SQL Tests" --ref <cabang>`. Alasannya di
+CLAUDE.md pasal 16: pemakaian Actions ditagih per job dibulatkan ke menit
+penuh, sedangkan seluruh isinya bisa dijalankan di laptop dalam hitungan
+detik. Konsekuensinya jalan satu arah: **kalau tidak dijalankan di sini, tidak
+ada yang menjalankannya di mana pun.**
+
 Untuk mencoba layarnya (butuh tiga terminal):
 
 ```bash


### PR DESCRIPTION
## What

- `sql-tests.yml` dan `shared-files.yml` tinggal `workflow_dispatch`. Tidak ada `push`, tidak ada `pull_request`.
- `concurrency` di keduanya dihapus — ia dipasang untuk membatalkan run PR yang tersalip, dan run PR sudah tidak ada.
- Kepala kedua berkas menulis kapan tetap harus dijalankan, beserta perintahnya.
- README: bagian "Menjalankan tes" menyebut perintah lokal yang tidak butuh database, mencatat bahwa port 55432 itu port container CI (instalasi biasa 5432), dan menyatakan terus terang bahwa tesnya tidak jalan sendiri di GitHub.
- CLAUDE.md / AGENTS.md pasal 16.5-16.9.

## Why

Seluruh isi kedua workflow itu bisa dijalankan di laptop, dan pasal 16.1 sudah menuntutnya sebelum PR dibuka. Menjalankan ulang bukti yang sama di jam GitHub tidak menambah apa pun.

Yang membuatnya mahal bukan lamanya: pemakaian dibulatkan ke atas **per job** ke menit penuh, jadi `Shared files` yang tujuh detik menagih sama dengan `SQL Tests` yang lima puluh detik. Dalam 20 jam terukur, 60 run sukses = 60 menit ditagih; 24 di antaranya salinan kedua dari pemeriksaan yang sudah hijau.

Setelah PR ini, satu perubahan biasa menagih **0 menit**. Yang tersisa cuma `publish-live.yml` saat `live/**` berubah — dan itu deploy, bukan pemeriksaan.

## Notes

**Konsekuensinya jalan satu arah.** Tidak ada lagi apa pun di GitHub yang memeriksa satu cabang pun dengan sendirinya. Mesin tanpa PostgreSQL lokal tidak punya cara memverifikasi apa-apa selain men-dispatch workflow-nya sendiri — dan itulah sebabnya perintahnya ditulis di tiga tempat: kepala workflow, README, dan pasal 16.7.

Jalur dispatch dari HP tetap ada: **Actions → SQL Tests → Run workflow**, pilih cabangnya.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 124 pass, 0 fail |
| `yaml.safe_load` atas ketiga workflow | `sql-tests`/`shared-files` → `workflow_dispatch` saja; `publish-live` tetap `push` |
| `diff` empat berkas bersama `web/` vs `live/` | sama |
| `periksa_impor` / `periksa_urutan_golongan` / `periksa_sekolah` / `pratinjau_cetak` | bersih |
| `diff` CLAUDE.md vs AGENTS.md | byte-identical |

`tests/run.sh` tidak dijalankan ulang: PR ini tidak menyentuh satu berkas SQL pun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
