### PR TITLE
fix: Kalkulator Keberangkatan memakai pembagi yang sama dengan database

### DIFF
--- a/tests/departure_calculator.test.mjs
+++ b/tests/departure_calculator.test.mjs
@@ -1,3 +1,15 @@
+// Kalkulator Keberangkatan harus menyebut jam yang SAMA dengan database.
+//
+// Ada dua tempat yang menghitung perkiraan berangkat, dan yang satu tidak
+// boleh membantah yang lain: `perkiraan_berangkat_kloter()` (migrasi 0105)
+// mengisi kertas kloter yang dibagikan ke peserta dan chip `~HH:MM` di layar
+// Keberangkatan, sedangkan berkas ini dipakai menyusun jadwal pagi. CLAUDE.md
+// 10.5: "kloter 9, kira-kira 08:45" adalah jawaban atas pertanyaan yang
+// panitia dan pembina benar-benar ajukan — dan jawabannya harus satu.
+//
+// Angka yang dipatok di bawah DIUKUR dari database, bukan diturunkan ulang di
+// sini. Menurunkannya ulang berarti menguji rumus terhadap dirinya sendiri.
+
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -5,7 +17,8 @@ import { hitungRekomendasiKloter } from "../web/js/departure-calculator.mjs";
 
 
 const hitung = (jumlahEksternal, jumlahIntern = 0,
-                waktuPertama = "07:00", waktuTerakhir = "10:00") =>
+                waktuPertama = "07:00", waktuTerakhir = "10:00",
+                kloterMaks = 75) =>
   hitungRekomendasiKloter({
     waktuPertama,
     waktuTerakhir,
@@ -13,36 +26,71 @@ const hitung = (jumlahEksternal, jumlahIntern = 0,
     jumlahIntern,
     maksEksternalPerKloter: 5,
     maksInternPerKloter: 3,
-    kloterMaks: 60,
+    kloterMaks,
   });
 
 
-test("300 Eksternal dan 50 Intern menjadi 60 kloter dalam tiga jam", () => {
+test("jamnya sama persis dengan perkiraan_berangkat_kloter()", () => {
+  // Diukur di PostgreSQL dengan konfigurasi edisi 37 — kloter_maks 75,
+  // jendela 07:00-10:00:
+  //
+  //   select k, perkiraan_berangkat_kloter(k) from unnest(array[1,10,30,60]) k
+  //     1  07:00:00
+  //    10  07:21:53
+  //    30  08:10:32
+  //    60  09:23:30
+  //
+  // Layar menampilkannya lewat jamMenit(), yang MEMOTONG detik.
   const hasil = hitung(300, 50);
-  assert.equal(hasil.length, 60);
+  assert.equal(hasil.length, 60, "yang direncanakan cuma kloter yang diisi");
+
+  const jam = (k) => hasil[k - 1].waktuBerangkat;
+  assert.equal(jam(1), "07:00");
+  assert.equal(jam(10), "07:21");
+  assert.equal(jam(30), "08:10");
+  assert.equal(jam(60), "09:23");
+});
+
+
+test("cadangan yang tidak terpakai TIDAK memajukan kloter terakhir ke batas", () => {
+  // Inilah yang membedakan kedua rumus. Membagi dengan jumlah kloter yang
+  // DIBUTUHKAN menaruh K60 tepat 10:00; membagi dengan seluruh kloter edisi
+  // menaruhnya 09:23, dan cadangan K61-K75 mengisi sisa jendelanya.
+  assert.notEqual(hitung(300, 50)[59].waktuBerangkat, "10:00");
+
+  // Kalau seluruh kloter edisi memang terpakai, yang terakhir jatuh tepat di
+  // batas — CLAUDE.md 10.1, dan ini yang dijaga 0105.
+  const penuh = hitung(375, 0);
+  assert.equal(penuh.length, 75);
+  assert.equal(penuh[74].waktuBerangkat, "10:00");
+});
+
+
+test("isi kloter tetap FIFO dengan dua kuota terpisah", () => {
+  const hasil = hitung(300, 50);
   assert.deepEqual(hasil[0], {
     kloter: 1, jumlahEksternal: 5, jumlahIntern: 3, waktuBerangkat: "07:00",
   });
-  assert.deepEqual(hasil[16], {
-    kloter: 17, jumlahEksternal: 5, jumlahIntern: 2, waktuBerangkat: "07:49",
-  });
-  assert.deepEqual(hasil[59], {
-    kloter: 60, jumlahEksternal: 5, jumlahIntern: 0, waktuBerangkat: "10:00",
-  });
+  // Intern habis di kloter ke-17: 50 dibagi 3 menyisakan 2.
+  assert.equal(hasil[16].jumlahEksternal, 5);
+  assert.equal(hasil[16].jumlahIntern, 2);
+  assert.equal(hasil[17].jumlahIntern, 0);
 });
+
 
 test("satu kloter memakai waktu berangkat pertama", () => {
   assert.deepEqual(hitung(1), [
     { kloter: 1, jumlahEksternal: 1, jumlahIntern: 0, waktuBerangkat: "07:00" },
   ]);
+  // Termasuk saat edisinya memang hanya punya satu kloter — pembaginya nol
+  // di situ, dan tidak boleh melahirkan NaN.
+  assert.deepEqual(hitung(1, 0, "07:00", "10:00", 1), [
+    { kloter: 1, jumlahEksternal: 1, jumlahIntern: 0, waktuBerangkat: "07:00" },
+  ]);
 });
 
-test("pembulatan menit tetap menaruh kloter terakhir tepat di batas", () => {
-  const hasil = hitung(13, 0, "07:00", "07:05");
-  assert.deepEqual(hasil.map(x => x.waktuBerangkat), ["07:00", "07:03", "07:05"]);
-});
 
 test("menolak jendela terbalik dan jumlah regu di atas kapasitas", () => {
   assert.throws(() => hitung(10, 0, "10:00", "07:00"), /harus setelah/);
-  assert.throws(() => hitung(301), /melebihi batas 60/);
+  assert.throws(() => hitung(376), /melebihi batas 75/);
 });

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -488,6 +488,11 @@ run tests/sql/73_sisipan_kloter_hak_gerbang.sql
 # tak dikenal.
 run supabase/migrations/0112_buang_v_klasemen_pratinjau.sql
 run tests/sql/74_satu_nama_klasemen.sql
+# Perkiraan berangkat dihitung DUA KALI di repo ini: fungsi database dan
+# web/js/departure-calculator.mjs. Tes 75 menjaga ujung-ujung jendelanya dari
+# sisi SQL; tests/departure_calculator.test.mjs menjaga sisi layar. Keduanya
+# sempat berpisah 37 menit tanpa satu pun galat.
+run tests/sql/75_perkiraan_berangkat_satu_rumus.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/75_perkiraan_berangkat_satu_rumus.sql
+++ b/tests/sql/75_perkiraan_berangkat_satu_rumus.sql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/75_perkiraan_berangkat_satu_rumus.sql
+-- Perkiraan berangkat menyebar ke SELURUH kloter edisi, bukan ke jumlah yang
+-- kebetulan dibutuhkan.
+--
+-- Pasangannya di sisi layar: `tests/departure_calculator.test.mjs`. Kedua
+-- berkas menjaga satu keputusan yang sama dari dua arah — kalau salah satu
+-- rumus diubah tanpa yang lain, Kalkulator Keberangkatan dan kertas kloter
+-- menyebut jam berbeda untuk kloter yang sama, dan tidak ada yang gagal.
+-- Pernah terjadi: 0105 mengganti pembagi di sini dan sisi JS tidak ikut,
+-- selisihnya 37 menit di K60.
+--
+-- Yang diperiksa UJUNG-UJUNGNYA, bukan angka jam tertentu. Jendela dan jumlah
+-- kloter adalah konfigurasi per edisi (CLAUDE.md 10.7); tes yang memaku
+-- "09:23" jadi pekerjaan tahunan untuk menjaga sesuatu yang bukan itu
+-- maksudnya.
+-- ============================================================================
+
+\echo '--- 75. perkiraan berangkat satu rumus'
+\set ON_ERROR_STOP on
+
+do $blok$
+declare
+  e         record;
+  v_mulai   timestamptz;
+  v_batas   timestamptz;
+  v_tengah  timestamptz;
+begin
+  select * into e from edisi where is_active;
+  if not found then
+    raise notice '75 dilewati: tidak ada edisi aktif.';
+    return;
+  end if;
+
+  v_mulai := (e.tanggal_lomba + e.jam_mulai_berangkat) at time zone 'Asia/Jakarta';
+  v_batas := (e.tanggal_lomba + e.jam_batas_berangkat) at time zone 'Asia/Jakarta';
+
+  -- 75.1 Kloter pertama berangkat tepat di awal jendela.
+  assert perkiraan_berangkat_kloter(1) = v_mulai,
+    format('75.1 GAGAL: K1 %s, harusnya %s', perkiraan_berangkat_kloter(1), v_mulai);
+
+  -- 75.2 Kloter TERAKHIR EDISI — bukan kloter terakhir yang terisi — jatuh
+  --      tepat di batas. Inilah keputusan yang diperdebatkan: membagi dengan
+  --      jumlah kloter yang dibutuhkan akan melempar cadangan ke luar jendela,
+  --      dan CLAUDE.md 10.1 menuntut yang terakhir sudah berangkat pukul
+  --      sepuluh.
+  assert perkiraan_berangkat_kloter(e.kloter_maks) = v_batas,
+    format('75.2 GAGAL: K%s (kloter terakhir edisi) %s, harusnya %s',
+           e.kloter_maks, perkiraan_berangkat_kloter(e.kloter_maks), v_batas);
+
+  -- 75.3 Tidak ada kloter edisi yang jatuh di luar jendela.
+  assert not exists (
+    select 1 from generate_series(1, e.kloter_maks) k
+    where perkiraan_berangkat_kloter(k) < v_mulai
+       or perkiraan_berangkat_kloter(k) > v_batas),
+    '75.3 GAGAL: ada kloter yang perkiraannya di luar jendela keberangkatan';
+
+  -- 75.4 Sebarannya merata: yang di tengah jatuh di tengah jendela. Menjaga
+  --      ujungnya saja akan tetap hijau untuk fungsi yang menaruh SEMUA kloter
+  --      selain yang pertama dan terakhir di jam yang sama.
+  if e.kloter_maks >= 3 and e.kloter_maks % 2 = 1 then
+    v_tengah := v_mulai + (v_batas - v_mulai) / 2;
+    assert perkiraan_berangkat_kloter((e.kloter_maks + 1) / 2) = v_tengah,
+      format('75.4 GAGAL: kloter tengah %s, harusnya %s',
+             perkiraan_berangkat_kloter((e.kloter_maks + 1) / 2), v_tengah);
+  end if;
+end;
+$blok$;
+
+select '75_perkiraan_berangkat_satu_rumus OK' as hasil;

--- a/web/js/departure-calculator.mjs
+++ b/web/js/departure-calculator.mjs
@@ -69,11 +69,33 @@ export function hitungRekomendasiKloter({
     );
   }
 
+  /* PEMBAGINYA `batasKloter`, BUKAN `jumlahKloter`, dan itu bukan pilihan
+     gaya — ia menyamakan kalkulator ini dengan `perkiraan_berangkat_kloter()`
+     di database (migrasi 0105).
+
+     Database menyebar seluruh kloter edisi, termasuk cadangan, supaya kloter
+     ke-61 dan seterusnya tetap punya perkiraan DI DALAM jendela 07:00-10:00
+     (CLAUDE.md 10.1: yang terakhir sudah berangkat pukul sepuluh). Membagi
+     dengan jumlah yang dibutuhkan saja membuat cadangan yang benar-benar
+     terpakai berangkat sesudah pukul sepuluh.
+
+     Angka databaselah yang tercetak di kertas kloter yang dibagikan ke peserta
+     dan yang muncul sebagai `~HH:MM` di chip layar Keberangkatan. Kalkulator
+     ini dipakai menyusun jadwal pagi. Dengan dua pembagi, keduanya menyebut
+     jam berbeda untuk kloter yang sama: pada 60 kloter dan batas 75, K60
+     terbaca 10:00 di sini dan 09:23 di sana — selisih 37 menit.
+
+     BARISNYA tetap sebanyak kloter yang dibutuhkan: yang direncanakan cuma
+     kloter yang benar-benar diisi.
+
+     `floor`, bukan `round`: database mengembalikan timestamptz berdetik dan
+     layar menampilkannya lewat jamMenit(), yang MEMOTONG detik. K10 di sana
+     07:21:53 terbaca "07:21"; membulatkan di sini akan menuliskannya 07:22. */
   const rentang = terakhir - pertama;
   return Array.from({ length: jumlahKloter }, (_, indeks) => {
-    const waktu = jumlahKloter === 1
+    const waktu = batasKloter === 1
       ? pertama
-      : pertama + Math.round(rentang * indeks / (jumlahKloter - 1));
+      : pertama + Math.floor(rentang * indeks / (batasKloter - 1));
     return {
       kloter: indeks + 1,
       jumlahEksternal: Math.max(0, Math.min(kapasitasEksternal,


### PR DESCRIPTION
## What

`web/js/departure-calculator.mjs` menyebar jam ke `kloterMaks`, bukan ke jumlah kloter yang dibutuhkan, dan memotong menit dengan `floor` alih-alih `round`.

Plus dua penjaga: `tests/departure_calculator.test.mjs` (ditulis ulang) dan `tests/sql/75_perkiraan_berangkat_satu_rumus.sql`.

## Why

Closes #571.

Diukur di PostgreSQL dengan konfigurasi edisi 37 (`kloter_maks` 75, jendela 07:00–10:00):

| Kloter | Database (tercetak & di chip) | Kalkulator sebelum | Kalkulator sesudah |
| --- | --- | --- | --- |
| K1 | 07:00 | 07:00 | 07:00 |
| K10 | 07:21 | 07:27 | **07:21** |
| K30 | 08:10 | 08:28 | **08:10** |
| K60 | 09:23 | 10:00 | **09:23** |

**Yang mengikuti layar, bukan database**, dan itu bukan pilihan sembarang:

1. `0105` memilih pembaginya dengan sadar dan menulis alasannya di kepalanya — supaya K61–K75 tetap punya perkiraan **di dalam** jendela. Pasal 10.1 menuntut yang terakhir sudah berangkat pukul sepuluh, dan itu termasuk cadangan yang benar-benar terpakai.
2. Angka databaselah yang **tercetak di kertas kloter** yang dibagikan ke peserta dan yang muncul sebagai `~HH:MM` di chip Keberangkatan. Menggesernya lima hari sebelum lomba berarti menggeser kertas yang sudah dibicarakan.

Kalkulator dipakai menyusun jadwal pagi. Dua pembagi berarti panitia dan pembina mendapat dua jawaban untuk "kloter 9 kira-kira jam berapa" — pertanyaan yang pasal 10.5 sebut sebagai satu-satunya yang benar-benar mereka ajukan.

## Notes

**`floor`, bukan `round`.** Database mengembalikan `timestamptz` berdetik — K10 sebenarnya 07:21:53 — dan layar menampilkannya lewat `jamMenit()`, yang MEMOTONG detik. Membulatkan di sisi kalkulator akan menuliskannya 07:22 dan selisih satu menitnya kembali.

**Barisnya tetap sebanyak kloter yang dibutuhkan.** Yang berubah cuma pembagi waktunya; yang direncanakan tetap kloter yang benar-benar diisi.

**Efek samping yang tetap ada dan memang keputusan pemilik acara:** 60 kloter yang terisi selesai 09:23, bukan 10:00, karena 15 cadangan ikut membagi jendela. Sekarang kedua layar setuju tentang itu. Kalau jendelanya ingin terpakai penuh oleh kloter yang benar-benar berangkat, yang diubah `kloter_maks` atau jendelanya — konfigurasi, bukan rumus.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `bash tests/run.sh` | `SEMUA TES LULUS`, tes 75 OK |
| `node --test tests/*.test.mjs` | 142 pass, 0 fail |
| Bandingkan langsung dengan `perkiraan_berangkat_kloter()` di psql | K1/K10/K30/K60 cocok persis |
| `periksa_impor` / `periksa_urutan_golongan` / `pratinjau_cetak` | bersih |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
