### PR TITLE
feat: form pendaftaran mencatat nama empat anggota, opsional

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -95,9 +95,17 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
       tidak ada penjumlahan yang bisa meleset dan tidak ada yang perlu
       divalidasi. Yang diperiksa hanya batas bawah ("Tambahkan minimal satu
       regu") dan batas atas per pengiriman.
-   5. **Untuk setiap regu:** nama regu dan nama ketua. **Nama empat anggota
-      lain tidak diminta** — untuk sekarang sistem tidak mencatatnya;
-      kelengkapan 5 orang dicek fisik di akhir lomba (bagian 10.9).
+   5. **Untuk setiap regu:** nama regu, nama ketua, dan **nama empat anggota
+      lain — opsional**. Ketua tetap satu-satunya yang wajib. Yang kosong
+      tidak disimpan sebagai nama kosong; regu yang pembinanya tidak mengisi
+      sama sekali tercatat tanpa daftar anggota, dan itu keadaan yang sah.
+      **Kelengkapan 5 orang tetap dicek FISIK di akhir lomba** (bagian 10.9) —
+      daftar nama ini tidak menggantikannya dan tidak dipakai menghitung
+      penalti anggota. Regu boleh datang berlima dengan satu nama tidak
+      tertulis, dan boleh menulis lima nama lalu datang bertiga.
+      *(Sampai 27 Agustus 2026 keempat nama itu sengaja TIDAK diminta;
+      keputusan itu dibalik pemilik acara, dan migrasi `0114` yang
+      mencatatnya.)*
    6. **Satu Contact Person** untuk keseluruhan batch: nama (wajib) dan nomor
       WhatsApp. Namanya disimpan sebagai `pendaftaran.nama_kontak` dan itulah
       yang dipanggil panitia saat menghubungi sekolah.
@@ -876,5 +884,5 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    *(Pertanyaan-pertanyaan lain di bagian ini yang sudah terjawab dan pindah ke
    badan dokumen: pembayaran sebagian tidak dilayani — bagian 3.5; kode
    pembayaran per batch terbit saat pendaftaran — bagian 3.4; nama anggota
-   selain ketua tidak dicatat untuk sekarang — bagian 3.2; isi dan waktu
-   tampilan live — bagian 1.5.)*
+   selain ketua kini dicatat dan opsional, sesudah sempat diputuskan tidak
+   dicatat — bagian 3.2; isi dan waktu tampilan live — bagian 1.5.)*

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0113`.
+Terakhir diperiksa terhadap kode: **24 Agustus 2026**, sampai migrasi `0114`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-113 migrasi, `0001` sampai `0113`, dijalankan berurutan tanpa lubang penomoran.
+114 migrasi, `0001` sampai `0114`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -75,7 +75,7 @@ const kosong = () => ({
     penegak_pa: 0, penegak_pi: 0,
     intern_pa: 0, intern_pi: 0,
   },
-  regu: [],                      // [{golongan, nama_regu, nama_ketua}]
+  regu: [],                      // [{golongan, nama_regu, nama_ketua, anggota[4]}]
   kontak_wa: "",
   nama_kontak: "",
   kunci_kirim: uuidDraf(),
@@ -499,7 +499,8 @@ function sinkronRegu() {
   for (const g of golonganForm()) {
     const bekas = lama.filter(r => r.golongan === g.kode);
     for (let i = 0; i < jawab.rincian[g.kode]; i++)
-      jawab.regu.push(bekas[i] ?? { golongan: g.kode, nama_regu: "", nama_ketua: "" });
+      jawab.regu.push(bekas[i]
+        ?? { golongan: g.kode, nama_regu: "", nama_ketua: "", anggota: ["", "", "", ""] });
   }
   simpanDraf();
 }
@@ -527,29 +528,58 @@ function perbaruiTotal() {
 
 /* ---------------- 4. nama regu ---------------- */
 
+/** Empat kotak anggota, selalu empat — draf lama yang belum punya kunci
+ *  `anggota` ikut terisi kotak kosong, bukan kehilangan barisnya. */
+const anggotaRegu = (r) => {
+  const a = Array.isArray(r.anggota) ? r.anggota : [];
+  return [0, 1, 2, 3].map(k => a[k] || "");
+};
+
 function gambarRegu() {
   const kotak = document.getElementById("isi-regu");
   if (!jawab.regu.length) {
     kotak.replaceChildren(h(`<p class="description">Belum ada regu.</p>`));
     return;
   }
-  kotak.replaceChildren(h(jawab.regu.map((r, i) => html`
+  /* Template BIASA, BUKAN tag html`` — keempat kotak anggota sudah berupa
+     HTML jadi, dan menyisipkannya ke dalam html`` membuatnya ikut di-escape:
+     tag-nya tampil sebagai teks mentah di dalam kartu. Persis jebakan yang
+     sudah ditulis di app.js untuk baris tabel, dan ia menggigit lagi di sini.
+     Data dari luar tetap lewat esc() satu per satu. */
+  kotak.replaceChildren(h(jawab.regu.map((r, i) => {
+    const kotakAnggota = anggotaRegu(r).map((a, k) => html`
+          <input type="text" id="r-anggota-${i}-${k}" value="${a}"
+                 style="margin-top:.35rem"
+                 placeholder="misal: nama anggota ${k + 2}">`).join("");
+    return `
     <div class="regu-card" id="regu-${i}">
-      <span class="badge badge-green">Regu ${i + 1} — ${labelGolongan(r.golongan)}</span>
+      <span class="badge badge-green">Regu ${i + 1} — ${esc(labelGolongan(r.golongan))}</span>
       <div class="two-column">
         <div class="field" style="margin:0">
           <label for="r-nama-${i}">Nama regu</label>
-          <input type="text" id="r-nama-${i}" value="${r.nama_regu}"
+          <input type="text" id="r-nama-${i}" value="${esc(r.nama_regu)}"
                  maxlength="${NAMA_MAKS}" placeholder="contoh: Rajawali">
           <div class="error" id="r-nama-galat-${i}" hidden>Nama regu wajib diisi.</div>
         </div>
         <div class="field" style="margin:0">
           <label for="r-ketua-${i}">Nama ketua</label>
-          <input type="text" id="r-ketua-${i}" value="${r.nama_ketua}" placeholder="contoh: Andi Saputra">
+          <input type="text" id="r-ketua-${i}" value="${esc(r.nama_ketua)}" placeholder="contoh: Andi Saputra">
           <div class="error" id="r-ketua-galat-${i}" hidden>Nama ketua wajib diisi.</div>
         </div>
       </div>
-    </div>`).join("")));
+      <!-- Empat kotak anggota, dan label "opsional" ditulis SEKALI di
+           judulnya — bukan di tiap kotak. Empat kata "opsional" berderet ke
+           bawah membuat yang wajib dan yang tidak sama-sama tenggelam.
+           Nomornya mulai dari 2: ketua adalah anggota pertama, dan regu
+           memang berlima (closing_regu.anggota_hadir 0-5). -->
+      <div class="field" style="margin:.7rem 0 0">
+        <label for="r-anggota-${i}-0">Anggota lain (opsional)</label>
+        ${kotakAnggota}
+        <div class="error" id="r-anggota-galat-${i}" hidden>
+          Nama anggota tidak boleh memakai angka.</div>
+      </div>
+    </div>`;
+  }).join("")));
 
   // Warning SEKETIKA kalau nama regu/ketua kosong — tidak menunggu tombol
   // Kirim ditekan dulu. Dua isian dicek bersama supaya kartu tidak salah
@@ -591,7 +621,22 @@ function gambarRegu() {
     const kotakKetua = document.getElementById(`r-ketua-galat-${i}`);
     kotakKetua.textContent = salahKetua || "";
     kotakKetua.hidden = !salahKetua;
-    document.getElementById(`regu-${i}`).classList.toggle("regu-card-error", !!salahNama || ketuaKosong);
+
+    // Anggota boleh kosong; yang tidak boleh cuma angka di namanya — aturan
+    // yang sama dengan nama ketua, dan database menolaknya juga (0114). Kotak
+    // yang salah ditandai satu per satu supaya pembina tahu yang mana.
+    const salahAnggota = [0, 1, 2, 3].some(k => {
+      const inp = document.getElementById(`r-anggota-${i}-${k}`);
+      if (!inp) return false;
+      const salah = ADA_ANGKA.test(inp.value);
+      inp.setAttribute("aria-invalid", String(salah));
+      return salah;
+    });
+    const kotakAnggota = document.getElementById(`r-anggota-galat-${i}`);
+    if (kotakAnggota) kotakAnggota.hidden = !salahAnggota;
+
+    document.getElementById(`regu-${i}`).classList.toggle("regu-card-error",
+      !!salahNama || ketuaKosong || salahAnggota);
   };
 
   /** Tanya server nama mana yang sudah terpakai — ditunda 450 ms supaya tiap
@@ -625,6 +670,18 @@ function gambarRegu() {
       r.nama_ketua = e.target.value.trim(); simpanDraf();
       cekRegu(i);
       if (sudahDiperiksa) periksa(false);
+    });
+    // Anggota opsional: yang bisa SALAH cuma angka di namanya, dan itu
+    // ditandai seketika — bukan saat tombol Kirim ditekan, karena saat itu
+    // pembina sudah mengisi belasan kotak dan harus mencari yang mana.
+    [0, 1, 2, 3].forEach(k => {
+      document.getElementById(`r-anggota-${i}-${k}`).addEventListener("input", e => {
+        if (!Array.isArray(r.anggota)) r.anggota = ["", "", "", ""];
+        r.anggota[k] = e.target.value.trim();
+        simpanDraf();
+        cekRegu(i);
+        if (sudahDiperiksa) periksa(false);
+      });
     });
     cekRegu(i);   // baris baru (kosong) langsung tertandai, tanpa perlu disentuh dulu
   });
@@ -671,7 +728,9 @@ function periksa(gulir = true) {
     const namaSalah = !n
       || jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n)
       || namaTerpakai.get(n) === true;
-    const kurang = namaSalah || !r.nama_ketua || ADA_ANGKA.test(r.nama_ketua);
+    const anggotaBerangka = (r.anggota || []).some(a => a && ADA_ANGKA.test(a));
+    const kurang = namaSalah || !r.nama_ketua || ADA_ANGKA.test(r.nama_ketua)
+      || anggotaBerangka;
     const el = document.getElementById(`regu-${i}`);
     if (el) el.classList.toggle("regu-card-error", kurang);
     if (kurang) {

--- a/supabase/migrations/0114_nama_anggota_regu.sql
+++ b/supabase/migrations/0114_nama_anggota_regu.sql
@@ -1,0 +1,209 @@
+-- ============================================================================
+-- hrcd-rekap : 0114_nama_anggota_regu.sql
+-- Nama empat anggota selain ketua kini DICATAT, dan opsional.
+--
+-- ---------------------------------------------------------------------------
+-- KEPUTUSAN YANG DIBALIK, BUKAN KELALAIAN YANG DIPERBAIKI
+--
+-- 0001 menulisnya terus terang di badan tabel:
+--
+--     -- Empat anggota lain sengaja tidak dicatat (alur 3.2.6);
+--     -- kelengkapan dicek fisik di closing (anggota_hadir).
+--
+-- dan `docs/alur-lomba.md` 3.2.5 mengulanginya. Itu keputusan sadar, dan
+-- sekarang pemilik acara membalikkannya: form pendaftaran meminta lima nama
+-- per regu, ketua tetap wajib dan empat sisanya boleh kosong.
+--
+-- Yang TIDAK berubah: `closing_regu.anggota_hadir` tetap hitungan fisik di
+-- garis finish, dan penalti anggota tetap dihitung darinya. Nama yang dicatat
+-- di sini tidak menggantikan hitungan itu — regu boleh datang berlima dengan
+-- satu nama tidak tertulis, dan boleh menulis lima nama lalu datang bertiga.
+--
+-- ---------------------------------------------------------------------------
+-- SATU KOLOM ARRAY, BUKAN TABEL ANAK
+--
+-- Empat nama tanpa atribut apa pun: tidak ada nomor dada per orang, tidak ada
+-- kehadiran per orang, tidak ada yang menunjuk ke sana. Tabel anak menambah
+-- satu join di setiap layar yang menampilkan regu, demi data yang tidak
+-- pernah ditanya sendirian. CLAUDE.md 6.4 — sedikit lapisan lebih baik.
+--
+-- Kalau suatu hari kehadiran perlu dicatat PER ORANG, barulah bentuknya
+-- berubah; sampai saat itu array adalah bentuk yang jujur.
+--
+-- ---------------------------------------------------------------------------
+-- KOSONG BERARTI TIDAK DICATAT
+--
+-- `anggota` NULL untuk seluruh regu yang mendaftar sebelum migrasi ini, dan
+-- untuk regu yang pembinanya memang tidak mengisi. Keduanya keadaan sah dan
+-- tidak dibedakan: yang menjamin kelengkapan tetap hitungan fisik di closing.
+-- Kotak yang dibiarkan kosong tidak disimpan sebagai string kosong — yang
+-- tersimpan hanya nama yang benar-benar diketik.
+-- ============================================================================
+
+alter table regu add column if not exists anggota text[];
+
+comment on column regu.anggota is
+  'Nama anggota selain ketua, maksimal empat, opsional. NULL = tidak dicatat. Kelengkapan tetap dihitung fisik lewat closing_regu.anggota_hadir.';
+
+alter table regu drop constraint if exists regu_anggota_maks_empat;
+alter table regu add constraint regu_anggota_maks_empat check (
+  anggota is null or coalesce(array_length(anggota, 1), 0) <= 4
+);
+
+-- Aturan yang sama dengan nama regu dan nama ketua (0052): angka di nama orang
+-- hampir selalu nomor urut yang ikut terketik, dan ia terbawa ke daftar hadir.
+alter table regu drop constraint if exists regu_anggota_tanpa_angka;
+alter table regu add constraint regu_anggota_tanpa_angka check (
+  anggota is null or array_to_string(anggota, ' ') !~ '[0-9]'
+);
+
+-- Nama kosong di tengah daftar berarti kotak yang dilewati ikut tersimpan, dan
+-- "anggota ke-3 bernama kosong" adalah baris yang tidak berarti apa-apa.
+alter table regu drop constraint if exists regu_anggota_tidak_kosong;
+alter table regu add constraint regu_anggota_tidak_kosong check (
+  anggota is null or '' <> all(anggota)
+);
+
+-- ---------------------------------------------------------------------------
+-- Salinan terakhir submit_pendaftaran (0110). Yang berubah: satu blok validasi
+-- anggota di dalam loop, dan satu kolom di INSERT.
+-- ---------------------------------------------------------------------------
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', tagihan_pendaftaran(v_ada.id),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+
+    -- Anggota OPSIONAL: kunci `anggota` boleh tidak ada sama sekali, dan
+    -- daftarnya boleh kosong. Yang ditolak cuma bentuk yang salah.
+    if v_r ? 'anggota' and jsonb_typeof(v_r -> 'anggota') <> 'null' then
+      if jsonb_typeof(v_r -> 'anggota') <> 'array' then
+        raise exception 'anggota harus berupa daftar nama';
+      end if;
+      if (select count(*) from jsonb_array_elements_text(v_r -> 'anggota') a
+          where trim(a) <> '') > 4 then
+        raise exception 'maksimal 4 anggota selain ketua';
+      end if;
+      -- Aturan yang sama dengan nama ketua (0052): angka di nama orang hampir
+      -- selalu nomor urut yang ikut terketik, dan ia terbawa ke daftar hadir.
+      if exists (select 1 from jsonb_array_elements_text(v_r -> 'anggota') a
+                 where a ~ '[0-9]') then
+        raise exception 'nama anggota tidak boleh memakai angka';
+      end if;
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim, nama_kontak)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''))
+  returning id into v_batch;
+
+  -- Kotak yang dibiarkan kosong TIDAK disimpan sebagai string kosong: yang
+  -- tersimpan hanya nama yang benar-benar diketik, berurutan. `array_agg` atas
+  -- nol baris mengembalikan NULL, dan NULL di sini berarti "tidak ada nama
+  -- anggota yang dicatat" — bukan "regunya kosong".
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan',
+         (select array_agg(trim(a) order by urut)
+          from jsonb_array_elements_text(coalesce(r -> 'anggota', '[]'::jsonb))
+               with ordinality as t(a, urut)
+          where trim(a) <> '')
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', tagihan_pendaftaran(v_batch),
+    'terkirim_ulang', false);
+end;
+$$;
+
+do $blok$
+declare v_dicatat integer;
+begin
+  assert exists (select 1 from information_schema.columns
+                 where table_name = 'regu' and column_name = 'anggota'),
+    '0114: kolom anggota tidak terpasang';
+
+  select count(*) into v_dicatat from regu where anggota is not null;
+  raise notice '0114: nama anggota kini dicatat (opsional). '
+               'Regu yang sudah punya daftar anggota: %.', v_dicatat;
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -499,6 +499,11 @@ run tests/sql/75_perkiraan_berangkat_satu_rumus.sql
 # dipakai.
 run supabase/migrations/0113_planning_berangkat_tersimpan.sql
 run tests/sql/76_planning_berangkat_tersimpan.sql
+# 0114 mencatat nama empat anggota selain ketua, opsional. Tes 77 menjaga
+# yang paling mudah salah: kotak yang dilewati pembina TIDAK boleh tersimpan
+# sebagai nama kosong, dan pagarnya berdiri di tabel — bukan hanya di RPC.
+run supabase/migrations/0114_nama_anggota_regu.sql
+run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
 run supabase/checks/live_json.sql

--- a/tests/sql/77_nama_anggota_regu.sql
+++ b/tests/sql/77_nama_anggota_regu.sql
@@ -1,0 +1,147 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/77_nama_anggota_regu.sql — migrasi 0114.
+-- Nama anggota dicatat, opsional, dan kotak kosong tidak ikut tersimpan.
+--
+-- Yang paling mudah salah di sini bukan penyimpanannya melainkan KEKOSONGANNYA:
+-- form mengirim empat kotak apa pun isinya, dan kotak yang dilewati akan
+-- tersimpan sebagai "" kalau tidak disaring. "Anggota ke-3 bernama kosong"
+-- adalah baris yang tidak berarti apa-apa, dan ia baru terlihat saat ada yang
+-- mencetak daftar hadir.
+-- ============================================================================
+
+\echo '--- 77. nama anggota regu'
+\set ON_ERROR_STOP on
+
+select set_config('app.uid', (select user_id::text from akun_panitia
+                              where peran = 'admin' and is_active limit 1), false);
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 77.1 Ketua wajib, anggota opsional — dan ketiadaan `anggota` bukan galat.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v jsonb; v_id uuid; v_ang text[];
+begin
+  v := submit_pendaftaran(
+    'SMPN Uji Anggota', 'Jl. Uji Anggota', false, '081200007701',
+    '[{"nama_regu":"Ujianggota Satu","nama_ketua":"Ketua Satu","golongan":"penegak_pa"}]');
+
+  select r.anggota into v_ang
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v ->> 'kode_pembayaran';
+
+  assert v_ang is null,
+    format('77.1 GAGAL: tanpa kunci anggota seharusnya NULL, dapat %s', v_ang);
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 77.2 Empat nama tersimpan berurutan, dan kotak kosong TIDAK ikut.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v jsonb; v_ang text[];
+begin
+  v := submit_pendaftaran(
+    'SMPN Uji Anggota Isi', 'Jl. Uji Isi', false, '081200007702',
+    '[{"nama_regu":"Ujianggota Dua","nama_ketua":"Ketua Dua","golongan":"penegak_pa",
+       "anggota":["Budi Santoso","","  ","Citra Lestari"]}]');
+
+  select r.anggota into v_ang
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v ->> 'kode_pembayaran';
+
+  assert v_ang = array['Budi Santoso', 'Citra Lestari'],
+    format('77.2 GAGAL: tersimpan %s', v_ang);
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 77.3 Bentuk yang salah ditolak, dan penolakannya tidak menyisakan setengah
+--      pendaftaran.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_sebelum integer;
+  v_tolak   boolean;
+begin
+  select count(*) into v_sebelum from pendaftaran;
+
+  -- Lebih dari empat.
+  v_tolak := false;
+  begin
+    perform submit_pendaftaran(
+      'SMPN Uji Anggota Lima', 'Jl. Uji Lima', false, '081200007703',
+      '[{"nama_regu":"Ujianggota Tiga","nama_ketua":"Ketua Tiga","golongan":"penegak_pa",
+         "anggota":["A Satu","B Dua","C Tiga","D Empat","E Lima"]}]');
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '77.3 GAGAL: lima anggota diterima';
+
+  -- Berangka — aturan yang sama dengan nama ketua (0052).
+  v_tolak := false;
+  begin
+    perform submit_pendaftaran(
+      'SMPN Uji Anggota Angka', 'Jl. Uji Angka', false, '081200007704',
+      '[{"nama_regu":"Ujianggota Empat","nama_ketua":"Ketua Empat","golongan":"penegak_pa",
+         "anggota":["Anggota 2"]}]');
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '77.3 GAGAL: nama anggota berangka diterima';
+
+  assert (select count(*) from pendaftaran) = v_sebelum,
+    '77.3 GAGAL: pendaftaran yang ditolak tetap tersimpan';
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 77.4 Ketua TETAP wajib. Yang dilonggarkan cuma anggotanya.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_tolak boolean := false;
+begin
+  begin
+    perform submit_pendaftaran(
+      'SMPN Uji Tanpa Ketua', 'Jl. Uji Ketua', false, '081200007705',
+      '[{"nama_regu":"Ujianggota Lima","nama_ketua":"","golongan":"penegak_pa",
+         "anggota":["Budi Santoso"]}]');
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '77.4 GAGAL: regu tanpa nama ketua diterima';
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 77.5 Pagar tabelnya berdiri sendiri, bukan hanya di dalam RPC. Jalur tulis
+--      lain — admin lewat SQL, migrasi berikutnya — harus ikut tertahan.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_daf   uuid;
+  v_tolak boolean;
+begin
+  select id into v_daf from pendaftaran limit 1;
+
+  v_tolak := false;
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+    values (v_daf, 'Ujianggota Enam', 'Ketua Enam', 'penegak_pa',
+            array['A', 'B', 'C', 'D', 'E']);
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '77.5 GAGAL: constraint maksimal empat tidak menahan';
+
+  v_tolak := false;
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+    values (v_daf, 'Ujianggota Tujuh', 'Ketua Tujuh', 'penegak_pa',
+            array['Budi', '']);
+  exception when others then v_tolak := true;
+  end;
+  assert v_tolak, '77.5 GAGAL: nama anggota kosong tidak ditahan';
+end;
+$blok$;
+
+rollback;
+
+select '77_nama_anggota_regu OK' as hasil;


### PR DESCRIPTION
## What

Tiap regu di form pendaftaran kini punya lima nama: **Nama ketua** (wajib) + **empat kotak "Anggota lain (opsional)"**.

- `0114_nama_anggota_regu.sql` — kolom `regu.anggota text[]`, tiga constraint, dan `submit_pendaftaran` yang menyaring kotak kosong.
- `live/js/daftar.js` — empat kotak per kartu regu, tersimpan ke draf, divalidasi sambil diketik.
- `docs/alur-lomba.md` 3.2.5 dan daftar pertanyaan terjawabnya ikut diperbarui.

## Why

Permintaan pemilik acara. **Ini membalik keputusan yang tertulis**, bukan menambal kelalaian — `0001` menyebutnya di badan tabel:

```
-- Empat anggota lain sengaja tidak dicatat (alur 3.2.6);
-- kelengkapan dicek fisik di closing (anggota_hadir).
```

Karena itu kedua dokumen diperbarui lengkap dengan tanggal pembalikannya, supaya pembaca berikutnya tidak mengira salah satunya keliru.

**Yang tidak berubah:** `closing_regu.anggota_hadir` tetap hitungan fisik di garis finish, dan penalti anggota tetap dihitung darinya. Daftar nama ini tidak menggantikannya — regu boleh datang berlima dengan satu nama tidak tertulis, dan boleh menulis lima nama lalu datang bertiga.

## Notes

**Satu kolom array, bukan tabel anak.** Empat nama tanpa atribut apa pun: tidak ada nomor dada per orang, tidak ada kehadiran per orang, tidak ada yang menunjuk ke sana. Tabel anak menambah satu join di setiap layar yang menampilkan regu demi data yang tidak pernah ditanya sendirian (pasal 6.4). Kalau suatu hari kehadiran perlu dicatat per orang, barulah bentuknya berubah.

**Kotak kosong tidak tersimpan sebagai nama kosong.** Form mengirim empat kotak apa pun isinya; RPC menyaringnya. "Anggota ke-3 bernama kosong" adalah baris yang tidak berarti apa-apa dan baru terlihat saat ada yang mencetak daftar hadir.

**Pagarnya di tabel, bukan hanya di RPC** — maksimal empat, tanpa angka (aturan yang sama dengan nama ketua sejak 0052), tanpa elemen kosong. Tes 77.5 menulis langsung ke tabel untuk membuktikan jalur tulis lain ikut tertahan.

**Satu jebakan yang menggigit lagi:** keempat kotak dirakit sebagai HTML lalu disisipkan ke dalam `` html`` `` — dan tag-nya tampil sebagai **teks mentah** di dalam kartu. Tidak ada tes yang menangkapnya; terlihat saat form dibuka di browser. Kartu regu sekarang template biasa dengan `esc()` satu per satu, persis catatan yang sudah ada di `app.js` untuk baris tabel.

**Belum ada layar panitia yang menampilkan nama-nama ini.** Yang diminta pencatatannya; bilang saja kalau perlu muncul di Meja Pembayaran, lookup gerbang, atau kertas kloter.

## Verifikasi lokal

Form diisi di browser dengan **kotak ke-2 sengaja dilewati**, lalu dikirim lewat `kirimPendaftaran()` yang sama dengan tombol Kirim:

```
draf   : anggota: ["Budi Santoso", "", "Citra Lestari", ""]
database: Budi Santoso / Citra Lestari      (array_length = 2)
```

| Perintah | Hasil |
| --- | --- |
| `bash tests/run.sh` | `SEMUA TES LULUS`, tes 77 OK |
| `node --test tests/*.test.mjs` | 169 pass, 0 fail |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
