### PR TITLE
fix: halaman peserta memakai kolomPos(), bukan salinan tangannya

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1061,6 +1061,26 @@ export function kolomPos(komponen) {
   return urut;
 }
 
+/** Varian mana dari satu kolom yang berlaku untuk satu regu — atau null.
+ *
+ *  Pasangan sisi layar dari `komponen_berlaku()` di database (migrasi 0091),
+ *  dan seperti fungsi itu ia TIDAK simetris: regu Intern hanya menerima
+ *  komponen bertanda `intern` atau golongannya sendiri, sedangkan golongan
+ *  Eksternal menerima baris umum (`golongan` null) maupun baris golongannya.
+ *  Komponen umum tidak otomatis berlaku untuk Intern — kalau iya, seluruh
+ *  lomba lapangan ikut tergambar untuk regu yang tidak mengikutinya.
+ *
+ *  Tempatnya di util.js bersama kolomPos(), bukan di app.js, karena papan
+ *  panitia dan papan peserta HARUS memilih varian yang sama. Aturan ini
+ *  pernah ditulis dua kali dan salinan yang di halaman peserta menyimpang;
+ *  yang menyimpang tidak menggagalkan apa pun, ia cuma membuat dua papan
+ *  saling membantah di depan pembina yang sedang membandingkan keduanya. */
+export const varianUntuk = (kol, golongan) => {
+  if (golongan === "intern_pa" || golongan === "intern_pi")
+    return kol.varian.find(k => k.golongan === golongan || k.golongan === "intern") || null;
+  return kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
+};
+
 /** Angka nilai sebagai TEKS, satu bagian atau dua.
  *
  *  Mengembalikan bagian-bagiannya, bukan HTML jadi, dan itu yang membuatnya

--- a/live/live.js
+++ b/live/live.js
@@ -64,7 +64,7 @@
    ditunda sampai DOM siap, yang justru lebih aman daripada sebelumnya. */
 import {
   esc, dada3, jamMenit, tanggalJam, berapaLalu,
-  angkaRapi, kontrakTeks,
+  angkaRapi, kontrakTeks, kolomPos, varianUntuk,
   GOLONGAN_LABEL, URUT_GOLONGAN,
 } from "./js/util.js";
 
