### PR TITLE
fix: lepaskan pendengar dan pengamat milik layar saat layarnya pergi

### DIFF
--- a/tests/screen_listener_cleanup.test.mjs
+++ b/tests/screen_listener_cleanup.test.mjs
@@ -1,0 +1,66 @@
+// Pendengar dan pengamat milik satu layar harus dilepas saat layarnya pergi.
+//
+// Kenapa dijaga mesin: kebocoran ini TIDAK punya gejala. `ulangYangGagal()`
+// sudah menjaga diri dengan `document.body.contains(tbody)`, jadi salinan lama
+// memang tidak melakukan apa-apa yang terlihat — yang tertinggal memorinya,
+// dan tidak ada yang akan menemukannya dengan mencoba layarnya. Satu-satunya
+// cara ia tidak kembali adalah ada yang memeriksa bentuknya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+test("router melepas pendengar layar yang ditinggalkan", () => {
+  const awal = app.indexOf("async function arahkan()");
+  assert.ok(awal > 0, "arahkan() tidak ditemukan");
+  const arahkan = app.slice(awal, app.indexOf("\nwindow.addEventListener", awal));
+  assert.match(arahkan, /pengendaliLayar\.abort\(\)/);
+});
+
+
+test("pendengar window di dalam layar selalu membawa signal", () => {
+  // Tiga pendengar dipasang sekali saat boot — hashchange, afterprint,
+  // beforeunload — dan memang harus hidup selama tab terbuka. Keduanya
+  // dibedakan oleh indentasi: yang di dalam fungsi layar menjorok.
+  const baris = app.split("\n").filter(l => l.includes("window.addEventListener("));
+  assert.ok(baris.length >= 4, "pendengar window tidak ditemukan");
+
+  for (const l of baris) {
+    if (!/^\s/.test(l)) continue;              // dipasang saat boot, bukan per layar
+    assert.match(l, /signal:/,
+      `pendengar window di dalam fungsi tanpa signal: ${l.trim()}`);
+  }
+});
+
+
+test("setiap pengamat yang dibuat diserahkan ke putusSaatPindah", () => {
+  const dibuat = [...app.matchAll(/new (Resize|Intersection|Mutation)Observer\(/g)].length;
+  const diputus = [...app.matchAll(/putusSaatPindah\(/g)].length;
+
+  assert.ok(dibuat > 0, "tidak ada pengamat sama sekali — cek polanya masih dipakai");
+  assert.equal(diputus, dibuat,
+    `${dibuat} pengamat dibuat tetapi ${diputus} diserahkan ke putusSaatPindah`);
+});
+
+
+test("putusSaatPindah benar-benar memutus, bukan cuma menyimpan", () => {
+  assert.match(app, /const putusSaatPindah = \(sinyal, pengamat\) =>\s*\n\s*sinyal\.addEventListener\("abort", \(\) => pengamat\.disconnect\(\), \{ once: true \}\)/);
+});
+
+
+test("layar yang memasang sendiri meminta sinyal baru, bukan menumpang router", () => {
+  // Dropdown pemilih pos memanggil layarInputPos() lagi tanpa lewat arahkan().
+  // Tanpa sinyal baru di dalam layarnya, salinan lama tidak pernah dilepas.
+  for (const nama of ["layarInputPos", "layarLiveScore", "layarFoto"]) {
+    const awal = app.indexOf(`async function ${nama}()`);
+    assert.ok(awal > 0, `${nama}() tidak ditemukan`);
+    const akhir = app.indexOf("\nasync function ", awal + 10);
+    const badan = app.slice(awal, akhir === -1 ? undefined : akhir);
+    assert.match(badan, /sinyalLayarBaru\(\)/,
+      `${nama}() tidak meminta sinyal layar baru`);
+  }
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -82,6 +82,45 @@ let EDISI = null;
    seluruh keadaan yang hidup selama satu sesi di satu tempat. */
 let segarkanDiTempat = null;
 
+/* ---------------------------------------------------------------------------
+   PENDENGAR DAN PENGAMAT MILIK SATU LAYAR
+
+   Yang dipasang pada `window` atau lewat Resize/IntersectionObserver TIDAK
+   ikut hilang ketika `LAYAR.replaceChildren()` mengganti isinya: keduanya
+   dipegang objek yang hidup lebih lama daripada elemennya. Tanpa dilepas,
+   tiap kunjungan menambah satu salinan — dan salinan itu menahan seluruh
+   closure layarnya, termasuk `lembar` yang berisi ratusan baris nilai.
+
+   Yang menumpuk paling cepat bukan navigasi biasa. Dropdown pemilih pos
+   memanggil `layarInputPos()` lagi tanpa lewat `arahkan()`, jadi koordinator
+   pos yang menyapu kelima pos bolak-balik sepanjang pagi menumpuk satu
+   salinan tiap perpindahan. Karena itu layarnya sendiri yang meminta sinyal
+   baru, bukan hanya router.
+
+   Gejalanya nol: `ulangYangGagal()` sudah menjaga diri dengan
+   `document.body.contains(tbody)`, jadi salinan lama memang tidak melakukan
+   apa-apa. Yang tertinggal memorinya, dan tidak ada yang akan melihatnya
+   sampai satu HP kehabisan.
+
+   Polanya menyalin `pengendaliFilterSekolah` di bawah, yang sudah memakai
+   AbortController justru untuk alasan yang sama. */
+let pengendaliLayar = new AbortController();
+
+/** Lepaskan semua yang dipasang layar sebelumnya, lalu beri sinyal baru. */
+function sinyalLayarBaru() {
+  pengendaliLayar.abort();
+  pengendaliLayar = new AbortController();
+  return pengendaliLayar.signal;
+}
+
+/** Putuskan pengamat saat layarnya ditinggalkan.
+ *
+ *  AbortController tidak mengenal Resize/IntersectionObserver — `signal`
+ *  hanya melepas `addEventListener`. Jadi pengamatnya dititipkan ke peristiwa
+ *  `abort` sinyal yang sama, supaya satu saklar tetap mengurus keduanya. */
+const putusSaatPindah = (sinyal, pengamat) =>
+  sinyal.addEventListener("abort", () => pengamat.disconnect(), { once: true });
+
 const terakhir = { pembayaran: [], "daftar-ulang": [], finish: [] };
 
 /* ---------------- kerangka ---------------- */
@@ -3978,8 +4017,11 @@ async function layarInputPos() {
   }
 
   // Internet kembali: jangan menunggu putaran 15 detik berikutnya.
-  window.addEventListener("online", ulangYangGagal);
-  window.addEventListener("offline", perbaruiRingkasan);
+  // Keduanya dilepas saat layar ini ditinggalkan — termasuk saat dropdown
+  // pemilih pos memanggil layar ini lagi, yang tidak lewat arahkan().
+  const sinyalLayar = sinyalLayarBaru();
+  window.addEventListener("online", ulangYangGagal, { signal: sinyalLayar });
+  window.addEventListener("offline", perbaruiRingkasan, { signal: sinyalLayar });
 
   // Baris yang sudah berisi nilai memang berasal dari database — ✓-nya
   // benar sejak halaman dibuka, bukan hanya untuk yang diketik hari ini.
@@ -5507,13 +5549,16 @@ async function layarLiveScore() {
      apa pun akan benar di satu ukuran dan meninggalkan celah atau tumpang
      tindih di ukuran lain. Diukur ulang saat lebarnya berubah, karena di situ
      pula pembungkusannya berubah. */
+  const sinyalLayar = sinyalLayarBaru();
   LAYAR.querySelectorAll(".table-live").forEach(tabel => {
     const baris1 = tabel.tHead && tabel.tHead.rows[0];
     if (!baris1) return;
     const ukur = () => tabel.style.setProperty(
       "--kepala-baris1", `${Math.round(baris1.getBoundingClientRect().height)}px`);
     ukur();
-    new ResizeObserver(ukur).observe(baris1);
+    const pengamatUkur = new ResizeObserver(ukur);
+    pengamatUkur.observe(baris1);
+    putusSaatPindah(sinyalLayar, pengamatUkur);
   });
 
   LAYAR.querySelectorAll("[data-fase]").forEach(tb => {
@@ -6251,6 +6296,7 @@ async function layarFoto() {
       if (u && !u.url && u.path) gambarUbin(u);
     }
   }, { rootMargin: "200px" });
+  putusSaatPindah(sinyalLayarBaru(), pengamat);
 
   async function gambarUbin(u) {
     try {
@@ -6541,6 +6587,10 @@ async function arahkan() {
   document.getElementById("cetakan")?.remove();
   hashLayar = tujuan;
   segarkanDiTempat = null;
+  // Pendengar window dan pengamat milik layar yang ditinggalkan dilepas di
+  // sini, bukan diserahkan ke layar berikutnya: layar tujuan boleh saja tidak
+  // memasang apa pun, dan yang lama tetap harus pergi.
+  pengendaliLayar.abort();
   if (!sesi()) { layarLogin(); return; }
   // Profil operasional dan centang hak bisa diubah admin saat petugas masih
   // login. Segarkan sekali per boot agar UI tidak memakai peran/pos lama;


### PR DESCRIPTION
## What

Satu `AbortController` untuk seluruh layar di `web/js/app.js`:

- `pengendaliLayar` + `sinyalLayarBaru()` + `putusSaatPindah()` di bagian keadaan modul.
- `arahkan()` melepas milik layar yang ditinggalkan.
- `layarInputPos`, `layarLiveScore`, `layarFoto` meminta sinyal baru sendiri.

Plus `tests/screen_listener_cleanup.test.mjs`.

## Why

Closes #573.

Tiga pendaftar peristiwa dipasang di dalam fungsi layar dan tidak pernah dilepas — dua `window.addEventListener` di Input Pos, satu `ResizeObserver` di Live Score, satu `IntersectionObserver` di Foto Jawaban. Ketiganya dipegang objek yang hidup lebih lama daripada elemennya, jadi `LAYAR.replaceChildren()` tidak membuangnya.

**Gejalanya nol,** dan itu justru masalahnya: `ulangYangGagal()` sudah menjaga diri dengan `document.body.contains(tbody)`, jadi salinan lama memang tidak melakukan apa-apa yang terlihat. Yang tertinggal memorinya — tiap kunjungan menahan satu closure penuh berisi `lembar` (ratusan baris nilai), `asli`, `kolom`, dan `komponen`.

**Yang menumpuk paling cepat bukan navigasi biasa.** Dropdown pemilih pos memanggil `layarInputPos()` lagi **tanpa lewat `arahkan()`**, jadi koordinator pos yang menyapu kelima pos bolak-balik sepanjang pagi menumpuk satu salinan tiap perpindahan. Karena itu router saja tidak cukup: layarnya sendiri yang meminta sinyal baru.

## Notes

**Pengamat tidak dikenal AbortController** — `signal` hanya melepas `addEventListener`. `putusSaatPindah()` menitipkan `.disconnect()` ke peristiwa `abort` sinyal yang sama, supaya satu saklar tetap mengurus keduanya alih-alih dua mekanisme untuk satu pertanyaan.

**Tiga `window.addEventListener` tingkat modul tidak disentuh** — `hashchange`, `afterprint`, `beforeunload` memang harus hidup selama tab terbuka. Tesnya membedakan keduanya lewat indentasi.

**Polanya bukan hal baru di berkas ini:** `pengendaliFilterSekolah` sudah memakai `AbortController` justru untuk alasan yang sama.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 132 pass, 0 fail (5 tes baru) |
| Cek negatif: satu `signal` dan satu `putusSaatPindah` dicabut sebentar | 2 dari 5 tes baru **gagal**, hijau lagi setelah dipulihkan |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
