### PR TITLE
fix: buang v_klasemen_pratinjau, nama klasemen yang sudah dinyatakan mati

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0111`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0112`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-111 migrasi, `0001` sampai `0111`, dijalankan berurutan tanpa lubang penomoran.
+112 migrasi, `0001` sampai `0112`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0112_buang_v_klasemen_pratinjau.sql
+++ b/supabase/migrations/0112_buang_v_klasemen_pratinjau.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- hrcd-rekap : 0112_buang_v_klasemen_pratinjau.sql
+-- Buang `v_klasemen_pratinjau` — nama yang sudah dinyatakan tidak dipakai lagi
+-- oleh 0050, lalu tanpa sengaja dihidupkan kembali oleh 0065.
+--
+-- ---------------------------------------------------------------------------
+-- RIWAYATNYA, KARENA INILAH YANG MEMBUATNYA MUDAH TERULANG
+--
+-- 0049 membuat `v_klasemen_pratinjau`. 0050 menggantinya jadi
+-- `v_klasemen_live_score` dengan alasan yang ditulis panjang di kepalanya:
+--
+--     Satu hal dengan dua nama — "Live Score" di menu, `pratinjau` di kode —
+--     memaksa setiap percakapan berikutnya membayar ongkos penerjemahan, dan
+--     pemelihara berikutnya adalah siswa SMA yang tidak ikut percakapan ini.
+--
+-- 0065 lalu menulis `drop view if exists v_klasemen_pratinjau;` diikuti
+-- `create or replace view v_klasemen_pratinjau ...` — nama lamanya lahir
+-- kembali sebagai view KEDUA, bukan sebagai penggantian yang sudah ada.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA INI BUKAN SEKADAR SAMPAH
+--
+-- Dua view berisi klasemen yang sama dengan pagar hak yang BERBEDA:
+--
+--   v_klasemen_live_score   lewat klasemen_live_score(), boleh('live_score')
+--                           sejak 0067/0069 — INI yang dibaca layar
+--   v_klasemen_pratinjau    boleh('pengaturan') — tidak dibaca apa pun
+--
+-- Siapa pun yang bertanya "siapa boleh melihat klasemen lebih awal" bisa
+-- menemukan yang salah lebih dulu, dan yang salah justru yang namanya sudah
+-- dinyatakan mati. CLAUDE.md 13.1 melarang dua mekanisme untuk satu
+-- pertanyaan; ini bentuknya yang lain.
+--
+-- ---------------------------------------------------------------------------
+-- EMPAT VIEW LAIN YANG SEMPAT DICURIGAI SAMA — DIPERIKSA, DAN TIDAK SAMA
+--
+-- Pemindaian yang menemukan ini juga menyebut `v_barak`, `v_kwitansi`,
+-- `v_lembar_nilai`, dan `v_monitoring_input` sebagai "tidak dibaca siapa pun".
+-- Diperiksa satu per satu di luar berkas migrasi, dan tiga di antaranya
+-- ternyata punya pembaca:
+--
+--   v_monitoring_input   tests/sql/03_alur.sql, 08_lembar_pos.sql, 31_view_hak.sql
+--   v_lembar_nilai       tests/sql/03_alur.sql
+--   v_barak              tests/sql/03_alur.sql
+--
+-- Tes yang menduduki kursi hak (31) memakai `v_monitoring_input` justru untuk
+-- membuktikan isolasi pos, jadi membuangnya berarti membuang penjaganya.
+-- Ketiganya DIBIARKAN, dan catatan ini ada supaya pemindaian berikutnya tidak
+-- mengangkatnya lagi dari nol.
+--
+-- `v_kwitansi` memang tidak punya pembaca di mana pun — kwitansi dicetak dari
+-- sisi layar, bukan dari view ini. Ia sengaja TIDAK ikut dibuang di sini:
+-- membuangnya keputusan pemilik acara, bukan keputusan berkas ini, dan tidak
+-- ada yang mendesak lima hari sebelum lomba.
+-- ============================================================================
+
+drop view if exists v_klasemen_pratinjau;
+
+do $blok$
+begin
+  assert not exists (select 1 from pg_views
+                     where schemaname = 'public'
+                       and viewname = 'v_klasemen_pratinjau'),
+    '0112: v_klasemen_pratinjau masih ada';
+
+  -- Yang dipakai layar tidak boleh ikut terbawa.
+  assert exists (select 1 from pg_views
+                 where schemaname = 'public'
+                   and viewname = 'v_klasemen_live_score'),
+    '0112: v_klasemen_live_score ikut hilang — ini yang dibaca layar';
+
+  raise notice '0112: v_klasemen_pratinjau dibuang; klasemen tinggal satu nama.';
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -482,6 +482,12 @@ run tests/sql/72_biaya_intern.sql
 # antara dua panggilan — bentuk tes 30-36.
 run supabase/migrations/0111_sisipan_kloter_hak_gerbang.sql
 run tests/sql/73_sisipan_kloter_hak_gerbang.sql
