### PR TITLE
feat: dua deret nomor dada, Intern 1001-1250

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0115`.
+Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0116`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-115 migrasi, `0001` sampai `0115`, dijalankan berurutan tanpa lubang penomoran.
+116 migrasi, `0001` sampai `0116`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -686,11 +686,28 @@ export async function lembarPos(pos) {
  *  Dibaca dari stok, bukan dari regu yang sudah terdaftar: stok adalah nomor
  *  dada FISIK yang benar-benar dicetak dan dibawa panitia, dan itulah rentang
  *  yang mungkin muncul di kotak penilaian. */
-export async function batasNomorDada() {
+/** Kedua deret nomor dada, dari `v_rentang_nomor_dada` (migrasi 0116).
+ *
+ *  Kain nomor dada dicetak dua set yang sama-sama mulai dari 001, jadi Intern
+ *  diketik 1001-1250 sementara Eksternal tetap 1-500. Yang dibaca di sini
+ *  UJUNG-UJUNGNYA saja, bukan seluruh 750 baris stok: layar cuma perlu tahu
+ *  nomor mana milik deret mana, dan meja daftar ulang bekerja di jaringan
+ *  yang sama dengan lima pos.
+ *
+ *  Nol berarti deretnya kosong — stok Intern yang belum pernah diisi admin.
+ *  Layar yang memakainya harus tetap jalan dalam keadaan itu, bukan menolak
+ *  semua nomor. */
+export async function rentangNomorDada() {
   const d = K.mode === "dev"
-    ? await baca("/batas-nomor-dada")
-    : await baca(null, "nomor_dada_stok?select=nomor&order=nomor.desc&limit=1");
-  return d.length ? Number(d[0].nomor) : 0;
+    ? await baca("/rentang-nomor-dada")
+    : await baca(null, "v_rentang_nomor_dada?select=*");
+  const r = d[0] || {};
+  return {
+    eksternalMulai: Number(r.eksternal_mulai) || 0,
+    eksternalSampai: Number(r.eksternal_sampai) || 0,
+    internMulai: Number(r.intern_mulai) || 0,
+    internSampai: Number(r.intern_sampai) || 0,
+  };
 }
 
 /** Satu baris saja, dibaca ulang sesudah menyimpan. Nilai Pos yang tampil di

--- a/supabase/migrations/0116_nomor_dada_intern_seribu.sql
+++ b/supabase/migrations/0116_nomor_dada_intern_seribu.sql
@@ -1,0 +1,402 @@
+-- ============================================================================
+-- hrcd-rekap : 0116_nomor_dada_intern_seribu.sql
+-- Dua deret nomor dada: Eksternal 1-500, Intern 1001-1250.
+--
+-- KENAPA
+--
+-- Panitia mencetak kain nomor dada dalam DUA set terpisah, dan keduanya mulai
+-- dari 001. Sampai hari ini sistem memakai satu deret: `regu.nomor_dada`
+-- unique (0001) dan tiap nomor harus ada di `nomor_dada_stok`. Akibatnya meja
+-- daftar ulang Intern akan berhenti di regu pertama dengan
+--
+--     nomor dada sudah dipakai regu lain: 1
+--
+-- Keputusan pemilik acara: nomor dada Intern DIKETIK 1001-1250. Jadi kain
+-- bertulis 001 dicatat sebagai 1001, dan yang tampil di seluruh layar,
+-- kertas, dan papan peserta adalah 1001 — bukan terjemahan yang cuma ada di
+-- satu layar.
+--
+-- KONSEKUENSI YANG HARUS DIKETAHUI PANITIA
+--
+-- Juri di pos menulis nomor dada dengan TANGAN, membaca dari kain di dada
+-- regu. Kain Intern harus ditandai supaya yang tertulis di blangko juga
+-- 1xxx — kalau kainnya polos bertulis 001, blangkonya ambigu dan tidak ada
+-- satu pun baris SQL yang bisa memulihkannya. Migrasi ini menutup jalur
+-- sistemnya, bukan jalur kertasnya.
+--
+-- KENAPA PAKAI DERET, BUKAN KOLOM BARU
+--
+-- Alternatifnya menambah kolom `kelompok` lalu mengganti kunci jadi
+-- (kelompok, nomor). Itu menyentuh 56 tempat di SQL yang mencari
+-- `where nomor_dada = ...`, seluruh layar panitia, dan halaman peserta — dua
+-- hari sebelum lomba. Dengan deret, kuncinya tetap SATU integer unik: unique
+-- constraint, foreign key ke stok, pensiun, foto, dan klasemen tidak berubah
+-- sama sekali. Yang ditambah cuma pagar yang menolak nomor dari deret yang
+-- salah.
+--
+-- BATASNYA KONFIGURASI, BUKAN KONSTANTA
+--
+-- `edisi.nomor_dada_intern_mulai` — alasan yang sama dengan jendela
+-- keberangkatan (CLAUDE.md 10.7): panitia tahun depan boleh mengubahnya tanpa
+-- menyentuh kode. Batas ATASNYA tidak ikut jadi konfigurasi karena sudah ada
+-- yang menyatakannya: `nomor_dada_stok` adalah daftar kain yang benar-benar
+-- dibawa. Dua tempat yang menjawab "sampai berapa" akan berselisih suatu
+-- hari.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Batas deret Intern, per edisi.
+-- ---------------------------------------------------------------------------
+alter table edisi add column if not exists nomor_dada_intern_mulai integer;
+
+update edisi set nomor_dada_intern_mulai = 1001
+ where nomor_dada_intern_mulai is null;
+
+alter table edisi alter column nomor_dada_intern_mulai set default 1001;
+alter table edisi alter column nomor_dada_intern_mulai set not null;
+
+do $blok$
+begin
+  -- `> 1`, bukan `> 0`: deret Eksternal harus punya sisa. Batas 1 membuat
+  -- SELURUH stok jadi milik Intern dan tidak ada satu nomor pun yang sah
+  -- untuk regu Eksternal — pagar yang menolak semua orang.
+  if not exists (select 1 from pg_constraint
+                 where conname = 'edisi_nomor_dada_intern_mulai_check') then
+    alter table edisi add constraint edisi_nomor_dada_intern_mulai_check
+      check (nomor_dada_intern_mulai > 1);
+  end if;
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Stok kain Intern: 1001-1250.
+--
+--    `on conflict do nothing` supaya migrasi ini boleh dijalankan dua kali,
+--    dan supaya ia tidak bertengkar dengan stok yang mungkin sudah diisi
+--    tangan lewat dashboard.
+-- ---------------------------------------------------------------------------
+insert into nomor_dada_stok (nomor)
+select generate_series(1001, 1250)
+on conflict (nomor) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. Satu tempat yang menyatakan kedua deret.
+--
+--    Dipakai layar Daftar Ulang untuk menyusun pesan galat dan menandai kotak
+--    isian, dan layar Input Pos untuk mencetak lembar cadangan hanya pada
+--    nomor yang BENAR-BENAR ada. Tanpa view ini layar harus mengunduh seluruh
+--    750 baris stok cuma untuk tahu ujung-ujungnya.
+--
+--    `security_invoker` supaya RLS `sel_stok` tetap yang memutuskan siapa
+--    boleh membacanya — panitia mana pun boleh, anon tidak.
+-- ---------------------------------------------------------------------------
+create or replace view v_rentang_nomor_dada
+with (security_invoker = true) as
+select
+  e.nomor_dada_intern_mulai as intern_mulai_konfigurasi,
+  (select min(s.nomor) from nomor_dada_stok s
+    where s.nomor < e.nomor_dada_intern_mulai) as eksternal_mulai,
+  (select max(s.nomor) from nomor_dada_stok s
+    where s.nomor < e.nomor_dada_intern_mulai) as eksternal_sampai,
+  (select min(s.nomor) from nomor_dada_stok s
+    where s.nomor >= e.nomor_dada_intern_mulai) as intern_mulai,
+  (select max(s.nomor) from nomor_dada_stok s
+    where s.nomor >= e.nomor_dada_intern_mulai) as intern_sampai
+from edisi e
+where e.is_active;
+
+grant select on v_rentang_nomor_dada to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. Pagarnya, satu fungsi untuk dua pintu.
+--
+--    Ada DUA jalur yang memberi nomor dada ke regu: `daftar_ulang_batch` dan
+--    `tukar_nomor_dada`. Menulis pemeriksaan yang sama dua kali berarti dua
+--    pesan yang lambat laun berbeda bunyinya, dan yang membacanya petugas
+--    yang sedang antre.
+--
+--    Pesannya menyebut RENTANG YANG BENAR, bukan cuma "salah deret". Petugas
+--    yang salah ketik butuh tahu harus mengetik apa, bukan bahwa ia keliru.
+-- ---------------------------------------------------------------------------
+create or replace function pesan_deret_nomor_dada(p_intern boolean)
+returns text
+language sql stable
+set search_path = public
+as $$
+  select format('Nomor dada %s adalah dari %s - %s.',
+                case when p_intern then 'intern' else 'eksternal' end,
+                case when p_intern then r.intern_mulai else r.eksternal_mulai end,
+                case when p_intern then r.intern_sampai else r.eksternal_sampai end)
+  from v_rentang_nomor_dada r;
+$$;
+
+create or replace function nomor_dada_sesuai_deret(p_golongan text, p_nomor integer)
+returns boolean
+language sql stable
+set search_path = public
+as $$
+  -- Sengaja ditulis sebagai perbandingan dua boolean, bukan dua cabang if:
+  -- intern harus di atas batas DAN eksternal harus di bawahnya adalah satu
+  -- aturan yang sama dibaca dari dua arah. Dua cabang membuka kemungkinan
+  -- salah satunya diperbaiki sendirian.
+  select (p_golongan in ('intern_pa', 'intern_pi'))
+       = (p_nomor >= (select nomor_dada_intern_mulai from edisi where is_active));
+$$;
+
+comment on function nomor_dada_sesuai_deret(text, integer) is
+  'Benar bila nomor dada berasal dari deret yang sesuai golongannya: Intern di atas edisi.nomor_dada_intern_mulai, Eksternal di bawahnya.';
+
+-- ---------------------------------------------------------------------------
+-- 5. daftar_ulang_batch — pintu utama.
+--
+--    Seluruh isi fungsi disalin ulang dari 0092; yang baru hanya blok
+--    pemeriksaan deret di antara "sudah dipakai regu lain" dan advisory lock.
+--    Migrasi tidak pernah diedit setelah diterapkan, jadi versi terbaru
+--    sebuah RPC memang selalu berada di berkas bernomor besar.
+-- ---------------------------------------------------------------------------
+create or replace function daftar_ulang_batch(p_kode text, p_nomor jsonb)
+returns table (regu_id uuid, nama_regu text, golongan text, nomor_dada integer, kloter smallint)
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_batch pendaftaran%rowtype;
+  v_berhak uuid[];
+  v_regu uuid[];
+  v_nomor integer[];
+  v_n int;
+  v_cfg edisi%rowtype;
+  v_kandidat smallint;
+  v_i int;
+  v_salah text;
+  v_intern boolean;
+begin
+  if not boleh('daftar_ulang') then raise exception 'tidak berhak: daftar_ulang'; end if;
+  if (select daftar_ulang_ditutup from status_acara) then
+    raise exception 'daftar ulang sudah ditutup';
+  end if;
+
+  select * into v_cfg from edisi where is_active;
+  select * into v_batch from pendaftaran where kode_pembayaran = p_kode for update;
+  if not found then raise exception 'kode pembayaran tidak dikenal: %', p_kode; end if;
+  if v_batch.status <> 'lunas' then
+    raise exception 'batch belum lunas (status: %)', v_batch.status;
+  end if;
+
+  select array_agg(r.id order by r.nama_regu, r.id) into v_berhak
+  from regu r
+  where r.pendaftaran_id = v_batch.id
+    and not r.is_cancelled and r.nomor_dada is null;
+  v_n := coalesce(array_length(v_berhak, 1), 0);
+  if v_n = 0 then
+    raise exception 'tidak ada regu yang menunggu nomor dada di batch ini (sudah daftar ulang, atau semua batal)';
+  end if;
+
+  select array_agg(x.regu_id order by r.nama_regu, r.id),
+         array_agg(x.nomor_dada order by r.nama_regu, r.id)
+    into v_regu, v_nomor
+  from jsonb_to_recordset(coalesce(p_nomor, '[]'::jsonb))
+       as x(regu_id uuid, nomor_dada integer)
+  join regu r on r.id = x.regu_id;
+
+  if coalesce(array_length(v_regu, 1), 0) <> v_n
+     or (select count(distinct g) from unnest(v_regu) t(g)) <> v_n
+     or exists (select 1 from unnest(v_regu) t(g) where not (t.g = any(v_berhak))) then
+    raise exception 'nomor dada harus diisi untuk SEMUA % regu batch ini, satu regu satu nomor', v_n;
+  end if;
+  if exists (select 1 from unnest(v_nomor) t(nomor)
+             where t.nomor is null or t.nomor <= 0) then
+    raise exception 'nomor dada harus angka lebih besar dari 0';
+  end if;
+  if (select count(distinct nomor) from unnest(v_nomor) t(nomor)) <> v_n then
+    raise exception 'nomor dada yang sama diketik untuk dua regu sekaligus';
+  end if;
+
+  perform 1 from nomor_dada_stok s
+  where s.nomor = any(v_nomor) order by s.nomor for update;
+
+  select string_agg(distinct nomor::text, ', ' order by nomor::text) into v_salah
+  from unnest(v_nomor) t(nomor)
+  where not exists (select 1 from nomor_dada_stok s where s.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada di luar stok yang disiapkan admin: %', v_salah;
+  end if;
+  select string_agg(distinct nomor::text, ', ' order by nomor::text) into v_salah
+  from unnest(v_nomor) t(nomor)
+  where exists (select 1 from nomor_dada_pensiun p where p.nomor = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipensiunkan (bekas tukar) dan tidak boleh terbit lagi: %', v_salah;
+  end if;
+  select string_agg(distinct nomor::text, ', ' order by nomor::text) into v_salah
+  from unnest(v_nomor) t(nomor)
+  where exists (select 1 from regu r where r.nomor_dada = t.nomor);
+  if v_salah is not null then
+    raise exception 'nomor dada sudah dipakai regu lain: %', v_salah;
+  end if;
+
+  -- BARU DI 0116. Diperiksa untuk SELURUH baris sekaligus, sama seperti tiga
+  -- pemeriksaan di atasnya: petugas mengisi belasan kotak sebelum menekan
+  -- Simpan, dan menolaknya satu per satu berarti belasan kali bolak-balik.
+  --
+  -- Satu batch selalu satu pendaftaran, dan satu pendaftaran selalu satu
+  -- jenis peserta — jadi dalam praktiknya cuma satu dari dua pesan ini yang
+  -- mungkin muncul. Keduanya tetap ditulis: yang menjaganya golongan REGU,
+  -- bukan jenis pendaftarannya, dan keduanya bisa berbeda kalau golongan
+  -- diperbaiki manual di kemudian hari.
+  for v_intern in select distinct (r.golongan in ('intern_pa', 'intern_pi'))
+                  from unnest(v_regu) t(id) join regu r on r.id = t.id
+  loop
+    select string_agg(distinct x.nomor::text, ', ' order by x.nomor::text) into v_salah
+    from (select v_nomor[i] as nomor,
+                 (select r.golongan from regu r where r.id = v_regu[i]) as golongan
+          from generate_subscripts(v_nomor, 1) i) x
+    where (x.golongan in ('intern_pa', 'intern_pi')) = v_intern
+      and not nomor_dada_sesuai_deret(x.golongan, x.nomor);
+    if v_salah is not null then
+      raise exception '% Nomor % ada di deret yang lain.',
+        pesan_deret_nomor_dada(v_intern), v_salah;
+    end if;
+  end loop;
+
+  -- Gerbang ini membuat urutan transaksi daftar ulang sekaligus urutan kloter.
+  perform pg_advisory_xact_lock(hashtext('hrcd_daftar_ulang'));
+
+  for v_i in 1..v_n loop
+    select r.golongan in ('intern_pa', 'intern_pi') into v_intern
+    from regu r where r.id = v_regu[v_i];
+
+    select k.nomor into v_kandidat
+    from kloter k
+    where k.jam_berangkat is null
+      and k.nomor <= v_cfg.kloter_maks
+      and (select count(*) from regu r
+           where r.kloter_nomor = k.nomor and not r.is_cancelled
+             and (r.golongan in ('intern_pa', 'intern_pi')) = v_intern)
+          < case when v_intern then v_cfg.maks_intern_per_kloter
+                 else v_cfg.maks_eksternal_per_kloter end
+    order by k.nomor
+    limit 1;
+
+    if v_kandidat is null then
+      raise exception 'semua kuota kloter yang belum berangkat penuh — tambah kloter atau periksa konfigurasi';
+    end if;
+
+    update regu set
+      nomor_dada = v_nomor[v_i],
+      kloter_nomor = v_kandidat,
+      urutan_kloter = slot_kloter_berikutnya(v_kandidat)
+    where id = v_regu[v_i];
+  end loop;
+
+  return query
+  select r.id, r.nama_regu, r.golongan, r.nomor_dada, r.kloter_nomor
+  from regu r where r.id = any(v_regu) order by r.nomor_dada;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. tukar_nomor_dada — pintu kedua, dan yang paling mudah terlupa.
+--
+--    Disalin dari 0064; yang baru hanya satu blok. Tanpa ini kain Intern yang
+--    sobek bisa ditukar dengan nomor Eksternal, dan lubang yang baru saja
+--    ditutup terbuka lagi lewat pintu samping.
+-- ---------------------------------------------------------------------------
+create or replace function tukar_nomor_dada(
+  p_regu       uuid,
+  p_nomor_baru integer,
+  p_alasan     text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_regu    regu%rowtype;
+  v_beredar boolean;
+begin
+  if not boleh('daftar_ulang') then
+    raise exception 'tidak berhak: daftar_ulang';
+  end if;
+  if coalesce(trim(p_alasan), '') = '' then
+    raise exception 'alasan tukar wajib diisi';
+  end if;
+
+  select * into v_regu from regu where id = p_regu for update;
+  if not found then
+    raise exception 'regu tidak ditemukan';
+  end if;
+  if v_regu.is_cancelled then
+    raise exception 'regu berstatus batal';
+  end if;
+  if v_regu.nomor_dada is null then
+    raise exception 'regu belum punya nomor dada';
+  end if;
+
+  v_beredar := exists (
+    select 1 from kloter where nomor = v_regu.kloter_nomor
+      and (dicetak_pada is not null or jam_berangkat is not null));
+
+  if not boleh('pengaturan') and v_beredar then
+    raise exception 'kertas kloter ini sudah beredar — tukar nomor hanya lewat admin';
+  end if;
+  if not exists (select 1 from nomor_dada_stok where nomor = p_nomor_baru) then
+    raise exception 'nomor % tidak ada di stok', p_nomor_baru;
+  end if;
+  if exists (select 1 from regu where nomor_dada = p_nomor_baru)
+     or exists (select 1 from nomor_dada_pensiun where nomor = p_nomor_baru) then
+    raise exception 'nomor % sudah terpakai / pensiun', p_nomor_baru;
+  end if;
+
+  -- BARU DI 0116.
+  if not nomor_dada_sesuai_deret(v_regu.golongan, p_nomor_baru) then
+    raise exception '% Nomor % ada di deret yang lain.',
+      pesan_deret_nomor_dada(v_regu.golongan in ('intern_pa', 'intern_pi')),
+      p_nomor_baru;
+  end if;
+
+  insert into history (table_name, row_id, regu_id, action, new_value, changed_by)
+  values ('regu', p_regu::text, p_regu, 'UPDATE',
+          jsonb_build_object('alasan_tukar_nomor', p_alasan,
+                             'nomor_lama', v_regu.nomor_dada,
+                             'nomor_baru', p_nomor_baru), auth.uid());
+
+  -- Nomor lama dipensiunkan HANYA bila kertasnya sudah beredar (0041), dan
+  -- patokannya SATU variabel dengan yang mengatur izin di atas — dua patokan
+  -- terpisah untuk pertanyaan yang sama adalah cara mereka mulai berbeda
+  -- pendapat, persis yang dibetulkan 0019.
+  if v_beredar then
+    insert into nomor_dada_pensiun (nomor, reason)
+    values (v_regu.nomor_dada, p_alasan);
+  end if;
+
+  update regu set nomor_dada = p_nomor_baru where id = p_regu;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 7. Laporkan keadaannya.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare r record;
+begin
+  select * into r from v_rentang_nomor_dada;
+  raise notice '0116: Eksternal % - %, Intern % - % (batas deret %).',
+               r.eksternal_mulai, r.eksternal_sampai,
+               r.intern_mulai, r.intern_sampai, r.intern_mulai_konfigurasi;
+
+  perform 1 from regu
+   where nomor_dada is not null and not nomor_dada_sesuai_deret(golongan, nomor_dada);
+  if found then
+    for r in
+      select nomor_dada, golongan, nama_regu from regu
+       where nomor_dada is not null and not nomor_dada_sesuai_deret(golongan, nomor_dada)
+       order by nomor_dada
+    loop
+      raise notice '0116: SUDAH TERLANJUR di deret yang salah — % (% , %)',
+                   r.nomor_dada, r.golongan, r.nama_regu;
+    end loop;
+    raise notice '0116: nomor di atas TIDAK diubah otomatis. Tukar lewat layar '
+                 'Daftar Ulang supaya nomor lamanya ikut dipensiunkan bila '
+                 'kertasnya sudah beredar.';
+  end if;
+end;
+$blok$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -61,5 +61,8 @@ insert into status_acara (id) values (true);
 -- 40 kloter (30 dasar + 31-40 cadangan).
 insert into kloter (nomor) select generate_series(1, 40);
 
--- Stok nomor dada fisik 1-500.
+-- Stok nomor dada fisik. DUA deret, karena kainnya dicetak dua set yang
+-- sama-sama mulai dari 001: Eksternal 1-500, Intern 1001-1250 (migrasi 0116).
+-- Batas antaranya `edisi.nomor_dada_intern_mulai`.
 insert into nomor_dada_stok (nomor) select generate_series(1, 500);
+insert into nomor_dada_stok (nomor) select generate_series(1001, 1250);

--- a/tests/concurrency_test.py
+++ b/tests/concurrency_test.py
@@ -94,27 +94,42 @@ def siapkan():
     return kode
 
 
-def stok_tersedia(jumlah):
-    """Nomor dada yang masih boleh dipakai, urut kecil ke besar."""
+def stok_tersedia(jumlah, intern=False):
+    """Nomor dada yang masih boleh dipakai, urut kecil ke besar.
+
+    DUA DERET sejak migrasi 0116: kain Intern dicetak set sendiri yang juga
+    mulai dari 001, jadi Intern diketik 1001-1250 dan nomor Eksternal untuk
+    regu Intern ditolak database. Batasnya dibaca dari `edisi`, tidak ditulis
+    di sini — tes yang mematok 1001 akan gugur diam-diam begitu panitia tahun
+    depan menggesernya.
+    """
     baris = jalankan("""
         select s.nomor from nomor_dada_stok s
-        where not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+        where (s.nomor >= (select nomor_dada_intern_mulai from edisi where is_active)) = %s
+          and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
           and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor)
         order by s.nomor limit %s
-    """, (jumlah,), role="service_role")
+    """, (intern, jumlah), role="service_role")
     return [r["nomor"] for r in baris]
 
 
-def pasangan(kode, nomor):
-    """Yang diketik petugas: regu ini nomornya ini (migrasi 0011)."""
+def pasangan(kode, nomor_eksternal, nomor_intern=()):
+    """Yang diketik petugas: regu ini nomornya ini (migrasi 0011).
+
+    Tiap regu mendapat nomor dari DERETNYA SENDIRI — persis yang dilakukan
+    petugas meja, yang memegang dua tumpukan kain terpisah.
+    """
     regu = jalankan("""
-        select r.id::text as id from regu r
+        select r.id::text as id, r.golongan from regu r
         join pendaftaran d on d.id = r.pendaftaran_id
         where d.kode_pembayaran = %s and not r.is_cancelled and r.nomor_dada is null
         order by r.nama_regu, r.id
     """, (kode,), role="service_role")
-    return json.dumps([{"regu_id": r["id"], "nomor_dada": n}
-                       for r, n in zip(regu, nomor)])
+    sisa = {False: iter(nomor_eksternal), True: iter(nomor_intern)}
+    return json.dumps([
+        {"regu_id": r["id"],
+         "nomor_dada": next(sisa[r["golongan"].startswith("intern_")])}
+        for r in regu])
 
 
 def serbu(kode):
@@ -125,13 +140,22 @@ def serbu(kode):
     jadi dua meja tidak pernah menawarkan nomor yang sama. Yang diadu di
     sini tetap sama seperti dulu: penempatan kloter dan penulisan serentak.
     """
-    butuh = len(kode) * REGU_PER_SEKOLAH
-    stok = stok_tersedia(butuh)
-    if len(stok) < butuh:
-        raise SystemExit(f"stok nomor dada kurang: butuh {butuh}, ada {len(stok)}")
+    # Dua tumpukan kain, dua deret (0116) — dan tiap meja memegang potongan
+    # sendiri dari keduanya, sama seperti panitia membaginya sebelum antrean
+    # dibuka.
+    butuh_ext = len(kode) * EKSTERNAL_PER_SEKOLAH
+    butuh_int = len(kode) * INTERN_PER_SEKOLAH
+    stok_ext = stok_tersedia(butuh_ext)
+    stok_int = stok_tersedia(butuh_int, intern=True)
+    if len(stok_ext) < butuh_ext or len(stok_int) < butuh_int:
+        raise SystemExit(
+            f"stok nomor dada kurang: butuh {butuh_ext} Eksternal / {butuh_int} "
+            f"Intern, ada {len(stok_ext)} / {len(stok_int)}")
     # Disiapkan SEBELUM barrier supaya yang diadu murni transaksinya, bukan
     # waktu menyusun JSON di Python.
-    bawaan = {k: pasangan(k, stok[i * REGU_PER_SEKOLAH:(i + 1) * REGU_PER_SEKOLAH])
+    bawaan = {k: pasangan(k,
+                          stok_ext[i * EKSTERNAL_PER_SEKOLAH:(i + 1) * EKSTERNAL_PER_SEKOLAH],
+                          stok_int[i * INTERN_PER_SEKOLAH:(i + 1) * INTERN_PER_SEKOLAH])
               for i, k in enumerate(kode)}
 
     hasil, galat = [], []

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -212,9 +212,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select * from v_riwayat_nilai where pos = %s "
                     "and nomor_dada = %s order by changed_at desc",
                     (p.get("pos") or 0, p.get("dada") or 0), uid=p.get("uid")))
-            elif u.path == "/batas-nomor-dada":
+            elif u.path == "/rentang-nomor-dada":
                 self._kirim(200, q(
-                    "select nomor from nomor_dada_stok order by nomor desc limit 1",
+                    "select * from v_rentang_nomor_dada",
                     uid=p.get("uid")))
             elif u.path == "/kelengkapan-pos":
                 self._kirim(200, q(

--- a/tests/nomor_dada_series.test.mjs
+++ b/tests/nomor_dada_series.test.mjs
@@ -1,0 +1,148 @@
+// ============================================================================
+// hrcd-rekap : tests/nomor_dada_series.test.mjs — migrasi 0116.
+//
+// DUA DERET NOMOR DADA, DAN LAYAR HARUS MENOLAK YANG SALAH SEBELUM SERVER.
+//
+// Panitia mencetak kain nomor dada dalam dua set yang sama-sama mulai dari
+// 001, jadi Intern diketik 1001-1250. Pagar sesungguhnya ada di database
+// (tes SQL 78); yang diuji di sini pagar di kotaknya — petugas meja mengisi
+// belasan kotak sebelum menekan Simpan, dan ditolak server berarti mencari
+// sendiri kotak mana yang salah.
+//
+// Angkanya SELALU datang dari `v_rentang_nomor_dada`, tidak pernah ditulis di
+// kode. Karena itu fixture di bawah memakai rentang yang sengaja BUKAN
+// 1001-1250 di beberapa tes: kalau ada yang diam-diam mematok 1001, tes itu
+// yang gugur.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { deretCocok, deretIntern, golonganIntern, nomorStok, pesanDeret }
+  from "../web/js/nomor-dada-series.mjs";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const migrasi = await readFile(
+  new URL("../supabase/migrations/0116_nomor_dada_intern_seribu.sql", import.meta.url), "utf8");
+
+const HRCD37 = {
+  eksternalMulai: 1, eksternalSampai: 500,
+  internMulai: 1001, internSampai: 1250,
+};
+
+
+test("golongan Intern dikenali dari awalannya, bukan dari daftar nama", () => {
+  assert.equal(golonganIntern("intern_pa"), true);
+  assert.equal(golonganIntern("intern_pi"), true);
+  assert.equal(golonganIntern("penggalang_pa"), false);
+  assert.equal(golonganIntern(null), false);
+});
+
+
+test("nomor Eksternal untuk regu Intern ditolak, dan sebaliknya", () => {
+  // Kekeliruan yang PASTI terjadi kalau tidak ditolak: kain Intern bertulis
+  // 001, dan mengetik apa yang terbaca adalah hal paling wajar sedunia.
+  assert.equal(deretCocok(HRCD37, "intern_pa", 1), false);
+  assert.equal(deretCocok(HRCD37, "intern_pa", 250), false);
+  assert.equal(deretCocok(HRCD37, "intern_pa", 1001), true);
+  assert.equal(deretCocok(HRCD37, "intern_pa", 1250), true);
+  assert.equal(deretCocok(HRCD37, "intern_pa", 1251), false);
+
+  assert.equal(deretCocok(HRCD37, "penggalang_pa", 1001), false);
+  assert.equal(deretCocok(HRCD37, "penggalang_pa", 1), true);
+  assert.equal(deretCocok(HRCD37, "penggalang_pa", 500), true);
+  assert.equal(deretCocok(HRCD37, "penggalang_pa", 501), false);
+});
+
+
+test("batasnya dari rentang, bukan dari angka 1001 yang dipatok", () => {
+  const lain = {
+    eksternalMulai: 1, eksternalSampai: 300,
+    internMulai: 601, internSampai: 700,
+  };
+  assert.equal(deretCocok(lain, "intern_pi", 1001), false);
+  assert.equal(deretCocok(lain, "intern_pi", 601), true);
+  assert.equal(deretCocok(lain, "penegak_pa", 400), false);
+});
+
+
+test("deret yang kosong tidak menghakimi apa pun", () => {
+  // Stok Intern yang belum diisi admin: layar berhenti menilai deret dan
+  // membiarkan database yang memutuskan. Menolak semua nomor di keadaan ini
+  // akan mematikan meja daftar ulang untuk seluruh peserta.
+  const belum = { eksternalMulai: 1, eksternalSampai: 500, internMulai: 0, internSampai: 0 };
+  assert.equal(deretCocok(belum, "intern_pa", 7), true);
+  assert.equal(deretCocok(belum, "intern_pa", 1001), true);
+});
+
+
+test("lembar cadangan memuat kedua deret dan TIDAK memuat lubang di antaranya", () => {
+  // Inilah yang dulu salah: lembar dicetak 1..batas, dan batas adalah nomor
+  // tertinggi di stok. Dengan deret Intern 1001-1250 itu berarti 500 baris
+  // kosong bernomor 501-1000 — nomor yang tidak pernah dibawa siapa pun, dan
+  // tiap barisnya menyuruh petugas mencari slip yang tidak ada.
+  const nomor = nomorStok(HRCD37);
+  assert.equal(nomor.length, 500 + 250);
+  assert.equal(nomor[0], 1);
+  assert.equal(nomor[499], 500);
+  assert.equal(nomor[500], 1001);
+  assert.equal(nomor.at(-1), 1250);
+  assert.ok(!nomor.includes(501) && !nomor.includes(1000),
+    "lembar cadangan masih memuat nomor di antara dua deret");
+});
+
+
+test("stok yang belum punya deret Intern tetap mencetak deret Eksternal", () => {
+  const belum = { eksternalMulai: 1, eksternalSampai: 3, internMulai: 0, internSampai: 0 };
+  assert.deepEqual(nomorStok(belum), [1, 2, 3]);
+});
+
+
+test("pesannya menyebut deret yang BENAR, bukan cuma bahwa nomornya salah", () => {
+  // Petugas yang salah ketik butuh tahu harus mengetik apa. Kalimatnya juga
+  // sama bunyinya dengan `pesan_deret_nomor_dada()` di database — dua pesan
+  // berbeda untuk satu pagar membuat petugas mengira ada dua aturan.
+  assert.equal(pesanDeret(HRCD37, "intern_pa"),
+    "Nomor dada intern adalah dari 1001 - 1250.");
+  assert.equal(pesanDeret(HRCD37, "penggalang_pi"),
+    "Nomor dada eksternal adalah dari 1 - 500.");
+  assert.match(migrasi, /format\('Nomor dada %s adalah dari %s - %s\.'/,
+    "kalimat di database berubah bentuk tanpa yang di layar ikut berubah");
+});
+
+
+test("batch Intern dikenali dari golongan regunya", () => {
+  assert.equal(deretIntern([{ golongan: "penggalang_pa" }, { golongan: "intern_pi" }]), true);
+  assert.equal(deretIntern([{ golongan: "penggalang_pa" }]), false);
+  assert.equal(deretIntern([]), false);
+});
+
+
+test("Meja Daftar Ulang benar-benar memakai pagarnya", () => {
+  // Modul yang benar tapi tidak dipanggil sama saja dengan tidak ada, dan itu
+  // tidak menggagalkan apa pun sampai ada yang mengetik di meja.
+  assert.match(app, /import \{ deretCocok, deretIntern, nomorStok, pesanDeret \}/);
+  assert.match(app, /if \(rentang && !deretCocok\(rentang, inp\.dataset\.golongan, angka\)\)/,
+    "kotak nomor dada tidak lagi memeriksa deretnya");
+  assert.match(app, /keluhan = keluhan \|\| pesanDeret\(rentang, inp\.dataset\.golongan\)/);
+  assert.match(app, /data-golongan="\$\{esc\(r\.golongan\)\}"/,
+    "kotak isian tidak membawa golongan, jadi pagarnya tidak punya bahan");
+});
+
+
+test("Input Pos mencetak lembar cadangan dari stok, bukan dari 1..batas", () => {
+  assert.match(app, /semua = nomorStok\(rentangStok\)\.map\(/);
+  assert.doesNotMatch(app, /Array\.from\(\{ length: batasStok \}/,
+    "lembar cadangan masih dibangun dari batas tertinggi");
+  assert.doesNotMatch(api, /export async function batasNomorDada/,
+    "wrapper lama masih dipublikasikan padahal tidak ada pemanggilnya");
+});
+
+
+test("rentangnya dibaca dari view, bukan dari tabel stok", () => {
+  // Seluruh 750 baris stok tidak perlu diunduh cuma untuk tahu ujung-ujungnya,
+  // dan meja daftar ulang berbagi jaringan dengan lima pos.
+  assert.match(api, /v_rentang_nomor_dada\?select=\*/);
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -509,6 +509,12 @@ run supabase/migrations/0114_nama_anggota_regu.sql
 # ada, jadi seluruh migrasinya no-op — yang diuji di sini cuma bahwa ia jalan
 # tanpa galat dan pagar akhirnya tidak menyala di daftar kurasi.
 run supabase/migrations/0115_sekolah_baku_dua_baris.sql
+
+# 0116 memecah nomor dada jadi dua deret: Eksternal 1-500, Intern 1001-1250.
+# Tes 78 menempati kursinya — memberi regu Intern nomor Eksternal harus
+# ditolak, dan sebaliknya, lewat KEDUA pintu yang memberi nomor.
+run supabase/migrations/0116_nomor_dada_intern_seribu.sql
+run tests/sql/78_deret_nomor_dada_intern.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.

--- a/tests/sql/78_deret_nomor_dada_intern.sql
+++ b/tests/sql/78_deret_nomor_dada_intern.sql
@@ -1,0 +1,164 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/78_deret_nomor_dada_intern.sql — migrasi 0116.
+-- Dua deret nomor dada, dan KEDUA pintu yang memberi nomor harus menjaganya.
+--
+-- Kain nomor dada dicetak dalam dua set yang sama-sama mulai dari 001, jadi
+-- Intern diketik 1001-1250. Yang diuji di sini bukan bahwa nomornya tersimpan
+-- — itu sudah dijaga unique sejak 0001 — melainkan bahwa nomor dari deret yang
+-- SALAH ditolak, dan bahwa pesannya menyebut deret yang benar. Petugas yang
+-- salah ketik butuh tahu harus mengetik apa.
+--
+-- Dua pintu, dan yang kedua paling mudah terlupa: `daftar_ulang_batch` memberi
+-- nomor pertama kali, `tukar_nomor_dada` menggantinya saat kainnya sobek.
+-- Menutup yang pertama saja meninggalkan pintu samping yang terbuka lebar.
+-- ============================================================================
+
+\echo '--- 78. dua deret nomor dada: Eksternal dan Intern'
+\set ON_ERROR_STOP on
+
+begin;
+
+do $blok$
+declare
+  v_sekolah    uuid;
+  v_daftar     uuid;
+  v_regu_intern uuid;
+  v_regu_ext   uuid;
+  v_eks        int;
+  v_eks_lain   int;
+  v_intern     int;
+  v_intern_lain int;
+  v_tolak      boolean;
+  v_pesan      text;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  update status_acara set daftar_ulang_ditutup = false where id;
+
+  -- ---------------------------------------------------------------------
+  -- 78.0 Rentangnya persis seperti yang diputuskan pemilik acara.
+  -- ---------------------------------------------------------------------
+  assert (select intern_mulai = 1001 and intern_sampai = 1250
+          from v_rentang_nomor_dada),
+    '78.0 GAGAL: stok Intern bukan 1001-1250';
+  assert (select eksternal_sampai < 1001 and eksternal_mulai = 1
+          from v_rentang_nomor_dada),
+    '78.0 GAGAL: deret Eksternal bocor ke wilayah Intern';
+
+  -- Nomor bebas dari masing-masing deret. Diambil dari stok, bukan ditulis
+  -- angkanya: tes yang mematok 7 dan 1001 akan gugur setiap kali fixture di
+  -- atasnya kebetulan memakai nomor itu.
+  select min(s.nomor) into v_eks from nomor_dada_stok s
+   where s.nomor < 1001
+     and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+     and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+  select min(s.nomor) into v_eks_lain from nomor_dada_stok s
+   where s.nomor < 1001 and s.nomor > v_eks
+     and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+     and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+  select min(s.nomor) into v_intern from nomor_dada_stok s
+   where s.nomor >= 1001
+     and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+     and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+  select min(s.nomor) into v_intern_lain from nomor_dada_stok s
+   where s.nomor >= 1001 and s.nomor > v_intern
+     and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+     and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+
+  select id into v_sekolah from sekolah order by name limit 1;
+  insert into pendaftaran
+    (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa, status)
+  values (v_sekolah, 'UJI-DERET-0116', 1, '081200000116', 'lunas')
+  returning id into v_daftar;
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_daftar, 'DERET INTERN UJI', 'Ketua Uji', 'intern_pa')
+  returning id into v_regu_intern;
+
+  -- ---------------------------------------------------------------------
+  -- 78.1 Regu Intern + nomor Eksternal: DITOLAK, dan pesannya menyebut
+  --      1001-1250. Inilah kekeliruan yang benar-benar akan terjadi di meja
+  --      — kain Intern bertulis 001, dan mengetik apa yang terbaca adalah
+  --      hal paling wajar sedunia.
+  -- ---------------------------------------------------------------------
+  v_tolak := false;
+  begin
+    perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
+      jsonb_build_object('regu_id', v_regu_intern, 'nomor_dada', v_eks)));
+    raise exception 'GAGAL: regu Intern menerima nomor dari deret Eksternal (%)', v_eks;
+  exception when others then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true; v_pesan := sqlerrm;
+  end;
+  assert v_tolak, '78.1 GAGAL: nomor Eksternal untuk regu Intern tidak ditolak';
+  assert v_pesan like '%1001 - 1250%',
+    format('78.1 GAGAL: pesan tidak menyebut deret Intern yang benar: %s', v_pesan);
+  assert v_pesan like '%intern%',
+    format('78.1 GAGAL: pesan tidak menyebut deret mana yang dimaksud: %s', v_pesan);
+
+  -- ---------------------------------------------------------------------
+  -- 78.2 Nomor dari deretnya sendiri: diterima.
+  --
+  --      Tanpa langkah ini 78.1 bisa lulus karena alasan yang salah — RPC
+  --      yang menolak SEMUA nomor juga menolak yang di deret Eksternal.
+  -- ---------------------------------------------------------------------
+  perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
+    jsonb_build_object('regu_id', v_regu_intern, 'nomor_dada', v_intern)));
+  assert (select nomor_dada = v_intern from regu where id = v_regu_intern),
+    '78.2 GAGAL: nomor Intern yang sah ikut ditolak';
+
+  -- ---------------------------------------------------------------------
+  -- 78.3 Arah sebaliknya. Aturannya satu kalimat dibaca dari dua sisi, jadi
+  --      menguji satu sisi saja membiarkan separuhnya tanpa kursi.
+  -- ---------------------------------------------------------------------
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_daftar, 'DERET EKSTERN UJI', 'Ketua Uji', 'penggalang_pa')
+  returning id into v_regu_ext;
+
+  v_tolak := false;
+  begin
+    perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
+      jsonb_build_object('regu_id', v_regu_ext, 'nomor_dada', v_intern_lain)));
+    raise exception 'GAGAL: regu Eksternal menerima nomor dari deret Intern (%)', v_intern_lain;
+  exception when others then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true; v_pesan := sqlerrm;
+  end;
+  assert v_tolak, '78.3 GAGAL: nomor Intern untuk regu Eksternal tidak ditolak';
+  assert v_pesan like '%eksternal%',
+    format('78.3 GAGAL: pesan tidak menyebut deret Eksternal: %s', v_pesan);
+
+  perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
+    jsonb_build_object('regu_id', v_regu_ext, 'nomor_dada', v_eks)));
+  assert (select nomor_dada = v_eks from regu where id = v_regu_ext),
+    '78.3 GAGAL: nomor Eksternal yang sah ikut ditolak';
+
+  -- ---------------------------------------------------------------------
+  -- 78.4 Pintu kedua: tukar kain sobek. Regu Intern tidak boleh berpindah ke
+  --      deret Eksternal lewat jalur ini.
+  -- ---------------------------------------------------------------------
+  v_tolak := false;
+  begin
+    perform tukar_nomor_dada(v_regu_intern, v_eks_lain, 'uji 78: kain sobek');
+    raise exception 'GAGAL: tukar memindahkan regu Intern ke deret Eksternal (%)', v_eks_lain;
+  exception when others then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true; v_pesan := sqlerrm;
+  end;
+  assert v_tolak, '78.4 GAGAL: tukar_nomor_dada menembus pagar deret';
+  assert v_pesan like '%1001 - 1250%',
+    format('78.4 GAGAL: pesan tukar tidak menyebut deret yang benar: %s', v_pesan);
+
+  -- 78.5 Tukar ke sesama deret Intern tetap jalan — pagarnya menyaring deret,
+  --      bukan mematikan penukaran.
+  perform tukar_nomor_dada(v_regu_intern, v_intern_lain, 'uji 78: kain sobek');
+  assert (select nomor_dada = v_intern_lain from regu where id = v_regu_intern),
+    '78.5 GAGAL: tukar sesama deret Intern ikut ditolak';
+
+  perform set_config('app.uid', '', true);
+  raise notice '78 OK — Eksternal % / %, Intern % / % diuji dua arah, dua pintu.',
+               v_eks, v_eks_lain, v_intern, v_intern_lain;
+end;
+$blok$;
+
+rollback;
+
+select '78_deret_nomor_dada_intern OK' as hasil;

