### PR TITLE
fix: buka daftar sisipan dengan hak keberangkatan, bukan Live Score

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0110`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0111`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-110 migrasi, `0001` sampai `0110`, dijalankan berurutan tanpa lubang penomoran.
+111 migrasi, `0001` sampai `0111`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0111_sisipan_kloter_hak_gerbang.sql
+++ b/supabase/migrations/0111_sisipan_kloter_hak_gerbang.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- hrcd-rekap : 0111_sisipan_kloter_hak_gerbang.sql
+-- Daftar sisipan mengikuti hak KEBERANGKATAN, bukan centang Live Score.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SALAH
+--
+-- `v_sisipan_kloter` lahir di 0009 sebagai `security_invoker = on` tanpa pagar
+-- hak sendiri, jadi yang menentukan siapa mendapat baris adalah policy tabel
+-- yang ia JOIN — dan yang paling sempit di antaranya `sel_pendaftaran`:
+--
+--   boleh_apa_saja('pendaftaran', 'pembayaran', 'daftar_ulang', 'cetak_kloter',
+--                  'rekap', 'live_score', 'pengaturan')          -- 0069
+--
+-- `keberangkatan` TIDAK ada di daftar itu. Paket peran `gerbang` berisi
+-- `keberangkatan, kedatangan, live_score` (0075), jadi satu-satunya hak yang
+-- membuka daftar sisipan untuk petugas gerbang adalah `live_score` — hak papan
+-- skor, yang tidak ada hubungannya dengan pekerjaannya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA INI BUKAN KERAPIAN
+--
+-- Matriks centang di layar Akun memang dimaksudkan untuk diubah panitia
+-- (CLAUDE.md 13.1), dan mencabut `live_score` dari satu akun gerbang adalah
+-- tindakan yang masuk akal. Yang mati bukan Live Score-nya, melainkan kartu
+-- merah sisipan — dan matinya SENYAP dua kali: RLS mengembalikan nol baris
+-- tanpa melempar, lalu `app.js` sengaja menelan galat daftar ini
+-- (`catch { /* daftar boleh telat */ }`) dan menggambar string kosong untuk
+-- daftar kosong. Layarnya terlihat baik-baik saja.
+--
+-- Yang hilang bukan hiasan: CLAUDE.md 12.3 dan komentar di app.js menyebut
+-- daftar ini "satu-satunya cara petugas staging tahu ada nomor yang tidak
+-- tercetak di kertasnya" — pada pagi hari lomba, saat kertasnya sudah beredar.
+--
+-- Ini pengulangan bentuk yang sudah dibetulkan 0100 untuk `v_regu_ringkas`.
+-- Kedua view dibaca layar YANG SAMA (`layarKeberangkatan`); yang satu ikut
+-- dipindahkan, yang satu tertinggal.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DEFINER, BUKAN MENAMBAH `keberangkatan` KE `sel_pendaftaran`
+--
+-- Alasan yang sama dengan 0100: membuka `pendaftaran` untuk gerbang berarti
+-- membuka nomor WA pembina seluruh sekolah kepada petugas yang cuma perlu tahu
+-- nomor dada mana yang tidak ada di kertasnya. Viewnya yang menjaga haknya
+-- sendiri, tabelnya tetap tertutup. Tes 73.2 menduduki kursi itu.
+--
+-- ---------------------------------------------------------------------------
+-- BADAN VIEW-NYA DISALIN DARI DATABASE, BUKAN DARI 0009
+--
+-- 0009 menulis `s.nama` dan `not r.batal`. Kedua kolom itu sudah berganti nama
+-- di 0012/0014, dan PostgreSQL ikut mengganti nama di dalam view yang sudah
+-- terpasang — jadi berkas 0009 tidak lagi menggambarkan view yang hidup.
+-- Yang disalin ke bawah adalah `pg_get_viewdef` dari database yang seluruh
+-- migrasinya sudah jalan: `s.name` dan `not r.is_cancelled`.
+--
+-- Delapan kolomnya dipertahankan pada nama dan urutan yang sama persis —
+-- `create or replace view` menuntut itu, dan `daftarSisipan()` di app.js
+-- membacanya per nama.
+-- ============================================================================
+
+create or replace view v_sisipan_kloter with (security_invoker = off) as
+select
+  r.kloter_nomor    as kloter,
+  r.nomor_dada,
+  r.nama_regu,
+  s.name            as nama_sekolah,
+  r.golongan,
+  r.disisipkan_pada,
+  r.alasan_sisip,
+  k.jam_berangkat is not null as sudah_berangkat
+from regu r
+join kloter k      on k.nomor = r.kloter_nomor
+join pendaftaran d on d.id = r.pendaftaran_id
+join sekolah s     on s.id = d.sekolah_id
+where r.disisipkan_pada is not null
+  and not r.is_cancelled
+  and boleh_apa_saja('keberangkatan', 'cetak_kloter', 'daftar_ulang',
+                     'pengaturan')
+order by r.kloter_nomor, r.nomor_dada;
+
+comment on view v_sisipan_kloter is
+  'Nomor yang TIDAK ADA di kertas petugas staging. Definer agar tidak membuka pendaftaran beserta nomor WA pembina; badannya wajib menjaga keberangkatan/cetak_kloter/daftar_ulang/pengaturan.';
+
+grant select on v_sisipan_kloter to authenticated;
+revoke all on v_sisipan_kloter from anon;
+
+-- ---------------------------------------------------------------------------
+-- Pemeriksaan penutup: pagarnya benar-benar tertulis di badan view, dan
+-- `security_invoker` benar-benar mati. Memindai nama tidak cukup — 0064 dan
+-- 0065 dua kali melapor bersih atas alasan itu (CLAUDE.md 13.3).
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_badan   text := pg_get_viewdef('v_sisipan_kloter'::regclass, true);
+  v_invoker text;
+begin
+  assert v_badan like '%boleh_apa_saja%',
+    '0111: v_sisipan_kloter tidak memuat pagar hak di badannya';
+  assert v_badan like '%keberangkatan%',
+    '0111: pagar v_sisipan_kloter tidak menyebut keberangkatan';
+
+  -- Nilainya disimpan APA ADANYA seperti yang ditulis, jadi `off` dan `false`
+  -- sama-sama sah dan tidak boleh dibandingkan dengan salah satunya saja.
+  -- Yang diperiksa adalah kebalikannya: ia tidak boleh menyala.
+  select option_value into v_invoker
+  from pg_class c, pg_options_to_table(c.reloptions)
+  where c.oid = 'v_sisipan_kloter'::regclass
+    and option_name = 'security_invoker';
+
+  assert coalesce(v_invoker, 'off') not in ('true', 'on', 'yes', '1'),
+    format('0111: v_sisipan_kloter masih security_invoker=%s', v_invoker);
+
+  raise notice '0111: daftar sisipan kini dibuka hak keberangkatan, bukan live_score.';
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -477,6 +477,11 @@ run tests/sql/71_kontrak_waktu_tiga_pilihan.sql
 # Pembayaran untuk membuktikan server menolak nominal rumus lama.
 run supabase/migrations/0110_biaya_intern_seratus_ribu.sql
 run tests/sql/72_biaya_intern.sql
