### PR TITLE
feat: simpan jendela Planning, dan ringkas kartu jadi Planning / Real

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0112`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0113`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-112 migrasi, `0001` sampai `0112`, dijalankan berurutan tanpa lubang penomoran.
+113 migrasi, `0001` sampai `0113`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -335,21 +335,31 @@ export async function infoEdisi() {
 /** Konfigurasi dan jumlah regu untuk nilai awal Kalkulator Keberangkatan. */
 export async function infoPengaturanKloter() {
   if (K.mode === "dev") return baca("/pengaturan-kloter");
-  const [edisi, regu] = await Promise.all([
+  const [edisi, regu, status] = await Promise.all([
     baca(null,
       "edisi?is_active=eq.true" +
       "&select=jam_mulai_berangkat,jam_batas_berangkat," +
       "maks_eksternal_per_kloter,maks_intern_per_kloter," +
       "perkiraan_regu_eksternal,perkiraan_regu_intern,kloter_maks"),
     baca(null, "regu?is_cancelled=eq.false&select=golongan"),
+    // Jendela Planning Keberangkatan (migrasi 0113). Tinggal di status_acara,
+    // bukan di edisi, karena ia disusun pada hari-H — hari yang sama saat
+    // kunci konfigurasi menyala dan menutup seluruh tabel setelan.
+    baca(null, "status_acara?id=eq.true" +
+      "&select=planning_berangkat_pertama,planning_berangkat_terakhir"),
   ]);
   if (!edisi.length) throw new ErrorApi("Belum ada edisi aktif.");
   return {
     ...edisi[0],
+    ...(status[0] || {}),
     jumlah_eksternal: regu.filter(r => !String(r.golongan).startsWith("intern_")).length,
     jumlah_intern: regu.filter(r => String(r.golongan).startsWith("intern_")).length,
   };
 }
+
+/** Simpan jendela Planning Keberangkatan. Kosong = ikut konfigurasi edisi. */
+export const aturPlanningBerangkat = (pertama, terakhir) =>
+  rpc("atur_planning_berangkat", { p_pertama: pertama, p_terakhir: terakhir });
 
 /** Apakah nama regu itu sudah dipakai (0051)? Dipanggil SAMBIL pembina
  *  mengetik — menolak saat tombol Kirim ditekan sudah terlambat, karena saat

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -843,6 +843,10 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  // Jarum di 10:10, bukan 12:00 — dua jarum yang bertindih terbaca
+  // sebagai satu garis pada ukuran ikon.
+  "clock":
+    '<circle cx="12" cy="12" r="9" /> <path d="M12 7v5l3 2" />',
   "camera":
     '<path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" /> <circle cx="12" cy="13" r="3" />',
   "lock":

--- a/supabase/migrations/0113_planning_berangkat_tersimpan.sql
+++ b/supabase/migrations/0113_planning_berangkat_tersimpan.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- hrcd-rekap : 0113_planning_berangkat_tersimpan.sql
+-- Jendela Planning Keberangkatan disimpan, bukan hilang tiap layar dimuat ulang.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DI `status_acara`, BUKAN DI `edisi`
+--
+-- Kolom yang "benar" secara arti adalah `edisi.jam_mulai_berangkat` dan
+-- `jam_batas_berangkat` — CLAUDE.md 10.7 memang menempatkan jendela sebagai
+-- konfigurasi per edisi. Tetapi seluruh tabel konfigurasi dijaga trigger
+-- `tolak_saat_terkunci` (0002): `edisi`, `pos`, `wahana`, `kontrak_opsi`,
+-- `konfig_penalti`. Begitu `konfigurasi_terkunci` menyala — dan ia MEMANG
+-- menyala pada hari-H — setiap tulisan ke sana ditolak.
+--
+-- Planning keberangkatan justru keputusan hari-H. Ia disusun sesudah nomor
+-- dada dibagikan dan digeser lagi sampai semua selesai daftar ulang.
+-- Menyimpannya di tabel terkunci berarti fitur ini mati tepat di hari ia
+-- dipakai, dengan pesan galat yang menyuruh panitia membuka kunci konfigurasi
+-- di tengah pagi — persis hal yang kunci itu dipasang untuk mencegah.
+--
+-- `status_acara` adalah saklar hari-H, dan ia satu-satunya tabel setelan yang
+-- TIDAK dijaga trigger itu — memang tidak boleh, karena `konfigurasi_terkunci`
+-- sendiri tinggal di sana dan tabel yang mengunci dirinya tidak bisa dibuka.
+--
+-- ---------------------------------------------------------------------------
+-- NULL BERARTI "IKUT KONFIGURASI EDISI"
+--
+-- Keduanya boleh kosong, dan itu keadaan awal setiap edisi. Layar membacanya
+-- `coalesce(planning, edisi.jam_*)`, jadi selama panitia belum menggeser apa
+-- pun hasilnya sama persis dengan sebelum migrasi ini — dan sama di semua
+-- alat, karena sumbernya satu.
+--
+-- Yang disimpan HANYA jendelanya, bukan jam tiap kloter. Jam per kloter
+-- diturunkan dari jendela dan dari kloter yang ada saat itu; menyimpannya
+-- berarti dua sumber untuk satu angka, dan yang satu akan basi begitu ada
+-- regu disisipkan.
+-- ============================================================================
+
+alter table status_acara
+  add column if not exists planning_berangkat_pertama  time,
+  add column if not exists planning_berangkat_terakhir time;
+
+alter table status_acara drop constraint if exists status_acara_planning_urut;
+alter table status_acara add constraint status_acara_planning_urut check (
+  planning_berangkat_pertama is null
+  or planning_berangkat_terakhir is null
+  or planning_berangkat_terakhir > planning_berangkat_pertama
+);
+
+comment on column status_acara.planning_berangkat_pertama is
+  'Jendela Planning Keberangkatan di layar Daftar Kloter. NULL = ikut edisi.jam_mulai_berangkat.';
+comment on column status_acara.planning_berangkat_terakhir is
+  'Jendela Planning Keberangkatan di layar Daftar Kloter. NULL = ikut edisi.jam_batas_berangkat.';
+
+-- ---------------------------------------------------------------------------
+-- RPC penyimpannya.
+--
+-- Bentuknya menyalin `atur_fase_live` (0068/0069): definer, pagar hak di baris
+-- pertama, satu UPDATE berklausa WHERE.
+--
+-- HAKNYA `cetak_kloter`, bukan `pengaturan`. Yang menyusun planning adalah
+-- orang yang mencetak daftar kloter — tombolnya ada di layar yang sama — dan
+-- mengikatnya ke `pengaturan` berarti hanya admin yang bisa menggeser jadwal
+-- pagi. `pengaturan` tetap ikut, karena admin memang membuka semua layar.
+--
+-- Policy `adm_status_acara` sendiri masih `boleh('pengaturan')` dan TIDAK
+-- diubah: jalur langsung ke tabel tetap milik admin, dan RPC inilah satu-
+-- satunya pintu yang lebih longgar. Definer supaya pagar di dalamnya yang
+-- berlaku, bukan policy tabelnya.
+-- ---------------------------------------------------------------------------
+create or replace function atur_planning_berangkat(p_pertama time, p_terakhir time)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if not boleh_apa_saja('cetak_kloter', 'pengaturan') then
+    raise exception 'tidak berhak: cetak_kloter';
+  end if;
+  if p_pertama is null or p_terakhir is null then
+    raise exception 'jam planning wajib diisi keduanya';
+  end if;
+  if p_terakhir <= p_pertama then
+    raise exception 'waktu berangkat terakhir harus setelah waktu pertama';
+  end if;
+
+  -- WHERE yang memang berarti: `status_acara` satu baris berkunci `id = true`,
+  -- dan UPDATE tanpa WHERE ditolak Supabase (CLAUDE.md 14.6) sementara
+  -- database uji tidak memasang `safeupdate` — tanpa klausa ini tesnya hijau
+  -- dan RPC-nya gagal di layar.
+  update status_acara
+  set planning_berangkat_pertama  = p_pertama,
+      planning_berangkat_terakhir = p_terakhir
+  where id = true;
+end;
+$$;
+
+comment on function atur_planning_berangkat(time, time) is
+  'Simpan jendela Planning Keberangkatan. Hak cetak_kloter atau pengaturan.';
+
+revoke execute on function atur_planning_berangkat(time, time) from public, anon;
+grant execute on function atur_planning_berangkat(time, time) to authenticated;
+
+do $blok$
+begin
+  assert exists (select 1 from information_schema.columns
+                 where table_name = 'status_acara'
+                   and column_name = 'planning_berangkat_pertama'),
+    '0113: kolom planning tidak terpasang';
+
+  raise notice '0113: jendela Planning Keberangkatan kini tersimpan di '
+               'status_acara — di luar jangkauan kunci konfigurasi.';
+end;
+$blok$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -57,6 +57,7 @@ RPC = {
     "buka_kunci_nilai_pos":  ["p_nomor_dada", "p_pos", "p_alasan"],
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
     "atur_fase_live":        ["p_fase"],
+    "atur_planning_berangkat": ["p_pertama", "p_terakhir"],
     "susun_barak":           [],
     "tandai_kloter_dicetak": ["p_kloter"],
     "pindah_kloter":         ["p_nomor_dada", "p_alasan", "p_kloter"],
@@ -121,6 +122,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select e.jam_mulai_berangkat, e.jam_batas_berangkat, "
                     "e.maks_eksternal_per_kloter, e.maks_intern_per_kloter, "
                     "e.perkiraan_regu_eksternal, e.perkiraan_regu_intern, e.kloter_maks, "
+                    "s.planning_berangkat_pertama, s.planning_berangkat_terakhir, "
                     # `%%`, bukan `%`: q() selalu memanggil cur.execute(sql, args),
                     # dan psycopg2 memperlakukan `%` sebagai penanda parameter apa pun
                     # isi args-nya. Ditulis `%` polos, rute ini melempar
@@ -129,7 +131,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     # di sana PostgREST yang menjawab.
                     "(select count(*) from regu where not is_cancelled and golongan not like 'intern_%%') as jumlah_eksternal, "
                     "(select count(*) from regu where not is_cancelled and golongan like 'intern_%%') as jumlah_intern "
-                    "from edisi e where e.is_active",
+                    "from edisi e, status_acara s where e.is_active and s.id",
                     uid=p.get("uid"), fetch="one"))
             elif u.path == "/penalti":
                 self._kirim(200, q(

--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -26,9 +26,9 @@ test("kartu kloter memakai satu perakit baris jam, bukan ternary di tempat", () 
 });
 
 
-test("kedua label tetap menyebut asal angkanya", () => {
-  assert.match(layar, /<strong>Prediksi Berangkat:<\/strong>/);
-  assert.match(layar, /<strong>Jam Berangkat di Lapangan:<\/strong>/);
+test("kedua label menyebut asal angkanya", () => {
+  assert.match(layar, /<strong>Planning<\/strong>/);
+  assert.match(layar, /<strong>Real<\/strong>/);
   // "Jam berangkat" polos terbaca seperti jadwal; "Estimasi" adalah kata
   // ketiga untuk hal yang kertasnya sebut "Perkiraan".
   assert.doesNotMatch(layar, /\? "Jam berangkat"/);
@@ -37,19 +37,26 @@ test("kedua label tetap menyebut asal angkanya", () => {
 
 
 test("keduanya digambar bersama, bukan saling menggantikan", () => {
-  // Dua `bagian.push` berurutan tanpa `else` di antaranya: kloter yang sudah
-  // berangkat menampilkan rencana DAN kenyataannya.
-  assert.match(layar, /if \(rencana\) \{\s*bagian\.push/);
-  assert.match(layar, /if \(v\.jamBerangkat\) \{\s*bagian\.push/);
+  // Dua push berurutan tanpa `else` di antaranya: kloter yang sudah berangkat
+  // menampilkan rencana DAN kenyataannya.
+  assert.match(layar, /if \(rencana\) bagian\.push/);
+  assert.match(layar, /if \(v\.jamBerangkat\) \{/);
   assert.match(layar, /bagian\.join\(" · "\)/);
 });
 
 
-test("planning layar menang, perkiraan database jadi cadangan", () => {
-  // Urutannya mengikat. Terbalik, jam yang baru saja diatur panitia diabaikan
-  // dan kartunya menampilkan sebaran database ke 75 kloter.
-  assert.match(layar,
-    /planning\.get\(Number\(nomor\)\)\s*\n\s*\/\/[^\n]*\n\s*\/\/[^\n]*\n\s*\|\| \(v\.perkiraanBerangkat/);
+test("baris jam dibuka ikon jam", () => {
+  assert.match(layar, /\$\{ikon\("clock"\)\} \$\{bagian\.join/);
+});
+
+
+test("selisihnya KATA, bukan tanda", () => {
+  // "+15" menuntut pembacanya mengingat mana yang rencana dan mana yang nyata
+  // sebelum tandanya berarti apa-apa. "telat 15 menit" tidak menuntut apa pun.
+  assert.match(layar, /menit === 0 \? "tepat waktu"/);
+  assert.match(layar, /telat \$\{menit\} menit/);
+  assert.match(layar, /terlalu cepat \$\{Math\.abs\(menit\)\} menit/);
+  assert.match(layar, /<span class="sub">\(\$\{kata\}\)<\/span>/);
 });
 
 
@@ -57,14 +64,37 @@ test("selisih dihitung pada hari yang TERCATAT, bukan kalender alat", () => {
   // "07:20" tidak membawa tanggal, dan layar ini dibuka juga di hari selain
   // hari-H. Memakai tanggal alat menghasilkan selisih berhari-hari.
   assert.match(layar, /jamPadaHari\(rencana, v\.jamBerangkat\)/);
-  assert.match(layar, /menit === 0\s*\n?\s*\? html` <span class="sub">tepat<\/span>`/);
+});
+
+
+test("planning layar menang, perkiraan database jadi cadangan", () => {
+  assert.match(layar,
+    /planning\.get\(Number\(nomor\)\)\s*\n\s*\/\/[^\n]*\n\s*\/\/[^\n]*\n\s*\|\| \(v\.perkiraanBerangkat/);
+});
+
+
+test("kotak jam terisi dari planning TERSIMPAN, bukan konfigurasi edisi", () => {
+  // Kalau nilai awalnya selalu dari edisi, jendela yang barusan digeser
+  // kembali sendiri tiap layar dimuat ulang — dan kertas yang dicetak
+  // sesudahnya berbeda dari yang sebelumnya tanpa ada yang mengubahnya.
+  assert.match(layar,
+    /cfg\.planning_berangkat_pertama \|\| cfg\.jam_mulai_berangkat/);
+  assert.match(layar,
+    /cfg\.planning_berangkat_terakhir \|\| cfg\.jam_batas_berangkat/);
+});
+
+
+test("jendela disimpan, ditunda, dan gagalnya tidak diam", () => {
+  assert.match(layar, /await aturPlanningBerangkat\(pertama, terakhir\)/);
+  // `dengar` menyala tiap penekanan tombol; "0"-"7"-"3"-"0" adalah empat
+  // keadaan yang tiga di antaranya belum berarti apa-apa.
+  assert.match(layar, /clearTimeout\(jadwalSimpan\)/);
+  assert.match(layar, /\}, 800\)/);
+  assert.match(layar, /Planning belum tersimpan: \$\{err\.message\}/);
 });
 
 
 test("kertas memakai planning yang sama dengan layar", () => {
-  // Tombol cetaknya ada di layar yang sama. Kertas yang menyebut jam lain dari
-  // yang baru saja dibaca petugas adalah kertas yang salah, dan yang
-  // memegangnya peserta.
   assert.match(layar, /siapkanCetakKloter\(semuaKloter, bentuk, planning\)/);
   assert.match(app,
     /function siapkanCetakKloter\(dipakai, bentuk = "staging", planning = new Map\(\)\)/);
@@ -73,20 +103,11 @@ test("kertas memakai planning yang sama dengan layar", () => {
 
 
 test("kertas staging tetap menyediakan garis jam sebenarnya", () => {
-  // Blangko difotokopi (pasal 8.1) dan petugas menulis jam nyata dengan
-  // tangan di sana — itu yang lalu diketik ke layar Keberangkatan.
   assert.match(app, /Jam sebenarnya: ________/);
 });
 
 
 test("layar planning tanpa judul dan tanpa paragraf penjelas", () => {
-  // Pasal 9.1 dan 9.3. Labelnya sendiri sudah menyebut "Planning Berangkat",
-  // jadi judul di atasnya mengulang label di bawahnya; dan kalimat yang
-  // menjelaskan bahwa jamnya dibagi rata lalu tercetak untuk peserta
-  // menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah sekali.
-  //
-  // Bukan kerapian: sebagai paragraf ia memakan sepertiga layar HP, dan yang
-  // terdorong turun justru kartu kloter yang dibaca petugas.
   assert.doesNotMatch(layar, /<h2[^>]*>Planning Keberangkatan<\/h2>/);
   assert.doesNotMatch(layar, /Sudah mengambil nomor dada/);
   assert.doesNotMatch(layar, /dibagi rata ke/);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -493,6 +493,12 @@ run tests/sql/74_satu_nama_klasemen.sql
 # sisi SQL; tests/departure_calculator.test.mjs menjaga sisi layar. Keduanya
 # sempat berpisah 37 menit tanpa satu pun galat.
 run tests/sql/75_perkiraan_berangkat_satu_rumus.sql
+# 0113 menyimpan jendela Planning Keberangkatan di status_acara, BUKAN di
+# edisi. Tes 76.3 menduduki kursi hari-H: konfigurasi dikunci, dan planning
+# tetap harus bisa disimpan — kalau tidak, fiturnya mati tepat di hari ia
+# dipakai.
+run supabase/migrations/0113_planning_berangkat_tersimpan.sql
+run tests/sql/76_planning_berangkat_tersimpan.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/76_planning_berangkat_tersimpan.sql
+++ b/tests/sql/76_planning_berangkat_tersimpan.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/76_planning_berangkat_tersimpan.sql — migrasi 0113.
+-- Jendela Planning Keberangkatan tersimpan, dan tetap bisa disimpan SAAT
+-- KONFIGURASI DIKUNCI.
+--
+-- Bagian 76.3 yang paling penting, dan ia satu-satunya alasan kolomnya tidak
+-- ditaruh di `edisi`: kunci konfigurasi menyala pada hari-H, sedangkan
+-- planning keberangkatan justru disusun pada hari-H. Kalau tes ini merah,
+-- fiturnya mati tepat di hari ia dipakai.
+-- ============================================================================
+
+\echo '--- 76. planning keberangkatan tersimpan'
+\set ON_ERROR_STOP on
+
+begin;
+
+do $blok$
+declare
+  v_admin   uuid;
+  v_cetak   uuid := '00000000-0000-0000-0000-0000000000d1';
+  v_juri    uuid := '00000000-0000-0000-0000-0000000000d2';
+  v_p       time;
+  v_t       time;
+  v_tolak   boolean;
+begin
+  select user_id into v_admin from akun_panitia
+  where peran = 'admin' and is_active limit 1;
+
+  -- 76.1 Keadaan awal: kosong, artinya "ikut konfigurasi edisi".
+  select planning_berangkat_pertama, planning_berangkat_terakhir
+    into v_p, v_t from status_acara where id = true;
+  assert v_p is null and v_t is null,
+    '76.1 GAGAL: kolom planning tidak lahir kosong';
+
+  -- 76.2 Pemegang cetak_kloter boleh menyimpan — bukan hanya admin. Yang
+  --      menyusun planning adalah orang yang mencetak daftar kloternya.
+  insert into auth.users (id, email) values (v_cetak, 'cetak.planning@uji.local')
+  on conflict (id) do nothing;
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_cetak, 'cetak.planning', 'juri_pos', 1, true)
+  on conflict (user_id) do update set peran = 'juri_pos', pos = 1, is_active = true;
+  update akun_panitia set peran = 'registrasi', pos = null where user_id = v_cetak;
+
+  perform set_config('app.uid', v_cetak::text, true);
+  perform atur_planning_berangkat(time '07:30', time '10:15');
+
+  select planning_berangkat_pertama, planning_berangkat_terakhir
+    into v_p, v_t from status_acara where id = true;
+  assert v_p = time '07:30' and v_t = time '10:15',
+    format('76.2 GAGAL: tersimpan %s-%s', v_p, v_t);
+
+  -- 76.3 TETAP BISA DISIMPAN SAAT KONFIGURASI DIKUNCI.
+  --      Inilah alasan kolomnya tidak di `edisi`: trigger tolak_saat_terkunci
+  --      menjaga seluruh tabel konfigurasi, dan kunci itu menyala pada hari-H
+  --      — hari yang sama saat planning disusun.
+  update status_acara set konfigurasi_terkunci = true where id = true;
+  perform atur_planning_berangkat(time '08:00', time '11:00');
+  select planning_berangkat_pertama into v_p from status_acara where id = true;
+  assert v_p = time '08:00',
+    '76.3 GAGAL: planning tidak bisa disimpan saat konfigurasi dikunci';
+  update status_acara set konfigurasi_terkunci = false where id = true;
+
+  -- 76.4 Jendela terbalik ditolak, dan yang lama tidak ikut rusak.
+  v_tolak := false;
+  begin
+    perform atur_planning_berangkat(time '10:00', time '07:00');
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '76.4 GAGAL: jendela terbalik diterima';
+  select planning_berangkat_pertama into v_p from status_acara where id = true;
+  assert v_p = time '08:00', '76.4 GAGAL: penolakan tetap mengubah yang tersimpan';
+
+  -- 76.5 Juri pos tidak berhak. Menempati kursinya, bukan memindai nama.
+  perform set_config('app.uid', '', true);
+  insert into auth.users (id, email) values (v_juri, 'juri.planning@uji.local')
+  on conflict (id) do nothing;
+  insert into akun_panitia (user_id, username, peran, pos, is_active)
+  values (v_juri, 'juri.planning', 'registrasi', null, true)
+  on conflict (user_id) do update set peran = 'registrasi', pos = null, is_active = true;
+  update akun_panitia set peran = 'juri_pos', pos = 2 where user_id = v_juri;
+
+  perform set_config('app.uid', v_juri::text, true);
+  v_tolak := false;
+  begin
+    perform atur_planning_berangkat(time '06:00', time '09:00');
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '76.5 GAGAL: juri pos bisa menggeser jadwal keberangkatan';
+
+  perform set_config('app.uid', coalesce(v_admin::text, ''), true);
+end;
+$blok$;
+
+rollback;
+
+select '76_planning_berangkat_tersimpan OK' as hasil;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -335,21 +335,31 @@ export async function infoEdisi() {
 /** Konfigurasi dan jumlah regu untuk nilai awal Kalkulator Keberangkatan. */
 export async function infoPengaturanKloter() {
   if (K.mode === "dev") return baca("/pengaturan-kloter");
-  const [edisi, regu] = await Promise.all([
+  const [edisi, regu, status] = await Promise.all([
     baca(null,
       "edisi?is_active=eq.true" +
       "&select=jam_mulai_berangkat,jam_batas_berangkat," +
       "maks_eksternal_per_kloter,maks_intern_per_kloter," +
       "perkiraan_regu_eksternal,perkiraan_regu_intern,kloter_maks"),
     baca(null, "regu?is_cancelled=eq.false&select=golongan"),
+    // Jendela Planning Keberangkatan (migrasi 0113). Tinggal di status_acara,
+    // bukan di edisi, karena ia disusun pada hari-H — hari yang sama saat
+    // kunci konfigurasi menyala dan menutup seluruh tabel setelan.
+    baca(null, "status_acara?id=eq.true" +
+      "&select=planning_berangkat_pertama,planning_berangkat_terakhir"),
   ]);
   if (!edisi.length) throw new ErrorApi("Belum ada edisi aktif.");
   return {
     ...edisi[0],
+    ...(status[0] || {}),
     jumlah_eksternal: regu.filter(r => !String(r.golongan).startsWith("intern_")).length,
     jumlah_intern: regu.filter(r => String(r.golongan).startsWith("intern_")).length,
   };
 }
+
+/** Simpan jendela Planning Keberangkatan. Kosong = ikut konfigurasi edisi. */
+export const aturPlanningBerangkat = (pertama, terakhir) =>
+  rpc("atur_planning_berangkat", { p_pertama: pertama, p_terakhir: terakhir });
 
 /** Apakah nama regu itu sudah dipakai (0051)? Dipanggil SAMBIL pembina
  *  mengetik — menolak saat tombol Kirim ditekan sudah terlambat, karena saat

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -10,7 +10,7 @@
 
 import {
   sesi, masuk, keluar, gantiPasswordSendiri, ErrorApi,
-  infoEdisi, infoPengaturanKloter, ringkasanMeja, daftarPendaftaran,
+  infoEdisi, infoPengaturanKloter, aturPlanningBerangkat, ringkasanMeja, daftarPendaftaran,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor,
   daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
   cariRegu, catatFinish, infoPenalti,
@@ -2042,11 +2042,13 @@ async function layarCetakKloter() {
       <div class="two-column" style="margin-top:1rem">
         <div class="field">
           <label for="planning-pertama-hh">Planning Berangkat Pertama</label>
-          ${kotakJamHtml("planning-pertama", jamPendek(cfg.jam_mulai_berangkat))}
+          ${kotakJamHtml("planning-pertama", jamPendek(
+            cfg.planning_berangkat_pertama || cfg.jam_mulai_berangkat))}
         </div>
         <div class="field">
           <label for="planning-terakhir-hh">Planning Berangkat Terakhir</label>
-          ${kotakJamHtml("planning-terakhir", jamPendek(cfg.jam_batas_berangkat))}
+          ${kotakJamHtml("planning-terakhir", jamPendek(
+            cfg.planning_berangkat_terakhir || cfg.jam_batas_berangkat))}
         </div>
       </div>
       <div class="error" id="planning-galat" hidden></div>
@@ -2104,12 +2106,9 @@ async function layarCetakKloter() {
       || (v.perkiraanBerangkat ? jamMenit(v.perkiraanBerangkat) : null);
 
     const bagian = [];
-    if (rencana) {
-      bagian.push(html`<strong>Prediksi Berangkat:</strong> ${rencana}`);
-    }
+    if (rencana) bagian.push(html`<strong>Planning</strong> ${rencana}`);
     if (v.jamBerangkat) {
-      bagian.push(html`<strong>Jam Berangkat di Lapangan:</strong> ${
-        jamMenit(v.jamBerangkat)}`);
+      bagian.push(html`<strong>Real</strong> ${jamMenit(v.jamBerangkat)}`);
     }
     if (!bagian.length) return "";
 
@@ -2120,12 +2119,15 @@ async function layarCetakKloter() {
       // selain hari-H (alasan yang sama dengan hariLomba() di Keberangkatan).
       const menit = Math.round(
         (new Date(v.jamBerangkat) - jamPadaHari(rencana, v.jamBerangkat)) / 60000);
-      selisih = menit === 0
-        ? html` <span class="sub">tepat</span>`
-        : html` <span class="sub">${menit > 0 ? "+" : "−"}${
-            Math.abs(menit)} menit</span>`;
+      // Kata, bukan tanda. "+15" menuntut pembacanya mengingat mana yang
+      // rencana dan mana yang nyata sebelum tandanya berarti apa-apa; "telat
+      // 15 menit" tidak menuntut apa pun.
+      const kata = menit === 0 ? "tepat waktu"
+        : menit > 0 ? `telat ${menit} menit`
+        : `terlalu cepat ${Math.abs(menit)} menit`;
+      selisih = html` <span class="sub">(${kata})</span>`;
     }
-    return `<p>${bagian.join(" · ")}${selisih}</p>`;
+    return `<p>${ikon("clock")} ${bagian.join(" · ")}${selisih}</p>`;
   };
 
   const gambarPratayang = (peta) => {
@@ -2212,9 +2214,36 @@ async function layarCetakKloter() {
   document.getElementById("cetak-petugas").addEventListener("click", () => cetak("staging"));
   document.getElementById("cetak-peserta").addEventListener("click", () => cetak("umum"));
 
+  /* Simpan jendelanya, jangan biarkan hilang saat layar dimuat ulang.
+     Panitia menggesernya berkali-kali sepanjang pagi, dan jendela yang
+     kembali ke 07:00 tiap refresh membuat kertas yang dicetak sesudahnya
+     berbeda dari yang sebelumnya tanpa ada yang sengaja mengubahnya.
+
+     DITUNDA 800 ms sesudah ketikan terakhir. `dengar` menyala pada tiap
+     penekanan tombol, dan "0"-"7"-"3"-"0" adalah empat keadaan yang tiga di
+     antaranya belum berarti apa-apa.
+
+     Gagalnya TIDAK diam: jam yang terlihat di layar tapi tidak tersimpan
+     adalah kertas yang dicetak dari rencana yang cuma ada di satu HP. */
+  let jadwalSimpan = null;
+  const simpanPlanning = () => {
+    clearTimeout(jadwalSimpan);
+    const pertama = waktuPertama.nilai();
+    const terakhir = waktuTerakhir.nilai();
+    if (!pertama || !terakhir || !planning.size) return;
+    jadwalSimpan = setTimeout(async () => {
+      try {
+        await aturPlanningBerangkat(pertama, terakhir);
+      } catch (err) {
+        galatPlanning.textContent = `Planning belum tersimpan: ${err.message}`;
+        galatPlanning.hidden = false;
+      }
+    }, 800);
+  };
+
   const perbarui = () => { hitungPlanning(); gambarPratayang(perKloter); };
-  waktuPertama.dengar(perbarui);
-  waktuTerakhir.dengar(perbarui);
+  waktuPertama.dengar(() => { perbarui(); simpanPlanning(); });
+  waktuTerakhir.dengar(() => { perbarui(); simpanPlanning(); });
   perbarui();
 }
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -843,6 +843,10 @@ export function ukuranRapi(bytes) {
    dan ikon yang gagal termuat meninggalkan tombol tanpa muka.            */
 
 const IKON = {
+  // Jarum di 10:10, bukan 12:00 — dua jarum yang bertindih terbaca
+  // sebagai satu garis pada ukuran ikon.
+  "clock":
+    '<circle cx="12" cy="12" r="9" /> <path d="M12 7v5l3 2" />',
   "camera":
     '<path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" /> <circle cx="12" cy="13" r="3" />',
   "lock":


### PR DESCRIPTION
## What

**Tersimpan.** Ubah 07:00 → 07:30, refresh, dan kotaknya tetap 07:30.

- `0113_planning_berangkat_tersimpan.sql` — dua kolom `time` di `status_acara` + RPC `atur_planning_berangkat`.
- Layar menyimpan otomatis, ditunda 800 ms sesudah ketikan terakhir.

**Kartu diringkas.**

```
🕐 Planning 07:30 · Real 07:00 (terlalu cepat 30 menit)
🕐 Planning 07:46 · Real 07:04 (terlalu cepat 42 menit)
🕐 Planning 09:20                     ← belum berangkat
```

## Why

**Kenapa `status_acara`, bukan `edisi`.** Kolom yang secara arti lebih tepat adalah `edisi.jam_mulai_berangkat` / `jam_batas_berangkat` — pasal 10.7 memang menempatkan jendela sebagai konfigurasi per edisi. Tapi seluruh tabel konfigurasi dijaga trigger `tolak_saat_terkunci` (0002), dan `konfigurasi_terkunci` **menyala pada hari-H** — hari yang sama saat planning disusun. Menyimpannya di sana berarti fiturnya mati tepat di hari ia dipakai, dengan galat yang menyuruh panitia membuka kunci konfigurasi di tengah pagi.

`status_acara` adalah satu-satunya tabel setelan tanpa trigger itu, dan memang tidak boleh punya: `konfigurasi_terkunci` sendiri tinggal di sana, dan tabel yang mengunci dirinya tidak bisa dibuka. **Tes 76.3 menduduki kursi itu** — menyimpan planning saat konfigurasi dikunci.

**NULL berarti "ikut konfigurasi edisi"**, jadi edisi yang belum disentuh berperilaku persis seperti sebelumnya, dan sama di semua alat karena sumbernya satu.

**Haknya `cetak_kloter`, bukan `pengaturan`.** Yang menyusun planning adalah orang yang mencetak daftar kloternya — tombolnya ada di layar yang sama. Policy `adm_status_acara` sendiri tidak diubah; jalur langsung ke tabel tetap milik admin, dan RPC inilah satu-satunya pintu yang lebih longgar.

**Selisihnya kata, bukan tanda.** "+15" menuntut pembacanya mengingat mana yang rencana dan mana yang nyata sebelum tandanya berarti apa-apa.

## Notes

Yang disimpan **hanya jendelanya**, bukan jam tiap kloter. Jam per kloter diturunkan dari jendela dan dari kloter yang ada saat itu; menyimpannya berarti dua sumber untuk satu angka, dan yang satu basi begitu ada regu disisipkan.

Ikon jam baru ditambahkan ke `util.js` — set ikonnya belum punya.

**Perbaikan sampingan:** rute `/pengaturan-kloter` di `dev_server.py` ikut membaca kolom baru, dan RPC-nya didaftarkan di sana.

## Verifikasi lokal

Diukur di browser dengan database dev:

| Langkah | Hasil |
| --- | --- |
| Geser 07:00 → 07:30 | Kartu ikut: `Planning 07:30 · Real 07:00 (terlalu cepat 30 menit)` |
| Baca `status_acara` | `07:30:00 \| 10:00:00` |
| **Refresh** | Kotak tetap **07:30**, kartu tetap 07:30 |

| Perintah | Hasil |
| --- | --- |
| `bash tests/run.sh` | `SEMUA TES LULUS`, tes 76 OK |
| `node --test tests/*.test.mjs` | 168 pass, 0 fail |
| `periksa_impor` / `periksa_urutan_golongan` / `pratinjau_cetak` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
