### PR TITLE
fix: batasi badan permintaan gateway walau Content-Length tidak dikirim

### DIFF
--- a/tests/gateway_body_limit.test.mjs
+++ b/tests/gateway_body_limit.test.mjs
@@ -1,0 +1,116 @@
+// ============================================================================
+// hrcd-rekap : tests/gateway_body_limit.test.mjs
+// Batas ukuran badan berlaku walau Content-Length TIDAK dikirim.
+//
+// Kenapa bentuk tesnya begini: pemeriksaan header sendirian TERLIHAT seperti
+// pagar. `Transfer-Encoding: chunked` tidak membawa Content-Length, jadi
+// angkanya 0 dan pemeriksaannya lolos apa pun isinya — lalu seluruh badan
+// diserap ke memori isolate sebelum ada yang bisa menolak. Satu-satunya cara
+// membuktikan pagarnya ada adalah mengirim badan tanpa Content-Length.
+//
+// `/daftar` adalah satu-satunya pintu yang terbuka ke internet tanpa login.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../workers/gateway/worker.js";
+
+
+/** Request berbadan STREAM: fetch tidak bisa menghitung panjangnya di muka,
+ *  jadi Content-Length tidak ikut — persis bentuk kiriman chunked. */
+function requestTanpaPanjang(jalur, isi, headers = {}) {
+  const badan = new ReadableStream({
+    start(c) { c.enqueue(new TextEncoder().encode(isi)); c.close(); },
+  });
+  return new Request(`https://gateway.example${jalur}`, {
+    method: "POST",
+    headers: { origin: "https://hrcd37.ciradyka.workers.dev",
+               "cf-connecting-ip": "203.0.113.9", ...headers },
+    body: badan,
+    duplex: "half",
+  });
+}
+
+const lingkungan = () => ({
+  RATE: { get: async () => "0", put: async () => {} },
+  SUPABASE_URL: "https://db.example",
+  SUPABASE_SERVICE_KEY: "service-key",
+});
+
+
+test("/daftar menolak badan besar tanpa Content-Length", async () => {
+  const asliFetch = globalThis.fetch;
+  let menyentuhSupabase = false;
+  globalThis.fetch = async () => { menyentuhSupabase = true; throw new Error("tidak boleh"); };
+  try {
+    const req = requestTanpaPanjang("/daftar", "x".repeat(32_001));
+    assert.equal(req.headers.get("content-length"), null,
+      "fixture salah: Content-Length ikut terkirim");
+
+    const r = await worker.fetch(req, lingkungan());
+    assert.equal(r.status, 413);
+    assert.equal(menyentuhSupabase, false,
+      "badan besar sempat diteruskan ke Supabase");
+  } finally {
+    globalThis.fetch = asliFetch;
+  }
+});
+
+
+test("/daftar tetap menerima badan wajar tanpa Content-Length", async () => {
+  const asliFetch = globalThis.fetch;
+  let dipanggil = null;
+  globalThis.fetch = async (u, opsi) => {
+    dipanggil = String(u);
+    return new Response(JSON.stringify({ kode_pembayaran: "HRCD37-AAA111" }),
+      { status: 200, headers: { "Content-Type": "application/json" } });
+  };
+  try {
+    const isi = JSON.stringify({ nama_sekolah: "SMPN Uji", regu: [] });
+    const r = await worker.fetch(requestTanpaPanjang("/daftar", isi), lingkungan());
+    assert.notEqual(r.status, 413, "badan wajar ikut tertolak");
+    assert.match(dipanggil || "", /submit_pendaftaran/);
+  } finally {
+    globalThis.fetch = asliFetch;
+  }
+});
+
+
+test("rute /akun memakai BATAS_AKUN_BYTE, bukan cuma menyebutnya", async () => {
+  const asliFetch = globalThis.fetch;
+  // pastikanBolehAkun() memanggil GoTrue lalu dua kali PostgREST. Ketiganya
+  // dijawab seolah pemanggilnya berhak, supaya yang teruji benar-benar batas
+  // ukurannya dan bukan pagar haknya.
+  globalThis.fetch = async (u) => {
+    const s = String(u);
+    if (s.includes("/auth/v1/user"))
+      return new Response(JSON.stringify({ id: "uid-1" }), { status: 200 });
+    if (s.includes("akun_panitia"))
+      return new Response(JSON.stringify([{ is_active: true }]), { status: 200 });
+    if (s.includes("akun_hak"))
+      return new Response(JSON.stringify([{ fitur: "akun" }]), { status: 200 });
+    throw new Error(`tidak boleh menyentuh ${s}`);
+  };
+  try {
+    for (const jalur of ["/akun", "/akun/password", "/akun/username"]) {
+      const r = await worker.fetch(
+        requestTanpaPanjang(jalur, "x".repeat(2_001),
+          { authorization: "Bearer token-uji",
+            origin: "https://panitia-hrcd37.ciradyka.workers.dev" }),
+        lingkungan());
+      assert.equal(r.status, 413, `${jalur} menerima badan 2001 byte`);
+    }
+  } finally {
+    globalThis.fetch = asliFetch;
+  }
+});
+
+
+test("tidak ada rute yang membaca badan tanpa batas", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const sumber = await readFile(
+    new URL("../workers/gateway/worker.js", import.meta.url), "utf8");
+  assert.doesNotMatch(sumber, /await req\.json\(\)/,
+    "masih ada req.json() tanpa batas di gateway");
+});

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -465,8 +465,16 @@ export default {
     if (req.method === "POST" && url.pathname.startsWith("/akun")) {
       const { galat } = await pastikanBolehAkun(req, env);
       if (galat) return galat;
-      let b;
-      try { b = await req.json(); } catch { return jawab(400, { message: "Format data salah." }, req); }
+      // bacaJsonTerbatas, bukan req.json(): BATAS_AKUN_BYTE tidak pernah
+      // menyentuh ketiga rute ini sebelumnya, jadi konstantanya membaca
+      // seolah ia sudah menjaga sesuatu. Ketiganya di balik
+      // pastikanBolehAkun(), jadi risikonya kecil — tapi batas yang cuma
+      // tertulis dan tidak berlaku lebih buruk daripada batas yang tidak ada,
+      // karena yang membacanya berhenti mencari.
+      const baca = await bacaJsonTerbatas(req, BATAS_AKUN_BYTE);
+      if (baca.terlaluBesar) return jawab(413, { message: "Data terlalu besar." }, req);
+      if (baca.salah) return jawab(400, { message: "Format data salah." }, req);
+      const b = baca.data;
       if (url.pathname === "/akun") return buatAkun(req, env, b);
       if (url.pathname === "/akun/password") return resetPassword(req, env, b);
       if (url.pathname === "/akun/username") return ubahUsername(req, env, b);
@@ -476,7 +484,17 @@ export default {
     if (req.method !== "POST" || url.pathname !== "/daftar")
       return jawab(404, { message: "tidak ada" }, req);
 
-    // 1. Batas ukuran — sebelum membaca isi.
+    // 1. Batas ukuran — jalan pintas murah, BUKAN pagarnya.
+    //
+    //    Kiriman `Transfer-Encoding: chunked` tidak membawa Content-Length,
+    //    jadi `panjang` bernilai 0 dan pemeriksaan ini lolos apa pun isinya.
+    //    Yang benar-benar menahan badan besar adalah bacaJsonTerbatas() di
+    //    langkah 3 — ia berhenti membaca segera setelah batasnya terlewati.
+    //    Baris ini dipertahankan karena ia menolak tanpa menyentuh badan sama
+    //    sekali untuk kiriman yang jujur menyebut ukurannya.
+    //
+    //    /daftar adalah SATU-SATUNYA pintu yang terbuka ke internet tanpa
+    //    login, dan pagar sisanya cuma rate limit 30/menit per IP.
     const panjang = Number(req.headers.get("content-length") || 0);
     if (panjang > BATAS_BYTE)
       return jawab(413, { message: "Data terlalu besar." }, req);
@@ -491,10 +509,13 @@ export default {
     if (hitung >= BATAS_PER_MENIT)
       return jawab(429, { message: "Terlalu sering mengirim. Tunggu satu menit, lalu coba lagi." }, req);
 
-    let b;
-    try { b = await req.json(); } catch { return jawab(400, { message: "Format data salah." }, req); }
+    // 3. Baca badannya, berbatas. Ini pagar ukuran yang sebenarnya.
+    const baca = await bacaJsonTerbatas(req, BATAS_BYTE);
+    if (baca.terlaluBesar) return jawab(413, { message: "Data terlalu besar." }, req);
+    if (baca.salah) return jawab(400, { message: "Format data salah." }, req);
+    const b = baca.data;
 
-    // 3. Turnstile — bukti pengirimnya manusia. Opsional: kalau secret belum
+    // 4. Turnstile — bukti pengirimnya manusia. Opsional: kalau secret belum
     //    diisi, lompati pemeriksaan ini (lihat catatan di kepala berkas).
     if (env.TURNSTILE_SECRET) {
       const cek = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
@@ -512,7 +533,7 @@ export default {
 
     await env.RATE.put(kunci, String(hitung + 1), { expirationTtl: 60 });
 
-    // 4. Teruskan ke RPC (service role — satu-satunya pemegang hak ini).
+    // 5. Teruskan ke RPC (service role — satu-satunya pemegang hak ini).
     const r = await fetch(`${env.SUPABASE_URL}/rest/v1/rpc/submit_pendaftaran`, {
       method: "POST",
       headers: {


### PR DESCRIPTION
## What

`workers/gateway/worker.js` — ketiga `await req.json()` diganti `bacaJsonTerbatas()` yang sudah ada di berkas yang sama.

Plus `tests/gateway_body_limit.test.mjs`.

## Why

Closes #570.

`bacaJsonTerbatas()` ditulis persis untuk kasus ini — kepalanya menyebut *"termasuk saat Content-Length tidak dikirim"* — tetapi hanya dipakai oleh `/akun/daftar`.

| Rute | Sebelum | Publik? |
| --- | --- | --- |
| `/akun/daftar` | `bacaJsonTerbatas` ✓ | ya |
| `/daftar` | header saja, lalu `req.json()` tanpa batas | **ya** |
| `/akun`, `/akun/password`, `/akun/username` | tidak ada pemeriksaan ukuran | tidak |

Kiriman `Transfer-Encoding: chunked` tidak membawa `Content-Length`, jadi `panjang` bernilai 0 dan pagarnya lolos apa pun isinya. Badan sebesar apa pun kemudian masuk ke `req.json()` — dan penolakannya terjadi **sesudah** badannya dibaca habis, tepat pada jendela waktu ketika pendaftaran sedang dipakai orang.

`/daftar` adalah satu-satunya pintu yang terbuka ke internet tanpa login. Pagar sisanya cuma rate limit 30/menit per IP.

Rute `/akun` di balik `pastikanBolehAkun()` jadi risikonya jauh lebih kecil — tetapi `BATAS_AKUN_BYTE` yang tidak pernah menyentuh ketiganya membaca seolah ia sudah menjaga sesuatu, dan batas yang cuma tertulis lebih buruk daripada batas yang tidak ada: yang membacanya berhenti mencari.

## Notes

**Pemeriksaan header dipertahankan** sebagai jalan pintas murah — ia menolak tanpa menyentuh badan sama sekali untuk kiriman yang jujur menyebut ukurannya. Komentarnya sekarang menyatakan terus terang bahwa ia BUKAN pagarnya.

**Tesnya mengirim badan lewat `ReadableStream`** supaya `Content-Length` benar-benar tidak ikut — memeriksanya dengan `fetch` biasa akan lulus untuk alasan yang salah. Ia juga memastikan Supabase tidak pernah tersentuh, dan satu tes menjaga badan wajar tetap diterima.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 141 pass, 0 fail (4 tes baru) |
| Cek negatif: `/daftar` dikembalikan ke `req.json()` | 2 dari 4 tes baru **gagal**, hijau lagi setelah dipulihkan |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