--- a/tools/periksa_impor.py
+++ b/tools/periksa_impor.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
     pasangan = [
         ("web/js/app.js", "web/js/api.js", "./api.js"),
         ("web/js/app.js", "web/js/util.js", "./util.js"),
+        ("web/js/app.js", "web/js/nomor-dada-series.mjs", "./nomor-dada-series.mjs"),
         ("live/js/daftar.js", "live/js/api.js", "./api.js"),
         ("live/js/daftar.js", "live/js/util.js", "./util.js"),
         ("live/js/daftar.js", "live/js/school-search.mjs", "./school-search.mjs"),

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -686,11 +686,28 @@ export async function lembarPos(pos) {
  *  Dibaca dari stok, bukan dari regu yang sudah terdaftar: stok adalah nomor
  *  dada FISIK yang benar-benar dicetak dan dibawa panitia, dan itulah rentang
  *  yang mungkin muncul di kotak penilaian. */
-export async function batasNomorDada() {
+/** Kedua deret nomor dada, dari `v_rentang_nomor_dada` (migrasi 0116).
+ *
+ *  Kain nomor dada dicetak dua set yang sama-sama mulai dari 001, jadi Intern
+ *  diketik 1001-1250 sementara Eksternal tetap 1-500. Yang dibaca di sini
+ *  UJUNG-UJUNGNYA saja, bukan seluruh 750 baris stok: layar cuma perlu tahu
+ *  nomor mana milik deret mana, dan meja daftar ulang bekerja di jaringan
+ *  yang sama dengan lima pos.
+ *
+ *  Nol berarti deretnya kosong — stok Intern yang belum pernah diisi admin.
+ *  Layar yang memakainya harus tetap jalan dalam keadaan itu, bukan menolak
+ *  semua nomor. */
+export async function rentangNomorDada() {
   const d = K.mode === "dev"
-    ? await baca("/batas-nomor-dada")
-    : await baca(null, "nomor_dada_stok?select=nomor&order=nomor.desc&limit=1");
-  return d.length ? Number(d[0].nomor) : 0;
+    ? await baca("/rentang-nomor-dada")
+    : await baca(null, "v_rentang_nomor_dada?select=*");
+  const r = d[0] || {};
+  return {
+    eksternalMulai: Number(r.eksternal_mulai) || 0,
+    eksternalSampai: Number(r.eksternal_sampai) || 0,
+    internMulai: Number(r.intern_mulai) || 0,
+    internSampai: Number(r.intern_sampai) || 0,
+  };
 }
 
 /** Satu baris saja, dibaca ulang sesudah menyimpan. Nilai Pos yang tampil di

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -18,7 +18,7 @@ import {
   konfirmasiKontrak, ceklisBerangkat, batalCeklisBerangkat, berangkatkanKloter,
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
-  batasNomorDada,
+  rentangNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto, klasemenLiveScore,
@@ -39,6 +39,8 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
          varianUntuk, kelompokLomba, ringkasLomba } from "./util.js";
 import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
+import { deretCocok, deretIntern, nomorStok, pesanDeret }
+  from "./nomor-dada-series.mjs";
 
 const LAYAR = document.getElementById("layar");
 
@@ -1229,8 +1231,17 @@ async function layarDaftarUlang() {
   LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
-  let semua;
-  try { semua = await daftarPendaftaran(); }
+  let semua, rentang;
+  try {
+    // Rentang deret ikut diambil di sini supaya nomor dari deret yang salah
+    // memerah DI KOTAKNYA, bukan baru ditolak server sesudah belasan kotak
+    // terisi. Gagal mengambilnya tidak boleh mematikan meja: `null` berarti
+    // layar berhenti menilai deret, dan database tetap yang memutuskan.
+    [semua, rentang] = await Promise.all([
+      daftarPendaftaran(),
+      rentangNomorDada().catch(() => null),
+    ]);
+  }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarDaftarUlang)); return; }
   if (location.hash !== layarIni) return;   // lihat catatan di layarPembayaran
 
@@ -1350,7 +1361,10 @@ async function layarDaftarUlang() {
                      kotak nomor dada tidak lagi jatuh tepat di bawah tombol
                      yang membukanya. Disembunyikan di bawah 941px — lihat
                      style.css. -->
-                <tr><th>Regu</th><th>Kategori</th><th>Ketua</th><th>Nomor dada</th>
+                <tr><th>Regu</th><th>Kategori</th><th>Ketua</th>
+                    <th>Nomor dada${deretIntern(menunggu) && rentang
+                      ? `<span class="sub">Intern ${rentang.internMulai}–${rentang.internSampai}</span>`
+                      : ""}</th>
                     <th class="kol-imbang"></th></tr>
               </thead>
               <tbody>
@@ -1361,6 +1375,7 @@ async function layarDaftarUlang() {
                     <td>${esc(r.nama_ketua)}</td>
                     <td><input type="number" class="small-input" inputmode="numeric" min="1"
                                data-dada="${esc(r.id)}" data-untuk="${kode}"
+                               data-golongan="${esc(r.golongan)}"
                                value="${esc(nilaiDada.get(r.id) ?? "")}"></td>
                     <td class="kol-imbang"></td>
                   </tr>`).join("")}
@@ -1490,6 +1505,15 @@ async function layarDaftarUlang() {
           if (dipakai.has(angka)) {
             inp.classList.add("input-error");
             keluhan = keluhan || `Nomor ${angka} diketik untuk dua regu.`;
+            continue;
+          }
+          // Kain Intern bertulis 001 sama seperti kain Eksternal, dan
+          // mengetik apa yang terbaca adalah hal paling wajar sedunia —
+          // karena itu yang ditolak di sini bukan salah ketik, melainkan
+          // kekeliruan yang PASTI terjadi kalau tidak ditolak.
+          if (rentang && !deretCocok(rentang, inp.dataset.golongan, angka)) {
+            inp.classList.add("input-error");
+            keluhan = keluhan || pesanDeret(rentang, inp.dataset.golongan);
             continue;
           }
           dipakai.add(angka);
@@ -3377,24 +3401,24 @@ async function layarInputPos() {
   pasangKepala(`Input ${judulPos(pos)}`, "lembar");
 
   let komponen, lembar;
-  // Batas stok nomor dada diambil DI SINI, bukan saat tombol cetak ditekan.
+  // Rentang stok nomor dada diambil DI SINI, bukan saat tombol cetak ditekan.
   // Alasannya bukan kecepatan: `window.print()` harus tetap berada di giliran
   // event tap, dan Safari iPhone memblokirnya begitu ada satu `await` lebih
   // dulu (lihat catatan yang sama di layarCetakKloter). Stok nomor dada juga
   // tidak berubah di tengah lomba — ia dicetak di kain, bukan di database.
   // Gagal membacanya tidak boleh menghalangi apa pun: nol berarti lembar
   // dicetak apa adanya, tanpa baris kosong penambal.
-  let batasStok = 0;
+  let rentangStok = null;
   /* null = status fotonya TIDAK diketahui, dan itu berbeda dari "tidak ada
      foto". Kalau permintaannya gagal — pos memang sering kehilangan sinyal —
      menandai semua baris "belum foto" akan menuduh ratusan regu sekaligus.
      Yang benar: berhenti menilai fotonya, dan katakan begitu di saringannya. */
   let fotoPos = null;
   try {
-    [komponen, lembar, batasStok, fotoPos] = await Promise.all([
+    [komponen, lembar, rentangStok, fotoPos] = await Promise.all([
       komponenPos(EDISI.nomor, pos.nomor),
       lembarPos(pos.nomor),
-      batasNomorDada().catch(() => 0),
+      rentangNomorDada().catch(() => null),
       fotoLembarPos(pos.nomor).catch(() => null),
     ]);
   } catch (e) {
@@ -4535,10 +4559,10 @@ async function layarInputPos() {
        sebagian regu — menyisipkan seluruh nomor kosong ke dalamnya
        mengembalikan tumpukan kertas yang tadi sengaja dipersempit. */
     let semua = tampil;
-    if (!slip && batasStok > 0 && [...tbody.children].every(tr => !tr.hidden)) {
+    if (!slip && rentangStok && [...tbody.children].every(tr => !tr.hidden)) {
       const peta = new Map(tampil.map(r => [Number(r.nomor_dada), r]));
-      semua = Array.from({ length: batasStok }, (_, i) =>
-        peta.get(i + 1) || { nomor_dada: i + 1, kosong: true });
+      semua = nomorStok(rentangStok).map(
+        n => peta.get(n) || { nomor_dada: n, kosong: true });
     }
 
     if (slip) {

--- a/web/js/nomor-dada-series.mjs
+++ b/web/js/nomor-dada-series.mjs
@@ -1,0 +1,61 @@
+/* ============================================================================
+   hrcd-rekap : nomor-dada-series.mjs — dua deret nomor dada (migrasi 0116).
+
+   Murni perhitungan: tidak membaca DOM dan tidak memanggil server. Karena itu
+   aturan yang sama bisa diuji di Node dan dipakai layar.
+
+   Kain nomor dada dicetak dalam DUA set yang sama-sama mulai dari 001, jadi
+   Intern diketik 1001-1250 sementara Eksternal tetap 1-500. Batasnya tidak
+   ditulis di berkas ini — ia datang dari `v_rentang_nomor_dada`, karena yang
+   menyatakan "sampai berapa" adalah stok kain yang benar-benar dibawa
+   panitia. Panitia tahun depan mengubah stoknya, bukan kodenya.
+
+   Dipakai dua layar. Meja Daftar Ulang menolak nomor dari deret yang salah
+   sebelum dikirim — kain Intern bertulis 001 sama seperti kain Eksternal, dan
+   mengetik apa yang terbaca adalah hal paling wajar sedunia. Input Pos
+   mencetak lembar cadangan hanya pada nomor yang benar-benar ada; tanpa itu
+   ia mencetak 500 baris kosong di antara 500 dan 1001, nomor yang tidak
+   pernah dibawa siapa pun.
+
+   Pagar yang sesungguhnya tetap di database (`nomor_dada_sesuai_deret`).
+   Yang di sini menahan kekeliruan di kotaknya, bukan menggantikan yang di
+   sana.
+   ========================================================================== */
+
+export const golonganIntern = (golongan) => String(golongan || "").startsWith("intern_");
+
+/** Daftar regu ini memberi nomor kepada Intern? Satu pendaftaran selalu satu
+ *  jenis peserta, jadi praktisnya ini "batch Intern" — tetapi yang diperiksa
+ *  tetap golongan REGUNYA, patokan yang sama dengan pagar di database. */
+export const deretIntern = (daftar) => daftar.some(r => golonganIntern(r.golongan));
+
+/** Seluruh nomor yang ada di stok, kedua deret berurutan. */
+export function nomorStok(rentang) {
+  const keluar = [];
+  for (const [dari, sampai] of [[rentang.eksternalMulai, rentang.eksternalSampai],
+                                [rentang.internMulai, rentang.internSampai]]) {
+    if (!dari || !sampai) continue;    // deret kosong: stok belum diisi admin
+    for (let n = dari; n <= sampai; n++) keluar.push(n);
+  }
+  return keluar;
+}
+
+/** Nomor ini milik deret golongannya? Deret yang kosong tidak menghakimi
+ *  apa pun — pagarnya di database tetap yang terakhir memutuskan. */
+export function deretCocok(rentang, golongan, nomor) {
+  const intern = golonganIntern(golongan);
+  const dari = intern ? rentang.internMulai : rentang.eksternalMulai;
+  const sampai = intern ? rentang.internSampai : rentang.eksternalSampai;
+  if (!dari || !sampai) return true;
+  return nomor >= dari && nomor <= sampai;
+}
+
+/** Kalimat yang sama bunyinya dengan `pesan_deret_nomor_dada()` di database.
+ *  Angkanya dari rentang yang sama, jadi keduanya tidak bisa berselisih —
+ *  yang harus dijaga tangan cuma bentuk kalimatnya. */
+export function pesanDeret(rentang, golongan) {
+  const intern = golonganIntern(golongan);
+  return `Nomor dada ${intern ? "intern" : "eksternal"} adalah dari `
+    + `${intern ? rentang.internMulai : rentang.eksternalMulai} - `
+    + `${intern ? rentang.internSampai : rentang.eksternalSampai}.`;
+}


### PR DESCRIPTION
## What

Nomor dada Intern kini deret sendiri: **1001–1250**. Eksternal tetap 1–500.

- `edisi.nomor_dada_intern_mulai` (1001) — konfigurasi per edisi, seperti jendela keberangkatan.
- Stok 1001–1250 ditambahkan; `on conflict do nothing`, boleh dijalankan dua kali.
- Pagar `nomor_dada_sesuai_deret()` dipasang di **kedua** pintu yang memberi nomor: `daftar_ulang_batch` dan `tukar_nomor_dada`.
- Pesannya menyebut rentang yang benar: **"Nomor dada intern adalah dari 1001 - 1250."**
- Di layar Daftar Ulang kotak yang salah deret **memerah di tempatnya** sebelum dikirim, dan judul kolomnya menyebut rentang Intern.

## Why

Panitia mencetak kain dalam dua set yang sama-sama mulai dari 001. Sistem memakai satu deret — `regu.nomor_dada` unique sejak 0001 — jadi meja daftar ulang Intern **berhenti** di regu pertama:

```
nomor dada sudah dipakai regu lain: 1
```

Bukan sekadar membingungkan: ditolak.

Alternatifnya mengganti kunci jadi `(kelompok, nomor)`, yang menyentuh 56 tempat di SQL, seluruh layar panitia, dan halaman peserta — dua hari sebelum lomba. Dengan deret, kuncinya tetap satu integer unik dan unique constraint, foreign key ke stok, pensiun, foto, serta klasemen tidak berubah sama sekali.

Batas atas sengaja **bukan** konfigurasi: yang menyatakan "sampai berapa" adalah stok kain yang benar-benar dibawa panitia. Dua tempat yang menjawab pertanyaan sama akan berselisih suatu hari.

## Satu bug yang ikut ketahuan

Lembar cadangan "form tabel" dicetak dari `1..nomor tertinggi di stok`. Dengan deret Intern itu berarti **500 baris kosong bernomor 501–1000** — nomor yang tidak pernah dibawa siapa pun, dan tiap barisnya menyuruh petugas mencari slip yang tidak ada. Sekarang dibangun dari kedua deret.

## Notes

- Lokal: `bash tests/run.sh` → **SEMUA TES LULUS** (tes SQL 78 baru: dua arah, dua pintu), `node --test tests/*.test.mjs` → **205 lulus** (11 tes modul baru), `periksa_impor.py`, `periksa_sekolah.py`.
- **Diukur**, bukan dikira: `1250` pada `.print-table .dada` memakan **10,6mm dari kolom 15mm**, jadi empat digit tidak memaksa apa pun membungkus. Kolom lembar pos sama.
- Migrasi melaporkan regu yang TERLANJUR memakai deret yang salah dan **tidak mengubahnya otomatis** — perbaikannya lewat layar Tukar supaya nomor lama ikut dipensiunkan bila kertasnya sudah beredar.
- **Yang tidak diselesaikan migrasi ini:** juri di pos menulis nomor dada dengan tangan dari kain di dada regu. Kain Intern harus ditandai supaya yang tertulis di blangko juga `1xxx` — kalau kainnya polos bertulis 001, blangkonya ambigu dan tidak ada satu pun baris SQL yang bisa memulihkannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)