### PR TITLE
feat: saringan Input Pos jadi Belum Input / Belum Foto / Lengkap / Semua

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -802,6 +802,21 @@ export async function daftarFotoLembar(pos, nomorDada) {
     `&select=*&order=diunggah_pada.desc`);
 }
 
+/** Foto slip SELURUH regu di satu pos, sekali ambil.
+ *
+ *  Dipakai saringan "Belum Foto" di layar Input Pos. Menanyakannya per baris
+ *  berarti ratusan permintaan di jaringan pos yang memang sering putus —
+ *  satu permintaan berisi dua kolom jauh lebih murah daripada 300 permintaan
+ *  berisi semuanya.
+ *
+ *  `path` sengaja TIDAK diambil: yang ditanya saringan cuma ADA atau TIDAK,
+ *  dan path adalah bagian paling gemuk dari barisnya. */
+export async function fotoLembarPos(pos) {
+  if (K.mode === "dev") return baca(`/foto-lembar-pos?pos=${encodeURIComponent(pos)}`);
+  return baca(null,
+    `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}&select=nomor_dada,kode_lomba`);
+}
+
 /** Link sementara untuk melihat satu foto. Bucket-nya privat, jadi tidak ada
  *  URL tetap — dan itu memang yang diinginkan: link yang tidak kedaluwarsa
  *  akan beredar di WhatsApp selamanya. Satu jam cukup untuk melihatnya. */

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -161,6 +161,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/status":
                 self._kirim(200, q(
                     "select * from status_acara", uid=p.get("uid"), fetch="one"))
