### PR TITLE
fix: pesan keberangkatan tidak memotong nomor dada empat digit

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0116`.
+Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0117`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-116 migrasi, `0001` sampai `0116`, dijalankan berurutan tanpa lubang penomoran.
+117 migrasi, `0001` sampai `0117`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0117_dada_empat_digit_berangkat.sql
+++ b/supabase/migrations/0117_dada_empat_digit_berangkat.sql
@@ -1,0 +1,140 @@
+-- ============================================================================
+-- hrcd-rekap : 0117_dada_empat_digit_berangkat.sql
+-- `lpad(nomor_dada, 3, '0')` MEMOTONG nomor Intern jadi tiga digit.
+--
+-- APA YANG SALAH
+--
+-- `berangkatkan_kloter` menolak kloter yang masih punya regu tanpa kontrak
+-- waktu, dan menyebut nomor dadanya:
+--
+--     regu nomor dada 001, 014 belum konfirmasi kontrak waktu
+--
+-- Nomornya diformat `lpad(r.nomor_dada::text, 3, '0')`, dan lpad TIDAK
+-- memanjangkan saja — ia juga MEMOTONG string yang lebih panjang dari
+-- targetnya. Sejak 0116 regu Intern bernomor 1001-1250, jadi pesan itu
+-- berbunyi:
+--
+--     regu nomor dada 100 belum konfirmasi kontrak waktu     <- regu 1001
+--
+-- dan 100 adalah regu Eksternal yang benar-benar ada. Petugas garis start
+-- membaca nomor itu, mencari regu yang salah, menemukan kontraknya sudah
+-- terisi, lalu tidak punya petunjuk apa pun tentang regu yang sebenarnya
+-- menahan kloternya — pada pukul tujuh pagi, dengan kloter berikutnya sudah
+-- berbaris.
+--
+-- KENAPA CUMA FUNGSI INI
+--
+-- Empat fungsi lain memformat nomor dada dengan cara yang sama —
+-- `catat_foto_lembar`, `hapus_nilai_pos`, `kunci_nilai_pos`, `tautkan_foto` —
+-- dan KEEMPATNYA sudah memakai pagar `case when ... between 0 and 999`.
+-- Jebakan lpad ini memang sudah diketahui dan ditulis di kepala 0023; yang
+-- ini satu-satunya yang luput. Diperiksa dengan membaca `pg_get_functiondef`
+-- seluruh fungsi di database, bukan dengan membaca berkas migrasi — versi
+-- terbaru sebuah fungsi tersebar di berkas bernomor besar, dan mata mudah
+-- membaca definisi yang sudah tidak berlaku.
+--
+-- Tidak ada view yang memformat nomor dada; sisi layar (`dada3()` di
+-- util.js, `padStart`) tidak pernah memotong.
+--
+-- KENAPA TIDAK DIBUAT SATU FUNGSI PEMBANTU
+--
+-- `dada_teks(integer)` akan lebih rapi daripada lima salinan `case`, tetapi
+-- itu berarti menulis ulang empat fungsi yang hari ini benar, dua hari
+-- sebelum lomba. Bentuk yang dipakai di bawah SAMA PERSIS dengan yang sudah
+-- ada di empat fungsi lain — tidak ada konsep baru yang harus dihafal siapa
+-- pun, dan penyeragamannya bisa menunggu edisi berikutnya.
+-- ============================================================================
+
+create or replace function berangkatkan_kloter(
+  p_kloter smallint,
+  p_jam    timestamptz
+) returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_tanpa_kontrak text;
+begin
+  if not boleh('keberangkatan') then
+    raise exception 'tidak berhak: keberangkatan';
+  end if;
+  if p_jam is null then
+    raise exception 'jam berangkat wajib diketik';
+  end if;
+  if exists (select 1 from kloter where nomor = p_kloter and jam_berangkat is not null) then
+    raise exception 'kloter % sudah berangkat', p_kloter;
+  end if;
+  -- Papan pipeline diturunkan dari max(nomor berangkat) — satu ketukan salah
+  -- (memberangkatkan kloter kosong / melompati) merusak seluruh papan.
+  -- Guard: kloter harus berisi regu, dan tidak boleh melompati kloter berisi
+  -- regu yang belum berangkat (temuan review).
+  if not exists (select 1 from regu r where r.kloter_nomor = p_kloter and not r.is_cancelled) then
+    raise exception 'kloter % tidak berisi regu', p_kloter;
+  end if;
+  if exists (
+       select 1 from kloter k
+       where k.nomor < p_kloter and k.jam_berangkat is null
+         and exists (select 1 from regu r
+                     where r.kloter_nomor = k.nomor and not r.is_cancelled)) then
+    raise exception 'masih ada kloter sebelum % yang belum berangkat — urutan keberangkatan wajib berurut', p_kloter;
+  end if;
+
+  -- Regu yang diceklis berangkat wajib sudah berkontrak — mencegah penalti
+  -- waktu yang tak terhitung (NULL) di kemudian hari.
+  --
+  -- Nomor 0-999 ditulis tiga digit, bentuk yang tertulis di kain; yang lebih
+  -- panjang dicetak apa adanya, karena lpad MEMOTONG kelebihannya dan sejak
+  -- 0116 kain Intern bernomor empat digit. ORDER BY supaya daftarnya tidak
+  -- berubah urutan tiap kali.
+  select string_agg(
+           case when r.nomor_dada between 0 and 999
+                then lpad(r.nomor_dada::text, 3, '0')
+                else r.nomor_dada::text end,
+           ', ' order by r.nomor_dada)
+    into v_tanpa_kontrak
+  from regu r
+  join keberangkatan_regu k on k.regu_id = r.id
+  where r.kloter_nomor = p_kloter and r.kontrak_menit is null;
+  if v_tanpa_kontrak is not null then
+    raise exception 'regu nomor dada % belum konfirmasi kontrak waktu', v_tanpa_kontrak;
+  end if;
+
+  update kloter set jam_berangkat = p_jam where nomor = p_kloter;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Pagar yang sama untuk seluruh fungsi, sekarang dan nanti: tidak boleh ada
+-- `lpad(..., 3, '0')` yang berdiri tanpa pemeriksaan `between 0 and 999` di
+-- dekatnya. Dibaca dari definisi fungsi yang BENAR-BENAR terpasang, bukan
+-- dari berkas migrasi.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare r record; v_telanjang text[] := '{}';
+begin
+  -- `as materialized` + `prokind = 'f'` bukan kerapian: menaruh
+  -- `pg_get_functiondef(...) like ...` langsung di WHERE membuat perencana
+  -- boleh memanggilnya SEBELUM saringan namespace, dan fungsi itu melempar
+  -- galat untuk agregat ("array_agg is an aggregate function"). Pemeriksa
+  -- yang gagal karena dirinya sendiri tidak memeriksa apa pun.
+  for r in
+    with fungsi as materialized (
+      select p.proname, pg_get_functiondef(p.oid) as isi
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'public' and p.prokind = 'f'
+    )
+    select proname, isi from fungsi where isi like '%lpad(%3, ''0'')%'
+  loop
+    if r.isi not like '%between 0 and 999%' then
+      v_telanjang := v_telanjang || r.proname;
+    end if;
+  end loop;
+
+  if array_length(v_telanjang, 1) is not null then
+    raise exception '0117: masih ada fungsi yang memotong nomor dada empat digit: %',
+      array_to_string(v_telanjang, ', ');
+  end if;
+  raise notice '0117: seluruh fungsi yang memformat nomor dada sudah aman untuk empat digit.';
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -515,6 +515,12 @@ run supabase/migrations/0115_sekolah_baku_dua_baris.sql
 # ditolak, dan sebaliknya, lewat KEDUA pintu yang memberi nomor.
 run supabase/migrations/0116_nomor_dada_intern_seribu.sql
 run tests/sql/78_deret_nomor_dada_intern.sql