@@ -401,14 +401,20 @@ function gambarPapan() {
   const pos = (META && META.pos) || [];
   const komponen = (META && META.komponen) || [];
 
-  // Satu kolom per komponen; versi per golongan digabung jadi satu kolom
-  // bernama sama — persis kolomPos() di layar panitia.
-  const perPos = pos.map(p => {
-    const milik = komponen.filter(w => w.pos === p.nomor);
-    const nama = [];
-    for (const w of milik) if (!nama.includes(w.name)) nama.push(w.name);
-    return { pos: p, nama, milik };
-  }).filter(x => x.nama.length);
+  // kolomPos() YANG SAMA dengan layar panitia, bukan aturan yang ditulis
+  // ulang di sini. Salinan tangan yang dulu berdiri di tempat ini
+  // menggabungkan menurut NAMA tanpa syarat, sedangkan kolomPos() hanya
+  // menggabungkan nama yang memang punya varian bergolongan dan selebihnya
+  // memakai `kode`. Selama tidak ada dua wahana bernama sama tanpa golongan
+  // di satu pos, keduanya menghasilkan kolom yang sama — dan menamai dua
+  // penilaian dengan nama yang sama adalah hal yang bisa dilakukan panitia
+  // dari data, tanpa menyentuh kode. Sesudah itu papan panitia menggambar dua
+  // kolom, papan ini menggambar satu, dan nilai komponen kedua hilang dari
+  // halaman peserta tanpa satu pun galat.
+  const perPos = pos.map(p => ({
+    pos: p,
+    kolom: kolomPos(komponen.filter(w => w.pos === p.nomor)),
+  })).filter(x => x.kolom.length);
 
   const kartu = URUT_GOLONGAN_PESERTA.map(g => {
     const baris = semua.filter(b => b.golongan === g);
@@ -454,7 +460,7 @@ function gambarPapan() {
                     aria-expanded="false"
                     title="Klik untuk menyaring per sekolah">Organisasi
                   <span class="hitung-filter"></span> <span aria-hidden="true">▾</span></th>
-                ${perPos.map(x => `<th class="pos" colspan="${x.nama.length}"
+                ${perPos.map(x => `<th class="pos" colspan="${x.kolom.length}"
                   >${esc(x.pos.bayangan ? x.pos.name
                         : `Pos ${x.pos.nomor} · ${x.pos.name}`)}</th>`).join("")}
                 <!-- Lima kolom perjalanan berdiri SEBELUM Penalti: Penalti
@@ -478,16 +484,19 @@ function gambarPapan() {
                    sudah poin akhir, dan "0 – 5" di kepala kolom berisi 80
                    membantahnya. Rentang menjelaskan apa yang boleh DIKETIK,
                    dan di papan ini tidak ada yang mengetik apa pun. -->
-              <tr>${perPos.map(x => x.nama.map(nm =>
-                `<th class="pos kol-komponen">${esc(nm)}</th>`).join("")).join("")}</tr>
+              <tr>${perPos.map(x => x.kolom.map(kol =>
+                `<th class="pos kol-komponen">${esc(kol.nama)}</th>`).join("")).join("")}</tr>
             </thead>
             <tbody>
               ${baris.map(b => {
                 const terisi = b.komponen_terisi || {};
                 const poin = b.poin || {};
-                const sel = perPos.map(x => x.nama.map(nm => {
-                  const w = x.milik.find(k =>
-                    k.name === nm && (!k.golongan || k.golongan === b.golongan));
+                const sel = perPos.map(x => x.kolom.map(kol => {
+                  // varianUntuk() YANG SAMA dengan layar panitia — dan ia
+                  // tidak simetris: Intern hanya menerima baris bertanda
+                  // `intern`, Eksternal menerima baris umum maupun baris
+                  // golongannya.
+                  const w = varianUntuk(kol, b.golongan);
                   if (!w) return `<td class="pos belum">–</td>`;
                   const kunci = `${x.pos.nomor}.${w.kode}`;
                   if (!penuh) {

--- a/tests/contest_group_fallback.test.mjs
+++ b/tests/contest_group_fallback.test.mjs
@@ -6,8 +6,12 @@ import test from "node:test";
 
 
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+// Potongannya dibatasi `kolomCetakPos`, yang berdiri tepat sesudah
+// kelompokLomba(). Patokan sebelumnya `const varianUntuk` — dan fungsi itu
+// PINDAH ke util.js supaya papan panitia dan papan peserta memilih varian
+// dengan aturan yang sama, lalu berkas ini berhenti menemukan patokannya.
 const awal = app.indexOf("const slugLomba =");
-const akhir = app.indexOf("const varianUntuk", awal);
+const akhir = app.indexOf("const kolomCetakPos", awal);
 const sumber = app.slice(awal, akhir);
 const { kelompokLomba } = new Function(
   `${sumber}; return { kelompokLomba };`,

--- a/tests/public_board_columns.test.mjs
+++ b/tests/public_board_columns.test.mjs
@@ -1,0 +1,72 @@
+// Papan peserta dan papan panitia menyusun kolom dengan aturan yang SAMA.
+//
+// Bukan tes tata letak. Yang dijaga: `live.js` tidak boleh punya rumus
+// kolomnya sendiri. Salinan tangan yang dulu berdiri di sana menggabungkan
+// menurut NAMA tanpa syarat, sedangkan `kolomPos()` hanya menggabungkan nama
+// yang memang punya varian bergolongan. Selama tidak ada dua wahana bernama
+// sama tanpa golongan di satu pos, keduanya sepakat — dan menamai dua
+// penilaian dengan nama yang sama adalah hal yang bisa dilakukan panitia dari
+// DATA, tanpa menyentuh kode.
+//
+// Kegagalannya senyap: papan panitia dua kolom, papan peserta satu, dan nilai
+// komponen kedua hilang dari halaman peserta tanpa satu pun galat.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { kolomPos, varianUntuk } from "../web/js/util.js";
+
+
+const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+
+
+test("dua wahana bernama sama tanpa golongan tetap dua kolom", () => {
+  // Inilah kasus yang membedakan kedua rumus. Rumus lama di live.js
+  // menghasilkan SATU kolom di sini.
+  const kolom = kolomPos([
+    { kode: "sandi_a", name: "Sandi", golongan: null },
+    { kode: "sandi_b", name: "Sandi", golongan: null },
+  ]);
+  assert.equal(kolom.length, 2);
+});
+
+
+test("varian bergolongan digabung jadi satu kolom bernama sama", () => {
+  const kolom = kolomPos([
+    { kode: "logika", name: "Logika", golongan: null },
+    { kode: "logika_intern", name: "Logika", golongan: "intern" },
+  ]);
+  assert.equal(kolom.length, 1);
+  assert.equal(kolom[0].nama, "Logika");
+  assert.equal(kolom[0].varian.length, 2);
+});
+
+
+test("varianUntuk tidak simetris: Intern tidak menerima komponen umum", () => {
+  const [kol] = kolomPos([
+    { kode: "semaphore", name: "Semaphore", golongan: null },
+  ]);
+  assert.equal(varianUntuk(kol, "penegak_pa").kode, "semaphore");
+  // Kalau baris umum ikut berlaku untuk Intern, seluruh lomba lapangan
+  // tergambar untuk regu yang tidak mengikutinya (migrasi 0091).
+  assert.equal(varianUntuk(kol, "intern_pa"), null);
+
+  const [kol2] = kolomPos([
+    { kode: "logika", name: "Logika", golongan: null },
+    { kode: "logika_intern", name: "Logika", golongan: "intern" },
+  ]);
+  assert.equal(varianUntuk(kol2, "intern_pi").kode, "logika_intern");
+  assert.equal(varianUntuk(kol2, "penegak_pa").kode, "logika");
+});
+
+
+test("live.js memakai aturan bersama, bukan salinannya sendiri", () => {
+  assert.match(live, /kolomPos, varianUntuk/);
+  assert.match(live, /kolom: kolomPos\(komponen\.filter\(w => w\.pos === p\.nomor\)\)/);
+  assert.match(live, /const w = varianUntuk\(kol, b\.golongan\)/);
+
+  // Bentuk salinan lamanya tidak boleh kembali.
+  assert.doesNotMatch(live, /if \(!nama\.includes\(w\.name\)\) nama\.push/);
+  assert.doesNotMatch(live, /x\.milik\.find/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -36,7 +36,8 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          kotakJamHtml, kecilkanFoto, ukuranRapi, ikon, ikonKotak, dada3,
          angkaRapi, nilaiTeks, nilaiBagian, kolomPos, kontrakTeks,
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
-         GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya } from "./util.js";
+         GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
+         varianUntuk } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
 
 const LAYAR = document.getElementById("layar");
@@ -2668,12 +2669,6 @@ function kelompokLomba(kolom) {
   }
   return urut;
 }
-
-const varianUntuk = (kol, golongan) => {
-  if (golongan === "intern_pa" || golongan === "intern_pi")
-    return kol.varian.find(k => k.golongan === golongan || k.golongan === "intern") || null;
-  return kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
-};
 
 /** Kolom KERTAS untuk satu kolom layar. Sebagian memakan dua kolom, dan
  *  pembagiannya sama persis dengan kotak di layar — supaya petugas yang

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1061,6 +1061,26 @@ export function kolomPos(komponen) {
   return urut;
 }
 
+/** Varian mana dari satu kolom yang berlaku untuk satu regu — atau null.
+ *
+ *  Pasangan sisi layar dari `komponen_berlaku()` di database (migrasi 0091),
+ *  dan seperti fungsi itu ia TIDAK simetris: regu Intern hanya menerima
+ *  komponen bertanda `intern` atau golongannya sendiri, sedangkan golongan
+ *  Eksternal menerima baris umum (`golongan` null) maupun baris golongannya.
+ *  Komponen umum tidak otomatis berlaku untuk Intern — kalau iya, seluruh
+ *  lomba lapangan ikut tergambar untuk regu yang tidak mengikutinya.
+ *
+ *  Tempatnya di util.js bersama kolomPos(), bukan di app.js, karena papan
+ *  panitia dan papan peserta HARUS memilih varian yang sama. Aturan ini
+ *  pernah ditulis dua kali dan salinan yang di halaman peserta menyimpang;
+ *  yang menyimpang tidak menggagalkan apa pun, ia cuma membuat dua papan
+ *  saling membantah di depan pembina yang sedang membandingkan keduanya. */
+export const varianUntuk = (kol, golongan) => {
+  if (golongan === "intern_pa" || golongan === "intern_pi")
+    return kol.varian.find(k => k.golongan === golongan || k.golongan === "intern") || null;
+  return kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
+};
+
 /** Angka nilai sebagai TEKS, satu bagian atau dua.
  *
  *  Mengembalikan bagian-bagiannya, bukan HTML jadi, dan itu yang membuatnya


### PR DESCRIPTION
## What

- `varianUntuk()` naik dari `web/js/app.js` ke `web/js/util.js` (dan salinannya di `live/`).
- `live/live.js` membangun `perPos` lewat `kolomPos()` dan memilih sel lewat `varianUntuk()`.
- `tests/public_board_columns.test.mjs` — tes perilaku, bukan tes teks.
- Patokan potongan di `contest_group_fallback.test.mjs` digeser.

## Why

Closes #574.

`live.js` membangun kolom tabelnya sendiri di bawah komentar yang berbunyi *"persis `kolomPos()` di layar panitia"*. Ia tidak persis:

| | menggabungkan kalau |
| --- | --- |
| `kolomPos()` | ada baris bernama itu yang **dibatasi golongan**; selebihnya kuncinya `kode` |
| salinan di `live.js` | namanya sama, **tanpa syarat** |

Hari ini keduanya sepakat, karena belum ada dua baris `wahana` bernama sama dalam satu pos yang dua-duanya bergolongan NULL. Begitu ada — dan menamai dua penilaian dengan nama yang sama adalah hal yang bisa dilakukan panitia **dari data, tanpa menyentuh kode** — papan panitia menggambar dua kolom, papan peserta satu, dan nilai komponen kedua hilang dari halaman peserta tanpa satu pun galat.

Ini persis kegagalan yang dijelaskan kepala `util.js`: *"Aturan itu pernah ditulis dua kali... Salinannya menyimpang, dan yang menyimpang tidak menggagalkan apa pun — ia cuma membuat dua papan saling membantah di depan pembina yang sedang membandingkan keduanya."*

Tidak ada penjaga yang menangkapnya: `shared-files.yml` memang menemukan `util.js` identik di kedua situs — yang tidak dipakai justru fungsi di dalamnya — dan `periksa_impor.py` hanya menuntut nama yang DIPANGGIL sudah diimpor.

## Notes

**`varianUntuk()` ikut pindah, dan itu bagian dari perbaikannya.** Memakai `kolomPos()` tetapi memilih varian dengan rumus lokal hanya memindahkan divergensinya satu lapis ke bawah. Fungsi itu pasangan sisi layar dari `komponen_berlaku()` (0091) dan **tidak simetris**: Intern hanya menerima baris bertanda `intern`, sedangkan Eksternal menerima baris umum maupun baris golongannya.

**Tesnya memanggil fungsinya, bukan mencocokkan teks.** Kasus yang membedakan kedua rumus — dua wahana bernama sama tanpa golongan — dibangun langsung dan jumlah kolomnya diperiksa.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 136 pass, 0 fail (4 tes baru) |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