+# 0111 memindahkan daftar sisipan dari hak Live Score ke hak keberangkatan.
+# Tes 73 menduduki kursi akun gerbang dan mencabut satu baris akun_hak di
+# antara dua panggilan — bentuk tes 30-36.
+run supabase/migrations/0111_sisipan_kloter_hak_gerbang.sql
+run tests/sql/73_sisipan_kloter_hak_gerbang.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/73_sisipan_kloter_hak_gerbang.sql
+++ b/tests/sql/73_sisipan_kloter_hak_gerbang.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/73_sisipan_kloter_hak_gerbang.sql — migrasi 0111.
+-- Daftar sisipan mengikuti hak keberangkatan, bukan centang Live Score.
+--
+-- Bentuknya tes 30-36 (CLAUDE.md 13.8): duduki kursi akun gerbang, panggil
+-- viewnya, ubah SATU baris `akun_hak`, panggil lagi. Kalau jawabannya tidak
+-- berubah, pagarnya tidak ada.
+--
+-- 73.1 sengaja MEMBUAT satu sisipan lebih dulu. Tanpa itu tes bisa lulus untuk
+-- alasan yang salah — nol baris karena memang tidak ada regu yang disisipkan,
+-- bukan karena haknya bekerja.
+-- ============================================================================
+
+\echo '--- 73. daftar sisipan mengikuti hak gerbang'
+\set ON_ERROR_STOP on
+
+-- Akun uji, sisipan uji, dan pencabutan haknya semua dibatalkan di akhir.
+begin;
+
+do $blok$
+declare
+  v_gerbang uuid := '00000000-0000-0000-0000-0000000000c7';
+  v_regu    uuid;
+  v_jumlah  integer;
+begin
+  select r.id into v_regu
+  from regu r
+  join kloter k on k.nomor = r.kloter_nomor
+  where not r.is_cancelled and r.nomor_dada is not null
+  limit 1;
+  assert v_regu is not null,
+    '73.0: tidak ada regu berkloter yang bisa dijadikan sisipan uji';
+
+  update regu
+  set disisipkan_pada = now(), alasan_sisip = 'uji 73'
+  where id = v_regu;
+
+  -- Akun dibuat sebagai juri_pos lalu peran-nya DIUBAH ke gerbang: trigger
+  -- `hak_ikut_peran` (0077) hanya menyala pada `update of peran`, jadi insert
+  -- langsung sebagai gerbang menghasilkan akun tanpa satu centang pun.
+  insert into auth.users (id, email)
+  values (v_gerbang, 'gerbang.sisipan@uji.local')
+  on conflict (id) do nothing;
+
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_gerbang, 'gerbang.sisipan', 'juri_pos', 1, true)
+  on conflict (user_id) do update
+    set peran = 'juri_pos', pos = 1, is_active = true;
+  update akun_panitia set peran = 'gerbang', pos = null
+  where user_id = v_gerbang;
+
+  -- Justru inilah tindakan yang wajar dan yang dulu mematikan kartu merahnya.
+  delete from akun_hak where user_id = v_gerbang and fitur = 'live_score';
+
+  perform set_config('app.uid', v_gerbang::text, true);
+  set local role authenticated;
+
+  select count(*) into v_jumlah from v_sisipan_kloter;
+  assert v_jumlah > 0,
+    '73.1 GAGAL: daftar sisipan kosong untuk gerbang yang tidak memegang live_score';
+
+  -- Pagarnya TIDAK boleh dibetulkan dengan membuka pendaftaran — di dalamnya
+  -- ada nomor WA pembina seluruh sekolah, dan petugas gerbang tidak perlu itu.
+  select count(*) into v_jumlah from pendaftaran;
+  assert v_jumlah = 0,
+    '73.2 GAGAL: gerbang bisa membaca tabel pendaftaran secara langsung';
+
+  reset role;
+  delete from akun_hak where user_id = v_gerbang and fitur = 'keberangkatan';
+  perform set_config('app.uid', v_gerbang::text, true);
+  set local role authenticated;
+
+  select count(*) into v_jumlah from v_sisipan_kloter;
+  assert v_jumlah = 0,
+    '73.3 GAGAL: daftar sisipan tetap terbuka sesudah hak keberangkatan dicabut';
+
+  reset role;
+  perform set_config('app.uid', '', true);
+end;
+$blok$;
+
+rollback;
+
+select '73_sisipan_kloter_hak_gerbang OK' as hasil;