+
+# 0117 membetulkan lpad(...,3) yang MEMOTONG nomor Intern empat digit jadi
+# tiga — dan tiga digit itu regu Eksternal yang benar-benar ada. Tes 79
+# membaca pesan yang keluar, bukan definisi fungsinya.
+run supabase/migrations/0117_dada_empat_digit_berangkat.sql
+run tests/sql/79_dada_empat_digit.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.

--- a/tests/sql/79_dada_empat_digit.sql
+++ b/tests/sql/79_dada_empat_digit.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/79_dada_empat_digit.sql — migrasi 0117.
+-- Pesan galat tidak boleh MEMOTONG nomor dada empat digit.
+--
+-- `lpad(nomor::text, 3, '0')` memanjangkan 1 jadi "001" — dan memotong 1001
+-- jadi "100". Yang membuatnya berbahaya: 100 adalah regu Eksternal yang
+-- benar-benar ada, jadi pesannya tidak tampak rusak sama sekali. Petugas
+-- garis start mencari regu yang salah pada pukul tujuh pagi.
+--
+-- Diuji lewat pesan yang benar-benar keluar dari `berangkatkan_kloter`, bukan
+-- dengan membaca definisinya: yang harus benar apa yang dibaca petugas.
+-- ============================================================================
+
+\echo '--- 79. nomor dada empat digit tidak terpotong di pesan galat'
+\set ON_ERROR_STOP on
+
+begin;
+
+do $blok$
+declare
+  v_sekolah uuid;
+  v_daftar  uuid;
+  v_regu    uuid;
+  v_kloter  smallint;
+  v_nomor   int;
+  v_tolak   boolean := false;
+  v_pesan   text;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  update status_acara set daftar_ulang_ditutup = false where id;
+
+  select min(s.nomor) into v_nomor from nomor_dada_stok s
+   where s.nomor >= 1001
+     and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
+     and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
+  assert v_nomor >= 1001, '79.0: tidak ada nomor Intern bebas di stok';
+
+  -- Kloter kosong yang belum berangkat, dan tidak boleh ada kloter berisi
+  -- sebelum ia — `berangkatkan_kloter` menolak yang melompati.
+  update kloter set jam_berangkat = null, dicetak_pada = null;
+  update regu set kloter_nomor = null, urutan_kloter = null, nomor_dada = null
+   where not is_cancelled;
+
+  select id into v_sekolah from sekolah order by name limit 1;
+  insert into pendaftaran
+    (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa, status)
+  values (v_sekolah, 'UJI-DIGIT-0117', 1, '081200000117', 'lunas')
+  returning id into v_daftar;
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+  values (v_daftar, 'EMPAT DIGIT UJI', 'Ketua Uji', 'intern_pa')
+  returning id into v_regu;
+
+  perform * from daftar_ulang_batch('UJI-DIGIT-0117', jsonb_build_array(
+    jsonb_build_object('regu_id', v_regu, 'nomor_dada', v_nomor)));
+  select kloter_nomor into v_kloter from regu where id = v_regu;
+
+  -- Regu SUDAH DICEKLIS HADIR tapi belum berkontrak: persis keadaan yang
+  -- memicu pesannya. Baris di `keberangkatan_regu` ITU SENDIRI yang berarti
+  -- hadir — tidak ada kolom `hadir`, dan yang mencatatnya wajib disebut.
+  insert into keberangkatan_regu (regu_id, recorded_by)
+  values (v_regu, '00000000-0000-0000-0000-00000000000a')
+  on conflict (regu_id) do nothing;
+  update regu set kontrak_menit = null where id = v_regu;
+
+  begin
+    perform berangkatkan_kloter(v_kloter, now());
+    raise exception 'GAGAL: kloter berangkat padahal ada regu tanpa kontrak';
+  exception when others then
+    if sqlerrm like 'GAGAL:%' then raise; end if;
+    v_tolak := true; v_pesan := sqlerrm;
+  end;
+
+  assert v_tolak, '79.1 GAGAL: regu tanpa kontrak tidak menahan keberangkatan';
+  assert v_pesan like '%' || v_nomor::text || '%',
+    format('79.1 GAGAL: pesan tidak menyebut nomor %s apa adanya: %s', v_nomor, v_pesan);
+  -- Inilah bentuk terpotongnya. Dituliskan terpisah supaya kalau tes ini
+  -- gugur, yang membacanya langsung tahu apa yang dicari.
+  assert v_pesan not like '%' || left(v_nomor::text, 3) || ' %'
+     and v_pesan not like '%' || left(v_nomor::text, 3),
+    format('79.1 GAGAL: nomor %s terpotong jadi %s di pesan: %s',
+           v_nomor, left(v_nomor::text, 3), v_pesan);
+
+  -- 79.2 Tiga digit TETAP ditulis tiga digit — bentuk yang tertulis di kain,
+  --      dan perbaikan empat digit tidak boleh menghapusnya.
+  assert lpad('7', 3, '0') = '007', '79.2: asumsi bentuk tiga digit berubah';
+
+  perform set_config('app.uid', '', true);
+  raise notice '79 OK — nomor % disebut utuh di pesan keberangkatan.', v_nomor;
+end;
+$blok$;
+
+rollback;
+
+select '79_dada_empat_digit OK' as hasil;


