### PR TITLE
feat: jeda antar kloter paling lama 5 menit, dan "Planning" jadi "Rencana"

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,7 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0117`.
+Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0118`.
 
 ---
 
@@ -62,7 +62,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-117 migrasi, `0001` sampai `0117`, dijalankan berurutan tanpa lubang penomoran.
+118 migrasi, `0001` sampai `0118`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -340,7 +340,13 @@ export async function infoPengaturanKloter() {
       "edisi?is_active=eq.true" +
       "&select=jam_mulai_berangkat,jam_batas_berangkat," +
       "maks_eksternal_per_kloter,maks_intern_per_kloter," +
-      "perkiraan_regu_eksternal,perkiraan_regu_intern,kloter_maks"),
+      "perkiraan_regu_eksternal,perkiraan_regu_intern,kloter_maks," +
+      // Jeda maksimal antar kloter (migrasi 0118). Kolomnya ADA sejak 0001,
+      // jadi menyebutnya di sini aman walau migrasinya belum dijalankan —
+      // yang berbeda cuma nilainya (4 sebelum, 5 sesudah). Kalau kolomnya
+      // yang belum ada, PostgREST menjawab 42703 dan seluruh layar Daftar
+      // Kloter mati; lihat catatan panjang di bawah.
+      "interval_berangkat_menit"),
     baca(null, "regu?is_cancelled=eq.false&select=golongan"),
     // Jendela Planning Keberangkatan (migrasi 0113). Tinggal di status_acara,
     // bukan di edisi, karena ia disusun pada hari-H — hari yang sama saat

