### PR TITLE
fix: tulis jam ubin Foto Jawaban dalam WIB, bukan zona alat

### DIFF
--- a/tests/photo_tile_time_zone.test.mjs
+++ b/tests/photo_tile_time_zone.test.mjs
@@ -1,0 +1,62 @@
+// Label jam di layar panitia memakai WIB, bukan zona waktu alat.
+//
+// Kenapa dijaga mesin: `toTimeString()` terlihat benar di laptop mana pun yang
+// zonanya kebetulan WIB, jadi kesalahannya tidak pernah muncul saat dicoba —
+// ia muncul di meja IT yang laptopnya UTC, pada hari lomba, sebagai jam yang
+// tidak cocok dengan jam mana pun di layar sebelahnya.
+//
+// util.js memaksa Asia/Jakarta lewat Intl.DateTimeFormat justru untuk itu, dan
+// kepala `jamMenit()` menyimpan alasannya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const akar = new URL("../", import.meta.url);
+const app = await readFile(new URL("web/js/app.js", akar), "utf8");
+const util = await readFile(new URL("web/js/util.js", akar), "utf8");
+const daftar = await readFile(new URL("live/js/daftar.js", akar), "utf8");
+const live = await readFile(new URL("live/live.js", akar), "utf8");
+
+
+/** Buang komentar sebelum memindai.
+ *
+ *  Wajib: kedua nama yang dilarang di bawah MUNCUL di berkas ini justru di
+ *  dalam komentar yang menjelaskan kenapa keduanya tidak boleh dipakai
+ *  (`app.js` di kepala `jam()`, `util.js` di kepala ZONA). Penjaga yang
+ *  memindai teks mentah akan menyalak pada penjelasannya sendiri, lalu
+ *  dilemahkan oleh orang berikutnya — dan yang hilang bukan penjelasannya,
+ *  melainkan penjaganya. `//` yang didahului titik dua dibiarkan supaya
+ *  `https://` tidak ikut terpotong. */
+const tanpaKomentar = (isi) => isi
+  .replace(/\/\*[\s\S]*?\*\//g, " ")
+  .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+
+test("tidak ada layar yang membaca jam lewat zona alat", () => {
+  for (const [nama, isi] of [["app.js", app], ["util.js", util],
+                             ["daftar.js", daftar], ["live.js", live]]) {
+    const kode = tanpaKomentar(isi);
+    assert.doesNotMatch(kode, /\.toTimeString\(/, `${nama} memakai toTimeString()`);
+    assert.doesNotMatch(kode, /\.getHours\(\)/, `${nama} memakai getHours()`);
+  }
+});
+
+
+test("ubin Foto Jawaban dinamai lewat jamMenit", () => {
+  const awal = app.indexOf("async function layarFoto()");
+  const akhir = app.indexOf("const RUTE = {", awal);
+  const layarFoto = app.slice(awal, akhir);
+
+  assert.match(layarFoto, /const jam = \(iso\) => \(iso \? jamMenit\(iso\) : ""\)/);
+  assert.match(layarFoto, /nama: `Pukul \$\{jam\(f\.diunggah_pada\)\}`/);
+});
+
+
+test("jamMenit benar-benar memaksa Asia/Jakarta", () => {
+  // Zonanya satu konstanta yang dipakai kedua formatter, bukan string yang
+  // ditulis ulang di tiap tempat — jadi yang diperiksa keduanya.
+  assert.match(util, /const ZONA = "Asia\/Jakarta"/);
+  assert.match(util, /FMT_JAM = new Intl\.DateTimeFormat\([^)]*timeZone: ZONA/s);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6150,9 +6150,16 @@ async function layarFoto() {
   const ubin = new Map();          // kunci -> keadaan ubin
   const dadaDiketik = new Map();   // kunci -> angka yang sudah diketik
 
-  const jam = (iso) => {
-    try { return new Date(iso).toTimeString().slice(0, 5); } catch { return ""; }
-  };
+  /* jamMenit(), bukan toTimeString(): yang terakhir memakai zona waktu ALAT.
+     Laptop meja IT yang zonanya UTC menulis "01:53" untuk foto yang diunggah
+     pukul 08:53 WIB — dan di layar ini jam itulah satu-satunya pembeda antara
+     dua foto yang gambarnya mirip, karena petugas menautkannya ke nomor dada
+     dengan mencocokkan urutan dan waktunya.
+
+     Kosongnya dijaga di sini, bukan diserahkan ke jamMenit(): ia mengembalikan
+     "—" untuk nilai kosong, dan ubin bernama "Pukul —" terbaca seperti foto
+     yang jamnya hilang, bukan seperti foto yang belum punya jam. */
+  const jam = (iso) => (iso ? jamMenit(iso) : "");
 
   function hitungUbin() {
     elBelum.textContent = String(elGrid.querySelectorAll(".ubin-foto").length);


### PR DESCRIPTION
## What

`web/js/app.js` — `jam()` di `layarFoto()` memakai `jamMenit()` alih-alih `toTimeString()`. Satu baris.

Plus `tests/photo_tile_time_zone.test.mjs` sebagai penjaga.

## Why

Closes #572.

`toTimeString()` memakai zona waktu alat; seluruh sisa sistem tidak. `jamMenit()` di `util.js` memaksa `Asia/Jakarta` lewat `Intl.DateTimeFormat`, dan kepala fungsinya menyimpan alasannya: *"Laptop meja IT yang zonanya UTC menampilkan 01:53 untuk pukul 08:53 WIB."*

Di layar Foto Jawaban akibatnya bukan kosmetik. Petugas menautkan foto ke nomor dada dengan mencocokkan **urutan dan jamnya**, dan pada foto yang gambarnya mirip jam itulah satu-satunya pembeda.

## Notes

**Penjaganya membuang komentar sebelum memindai,** dan itu bukan kerapian: `toTimeString` dan `getHours` sama-sama MUNCUL di repo justru di dalam komentar yang menjelaskan kenapa keduanya tidak boleh dipakai — di kepala `jam()` yang baru dan di kepala `ZONA` di util.js. Penjaga yang memindai teks mentah akan menyalak pada penjelasannya sendiri, lalu dilemahkan orang berikutnya; yang hilang bukan penjelasannya melainkan penjaganya.

Cakupannya sengaja empat berkas layar, bukan cuma `layarFoto` — kalau nama itu muncul lagi di layar mana pun, penjaganya menyalak.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 127 pass, 0 fail (3 tes baru) |
| Cek negatif: `toTimeString` dikembalikan sebentar | 2 dari 3 tes baru **gagal**, lalu hijau lagi setelah dipulihkan |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
