### PR TITLE
chore: buang kode_lomba yang disebut dua kali di select komponenPos

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -573,7 +573,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,kode_lomba,kode_lomba,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,kode_lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -573,7 +573,7 @@ export async function komponenPos(edisi, pos) {
     // beberapa baris wahana (Tebak Simpul, 0030), lalu menawarkan semuanya ke
     // setiap regu — dan server menolak yang salah dengan pesan yang benar tapi
     // terlambat.
-    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,kode_lomba,kode_lomba,` +
+    `poin_salah,total_soal,tingkat,satuan,golongan,petunjuk,judul_isian,lomba,kode_lomba,` +
     `rentang_mentah_min,rentang_mentah_maks,sort_order` +
     `&order=sort_order.asc`);
 }


### PR DESCRIPTION
## What

`web/js/api.js:576` menyebut `kode_lomba` dua kali dalam satu daftar `select` PostgREST. Salah satunya dibuang, dan `live/js/api.js` disamakan lewat `cp` (bukan disunting terpisah — `shared-files.yml` menolak kalau hanya satu yang berubah).

## Why

Closes #577.

Tidak ada akibat di layar: PostgREST menerimanya dan JSON-nya tetap memuat kuncinya sekali. Yang diperbaiki keterbacaan baris yang paling sering disunting setiap kali kolom baru ditambahkan ke `wahana` — tepat di bawah komentar yang menjelaskan kenapa `golongan` wajib ikut.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --input-type=module --check` atas kedua api.js | parse OK |
| `node --test tests/*.test.mjs` | 127 pass, 0 fail |
| `diff web/js/api.js live/js/api.js` | sama |
| `periksa_impor` | bersih |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