--- a/supabase/migrations/0118_jeda_kloter_maksimal.sql
+++ b/supabase/migrations/0118_jeda_kloter_maksimal.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- hrcd-rekap : 0118_jeda_kloter_maksimal.sql
+-- Jendela keberangkatan jadi BATAS ATAS, bukan perintah menyebar.
+--
+-- APA YANG SALAH
+--
+-- `perkiraan_berangkat_kloter()` (0105) membagi jendela 07:00-10:00 rata ke
+-- seluruh kloter edisi. Itu benar ketika kloternya banyak, dan konyol ketika
+-- sedikit:
+--
+--     2 kloter, jendela 07:00-10:00  ->  K1 07:00, K2 10:00
+--
+-- seolah kloter kedua menunggu tiga jam di lapangan. Dilaporkan dari layar
+-- Cetak Kloter dengan dua kloter yang benar-benar ada.
+--
+-- Di lapangan kloter berangkat BERUNTUN: satu kloter dilepas, kloter
+-- berikutnya maju dari Staging 1 (alur 10.3), dan jaraknya tidak pernah lebih
+-- dari beberapa menit. Pemilik acara menetapkan jeda maksimal 5 menit.
+--
+-- ATURANNYA
+--
+--     perkiraan K-n = jam_mulai + yang lebih kecil antara
+--                       (jam_batas - jam_mulai) x (n-1)/(kloter_maks-1)  <- rata
+--                       interval_berangkat_menit x (n-1)                 <- batas
+--
+-- Kloter terakhir karena itu boleh berangkat jauh sebelum ujung jendela —
+-- memang begitu kalau regunya sedikit. Yang dijamin jendela bukan lagi "yang
+-- terakhir berangkat pukul sepuluh" melainkan "tidak ada yang berangkat
+-- SESUDAH pukul sepuluh", dan itu yang sebenarnya diminta pasal 10.1.
+--
+-- KENAPA KOLOM LAMA, BUKAN KOLOM BARU
+--
+-- `edisi.interval_berangkat_menit` sudah ada sejak 0001 dengan arti yang
+-- nyaris sama — jarak antar keberangkatan — dan dipakai rumus perkiraan lama
+-- (0053, 0056) sebagai jarak TETAP. Sejak 0105 tidak ada satu pun fungsi atau
+-- view yang membacanya: kolom mati, bernama tepat. Menghidupkannya kembali
+-- sebagai BATAS ATAS lebih baik daripada menambah kolom kedua yang artinya
+-- bertumpang tindih — dua angka untuk satu pertanyaan adalah cara mereka
+-- mulai berbeda pendapat.
+--
+-- Nilainya dinaikkan 4 -> 5 menit sesuai keputusan pemilik acara.
+--
+-- SATU ATURAN, TIGA TEMPAT
+--
+-- Batas yang sama dipakai `jadwalPlanning()` (kertas kloter) dan
+-- `hitungRekomendasiKloter()` (Kalkulator Keberangkatan) di
+-- web/js/departure-calculator.mjs, keduanya membaca kolom ini lewat
+-- `infoPengaturanKloter()`. Kalau angkanya diubah, ubah di sini — ketiganya
+-- ikut.
+-- ============================================================================
+
+comment on column edisi.interval_berangkat_menit is
+  'Jeda MAKSIMAL antar kloter, menit. Perkiraan berangkat memakai yang lebih kecil antara pembagian rata jendela dan angka ini (migrasi 0118).';
+
+update edisi set interval_berangkat_menit = 5
+ where is_active and interval_berangkat_menit <> 5;
+
+create or replace function perkiraan_berangkat_kloter(p_kloter integer)
+returns timestamptz
+language sql stable
+set search_path = public
+as $$
+  with cfg as (
+    select e.*,
+      greatest(e.kloter_maks, 1)::int as jumlah_kloter
+    from edisi e
+    where e.is_active
+  )
+  select ((tanggal_lomba + jam_mulai_berangkat) at time zone 'Asia/Jakarta')
+    -- Yang dibandingkan JARAK DARI KLOTER PERTAMA, bukan jeda per langkah.
+    -- Bentuk "bagi dulu lalu kalikan" menumpuk pembulatan mikrodetik: 180
+    -- menit dibagi 74 lalu dikalikan 74 lagi menghasilkan 4 mikrodetik LEBIH
+    -- dari tiga jam, dan kloter terakhir jatuh sesudah jendelanya habis.
+    -- Bentuk di bawah mempertahankan aritmetika 0105 apa adanya selama
+    -- batasnya tidak menggigit, jadi jam yang sudah diuji tidak bergeser
+    -- satu detik pun.
+    + least(
+        case when jumlah_kloter = 1 then interval '0'
+             else (jam_batas_berangkat - jam_mulai_berangkat)
+                    * ((p_kloter - 1)::double precision / (jumlah_kloter - 1))
+        end,
+        make_interval(mins => interval_berangkat_menit) * (p_kloter - 1)
+      )
+  from cfg
+$$;
+
+comment on function perkiraan_berangkat_kloter(integer) is
+  'Perkiraan FIFO: jam mulai + jeda x (nomor - 1), dengan jeda = yang lebih kecil antara pembagian rata jendela dan edisi.interval_berangkat_menit.';
+
+do $blok$
+declare v_jeda int; v_kloter int; v_akhir text; v_batas text;
+begin
+  select interval_berangkat_menit, kloter_maks,
+         to_char(jam_batas_berangkat, 'HH24:MI')
+    into v_jeda, v_kloter, v_batas
+  from edisi where is_active;
+
+  select to_char(perkiraan_berangkat_kloter(v_kloter) at time zone 'Asia/Jakarta',
+                 'HH24:MI')
+    into v_akhir;
+
+  raise notice '0118: jeda maksimal % menit, % kloter, K% -> % (jendela habis %).',
+               v_jeda, v_kloter, v_kloter, v_akhir, v_batas;
+
+  assert perkiraan_berangkat_kloter(1)
+       = ((select tanggal_lomba + jam_mulai_berangkat from edisi where is_active)
+          at time zone 'Asia/Jakarta'),
+    '0118: K1 tidak lagi berangkat tepat di awal jendela';
+  assert perkiraan_berangkat_kloter(v_kloter)
+       <= ((select tanggal_lomba + jam_batas_berangkat from edisi where is_active)
+           at time zone 'Asia/Jakarta'),
+    '0118: kloter terakhir diperkirakan berangkat SESUDAH jendela habis';
+end;
+$blok$;

