### PR TITLE
feat: pencarian sekolah mengenali singkatan yang dirapatkan

### DIFF
--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -20,7 +20,9 @@ tanpa permintaan server per huruf.
 
 Penyaringnya **per kata, bukan per potongan**: tiap kata yang diketik cukup
 jadi awalan salah satu kata di nama sekolah, jadi "SMA 2" menemukan
-"SMAN 2 Ciamis". Sampai 27 Agustus 2026 ia menuntut ketikan menjadi potongan
+"SMAN 2 Ciamis". Satu kata ketikan juga boleh merapatkan beberapa kata
+sekaligus — "Almut" menemukan "SMA Al-Muttaqin" — karena nama di daftar ini
+penuh partikel dua huruf yang tidak pernah diberi jeda waktu diucapkan. Sampai 27 Agustus 2026 ia menuntut ketikan menjadi potongan
 utuh dari namanya — dan huruf `N` yang tidak diucapkan siapa pun membuat
 sekolah yang jelas-jelas ada di daftar seolah tidak terdaftar. Yang lahir dari
 situ baris kembar, yang persis dicegah seluruh runbook ini.

--- a/live/js/school-search.mjs
+++ b/live/js/school-search.mjs
@@ -99,6 +99,7 @@ export function kataSekolah(teks) {
  *
  *   0  tiap kata yang diketik ada persis di namanya
  *   1  per kata yang cuma jadi awalan  ("sma" -> "sman")
+ *   1  per kata yang merapatkan beberapa kata  ("almut" -> "Al-Muttaqin")
  *   2  per kata yang justru LEBIH PANJANG daripada kata di namanya
  *      (hanya kalau kata di namanya minimal tiga huruf)
  *
@@ -149,6 +150,19 @@ export function skorSekolah(ketikan, nama) {
       tambah = 1;
     }
     if (ke < 0) {
+      // Singkatan yang MERAPATKAN kata berurutan: "Almut" untuk
+      // "SMA Al-Muttaqin", "arrahman" untuk "MA Terpadu Ar-Rahman". Nama
+      // sekolah di sini penuh partikel dua huruf — al, ar, as, el, nu —
+      // dan yang menyebutnya tidak pernah memberi jeda di situ.
+      const rentang = rentangGabungan(dimiliki, terpakai, kata);
+      if (rentang) {
+        for (let i = rentang[0]; i <= rentang[1]; i++) terpakai[i] = true;
+        skor += 1;
+        continue;
+      }
+    }
+
+    if (ke < 0) {
       // Kata pendek TIDAK boleh dicocokkan terbalik. Tanpa batas ini
       // "nurul" mencocokkan "NU" pada "SMK Ma'arif NU Ciamis", dan dua
       // baris saran dihabiskan sekolah yang jelas bukan itu — "al", "it",
@@ -163,6 +177,30 @@ export function skorSekolah(ketikan, nama) {
     skor += tambah;
   }
   return skor;
+}
+
+/**
+ * Rentang kata BERURUTAN yang, kalau dirapatkan, diawali `kata`.
+ *
+ * Minimal dua kata: yang satu kata sudah diurus aturan awalan biasa, dan
+ * membiarkannya di sini cuma menduakan jawaban yang sama.
+ *
+ * Yang dipakai habis seluruh rentangnya, bukan kata pertamanya saja — huruf
+ * "muttaqin" memang ikut terketik di dalam "almut", jadi ia tidak boleh
+ * dipakai lagi oleh kata berikutnya.
+ *
+ * @returns {[number, number] | null} indeks awal dan akhir, keduanya inklusif
+ */
+function rentangGabungan(dimiliki, terpakai, kata) {
+  for (let awal = 0; awal < dimiliki.length; awal++) {
+    if (terpakai[awal]) continue;
+    let gabung = dimiliki[awal];
+    for (let akhir = awal + 1; akhir < dimiliki.length && !terpakai[akhir]; akhir++) {
+      gabung += dimiliki[akhir];
+      if (gabung.startsWith(kata)) return [awal, akhir];
+    }
+  }
+  return null;
 }
 
 /**

--- a/tests/school_search.test.mjs
+++ b/tests/school_search.test.mjs
@@ -42,6 +42,8 @@ const SEKOLAH = [
   { id: 7, name: "MA Agrowisata Shaleha", address: "Cisaga, Ciamis" },
   { id: 8, name: "SMK Galuh Rahayu", address: "Sindangkasih, Ciamis" },
   { id: 9, name: "SMA Islam Nurul Fikri", address: "Ciamis" },
+  { id: 14, name: "SMA Al-Muttaqin", address: "Jl. A. Yani No. 140, Tasikmalaya" },
+  { id: 15, name: "MA Terpadu Ar-Rahman", address: "Nasol, Cikoneng" },
   { id: 10, name: "SMAN 18 Garut", address: "Garut" },
   { id: 11, name: "MTsN 2 Ciamis", address: "Jl. Kertasari, Ciamis" },
   // Di luar Ciamis, dan memang tidak ada di daftar kurasi. Ia ada di sini
@@ -97,6 +99,26 @@ test("huruf status Dapodik tetap diabaikan", () => {
   // ditulis ulang: S di "MAS" berarti Swasta, bukan bagian nama.
   assert.ok(nama(cariSekolah(SEKOLAH, "MAS Agro")).includes("MA Agrowisata Shaleha"));
   assert.ok(nama(cariSekolah(SEKOLAH, "SMKS Galuh")).includes("SMK Galuh Rahayu"));
+});
+
+test("singkatan yang merapatkan kata tetap ketemu", () => {
+  // Nama sekolah di sini penuh partikel dua huruf — al, ar, as, el — dan
+  // yang menyebutnya tidak pernah memberi jeda di situ. "Almut" adalah cara
+  // orang menyebut SMA Al-Muttaqin, bukan salah ketik.
+  for (const [ketik, harap] of [
+    ["Almut",      "SMA Al-Muttaqin"],
+    ["almuttaqin", "SMA Al-Muttaqin"],
+    ["arrahman",   "MA Terpadu Ar-Rahman"],
+    ["nurulfik",   "SMA Islam Nurul Fikri"],
+  ])
+    assert.equal(cariSekolah(SEKOLAH, ketik)[0].name, harap,
+      `"${ketik}" tidak menaruh ${harap} di urutan pertama`);
+});
+
+test("kata rapat tidak boleh memakai kata yang sudah terpakai", () => {
+  // Seluruh rentangnya ikut dipakai habis: huruf "muttaqin" memang terketik
+  // di dalam "almut", jadi ketikan berikutnya tidak boleh memakainya lagi.
+  assert.equal(skorSekolah("almut muttaqin", "SMA Al-Muttaqin"), -1);
 });
 
 test("kata boleh diketik sebagian dan tidak harus berurutan", () => {


### PR DESCRIPTION
## What

Satu kata ketikan sekarang boleh merapatkan beberapa kata nama sekolah sekaligus — cocok kalau ia jadi awalan gabungannya.

| Ketik | Dulu | Sekarang |
| --- | --- | --- |
| `Almut` | kosong | SMA Al-Muttaqin |
| `arrahman` | kosong | MA Terpadu Ar-Rahman, MTs Ar-Rahman |
| `alkautsar` | kosong | MA Al-Kautsar |
| `elbas` | kosong | MA El-Bas, MTs El-Bas |
| `arrisalah` | kosong | SMA Terpadu Ar-Risalah, SMP Terpadu Ar-Risalah |
| `riyadlululum` | kosong | SMA Terpadu Riyadlul Ulum |

## Why

Dilaporkan menyusul #607: pencocokan per kata menuntut ketikan jadi awalan **satu** kata, sedangkan "almut" memotong di tengah kata kedua.

Bukan kebetulan semua contoh di atas berbentuk sama: nama sekolah di daftar ini penuh partikel dua huruf — `al`, `ar`, `as`, `el`, `nu` — dan yang menyebutnya tidak pernah memberi jeda di situ. Tanda hubungnya sendiri sudah hilang lebih dulu di `kunciSekolah()`, jadi "Al-Muttaqin" memang sudah jadi dua kata sebelum dicocokkan.

Seluruh rentang yang dipakai ditandai terpakai, bukan kata pertamanya saja — huruf "muttaqin" ikut terketik di dalam "almut", jadi ketikan berikutnya tidak boleh memakainya lagi. Ada tesnya (`skorSekolah("almut muttaqin", ...)` harus `-1`).

## Notes

- Dijalankan lokal: `node --test tests/*.test.mjs` (194 lulus).
- Dicoba juga terhadap **seluruh 190 baris sekolah produksi**, bukan cuma fixture tes — tidak ada ketikan yang jadi menyapu daftar.
- Tidak ada migrasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)