+            elif u.path == "/foto-lembar-pos":
+                self._kirim(200, q(
+                    "select nomor_dada, kode_lomba from v_foto_lembar "
+                    "where pos = %s",
+                    (p.get("pos") or 0,), uid=p.get("uid")))
             elif u.path == "/foto-belum-taut":
                 # nomor_dada NULL = foto borongan yang belum ditautkan (0074).
                 self._kirim(200, q(

--- a/tests/pos_photo_filter.test.mjs
+++ b/tests/pos_photo_filter.test.mjs
@@ -1,0 +1,97 @@
+// Saringan Input Pos: Belum Input · Belum Foto · Lengkap · Semua.
+//
+// Yang paling mudah salah di sini bukan saringannya melainkan KEGAGALAN
+// permintaan fotonya. Pos memang sering kehilangan sinyal, dan kalau status
+// foto yang tidak terbaca diperlakukan sebagai "tidak ada foto", layar akan
+// menuduh ratusan regu sekaligus — alarm yang tidak bisa dipenuhi siapa pun,
+// dan yang paling mungkin terjadi sesudahnya adalah orang berhenti memercayai
+// alarmnya.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const akar = new URL("../", import.meta.url);
+const app = await readFile(new URL("web/js/app.js", akar), "utf8");
+const api = await readFile(new URL("web/js/api.js", akar), "utf8");
+
+const awal = app.indexOf("async function layarInputPos()");
+const layar = app.slice(awal, app.indexOf("\nasync function ", awal + 10));
+
+
+test("empat saringan, dengan kode yang dipakai logikanya", () => {
+  assert.ok(awal > 0, "layarInputPos tidak ditemukan");
+  for (const [kode, label] of [
+    ["belum-input", "Belum Input"],
+    ["belum-foto", "Belum Foto"],
+    ["lengkap", "Lengkap"],
+    ["semua", "Semua"],
+  ]) {
+    assert.match(layar, new RegExp(`kode: "${kode}", label: "${label}" \}`));
+  }
+
+  // Tanpa `pendek` yang isinya sama dengan `label`: kedua span dibaca pembaca
+  // layar, jadi label kembar terdengar dua kali.
+  assert.doesNotMatch(layar, /label: "Belum Input", pendek:/);
+  assert.doesNotMatch(layar, /label: "Belum Foto", pendek:/);
+  // Nama lama tidak boleh tertinggal: logikanya sudah tidak mengenalinya, dan
+  // tombol yang kodenya tidak dikenal menyaring menjadi NOL baris tanpa galat.
+  assert.doesNotMatch(layar, /kode: "sudah"/);
+  assert.doesNotMatch(layar, /kode: "belum",/);
+});
+
+
+test("Lengkap menuntut nilai DAN foto", () => {
+  // Kalau ia cuma menuntut nilainya, regu yang fotonya kurang berdiri di
+  // "Belum Foto" dan di "Lengkap" sekaligus — dua label yang saling
+  // membantah tentang regu yang sama.
+  assert.match(layar, /: lengkap\(tr\) && !\(fotoTahu && fotoKurang\)/);
+});
+
+
+test("status foto yang TIDAK terbaca tidak dianggap tidak ada", () => {
+  // null = belum diketahui. Tanda "" pada baris, dan kedua saringan berhenti
+  // menilai fotonya alih-alih menuduh.
+  assert.match(layar, /fotoLembarPos\(pos\.nomor\)\.catch\(\(\) => null\)/);
+  assert.match(layar, /if \(fotoPos === null\) return "";/);
+  assert.match(layar, /const fotoTahu = tr\.dataset\.fotoKurang !== ""/);
+});
+
+
+test("yang dihitung kurang adalah LOMBA, bukan kolom penilaian", () => {
+  // Satu slip satu lomba (bagian 11.6): Pembidaian lima kriteria berbagi satu
+  // kertas dan satu kode_lomba. Menghitung per kolom menuntut lima foto untuk
+  // satu kertas.
+  assert.match(layar, /const lombaPos = kelompokLomba\(kolom\)/);
+  assert.match(layar, /lombaPos\.some\(l =>\s*\n\s*l\.kolom\.some\(kol => varianUntuk\(kol, r\.golongan\)\) && !punya\.has\(l\.kode\)\)/);
+});
+
+
+test("lomba yang tidak berlaku untuk golongannya tidak dituntut fotonya", () => {
+  // Regu Penggalang tidak pernah punya slip Tebak Simpul Penegak.
+  assert.match(layar, /l\.kolom\.some\(kol => varianUntuk\(kol, r\.golongan\)\)/);
+});
+
+
+test("foto sepos diambil SEKALI, bukan per baris", () => {
+  // Ratusan permintaan di jaringan pos yang sering putus adalah cara paling
+  // mudah membuat layar tersibuk terasa rusak.
+  assert.match(api, /export async function fotoLembarPos\(pos\)/);
+  assert.match(api, /v_foto_lembar\?pos=eq\.\$\{encodeURIComponent\(pos\)\}&select=nomor_dada,kode_lomba/);
+  // `path` tidak ikut: yang ditanya cuma ADA atau TIDAK.
+  assert.doesNotMatch(api,
+    /fotoLembarPos[\s\S]{0,400}select=nomor_dada,kode_lomba,path/);
+});
+
+
+test("penanda foto disegarkan sesudah dialog foto ditutup", () => {
+  // Di dalamnya foto bisa diunggah atau dihapus. Penanda yang tidak ikut
+  // berubah membuat saringan berbohong tentang pekerjaan yang baru selesai.
+  assert.match(layar, /bukaFoto\(b\.closest\("tr"\)\)\.then\(segarkanFoto\)/);
+  assert.match(layar, /const segarkanFoto = async \(\) =>/);
+  // Saringan yang SEDANG menyala ikut diterapkan ulang.
+  assert.match(layar, /terapkanSaringan\(\);/);
+  assert.match(app, /const terapkanSaringan = pasangAlatTabel\(/);
+  assert.match(app, /  return jalan;\r?\n\}/);
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -802,6 +802,21 @@ export async function daftarFotoLembar(pos, nomorDada) {
     `&select=*&order=diunggah_pada.desc`);
 }
 
+/** Foto slip SELURUH regu di satu pos, sekali ambil.
+ *
+ *  Dipakai saringan "Belum Foto" di layar Input Pos. Menanyakannya per baris
+ *  berarti ratusan permintaan di jaringan pos yang memang sering putus —
+ *  satu permintaan berisi dua kolom jauh lebih murah daripada 300 permintaan
+ *  berisi semuanya.
+ *
+ *  `path` sengaja TIDAK diambil: yang ditanya saringan cuma ADA atau TIDAK,
+ *  dan path adalah bagian paling gemuk dari barisnya. */
+export async function fotoLembarPos(pos) {
+  if (K.mode === "dev") return baca(`/foto-lembar-pos?pos=${encodeURIComponent(pos)}`);
+  return baca(null,
+    `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}&select=nomor_dada,kode_lomba`);
+}
+
 /** Link sementara untuk melihat satu foto. Bucket-nya privat, jadi tidak ada
  *  URL tetap — dan itu memang yang diinginkan: link yang tidak kedaluwarsa
  *  akan beredar di WhatsApp selamanya. Satu jam cukup untuk melihatnya. */

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -21,7 +21,7 @@ import {
   batasNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
-  unggahFotoLembar, daftarFotoLembar, tautanFoto, klasemenLiveScore,
+  unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto, klasemenLiveScore,
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
   statusAcara, bolehLihat, lengkapiHakSesi,
   aturFaseLive,
@@ -823,6 +823,11 @@ function pasangAlatTabel(gambar) {
     }));
   inp.focus();
   jalan();
+  // Dikembalikan supaya pemanggil bisa menerapkan ulang saringan yang SEDANG
+  // menyala sesudah datanya berubah di belakang layar — tanpa itu, baris yang
+  // baru saja difoto tetap duduk di daftar "Belum Foto" sampai ada yang
+  // menyentuh saringannya.
+  return jalan;
 }
 
 /** Filter bersama: kode pembayaran, nama sekolah, atau nama salah satu regu
@@ -3369,11 +3374,17 @@ async function layarInputPos() {
   // Gagal membacanya tidak boleh menghalangi apa pun: nol berarti lembar
   // dicetak apa adanya, tanpa baris kosong penambal.
   let batasStok = 0;
+  /* null = status fotonya TIDAK diketahui, dan itu berbeda dari "tidak ada
+     foto". Kalau permintaannya gagal — pos memang sering kehilangan sinyal —
+     menandai semua baris "belum foto" akan menuduh ratusan regu sekaligus.
+     Yang benar: berhenti menilai fotonya, dan katakan begitu di saringannya. */
+  let fotoPos = null;
   try {
-    [komponen, lembar, batasStok] = await Promise.all([
+    [komponen, lembar, batasStok, fotoPos] = await Promise.all([
       komponenPos(EDISI.nomor, pos.nomor),
       lembarPos(pos.nomor),
       batasNomorDada().catch(() => 0),
+      fotoLembarPos(pos.nomor).catch(() => null),
     ]);
   } catch (e) {
     LAYAR.replaceChildren(kartuGagalMuat(e.message, layarInputPos)); return;
@@ -3451,9 +3462,22 @@ async function layarInputPos() {
         // panjang terpotong di tengah kata — yang justru lebih buruk daripada
         // petunjuk singkat, karena terlihat seperti layar yang rusak.
         cariContoh: "Cari nomor dada / regu / organisasi…",
+        /* Empat saringan, dan keduanya yang "belum" TIDAK saling meniadakan:
+           satu regu bisa belum diinput DAN belum difoto, lalu muncul di
+           kedua-duanya. Itu benar — ini pandangan, bukan kotak yang harus
+           berisi tepat satu kali tiap regu.
+
+           "Lengkap" menuntut KEDUANYA: nilai penuh dan foto penuh. Kalau ia
+           cuma menuntut nilainya, regu yang fotonya kurang akan berdiri di
+           "Belum Foto" dan di "Lengkap" sekaligus — dua label yang saling
+           membantah tentang regu yang sama. */
         saringan: [
-          { kode: "belum", label: "Belum lengkap", pendek: "Belum" },
-          { kode: "sudah", label: "Sudah lengkap", pendek: "Sudah" },
+          // Tanpa `pendek`: keempat labelnya sudah dua kata, dan `pendek` yang
+          // isinya sama persis dengan `label` cuma menggandakan teksnya bagi
+          // pembaca layar — yang dibaca kedua span, bukan yang terlihat.
+          { kode: "belum-input", label: "Belum Input" },
+          { kode: "belum-foto", label: "Belum Foto" },
+          { kode: "lengkap", label: "Lengkap" },
           { kode: "semua", label: "Semua" },
         ],
         saringAktif: "semua",
@@ -3498,10 +3522,38 @@ async function layarInputPos() {
     </div>
   `));
 
+  /* ---------- status foto per regu ----------
+
+     Satu slip = satu LOMBA (bagian 11.6), bukan satu penilaian: Pembidaian
+     lima kriteria berbagi satu kertas dan satu `kode_lomba`. Jadi yang
+     dihitung kurang di sini lomba, bukan kolom.
+
+     Lomba yang komponennya tidak berlaku untuk golongan regu itu TIDAK ikut
+     dituntut — regu Penggalang tidak pernah punya slip Tebak Simpul Penegak,
+     dan menuduhnya belum foto adalah alarm yang tidak bisa dipenuhi siapa
+     pun. */
+  const lombaPos = kelompokLomba(kolom);
+  const fotoPunya = new Map();
+  (fotoPos || []).forEach(f => {
+    const dada = Number(f.nomor_dada);
+    if (!fotoPunya.has(dada)) fotoPunya.set(dada, new Set());
+    fotoPunya.get(dada).add(f.kode_lomba);
+  });
+
+  /** "1" kurang, "0" lengkap, "" belum diketahui (permintaannya gagal). */
+  const tandaFoto = (r) => {
+    if (fotoPos === null) return "";
+    const punya = fotoPunya.get(Number(r.nomor_dada)) || new Set();
+    const kurang = lombaPos.some(l =>
+      l.kolom.some(kol => varianUntuk(kol, r.golongan)) && !punya.has(l.kode));
+    return kurang ? "1" : "0";
+  };
+
   const tbody = document.getElementById("isi-tabel");
   tbody.replaceChildren(h(lembar.map(r => `
     <tr data-dada="${esc(r.nomor_dada)}" data-terisi="${esc(r.jumlah_terisi)}"
         data-golongan="${esc(r.golongan)}" data-komponen="${esc(r.jumlah_komponen)}"
+        data-foto-kurang="${tandaFoto(r)}"
         data-terkunci="${r.terkunci ? "1" : ""}">
       <td class="angka text-center" data-label="Nomor Dada">${esc(dada3(r.nomor_dada))}</td>
       <td data-label="Nama Regu"><strong>${esc(r.nama_regu)}</strong></td>
@@ -3529,9 +3581,34 @@ async function layarInputPos() {
      berbeda dengan gembok dan penanda simpan, yang berganti rupa mengikuti
      keadaan barisnya. Menempelkan ~300 pendengar untuk tombol yang tidak
      pernah berubah adalah ongkos yang tidak dibayar apa-apa. */
+  /** Baca ulang status foto sepos, lalu tandai ulang tiap baris.
+   *
+   *  Dipanggil sesudah dialog foto ditutup: di dalamnya foto bisa diunggah
+   *  atau dihapus, dan penanda yang tidak ikut berubah membuat saringan
+   *  "Belum Foto" berbohong tentang pekerjaan yang baru saja selesai. */
+  const segarkanFoto = async () => {
+    let baru;
+    try { baru = await fotoLembarPos(pos.nomor); }
+    catch { return; }   // pos sering kehilangan sinyal; penanda lama dibiarkan
+    if (location.hash !== layarIni) return;
+    fotoPos = baru;
+    fotoPunya.clear();
+    baru.forEach(f => {
+      const dada = Number(f.nomor_dada);
+      if (!fotoPunya.has(dada)) fotoPunya.set(dada, new Set());
+      fotoPunya.get(dada).add(f.kode_lomba);
+    });
+    [...tbody.children].forEach(tr => {
+      tr.dataset.fotoKurang = tandaFoto({
+        nomor_dada: tr.dataset.dada, golongan: tr.dataset.golongan,
+      });
+    });
+    terapkanSaringan();
+  };
+
   tbody.addEventListener("click", (e) => {
     const b = e.target.closest("[data-foto]");
-    if (b) bukaFoto(b.closest("tr"));
+    if (b) bukaFoto(b.closest("tr")).then(segarkanFoto);
   });
 
   /* ---------- keadaan simpan per baris ----------
@@ -4484,10 +4561,18 @@ async function layarInputPos() {
   document.getElementById("cetak-per-lomba")
     .addEventListener("click", () => cetak(true));
 
-  pasangAlatTabel((cari, saring) => {
+  const terapkanSaringan = pasangAlatTabel((cari, saring) => {
     [...tbody.children].forEach(tr => {
-      const lolosSaring = saring === "semua"
-        || (saring === "sudah" ? lengkap(tr) : !lengkap(tr));
+      // `fotoKurang` kosong berarti BELUM DIKETAHUI, bukan lengkap: saringan
+      // "Belum Foto" lalu tidak menuduh siapa pun, dan "Lengkap" berhenti
+      // menilai fotonya alih-alih menyatakan lengkap tanpa dasar.
+      const fotoKurang = tr.dataset.fotoKurang === "1";
+      const fotoTahu = tr.dataset.fotoKurang !== "";
+      const lolosSaring =
+        saring === "semua" ? true
+        : saring === "belum-input" ? !lengkap(tr)
+        : saring === "belum-foto" ? fotoKurang
+        : lengkap(tr) && !(fotoTahu && fotoKurang);
       tr.hidden = !(cocok(tr, cari) && lolosSaring);
     });
     hitungUlangJumlah();


### PR DESCRIPTION
## What

Saringan layar Input Pos: **Belum lengkap · Sudah lengkap · Semua** → **Belum Input · Belum Foto · Lengkap · Semua**.

- `fotoLembarPos(pos)` di api.js — foto seluruh regu di satu pos, sekali ambil, dua kolom.
- Tiap baris ditandai `data-foto-kurang`, dan penandanya disegarkan sesudah dialog foto ditutup.

## Why

Ini gap yang saya sebut waktu menilai permintaan Rekapitulasi: **tidak ada satu pun tempat yang menjawab "regu mana saja yang fotonya kurang".** Satu-satunya jalan adalah membuka dialog foto per regu, satu per satu. Sekarang jawabannya satu ketukan, di layar tempat orang memang bekerja.

**Yang dihitung kurang adalah LOMBA, bukan kolom penilaian.** Satu slip satu lomba (pasal 11.6): Pembidaian lima kriteria berbagi satu kertas dan satu `kode_lomba`. Menghitung per kolom akan menuntut lima foto untuk satu kertas yang sama.

**Lomba yang tidak berlaku untuk golongan regu itu tidak dituntut** — regu Penggalang tidak pernah punya slip Tebak Simpul Penegak, dan menuduhnya belum foto adalah alarm yang tidak bisa dipenuhi siapa pun.

**"Lengkap" menuntut keduanya.** Kalau ia cuma menuntut nilainya, regu yang fotonya kurang berdiri di "Belum Foto" dan di "Lengkap" sekaligus — dua label yang saling membantah tentang regu yang sama.

## Notes

**Gagalnya tidak dianggap "tidak ada foto".** Pos memang sering kehilangan sinyal. Kalau permintaan fotonya gagal, statusnya **belum diketahui**: penandanya kosong, "Belum Foto" tidak menuduh siapa pun, dan "Lengkap" berhenti menilai fotonya. Menandai semua baris kurang akan menuduh ratusan regu sekaligus — dan reaksi paling mungkin terhadap alarm yang tidak bisa dipenuhi adalah berhenti memercayai alarmnya. Ini pelajaran dari #600, dan kali ini saya pasang sejak awal.

**Satu permintaan per pos, bukan per baris.** `path` sengaja tidak diambil: yang ditanya saringan cuma ADA atau TIDAK, dan path adalah bagian paling gemuk dari barisnya.

## Verifikasi lokal

Diukur di browser, 50 regu di Pos 1, foto disemai supaya dada 001 lengkap kelima lomba dan 002 baru dua:

| Saringan | Ditampilkan |
| --- | --- |
| Semua | 50/50 |
| Belum Input | 15/50 |
| Belum Foto | 49/50 |
| Lengkap | **1/50** (dada 001 — nilai penuh dan foto penuh) |

**Jalur gagal**, dengan permintaan foto sengaja ditolak:

| | |
| --- | --- |
| Layar | tetap hidup, 50 baris |
| Penanda | `""` (belum diketahui) |
| Belum Foto | 0 — tidak menuduh siapa pun |
| Lengkap | 35 — berhenti menilai foto |

| Perintah | Hasil |
| --- | --- |
| `node --test tests/*.test.mjs` | 176 pass, 0 fail (7 tes baru) |
| `periksa_impor` / `periksa_urutan_golongan` | bersih |
| `diff` empat berkas bersama `web/` vs `live/` | sama |

`tests/run.sh` tidak dijalankan: PR ini tidak menyentuh SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