--- a/tests/departure_calculator.test.mjs
+++ b/tests/departure_calculator.test.mjs
@@ -137,3 +137,69 @@ test("jendela terbalik dan jam tidak lengkap ditolak", () => {
   assert.throws(() => jadwalPlanning([1, 2], "10:00", "07:00"), /harus setelah/);
   assert.throws(() => jadwalPlanning([1, 2], "", "10:00"), /belum lengkap/);
 });
+
+
+// ============================================================================
+// JEDA MAKSIMAL ANTAR KLOTER (migrasi 0118).
+//
+// Menyebar rata ke seluruh jendela benar ketika kloternya banyak, dan konyol
+// ketika sedikit: dua kloter di jendela 07:00-10:00 terbaca "07:00 dan 10:00",
+// seolah kloter kedua menunggu tiga jam di lapangan. Dilaporkan dari layar
+// Cetak Kloter, dengan dua kloter yang benar-benar ada.
+//
+// Jendelanya karena itu jadi BATAS ATAS, bukan target.
+// ============================================================================
+
+test("dua kloter tidak dilempar ke ujung jendela", () => {
+  const jadwal = jadwalPlanning([1, 2], "07:00", "10:00", 5);
+  assert.equal(jadwal.get(1), "07:00");
+  assert.equal(jadwal.get(2), "07:05");
+});
+
+
+test("jeda maksimal tidak melebar-lebarkan yang sudah rapat", () => {
+  // 50 kloter di jendela 07:00-10:00 berjarak 3,67 menit — di bawah batas,
+  // jadi batasnya tidak boleh menyentuh apa pun. Pagar ini yang menahan
+  // "maksimal" diam-diam berubah jadi "selalu".
+  const jadwal = jadwalPlanning(
+    Array.from({ length: 50 }, (_, i) => i + 1), "07:00", "10:00", 5);
+  assert.equal(jadwal.get(1), "07:00");
+  assert.equal(jadwal.get(50), "10:00");
+  assert.equal(jadwal.get(2), "07:03");
+});
+
+
+test("tanpa batas, perilakunya persis seperti sebelum 0118", () => {
+  // Layar boleh terbit sebelum migrasinya dijalankan (pasal 7.6), dan di sela
+  // itu kolom jedanya bisa belum berisi. Kosong = tidak membatasi apa pun.
+  const jadwal = jadwalPlanning([1, 2], "07:00", "10:00");
+  assert.equal(jadwal.get(2), "10:00");
+});
+
+
+test("satu kloter berangkat di awal jendela, bukan di ujungnya", () => {
+  assert.equal(jadwalPlanning([7], "07:00", "10:00", 5).get(7), "07:00");
+});
+
+
+test("kalkulator memakai batas jeda yang sama", () => {
+  // Dua kloter dibutuhkan, batas edisi 52: tanpa batas jeda, K2 jatuh di
+  // 07:03 karena pembaginya 52. Dengan batas 5 ia tetap 07:03 — batasnya
+  // hanya menahan yang MELEBIHI, dan 3 menit tidak melebihi.
+  const rapat = hitungRekomendasiKloter({
+    waktuPertama: "07:00", waktuTerakhir: "10:00",
+    jumlahEksternal: 10, jumlahIntern: 0,
+    maksEksternalPerKloter: 5, maksInternPerKloter: 3,
+    kloterMaks: 52, jedaMaksMenit: 5,
+  });
+  assert.equal(rapat[1].waktuBerangkat, "07:03");
+
+  // Batas edisi 2 kloter: pembaginya 1, jadi tanpa batas K2 jatuh 10:00.
+  const jarang = hitungRekomendasiKloter({
+    waktuPertama: "07:00", waktuTerakhir: "10:00",
+    jumlahEksternal: 10, jumlahIntern: 0,
+    maksEksternalPerKloter: 5, maksInternPerKloter: 3,
+    kloterMaks: 2, jedaMaksMenit: 5,
+  });
+  assert.equal(jarang[1].waktuBerangkat, "07:05");
+});

