### PR TITLE
feat: pencarian sekolah per kata, bukan per potongan

### DIFF
--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -14,9 +14,16 @@ daftarnya, **bagian 12** untuk jebakan waktu memasangnya ke database.
 ## 1. Kenapa daftar ini ada
 
 Form pendaftaran memuat autocomplete sekolah yang berjalan **di browser**:
-seluruh tabel `sekolah` dimuat sekali, lalu disaring dengan
-`SEKOLAH.filter(...)` (`live/js/daftar.js`). Instan, tanpa permintaan server
-per huruf.
+seluruh tabel `sekolah` dimuat sekali, lalu disaring dengan `cariSekolah()`
+(`live/js/school-search.mjs`, dipanggil dari `live/js/daftar.js`). Instan,
+tanpa permintaan server per huruf.
+
+Penyaringnya **per kata, bukan per potongan**: tiap kata yang diketik cukup
+jadi awalan salah satu kata di nama sekolah, jadi "SMA 2" menemukan
+"SMAN 2 Ciamis". Sampai 27 Agustus 2026 ia menuntut ketikan menjadi potongan
+utuh dari namanya — dan huruf `N` yang tidak diucapkan siapa pun membuat
+sekolah yang jelas-jelas ada di daftar seolah tidak terdaftar. Yang lahir dari
+situ baris kembar, yang persis dicegah seluruh runbook ini.
 
 Isinya sekolah yang **benar-benar pernah ikut HRCD**, dan itulah gunanya —
 mereka yang diprioritaskan diundang lagi tahun berikutnya. Pembina yang

--- a/live/_headers
+++ b/live/_headers
@@ -36,7 +36,7 @@
 #
 # Jadi tiap jenis berkas menyebut aturannya sendiri. Halaman HTML disebut
 # empat kali karena Workers menyajikan satu berkas di dua alamat: `/` dan
-# `/index.html`, `/daftar` dan `/daftar.html`. Isi folder ini cuma sebelas
+# `/index.html`, `/daftar` dan `/daftar.html`. Isi folder ini cuma dua belas
 # berkas — menyebutkannya satu per satu lebih murah daripada satu aturan
 # menyapu yang diam-diam merusak aturan lain.
 # ============================================================================
@@ -65,6 +65,15 @@
   Content-Type: application/json; charset=utf-8
 
 /*.js
+  Cache-Control: no-cache
+  Content-Type: text/javascript; charset=utf-8
+
+# `.mjs` disebut sendiri karena `/*.js` TIDAK mengenainya — pola Cloudflare
+# mencocokkan akhiran nama berkas, dan "school-search.mjs" tidak berakhir
+# ".js". Tanpa baris ini modul pencarian sekolah memakai header bawaan, jadi
+# perbaikan mendadak pada pagi hari-H bisa tertutup salinan lama di HP yang
+# sudah pernah membuka form.
+/*.mjs
   Cache-Control: no-cache
   Content-Type: text/javascript; charset=utf-8
 

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -18,6 +18,7 @@
 import { daftarSekolah, kirimPendaftaran, infoEdisi, namaReguDipakai, ErrorApi } from "./api.js";
 import { esc, h, html, rupiah, notif, kartuGagalMuat,
          pemuat, biayaRegu, totalBiaya } from "./util.js";
+import { cariSekolah, kunciSekolah } from "./school-search.mjs";
 
 const LAYAR = document.getElementById("layar");
 const GOLONGAN = [
@@ -105,28 +106,13 @@ const totalRincian = () => Object.values(jawab.rincian).reduce((a, b) => a + b, 
 const internal = () => jawab.jenis_peserta === "internal";
 
 const golonganForm = () => internal() ? GOLONGAN_INTERNAL : GOLONGAN;
-/* Penyamaan untuk PENCARIAN sekolah, bukan untuk menyimpan.
- *
- *  Pembina mengetik nama yang dia ucapkan, bukan nama yang tertulis di
- *  Dapodik. "MAS Agro" harus tetap menemukan "MA Agrowisata Shaleha" —
- *  huruf S di "MAS" itu status Swasta, bukan bagian nama, dan tidak ada
- *  seorang pun yang menyebutnya.
- *
- *  Urutannya penting: huruf statusnya dibuang SELAGI spasinya masih ada.
- *  Versi lama langsung membuang seluruh non-huruf, jadi "MAS Agro" jadi
- *  "masagro" dan tidak pernah cocok dengan "maagrowisatashaleha" — sekolahnya
- *  seolah tidak terdaftar, dan pembina mendaftarkannya lagi sebagai baris
- *  baru.
- *
- *  Aturannya sama dengan kunci_sekolah() di database (migrasi 0062), dan
- *  memang harus sama: yang satu memutuskan apa yang TERLIHAT saat mencari,
- *  yang satu memutuskan apa yang dianggap SEKOLAH YANG SAMA saat menyimpan. */
-const normal = s => String(s || "").toLowerCase()
-  // "SMP Negeri 1" dan "SMP N 1" adalah "SMPN 1".
-  .replace(/\b(sd|smp|sma|smk|mi|mts|ma)\s+n(egeri)?\b/g, "$1n")
-  // Huruf status Dapodik di awal nama: MAS, SMKS, SMAS, SMPS, MTsS, MIS.
-  .replace(/^\s*(sd|smp|sma|smk|mi|mts|ma)s\b/, "$1")
-  .replace(/[^a-z0-9]/g, "");
+/* Pencocokan nama sekolah pindah ke school-search.mjs — aturannya panjang,
+ *  murni perhitungan, dan sekarang punya tesnya sendiri
+ *  (tests/school_search.test.mjs). Yang perlu diingat di sini cuma bahwa ada
+ *  DUA fungsi dan keduanya tidak boleh tertukar (CLAUDE.md 12.10):
+ *  `cariSekolah()` memutuskan apa yang TERLIHAT saat mencari, `kunciSekolah()`
+ *  memutuskan apa yang dianggap SEKOLAH YANG SAMA — dan yang kedua harus tetap
+ *  sama persis dengan kunci_sekolah() di database.                          */
 const labelGolongan = k => golonganForm().find(g => g.kode === k)?.label
   ?? [...GOLONGAN, ...GOLONGAN_INTERNAL].find(g => g.kode === k).label;
 
