### PR TITLE
fix: potong judul dan paragraf di Planning Keberangkatan

### DIFF
--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -77,3 +77,23 @@ test("kertas staging tetap menyediakan garis jam sebenarnya", () => {
   // tangan di sana — itu yang lalu diketik ke layar Keberangkatan.
   assert.match(app, /Jam sebenarnya: ________/);
 });
+
+
+test("layar planning tanpa judul dan tanpa paragraf penjelas", () => {
+  // Pasal 9.1 dan 9.3. Labelnya sendiri sudah menyebut "Planning Berangkat",
+  // jadi judul di atasnya mengulang label di bawahnya; dan kalimat yang
+  // menjelaskan bahwa jamnya dibagi rata lalu tercetak untuk peserta
+  // menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah sekali.
+  //
+  // Bukan kerapian: sebagai paragraf ia memakan sepertiga layar HP, dan yang
+  // terdorong turun justru kartu kloter yang dibaca petugas.
+  assert.doesNotMatch(layar, /<h2[^>]*>Planning Keberangkatan<\/h2>/);
+  assert.doesNotMatch(layar, /Sudah mengambil nomor dada/);
+  assert.doesNotMatch(layar, /dibagi rata ke/);
+});
+
+
+test("jumlah Eksternal dan Intern tetap ada, sebagai baris tabel", () => {
+  assert.match(layar, /<td>Eksternal<\/td><td class="angka">\$\{jumlahEksternal\}<\/td>/);
+  assert.match(layar, /<td>Intern<\/td><td class="angka">\$\{jumlahIntern\}<\/td>/);
+});

--- a/tests/time_input_labels.test.mjs
+++ b/tests/time_input_labels.test.mjs
@@ -12,6 +12,8 @@ test("semua label kotak jam manual menunjuk input HH", () => {
   const pasangan = [
     ["kloter-pertama", "Waktu Berangkat Pertama"],
     ["kloter-terakhir", "Waktu Berangkat Terakhir"],
+    ["planning-pertama", "Planning Berangkat Pertama"],
+    ["planning-terakhir", "Planning Berangkat Terakhir"],
     ["jam-berangkat", "Jam berangkat"],
     ["jam", "Jam datang"],
   ];

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2018,30 +2018,37 @@ async function layarCetakKloter() {
 
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
+      <!-- Eksternal dan Intern jadi BARIS TABEL, bukan kalimat. Angkanya
+           yang dicari, dan tabel yang sudah ada di sini adalah tempat angka.
+           Sebagai paragraf ia memakan sepertiga layar HP untuk mengulang
+           "Total Kloter" yang tercetak dua baris di atasnya. -->
       <table class="table">
         <tr><td>Total Kloter</td><td class="angka">${perKloter.size}</td></tr>
         <tr><td>Total Regu</td><td class="angka">${baris.length}</td></tr>
+        <tr><td>Eksternal</td><td class="angka">${jumlahEksternal}</td></tr>
+        <tr><td>Intern</td><td class="angka">${jumlahIntern}</td></tr>
       </table>
       <!-- Planning berdiri DI ATAS tombol cetak, dan urutan itu berarti:
            yang tercetak adalah jam yang baru saja diatur di sini. Menaruhnya
            di bawah membuat petugas menekan Cetak lebih dulu, lalu menemukan
-           kotak jamnya sesudah kertasnya keluar. -->
-      <h2 style="margin-top:1rem">Planning Keberangkatan</h2>
-      <div class="two-column">
+           kotak jamnya sesudah kertasnya keluar.
+
+           TANPA judul dan TANPA paragraf penjelas. Labelnya sendiri sudah
+           menyebut "Planning Berangkat", jadi judul "Planning Keberangkatan"
+           di atasnya cuma mengulang label yang ada di bawahnya (pasal 9.3),
+           dan kalimat "jam ini dibagi rata lalu tercetak untuk peserta"
+           menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah
+           sekali (pasal 9.1 dan 9.6). -->
+      <div class="two-column" style="margin-top:1rem">
         <div class="field">
-          <label for="planning-pertama-hh">Waktu Berangkat Pertama</label>
+          <label for="planning-pertama-hh">Planning Berangkat Pertama</label>
           ${kotakJamHtml("planning-pertama", jamPendek(cfg.jam_mulai_berangkat))}
         </div>
         <div class="field">
-          <label for="planning-terakhir-hh">Waktu Berangkat Terakhir</label>
+          <label for="planning-terakhir-hh">Planning Berangkat Terakhir</label>
           ${kotakJamHtml("planning-terakhir", jamPendek(cfg.jam_batas_berangkat))}
         </div>
       </div>
-      <p class="description">Sudah mengambil nomor dada:
-         <strong>${jumlahEksternal} Eksternal</strong> ·
-         <strong>${jumlahIntern} Intern</strong>, terbagi
-         <strong>${perKloter.size} kloter</strong>. Jam di bawah dibagi rata ke
-         kloter itu, dan itu pula yang tercetak untuk peserta.</p>
       <div class="error" id="planning-galat" hidden></div>
       <div class="option-row" style="margin-top:.9rem">
         <button class="button button-primary" id="cetak-petugas" type="button">


### PR DESCRIPTION
## What

- Label: **Planning Berangkat Pertama** / **Planning Berangkat Terakhir**.
- Judul `<h2>Planning Keberangkatan</h2>` dibuang.
- Paragraf penjelas dibuang seluruhnya.
- Eksternal dan Intern pindah jadi baris tabel, di tabel yang sudah ada.

## Why

Pasal 9.3 — label yang sudah menyebut "Planning" membuat judul di atasnya mengulang label di bawahnya. Dua label untuk satu fakta tidak saling menguatkan.

Pasal 9.1 dan 9.6 — separuh belakang paragrafnya ("jam ini dibagi rata ke kloter itu, dan itu pula yang tercetak untuk peserta") menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah sekali. Kalau kalimat itu hilang, tidak ada kesalahan yang bisa dibuat petugas.

Separuh depannya angka — dan angka tempatnya di tabel, bukan di kalimat. Sebagai paragraf ia memakan empat baris di layar HP untuk mengulang "Total Kloter" yang sudah tercetak dua baris di atasnya.

## Verifikasi lokal

Diukur di iframe selebar **412px** (lebar HP Android yang dipakai panitia), bukan di jendela desktop:

| | sebelum | sesudah |
| --- | --- | --- |
| Tinggi kartu atas | 552px | **509px** |
| Kartu Kloter 1 mulai di | y=624 | **y=581** |

Tidak ada penggulir mendatar, dan tidak ada label yang meluap walau kedua label bertambah panjang.

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 164 pass, 0 fail (2 tes baru) |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