--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -27,7 +27,11 @@ test("kartu kloter memakai satu perakit baris jam, bukan ternary di tempat", () 
 
 
 test("kedua label menyebut asal angkanya", () => {
-  assert.match(layar, /<strong>Planning<\/strong>/);
+  // "Rencana", bukan "Planning": teks layar berbahasa Indonesia (pasal 5.2).
+  // Yang dijaga tetap PASANGANNYA — rencana dan jam sebenarnya digambar
+  // berdampingan, bukan saling menggantikan.
+  assert.match(layar, /<strong>Rencana<\/strong>/);
+  assert.doesNotMatch(layar, /<strong>Planning<\/strong>/);
   assert.match(layar, /<strong>Real<\/strong>/);
   // "Jam berangkat" polos terbaca seperti jadwal; "Estimasi" adalah kata
   // ketiga untuk hal yang kertasnya sebut "Perkiraan".
@@ -90,7 +94,7 @@ test("jendela disimpan, ditunda, dan gagalnya tidak diam", () => {
   // keadaan yang tiga di antaranya belum berarti apa-apa.
   assert.match(layar, /clearTimeout\(jadwalSimpan\)/);
   assert.match(layar, /\}, 800\)/);
-  assert.match(layar, /Planning belum tersimpan: \$\{err\.message\}/);
+  assert.match(layar, /Rencana belum tersimpan: \$\{err\.message\}/);
 });
 
 
@@ -109,6 +113,7 @@ test("kertas staging tetap menyediakan garis jam sebenarnya", () => {
 
 test("layar planning tanpa judul dan tanpa paragraf penjelas", () => {
   assert.doesNotMatch(layar, /<h2[^>]*>Planning Keberangkatan<\/h2>/);
+  assert.doesNotMatch(layar, /<h2[^>]*>Rencana Keberangkatan<\/h2>/);
   assert.doesNotMatch(layar, /Sudah mengambil nomor dada/);
   assert.doesNotMatch(layar, /dibagi rata ke/);
 });

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -521,6 +521,12 @@ run tests/sql/78_deret_nomor_dada_intern.sql
 # membaca pesan yang keluar, bukan definisi fungsinya.
 run supabase/migrations/0117_dada_empat_digit_berangkat.sql
 run tests/sql/79_dada_empat_digit.sql
+
+# 0118 membuat jendela keberangkatan jadi BATAS ATAS: jeda antar kloter paling
+# lama 5 menit. Tes 80 mengujinya dua arah — yang jarang dibatasi, yang rapat
+# tidak ikut dipendekkan.
+run supabase/migrations/0118_jeda_kloter_maksimal.sql
+run tests/sql/80_jeda_kloter_maksimal.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.

--- a/tests/sql/80_jeda_kloter_maksimal.sql
+++ b/tests/sql/80_jeda_kloter_maksimal.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/80_jeda_kloter_maksimal.sql — migrasi 0118.
+-- Jendela keberangkatan adalah BATAS ATAS, bukan perintah menyebar.
+--
+-- Dua kloter di jendela 07:00-10:00 pernah terbaca "07:00 dan 10:00", seolah
+-- kloter kedua menunggu tiga jam di lapangan. Yang diuji di sini dua arah
+-- sekaligus, karena "maksimal" gampang sekali berubah jadi "selalu":
+--
+--   sedikit kloter -> jeda DIBATASI, kloter terakhir jauh sebelum ujung
+--   banyak kloter  -> jeda apa adanya, kloter terakhir TEPAT di ujung
+--
+-- Konfigurasi edisi diubah di dalam transaksi lalu di-rollback, jadi tes ini
+-- tidak meninggalkan jejak pada edisi uji.
+-- ============================================================================
+
+\echo '--- 80. jeda maksimal antar kloter'
+\set ON_ERROR_STOP on
+
+begin;
+
+do $blok$
+declare
+  v_mulai time; v_jam text; v_jam2 text;
+begin
+  select jam_mulai_berangkat into v_mulai from edisi where is_active;
+
+  update edisi set jam_mulai_berangkat = '07:00', jam_batas_berangkat = '10:00',
+                   interval_berangkat_menit = 5, kloter_dasar = 2, kloter_maks = 2
+   where is_active;
+
+  select to_char(perkiraan_berangkat_kloter(1) at time zone 'Asia/Jakarta', 'HH24:MI')
+    into v_jam;
+  select to_char(perkiraan_berangkat_kloter(2) at time zone 'Asia/Jakarta', 'HH24:MI')
+    into v_jam2;
+  assert v_jam = '07:00', format('80.1 GAGAL: K1 berangkat %s, seharusnya 07:00', v_jam);
+  assert v_jam2 = '07:05',
+    format('80.1 GAGAL: dua kloter, K2 diperkirakan %s — seharusnya 07:05, '
+           'bukan dilempar ke ujung jendela', v_jam2);
+
+  -- 80.2 Banyak kloter: jedanya sudah di bawah batas, jadi batas itu tidak
+  --      boleh menyentuh apa pun. 61 kloter -> tepat 3 menit, dan K61 tepat
+  --      di ujung jendela.
+  update edisi set kloter_dasar = 61, kloter_maks = 61 where is_active;
+  select to_char(perkiraan_berangkat_kloter(61) at time zone 'Asia/Jakarta', 'HH24:MI')
+    into v_jam;
+  assert v_jam = '10:00',
+    format('80.2 GAGAL: 61 kloter, K61 diperkirakan %s — batas jeda ikut '
+           'memendekkan yang sudah rapat', v_jam);
+  select to_char(perkiraan_berangkat_kloter(2) at time zone 'Asia/Jakarta', 'HH24:MI')
+    into v_jam;
+  assert v_jam = '07:03', format('80.2 GAGAL: K2 %s, seharusnya 07:03', v_jam);
+
+  -- 80.3 Tidak ada kloter yang diperkirakan berangkat SESUDAH jendela habis,
+  --      berapa pun jumlah kloternya. Itu jaminan pasal 10.1 yang tersisa
+  --      sesudah jendelanya jadi batas atas.
+  update edisi set kloter_dasar = 52, kloter_maks = 52 where is_active;
+  assert (select perkiraan_berangkat_kloter(52))
+       <= ((select tanggal_lomba + jam_batas_berangkat from edisi where is_active)
+           at time zone 'Asia/Jakarta'),
+    '80.3 GAGAL: kloter terakhir melewati ujung jendela';
+
+  -- 80.4 Satu kloter: tidak ada jeda sama sekali, dan tidak ada pembagian
+  --      dengan nol.
+  update edisi set kloter_dasar = 1, kloter_maks = 1 where is_active;
+  select to_char(perkiraan_berangkat_kloter(1) at time zone 'Asia/Jakarta', 'HH24:MI')
+    into v_jam;
+  assert v_jam = '07:00', format('80.4 GAGAL: satu kloter berangkat %s', v_jam);
+
+  raise notice '80 OK — jendela jadi batas atas, dan yang rapat tidak ikut dipendekkan.';
+end;
+$blok$;
+
+rollback;
+
+select '80_jeda_kloter_maksimal OK' as hasil;

--- a/tests/time_input_labels.test.mjs
+++ b/tests/time_input_labels.test.mjs
@@ -12,8 +12,8 @@ test("semua label kotak jam manual menunjuk input HH", () => {
   const pasangan = [
     ["kloter-pertama", "Waktu Berangkat Pertama"],
     ["kloter-terakhir", "Waktu Berangkat Terakhir"],
-    ["planning-pertama", "Planning Berangkat Pertama"],
-    ["planning-terakhir", "Planning Berangkat Terakhir"],
+    ["planning-pertama", "Rencana Berangkat Pertama"],
+    ["planning-terakhir", "Rencana Berangkat Terakhir"],
     ["jam-berangkat", "Jam berangkat"],
     ["jam", "Jam datang"],
   ];

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -340,7 +340,13 @@ export async function infoPengaturanKloter() {
       "edisi?is_active=eq.true" +
       "&select=jam_mulai_berangkat,jam_batas_berangkat," +
       "maks_eksternal_per_kloter,maks_intern_per_kloter," +
-      "perkiraan_regu_eksternal,perkiraan_regu_intern,kloter_maks"),
+      "perkiraan_regu_eksternal,perkiraan_regu_intern,kloter_maks," +
+      // Jeda maksimal antar kloter (migrasi 0118). Kolomnya ADA sejak 0001,
+      // jadi menyebutnya di sini aman walau migrasinya belum dijalankan —
+      // yang berbeda cuma nilainya (4 sebelum, 5 sesudah). Kalau kolomnya
+      // yang belum ada, PostgREST menjawab 42703 dan seluruh layar Daftar
+      // Kloter mati; lihat catatan panjang di bawah.
+      "interval_berangkat_menit"),
     baca(null, "regu?is_cancelled=eq.false&select=golongan"),
     // Jendela Planning Keberangkatan (migrasi 0113). Tinggal di status_acara,
     // bukan di edisi, karena ia disusun pada hari-H — hari yang sama saat

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -674,6 +674,7 @@ async function layarPengaturanKloter() {
         maksEksternalPerKloter: Number(cfg.maks_eksternal_per_kloter),
         maksInternPerKloter: Number(cfg.maks_intern_per_kloter),
         kloterMaks: Number(cfg.kloter_maks),
+        jedaMaksMenit: Number(cfg.interval_berangkat_menit) || Infinity,
       });
       waktuTerakhir.salah(false);
       tbody.replaceChildren(h(baris.map(x => html`
@@ -2068,25 +2069,25 @@ async function layarCetakKloter() {
           </tr>
         </tbody>
       </table>
-      <!-- Planning berdiri DI ATAS tombol cetak, dan urutan itu berarti:
+      <!-- Rencana berangkat berdiri DI ATAS tombol cetak, dan urutan itu berarti:
            yang tercetak adalah jam yang baru saja diatur di sini. Menaruhnya
            di bawah membuat petugas menekan Cetak lebih dulu, lalu menemukan
            kotak jamnya sesudah kertasnya keluar.
 
            TANPA judul dan TANPA paragraf penjelas. Labelnya sendiri sudah
-           menyebut "Planning Berangkat", jadi judul "Planning Keberangkatan"
-           di atasnya cuma mengulang label yang ada di bawahnya (pasal 9.3),
+           menyebut "Rencana Berangkat", jadi judul di atasnya cuma mengulang
+           label yang ada di bawahnya (pasal 9.3),
            dan kalimat "jam ini dibagi rata lalu tercetak untuk peserta"
            menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah
            sekali (pasal 9.1 dan 9.6). -->
       <div class="two-column planning-jam" style="margin-top:1rem">
         <div class="field">
-          <label for="planning-pertama-hh">Planning Berangkat Pertama</label>
+          <label for="planning-pertama-hh">Rencana Berangkat Pertama</label>
           ${kotakJamHtml("planning-pertama", jamPendek(
             cfg.planning_berangkat_pertama || cfg.jam_mulai_berangkat))}
         </div>
         <div class="field">
-          <label for="planning-terakhir-hh">Planning Berangkat Terakhir</label>
+          <label for="planning-terakhir-hh">Rencana Berangkat Terakhir</label>
           ${kotakJamHtml("planning-terakhir", jamPendek(
             cfg.planning_berangkat_terakhir || cfg.jam_batas_berangkat))}
         </div>
@@ -2121,7 +2122,8 @@ async function layarCetakKloter() {
     const terakhir = waktuTerakhir.nilai();
     if (!pertama || !terakhir) { planning = new Map(); return; }
     try {
-      planning = jadwalPlanning([...perKloter.keys()], pertama, terakhir);
+      planning = jadwalPlanning([...perKloter.keys()], pertama, terakhir,
+                                Number(cfg.interval_berangkat_menit) || Infinity);
     } catch (e) {
       planning = new Map();
       if (/waktu berangkat terakhir/i.test(e.message)) waktuTerakhir.salah(true);
@@ -2146,7 +2148,7 @@ async function layarCetakKloter() {
       || (v.perkiraanBerangkat ? jamMenit(v.perkiraanBerangkat) : null);
 
     const bagian = [];
-    if (rencana) bagian.push(html`<strong>Planning</strong> ${rencana}`);
+    if (rencana) bagian.push(html`<strong>Rencana</strong> ${rencana}`);
     if (v.jamBerangkat) {
       bagian.push(html`<strong>Real</strong> ${jamMenit(v.jamBerangkat)}`);
     }
@@ -2275,7 +2277,7 @@ async function layarCetakKloter() {
       try {
         await aturPlanningBerangkat(pertama, terakhir);
       } catch (err) {
-        galatPlanning.textContent = `Planning belum tersimpan: ${err.message}`;
+        galatPlanning.textContent = `Rencana belum tersimpan: ${err.message}`;
         galatPlanning.hidden = false;
       }
     }, 800);

--- a/web/js/departure-calculator.mjs
+++ b/web/js/departure-calculator.mjs
@@ -44,7 +44,8 @@ function jamDariMenit(total) {
  *
  * @returns {Map<number, string>} nomor kloter -> "HH:MM"
  */
-export function jadwalPlanning(nomorKloter, waktuPertama, waktuTerakhir) {
+export function jadwalPlanning(nomorKloter, waktuPertama, waktuTerakhir,
+                               jedaMaksMenit = Infinity) {
   const pertama = menitDariJam(waktuPertama);
   const terakhir = menitDariJam(waktuTerakhir);
   if (pertama === null || terakhir === null) {
@@ -59,12 +60,32 @@ export function jadwalPlanning(nomorKloter, waktuPertama, waktuTerakhir) {
     .sort((a, b) => a - b);
   const rentang = terakhir - pertama;
 
-  return new Map(urut.map((nomor, i) => [
-    nomor,
-    jamDariMenit(urut.length === 1
-      ? pertama
-      : pertama + Math.floor(rentang * i / (urut.length - 1))),
-  ]));
+  /* JEDANYA DIBATASI, dan itu yang membuat jendela bukan perintah menyebar.
+
+     Menyebar rata ke seluruh jendela benar ketika kloternya banyak, dan
+     konyol ketika sedikit: dua kloter di jendela 07:00-10:00 terbaca "07:00
+     dan 10:00", seolah kloter kedua menunggu tiga jam di lapangan. Yang
+     sebenarnya terjadi di lapangan: kloter berangkat beruntun, dan jarak
+     antar kloter tidak pernah lebih dari beberapa menit.
+
+     Jadi jendelanya jadi BATAS ATAS, bukan target: jeda = yang lebih kecil
+     antara "rata di jendela" dan jeda maksimal. Kloter terakhir boleh
+     berangkat jauh sebelum ujung jendela — memang begitu kalau regunya
+     sedikit. */
+  const jedaMaks = Number(jedaMaksMenit) || Infinity;
+  // Yang dibandingkan JARAK DARI KLOTER PERTAMA, bukan jeda per langkah:
+  // `rentang / (n-1) * i` menumpuk pembulatan pecahan dan membuat kloter
+  // terakhir meleset satu menit ke bawah, sementara `rentang * i / (n-1)`
+  // jatuh tepat di ujung jendela — bentuk yang sama dengan database.
+  // `i === 0` disebut sendiri, dan itu BUKAN kerapian: tanpa batas jeda,
+  // `jedaMaks` bernilai Infinity, dan `Infinity * 0` di JavaScript adalah NaN
+  // — bukan 0. Kloter pertama lalu tercetak "NaN:NaN" pada jalur yang paling
+  // sering dipakai.
+  const menit = (i) => (i === 0 || urut.length === 1)
+    ? pertama
+    : pertama + Math.floor(Math.min(rentang * i / (urut.length - 1), jedaMaks * i));
+
+  return new Map(urut.map((nomor, i) => [nomor, jamDariMenit(menit(i))]));
 }
 
 /**
@@ -79,6 +100,7 @@ export function hitungRekomendasiKloter({
   maksEksternalPerKloter,
   maksInternPerKloter,
   kloterMaks,
+  jedaMaksMenit = Infinity,
 }) {
   const pertama = menitDariJam(waktuPertama);
   const terakhir = menitDariJam(waktuTerakhir);
@@ -139,10 +161,16 @@ export function hitungRekomendasiKloter({
      layar menampilkannya lewat jamMenit(), yang MEMOTONG detik. K10 di sana
      07:21:53 terbaca "07:21"; membulatkan di sini akan menuliskannya 07:22. */
   const rentang = terakhir - pertama;
+  // Jeda maksimalnya sama dengan yang dipakai jadwalPlanning() dan
+  // perkiraan_berangkat_kloter(): satu aturan lapangan, bukan tiga.
+  const jedaMaks = Number(jedaMaksMenit) || Infinity;
   return Array.from({ length: jumlahKloter }, (_, indeks) => {
-    const waktu = batasKloter === 1
+    // `indeks === 0` disebut sendiri: `Infinity * 0` adalah NaN (lihat
+    // catatan yang sama di jadwalPlanning).
+    const waktu = (indeks === 0 || batasKloter === 1)
       ? pertama
-      : pertama + Math.floor(rentang * indeks / (batasKloter - 1));
+      : pertama + Math.floor(Math.min(rentang * indeks / (batasKloter - 1),
+                                      jedaMaks * indeks));
     return {
       kloter: indeks + 1,
       jumlahEksternal: Math.max(0, Math.min(kapasitasEksternal,


### PR DESCRIPTION
## What

Jendela keberangkatan sekarang **batas atas**, bukan perintah menyebar:

```
K-n = jam mulai + yang lebih kecil antara
        (jam batas - jam mulai) x (n-1)/(kloter-1)   <- rata
        jeda maksimal x (n-1)                        <- batas (5 menit)
```

Dua kloter di jendela 07:00–10:00 jadi **07:00 dan 07:05**, bukan 07:00 dan 10:00.

Istilah layar **"Planning" → "Rencana"** (label kotak jam, baris jam di kartu kloter, dan pesan galatnya).

## Why

Dilaporkan dari layar Cetak Kloter: dua kloter yang benar-benar ada terbaca "Planning 07:00" dan "Planning 10:00", seolah kloter kedua menunggu tiga jam di lapangan. Menyebar rata ke seluruh jendela benar ketika kloternya banyak dan konyol ketika sedikit — di lapangan kloter berangkat beruntun, satu dilepas dan berikutnya maju dari Staging 1 (alur 10.3).

Yang dijamin jendela bukan lagi "yang terakhir berangkat pukul sepuluh" melainkan **"tidak ada yang berangkat sesudah pukul sepuluh"**, dan itu yang sebenarnya diminta CLAUDE.md 10.1.

**Satu aturan, tiga tempat.** Perkiraan database, jadwal Rencana di kertas kloter, dan Kalkulator Keberangkatan memakai batas yang sama dari `edisi.interval_berangkat_menit`. Kolom itu ada sejak `0001` dengan arti nyaris sama dan mati sejak `0105` — dihidupkan lagi sebagai batas atas (4 → 5 menit) daripada menambah kolom kedua yang artinya bertumpang tindih.

## Dua jebakan yang sempat menggigit

1. **`Infinity * 0` di JavaScript adalah NaN**, bukan 0. Tanpa batas jeda, kloter pertama tercetak `NaN:NaN` — di jalur yang paling sering dipakai. Ketahuan karena empat tes yang sudah ada langsung gugur.
2. **Membagi interval lalu mengalikannya kembali menumpuk pembulatan mikrodetik**: 180 menit ÷ 74 × 74 menghasilkan 4 µs *lebih* dari tiga jam, dan kloter terakhir jatuh sesudah jendelanya habis (assertion migrasi ini sendiri yang menangkapnya). Bentuk perkalian pecahan dari `0105` dipertahankan, jadi jam yang sudah diuji tidak bergeser sedetik pun.

## Notes

- Tes SQL 80 menguji **dua arah**: yang jarang dibatasi, yang rapat tidak ikut dipendekkan (61 kloter tetap berujung 10:00). Lima tes JS baru untuk `jadwalPlanning` dan kalkulatornya.
- Lokal: `tests/run.sh` → SEMUA TES LULUS, `node --test` → **210 lulus**, `periksa_impor.py`, `live/js/api.js` disalin.
- Nama kolom, id elemen, dan nama fungsi **tidak** ikut berganti istilah — itu kosakata teknis (CLAUDE.md 5.4); yang berbahasa Indonesia teks layarnya (5.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)