### PR TITLE
feat: require regu names to be at least three letters

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -142,6 +142,14 @@ const NAMA_MAKS = 20;
 const ADA_ANGKA = /[0-9]/;
 const normalNama = (t) => String(t || "").trim().toLowerCase().replace(/\s+/g, " ");
 
+/* Batas BAWAH nama regu (0120). Yang dihitung hurufnya, bukan panjang
+   karakternya: "A B" tiga karakter tetapi dua huruf, dan yang dibacakan di
+   lapangan saat pemberangkatan dan saat juara diumumkan adalah hurufnya.
+   Tanda baca dan spasi karena itu dibuang dulu — "Ma'ruf" dan "Nur-Aini"
+   tetap lolos. Aturan yang sama ditegakkan database. */
+const HURUF_MIN = 3;
+const cukupHuruf = (t) => (String(t || "").match(/\p{L}/gu) || []).length >= HURUF_MIN;
+
 /* Jawaban server, diingat per nama supaya satu nama tidak ditanyakan berkali
    -kali sementara pembina masih mengetik nama berikutnya. */
 const namaTerpakai = new Map();
@@ -590,6 +598,7 @@ function gambarRegu() {
     const n = normalNama(jawab.regu[i].nama_regu);
     if (!n) return "Nama regu wajib diisi.";
     if (ADA_ANGKA.test(n)) return "Nama regu tidak boleh memakai angka.";
+    if (!cukupHuruf(n)) return `Nama regu minimal ${HURUF_MIN} huruf.`;
     if (jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n))
       return "Nama ini sudah dipakai regu lain di form ini.";
     if (namaTerpakai.get(n))
@@ -718,17 +727,21 @@ function periksa(gulir = true) {
     // pun database menolaknya, dan ditolak di sini pembina masih melihat
     // kartu mana yang harus diubah.
     const n = normalNama(r.nama_regu);
-    const namaSalah = !n
-      || jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n)
-      || namaTerpakai.get(n) === true;
+    const namaPendek = !!n && !cukupHuruf(n);
+    const namaKembar = !!n
+      && (jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n)
+          || namaTerpakai.get(n) === true);
+    const namaSalah = !n || namaPendek || namaKembar;
     const anggotaBerangka = (r.anggota || []).some(a => a && ADA_ANGKA.test(a));
     const kurang = namaSalah || !r.nama_ketua || ADA_ANGKA.test(r.nama_ketua)
       || anggotaBerangka;
     const el = document.getElementById(`regu-${i}`);
     if (el) el.classList.toggle("regu-card-error", kurang);
     if (kurang) {
-      galat.push({ ke: `regu-${i}`, teks: namaSalah && n
-        ? `Regu ${i + 1}: nama sudah dipakai` : `Regu ${i + 1} belum lengkap` });
+      galat.push({ ke: `regu-${i}`, teks:
+        namaPendek ? `Regu ${i + 1}: nama minimal ${HURUF_MIN} huruf`
+        : namaKembar ? `Regu ${i + 1}: nama sudah dipakai`
+        : `Regu ${i + 1} belum lengkap` });
     }
   });
 

