### PR TITLE
fix: let the three-letter rule bind new rows only

### DIFF
--- a/supabase/migrations/0120_nama_regu_tiga_huruf.sql
+++ b/supabase/migrations/0120_nama_regu_tiga_huruf.sql
@@ -35,12 +35,37 @@
 -- Alasan yang sama dengan 0052: form pendaftaran menolaknya sambil diketik,
 -- tetapi RPC-nya terbuka dan panitia juga menulis nama lewat layar meja. Yang
 -- menegakkan aturan harus yang paling akhir menyentuh datanya.
+--
+-- Berlaku untuk SELURUH golongan, Internal maupun Eksternal. Constraint-nya
+-- duduk di kolom `regu.nama_regu` dan tidak menyebut golongan sama sekali,
+-- jadi tidak ada satu jalur pun yang lolos: form pendaftaran, layar meja, dan
+-- RPC ketiganya menulis ke kolom yang sama.
+--
+-- ---------------------------------------------------------------------------
+-- BARIS LAMA DIBIARKAN — `NOT VALID`, DAN ITU KEPUTUSAN PEMILIK ACARA
+--
+-- Empat regu di produksi bernama satu huruf (D, H, S, Y). Versi pertama
+-- migrasi ini BERHENTI dan menyuruh menggantinya dulu; jalannya ditolak
+-- 27 Agustus 2026, lalu pemilik acara memutuskan: biarkan yang lama, yang
+-- penting yang baru minimal tiga huruf.
+--
+-- `NOT VALID` mengerjakan persis itu. Ia melewati pemindaian baris yang sudah
+-- ada, tetapi TETAP menegakkan syaratnya pada setiap INSERT dan UPDATE — jadi
+-- pendaftaran baru tidak bisa lagi bernama satu huruf, dan keempat baris lama
+-- itu tetap ada apa adanya sampai ada yang menyentuhnya.
+--
+-- Konsekuensinya, dan panitia perlu tahu: MENGUBAH salah satu dari keempat
+-- baris itu menuntut namanya sekalian dibetulkan. Mengganti nama ketua regu
+-- "D" tanpa memanjangkan "D" akan ditolak database.
+--
+-- Jangan menjalankan `validate constraint` di kemudian hari tanpa mengganti
+-- keempat nama itu lebih dulu — perintah itu memindai seluruh tabel dan akan
+-- gagal dengan pesan yang jauh lebih sulit dibaca daripada daftar di bawah.
 -- ============================================================================
 
--- Baris lama yang melanggar disebutkan namanya, dan migrasi ini BERHENTI.
--- Menambahkan constraint sambil diam-diam membiarkan barisnya berarti aturan
--- itu berlaku untuk pendaftar berikutnya saja, dan regu yang sudah terlanjur
--- bernama satu huruf akan tetap dipanggil dengan satu huruf di lapangan.
+-- Baris lama yang melanggar tetap DISEBUTKAN namanya — dibiarkan bukan berarti
+-- tidak dicatat. Yang membacanya adalah panitia yang memanggil nama itu di
+-- lapangan, dan daftar ini satu-satunya tempat keempatnya pernah tertulis.
 do $$
 declare v_regu text;
 begin
@@ -53,17 +78,22 @@ begin
     and length(regexp_replace(nama_regu, '[^[:alpha:]]', '', 'g')) < 3;
 
   if v_regu is not null then
-    raise exception '0120: nama regu berikut kurang dari tiga huruf — ganti dulu lewat layar meja, baru jalankan ulang migrasi ini: %', v_regu;
+    raise notice '0120: nama regu berikut kurang dari tiga huruf dan SENGAJA dibiarkan (NOT VALID): %', v_regu;
+    raise notice '0120: mengubah baris itu di kemudian hari menuntut namanya sekalian dipanjangkan.';
+  else
+    raise notice '0120: data yang ada lolos — semua nama regu tiga huruf atau lebih.';
   end if;
-  raise notice '0120: data yang ada lolos — semua nama regu tiga huruf atau lebih.';
 end;
 $$;
 
 alter table regu drop constraint if exists regu_nama_regu_tiga_huruf;
 alter table regu add constraint regu_nama_regu_tiga_huruf
-  check (length(regexp_replace(nama_regu, '[^[:alpha:]]', '', 'g')) >= 3);
+  check (length(regexp_replace(nama_regu, '[^[:alpha:]]', '', 'g')) >= 3)
+  not valid;
 
 comment on constraint regu_nama_regu_tiga_huruf on regu is
   'Nama regu dibacakan di lapangan; satu atau dua huruf tidak terdengar '
   'sebagai nama. Yang dihitung hurufnya, bukan panjang karakternya — spasi '
-  'dan tanda baca dibuang dulu.';
+  'dan tanda baca dibuang dulu. NOT VALID: berlaku untuk setiap baris baru '
+  'dan setiap perubahan, sementara empat baris satu huruf dari sebelum '
+  '27 Agustus 2026 dibiarkan apa adanya.';

--- a/tests/sql/82_nama_regu_tiga_huruf.sql
+++ b/tests/sql/82_nama_regu_tiga_huruf.sql
@@ -12,6 +12,15 @@
 -- persis sesempit syarat yang terlalu longgar meloloskan yang bukan nama:
 -- "Ma'ruf" dan "Nur-Aini" wajib tetap masuk.
 --
