### PR TITLE
feat: Planning Keberangkatan di Daftar Kloter, disandingkan dengan yang nyata

### DIFF
--- a/tests/departure_calculator.test.mjs
+++ b/tests/departure_calculator.test.mjs
@@ -13,7 +13,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { hitungRekomendasiKloter } from "../web/js/departure-calculator.mjs";
+import { hitungRekomendasiKloter, jadwalPlanning } from "../web/js/departure-calculator.mjs";
 
 
 const hitung = (jumlahEksternal, jumlahIntern = 0,
@@ -93,4 +93,47 @@ test("satu kloter memakai waktu berangkat pertama", () => {
 test("menolak jendela terbalik dan jumlah regu di atas kapasitas", () => {
   assert.throws(() => hitung(10, 0, "10:00", "07:00"), /harus setelah/);
   assert.throws(() => hitung(376), /melebihi batas 75/);
+});
+
+
+/* ---------------------------------------------------------------------------
+   jadwalPlanning — rencana untuk kloter yang SUDAH terbentuk.
+
+   Pertanyaannya berbeda dari hitungRekomendasiKloter di atas: yang itu
+   proyeksi sebelum daftar ulang, yang ini rencana sesudahnya. Karena itu
+   pembaginya juga berbeda, dan perbedaan itu disengaja.
+   ------------------------------------------------------------------------- */
+
+test("kloter yang ada disebar penuh di jendela, bukan ke kloter cadangan", () => {
+  const jadwal = jadwalPlanning([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "07:00", "10:00");
+  assert.equal(jadwal.size, 10);
+  assert.equal(jadwal.get(1), "07:00");
+  assert.equal(jadwal.get(2), "07:20");
+  assert.equal(jadwal.get(10), "10:00");
+
+  // Inilah bedanya dengan perkiraan database, yang menyebar ke SELURUH 75
+  // kloter edisi: di sana kesepuluh kloter ini berangkat sebelum 07:25 dan
+  // jendela sampai pukul sepuluh tidak terpakai sama sekali.
+  assert.notEqual(jadwal.get(10), "07:21");
+});
+
+
+test("satu kloter berangkat di jam pertama, bukan NaN", () => {
+  assert.deepEqual([...jadwalPlanning([1], "07:00", "10:00")], [[1, "07:00"]]);
+});
+
+
+test("nomor kloter berlubang tetap berurutan menurut nomornya", () => {
+  // Kloter kosong memang tidak ada di daftar ini. Yang menentukan posisinya
+  // dalam urutan, bukan nomornya.
+  const jadwal = jadwalPlanning([7, 1, 3], "07:00", "10:00");
+  assert.deepEqual([...jadwal.keys()], [1, 3, 7]);
+  assert.equal(jadwal.get(1), "07:00");
+  assert.equal(jadwal.get(7), "10:00");
+});
+
+
+test("jendela terbalik dan jam tidak lengkap ditolak", () => {
+  assert.throws(() => jadwalPlanning([1, 2], "10:00", "07:00"), /harus setelah/);
+  assert.throws(() => jadwalPlanning([1, 2], "", "10:00"), /belum lengkap/);
 });

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -121,8 +121,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select e.jam_mulai_berangkat, e.jam_batas_berangkat, "
                     "e.maks_eksternal_per_kloter, e.maks_intern_per_kloter, "
                     "e.perkiraan_regu_eksternal, e.perkiraan_regu_intern, e.kloter_maks, "
-                    "(select count(*) from regu where not is_cancelled and golongan not like 'intern_%') as jumlah_eksternal, "
-                    "(select count(*) from regu where not is_cancelled and golongan like 'intern_%') as jumlah_intern "
+                    # `%%`, bukan `%`: q() selalu memanggil cur.execute(sql, args),
+                    # dan psycopg2 memperlakukan `%` sebagai penanda parameter apa pun
+                    # isi args-nya. Ditulis `%` polos, rute ini melempar
+                    # "IndexError: tuple index out of range" dan layar yang
+                    # memanggilnya mati di dev — tanpa gejala di produksi, karena
+                    # di sana PostgREST yang menjawab.
+                    "(select count(*) from regu where not is_cancelled and golongan not like 'intern_%%') as jumlah_eksternal, "
+                    "(select count(*) from regu where not is_cancelled and golongan like 'intern_%%') as jumlah_intern "
                     "from edisi e where e.is_active",
                     uid=p.get("uid"), fetch="one"))
             elif u.path == "/penalti":

--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -1,14 +1,12 @@
-// Daftar Kloter menyebut ASAL jam yang ia tampilkan.
+// Daftar Kloter menyandingkan RENCANA dan KENYATAAN, dan menyebut yang mana.
 //
-// Pasal 10.6: perkiraan bukan catatan, dan layar yang menampilkan keduanya
-// harus menyebut yang mana. Keduanya jam yang terlihat sama — "07:05" — dan
-// sama sekali bukan hal yang sama: yang satu dihitung sistem untuk
-// merencanakan pagi, yang satu diketik petugas dari jam dinding dan menjadi
+// Pasal 10.6: perkiraan bukan catatan. Keduanya jam yang terlihat sama —
+// "07:20" — dan sama sekali bukan hal yang sama: yang satu rencana yang
+// dibagikan ke peserta, yang satu diketik petugas dari jam dinding dan menjadi
 // dasar penalti seluruh regu di kloter itu.
 //
-// Dijaga mesin karena kegagalannya tidak menimbulkan galat apa pun: labelnya
-// tetap tergambar, angkanya tetap benar, dan yang keliru cuma kesimpulan yang
-// diambil orang yang membacanya.
+// Panitia perlu KEDUANYA sekaligus, bukan yang satu menggantikan yang lain:
+// selisihnya yang mereka pakai memutuskan apakah kloter berikutnya digeser.
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
@@ -17,41 +15,65 @@ import test from "node:test";
 
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
 
-const awal = app.indexOf("async function layarDaftarKloter()") >= 0
-  ? app.indexOf("async function layarDaftarKloter()")
-  : app.indexOf('pasangKepala("Daftar Kloter")');
-const daftarKloter = app.slice(awal, app.indexOf("\nfunction siapkanCetakKloter", awal));
+const awal = app.indexOf('pasangKepala("Daftar Kloter")');
+const layar = app.slice(awal, app.indexOf("\nfunction siapkanCetakKloter", awal));
 
 
-test("kartu kloter memilih label menurut ada tidaknya jam tercatat", () => {
+test("kartu kloter memakai satu perakit baris jam, bukan ternary di tempat", () => {
   assert.ok(awal > 0, "layar Daftar Kloter tidak ditemukan");
-  assert.match(daftarKloter, /v\.jamBerangkat\s*\n?\s*\? "Jam Berangkat di Lapangan"/);
-  assert.match(daftarKloter, /: "Prediksi Berangkat"/);
+  assert.match(layar, /const barisJamKloter = \(nomor, v\) =>/);
+  assert.match(layar, /\$\{barisJamKloter\(nomor, v\)\}/);
 });
 
 
-test("label lama yang tidak menyebut asal angkanya tidak kembali", () => {
-  // "Jam berangkat" polos terbaca seperti jadwal, dan "Estimasi" adalah kata
-  // KETIGA untuk hal yang kertasnya sebut "Perkiraan".
-  assert.doesNotMatch(daftarKloter, /\? "Jam berangkat"/);
-  assert.doesNotMatch(daftarKloter, /"Estimasi jam berangkat"/);
+test("kedua label tetap menyebut asal angkanya", () => {
+  assert.match(layar, /<strong>Prediksi Berangkat:<\/strong>/);
+  assert.match(layar, /<strong>Jam Berangkat di Lapangan:<\/strong>/);
+  // "Jam berangkat" polos terbaca seperti jadwal; "Estimasi" adalah kata
+  // ketiga untuk hal yang kertasnya sebut "Perkiraan".
+  assert.doesNotMatch(layar, /\? "Jam berangkat"/);
+  assert.doesNotMatch(layar, /"Estimasi jam berangkat"/);
 });
 
 
-test("angkanya tetap jatuh ke perkiraan hanya saat belum tercatat", () => {
-  // Urutannya mengikat: `jamBerangkat` dulu, perkiraan sebagai cadangan.
-  // Terbalik, kloter yang SUDAH berangkat akan menampilkan perkiraannya dan
-  // penalti dihitung dari angka yang tidak tertulis di mana pun.
-  assert.match(daftarKloter,
-    /jamMenit\(v\.jamBerangkat \|\| v\.perkiraanBerangkat\)/);
+test("keduanya digambar bersama, bukan saling menggantikan", () => {
+  // Dua `bagian.push` berurutan tanpa `else` di antaranya: kloter yang sudah
+  // berangkat menampilkan rencana DAN kenyataannya.
+  assert.match(layar, /if \(rencana\) \{\s*bagian\.push/);
+  assert.match(layar, /if \(v\.jamBerangkat\) \{\s*bagian\.push/);
+  assert.match(layar, /bagian\.join\(" · "\)/);
 });
 
 
-test("kertas kloter TIDAK ikut berubah kata", () => {
-  // Blangko difotokopi dan masternya bisa sudah beredar (pasal 8.1). Kertas
-  // peserta memang selalu memuat perkiraan — ia dicetak sebelum ada yang
-  // berangkat — dan kertas staging menyediakan garis kosong "Jam sebenarnya"
-  // untuk ditulis tangan. Keduanya benar apa adanya.
-  assert.match(app, /Perkiraan jam berangkat: \$\{esc\(perkiraan\)\}/);
+test("planning layar menang, perkiraan database jadi cadangan", () => {
+  // Urutannya mengikat. Terbalik, jam yang baru saja diatur panitia diabaikan
+  // dan kartunya menampilkan sebaran database ke 75 kloter.
+  assert.match(layar,
+    /planning\.get\(Number\(nomor\)\)\s*\n\s*\/\/[^\n]*\n\s*\/\/[^\n]*\n\s*\|\| \(v\.perkiraanBerangkat/);
+});
+
+
+test("selisih dihitung pada hari yang TERCATAT, bukan kalender alat", () => {
+  // "07:20" tidak membawa tanggal, dan layar ini dibuka juga di hari selain
+  // hari-H. Memakai tanggal alat menghasilkan selisih berhari-hari.
+  assert.match(layar, /jamPadaHari\(rencana, v\.jamBerangkat\)/);
+  assert.match(layar, /menit === 0\s*\n?\s*\? html` <span class="sub">tepat<\/span>`/);
+});
+
+
+test("kertas memakai planning yang sama dengan layar", () => {
+  // Tombol cetaknya ada di layar yang sama. Kertas yang menyebut jam lain dari
+  // yang baru saja dibaca petugas adalah kertas yang salah, dan yang
+  // memegangnya peserta.
+  assert.match(layar, /siapkanCetakKloter\(semuaKloter, bentuk, planning\)/);
+  assert.match(app,
+    /function siapkanCetakKloter\(dipakai, bentuk = "staging", planning = new Map\(\)\)/);
+  assert.match(app, /const perkiraan = planning\.get\(Number\(nomor\)\)/);
+});
+
+
+test("kertas staging tetap menyediakan garis jam sebenarnya", () => {
+  // Blangko difotokopi (pasal 8.1) dan petugas menulis jam nyata dengan
+  // tangan di sana — itu yang lalu diketik ke layar Keberangkatan.
   assert.match(app, /Jam sebenarnya: ________/);
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -38,7 +38,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
          GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
          varianUntuk, kelompokLomba, ringkasLomba } from "./util.js";
-import { hitungRekomendasiKloter } from "./departure-calculator.mjs";
+import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
 
 const LAYAR = document.getElementById("layar");
 
@@ -1967,8 +1967,11 @@ async function layarCetakKloter() {
   pasangKepala("Daftar Kloter");
   LAYAR.replaceChildren(h(pemuat()));
 
-  let baris;
-  try { baris = await daftarKloter(); }
+  let baris, cfg;
+  // Jendela keberangkatan datang dari konfigurasi edisi — itu nilai awalnya,
+  // bukan nilai matinya. Panitia menggesernya di layar ini sesudah melihat
+  // berapa regu yang benar-benar mengambil nomor dada.
+  try { [baris, cfg] = await Promise.all([daftarKloter(), infoPengaturanKloter()]); }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarCetakKloter)); return; }
 
   if (!baris.length) {
@@ -1995,12 +1998,51 @@ async function layarCetakKloter() {
 
   let perKloter = kelompokkan(baris);
 
+  /* Yang dihitung REGU YANG SUDAH MENGAMBIL NOMOR DADA, bukan yang mendaftar.
+     Keduanya berbeda jauh pada pagi hari-H: sekolah yang mendaftar tapi tidak
+     datang tetap ada di `pendaftaran`, dan merencanakan keberangkatan dari
+     angka itu menyebar jendela ke kloter yang tidak akan pernah berangkat.
+
+     Sumbernya baris yang sudah ada di layar ini — tiap baris `v_daftar_kloter`
+     adalah regu yang berkloter, dan constraint `regu_check` menjamin nomor
+     dada dan kloter selalu ada bersama-sama. Jadi tidak ada permintaan kedua
+     ke server untuk menghitungnya. */
+  const jumlahIntern = baris.filter(
+    b => String(b.golongan || "").startsWith("intern_")).length;
+  const jumlahEksternal = baris.length - jumlahIntern;
+
+  const jamPendek = (nilai) => {
+    const teks = String(nilai || "");
+    return /^\d{2}:\d{2}/.test(teks) ? teks.slice(0, 5) : "";
+  };
+
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
       <table class="table">
         <tr><td>Total Kloter</td><td class="angka">${perKloter.size}</td></tr>
         <tr><td>Total Regu</td><td class="angka">${baris.length}</td></tr>
       </table>
+      <!-- Planning berdiri DI ATAS tombol cetak, dan urutan itu berarti:
+           yang tercetak adalah jam yang baru saja diatur di sini. Menaruhnya
+           di bawah membuat petugas menekan Cetak lebih dulu, lalu menemukan
+           kotak jamnya sesudah kertasnya keluar. -->
+      <h2 style="margin-top:1rem">Planning Keberangkatan</h2>
+      <div class="two-column">
+        <div class="field">
+          <label for="planning-pertama-hh">Waktu Berangkat Pertama</label>
+          ${kotakJamHtml("planning-pertama", jamPendek(cfg.jam_mulai_berangkat))}
+        </div>
+        <div class="field">
+          <label for="planning-terakhir-hh">Waktu Berangkat Terakhir</label>
+          ${kotakJamHtml("planning-terakhir", jamPendek(cfg.jam_batas_berangkat))}
+        </div>
+      </div>
+      <p class="description">Sudah mengambil nomor dada:
+         <strong>${jumlahEksternal} Eksternal</strong> ·
+         <strong>${jumlahIntern} Intern</strong>, terbagi
+         <strong>${perKloter.size} kloter</strong>. Jam di bawah dibagi rata ke
+         kloter itu, dan itu pula yang tercetak untuk peserta.</p>
+      <div class="error" id="planning-galat" hidden></div>
       <div class="option-row" style="margin-top:.9rem">
         <button class="button button-primary" id="cetak-petugas" type="button">
           ${ikon("printer")} Cetak Kloter untuk Petugas
@@ -2012,6 +2054,72 @@ async function layarCetakKloter() {
     </div>
     <div id="pratayang"></div>
   `));
+
+  const waktuPertama = pasangKotakJam("planning-pertama");
+  const waktuTerakhir = pasangKotakJam("planning-terakhir");
+  const galatPlanning = document.getElementById("planning-galat");
+
+  /** Jam planning tiap kloter, atau Map kosong kalau jendelanya belum sah.
+   *  Kosong = kartu jatuh kembali ke perkiraan database, bukan kartu tanpa
+   *  jam sama sekali — layar ini tetap harus bisa dibaca sambil jendelanya
+   *  sedang diketik. */
+  let planning = new Map();
+
+  const hitungPlanning = () => {
+    galatPlanning.hidden = true;
+    waktuTerakhir.salah(false);
+    const pertama = waktuPertama.nilai();
+    const terakhir = waktuTerakhir.nilai();
+    if (!pertama || !terakhir) { planning = new Map(); return; }
+    try {
+      planning = jadwalPlanning([...perKloter.keys()], pertama, terakhir);
+    } catch (e) {
+      planning = new Map();
+      if (/waktu berangkat terakhir/i.test(e.message)) waktuTerakhir.salah(true);
+      galatPlanning.textContent = e.message;
+      galatPlanning.hidden = false;
+    }
+  };
+
+  /** Satu baris jam untuk kartu kloter — planning, dan yang sebenarnya.
+   *
+   *  KEDUANYA ditampilkan begitu kloter berangkat, bukan yang satu menggantikan
+   *  yang lain. Panitia perlu menyandingkannya: rencana yang dibagikan ke
+   *  peserta lawan apa yang benar-benar terjadi, dan selisihnya adalah kabar
+   *  yang mereka pakai memutuskan apakah kloter berikutnya perlu digeser.
+   *
+   *  Yang tercatat itu pula dasar penalti seluruh regu di kloter ini, jadi ia
+   *  tidak boleh terbaca seperti jadwal — pasal 10.6. */
+  const barisJamKloter = (nomor, v) => {
+    const rencana = planning.get(Number(nomor))
+      // Jendela belum diketik lengkap: pakai perkiraan database, supaya
+      // kartunya tidak pernah kehilangan jam sama sekali.
+      || (v.perkiraanBerangkat ? jamMenit(v.perkiraanBerangkat) : null);
+
+    const bagian = [];
+    if (rencana) {
+      bagian.push(html`<strong>Prediksi Berangkat:</strong> ${rencana}`);
+    }
+    if (v.jamBerangkat) {
+      bagian.push(html`<strong>Jam Berangkat di Lapangan:</strong> ${
+        jamMenit(v.jamBerangkat)}`);
+    }
+    if (!bagian.length) return "";
+
+    let selisih = "";
+    if (rencana && v.jamBerangkat) {
+      // Tanggalnya diambil dari jam yang TERCATAT, bukan dari kalender alat:
+      // "07:20" tidak membawa tanggal, dan layar ini dibuka juga di hari-hari
+      // selain hari-H (alasan yang sama dengan hariLomba() di Keberangkatan).
+      const menit = Math.round(
+        (new Date(v.jamBerangkat) - jamPadaHari(rencana, v.jamBerangkat)) / 60000);
+      selisih = menit === 0
+        ? html` <span class="sub">tepat</span>`
+        : html` <span class="sub">${menit > 0 ? "+" : "−"}${
+            Math.abs(menit)} menit</span>`;
+    }
+    return `<p>${bagian.join(" · ")}${selisih}</p>`;
+  };
 
   const gambarPratayang = (peta) => {
     // CATATAN: baris tabel dirakit dengan html`` (nilai di-escape), lalu
@@ -2038,10 +2146,7 @@ async function layarCetakKloter() {
                  memutuskan apakah sebuah kloter sudah jalan tidak punya cara
                  membedakan keduanya selain mengingat kloter mana yang sudah
                  ia ceklis. -->
-            <p><strong>${v.jamBerangkat
-              ? "Jam Berangkat di Lapangan"
-              : "Prediksi Berangkat"}:</strong>
-              ${esc(jamMenit(v.jamBerangkat || v.perkiraanBerangkat))}</p>
+            ${barisJamKloter(nomor, v)}
             <table class="table">${baris}</table>
           </div>`;
       }).join("")));
@@ -2057,7 +2162,10 @@ async function layarCetakKloter() {
    *  diperiksa petugas. Buka ulang layar untuk mengambil perubahan terbaru. */
   function cetak(bentuk) {
     const semuaKloter = [...perKloter.entries()];
-    siapkanCetakKloter(semuaKloter, bentuk);
+    // Jam yang tercetak = jam yang barusan diatur di layar ini. Kertas yang
+    // menyebut jam lain dari layar yang tombolnya baru saja ditekan adalah
+    // kertas yang salah, dan yang memegangnya peserta.
+    siapkanCetakKloter(semuaKloter, bentuk, planning);
     window.print();
     tanyaWaktuCetak(semuaKloter.map(([n]) => Number(n)));
   }
@@ -2096,7 +2204,11 @@ async function layarCetakKloter() {
 
   document.getElementById("cetak-petugas").addEventListener("click", () => cetak("staging"));
   document.getElementById("cetak-peserta").addEventListener("click", () => cetak("umum"));
-  gambarPratayang(perKloter);
+
+  const perbarui = () => { hitungPlanning(); gambarPratayang(perKloter); };
+  waktuPertama.dengar(perbarui);
+  waktuTerakhir.dengar(perbarui);
+  perbarui();
 }
 
 /** Blok cetak daftar kloter — satu kloter per halaman kertas.
@@ -2107,13 +2219,16 @@ async function layarCetakKloter() {
  *                 peserta — perkiraan berangkat dibesarkan, kolom centang
  *                 dihilangkan karena tidak ada gunanya bagi peserta.
  */
-function siapkanCetakKloter(dipakai, bentuk = "staging") {
+function siapkanCetakKloter(dipakai, bentuk = "staging", planning = new Map()) {
   document.getElementById("cetakan")?.remove();
   const dicetak = tanggalJam(new Date().toISOString());
 
   const halaman = dipakai.map(([nomor, v]) => {
     const contoh = v.isi[0] || {};
-    const perkiraan = jamMenit(contoh.perkiraan_berangkat);
+    // Planning dari layar kalau ada; perkiraan database sebagai cadangan,
+    // supaya kertas tidak pernah keluar tanpa jam sama sekali.
+    const perkiraan = planning.get(Number(nomor))
+      || jamMenit(contoh.perkiraan_berangkat);
 
     const baris = v.isi.map(r => bentuk === "staging"
       ? html`

--- a/web/js/departure-calculator.mjs
+++ b/web/js/departure-calculator.mjs
@@ -21,6 +21,53 @@ function jamDariMenit(total) {
 }
 
 /**
+ * Jadwal PLANNING untuk kloter yang SUDAH terbentuk.
+ *
+ * Menjawab pertanyaan yang berbeda dari hitungRekomendasiKloter() di bawah.
+ * Yang itu proyeksi SEBELUM daftar ulang: "kalau nanti ada 300 regu, berapa
+ * kloter dan jam berapa". Yang ini rencana SESUDAHNYA: "kloter-kloter ini
+ * sudah ada isinya, jam berapa masing-masing berangkat" — dan itulah yang
+ * dibagikan ke peserta.
+ *
+ * Disebar ke kloter yang ADA, bukan ke seluruh kloter edisi. Sepuluh kloter
+ * yang disebar ke 75 slot berangkat semua sebelum pukul 07:25, dan jendela
+ * sampai pukul sepuluh tidak terpakai sama sekali — sementara pasal 10.1
+ * menuntut yang terakhir berangkat pukul sepuluh.
+ *
+ * Nomor kloter TIDAK harus berurutan tanpa lubang: yang menentukan urutan
+ * berangkat adalah urutan nomornya, dan kloter yang kosong memang tidak ada
+ * di daftar ini. Yang dipakai posisinya dalam daftar, bukan nomornya.
+ *
+ * `floor`, bukan `round` — sama dengan sibling-nya di bawah, dan sebuah
+ * rencana keberangkatan yang membulatkan ke bawah tidak pernah melewati
+ * ujung jendelanya.
+ *
+ * @returns {Map<number, string>} nomor kloter -> "HH:MM"
+ */
+export function jadwalPlanning(nomorKloter, waktuPertama, waktuTerakhir) {
+  const pertama = menitDariJam(waktuPertama);
+  const terakhir = menitDariJam(waktuTerakhir);
+  if (pertama === null || terakhir === null) {
+    throw new Error("Waktu keberangkatan belum lengkap.");
+  }
+  if (terakhir <= pertama) {
+    throw new Error("Waktu berangkat terakhir harus setelah waktu pertama.");
+  }
+
+  const urut = [...new Set(nomorKloter.map(Number))]
+    .filter(n => Number.isFinite(n))
+    .sort((a, b) => a - b);
+  const rentang = terakhir - pertama;
+
+  return new Map(urut.map((nomor, i) => [
+    nomor,
+    jamDariMenit(urut.length === 1
+      ? pertama
+      : pertama + Math.floor(rentang * i / (urut.length - 1))),
+  ]));
+}
+
+/**
  * Isi kloter FIFO dengan kuota terpisah Eksternal dan Intern, lalu sebarkan
  * jam K1 sampai kloter terakhir merata di seluruh jendela.
  */


### PR DESCRIPTION
## What

Layar Daftar Kloter (`#/cetak-kloter`) mendapat **Planning Keberangkatan**:

- Dua kotak jam — Waktu Berangkat Pertama dan Terakhir — bentuknya sama dengan Kalkulator Keberangkatan, nilai awalnya dari konfigurasi edisi.
- Jumlah **Eksternal** dan **Intern yang sudah mengambil nomor dada**, dihitung sendiri.
- Jamnya dibagi rata ke kloter yang benar-benar ada, dan kartu kloter menampilkan **Prediksi Berangkat** serta **Jam Berangkat di Lapangan** berdampingan beserta selisihnya.
- Kertas cetak memakai jam yang sama.

Plus `jadwalPlanning()` di `departure-calculator.mjs`, dan satu perbaikan `tests/dev_server.py`.

## Why

Panitia menyusun rencana keberangkatan **sesudah** nomor dada dibagikan, dan rencana itu berubah-ubah sampai semua selesai daftar ulang. Sebelum ini layar cuma menampilkan perkiraan database, yang menyebar jendela ke seluruh 75 kloter edisi termasuk cadangan:

| | 10 kloter terisi, jendela 07:00–10:00 |
| --- | --- |
| Perkiraan database | K1 07:00 … K10 **07:21** — jendela tidak terpakai |
| Planning | K1 07:00 … K10 **10:00** |

**Jumlahnya dari regu yang sudah mengambil nomor dada, bukan yang mendaftar.** Keduanya berbeda jauh pada pagi hari-H: sekolah yang mendaftar tapi tidak datang tetap ada di `pendaftaran`, dan merencanakan dari angka itu menyebar jendela ke kloter yang tidak akan pernah berangkat. Sumbernya baris yang sudah ada di layar — tidak ada permintaan kedua ke server.

**Keduanya ditampilkan, bukan saling menggantikan.** Selisih itulah yang dipakai panitia memutuskan apakah kloter berikutnya digeser. Pasal 10.6 memang menuntut layar yang menampilkan keduanya menyebut yang mana.

## Notes

**Jendelanya TIDAK disimpan, dan itu keputusan sadar.** Kolom `edisi.jam_mulai_berangkat` / `jam_batas_berangkat` dijaga trigger `kunci_edisi`, dan konfigurasi memang dikunci pada hari-H — menyimpan ke sana berarti fitur ini mati justru di hari ia dipakai. Nilai awalnya dibaca dari konfigurasi edisi, jadi selama tidak disentuh hasilnya sama di semua alat. Kalau jendelanya perlu digeser permanen lintas alat, itu perubahan konfigurasi dan tempatnya di sana.

**Jendela yang tidak sah tidak pernah mengosongkan kartu.** Galatnya tampil, dan kartu jatuh kembali ke perkiraan database — diukur, bukan diasumsikan.

**Satu tegangan yang perlu Anda putuskan, tidak saya ubah sendiri.** Kalkulator Keberangkatan (`#/pengaturan-kloter`) sejak #594 membagi dengan `kloter_maks` supaya cocok dengan perkiraan database. Planning ini membagi dengan kloter yang benar-benar ada. Keduanya menjawab pertanyaan berbeda — proyeksi sebelum daftar ulang lawan rencana sesudahnya — tapi kalau Anda ingin Kalkulator ikut aturan "sebar yang benar-benar berangkat", bilang saja.

**Perbaikan sampingan:** rute `/pengaturan-kloter` di `tests/dev_server.py` melempar `IndexError: tuple index out of range` — `like 'intern_%'` ditulis `%` tunggal sedangkan `q()` selalu memanggil `cur.execute(sql, args)`. Rutenya mati di dev tanpa gejala di produksi, jadi Kalkulator Keberangkatan sudah rusak di dev sejak rute itu ada.

## Verifikasi lokal

Diukur di browser, database dev 50 regu / 10 kloter (7 sudah berangkat):

```
Sudah mengambil nomor dada: 50 Eksternal · 0 Intern, terbagi 10 kloter

Kloter 1  Prediksi Berangkat: 07:00 · Jam Berangkat di Lapangan: 07:00 tepat
Kloter 2  Prediksi Berangkat: 07:20 · Jam Berangkat di Lapangan: 07:04 −16 menit
Kloter 8  Prediksi Berangkat: 09:20
```

Jendela diubah ke 08:00–09:30 → seluruh kartu ikut (08:00 … 09:30). Jendela dibalik → galat tampil dan kartu jatuh ke perkiraan database; dibetulkan → galat hilang, planning kembali.

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 162 pass, 0 fail (11 tes baru/ditulis ulang) |
| `periksa_impor` / `periksa_urutan_golongan` / `pratinjau_cetak` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