+# 0112 membuang v_klasemen_pratinjau — nama yang sudah dinyatakan mati 0050
+# lalu lahir kembali di 0065 sebagai view kedua berpagar hak berbeda. Tes 74
+# menjaga nama itu tidak hidup lagi, dan tidak ada view klasemen lain yang
+# tak dikenal.
+run supabase/migrations/0112_buang_v_klasemen_pratinjau.sql
+run tests/sql/74_satu_nama_klasemen.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/74_satu_nama_klasemen.sql
+++ b/tests/sql/74_satu_nama_klasemen.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/74_satu_nama_klasemen.sql — migrasi 0112.
+-- Klasemen punya SATU nama, dan nama lamanya tidak hidup lagi.
+--
+-- Kenapa dijaga: nama itu sudah dinyatakan mati oleh 0050, lalu lahir kembali
+-- di 0065 sebagai view kedua berpagar hak BERBEDA — tanpa satu pun galat, dan
+-- tanpa ada yang membacanya. Yang menahan itu terulang bukan ingatan orang,
+-- melainkan pemeriksaan yang menyalak.
+-- ============================================================================
+
+\echo '--- 74. klasemen satu nama'
+\set ON_ERROR_STOP on
+
+do $blok$
+declare v_lain text;
+begin
+  assert not exists (select 1 from pg_views
+                     where schemaname = 'public'
+                       and viewname = 'v_klasemen_pratinjau'),
+    '74.1 GAGAL: v_klasemen_pratinjau hidup lagi';
+
+  assert exists (select 1 from pg_views
+                 where schemaname = 'public'
+                   and viewname = 'v_klasemen_live_score'),
+    '74.2 GAGAL: v_klasemen_live_score tidak ada';
+
+  -- Pemeriksaan yang lebih luas daripada satu nama: tidak boleh ada view lain
+  -- yang namanya menjanjikan klasemen. Memeriksa satu nama saja akan tetap
+  -- hijau pada hari seseorang membuat `v_klasemen_admin` (CLAUDE.md 13.3).
+  select string_agg(viewname, ', ' order by viewname) into v_lain
+  from pg_views
+  where schemaname = 'public'
+    and viewname like 'v_klasemen%'
+    and viewname not in ('v_klasemen', 'v_klasemen_live_score',
+                         'v_klasemen_publik');
+
+  assert v_lain is null,
+    format('74.3 GAGAL: ada view klasemen lain yang tidak dikenal — %s', v_lain);
+end;
+$blok$;
+
+select '74_satu_nama_klasemen OK' as hasil;


### PR DESCRIPTION
## What

`0112_buang_v_klasemen_pratinjau.sql` + `tests/sql/74_satu_nama_klasemen.sql`, terdaftar di `tests/run.sh`, checkpoint arsitektur ke 0112.

## Why

Closes #575.

0049 membuat `v_klasemen_pratinjau`. 0050 menggantinya jadi `v_klasemen_live_score` dengan alasan yang ditulis panjang: *"Satu hal dengan dua nama... memaksa setiap percakapan berikutnya membayar ongkos penerjemahan, dan pemelihara berikutnya adalah siswa SMA yang tidak ikut percakapan ini."*

0065 menulis `drop view if exists v_klasemen_pratinjau;` **diikuti** `create or replace view v_klasemen_pratinjau ...` — nama lamanya lahir kembali sebagai view kedua, bukan sebagai penggantian.

| View | Pagar | Dibaca? |
| --- | --- | --- |
| `v_klasemen_live_score` | `boleh('live_score')` lewat `klasemen_live_score()` | ya, `web/js/api.js` |
| `v_klasemen_pratinjau` | `boleh('pengaturan')` | **tidak, di mana pun** |

Dua view berisi klasemen yang sama dengan pagar hak berbeda. Siapa pun yang bertanya "siapa boleh melihat klasemen lebih awal" bisa menemukan yang salah lebih dulu — dan yang salah justru yang namanya sudah dinyatakan mati.

## Notes

**Empat view lain yang ikut disebut issue ternyata TIDAK sama, dan saya periksa satu per satu:**

| View | Pembaca di luar migrasi |
| --- | --- |
| `v_monitoring_input` | `03_alur.sql`, `08_lembar_pos.sql`, **`31_view_hak.sql`** |
| `v_lembar_nilai` | `03_alur.sql` |
| `v_barak` | `03_alur.sql` |
| `v_kwitansi` | — tidak ada |

`31_view_hak.sql` memakai `v_monitoring_input` justru untuk membuktikan isolasi pos, jadi membuangnya berarti membuang penjaganya. Ketiganya dibiarkan, dan temuan ini ditulis di kepala migrasi supaya pemindaian berikutnya tidak mengangkatnya lagi dari nol.

**`v_kwitansi` memang tanpa pembaca** — kwitansi dicetak dari sisi layar. Ia sengaja tidak ikut dibuang: itu keputusan pemilik acara, dan tidak ada yang mendesak lima hari sebelum lomba. Bilang saja kalau mau dibuang.

**Tesnya tidak memeriksa satu nama.** Ia menolak view `v_klasemen%` mana pun yang tidak dikenal, karena memeriksa satu nama akan tetap hijau pada hari seseorang membuat `v_klasemen_admin` — bentuk kegagalan yang persis ditulis pasal 13.3.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `bash tests/run.sh` | `SEMUA TES LULUS`, tes 74 OK |
| `node --test tests/*.test.mjs` | 137 pass, 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