+-- Diuji untuk KEDUA jenis peserta. Constraint-nya memang tidak menyebut
+-- golongan, tetapi "berlaku untuk semua" adalah persis jenis kalimat yang
+-- benar saat ditulis dan diam-diam berhenti benar nanti — pos, kelengkapan,
+-- dan penalti semuanya sudah pernah bercabang untuk Intern.
+--
+-- Dan constraint-nya NOT VALID: empat baris satu huruf yang sudah ada di
+-- produksi sengaja dibiarkan. Yang dijaga tes terakhir adalah bahwa
+-- "dibiarkan" itu hanya berlaku ke belakang — baris BARU tetap ditolak.
+--
 -- Seluruhnya di-rollback, jadi tidak ada baris uji yang tertinggal.
 -- ============================================================================
 
@@ -22,6 +31,7 @@ do $blok$
 declare
   v_pendaftaran uuid;
   v_nama        text;
+  v_golongan    text;
   v_diterima    boolean;
 begin
   select id into v_pendaftaran from pendaftaran limit 1;
@@ -29,19 +39,22 @@ begin
     '82 GAGAL: tidak ada pendaftaran untuk disisipi — tes ini akan lulus '
     'tanpa menguji apa pun';
 
-  -- 82.1 Yang harus DITOLAK. Dua yang terakhir punya cukup karakter tetapi
-  -- tidak cukup huruf, dan itulah kekeliruan yang dijaga tes ini.
-  foreach v_nama in array array['A', 'Ab', 'A B', 'A.B', 'C -'] loop
-    begin
-      insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
-      values (v_pendaftaran, v_nama, 'Ketua Uji', 'penegak_pa');
-      v_diterima := true;
-    exception when check_violation then
-      v_diterima := false;
-    end;
-    assert not v_diterima,
-      format('82.1 GAGAL: "%s" diterima, padahal hurufnya kurang dari tiga',
-             v_nama);
+  -- 82.1 Yang harus DITOLAK, dan ditolak untuk KEDUA jenis peserta. Tiga yang
+  -- terakhir punya cukup karakter tetapi tidak cukup huruf, dan itulah
+  -- kekeliruan yang dijaga tes ini.
+  foreach v_golongan in array array['penegak_pa', 'intern_pa'] loop
+    foreach v_nama in array array['A', 'Ab', 'A B', 'A.B', 'C -'] loop
+      begin
+        insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+        values (v_pendaftaran, v_nama, 'Ketua Uji', v_golongan);
+        v_diterima := true;
+      exception when check_violation then
+        v_diterima := false;
+      end;
+      assert not v_diterima,
+        format('82.1 GAGAL: "%s" diterima sebagai %s, padahal hurufnya '
+               'kurang dari tiga', v_nama, v_golongan);
+    end loop;
   end loop;
 
   -- 82.2 Yang harus DITERIMA. "Abc" tepat di batas; sisanya nama sungguhan
@@ -58,6 +71,28 @@ begin
       format('82.2 GAGAL: "%s" ditolak, padahal hurufnya tiga atau lebih',
              v_nama);
   end loop;
+
+  -- 82.3 Nama Intern yang cukup panjang tetap masuk — supaya 82.1 tidak
+  -- lulus hanya karena golongan Intern kebetulan ditolak oleh hal lain.
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    values (v_pendaftaran, 'Cakrawala', 'Ketua Uji', 'intern_pa');
+    v_diterima := true;
+  exception when check_violation then
+    v_diterima := false;
+  end;
+  assert v_diterima,
+    '82.3 GAGAL: regu Intern bernama "Cakrawala" ditolak — 82.1 tidak '
+    'membuktikan apa pun kalau semua Intern memang ditolak';
+
+  -- 82.4 Constraint-nya NOT VALID: baris lama dibiarkan, baris baru tidak.
+  -- Kalau suatu saat ia divalidasi, keempat nama satu huruf di produksi harus
+  -- diganti LEBIH DULU — dan tes ini yang mengingatkannya.
+  assert exists (select 1 from pg_constraint
+                 where conname = 'regu_nama_regu_tiga_huruf'
+                   and not convalidated),
+    '82.4 GAGAL: regu_nama_regu_tiga_huruf sudah divalidasi — empat regu satu '
+    'huruf di produksi akan membuat migrasinya gagal';
 
   raise exception 'ROLLBACK UJI 82';
 exception when others then


### PR DESCRIPTION
## What

- `0120` now adds `regu_nama_regu_tiga_huruf` as **`NOT VALID`**, and its guard block reports the offending rows as a notice instead of stopping.
- `tests/sql/82` proves the rule for **Internal and Eksternal** rather than asserting it, and pins the constraint as `NOT VALID`.

## Why

Four regu in production are named with a single letter — `D`, `H`, `S`, `Y` — so `0120` refused to run. That was the intended behaviour: do not add a constraint over data it cannot enforce. The event owner decided to leave the old ones and require three letters only of new ones.

`NOT VALID` is exactly that rule. It skips the scan of existing rows while still enforcing the check on every `INSERT` and `UPDATE`.

## Notes

**Editing 0120 in place rather than adding 0121**: it never reached any database — its only production run failed on that guard — and the local test database is rebuilt from scratch each run.

**Consequence worth knowing:** editing one of those four rows later will require lengthening its name at the same time. And `validate constraint` must not be run until they are renamed; the migration header says so.

**Internal vs Eksternal**: the rule always covered both — the constraint sits on `regu.nama_regu` and names no golongan, and the form validates every regu card regardless of jenis peserta. Test 82 now demonstrates it instead of relying on that reading.

**Verified locally.** `tests/run.sh` passes in full. Separately, `0120` was applied to a database seeded with the same four single-letter names production has:

- migration succeeds, naming all four in a notice
- the four rows survive
- a new Eksternal `K` is rejected, a new Internal `M` is rejected
- a new Internal `Cakrawala` is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)