--- a/supabase/migrations/0120_nama_regu_tiga_huruf.sql
+++ b/supabase/migrations/0120_nama_regu_tiga_huruf.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- hrcd-rekap : 0120_nama_regu_tiga_huruf.sql
+--
+-- Nama regu sekurang-kurangnya tiga huruf.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Batas nama regu selama ini hanya di ujung ATAS: maksimal 20 karakter (0051),
+-- tanpa angka (0052), dan tidak boleh kembar. Ujung bawahnya satu karakter,
+-- jadi "A" dan "-" sama-sama lolos.
+--
+-- Nama sependek itu tidak dapat dipanggil. Nama regu dibacakan di lapangan
+-- saat pemberangkatan dan saat juara diumumkan, dan satu huruf yang diteriakkan
+-- di antara puluhan regu tidak terdengar sebagai nama. Ia juga tidak dapat
+-- dibedakan di lembar per pos, tempat kolomnya bersebelahan dengan nomor dada
+-- yang justru memang pendek.
+--
+-- ---------------------------------------------------------------------------
+-- YANG DIHITUNG ADALAH HURUFNYA, BUKAN PANJANG KARAKTERNYA
+--
+-- "A B" panjangnya tiga karakter tetapi hurufnya dua, dan yang dibacakan di
+-- lapangan adalah hurufnya. Karena itu tanda baca dan spasi dibuang dulu, baru
+-- sisanya dihitung — sejalan dengan 0052 yang juga menyempitkan syaratnya
+-- seketat mungkin supaya nama sungguhan tidak ikut tertolak: "Ma'ruf" dan
+-- "Siti Nur-Aini" tetap lolos, karena hurufnya jauh lebih dari tiga.
+--
+-- Batas atas 20 di `regu_nama_panjang` sengaja TIDAK diutak-atik. Ia menghitung
+-- karakter karena yang dijaganya adalah lebar kolom di kertas, dan di sana
+-- spasi memang memakan tempat.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DI DATABASE, BUKAN CUKUP DI FORM
+--
+-- Alasan yang sama dengan 0052: form pendaftaran menolaknya sambil diketik,
+-- tetapi RPC-nya terbuka dan panitia juga menulis nama lewat layar meja. Yang
+-- menegakkan aturan harus yang paling akhir menyentuh datanya.
+-- ============================================================================
+
+-- Baris lama yang melanggar disebutkan namanya, dan migrasi ini BERHENTI.
+-- Menambahkan constraint sambil diam-diam membiarkan barisnya berarti aturan
+-- itu berlaku untuk pendaftar berikutnya saja, dan regu yang sudah terlanjur
+-- bernama satu huruf akan tetap dipanggil dengan satu huruf di lapangan.
+do $$
+declare v_regu text;
+begin
+  select string_agg(format('%s (%s huruf)', nama_regu,
+                           length(regexp_replace(nama_regu, '[^[:alpha:]]', '', 'g'))),
+                    ', ' order by nama_regu)
+    into v_regu
+  from regu
+  where not is_cancelled
+    and length(regexp_replace(nama_regu, '[^[:alpha:]]', '', 'g')) < 3;
+
+  if v_regu is not null then
+    raise exception '0120: nama regu berikut kurang dari tiga huruf — ganti dulu lewat layar meja, baru jalankan ulang migrasi ini: %', v_regu;
+  end if;
+  raise notice '0120: data yang ada lolos — semua nama regu tiga huruf atau lebih.';
+end;
+$$;
+
+alter table regu drop constraint if exists regu_nama_regu_tiga_huruf;
+alter table regu add constraint regu_nama_regu_tiga_huruf
+  check (length(regexp_replace(nama_regu, '[^[:alpha:]]', '', 'g')) >= 3);
+
+comment on constraint regu_nama_regu_tiga_huruf on regu is
+  'Nama regu dibacakan di lapangan; satu atau dua huruf tidak terdengar '
+  'sebagai nama. Yang dihitung hurufnya, bukan panjang karakternya — spasi '
+  'dan tanda baca dibuang dulu.';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -535,6 +535,12 @@ run tests/sql/80_jeda_kloter_maksimal.sql
 # dijalankan dua kali. Tes 81 memeriksa jejak tiap migrasinya satu per satu.
 run supabase/migrations/0119_terapkan_migrasi_terlewat.sql
 run tests/sql/81_migrasi_terlewat.sql
+
+# 0120 memberi nama regu batas BAWAH: minimal tiga huruf. Tes 82 menguji dua
+# arah, karena yang mudah salah bukan angkanya melainkan cara menghitungnya —
+# "A B" tiga karakter, dua huruf, dan yang dibacakan di lapangan hurufnya.
+run supabase/migrations/0120_nama_regu_tiga_huruf.sql
+run tests/sql/82_nama_regu_tiga_huruf.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.