### PR DESCRIPTION
## What

`0111_sisipan_kloter_hak_gerbang.sql` — `v_sisipan_kloter` jadi `security_invoker = off` dengan pagarnya sendiri di badan view: `boleh_apa_saja('keberangkatan', 'cetak_kloter', 'daftar_ulang', 'pengaturan')`.

Plus `tests/sql/73_sisipan_kloter_hak_gerbang.sql`, terdaftar di `tests/run.sh`, dan checkpoint arsitektur ke 0111.

## Why

Closes #569.

View ini lahir di 0009 tanpa pagar hak sendiri, jadi yang menentukan barisnya adalah policy tabel yang ia JOIN — dan yang paling sempit di antaranya `sel_pendaftaran` (0069), yang **tidak memuat `keberangkatan`**. Satu-satunya hak milik peran `gerbang` yang kebetulan ada di daftar itu adalah `live_score`.

Jadi mencabut centang Live Score dari satu akun gerbang — tindakan yang memang dimaksudkan bisa dilakukan panitia (pasal 13.1) — tidak mematikan papan skor, melainkan **kartu merah "regu TIDAK ADA di kertas"**. Dan matinya senyap dua kali: RLS mengembalikan nol baris tanpa melempar, lalu `app.js` menelan galatnya (`catch { /* daftar boleh telat */ }`) dan menggambar string kosong.

Pasal 12.3 menyebut daftar ini "satu-satunya cara petugas staging tahu ada nomor yang tidak tercetak di kertasnya" — pada pagi hari lomba, saat kertasnya sudah beredar.

Ini pengulangan bentuk yang sudah dibetulkan `0100` untuk `v_regu_ringkas`. Kedua view dibaca layar yang sama (`layarKeberangkatan`); yang satu ikut dipindahkan, yang satu tertinggal.

## Notes

**Badan viewnya disalin dari `pg_get_viewdef`, bukan dari berkas 0009.** 0009 menulis `s.nama` dan `not r.batal`; keduanya berganti nama di 0012/0014 dan PostgreSQL ikut mengganti di dalam view yang terpasang, jadi berkas 0009 sudah tidak menggambarkan view yang hidup. Delapan kolomnya dipertahankan pada nama dan urutan yang sama — `daftarSisipan()` membacanya per nama.

**Juri pos kehilangan akses ke daftar ini,** dan itu memang maksudnya: mereka tidak bekerja di gerbang. Sebelumnya mereka mendapatkannya lewat `live_score`.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `bash tests/run.sh` | `SEMUA TES LULUS`, tes 73 OK |
| Probe langsung: satu regu sisipan + akun gerbang tanpa `live_score` | view lama **0 baris**, view baru **1 baris** |
| `node --test tests/*.test.mjs` | 124 pass, 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
