### PR TITLE
fix: ringkasan Pengaturan Kloter mendatar, planning rata tengah

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -322,6 +322,58 @@ input.jam-ketik {
   letter-spacing: .08em;
   text-align: center;
 }
+/* Ringkasan Pengaturan Kloter: empat angka MENDATAR.
+
+   Keempat kolomnya dipatok 25% di bawah `table-layout: fixed` — kolom yang
+   tidak dipatok mendapat NOL, bukan sisanya (pasal 15.3), dan kolom yang
+   lebarnya ikut isinya membuat "Intern" jauh lebih sempit daripada "Total
+   Kloter" sehingga angkanya tidak lagi berjarak sama.
+
+   Rantai anak, bukan selektor keturunan (pasal 15.5): kartu ini tidak
+   bersarang hari ini, dan aturan yang menganggap itu selamanya adalah
+   aturan yang bocor pada perubahan berikutnya.
+
+   Garis bawah baris angkanya dibuang: tabel ini bukan daftar yang dibaca
+   baris demi baris, dan satu garis di bawah empat angka membelah kartu tepat
+   di tempat yang tidak perlu dibelah. */
+.table-ringkas-kloter { table-layout: fixed; }
+.table-ringkas-kloter > thead > tr > th,
+.table-ringkas-kloter > tbody > tr > td {
+  text-align: center;
+  padding-left: .25rem; padding-right: .25rem;
+}
+.table-ringkas-kloter > thead > tr > th { width: 25%; }
+.table-ringkas-kloter > tbody > tr > td { border-bottom: 0; }
+/* Di HP keempat label harus muat DALAM kolomnya, bukan cuma di dalam kartu.
+   Diukur pada iframe 360px: kartu 345px, kolom 76,5px, dan "EKSTERNAL" dengan
+   ukuran kepala biasa selebar 79,9px — ia meluap 11px ke luar kotaknya lalu
+   menempel pada "INTERN" di sebelahnya, jadi keduanya terbaca sebagai satu
+   kata. Tidak ada penggulir mendatar yang menandainya; yang terlihat cuma dua
+   label yang berdempetan.
+
+   Yang dipangkas ukuran huruf DAN letter-spacing kepala tabel — .04em pada
+   sembilan huruf sendirian sudah 5px. Hasilnya "EKSTERNAL" ~63px di kotak
+   68,5px. */
+@media (max-width: 640px) {
+  .table-ringkas-kloter > thead > tr > th {
+    font-size: .72rem;
+    letter-spacing: 0;
+  }
+}
+
+/* Planning Berangkat: label dan kotak jamnya rata TENGAH, bukan rata kiri.
+
+   Kartunya berisi tabel angka yang rata kanan lalu dua tombol Cetak selebar
+   setengah kartu, dan dua kotak jam yang menggantung di tepi kiri kolomnya
+   membentuk tepi keempat yang tidak sejajar dengan satu pun di antaranya.
+   Ditengahkan, keduanya duduk tepat di atas tombol yang mencetaknya.
+
+   Hanya di sini. Kotak jam lain — Keberangkatan, Kedatangan, dialog koreksi —
+   berdiri di sebelah teks yang rata kiri, dan menengahkan yang di sana justru
+   melepasnya dari barisnya. */
+.planning-jam { text-align: center; }
+.planning-jam .field label { text-align: center; }
+
 /* Merah dipasang di WADAH, bukan salah satu kotak: yang salah adalah jamnya
    sebagai satu kesatuan. Menyalahkan kotak menit untuk "jam 25" menyuruh
    petugas membetulkan tempat yang keliru. */

--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -114,9 +114,23 @@ test("layar planning tanpa judul dan tanpa paragraf penjelas", () => {
 });
 
 
