### PR TITLE
fix: kapitalkan label Nama Regu dan Nama Ketua

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -556,13 +556,13 @@ function gambarRegu() {
       <span class="badge badge-green">Regu ${i + 1} — ${esc(labelGolongan(r.golongan))}</span>
       <div class="two-column">
         <div class="field" style="margin:0">
-          <label for="r-nama-${i}">Nama regu</label>
+          <label for="r-nama-${i}">Nama Regu</label>
           <input type="text" id="r-nama-${i}" value="${esc(r.nama_regu)}"
                  maxlength="${NAMA_MAKS}" placeholder="contoh: Rajawali">
           <div class="error" id="r-nama-galat-${i}" hidden>Nama regu wajib diisi.</div>
         </div>
         <div class="field" style="margin:0">
-          <label for="r-ketua-${i}">Nama ketua</label>
+          <label for="r-ketua-${i}">Nama Ketua</label>
           <input type="text" id="r-ketua-${i}" value="${esc(r.nama_ketua)}" placeholder="contoh: Andi Saputra">
           <div class="error" id="r-ketua-galat-${i}" hidden>Nama ketua wajib diisi.</div>
         </div>


### PR DESCRIPTION
## What

| Sebelum | Sesudah |
| --- | --- |
| Nama regu | **Nama Regu** |
| Nama ketua | **Nama Ketua** |

Seragam dengan **Nama Anggota** yang baru — ketiganya label kotak isian.

## Notes

**Pesan galatnya tidak ikut diubah.** "Nama regu wajib diisi." adalah kalimat, bukan label, dan di kalimat huruf besar cuma di awalnya. Menyamakannya jadi "Nama Regu wajib diisi." akan salah secara bahasa demi keseragaman yang tidak dilihat siapa pun — label dan kalimat memang dua register berbeda.

## Verifikasi lokal

Dibuka di browser lewat jalur **Intern** (sekaligus menjawab pertanyaan apakah Intern ikut dapat kotak anggota):

```
label       : ["Nama Regu", "Nama Ketua", "Nama Anggota (opsional)"]
placeholder : ["contoh: Rajawali", "contoh: Andi Saputra",
               "Nama Anggota 1" … "Nama Anggota 4"]
```

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 169 pass, 0 fail |
| `periksa_impor` | bersih |
| `diff web/config.js live/config.js` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
