### PR TITLE
fix: kolom nomor dada lembar pos muat empat digit

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1370,9 +1370,21 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      pernah berlaku: kolomnya diam-diam melebar mengikuti judul "NO DADA"
      yang 13,04mm satu baris. Terlihat di lembar tercetak — judulnya tidak
      pernah membungkus, padahal 10mm mestinya memaksanya. */
+  /* 12mm, naik dari 10mm sejak nomor dada bisa EMPAT digit (migrasi 0116:
+     Intern 1001-1250). Diukur pada tiruan lembar Pos 3 melintang 277mm,
+     kondisi terlebar:
+
+       "1250" pada 11pt      8,85mm tinta
+       kotak isi 10mm        9,29mm  -> sisa 0,44mm
+       kotak isi 12mm       11,30mm  -> sisa 2,45mm
+
+     0,44mm bukan lega, itu kebetulan — dan lembar ini difotokopi lalu diisi
+     tangan. Dua milimeternya diambil dari kolom penilaian yang punya 23mm
+     masing-masing; sesudahnya 22,82mm, dan tinggi baris (4,32mm) maupun
+     tinggi kepala (6,22mm) tidak bergeser sama sekali. */
   .lembar-pos .print-table td.dada,
   .lembar-pos .print-table th:nth-child(1) {
-    width: 10mm; max-width: 10mm; padding-left: 1pt; padding-right: 1pt;
+    width: 12mm; max-width: 12mm; padding-left: 1pt; padding-right: 1pt;
   }
   /* 11pt, turun dari 12pt — SATU-SATUNYA huruf yang dikecilkan di lembar ini,
      dan ia yang menentukan tinggi seluruh baris.

--- a/web/style.css
+++ b/web/style.css
@@ -1370,9 +1370,21 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      pernah berlaku: kolomnya diam-diam melebar mengikuti judul "NO DADA"
      yang 13,04mm satu baris. Terlihat di lembar tercetak — judulnya tidak
      pernah membungkus, padahal 10mm mestinya memaksanya. */
+  /* 12mm, naik dari 10mm sejak nomor dada bisa EMPAT digit (migrasi 0116:
+     Intern 1001-1250). Diukur pada tiruan lembar Pos 3 melintang 277mm,
+     kondisi terlebar:
+
+       "1250" pada 11pt      8,85mm tinta
+       kotak isi 10mm        9,29mm  -> sisa 0,44mm
+       kotak isi 12mm       11,30mm  -> sisa 2,45mm
+
+     0,44mm bukan lega, itu kebetulan — dan lembar ini difotokopi lalu diisi
+     tangan. Dua milimeternya diambil dari kolom penilaian yang punya 23mm
+     masing-masing; sesudahnya 22,82mm, dan tinggi baris (4,32mm) maupun
+     tinggi kepala (6,22mm) tidak bergeser sama sekali. */
   .lembar-pos .print-table td.dada,
   .lembar-pos .print-table th:nth-child(1) {
-    width: 10mm; max-width: 10mm; padding-left: 1pt; padding-right: 1pt;
+    width: 12mm; max-width: 12mm; padding-left: 1pt; padding-right: 1pt;
   }
   /* 11pt, turun dari 12pt — SATU-SATUNYA huruf yang dikecilkan di lembar ini,
      dan ia yang menentukan tinggi seluruh baris.


### PR DESCRIPTION
## What

Sapuan **seluruh** tempat nomor dada ditampilkan, sesudah Intern jadi 1001–1250. Sembilan tempat diukur; satu yang perlu digeser: kolom nomor dada pada lembar pos, `10mm` → `12mm`.

| Tempat | Patokan | "1250" | Hasil |
| --- | --- | --- | --- |
| Papan peserta (kolom dipaku sticky) | 56px | 32,8px | aman — kolom tetap 56px, patokan sticky nama regu (102px) tidak meleset |
| Pil nomor Meja Daftar Ulang (tabel `fixed`) | persen | 77,2px | aman, tanpa penggulir mendatar |
| Input Pos di layar | `table-layout: auto` | — | aman |
| Cetak kloter `.print-table .dada` | 15mm | 10,6mm tinta | aman |
| **Lembar pos `.lembar-pos … td.dada`** | **10mm** | **8,85mm tinta** | **sisa 0,44mm → digeser** |
| Blangko per lomba `.bl-dada` | 34mm | ditulis tangan | aman |
| Podium Live Score `.dada-juara` | tanpa lebar | — | aman |
| Kotak ketik Kedatangan `.besar` | tanpa `maxlength` | — | aman |
| Pesan galat SQL | `lpad(…,3)` | dipotong | sudah dibetulkan #613 |

## Why

0,44mm bukan lega, itu kebetulan — dan lembar inilah yang difotokopi lalu diisi tangan di lima pos, dengan nomor dada sebagai satu-satunya kunci barisnya. Pada 12mm kotak isinya 11,30mm dan sisanya 2,45mm.

Dua milimeternya diambil dari tujuh kolom penilaian yang masing-masing punya 23,11mm; sesudahnya 22,82mm. Tinggi baris (4,32mm) dan tinggi kepala (6,22mm) tidak bergeser sama sekali, jadi **jumlah baris per lembar tetap**.

## Notes

- **Diukur** pada tiruan setia lembar Pos 3 melintang 277mm — tujuh kolom isian, identitas selebar aslinya — bukan dikira-kira dari perbandingan ukuran huruf.
- Percobaan pertama tidak setia: `.lembar-pos` harus jadi **leluhur** tabelnya, bukan kelas di tabel itu sendiri, dan tanpa itu aturan 11pt maupun lebar 10mm tidak berlaku sedikit pun. Yang menyelamatkannya: tinggi baris terukur 4,45mm — angka yang memang tertulis di komentar CSS-nya.
- Sudah dipastikan tidak perlu disentuh: `dada3()` mengembalikan >999 apa adanya, `padStart` tidak pernah memotong, tidak ada `maxlength` di kotak nomor dada, tidak ada view yang memformat nomor dada, dan tidak satu pun aturan `text-overflow: ellipsis` mengenai kolomnya (yang terdekat kolom organisasi dan golongan, `nth-child` 3 dan 4).
- `live/style.css` ikut disalin — pasangannya dijaga `shared-files.yml`. `node --test` → 205 lulus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)