--- a/tests/sql/82_nama_regu_tiga_huruf.sql
+++ b/tests/sql/82_nama_regu_tiga_huruf.sql
@@ -1,0 +1,68 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/82_nama_regu_tiga_huruf.sql — migrasi 0120.
+--
+-- Batas nama regu selama ini hanya di ujung ATAS: maksimal 20 karakter, tanpa
+-- angka, tidak boleh kembar. Yang diuji di sini ujung bawahnya.
+--
+-- Yang paling mudah salah adalah CARA menghitungnya. "A B" panjangnya tiga
+-- karakter tetapi hurufnya dua, dan yang dibacakan di lapangan adalah
+-- hurufnya — jadi menghitung `length()` saja akan meloloskannya.
+--
+-- Diuji dua arah, karena syarat yang terlalu ketat menolak nama sungguhan
+-- persis sesempit syarat yang terlalu longgar meloloskan yang bukan nama:
+-- "Ma'ruf" dan "Nur-Aini" wajib tetap masuk.
+--
+-- Seluruhnya di-rollback, jadi tidak ada baris uji yang tertinggal.
+-- ============================================================================
+
+\echo '--- 82. nama regu minimal tiga huruf'
+\set ON_ERROR_STOP on
+
+do $blok$
+declare
+  v_pendaftaran uuid;
+  v_nama        text;
+  v_diterima    boolean;
+begin
+  select id into v_pendaftaran from pendaftaran limit 1;
+  assert v_pendaftaran is not null,
+    '82 GAGAL: tidak ada pendaftaran untuk disisipi — tes ini akan lulus '
+    'tanpa menguji apa pun';
+
+  -- 82.1 Yang harus DITOLAK. Dua yang terakhir punya cukup karakter tetapi
+  -- tidak cukup huruf, dan itulah kekeliruan yang dijaga tes ini.
+  foreach v_nama in array array['A', 'Ab', 'A B', 'A.B', 'C -'] loop
+    begin
+      insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+      values (v_pendaftaran, v_nama, 'Ketua Uji', 'penegak_pa');
+      v_diterima := true;
+    exception when check_violation then
+      v_diterima := false;
+    end;
+    assert not v_diterima,
+      format('82.1 GAGAL: "%s" diterima, padahal hurufnya kurang dari tiga',
+             v_nama);
+  end loop;
+
+  -- 82.2 Yang harus DITERIMA. "Abc" tepat di batas; sisanya nama sungguhan
+  -- bertanda baca, yang oleh syarat terlalu ketat akan ikut tertolak.
+  foreach v_nama in array array['Abc', 'A B C', 'Ma''ruf', 'Nur-Aini'] loop
+    begin
+      insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+      values (v_pendaftaran, v_nama, 'Ketua Uji', 'penegak_pa');
+      v_diterima := true;
+    exception when check_violation then
+      v_diterima := false;
+    end;
+    assert v_diterima,
+      format('82.2 GAGAL: "%s" ditolak, padahal hurufnya tiga atau lebih',
+             v_nama);
+  end loop;
+
+  raise exception 'ROLLBACK UJI 82';
+exception when others then
+  if sqlerrm <> 'ROLLBACK UJI 82' then raise; end if;
+end;
+$blok$;
+
+\echo '    82 LULUS'


### PR DESCRIPTION
## What

- `supabase/migrations/0120_nama_regu_tiga_huruf.sql` — check constraint `regu_nama_regu_tiga_huruf`.
- `live/js/daftar.js` — the registration form says "Nama regu minimal 3 huruf." while typing, and a short name holds back **Kirim** the same way a duplicate one does.
- `tests/sql/82_nama_regu_tiga_huruf.sql` — both directions, wired into `tests/run.sh`.

## Why

Regu names were bounded only at the top: 20 characters (0051), no digits (0052), no duplicates. The lower bound was one character, so `A` and `-` both passed.

A name that short cannot be called. Regu names are read out at departure and again when winners are announced, and one letter shouted across a field of dozens does not register as a name.

## Notes

**Letters are counted, not character length.** `A B` is three characters and two letters, and letters are what gets read aloud — so punctuation and spaces are stripped first. `Ma'ruf` and `Nur-Aini` stay valid; `A.B` does not.

The 20-character ceiling in `regu_nama_panjang` is deliberately untouched. It counts characters because what it protects is column width on the per-pos sheet, where a space does take room.

Enforced in the database for the same reason as 0052: the form rejects it while typing, but the RPC is open and panitia also type names from the desk screens.

**The migration refuses to run if existing rows violate it**, naming them, rather than adding the constraint over data it cannot enforce. If it stops, rename those regu from the desk screen and run it again.

**Verified locally.** `tests/run.sh` passes in full; the form parses as an ES module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)