### PR TITLE
fix: pratinjau cetak membaca SEMUA blok @media print

### DIFF
--- a/tests/print_preview_tool.test.mjs
+++ b/tests/print_preview_tool.test.mjs
@@ -17,6 +17,20 @@ test("extractor mengenali seluruh selector layar yang disembunyikan", () => {
 });
 
 
+test("extractor membaca SEMUA blok @media print, bukan yang pertama", () => {
+  // style.css punya lebih dari satu blok cetak, dan `.index()` mengambil yang
+  // pertama saja. Yang hilang dari pratinjau tidak menimbulkan tanda apa pun,
+  // sementara keputusan bentuk kertas diambil dari pratinjau itu.
+  const jumlah = [...css.matchAll(/@media print \{/g)].length;
+  assert.ok(jumlah >= 2,
+    "style.css tinggal satu blok cetak — cek apakah penjaga ini masih perlu");
+
+  assert.doesNotMatch(alat, /css\.index\("@media print \{"\)/);
+  assert.match(alat, /while i != -1:/);
+  assert.match(alat, /len\(potongan\) != css\.count\(AWAL\)/);
+});
+
+
 test("workflow menjalankan extractor Python", async () => {
   const workflow = await readFile(
     new URL("../.github/workflows/sql-tests.yml", import.meta.url), "utf8");

--- a/tools/pratinjau_cetak.py
+++ b/tools/pratinjau_cetak.py
@@ -28,10 +28,11 @@ SEMBUNYI = (".header, .isi, .notification, .overlay,\n"
             "  .bottom-nav { display: none !important; }")
 
 
-def css_cetak() -> str:
-    """Isi blok @media print, siap ditempel ke halaman pratinjau."""
-    css = (AKAR / "web" / "style.css").read_text(encoding="utf-8")
-    i = css.index("@media print {")
+AWAL = "@media print {"
+
+
+def _isi_blok(css: str, i: int) -> str:
+    """Isi satu blok yang dimulai di `i`, dihitung dengan mencocokkan kurung."""
     dalam = 0
     for j in range(i, len(css)):
         if css[j] == "{":
@@ -39,8 +40,41 @@ def css_cetak() -> str:
         elif css[j] == "}":
             dalam -= 1
             if dalam == 0:
-                break
-    blok = css[i + len("@media print {"):j]
+                return css[i + len(AWAL):j]
+    raise SystemExit(f"Blok @media print di offset {i} tidak pernah ditutup.")
+
+
+def css_cetak() -> str:
+    """Isi SELURUH blok @media print, siap ditempel ke halaman pratinjau.
+
+    Seluruhnya, bukan yang pertama. `style.css` punya lebih dari satu blok
+    cetak, dan versi sebelumnya memakai `.index()` — yang mengambil kemunculan
+    pertama saja. Aturan di blok kedua tidak pernah ikut pratinjau, tanpa satu
+    pun tanda, sementara keputusan bentuk kertas diambil dari pratinjau itu.
+    """
+    css = (AKAR / "web" / "style.css").read_text(encoding="utf-8")
+
+    potongan, i = [], css.find(AWAL)
+    while i != -1:
+        potongan.append(_isi_blok(css, i))
+        i = css.find(AWAL, i + len(AWAL))
+
+    if not potongan:
+        raise SystemExit("Tidak ada blok @media print sama sekali di "
+                         "web/style.css — aturan cetak hilang, atau "
+                         "penulisannya berubah.")
+
+    # Pagar yang menahan cacat ini kembali: kalau suatu hari ada yang
+    # menggantinya dengan pembacaan satu blok lagi, jumlahnya tidak akan cocok
+    # dan berkas ini berhenti dengan galat alih-alih diam-diam menerbitkan
+    # pratinjau yang bohong.
+    if len(potongan) != css.count(AWAL):
+        raise SystemExit(
+            f"{css.count(AWAL)} blok @media print di style.css, tetapi "
+            f"{len(potongan)} yang terbaca. Pratinjau tidak boleh memakai "
+            f"sebagian aturan cetak saja.")
+
+    blok = "\n".join(potongan)
 
     if SEMBUNYI not in blok:
         raise SystemExit(


### PR DESCRIPTION
## What

`tools/pratinjau_cetak.py` mengumpulkan seluruh blok `@media print`, bukan yang pertama saja, dan berhenti dengan galat kalau jumlah yang terbaca tidak sama dengan jumlah kemunculannya di `style.css`.

Plus satu tes di `tests/print_preview_tool.test.mjs`.

## Why

Closes #576.

`css.index("@media print {")` mengambil kemunculan **pertama**, dan `web/style.css` punya dua blok — baris 858 dan baris 3449. Dibuktikan dengan memanggil `css_cetak()` langsung:

| | sebelum | sesudah |
| --- | --- | --- |
| panjang blok | 29.484 | 29.557 |
| `ikon-kotak` ikut? | **False** | True |

Berkas ini ada persis untuk menjamin pratinjau memakai CSS yang sama dengan yang dicetak — docstring-nya sendiri yang menulis itu, dan menulis "lebih baik gagal daripada diam-diam menghapus yang salah".

Yang hilang sekarang kebetulan tidak berbahaya: satu aturan yang mematikan tint ikon, dan ikon memang tidak dicetak di blangko mana pun. **Tapi mekanismenya tidak tahu itu.** Blok cetak ketiga yang ditambahkan besok akan hilang dengan cara yang sama, tanpa satu pun tanda, dan keputusan bentuk kertas — potret atau melintang, memotong nama atau membungkusnya — diambil dari pratinjau.

## Notes

Pagar barunya membandingkan `len(potongan)` dengan `css.count(AWAL)`. Gunanya bukan menghitung blok, melainkan **menahan cacat ini kembali**: kalau suatu hari ada yang menggantinya lagi dengan pembacaan satu blok, jumlahnya tidak cocok dan berkas ini berhenti alih-alih menerbitkan pratinjau yang bohong.

Kedua pagar lama — `SEMBUNYI` dan `.isian` — tidak disentuh dan masih lolos atas blok gabungan.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `python tools/pratinjau_cetak.py` | jalan, `ikon-kotak` kini ikut |
| `node --test tests/*.test.mjs` | 137 pass, 0 fail |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
