### PR TITLE
feat: Live Score menampilkan total per lomba, bukan per penilaian

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1081,6 +1081,70 @@ export const varianUntuk = (kol, golongan) => {
   return kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
 };
 
+const slugLomba = (nama) => String(nama).toLowerCase()
+  .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
+
+/** Kolom layar dikelompokkan jadi LOMBA — tingkat ketiga yang tidak dimiliki
+ *  `wahana` sampai migrasi 0054 (CLAUDE.md bagian 11).
+ *
+ *  `lomba` kosong berarti komponen itu lomba tersendiri, keadaan yang benar
+ *  untuk sebagian besar baris — Semaphore, Menaksir, Bakiak. Yang berkelompok
+ *  cuma Pembidaian (lima kriteria), PBB (empat), dan Yel-Yel (empat).
+ *
+ *  Tempatnya di util.js, bukan di app.js: papan panitia dan papan peserta
+ *  sama-sama menyusun kolomnya dari sini. Dua papan yang mengelompokkan
+ *  dengan aturan berbeda adalah bentuk kegagalan yang sudah pernah terjadi
+ *  dan tidak menggagalkan apa pun — ia cuma membuat keduanya saling membantah
+ *  di depan pembina yang sedang membandingkan. */
+export function kelompokLomba(kolom) {
+  const urut = [], peta = new Map();
+  for (const kol of kolom) {
+    const k = kol.varian[0];
+    const nama = k.lomba || kol.nama;
+    if (!peta.has(nama)) {
+      // `kode` adalah kunci TETAP lomba ini (0079), dan ia dibaca dari
+      // database — bukan diturunkan dari namanya. Foto slip disimpan dengan
+      // kunci itu, jadi menurunkannya dari nama berarti mengganti nama lomba
+      // menghilangkan seluruh fotonya tanpa satu pun galat. Cadangan slug
+      // dipakai hanya untuk baris yang kolomnya belum terisi.
+      peta.set(nama, { nama, kode: k.kode_lomba || slugLomba(nama), kolom: [] });
+      urut.push(peta.get(nama));
+    }
+    peta.get(nama).kolom.push(kol);
+  }
+  return urut;
+}
+
+/** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
+ *  berapa yang sudah ada isinya, dan jumlah nilainya.
+ *
+ *  Dipakai kedua papan Live Score, dan sengaja hanya satu fungsi walau
+ *  keduanya menampilkan hal berbeda — panitia menggambar `jumlah`, peserta
+ *  menggambar centang dari `terisi` lawan `berlaku`. Yang harus sama persis
+ *  adalah CARA MEMBACANYA; kalau tidak, satu papan bisa menyebut Pembidaian
+ *  lengkap sementara papan sebelahnya menyebutnya baru sebagian.
+ *
+ *  `peta` berkunci `"<pos>.<kode wahana>"` — bentuk yang sama dipakai
+ *  `poin` maupun `komponen_terisi` di rekap.json (migrasi 0107 dan 0072).
+ *
+ *  `berlaku === 0` berarti lomba ini memang bukan untuk golongan regu itu.
+ *  Itu keadaan sah, bukan konfigurasi rusak: Tebak Simpul Penegak tidak ada
+ *  urusannya dengan regu Penggalang, dan seluruh lomba lapangan tidak ada
+ *  urusannya dengan regu Intern (migrasi 0091). */
+export function ringkasLomba(lomba, golongan, pos, peta) {
+  let berlaku = 0, terisi = 0, jumlah = 0;
+  for (const kol of lomba.kolom) {
+    const w = varianUntuk(kol, golongan);
+    if (!w) continue;
+    berlaku++;
+    const v = (peta || {})[`${pos}.${w.kode}`];
+    if (v === null || v === undefined) continue;
+    terisi++;
+    jumlah += Number(v) || 0;
+  }
+  return { berlaku, terisi, jumlah };
+}
+
 /** Angka nilai sebagai TEKS, satu bagian atau dua.
  *
  *  Mengembalikan bagian-bagiannya, bukan HTML jadi, dan itu yang membuatnya

--- a/live/live.css
+++ b/live/live.css
@@ -108,9 +108,11 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
    sini deretan centang per pos — bentuk baris itulah isinya, dan menumpuknya
    membuat satu regu memakan satu layar penuh. */
 .gulir { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-/* Kolom komponen: sempit, rata tengah, dan judulnya boleh membungkus.
-   Bentuknya mengikuti tabel panitia — satu kolom per komponen, bukan per
-   pos. */
+/* Kolom lomba: sempit, rata tengah, dan judulnya boleh membungkus.
+   Bentuknya mengikuti tabel panitia — satu kolom per LOMBA, bukan per pos dan
+   bukan per penilaian. Pembidaian lima kriteria berbagi satu kolom; nama
+   kelasnya masih `kol-komponen` karena ia dipakai di banyak tempat dan
+   mengganti nama kelas CSS tidak menambah satu keterangan pun. */
 /* Rentang di bawah nama kolom SUDAH TIDAK ADA di papan ini, dan aturannya
    ikut dibuang bersamanya: yang tergambar di bawah kepala kolom sekarang poin
    akhir, sementara rentang menjelaskan apa yang boleh DIKETIK — dan di sini
@@ -192,6 +194,20 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 .tabel td.pos.ada { color: var(--hijau); background: var(--hijau-muda); }
 .tabel td.pos.belum { color: #c7c7c2; }
 .tabel tbody tr:nth-child(even) td.pos.ada { background: #dfeee0; }
+
+/* Sebagian terisi — satu kolom lomba yang komponennya baru masuk separuh.
+   Lahir bersama kolom per lomba: Pembidaian dinilai lima kriteria oleh satu
+   juri, dan "sudah dinilai" berbeda dari "baru tiga dari lima yang masuk".
+   Sengaja BUKAN hijau muda yang lebih pudar — pucat di layar HP di bawah
+   matahari tidak terbaca sebagai keadaan tersendiri, ia terbaca sebagai
+   hijau yang layarnya jelek. Warnanya berpindah ke kuning, dan bentuknya
+   ikut berbeda lewat garis bawah putus-putus. */
+.tabel td.pos.sebagian {
+  color: #8a6100; background: #fdf3d6;
+  text-decoration: underline dotted currentColor;
+  text-underline-offset: .18em;
+}
+.tabel tbody tr:nth-child(even) td.pos.sebagian { background: #f7ead0; }
 
 /* ---- klasemen (fase penuh) ---- */
 .tabel td.total { font-weight: 800; font-variant-numeric: tabular-nums; }

--- a/live/live.js
+++ b/live/live.js
@@ -64,7 +64,7 @@
    ditunda sampai DOM siap, yang justru lebih aman daripada sebelumnya. */
 import {
   esc, dada3, jamMenit, tanggalJam, berapaLalu,
-  angkaRapi, kontrakTeks, kolomPos, varianUntuk,
+  angkaRapi, kontrakTeks, kolomPos, kelompokLomba, ringkasLomba,
   GOLONGAN_LABEL, URUT_GOLONGAN,
 } from "./js/util.js";
 
@@ -411,10 +411,13 @@ function gambarPapan() {
   // dari data, tanpa menyentuh kode. Sesudah itu papan panitia menggambar dua
   // kolom, papan ini menggambar satu, dan nilai komponen kedua hilang dari
   // halaman peserta tanpa satu pun galat.
+  // Satu kolom per LOMBA, bukan per penilaian — keputusan pemilik acara, dan
+  // papan panitia memakai pengelompokan yang sama. Pembidaian lima kriteria
+  // jadi satu kolom, PBB empat jadi satu, Yel-Yel empat jadi satu.
   const perPos = pos.map(p => ({
     pos: p,
-    kolom: kolomPos(komponen.filter(w => w.pos === p.nomor)),
-  })).filter(x => x.kolom.length);
+    lomba: kelompokLomba(kolomPos(komponen.filter(w => w.pos === p.nomor))),
+  })).filter(x => x.lomba.length);
 
   const kartu = URUT_GOLONGAN_PESERTA.map(g => {
     const baris = semua.filter(b => b.golongan === g);
@@ -460,7 +463,7 @@ function gambarPapan() {
                     aria-expanded="false"
                     title="Klik untuk menyaring per sekolah">Organisasi
                   <span class="hitung-filter"></span> <span aria-hidden="true">▾</span></th>
-                ${perPos.map(x => `<th class="pos" colspan="${x.kolom.length}"
+                ${perPos.map(x => `<th class="pos" colspan="${x.lomba.length}"
                   >${esc(x.pos.bayangan ? x.pos.name
                         : `Pos ${x.pos.nomor} · ${x.pos.name}`)}</th>`).join("")}
                 <!-- Lima kolom perjalanan berdiri SEBELUM Penalti: Penalti
@@ -484,37 +487,50 @@ function gambarPapan() {
                    sudah poin akhir, dan "0 – 5" di kepala kolom berisi 80
                    membantahnya. Rentang menjelaskan apa yang boleh DIKETIK,
                    dan di papan ini tidak ada yang mengetik apa pun. -->
-              <tr>${perPos.map(x => x.kolom.map(kol =>
-                `<th class="pos kol-komponen">${esc(kol.nama)}</th>`).join("")).join("")}</tr>
+              <tr>${perPos.map(x => x.lomba.map(l =>
+                `<th class="pos kol-komponen">${esc(l.nama)}</th>`).join("")).join("")}</tr>
             </thead>
             <tbody>
               ${baris.map(b => {
                 const terisi = b.komponen_terisi || {};
                 const poin = b.poin || {};
-                const sel = perPos.map(x => x.kolom.map(kol => {
-                  // varianUntuk() YANG SAMA dengan layar panitia — dan ia
-                  // tidak simetris: Intern hanya menerima baris bertanda
-                  // `intern`, Eksternal menerima baris umum maupun baris
-                  // golongannya.
-                  const w = varianUntuk(kol, b.golongan);
-                  if (!w) return `<td class="pos belum">–</td>`;
-                  const kunci = `${x.pos.nomor}.${w.kode}`;
+                const sel = perPos.map(x => x.lomba.map(l => {
+                  // ringkasLomba() YANG SAMA dengan layar panitia. Yang
+                  // berbeda cuma apa yang digambar dari hasilnya: di sini
+                  // centang, di sana angka. Cara membacanya harus sama, kalau
+                  // tidak satu papan bisa menyebut Pembidaian lengkap
+                  // sementara papan sebelahnya menyebutnya baru sebagian.
+                  //
+                  // `berlaku === 0` berarti lomba ini memang bukan untuk
+                  // golongan regu itu — bukan berarti nilainya belum masuk.
+                  const r = ringkasLomba(l, b.golongan, x.pos.nomor,
+                                         penuh ? poin : terisi);
+                  if (!r.berlaku) return `<td class="pos belum">–</td>`;
+
                   if (!penuh) {
-                    const ada = terisi[kunci];
-                    return `<td class="pos ${ada ? "ada" : "belum"}">${ada ? "✓" : ""}</td>`;
+                    if (!r.terisi) return `<td class="pos belum"></td>`;
+                    // Sebagian terisi dapat centangnya sendiri, bukan centang
+                    // penuh. Pembidaian dinilai lima kriteria oleh satu juri:
+                    // "sudah dinilai" dan "baru tiga dari lima yang masuk"
+                    // adalah dua jawaban berbeda atas satu-satunya pertanyaan
+                    // yang dibawa peserta ke halaman ini.
+                    return r.terisi === r.berlaku
+                      ? `<td class="pos ada">✓</td>`
+                      : `<td class="pos sebagian" title="${
+                          esc(`${r.terisi} dari ${r.berlaku} penilaian sudah masuk`)
+                        }">✓</td>`;
                   }
+
                   // POIN AKHIR, bukan angka mentah. "4" di Semaphore, "8.55"
                   // di Menaksir, dan "01:14" di Bakiak adalah tiga satuan yang
                   // berbeda dan tidak satu pun menyebut sumbangannya ke Total
                   // di ujung baris — sementara yang membaca papan ini persis
                   // orang yang tidak memegang tangga poin tiap lomba.
                   // Angkanya datang JADI dari rekap.json (migrasi 0107);
-                  // halaman ini tidak menghitung apa pun.
-                  const p = poin[kunci];
-                  if (p === null || p === undefined) {
-                    return `<td class="pos belum">–</td>`;
-                  }
-                  return `<td class="pos ada">${esc(angkaRapi(p))}</td>`;
+                  // yang dilakukan halaman ini cuma menjumlahkan poin
+                  // komponen satu lomba, tidak menghitung poin apa pun.
+                  if (!r.terisi) return `<td class="pos belum">–</td>`;
+                  return `<td class="pos ada">${esc(angkaRapi(r.jumlah))}</td>`;
                 }).join("")).join("");
                 const penalti = penuh
                   ? Number(b.penalti_waktu || 0) + Number(b.penalti_checkout || 0)