@@ -336,9 +322,7 @@ function gambarSekolah() {
   const saran = document.getElementById("saran");
 
   cari.addEventListener("input", () => {
-    const q = normal(cari.value.trim());
-    if (q.length < 2) { saran.hidden = true; return; }
-    const cocok = SEKOLAH.filter(s => normal(s.name).includes(q)).slice(0, 6);
+    const cocok = cariSekolah(SEKOLAH, cari.value, 6);
     saran.hidden = cocok.length === 0;
     saran.replaceChildren(...cocok.map(s => {
       const b = document.createElement("button");
@@ -382,7 +366,7 @@ function gambarSekolah() {
   function gambarManual() {
     const teks = cari.value.trim();
     if (teks.length < 3) { document.getElementById("manual").replaceChildren(); return; }
-    if (SEKOLAH.some(s => normal(s.name) === normal(teks))) {
+    if (SEKOLAH.some(s => kunciSekolah(s.name) === kunciSekolah(teks))) {
       document.getElementById("manual").replaceChildren(); return;
     }
     if (document.getElementById("m-alamat")) return;    // sudah tergambar
@@ -422,7 +406,8 @@ function gambarSekolah() {
 }
 
 function sekolahInternal() {
-  const tersimpan = SEKOLAH.find(s => normal(s.name) === normal(SEKOLAH_INTERNAL.nama));
+  const tersimpan = SEKOLAH.find(
+    s => kunciSekolah(s.name) === kunciSekolah(SEKOLAH_INTERNAL.nama));
   return tersimpan
     ? { id: tersimpan.id, nama: tersimpan.name, alamat: tersimpan.address }
     : { ...SEKOLAH_INTERNAL };

--- a/live/js/school-search.mjs
+++ b/live/js/school-search.mjs
@@ -1,0 +1,195 @@
+/* ============================================================================
+   hrcd-rekap : school-search.mjs — pencocokan nama sekolah untuk autocomplete
+   form pendaftaran.
+
+   Murni perhitungan: tidak membaca DOM dan tidak memanggil server. Karena itu
+   aturan yang sama bisa diuji di Node dan dipakai `daftar.js`.
+
+   KENAPA BUKAN `includes()` LAGI
+
+   Sampai 27 Agustus 2026 pencariannya satu baris: nama sekolah dan ketikan
+   sama-sama dirapatkan jadi satu kata tanpa spasi, lalu `includes()`. Bentuk
+   itu menuntut ketikan menjadi POTONGAN UTUH dari namanya, dan pembina tidak
+   mengetik begitu — dilaporkan dari lapangan:
+
+       ketik "SMA 2"  ->  "sma2"        (ketikan)
+                          "sman2ciamis" (SMAN 2 Ciamis di database)
+
+   `"sman2ciamis".includes("sma2")` bernilai false karena satu huruf `n` di
+   tengah, jadi sekolahnya seolah tidak terdaftar — dan pembina mendaftarkan
+   ulang sebagai baris baru. Persis itu yang terjadi: `sma 2 ciamis` dengan
+   alamat `jl ahmad yani` sekarang duduk di sebelah `SMAN 2 Ciamis`, dan baris
+   kembar memecah pencarian, rekap, dan identitas pendaftaran (CLAUDE.md 12.9).
+
+   Huruf `N` itu justru yang paling sering hilang: orang menyebut sekolahnya
+   "SMA 2", bukan "SMA Negeri 2". Yang salah bukan ketikannya — yang salah
+   pencarian yang menuntut ketikan berurutan huruf demi huruf.
+
+   GANTINYA: PER KATA, BUKAN PER POTONGAN
+
+   Ketikan dipecah jadi kata, dan tiap kata cukup jadi AWALAN salah satu kata
+   di nama sekolah. "sma" adalah awalan "sman", jadi "sma 2" menemukan
+   "SMAN 2 Ciamis" tanpa satu pun aturan khusus tentang huruf N.
+
+   DUA KUNCI, DAN JANGAN TERTUKAR (CLAUDE.md 12.10)
+
+   - `kunciSekolah()` menjawab "ini sekolah yang SAMA?" dan harus sama persis
+     dengan `kunci_sekolah()` di database (migrasi 0062). Sengaja jinak.
+   - `cariSekolah()` menjawab "ini yang mungkin DIMAKSUD?" dan boleh jauh
+     lebih longgar: hasilnya cuma daftar saran yang dibaca manusia, dan yang
+     dipilih tetap baris database beserta id-nya.
+
+   Melonggarkan yang pertama akan melebur dua sekolah yang berbeda. Yang kedua
+   paling buruk memunculkan satu saran yang tidak diklik siapa pun.
+   ========================================================================== */
+
+/** Ketikan sependek ini menyaring terlalu sedikit: satu huruf mencocokkan
+ *  ratusan sekolah, dan daftar saran yang panjang sama tidak bergunanya
+ *  dengan daftar yang kosong. */
+const MIN_KETIKAN = 2;
+
+/** Kata yang seluruhnya angka: nomor sekolah, dan itu dicocokkan utuh. */
+const ANGKA = /^[0-9]+$/;
+
+/**
+ * Penyamaan untuk MENYIMPAN — cerminan `kunci_sekolah()` di database.
+ *
+ * Urutan penggantinya ikut dicerminkan, bukan cuma hasilnya: huruf status
+ * Dapodik dibuang SELAGI spasinya masih ada, karena `^(sma)s\b` tidak akan
+ * pernah cocok kalau spasinya sudah lebih dulu dirapatkan.
+ *
+ * Yang disamakan cuma yang PASTI sama: besar-kecil huruf, tanda baca, bentuk
+ * "Negeri", dan huruf status Swasta. `SMAT` (Terpadu) dan `SMAI` (Islam)
+ * sengaja dibiarkan — membuang T dari "SMA Terpadu X" akan menyamakannya
+ * dengan "SMA X", dan itu bisa saja dua sekolah yang berbeda.
+ */
+export function kunciSekolah(nama) {
+  return String(nama ?? "").toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    // "SMP Negeri 1" dan "SMP N 1" adalah "SMPN 1".
+    .replace(/\b(sd|smp|sma|smk|mi|mts|ma)\s+n(egeri)?\b/g, "$1n")
+    // Huruf status Dapodik di AWAL nama: SMKS, SMAS, SMPS, MAS, MTsS, MIS.
+    // "S" itu Swasta — status, bukan nama.
+    .replace(/^(sd|smp|sma|smk|mi|mts|ma)s\b/, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Kata-kata untuk PENCARIAN.
+ *
+ * Sama dengan `kunciSekolah()`, ditambah satu hal: angka dipisahkan dari
+ * huruf. "SMAN2" yang diketik tanpa spasi jadi kata yang sama dengan
+ * "SMAN 2", dan angkanya bisa dibandingkan sebagai angka utuh — tanpa itu
+ * "sman2" tidak akan pernah cocok dengan "sman 2 ciamis".
+ */
+export function kataSekolah(teks) {
+  return kunciSekolah(teks)
+    .replace(/([a-z])([0-9])/g, "$1 $2")
+    .replace(/([0-9])([a-z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean);
+}
+
+/**
+ * Seberapa jauh sebuah nama sekolah dari ketikannya.
+ *
+ * Kecil berarti mirip; `-1` berarti tidak cocok sama sekali. Angkanya cuma
+ * dipakai untuk MENGURUTKAN saran, jadi yang penting arahnya, bukan skalanya:
+ *
+ *   0  tiap kata yang diketik ada persis di namanya
+ *   1  per kata yang cuma jadi awalan  ("sma" -> "sman")
+ *   2  per kata yang justru LEBIH PANJANG daripada kata di namanya
+ *      (hanya kalau kata di namanya minimal tiga huruf)
+ *
+ * Yang ketiga terbalik dari yang kedua dan tetap dihitung cocok, karena
+ * database sudah terlanjur memuat baris yang ditulis lebih pendek daripada
+ * nama resminya. Pembina yang mengetik "SMAN 2 Ciamis" dengan benar tetap
+ * harus melihat baris `sma 2 ciamis` yang sudah ada — kalau tidak, ia
+ * membuat baris kembar yang KETIGA. Ia diberi skor lebih besar supaya duduk
+ * di bawah yang ejaannya benar.
+ *
+ * Satu kata di nama sekolah hanya boleh dipakai satu kali, supaya ketikan
+ * "ciamis ciamis" tidak cocok dengan "SMAN 1 Ciamis".
+ *
+ * ANGKA DICOCOKKAN UTUH, huruf boleh sepotong. Nomor sekolah adalah namanya,
+ * bukan awalan namanya: "SMAN 18 Garut" bukan jawaban atas ketikan "sman 1",
+ * dan "SMAN 1 Ciamis" bukan jawaban atas "sman 18". Tanpa aturan ini satu
+ * ketikan "sman 1" memenuhi keenam baris saran dengan SMAN 10 sampai SMAN 18.
+ */
+export function skorSekolah(ketikan, nama) {
+  const dicari = kataSekolah(ketikan);
+  const dimiliki = kataSekolah(nama);
+  if (!dicari.length) return -1;
+
+  const terpakai = dimiliki.map(() => false);
+  let skor = 0;
+
+  for (const kata of dicari) {
+    if (ANGKA.test(kata)) {
+      const keAngka = dimiliki.findIndex((k, i) => !terpakai[i] && k === kata);
+      if (keAngka < 0) return -1;
+      terpakai[keAngka] = true;
+      continue;
+    }
+
+    // Tiga putaran, dari yang paling meyakinkan ke yang paling longgar, dan
+    // urutannya yang membuat skornya jujur: pada "MA Mandiri", ketikan "man"
+    // harus mendarat di "mandiri" (awalan, skor 1), bukan di "ma" (terbalik,
+    // skor 2) — dan yang belakangan juga akan memakai habis kata "ma" yang
+    // mungkin masih dibutuhkan kata berikutnya.
+    //
+    // Serakah, tanpa mundur mencoba pasangan lain. Yang dipertaruhkan cuma
+    // urutan enam baris saran, dan backtracking penuh menukar itu dengan kode
+    // yang tidak bisa dibaca sekali lewat.
+    let ke = dimiliki.findIndex((k, i) => !terpakai[i] && k === kata);
+    let tambah = 0;
+    if (ke < 0) {
+      ke = dimiliki.findIndex((k, i) => !terpakai[i] && k.startsWith(kata));
+      tambah = 1;
+    }
+    if (ke < 0) {
+      // Kata pendek TIDAK boleh dicocokkan terbalik. Tanpa batas ini
+      // "nurul" mencocokkan "NU" pada "SMK Ma'arif NU Ciamis", dan dua
+      // baris saran dihabiskan sekolah yang jelas bukan itu — "al", "it",
+      // "bp", "nu" ada di belasan nama. Tiga huruf adalah yang terpendek
+      // yang masih menyebut sesuatu: "sma" pada `sma 2 ciamis`.
+      ke = dimiliki.findIndex(
+        (k, i) => !terpakai[i] && k.length >= 3 && kata.startsWith(k));
+      tambah = 2;
+    }
+    if (ke < 0) return -1;
+    terpakai[ke] = true;
+    skor += tambah;
+  }
+  return skor;
+}
+
+/**
+ * Saran sekolah untuk ketikan, sudah terurut: yang paling mirip di atas.
+ *
+ * Seri diputus oleh panjang nama. Alasannya sederhana: kalau "sman 1" cocok
+ * dengan "SMAN 1 Ciamis" dan "SMAN 1 Cijeungjing", yang lebih pendek adalah
+ * yang lebih sedikit menambahkan kata yang tidak diketik siapa pun.
+ *
+ * @param {Array<{name?: string, nama?: string}>} daftar seluruh tabel sekolah
+ * @param {string} ketikan apa yang sedang diketik pembina
+ * @param {number} maks jumlah saran yang digambar
+ */
+export function cariSekolah(daftar, ketikan, maks = 6) {
+  const kata = kataSekolah(ketikan);
+  if (kata.join("").length < MIN_KETIKAN) return [];
+
+  return (daftar ?? [])
+    .map(sekolah => ({ sekolah, skor: skorSekolah(ketikan, sekolah.name ?? sekolah.nama) }))
+    .filter(x => x.skor >= 0)
+    .sort((a, b) => a.skor - b.skor
+      || namaSekolah(a.sekolah).length - namaSekolah(b.sekolah).length
+      || namaSekolah(a.sekolah).localeCompare(namaSekolah(b.sekolah)))
+    .slice(0, maks)
+    .map(x => x.sekolah);
+}
+
+/** Baris database memakai `name`; isian manual di form memakai `nama`. Sudah
+ *  begitu sejak migrasi 0014 dan keduanya memang beredar bersama. */
+const namaSekolah = s => String(s.name ?? s.nama ?? "");

--- a/tests/school_search.test.mjs
+++ b/tests/school_search.test.mjs
@@ -1,0 +1,198 @@
+// ============================================================================
+// hrcd-rekap : tests/school_search.test.mjs
+//
+// AUTOCOMPLETE SEKOLAH HARUS MENEMUKAN NAMA YANG DIUCAPKAN, BUKAN YANG DITULIS
+// DAPODIK.
+//
+// Dilaporkan dari lapangan 27 Agustus 2026: pembina mengetik "SMA 2",
+// "SMAN 2 Ciamis" tidak muncul, dan ia mendaftarkan sekolahnya sendiri sebagai
+// `sma 2 ciamis` — baris kembar untuk sekolah yang sudah ada di daftar kurasi.
+//
+// Sebabnya pencarian lama menuntut ketikan menjadi potongan utuh dari namanya:
+// "sma2" bukan potongan dari "sman2ciamis" karena satu huruf `n` di tengah.
+// Huruf itulah yang paling sering tidak diucapkan.
+//
+// Kembar bukan kerapian: ia memecah pencarian, rekap, dan identitas
+// pendaftaran (CLAUDE.md 12.9), dan yang membuatnya lahir adalah pencarian
+// yang gagal — bukan pembina yang ceroboh.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { cariSekolah, kunciSekolah, skorSekolah } from "../live/js/school-search.mjs";
+
+const modul = await readFile(
+  new URL("../live/js/school-search.mjs", import.meta.url), "utf8");
+const migrasi0062 = await readFile(
+  new URL("../supabase/migrations/0062_sekolah_nama_dapodik.sql", import.meta.url), "utf8");
+const daftarJs = await readFile(
+  new URL("../live/js/daftar.js", import.meta.url), "utf8");
+
+// Nama sungguhan dari daftar kurasi (migrasi 0063), ditambah satu baris kembar
+// yang benar-benar ada di produksi sekarang.
+const SEKOLAH = [
+  { id: 1, name: "SMAN 2 Ciamis", address: "Jl. KH. Ahmad Dahlan No. 2, Ciamis" },
+  { id: 2, name: "SMAN 2 Banjarsari", address: "Cigayam, Banjaranyar" },
+  { id: 3, name: "SMAN 1 Ciamis", address: "Jl. Gunung Galuh No. 37, Ciamis" },
+  { id: 4, name: "SMPN 1 Ciamis", address: "Jl. Jenderal Sudirman, Ciamis" },
+  { id: 5, name: "SMPN 2 Ciamis", address: "Jl. Kertasari, Ciamis" },
+  { id: 6, name: "MAN 2 Ciamis", address: "Jl. Cigembor, Ciamis" },
+  { id: 7, name: "MA Agrowisata Shaleha", address: "Cisaga, Ciamis" },
+  { id: 8, name: "SMK Galuh Rahayu", address: "Sindangkasih, Ciamis" },
+  { id: 9, name: "SMA Islam Nurul Fikri", address: "Ciamis" },
+  { id: 10, name: "SMAN 18 Garut", address: "Garut" },
+  { id: 11, name: "MTsN 2 Ciamis", address: "Jl. Kertasari, Ciamis" },
+  // Di luar Ciamis, dan memang tidak ada di daftar kurasi. Ia ada di sini
+  // karena disebut waktu perbaikan ini dilaporkan: bentuk rapat tanpa spasi
+  // harus ikut jalan untuk sekolah mana pun, bukan cuma yang lokal.
+  { id: 12, name: "SMAN 3 Yogyakarta", address: "Yogyakarta" },
+  { id: 13, name: "sma 2 ciamis", address: "jl ahmad yani" },   // kembar, buatan pembina
+];
+
+const nama = daftar => daftar.map(s => s.name);
+
+test('"SMA 2" menemukan SMAN 2 Ciamis', () => {
+  // Laporan aslinya, huruf per huruf. Kalau tes ini gugur, pencariannya
+  // kembali menuntut huruf N yang tidak diucapkan siapa pun.
+  assert.ok(nama(cariSekolah(SEKOLAH, "sma 2")).includes("SMAN 2 Ciamis"),
+    "ketikan yang persis dilaporkan dari lapangan masih tidak menemukannya");
+});
+
+test("huruf N boleh hilang di mana saja", () => {
+  for (const [ketik, harap] of [
+    ["sma 2 ciamis", "SMAN 2 Ciamis"],
+    ["smp 1 ciamis", "SMPN 1 Ciamis"],
+    ["ma 2 ciamis",  "MAN 2 Ciamis"],
+    ["sma 18",       "SMAN 18 Garut"],
+  ])
+    assert.ok(nama(cariSekolah(SEKOLAH, ketik)).includes(harap),
+      `"${ketik}" tidak menemukan ${harap}`);
+});
+
+test("nama yang ditulis rapat tanpa spasi tetap ketemu", () => {
+  // Diketik di HP, dan spasi adalah yang pertama hilang. Angka yang menempel
+  // di huruf dipisahkan lebih dulu, jadi "SMP1Ciamis" dibaca "smp 1 ciamis".
+  for (const [ketik, harap] of [
+    ["SMP1Ciamis", "SMPN 1 Ciamis"],
+    ["SMA3Yogya",  "SMAN 3 Yogyakarta"],
+    ["MA2Ciamis",  "MAN 2 Ciamis"],
+    ["MTS2CIAMIS", "MTsN 2 Ciamis"],
+    ["MA 2Ciamis", "MAN 2 Ciamis"],
+  ])
+    assert.equal(cariSekolah(SEKOLAH, ketik)[0].name, harap,
+      `"${ketik}" tidak menaruh ${harap} di urutan pertama`);
+});
+
+test("bentuk panjang, singkat, dan tanpa spasi sama saja", () => {
+  for (const ketik of ["SMA Negeri 2 Ciamis", "SMA N 2 Ciamis", "sman2ciamis",
+                       "SMAN 2 CIAMIS", "sman 2, ciamis"])
+    assert.equal(cariSekolah(SEKOLAH, ketik)[0].name, "SMAN 2 Ciamis",
+      `"${ketik}" tidak menaruh SMAN 2 Ciamis di urutan pertama`);
+});
+
+test("huruf status Dapodik tetap diabaikan", () => {
+  // Sudah benar sejak migrasi 0062 dan tidak boleh hilang saat pencariannya
+  // ditulis ulang: S di "MAS" berarti Swasta, bukan bagian nama.
+  assert.ok(nama(cariSekolah(SEKOLAH, "MAS Agro")).includes("MA Agrowisata Shaleha"));
+  assert.ok(nama(cariSekolah(SEKOLAH, "SMKS Galuh")).includes("SMK Galuh Rahayu"));
+});
+
+test("kata boleh diketik sebagian dan tidak harus berurutan", () => {
+  assert.ok(nama(cariSekolah(SEKOLAH, "nurul fik")).includes("SMA Islam Nurul Fikri"));
+  assert.ok(nama(cariSekolah(SEKOLAH, "ciamis sman 2")).includes("SMAN 2 Ciamis"));
+});
+
+test("ejaan yang benar tetap memunculkan baris kembar yang sudah ada", () => {
+  // Justru ini yang menahan kembar KETIGA: pembina yang mengetik nama resmi
+  // harus melihat baris `sma 2 ciamis` yang sudah terlanjur ada, walau ia
+  // duduk di bawah yang ejaannya benar.
+  const hasil = nama(cariSekolah(SEKOLAH, "SMAN 2 Ciamis"));
+  assert.equal(hasil[0], "SMAN 2 Ciamis");
+  assert.ok(hasil.includes("sma 2 ciamis"), "baris kembar tidak ikut muncul");
+});
+
+test("yang ejaannya persis duduk di atas yang cuma seawalan", () => {
+  assert.equal(cariSekolah(SEKOLAH, "sman 1 ciamis")[0].name, "SMAN 1 Ciamis");
+  assert.equal(cariSekolah(SEKOLAH, "smpn 2")[0].name, "SMPN 2 Ciamis");
+});
+
+test("angka tidak cocok sebagian", () => {
+  // "SMAN 18 Garut" bukan jawaban untuk "sman 1", dan sebaliknya. Nomor
+  // sekolah adalah angka utuh, bukan awalan.
+  assert.ok(!nama(cariSekolah(SEKOLAH, "sman 1")).includes("SMAN 18 Garut"));
+  assert.ok(!nama(cariSekolah(SEKOLAH, "sman 18")).includes("SMAN 1 Ciamis"));
+});
+
+test("sekolah yang tidak dimaksud tidak ikut muncul", () => {
+  assert.deepEqual(cariSekolah(SEKOLAH, "sman 3 tasikmalaya"), []);
+  assert.ok(!nama(cariSekolah(SEKOLAH, "sma 2 ciamis")).includes("SMPN 2 Ciamis"));
+});
+
+test("satu kata nama hanya dipakai satu kali", () => {
+  assert.equal(skorSekolah("ciamis ciamis", "SMAN 2 Ciamis"), -1);
+});
+
+test("ketikan sependek satu huruf tidak menyarankan apa pun", () => {
+  // Daftar 189 sekolah yang muncul semua sama tidak bergunanya dengan daftar
+  // kosong, dan ia menutupi kartu "sekolahmu belum ada di daftar".
+  assert.deepEqual(cariSekolah(SEKOLAH, "s"), []);
+  assert.deepEqual(cariSekolah(SEKOLAH, " "), []);
+  assert.deepEqual(cariSekolah(SEKOLAH, ""), []);
+});
+
+test("jumlah saran dibatasi", () => {
+  assert.equal(cariSekolah(SEKOLAH, "ciamis", 6).length, 6);
+  assert.equal(cariSekolah(SEKOLAH, "ciamis", 3).length, 3);
+});
+
+// ---------------------------------------------------------------------------
+// kunciSekolah() adalah cermin kunci_sekolah() di database, dan cermin yang
+// menyimpang lebih buruk daripada tidak ada cermin: form akan menganggap dua
+// nama sama sementara database membuat baris kedua, atau sebaliknya.
+// ---------------------------------------------------------------------------
+
+test("kunciSekolah menyamakan yang PASTI sama", () => {
+  const sama = (a, b) => assert.equal(kunciSekolah(a), kunciSekolah(b), `${a} != ${b}`);
+  sama("SMP Negeri 1 Ciamis", "SMPN 1 Ciamis");
+  sama("SMP N 1 Ciamis", "SMPN 1 Ciamis");
+  sama("SMKS Galuh Rahayu", "SMK Galuh Rahayu");
+  sama("MAS Al-Kautsar", "MA Al Kautsar");
+  sama("SMAN 2 CIAMIS", "sman 2 ciamis");
+});
+
+test("kunciSekolah TIDAK menyamakan yang cuma mirip", () => {
+  const beda = (a, b) => assert.notEqual(kunciSekolah(a), kunciSekolah(b), `${a} = ${b}`);
+  // SMAT/SMAI sengaja dibiarkan (migrasi 0062): membuang T dari "SMA Terpadu
+  // X" akan menyamakannya dengan "SMA X", dan itu bisa dua sekolah berbeda.
+  beda("SMAT Riyadlul Ulum", "SMA Riyadlul Ulum");
+  beda("SMAN 2 Ciamis", "SMAN 2 Banjarsari");
+  // Longgarnya pencarian tidak boleh menular ke kunci penyimpanan: "SMA 2"
+  // yang diketik sendiri memang baris lain sampai ada yang menggabungkannya.
+  beda("SMA 2 Ciamis", "SMAN 2 Ciamis");
+});
+
+test("kunciSekolah memakai aturan yang sama persis dengan migrasi 0062", () => {
+  // Daftar jenjangnya yang paling mudah menyimpang — satu jenjang baru
+  // ditambahkan di satu sisi saja dan tidak ada yang gagal sampai ada yang
+  // mengetiknya.
+  const jenjang = teks => [...teks.matchAll(/\(sd\|smp\|sma\|smk\|mi\|mts\|ma\)/g)].length;
+  assert.equal(jenjang(migrasi0062), 2, "migrasi 0062 bukan lagi bentuk yang dicerminkan");
+  assert.equal(jenjang(modul), 2, "school-search.mjs tidak lagi memakai dua aturan yang sama");
+  assert.ok(migrasi0062.includes("n(egeri)?") && modul.includes("n(egeri)?"),
+    'aturan "Negeri" hilang dari salah satu sisi');
+  // Batas kata di ujung huruf status ditulis berbeda di kedua bahasa: \y di
+  // PostgreSQL, \b di JavaScript. Yang harus sama artinya, bukan hurufnya.
+  assert.ok(migrasi0062.includes("ma)s\\y") && modul.includes("ma)s\\b"),
+    "aturan huruf status Dapodik hilang dari salah satu sisi");
+});
+
+test("form pendaftaran benar-benar memakai modulnya", () => {
+  // Modul yang benar tapi tidak dipanggil sama saja dengan tidak ada — dan
+  // itu tidak menggagalkan apa pun sampai ada yang mengetik di layar.
+  assert.match(daftarJs, /import \{ cariSekolah, kunciSekolah \} from "\.\/school-search\.mjs";/);
+  assert.match(daftarJs, /const cocok = cariSekolah\(SEKOLAH, cari\.value, 6\);/);
+  assert.doesNotMatch(daftarJs, /normal\(s\.name\)\.includes\(/,
+    "pencarian potongan utuh yang lama masih terpasang");
+});

--- a/tools/periksa_impor.py
+++ b/tools/periksa_impor.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         ("web/js/app.js", "web/js/util.js", "./util.js"),
         ("live/js/daftar.js", "live/js/api.js", "./api.js"),
         ("live/js/daftar.js", "live/js/util.js", "./util.js"),
+        ("live/js/daftar.js", "live/js/school-search.mjs", "./school-search.mjs"),
         ("live/live.js", "live/js/util.js", "./js/util.js"),
     ]
     gagal = []


### PR DESCRIPTION
## What

Autocomplete sekolah di form pendaftaran sekarang mencocokkan **per kata**, bukan menuntut ketikan menjadi potongan utuh dari nama sekolah.

- Tiap kata yang diketik cukup jadi **awalan** salah satu kata di nama sekolah — "sma" cocok dengan "sman".
- Angka yang menempel di huruf dipisahkan lebih dulu: `SMP1Ciamis` dibaca `smp 1 ciamis`.
- Angka dicocokkan **utuh**: `sman 1` tidak memunculkan SMAN 18, dan sebaliknya.
- Saran diurutkan: yang ejaannya persis di atas yang cuma seawalan.
- Aturannya pindah ke `live/js/school-search.mjs` (murni perhitungan, bisa diuji di Node), dengan 17 tes baru di `tests/school_search.test.mjs`.

Yang sekarang ketemu, dan sebelumnya tidak:

| Ketik | Hasil |
| --- | --- |
| `SMA 2` | SMAN 2 Ciamis |
| `SMP1Ciamis` | SMPN 1 Ciamis |
| `MA2Ciamis` | MAN 2 Ciamis |
| `SMA3Yogya` | SMAN 3 Yogyakarta |
| `MTS2CIAMIS` | MTsN 2 Ciamis |

## Why

Dilaporkan dari lapangan: pembina mengetik "SMA 2", SMAN 2 Ciamis tidak muncul, lalu ia mendaftarkan sekolahnya sendiri. Baris `sma 2 ciamis` beralamat `jl ahmad yani` sekarang benar-benar duduk di sebelah SMAN 2 Ciamis di produksi.

Sebabnya pencarian lama merapatkan ketikan dan nama jadi satu kata lalu `includes()`. `"sman2ciamis".includes("sma2")` bernilai false karena satu huruf `n` di tengah — dan huruf N itu yang paling sering tidak diucapkan siapa pun. Yang lahir dari situ baris kembar, yang memecah pencarian, rekap, dan identitas pendaftaran (CLAUDE.md 12.9).

Dua kuncinya sengaja dipisah tegas (CLAUDE.md 12.10): `cariSekolah()` boleh longgar karena hasilnya cuma saran yang dibaca manusia dan yang dipilih tetap baris database beserta id-nya; `kunciSekolah()` tetap cerminan persis `kunci_sekolah()` migrasi 0062 karena ia yang memutuskan dua nama itu satu baris atau dua. Satu tes membandingkan kedua sisi langsung ke berkas migrasinya.

## Notes

- Dijalankan lokal: `node --test tests/*.test.mjs` (192 lulus), `python tools/periksa_impor.py`, `periksa_sekolah.py`, `periksa_urutan_golongan.py`.
- Diperiksa juga di browser sungguhan terhadap daftar sekolah produksi, bukan cuma lewat tes: ketik "sma 2" → SMAN 2 Ciamis muncul.
- Tidak ada migrasi. Sisi database tidak disentuh sama sekali.
- **Masih tersisa pekerjaan data**: baris kembar `sma 2 ciamis` sudah terlanjur ada di produksi dan harus digabungkan ke `SMAN 2 Ciamis`. Perbaikan ini menahan kembar berikutnya, tidak menghapus yang sudah ada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)