-test("jumlah Eksternal dan Intern tetap ada, sebagai baris tabel", () => {
-  assert.match(layar, /<td>Eksternal<\/td><td class="angka">\$\{jumlahEksternal\}<\/td>/);
-  assert.match(layar, /<td>Intern<\/td><td class="angka">\$\{jumlahIntern\}<\/td>/);
+test("jumlah Eksternal dan Intern tetap ada, sebagai kolom mendatar", () => {
+  // Yang dijaga ANGKANYA tetap terbit, bukan bentuk tabelnya: keempatnya
+  // dibalik jadi mendatar 27 Agustus 2026 supaya kotak jam dan tombol Cetak
+  // di bawahnya tidak terdorong keluar layar HP.
+  assert.match(layar, /<th>Eksternal<\/th><th>Intern<\/th>/);
+  assert.match(layar, /<td class="angka">\$\{jumlahEksternal\}<\/td>/);
+  assert.match(layar, /<td class="angka">\$\{jumlahIntern\}<\/td>/);
+  // Kepala kolom dan angkanya harus berurutan sama. Tertukar, "Eksternal 0
+  // Intern 6" terbaca meyakinkan dan salah total.
+  const kepala = layar.match(/<th>Total Kloter<\/th>[\s\S]*?<\/tr>/)[0];
+  const isi = layar.match(/<tbody>[\s\S]*?<\/tbody>/)[0];
+  assert.deepEqual(
+    [...kepala.matchAll(/<th>([^<]+)<\/th>/g)].map(m => m[1]),
+    ["Total Kloter", "Total Regu", "Eksternal", "Intern"]);
+  assert.deepEqual(
+    [...isi.matchAll(/\$\{(\w+)/g)].map(m => m[1]),
+    ["perKloter", "baris", "jumlahEksternal", "jumlahIntern"]);
 });
 
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2019,15 +2019,30 @@ async function layarCetakKloter() {
 
   LAYAR.replaceChildren(h(`
     <div class="card" style="border-color:var(--utama)">
-      <!-- Eksternal dan Intern jadi BARIS TABEL, bukan kalimat. Angkanya
-           yang dicari, dan tabel yang sudah ada di sini adalah tempat angka.
-           Sebagai paragraf ia memakan sepertiga layar HP untuk mengulang
-           "Total Kloter" yang tercetak dua baris di atasnya. -->
-      <table class="table">
-        <tr><td>Total Kloter</td><td class="angka">${perKloter.size}</td></tr>
-        <tr><td>Total Regu</td><td class="angka">${baris.length}</td></tr>
-        <tr><td>Eksternal</td><td class="angka">${jumlahEksternal}</td></tr>
-        <tr><td>Intern</td><td class="angka">${jumlahIntern}</td></tr>
+      <!-- Empat angka MENDATAR: label jadi kepala kolom, angkanya satu baris
+           di bawahnya. Sebagai empat baris ia memakan setengah layar HP untuk
+           empat angka yang cuma dilirik — dan yang dicari di bawahnya, kotak
+           jam dan tombol Cetak, terdorong keluar layar.
+
+           Tetap tabel, bukan grid: kepala kolom table th sudah membawa
+           bentuk label yang dipakai tabel lain di layar ini, dan angkanya
+           tetap sel angka yang sama. (Tanpa backtick: seluruh markup ini
+           duduk di dalam template literal.) -->
+      <table class="table table-ringkas-kloter">
+        <thead>
+          <tr>
+            <th>Total Kloter</th><th>Total Regu</th>
+            <th>Eksternal</th><th>Intern</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="angka">${perKloter.size}</td>
+            <td class="angka">${baris.length}</td>
+            <td class="angka">${jumlahEksternal}</td>
+            <td class="angka">${jumlahIntern}</td>
+          </tr>
+        </tbody>
       </table>
       <!-- Planning berdiri DI ATAS tombol cetak, dan urutan itu berarti:
            yang tercetak adalah jam yang baru saja diatur di sini. Menaruhnya
@@ -2040,7 +2055,7 @@ async function layarCetakKloter() {
            dan kalimat "jam ini dibagi rata lalu tercetak untuk peserta"
            menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah
            sekali (pasal 9.1 dan 9.6). -->
-      <div class="two-column" style="margin-top:1rem">
+      <div class="two-column planning-jam" style="margin-top:1rem">
         <div class="field">
           <label for="planning-pertama-hh">Planning Berangkat Pertama</label>
           ${kotakJamHtml("planning-pertama", jamPendek(

--- a/web/style.css
+++ b/web/style.css
@@ -322,6 +322,58 @@ input.jam-ketik {
   letter-spacing: .08em;
   text-align: center;
 }
+/* Ringkasan Pengaturan Kloter: empat angka MENDATAR.
+
+   Keempat kolomnya dipatok 25% di bawah `table-layout: fixed` — kolom yang
+   tidak dipatok mendapat NOL, bukan sisanya (pasal 15.3), dan kolom yang
+   lebarnya ikut isinya membuat "Intern" jauh lebih sempit daripada "Total
+   Kloter" sehingga angkanya tidak lagi berjarak sama.
+
+   Rantai anak, bukan selektor keturunan (pasal 15.5): kartu ini tidak
+   bersarang hari ini, dan aturan yang menganggap itu selamanya adalah
+   aturan yang bocor pada perubahan berikutnya.
+
+   Garis bawah baris angkanya dibuang: tabel ini bukan daftar yang dibaca
+   baris demi baris, dan satu garis di bawah empat angka membelah kartu tepat
+   di tempat yang tidak perlu dibelah. */
+.table-ringkas-kloter { table-layout: fixed; }
+.table-ringkas-kloter > thead > tr > th,
+.table-ringkas-kloter > tbody > tr > td {
+  text-align: center;
+  padding-left: .25rem; padding-right: .25rem;
+}
+.table-ringkas-kloter > thead > tr > th { width: 25%; }
+.table-ringkas-kloter > tbody > tr > td { border-bottom: 0; }
+/* Di HP keempat label harus muat DALAM kolomnya, bukan cuma di dalam kartu.
+   Diukur pada iframe 360px: kartu 345px, kolom 76,5px, dan "EKSTERNAL" dengan
+   ukuran kepala biasa selebar 79,9px — ia meluap 11px ke luar kotaknya lalu
+   menempel pada "INTERN" di sebelahnya, jadi keduanya terbaca sebagai satu
+   kata. Tidak ada penggulir mendatar yang menandainya; yang terlihat cuma dua
+   label yang berdempetan.
+
+   Yang dipangkas ukuran huruf DAN letter-spacing kepala tabel — .04em pada
+   sembilan huruf sendirian sudah 5px. Hasilnya "EKSTERNAL" ~63px di kotak
+   68,5px. */
+@media (max-width: 640px) {
+  .table-ringkas-kloter > thead > tr > th {
+    font-size: .72rem;
+    letter-spacing: 0;
+  }
+}
+
+/* Planning Berangkat: label dan kotak jamnya rata TENGAH, bukan rata kiri.
+
+   Kartunya berisi tabel angka yang rata kanan lalu dua tombol Cetak selebar
+   setengah kartu, dan dua kotak jam yang menggantung di tepi kiri kolomnya
+   membentuk tepi keempat yang tidak sejajar dengan satu pun di antaranya.
+   Ditengahkan, keduanya duduk tepat di atas tombol yang mencetaknya.
+
+   Hanya di sini. Kotak jam lain — Keberangkatan, Kedatangan, dialog koreksi —
+   berdiri di sebelah teks yang rata kiri, dan menengahkan yang di sana justru
+   melepasnya dari barisnya. */
+.planning-jam { text-align: center; }
+.planning-jam .field label { text-align: center; }
+
 /* Merah dipasang di WADAH, bukan salah satu kotak: yang salah adalah jamnya
    sebagai satu kesatuan. Menyalahkan kotak menit untuk "jam 25" menyuruh
    petugas membetulkan tempat yang keliru. */


### PR DESCRIPTION
## What

Dua perubahan di kartu atas layar Pengaturan Kloter:

1. **Empat angka ringkasan jadi mendatar.** Total Kloter / Total Regu / Eksternal / Intern kini kepala kolom, angkanya satu baris di bawahnya — bukan empat baris tabel.
2. **Planning Berangkat rata tengah.** Label dan kotak jamnya, keduanya.

Ukuran huruf kepala kolom dipangkas di bawah 640px supaya "EKSTERNAL" muat dalam kolomnya.

## Why

Empat baris untuk empat angka yang cuma dilirik memakan setengah layar HP, dan yang benar-benar dipakai — kotak jam dan dua tombol Cetak — terdorong keluar layar.

Kotak jam yang menggantung di tepi kiri kolomnya membentuk tepi keempat yang tidak sejajar dengan apa pun di kartu itu: tabel angkanya rata kanan, tombolnya selebar setengah kartu. Ditengahkan, keduanya duduk tepat di atas tombol yang mencetaknya. Hanya di layar ini — kotak jam Keberangkatan, Kedatangan, dan dialog koreksi berdiri di sebelah teks rata kiri, dan menengahkan yang di sana justru melepasnya dari barisnya.

## Notes

**Diukur, bukan dibaca** (CLAUDE.md 15.9), lewat halaman contoh di dalam iframe (15.10):

| Lebar | Temuan |
| --- | --- |
| 360px | kartu 345px, kolom 76,5px, `EKSTERNAL` **79,9px** — meluap 11px dan menempel pada `INTERN`, tanpa penggulir mendatar yang menandainya |
| 360px sesudah perbaikan | `EKSTERNAL` 63,6px di kotak 68,5px |
| 760px & 360px | tengah kotak jam vs tengah kolomnya: **0,0px**; tidak ada penggulir mendatar |

- `live/style.css` ikut disalin — pasangannya dijaga `shared-files.yml`.
- `node --test tests/*.test.mjs` → 194 lulus. Tes `kloter_departure_label` ikut berubah bentuk tapi tidak melemah: yang dijaga sekarang urutan kepala kolom dan angkanya harus sama, karena tertukar berarti "Eksternal 0 Intern 6" terbaca meyakinkan dan salah total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)