### PR TITLE
fix: layar Daftar Kloter tidak mati saat migrasi 0113 belum diterapkan

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -345,8 +345,22 @@ export async function infoPengaturanKloter() {
     // Jendela Planning Keberangkatan (migrasi 0113). Tinggal di status_acara,
     // bukan di edisi, karena ia disusun pada hari-H — hari yang sama saat
     // kunci konfigurasi menyala dan menutup seluruh tabel setelan.
+    // GAGALNYA DITELAN, dan itu wajib. Kolom ini lahir di migrasi 0113,
+    // sementara situs panitia terbit pada TIAP MERGE dan migrasi dijalankan
+    // terpisah sesudahnya (CLAUDE.md 7.6). Di sela keduanya PostgREST
+    // menjawab 42703 "column does not exist" — dan tanpa penangkap ini
+    // Promise.all melempar, `infoPengaturanKloter()` gagal, lalu SELURUH
+    // layar Daftar Kloter mati. Bukan cuma planningnya: daftar kloter,
+    // pratayang, dan kedua tombol cetak ikut hilang.
+    //
+    // Sudah terjadi sekali, pada 27 Agustus 2026, dua hari sebelum lomba.
+    //
+    // Kosong = jendela jatuh ke konfigurasi edisi, persis perilaku sebelum
+    // 0113. Yang hilang cuma penyimpanannya, dan itu menyalak sendiri saat
+    // panitia menggeser jamnya.
     baca(null, "status_acara?id=eq.true" +
-      "&select=planning_berangkat_pertama,planning_berangkat_terakhir"),
+      "&select=planning_berangkat_pertama,planning_berangkat_terakhir")
+      .catch(() => []),
   ]);
   if (!edisi.length) throw new ErrorApi("Belum ada edisi aktif.");
   return {

--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -118,3 +118,17 @@ test("jumlah Eksternal dan Intern tetap ada, sebagai baris tabel", () => {
   assert.match(layar, /<td>Eksternal<\/td><td class="angka">\$\{jumlahEksternal\}<\/td>/);
   assert.match(layar, /<td>Intern<\/td><td class="angka">\$\{jumlahIntern\}<\/td>/);
 });
+
+
+test("kolom planning yang belum ada TIDAK mematikan layar", async () => {
+  // Situs panitia terbit tiap merge; migrasi dijalankan terpisah sesudahnya
+  // (pasal 7.6). Di sela keduanya PostgREST menjawab 42703, dan tanpa
+  // penangkap ini Promise.all melempar lalu SELURUH layar Daftar Kloter mati
+  // — daftar kloter, pratayang, dan kedua tombol cetak sekaligus.
+  //
+  // Sudah terjadi sekali, 27 Agustus 2026, dua hari sebelum lomba.
+  const { readFile } = await import("node:fs/promises");
+  const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+  assert.match(api,
+    /planning_berangkat_pertama,planning_berangkat_terakhir"\)\s*\n\s*\.catch\(\(\) => \[\]\)/);
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -345,8 +345,22 @@ export async function infoPengaturanKloter() {
     // Jendela Planning Keberangkatan (migrasi 0113). Tinggal di status_acara,
     // bukan di edisi, karena ia disusun pada hari-H — hari yang sama saat
     // kunci konfigurasi menyala dan menutup seluruh tabel setelan.
+    // GAGALNYA DITELAN, dan itu wajib. Kolom ini lahir di migrasi 0113,
+    // sementara situs panitia terbit pada TIAP MERGE dan migrasi dijalankan
+    // terpisah sesudahnya (CLAUDE.md 7.6). Di sela keduanya PostgREST
+    // menjawab 42703 "column does not exist" — dan tanpa penangkap ini
+    // Promise.all melempar, `infoPengaturanKloter()` gagal, lalu SELURUH
+    // layar Daftar Kloter mati. Bukan cuma planningnya: daftar kloter,
+    // pratayang, dan kedua tombol cetak ikut hilang.
+    //
+    // Sudah terjadi sekali, pada 27 Agustus 2026, dua hari sebelum lomba.
+    //
+    // Kosong = jendela jatuh ke konfigurasi edisi, persis perilaku sebelum
+    // 0113. Yang hilang cuma penyimpanannya, dan itu menyalak sendiri saat
+    // panitia menggeser jamnya.
     baca(null, "status_acara?id=eq.true" +
-      "&select=planning_berangkat_pertama,planning_berangkat_terakhir"),
+      "&select=planning_berangkat_pertama,planning_berangkat_terakhir")
+      .catch(() => []),
   ]);
   if (!edisi.length) throw new ErrorApi("Belum ada edisi aktif.");
   return {


### PR DESCRIPTION
## What

Bacaan kolom `status_acara.planning_berangkat_*` di `infoPengaturanKloter()` diberi `.catch(() => [])`.

## Why

**Ini sedang terjadi di produksi sekarang.** PR #599 merge, situs panitia terbit dalam 30 detik lewat koneksi Git Cloudflare, dan migrasi `0113` tertahan karena billing Actions. Kolomnya belum ada:

```
$ curl .../status_acara?select=planning_berangkat_pertama
{"code":"42703","message":"column status_acara.planning_berangkat_pertama does not exist"}
```

`Promise.all` melempar, `infoPengaturanKloter()` gagal, dan `layarCetakKloter` menangkapnya sebagai gagal muat — jadi yang hilang bukan cuma planningnya melainkan **daftar kloter, pratayang, dan kedua tombol cetak sekaligus**.

Ini kesalahan saya di #599: pola yang benar sudah saya pakai untuk migrasi 0110 (`biayaRegu()` jatuh ke `biaya_per_regu` kalau kolom intern belum ada), dan di sini terlewat.

## Notes

Sesudah PR ini, sela antara merge dan migrasi berperilaku persis seperti sebelum 0113: jendela jatuh ke konfigurasi edisi, layar utuh. Yang hilang cuma penyimpanannya — dan itu menyalak sendiri di baris galat saat panitia menggeser jamnya, bukan diam.

**Migrasi 0113 tetap perlu dijalankan** begitu Actions hidup lagi.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 169 pass, 0 fail (1 tes baru) |
| `diff web/js/api.js live/js/api.js` | sama |
| `periksa_impor` | bersih |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