--- a/tests/contest_group_fallback.test.mjs
+++ b/tests/contest_group_fallback.test.mjs
@@ -1,21 +1,15 @@
 // Fallback kode lomba harus bisa dipanggil dari kelompokLomba di module scope.
+//
+// `kelompokLomba()` dulu tinggal di app.js dan diuji dengan memotong sumbernya
+// lalu menjalankannya lewat `new Function`. Ia PINDAH ke util.js supaya papan
+// panitia dan papan peserta mengelompokkan lomba dengan aturan yang sama, jadi
+// sekarang ia diimpor seperti fungsi biasa — dan yang teruji fungsi yang
+// benar-benar dipakai kedua papan, bukan salinan yang dievaluasi ulang.
 
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-
-const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
-// Potongannya dibatasi `kolomCetakPos`, yang berdiri tepat sesudah
-// kelompokLomba(). Patokan sebelumnya `const varianUntuk` — dan fungsi itu
-// PINDAH ke util.js supaya papan panitia dan papan peserta memilih varian
-// dengan aturan yang sama, lalu berkas ini berhenti menemukan patokannya.
-const awal = app.indexOf("const slugLomba =");
-const akhir = app.indexOf("const kolomCetakPos", awal);
-const sumber = app.slice(awal, akhir);
-const { kelompokLomba } = new Function(
-  `${sumber}; return { kelompokLomba };`,
-)();
+import { kelompokLomba } from "../web/js/util.js";
 
 
 test("kelompokLomba membuat fallback saat kode_lomba kosong", () => {
@@ -23,19 +17,26 @@ test("kelompokLomba membuat fallback saat kode_lomba kosong", () => {
     nama: "Pembidaian & PPPK",
     varian: [{ lomba: "Pembidaian & PPPK", kode_lomba: null }],
   }]);
-
   assert.equal(hasil.length, 1);
-  assert.equal(hasil[0].nama, "Pembidaian & PPPK");
   assert.equal(hasil[0].kode, "pembidaian-pppk");
 });
 
 