### PR DESCRIPTION
## What

`berangkatkan_kloter` memformat nomor dada dengan `lpad(..., 3, '0')`, yang **memotong** string lebih panjang dari targetnya. Sejak #611 regu Intern bernomor 1001–1250:

```
regu nomor dada 100 belum konfirmasi kontrak waktu     <- sebenarnya regu 1001
```

Sekarang nomor 0–999 tetap tiga digit (bentuk yang tertulis di kain) dan yang lebih panjang dicetak apa adanya — pagar `case when ... between 0 and 999` yang sama dengan empat fungsi lain.

## Why

`100` adalah regu Eksternal yang **benar-benar ada**, jadi pesannya tidak tampak rusak sama sekali. Petugas garis start mencari regu yang salah, menemukan kontraknya sudah terisi, lalu tidak punya petunjuk apa pun tentang regu yang sebenarnya menahan kloternya — pukul tujuh pagi, kloter berikutnya sudah berbaris.

Empat fungsi lain yang memformat nomor dada (`catat_foto_lembar`, `hapus_nilai_pos`, `kunci_nilai_pos`, `tautkan_foto`) **sudah** memakai pagarnya; jebakan lpad ini tertulis di kepala `0023`. `berangkatkan_kloter` satu-satunya yang luput.

## Notes

- Yang menemukannya: membaca `pg_get_functiondef` seluruh fungsi yang benar-benar terpasang, bukan berkas migrasi — definisi terbaru sebuah fungsi tersebar di berkas bernomor besar. Pemeriksaan itu ikut dipasang di ujung migrasi supaya salinan berikutnya tidak lolos lagi.
- Tidak ada view yang memformat nomor dada; sisi layar (`dada3()`, `padStart`) tidak pernah memotong.
- Tes SQL 79 membaca pesan yang **keluar**, bukan definisi fungsinya.
- Lokal: `tests/run.sh` → SEMUA TES LULUS, `node --test` → 205 lulus, `concurrency_test.py` → SEMUA PEMERIKSAAN LULUS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)