### PR TITLE
feat: Daftar Kloter menyebut asal jam yang ditampilkannya

### DIFF
--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -1,0 +1,57 @@
+// Daftar Kloter menyebut ASAL jam yang ia tampilkan.
+//
+// Pasal 10.6: perkiraan bukan catatan, dan layar yang menampilkan keduanya
+// harus menyebut yang mana. Keduanya jam yang terlihat sama — "07:05" — dan
+// sama sekali bukan hal yang sama: yang satu dihitung sistem untuk
+// merencanakan pagi, yang satu diketik petugas dari jam dinding dan menjadi
+// dasar penalti seluruh regu di kloter itu.
+//
+// Dijaga mesin karena kegagalannya tidak menimbulkan galat apa pun: labelnya
+// tetap tergambar, angkanya tetap benar, dan yang keliru cuma kesimpulan yang
+// diambil orang yang membacanya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+const awal = app.indexOf("async function layarDaftarKloter()") >= 0
+  ? app.indexOf("async function layarDaftarKloter()")
+  : app.indexOf('pasangKepala("Daftar Kloter")');
+const daftarKloter = app.slice(awal, app.indexOf("\nfunction siapkanCetakKloter", awal));
+
+
+test("kartu kloter memilih label menurut ada tidaknya jam tercatat", () => {
+  assert.ok(awal > 0, "layar Daftar Kloter tidak ditemukan");
+  assert.match(daftarKloter, /v\.jamBerangkat\s*\n?\s*\? "Jam Berangkat di Lapangan"/);
+  assert.match(daftarKloter, /: "Prediksi Berangkat"/);
+});
+
+
+test("label lama yang tidak menyebut asal angkanya tidak kembali", () => {
+  // "Jam berangkat" polos terbaca seperti jadwal, dan "Estimasi" adalah kata
+  // KETIGA untuk hal yang kertasnya sebut "Perkiraan".
+  assert.doesNotMatch(daftarKloter, /\? "Jam berangkat"/);
+  assert.doesNotMatch(daftarKloter, /"Estimasi jam berangkat"/);
+});
+
+
+test("angkanya tetap jatuh ke perkiraan hanya saat belum tercatat", () => {
+  // Urutannya mengikat: `jamBerangkat` dulu, perkiraan sebagai cadangan.
+  // Terbalik, kloter yang SUDAH berangkat akan menampilkan perkiraannya dan
+  // penalti dihitung dari angka yang tidak tertulis di mana pun.
+  assert.match(daftarKloter,
+    /jamMenit\(v\.jamBerangkat \|\| v\.perkiraanBerangkat\)/);
+});
+
+
+test("kertas kloter TIDAK ikut berubah kata", () => {
+  // Blangko difotokopi dan masternya bisa sudah beredar (pasal 8.1). Kertas
+  // peserta memang selalu memuat perkiraan — ia dicetak sebelum ada yang
+  // berangkat — dan kertas staging menyediakan garis kosong "Jam sebenarnya"
+  // untuk ditulis tangan. Keduanya benar apa adanya.
+  assert.match(app, /Perkiraan jam berangkat: \$\{esc\(perkiraan\)\}/);
+  assert.match(app, /Jam sebenarnya: ________/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2027,9 +2027,20 @@ async function layarCetakKloter() {
         return `
           <div class="card">
             <h2>Kloter ${esc(nomor)}</h2>
+            <!-- Labelnya menyebut ASAL angkanya, bukan cuma "jam berangkat".
+                 Keduanya jam yang terlihat sama di layar dan sama sekali bukan
+                 hal yang sama: yang satu dihitung sistem untuk merencanakan
+                 pagi, yang satu diketik petugas dari jam dinding dan menjadi
+                 dasar penalti SELURUH regu di kloter itu (pasal 10.6).
+
+                 "di Lapangan" bukan hiasan. Tanpa itu "Jam berangkat" terbaca
+                 seperti jadwal — dan petugas yang membaca kartu ini untuk
+                 memutuskan apakah sebuah kloter sudah jalan tidak punya cara
+                 membedakan keduanya selain mengingat kloter mana yang sudah
+                 ia ceklis. -->
             <p><strong>${v.jamBerangkat
-              ? "Jam berangkat"
-              : "Estimasi jam berangkat"}:</strong>
+              ? "Jam Berangkat di Lapangan"
+              : "Prediksi Berangkat"}:</strong>
               ${esc(jamMenit(v.jamBerangkat || v.perkiraanBerangkat))}</p>
             <table class="table">${baris}</table>
           </div>`;


### PR DESCRIPTION
## What

Label di kartu kloter pada layar Daftar Kloter:

| Keadaan | Sebelum | Sesudah |
| --- | --- | --- |
| Belum berangkat | Estimasi jam berangkat | **Prediksi Berangkat** |
| Sudah berangkat | Jam berangkat | **Jam Berangkat di Lapangan** |

Plus `tests/kloter_departure_label.test.mjs`.

## Why

Pasal 10.6: *"An estimate is never a record... a screen showing both must say which is which."*

Keduanya jam yang terlihat sama — "07:05" — dan sama sekali bukan hal yang sama. Yang satu dihitung sistem untuk merencanakan pagi; yang satu diketik petugas dari jam dinding dan menjadi dasar penalti **seluruh regu di kloter itu**.

Label lamanya tidak menyebut bedanya: "Jam berangkat" polos terbaca seperti jadwal, dan petugas yang membaca kartu ini untuk memutuskan apakah sebuah kloter sudah jalan tidak punya cara membedakan keduanya selain mengingat kloter mana yang sudah ia ceklis.

## Notes

**Kertas TIDAK ikut berubah, dan ada tes yang menjaganya.** Blangko difotokopi dan masternya bisa sudah beredar (pasal 8.1). Lagi pula keduanya sudah benar apa adanya: kertas peserta memang selalu memuat perkiraan — ia dicetak sebelum ada yang berangkat — dan kertas staging menyediakan garis kosong "Jam sebenarnya: ______" untuk ditulis tangan.

**Satu hal, tiga nama — dan sekarang masih dua.** Sebelum PR ini layar menyebutnya "Estimasi", kertas menyebutnya "Perkiraan", dan chip Keberangkatan menandainya "~". PR ini menyatukan layar ke "Prediksi" sesuai permintaan pemilik acara, tetapi kertas masih "Perkiraan". Menyamakannya bisa dikerjakan kapan saja setelah lomba — bukan dua hari sebelumnya, saat masternya mungkin sudah di mesin fotokopi.

## Verifikasi lokal

Diukur di browser dengan database dev berisi 10 kloter, 7 di antaranya sudah berangkat:

```
Kloter 1  Jam Berangkat di Lapangan: 07:00
...
Kloter 7  Jam Berangkat di Lapangan: 07:24
Kloter 8  Prediksi Berangkat: 07:21
Kloter 9  Prediksi Berangkat: 07:24
Kloter 10 Prediksi Berangkat: 07:27
```

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 155 pass, 0 fail (4 tes baru) |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