-test("kode_lomba database tetap menang atas fallback nama", () => {
+test("kode_lomba dari database menang atas slug", () => {
+  // `kode_lomba` dibekukan 0079 supaya mengganti NAMA lomba tidak memutus foto
+  // yang sudah diunggah dengan kunci lamanya.
   const hasil = kelompokLomba([{
-    nama: "Pembidaian & PPPK",
-    varian: [{ lomba: "Pembidaian & PPPK", kode_lomba: "pembidaian" }],
+    nama: "Nama Baru",
+    varian: [{ lomba: "Nama Baru", kode_lomba: "kunci-lama" }],
   }]);
-
-  assert.equal(hasil[0].kode, "pembidaian");
+  assert.equal(hasil[0].kode, "kunci-lama");
 });
 
+
+test("komponen tanpa lomba berdiri sebagai lomba tersendiri", () => {
+  const hasil = kelompokLomba([
+    { nama: "Semaphore", varian: [{ lomba: null, kode_lomba: null }] },
+    { nama: "Menaksir", varian: [{ lomba: null, kode_lomba: null }] },
+  ]);
+  assert.deepEqual(hasil.map(l => l.nama), ["Semaphore", "Menaksir"]);
+});

--- a/tests/live_score_per_lomba.test.mjs
+++ b/tests/live_score_per_lomba.test.mjs
@@ -1,0 +1,145 @@
+// Live Score menggambar TOTAL PER LOMBA, dan kedua papan membacanya sama.
+//
+// Pembidaian lima kriteria jadi satu angka, PBB empat jadi satu, Yel-Yel empat
+// jadi satu. Rinciannya tidak hilang — ia tetap utuh di layar Input Pos dan di
+// Rekapitulasi, tempat ia memang menjawab pertanyaan.
+//
+// Yang dijaga di sini bukan tata letaknya melainkan CARA MEMBACANYA: satu
+// fungsi untuk dua papan. Papan panitia menggambar `jumlah`, papan peserta
+// menggambar centang dari `terisi` lawan `berlaku` — kalau keduanya membaca
+// dengan aturan berbeda, satu papan bisa menyebut Pembidaian lengkap sementara
+// papan sebelahnya menyebutnya baru sebagian, untuk regu yang sama.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { kolomPos, kelompokLomba, ringkasLomba } from "../web/js/util.js";
+
+
+const akar = new URL("../", import.meta.url);
+const app = await readFile(new URL("web/js/app.js", akar), "utf8");
+const live = await readFile(new URL("live/live.js", akar), "utf8");
+
+/* Konfigurasi Pos 3 yang sebenarnya (dibaca dari `wahana` edisi 37): lima
+   kriteria Pembidaian di bawah satu `lomba`, KIM Lihat dan KIM Cium sebagai
+   lomba tersendiri sejak 0087, dan Logika dengan varian Intern-nya. */
+const POS3 = [
+  { kode: "bidai_diagnosis", name: "Diagnosis dan Penanganan Awal", lomba: "Pembidaian", golongan: null },
+  { kode: "bidai_teknik", name: "Teknik Bidai", lomba: "Pembidaian", golongan: null },
+  { kode: "bidai_kecepatan_kerja_sama", name: "Kecepatan dan Kerja Sama", lomba: "Pembidaian", golongan: null },
+  { kode: "bidai_posisi", name: "Posisi Bidai", lomba: "Pembidaian", golongan: null },
+  { kode: "bidai_kerapihan", name: "Kerapihan dan Kebersihan", lomba: "Pembidaian", golongan: null },
+  { kode: "kim_lihat", name: "Kim Lihat", lomba: null, golongan: null },
+  { kode: "kim_cium", name: "Kim Cium", lomba: null, golongan: null },
+  { kode: "logika", name: "Logika", lomba: null, golongan: null },
+  { kode: "logika_intern", name: "Logika", lomba: null, golongan: "intern" },
+];
+
+const POS4 = [
+  { kode: "pbb_sikap", name: "Sikap Sempurna", lomba: "PBB", golongan: null },
+  { kode: "pbb_gerakan", name: "Gerakan Dasar", lomba: "PBB", golongan: null },
+  { kode: "pbb_kekompakan", name: "Kekompakan", lomba: "PBB", golongan: null },
+  { kode: "pbb_kerapihan", name: "Kerapihan", lomba: "PBB", golongan: null },
+];
+
+const lombaPos = (komponen) => kelompokLomba(kolomPos(komponen));
+
+
+test("Pos 3 jadi empat kolom, Pos 4 jadi satu", () => {
+  assert.deepEqual(lombaPos(POS3).map(l => l.nama),
+    ["Pembidaian", "Kim Lihat", "Kim Cium", "Logika"]);
+  assert.deepEqual(lombaPos(POS4).map(l => l.nama), ["PBB"]);
+});
+
+
+test("nilai satu lomba adalah jumlah komponennya", () => {
+  const [pembidaian] = lombaPos(POS3);
+  const poin = {
+    "3.bidai_diagnosis": 25, "3.bidai_teknik": 20,
+    "3.bidai_kecepatan_kerja_sama": 18, "3.bidai_posisi": 15,
+    "3.bidai_kerapihan": 12,
+  };
+  const r = ringkasLomba(pembidaian, "penegak_pa", 3, poin);
+  assert.equal(r.berlaku, 5);
+  assert.equal(r.terisi, 5);
+  assert.equal(r.jumlah, 90);
+
+  const [pbb] = lombaPos(POS4);
+  assert.equal(ringkasLomba(pbb, "penegak_pa", 4, {
+    "4.pbb_sikap": 20, "4.pbb_gerakan": 28,
+    "4.pbb_kekompakan": 25, "4.pbb_kerapihan": 18,
+  }).jumlah, 91);
+});
+
+
+test("terisi sebagian dilaporkan sebagian, bukan lengkap dan bukan kosong", () => {
+  const [pembidaian] = lombaPos(POS3);
+  const r = ringkasLomba(pembidaian, "penegak_pa", 3,
+    { "3.bidai_diagnosis": 25, "3.bidai_teknik": 20 });
+  assert.equal(r.berlaku, 5);
+  assert.equal(r.terisi, 2);
+  assert.equal(r.jumlah, 45);
+  assert.notEqual(r.terisi, r.berlaku, "sebagian tidak boleh terbaca lengkap");
+  assert.notEqual(r.terisi, 0, "sebagian tidak boleh terbaca kosong");
+});
+
+
+test("lomba yang tidak berlaku untuk golongannya dilaporkan berlaku=0", () => {
+  // Regu Intern hanya dinilai Soal Tulis dan ketepatan waktu (0091); seluruh
+  // lomba lapangan tidak berlaku untuknya. Itu keadaan sah, dan papan harus
+  // membedakannya dari "nilainya belum masuk".
+  const [pembidaian, , , logika] = lombaPos(POS3);
+  assert.equal(ringkasLomba(pembidaian, "intern_pa", 3, {}).berlaku, 0);
+
+  // Logika punya varian Intern, jadi ia TETAP berlaku — dan yang dibaca
+  // varian internnya, bukan baris umum.
+  const r = ringkasLomba(logika, "intern_pa", 3, { "3.logika_intern": 80, "3.logika": 55 });
+  assert.equal(r.berlaku, 1);
+  assert.equal(r.jumlah, 80);
+});
+
+
+test("nol komponen terisi berbeda dari nol poin", () => {
+  const [pbb] = lombaPos(POS4);
+  const kosong = ringkasLomba(pbb, "penegak_pa", 4, {});
+  assert.equal(kosong.terisi, 0);
+  assert.equal(kosong.jumlah, 0);
+
+  const nol = ringkasLomba(pbb, "penegak_pa", 4, { "4.pbb_sikap": 0 });
+  assert.equal(nol.terisi, 1, "nilai 0 yang tersimpan tetap terhitung terisi");
+  assert.equal(nol.jumlah, 0);
+});
+
+
+test("kedua papan memakai ringkasLomba yang sama", () => {
+  assert.match(app, /ringkasLomba\(l, k\.golongan, p\.nomor, poinKomponen\)/);
+  assert.match(live, /ringkasLomba\(l, b\.golongan, x\.pos\.nomor,/);
+
+  // Tidak ada lagi kolom per penilaian di kedua papan Live Score.
+  const awalPapan = app.indexOf("async function layarLiveScore()");
+  const akhirPapan = app.indexOf("\nasync function ", awalPapan + 10);
+  const papan = app.slice(awalPapan, akhirPapan);
+  assert.doesNotMatch(papan, /p\.kolom/,
+    "Live Score panitia masih menggambar kolom per penilaian");
+});
+
+
+test("kolom Nilai per pos hilang saat posnya cuma punya satu lomba", () => {
+  // Pos 4 cuma PBB: "PBB 82 | Nilai 82" adalah angka yang sama dua kali,
+  // bersebelahan.
+  assert.match(app, /const satuLomba = p\.lomba\.length === 1/);
+  assert.match(app, /satuLomba \? "" : `<th class="pos-kol rekap-batas">Nilai<\/th>`/);
+});
+
+
+test("Rekapitulasi TETAP satu kolom per penilaian", () => {
+  // Bagian 11.7: papan dan blangko boleh berbeda bentuk, dan yang satu tidak
+  // "diperbaiki" mengikuti yang lain. Rekapitulasi adalah lembar rinci —
+  // ia justru tempat kelima kriteria Pembidaian dibaca satu per satu.
+  const awal = app.indexOf("async function layarRekap()");
+  const akhir = app.indexOf("\nasync function ", awal + 10);
+  const rekap = app.slice(awal, akhir);
+  assert.match(rekap, /kolom: kolomPos\(komponen\)/);
+  assert.doesNotMatch(rekap, /kelompokLomba\(/);
+});

--- a/tests/live_score_poin.test.mjs
+++ b/tests/live_score_poin.test.mjs
@@ -40,8 +40,12 @@ const papanPeserta = (() => {
 })();
 
 test("sel lomba panitia membaca poin per komponen, bukan nilai mentah", () => {
-  assert.match(papanPanitia, /selPoin\(poinKomponen\[/,
+  // Poin per komponen kini dijumlahkan per LOMBA sebelum digambar — sumbernya
+  // tetap `poin` dari rekap.json (0107), yang berubah cuma pengelompokannya.
+  assert.match(papanPanitia, /ringkasLomba\(l, k\.golongan, p\.nomor, poinKomponen\)/,
     "sel Live Score panitia tidak lagi membaca poin per komponen");
+  assert.match(papanPanitia, /selPoin\(r\.jumlah\)/,
+    "sel Live Score panitia tidak menggambar jumlah poin lombanya");
   assert.doesNotMatch(papanPanitia, /selRekap\(/,
     "sel Live Score panitia kembali menggambar angka mentah lewat selRekap()");
 });

--- a/tests/public_board_columns.test.mjs
+++ b/tests/public_board_columns.test.mjs
@@ -62,9 +62,10 @@ test("varianUntuk tidak simetris: Intern tidak menerima komponen umum", () => {
 
 
 test("live.js memakai aturan bersama, bukan salinannya sendiri", () => {
-  assert.match(live, /kolomPos, varianUntuk/);
-  assert.match(live, /kolom: kolomPos\(komponen\.filter\(w => w\.pos === p\.nomor\)\)/);
-  assert.match(live, /const w = varianUntuk\(kol, b\.golongan\)/);
+  assert.match(live, /kolomPos, kelompokLomba, ringkasLomba/);
+  assert.match(live,
+    /lomba: kelompokLomba\(kolomPos\(komponen\.filter\(w => w\.pos === p\.nomor\)\)\)/);
+  assert.match(live, /const r = ringkasLomba\(l, b\.golongan, x\.pos\.nomor,/);
 
   // Bentuk salinan lamanya tidak boleh kembali.
   assert.doesNotMatch(live, /if \(!nama\.includes\(w\.name\)\) nama\.push/);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -37,7 +37,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          angkaRapi, nilaiTeks, nilaiBagian, kolomPos, kontrakTeks,
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
          GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
-         varianUntuk } from "./util.js";
+         varianUntuk, kelompokLomba, ringkasLomba } from "./util.js";
 import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
 
 const LAYAR = document.getElementById("layar");
@@ -2632,44 +2632,6 @@ function bacaSel(tr, k) {
   return v === "" ? null : { nilai_1: Number(v), nilai_2: null };
 }
 
-/** Varian yang berhak diisi regu bergolongan ini — cerminan persis
- *  `komponen_berlaku()` di database. Kalau keduanya berbeda pendapat, yang
- *  menang server, dan petugas menatap penolakan yang tidak bisa ia perbaiki.
- *
- *  null = kolom ini memang bukan untuk golongannya. Itu keadaan sah, bukan
- *  konfigurasi rusak: Tebak Simpul Penegak tidak ada urusannya dengan regu
- *  Penggalang. */
-/** Kolom layar dikelompokkan jadi LOMBA — tingkat ketiga yang tidak dimiliki
- *  `wahana` sampai migrasi 0054 (CLAUDE.md bagian 11).
- *
- *  Kolom di layar tetap satu per PENILAIAN: Pembidaian lima kolom. Blangko
- *  tetap satu per LOMBA: Pembidaian selembar dengan lima kotak. Keduanya
- *  benar, dan yang satu tidak boleh "diperbaiki" mengikuti yang lain — 11.6.
- *
- *  `lomba` kosong berarti komponen itu lomba tersendiri, keadaan yang benar
- *  untuk sebagian besar baris. */
-const slugLomba = (nama) => String(nama).toLowerCase()
-  .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
-
-function kelompokLomba(kolom) {
-  const urut = [], peta = new Map();
-  for (const kol of kolom) {
-    const k = kol.varian[0];
-    const nama = k.lomba || kol.nama;
-    if (!peta.has(nama)) {
-      // `kode` adalah kunci TETAP lomba ini (0079), dan ia dibaca dari
-      // database — bukan diturunkan dari namanya. Foto slip disimpan dengan
-      // kunci itu, jadi menurunkannya dari nama berarti mengganti nama lomba
-      // menghilangkan seluruh fotonya tanpa satu pun galat. Cadangan slug
-      // dipakai hanya untuk baris yang kolomnya belum terisi.
-      peta.set(nama, { nama, kode: k.kode_lomba || slugLomba(nama), kolom: [] });
-      urut.push(peta.get(nama));
-    }
-    peta.get(nama).kolom.push(kol);
-  }
-  return urut;
-}
-
 /** Kolom KERTAS untuk satu kolom layar. Sebagian memakan dua kolom, dan
  *  pembagiannya sama persis dengan kotak di layar — supaya petugas yang
  *  menyalin dari kertas ke layar menemukan urutan yang sama, tidak perlu
@@ -5250,9 +5212,21 @@ async function layarLiveScore() {
      Pos 1 memakan empat kolom "Tebak Simpul" yang isinya saling meniadakan,
      satu per golongan, dan tabelnya memanjang tanpa menambah satu keterangan
      pun. */
+  /* Satu kolom per LOMBA, bukan per penilaian — keputusan pemilik acara.
+     Pembidaian lima kriteria jadi satu angka, PBB empat jadi satu, Yel-Yel
+     empat jadi satu. Yang dibaca orang di papan ini adalah "berapa nilai
+     Pembidaian regu itu", bukan berapa nilai Posisi Bidai-nya; rinciannya
+     tetap utuh di Rekapitulasi dan di layar Input Pos, tempat ia memang
+     menjawab pertanyaan.
+
+     Ini TIDAK mengubah cara nilai dihitung. `poin_per_pos` tetap datang dari
+     database; yang dijumlahkan di sini cuma tampilannya. */
   const posKolom = posSemua
     .filter(p => p.jumlah_komponen > 0)
-    .map(p => ({ ...p, kolom: kolomPos(komponen.filter(k => k.pos === p.nomor)) }));
+    .map(p => ({
+      ...p,
+      lomba: kelompokLomba(kolomPos(komponen.filter(k => k.pos === p.nomor))),
+    }));
   const rekapDada = new Map(rekap.map(r => [r.nomor_dada, r]));
   /* KEEMPAT golongan selalu digambar, dengan urutan tetap — bukan hanya yang
      kebetulan sudah punya baris.
@@ -5375,7 +5349,11 @@ async function layarLiveScore() {
                       role="button" aria-expanded="false"
                       title="Klik untuk menyaring per sekolah">Organisasi
                     <span class="hitung-filter"></span> <span aria-hidden="true">▾</span></th>
-                  ${posKolom.map(p => `<th colspan="${p.kolom.length + 1}"
+                  <!-- Kolom "Nilai" per pos hanya digambar kalau posnya
+                       memuat LEBIH DARI SATU lomba. Pos 4 cuma punya PBB dan
+                       Pos 5 cuma punya Yel-Yel: di sana "PBB 82 | Nilai 82"
+                       adalah angka yang sama dua kali, bersebelahan. -->
+                  ${posKolom.map(p => `<th colspan="${p.lomba.length + (p.lomba.length > 1 ? 1 : 0)}"
                     class="rekap-batas">Pos ${esc(String(p.nomor))} · ${esc(p.name)}</th>`).join("")}
                   <!-- Lima kolom perjalanan mendahului Penalti, dan urutan
                        itu yang membuatnya berguna: Penalti selalu dibaca
@@ -5399,9 +5377,13 @@ async function layarLiveScore() {
                        "0 – 5" di bawah kolom berisi 80 justru membantahnya.
                        Rentangnya tetap ada di layar Input Pos dan di
                        Rekapitulasi, tempat ia memang menjawab pertanyaan. -->
-                  ${posKolom.map(p => p.kolom.map(kol =>
-                      `<th class="pos-kol">${esc(kol.nama)}</th>`).join("")
-                    + `<th class="pos-kol rekap-batas">Nilai</th>`).join("")}
+                  ${posKolom.map(p => {
+                    const satuLomba = p.lomba.length === 1;
+                    return p.lomba.map((l, i) =>
+                      `<th class="pos-kol${satuLomba && i === p.lomba.length - 1
+                        ? " rekap-batas" : ""}">${esc(l.nama)}</th>`).join("")
+                      + (satuLomba ? "" : `<th class="pos-kol rekap-batas">Nilai</th>`);
+                  }).join("")}
                 </tr>
               </thead>
               <tbody>
@@ -5418,17 +5400,26 @@ async function layarLiveScore() {
                     <td class="angka">${esc(dada3(k.nomor_dada))}</td>
                     <td>${esc(k.nama_regu)}</td>
                     <td class="rekap-batas sub-kolom">${esc(k.nama_sekolah)}</td>
-                    ${posKolom.map(p => p.kolom.map(kol => {
+                    ${posKolom.map(p => {
+                      const satuLomba = p.lomba.length === 1;
+                      return p.lomba.map((l, i) => {
                         // Satu lomba bisa punya baris wahana berbeda per
                         // golongan; yang berlaku untuk regu INI yang dibaca.
-                        const w = varianUntuk(kol, k.golongan);
-                        return `<td class="text-center">${w
-                          ? selPoin(poinKomponen[`${p.nomor}.${w.kode}`])
-                          : `<span class="sel-mati">–</span>`}</td>`;
+                        // `berlaku === 0` berarti lomba ini memang bukan untuk
+                        // golongannya — bukan berarti nilainya belum masuk.
+                        const r = ringkasLomba(l, k.golongan, p.nomor, poinKomponen);
+                        const batas = satuLomba && i === p.lomba.length - 1
+                          ? " rekap-batas" : "";
+                        if (!r.berlaku)
+                          return `<td class="text-center${batas}"><span class="sel-mati">–</span></td>`;
+                        return `<td class="text-center${batas}">${
+                          r.terisi ? selPoin(r.jumlah) : "–"}</td>`;
                       }).join("")
-                      + `<td class="text-center pos-nilai rekap-batas">${
-                          poin[String(p.nomor)] === undefined
-                            ? "–" : esc(angkaRapi(poin[String(p.nomor)]))}</td>`).join("")}
+                      + (satuLomba ? ""
+                        : `<td class="text-center pos-nilai rekap-batas">${
+                            poin[String(p.nomor)] === undefined
+                              ? "–" : esc(angkaRapi(poin[String(p.nomor)]))}</td>`);
+                    }).join("")}
                     <td class="text-center">${esc(kontrakTeks(rk.kontrak_menit))}</td>
                     <td class="text-center">${esc(rk.kloter ?? "—")}</td>
                     <td class="text-center">${esc(rk.jam_berangkat

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1081,6 +1081,70 @@ export const varianUntuk = (kol, golongan) => {
   return kol.varian.find(k => !k.golongan || k.golongan === golongan) || null;
 };
 
+const slugLomba = (nama) => String(nama).toLowerCase()
+  .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "lomba";
+
+/** Kolom layar dikelompokkan jadi LOMBA — tingkat ketiga yang tidak dimiliki
+ *  `wahana` sampai migrasi 0054 (CLAUDE.md bagian 11).
+ *
+ *  `lomba` kosong berarti komponen itu lomba tersendiri, keadaan yang benar
+ *  untuk sebagian besar baris — Semaphore, Menaksir, Bakiak. Yang berkelompok
+ *  cuma Pembidaian (lima kriteria), PBB (empat), dan Yel-Yel (empat).
+ *
+ *  Tempatnya di util.js, bukan di app.js: papan panitia dan papan peserta
+ *  sama-sama menyusun kolomnya dari sini. Dua papan yang mengelompokkan
+ *  dengan aturan berbeda adalah bentuk kegagalan yang sudah pernah terjadi
+ *  dan tidak menggagalkan apa pun — ia cuma membuat keduanya saling membantah
+ *  di depan pembina yang sedang membandingkan. */
+export function kelompokLomba(kolom) {
+  const urut = [], peta = new Map();
+  for (const kol of kolom) {
+    const k = kol.varian[0];
+    const nama = k.lomba || kol.nama;
+    if (!peta.has(nama)) {
+      // `kode` adalah kunci TETAP lomba ini (0079), dan ia dibaca dari
+      // database — bukan diturunkan dari namanya. Foto slip disimpan dengan
+      // kunci itu, jadi menurunkannya dari nama berarti mengganti nama lomba
+      // menghilangkan seluruh fotonya tanpa satu pun galat. Cadangan slug
+      // dipakai hanya untuk baris yang kolomnya belum terisi.
+      peta.set(nama, { nama, kode: k.kode_lomba || slugLomba(nama), kolom: [] });
+      urut.push(peta.get(nama));
+    }
+    peta.get(nama).kolom.push(kol);
+  }
+  return urut;
+}
+
+/** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
+ *  berapa yang sudah ada isinya, dan jumlah nilainya.
+ *
+ *  Dipakai kedua papan Live Score, dan sengaja hanya satu fungsi walau
+ *  keduanya menampilkan hal berbeda — panitia menggambar `jumlah`, peserta
+ *  menggambar centang dari `terisi` lawan `berlaku`. Yang harus sama persis
+ *  adalah CARA MEMBACANYA; kalau tidak, satu papan bisa menyebut Pembidaian
+ *  lengkap sementara papan sebelahnya menyebutnya baru sebagian.
+ *
+ *  `peta` berkunci `"<pos>.<kode wahana>"` — bentuk yang sama dipakai
+ *  `poin` maupun `komponen_terisi` di rekap.json (migrasi 0107 dan 0072).
+ *
+ *  `berlaku === 0` berarti lomba ini memang bukan untuk golongan regu itu.
+ *  Itu keadaan sah, bukan konfigurasi rusak: Tebak Simpul Penegak tidak ada
+ *  urusannya dengan regu Penggalang, dan seluruh lomba lapangan tidak ada
+ *  urusannya dengan regu Intern (migrasi 0091). */
+export function ringkasLomba(lomba, golongan, pos, peta) {
+  let berlaku = 0, terisi = 0, jumlah = 0;
+  for (const kol of lomba.kolom) {
+    const w = varianUntuk(kol, golongan);
+    if (!w) continue;
+    berlaku++;
+    const v = (peta || {})[`${pos}.${w.kode}`];
+    if (v === null || v === undefined) continue;
+    terisi++;
+    jumlah += Number(v) || 0;
+  }
+  return { berlaku, terisi, jumlah };
+}
+
 /** Angka nilai sebagai TEKS, satu bagian atau dua.
  *
  *  Mengembalikan bagian-bagiannya, bukan HTML jadi, dan itu yang membuatnya


### PR DESCRIPTION
## What

Kedua papan Live Score — panitia dan peserta — menggambar satu kolom per **lomba**.

| Pos | Sebelum | Sesudah |
| --- | --- | --- |
| Pos 3 | 9 kolom | **Pembidaian**, Kim Lihat, Kim Cium, Logika |
| Pos 4 | 4 kolom | **PBB** |
| Pos 5 | 4 kolom | **Yel-Yel** |

Pos 1 dan Pos 2 tidak berubah — komponennya memang sudah satu lomba masing-masing.

- `kelompokLomba()` naik dari `app.js` ke `util.js`, bersama fungsi baru `ringkasLomba()`.
- Kolom "Nilai" per pos hilang untuk pos yang cuma punya satu lomba.
- Papan peserta mendapat keadaan ketiga di fase `progres`: **sebagian terisi**.

## Why

Keputusan pemilik acara: yang dibaca orang di papan ini adalah "berapa nilai Pembidaian regu itu", bukan berapa nilai Posisi Bidai-nya.

Rinciannya tidak hilang — ia tetap utuh di layar Input Pos dan di Rekapitulasi, dan sebuah tes menjaga Rekapitulasi tetap satu kolom per penilaian. Pasal 11.7 tentang papan dan blangko yang boleh berbeda bentuk tetap berlaku; yang berubah cuma papannya.

**Kedua papan ikut, dan itu bagian dari perbaikannya.** Mengubah papan panitia saja akan membuat peserta melihat rincian berbeda untuk regu yang sama begitu fase dibuka ke `penuh` — bentuk divergensi yang persis baru ditutup di #574. Karena itu aturannya satu fungsi bersama, bukan dua salinan.

**Keadaan "sebagian" bukan hiasan.** Pembidaian dinilai lima kriteria oleh satu juri; "sudah dinilai" dan "baru tiga dari lima yang masuk" adalah dua jawaban berbeda atas satu-satunya pertanyaan yang dibawa peserta ke halaman itu. Warnanya amber dengan garis bawah putus-putus, bukan hijau yang dipudarkan — pucat di layar HP di bawah matahari terbaca sebagai layar jelek, bukan sebagai keadaan tersendiri.

**Nilai tidak dihitung ulang di mana pun.** Poin per komponen tetap datang jadi dari database (0107); yang dijumlahkan cuma tampilannya, dan Nilai per pos tetap dibaca dari `poin_per_pos`. Tidak ada migrasi di PR ini.

## Verifikasi lokal

Diukur di browser dengan database dev berisi 50 regu dan 625 nilai (pasal 15.9 — aturan CSS baru wajib diukur, bukan dibaca):

**Keselarasan kolom**, dibaca dari DOM: `colspan` baris kepala = jumlah `<th>` sub = jumlah `<td>` badan (19 = 19 = 19), sisa 7 kolom ekor tepat Kontrak/Kloter/Berangkat/Datang/Anggota/Penalti/Total.

**Aritmetikanya cocok**: Pembidaian 83 adalah jumlah kelima kriterianya, dan Nilai Pos 3 288 = 83 + 100 + 70 + 35.

**CSS `.pos.sebagian` benar-benar berlaku** (bukan tertimpa): amber `#8a6100` di atas `#fdf3d6` dengan `underline dotted`, berbeda tegas dari `ada` (hijau `#2e7d32`) dan `belum` (abu, transparan). Baris genap ikut berganti latar untuk kedua keadaan.

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 151 pass, 0 fail (8 tes baru) |
| `periksa_impor` / `periksa_urutan_golongan` / `pratinjau_cetak` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
