### PR TITLE
docs: betulkan hitungan commit tanpa merge point, dua jadi tujuh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,14 +144,26 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    something GitHub enforces. Follow it deliberately.
 3. Git identity is configured **repo-locally**, not globally:
    `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
-4. **Two commits on `main` have no merge point**, and the root
-   `Initial commit` besides. PR #1 predates this convention and was
-   squash-merged; `5502a5a` (15 August) was pushed straight to `main` by
-   mistake and could not be undone without force-pushing the default branch,
-   which is worse than untidy history. Leave all three as they are. Verify the
-   count with `git log --first-parent` and check each commit's parent count —
-   a commit reached as a merge's *second* parent is normal and must not be
-   counted.
+4. **Seven commits on `main` have no merge point**, and the root
+   `Initial commit` besides. All of them predate 22 August 2026, and all are
+   known — none is new damage:
+
+   | Commit | Date | Why |
+   | --- | --- | --- |
+   | `4fb9fcb` | 4 Aug | PR #1, squash-merged before this convention existed |
+   | `5502a5a` | 15 Aug | pushed straight to `main` by mistake |
+   | `f133c8d` `b532dd9` `23ec32b` `aa28b57` `769d760` | 17 Aug | five more direct pushes, same mistake repeated |
+
+   Leave all eight as they are: undoing any of them means force-pushing the
+   default branch, which is worse than untidy history. Verify the count with
+   `git log --first-parent` and check each commit's parent count — a commit
+   reached as a merge's *second* parent is normal and must not be counted.
+
+   **This clause said "two" until 27 August 2026, when a branch audit found
+   seven.** The five from 17 August were never recorded. A stale count is not
+   a cosmetic error: whoever runs the check next reads five false alarms and
+   cannot tell known history from fresh damage. If the number changes again,
+   change it HERE — do not leave the discrepancy for the next reader.
 5. **`tests/run.sh` lists every migration by hand.** A new migration is NOT
    tested until it is added there, and CI stays green while ignoring it
    completely. Seven migrations and three test files once sat unrun for a day

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,14 +142,26 @@ Guidance for Claude Code when working in this repository.
    something GitHub enforces. Follow it deliberately.
 3. Git identity is configured **repo-locally**, not globally:
    `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
-4. **Two commits on `main` have no merge point**, and the root
-   `Initial commit` besides. PR #1 predates this convention and was
-   squash-merged; `5502a5a` (15 August) was pushed straight to `main` by
-   mistake and could not be undone without force-pushing the default branch,
-   which is worse than untidy history. Leave all three as they are. Verify the
-   count with `git log --first-parent` and check each commit's parent count —
-   a commit reached as a merge's *second* parent is normal and must not be
-   counted.
+4. **Seven commits on `main` have no merge point**, and the root
+   `Initial commit` besides. All of them predate 22 August 2026, and all are
+   known — none is new damage:
+
+   | Commit | Date | Why |
+   | --- | --- | --- |
+   | `4fb9fcb` | 4 Aug | PR #1, squash-merged before this convention existed |
+   | `5502a5a` | 15 Aug | pushed straight to `main` by mistake |
+   | `f133c8d` `b532dd9` `23ec32b` `aa28b57` `769d760` | 17 Aug | five more direct pushes, same mistake repeated |
+
+   Leave all eight as they are: undoing any of them means force-pushing the
+   default branch, which is worse than untidy history. Verify the count with
+   `git log --first-parent` and check each commit's parent count — a commit
+   reached as a merge's *second* parent is normal and must not be counted.
+
+   **This clause said "two" until 27 August 2026, when a branch audit found
+   seven.** The five from 17 August were never recorded. A stale count is not
+   a cosmetic error: whoever runs the check next reads five false alarms and
+   cannot tell known history from fresh damage. If the number changes again,
+   change it HERE — do not leave the discrepancy for the next reader.
 5. **`tests/run.sh` lists every migration by hand.** A new migration is NOT
    tested until it is added there, and CI stays green while ignoring it
    completely. Seven migrations and three test files once sat unrun for a day


### PR DESCRIPTION
## What

Pasal 7.4 di CLAUDE.md dan AGENTS.md: **"Two commits"** → **"Seven commits"**, lengkap dengan tabel commit, tanggal, dan sebabnya.

## Why

Audit cabang menemukan pasal itu sudah basi. `git log --first-parent` lalu memeriksa jumlah parent tiap commit:

| Commit | Tanggal | Sebab | Tercatat? |
| --- | --- | --- | --- |
| `4fb9fcb` | 4 Agu | PR #1, squash-merge sebelum konvensi ada | ya |
| `5502a5a` | 15 Agu | push langsung ke `main`, keliru | ya |
| `f133c8d` `b532dd9` `23ec32b` `aa28b57` `769d760` | 17 Agu | lima push langsung lagi | **tidak** |

Kelimanya mendahului sesi ini — tidak satu pun kerusakan baru.

**Hitungan basi bukan salah kosmetik.** Pasal itu ada persis supaya yang memeriksa berikutnya bisa membedakan riwayat yang sudah diketahui dari kerusakan segar. Dengan angka "dua", pemeriksaan berikutnya membaca lima alarm palsu — dan reaksi yang paling mungkin terhadap alarm palsu adalah berhenti memercayai alarmnya.

Tidak ada riwayat yang disentuh: membatalkan salah satunya menuntut force-push ke branch default, yang lebih buruk daripada riwayat tidak rapi.

## Verifikasi lokal

| Perintah | Hasil |
| --- | --- |
| `git log --first-parent` + hitung parent | 7 commit tunggal + root, sesuai tabel |
| Merge #583–#603 | 21/21 dua parent, subjek `<judul> (#nomor)` |
| `node --test tests/*.test.mjs` | 169 pass, 0 fail |
| `diff` CLAUDE.md vs AGENTS.md | byte-identical |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
