### PR TITLE
feat: pembina picks how to pay, and transfers upload proof

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -411,6 +411,65 @@ export async function kirimPendaftaran(payload, tokenTurnstile) {
   });
 }
 
+/* ---------------------- BUKTI TRANSFER (migrasi 0121) --------------------
+
+   Satu-satunya unggahan di seluruh sistem yang datang dari orang yang TIDAK
+   login. Karena itu jalannya sengaja beda dari unggahFotoLembar di bawah: ia
+   tidak pernah menyegarkan sesi, dan tidak pernah memakai token siapa pun —
+   anon key saja, persis seperti pembina yang membuka form dari HP-nya.
+
+   Folder pertama WAJIB kunci_kirim, dan itu ditegakkan dua kali: policy
+   storage.objects hanya menerima nama berbentuk `<uuid>/<sesuatu>.jpg`, dan
+   submit_pendaftaran menolak path yang folder-nya bukan kunci_kirim kiriman
+   itu sendiri. Yang pertama menjaga bucket, yang kedua menjaga supaya satu
+   pendaftaran tidak mengaku memakai bukti milik pendaftaran lain.           */
+
+const BUCKET_BUKTI = "bukti";
+
+export function namaObjekBukti(kunciKirim) {
+  const acak = Math.random().toString(36).slice(2, 8);
+  return `${kunciKirim}/bukti-${Date.now()}-${acak}.jpg`;
+}
+
+/** Unggah satu bukti transfer, kembalikan path-nya untuk dikirim ke RPC.
+ *
+ *  Gambarnya sudah dikecilkan pemanggil lewat kecilkanFoto(). Bucket menolak
+ *  apa pun di atas 1 MB dan apa pun yang bukan JPEG — pagar kedua untuk saat
+ *  pengecilan itu gagal diam-diam. */
+export async function unggahBuktiTransfer(kunciKirim, blob) {
+  const path = namaObjekBukti(kunciKirim);
+  // Dev server tidak punya Storage. Path-nya tetap dikembalikan supaya alur
+  // formnya bisa dicoba tanpa Supabase.
+  if (K.mode === "dev") return path;
+
+  await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET_BUKTI}/${path}`, {
+    method: "POST",
+    headers: {
+      apikey: K.anonKey,
+      Authorization: `Bearer ${K.anonKey}`,
+      "Content-Type": "image/jpeg",
+      "x-upsert": "false",
+    },
+    body: blob,
+  });
+  return path;
+}
+
+/** Link sementara untuk melihat satu bukti transfer di Meja Pembayaran.
+ *  Alasannya sama dengan tautanFoto(): bucket-nya privat, dan link yang tidak
+ *  kedaluwarsa akan beredar di WhatsApp selamanya. */
+export async function tautanBukti(path) {
+  if (K.mode === "dev" || !path) return null;
+  await pastikanSesiSegar();
+  const j = await kirim(
+    `${K.supabaseUrl}/storage/v1/object/sign/${BUCKET_BUKTI}/${path}`, {
+      method: "POST",
+      headers: kepalaSupabase(),
+      body: JSON.stringify({ expiresIn: 3600 }),
+    });
+  return `${K.supabaseUrl}/storage/v1${j.signedURL || j.signedUrl}`;
+}
+
 /* ============================ MEJA ====================================== */
 
 export async function ringkasanMeja() {
@@ -442,7 +501,7 @@ export async function daftarPendaftaran() {
   if (K.mode === "dev") return baca("/daftar-pendaftaran");
   return baca(null,
     "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping," +
-    "butuh_barak,kontak_wa,created_at," +
+    "butuh_barak,kontak_wa,created_at,metode_bayar,bukti_transfer," +
     "sekolah(name,address)," +
     "regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled)," +
     "pembayaran(amount,method,nomor_kwitansi,verified_at)" +

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -15,9 +15,10 @@
      tidak ada "perbaiki satu, ketemu satu lagi".
    ========================================================================== */
 
-import { daftarSekolah, kirimPendaftaran, infoEdisi, namaReguDipakai, ErrorApi } from "./api.js";
+import { daftarSekolah, kirimPendaftaran, infoEdisi, namaReguDipakai,
+         unggahBuktiTransfer, ErrorApi } from "./api.js";
 import { esc, h, html, rupiah, notif, kartuGagalMuat,
-         pemuat, biayaRegu, totalBiaya } from "./util.js";
+         pemuat, biayaRegu, totalBiaya, kecilkanFoto } from "./util.js";
 import { cariSekolah, kunciSekolah } from "./school-search.mjs";
 
 const LAYAR = document.getElementById("layar");
@@ -79,6 +80,11 @@ const kosong = () => ({
   regu: [],                      // [{golongan, nama_regu, nama_ketua, anggota[4]}]
   kontak_wa: "",
   nama_kontak: "",
+  metode_bayar: null,            // "transfer" atau "tunai"
+  // Path objek di bucket `bukti`, BUKAN berkasnya. Ia ikut tersimpan di draf
+  // supaya HP yang mati sesudah mengunggah tidak menyuruh mengunggah lagi.
+  bukti_transfer: null,
+  bukti_nama: "",                // nama berkas asli, untuk ditampilkan saja
   kunci_kirim: uuidDraf(),
 });
 
@@ -147,6 +153,12 @@ const normalNama = (t) => String(t || "").trim().toLowerCase().replace(/\s+/g, "
    lapangan saat pemberangkatan dan saat juara diumumkan adalah hurufnya.
    Tanda baca dan spasi karena itu dibuang dulu — "Ma'ruf" dan "Nur-Aini"
    tetap lolos. Aturan yang sama ditegakkan database. */
+/* Rekening panitia. Ditulis SEKALI di sini: nomor rekening yang salah satu
+   digit membuat uang masuk ke orang lain, dan angka yang tersalin di dua
+   tempat pada akhirnya berbeda di salah satunya. */
+const REKENING = "BJB 0161891614100 a.n. Hiking Rally Ciradyka";
+const KAMPUS = "kampus SMAN 1 Ciamis";
+
 const HURUF_MIN = 3;
 const cukupHuruf = (t) => (String(t || "").match(/\p{L}/gu) || []).length >= HURUF_MIN;
 
@@ -162,6 +174,7 @@ function halaman() {
   const nomorJumlah = internal() ? 3 : 4;
   const nomorRegu = nomorJumlah + 1;
   const nomorKontak = nomorRegu + 1;
+  const nomorBayar = nomorKontak + 1;
   LAYAR.replaceChildren(h(`
     <section class="card" id="bagian-jenis">
       <h2><span class="section-number">1</span> Peserta</h2>
@@ -225,6 +238,19 @@ function halaman() {
       </div>
     </section>
 
+    <!-- Pembayaran -->
+    <section class="card" id="bagian-bayar">
+      <h2><span class="section-number">${nomorBayar}</span> Pembayaran</h2>
+      <div class="option-row" style="margin-top:.8rem">
+        <button class="option" id="b-transfer" type="button"
+                aria-pressed="${jawab.metode_bayar === "transfer"}">Transfer</button>
+        <button class="option" id="b-tunai" type="button"
+                aria-pressed="${jawab.metode_bayar === "tunai"}">Tunai</button>
+      </div>
+      <div id="isi-bayar" style="margin-top:.9rem"></div>
+      <div class="error" id="g-bayar" hidden>Pilih salah satu.</div>
+    </section>
+
     <div id="turnstile-kotak"></div>
     <div id="ringkas-galat"></div>
 
@@ -262,6 +288,22 @@ function halaman() {
   document.getElementById("p-internal").addEventListener("click", () => pilihJenis("internal"));
   if (!jenisDipilih) return;
 
+  // Bukti yang sudah naik TIDAK dibuang saat pembina bolak-balik antara
+  // Transfer dan Tunai: berkasnya sudah ada di bucket, dan menghapus
+  // catatannya cuma menyuruh mengunggah ulang berkas yang sama.
+  const pilihBayar = (metode) => {
+    if (jawab.metode_bayar === metode) return;
+    jawab.metode_bayar = metode;
+    simpanDraf();
+    for (const [id, m] of [["b-transfer", "transfer"], ["b-tunai", "tunai"]])
+      document.getElementById(id).setAttribute("aria-pressed", String(metode === m));
+    document.getElementById("g-bayar").hidden = true;
+    gambarBayar();
+    if (sudahDiperiksa) periksa(false);
+  };
+  document.getElementById("b-transfer").addEventListener("click", () => pilihBayar("transfer"));
+  document.getElementById("b-tunai").addEventListener("click", () => pilihBayar("tunai"));
+
   gambarSekolah();
   if (!internal()) gambarBarak();
   gambarStepper();
@@ -286,9 +328,69 @@ function halaman() {
     if (sudahDiperiksa) periksa(false);
   });
 
+  gambarBayar();
   document.getElementById("kirim").addEventListener("click", kirim);
   pasangTurnstile();
   perbaruiTotal();
+}
+
+/* ---------------- 7. pembayaran ---------------- */
+
+/* Nominalnya disebut di dalam kalimatnya, bukan di baris terpisah: yang
+   ditanyakan pembina bukan "berapa totalnya" — itu sudah terbaca di bar bawah
+   sepanjang form — melainkan "berapa yang harus saya transfer SEKARANG".
+
+   Yang tidak bisa ditebak sendiri cuma nomor rekeningnya dan tempatnya, dan
+   itulah satu-satunya isi kalimat ini. Tidak ada penjelasan cara mengunggah:
+   tombolnya sudah bernama Unggah Bukti Transfer.                            */
+function gambarBayar() {
+  const kotak = document.getElementById("isi-bayar");
+  if (!kotak) return;
+  const tagihan = rupiah(totalBiaya(EDISI, jawab.regu));
+
+  if (jawab.metode_bayar === "tunai") {
+    kotak.replaceChildren(h(html`
+      <p>Pembayaran senilai <strong>${tagihan}</strong> dapat dilakukan di
+         ${KAMPUS}.</p>`));
+    return;
+  }
+  if (jawab.metode_bayar !== "transfer") { kotak.replaceChildren(); return; }
+
+  const sudah = !!jawab.bukti_transfer;
+  kotak.replaceChildren(h(html`
+    <p>Silakan transfer senilai <strong>${tagihan}</strong> ke rekening
+       <strong>${REKENING}</strong>.</p>
+    <div class="field" style="margin-top:.8rem">
+      <label for="bukti">Unggah Bukti Transfer</label>
+      <input type="file" id="bukti" accept="image/*">
+      <div class="description" id="bukti-status">${
+        sudah ? `Terunggah${jawab.bukti_nama ? `: ${jawab.bukti_nama}` : ""}.`
+              : ""}</div>
+      <div class="error" id="g-bukti" hidden>Bukti transfer wajib diunggah.</div>
+    </div>`));
+
+  document.getElementById("bukti").addEventListener("change", async (e) => {
+    const berkas = e.target.files && e.target.files[0];
+    if (!berkas) return;
+    const status = document.getElementById("bukti-status");
+    // Bukti yang lama TIDAK dilupakan sebelum yang baru berhasil naik: sinyal
+    // putus di tengah unggahan kedua tidak boleh menghapus bukti yang sudah
+    // sah, karena Kirim akan tertahan olehnya.
+    status.textContent = "Mengunggah…";
+    try {
+      const kecil = await kecilkanFoto(berkas);
+      jawab.bukti_transfer = await unggahBuktiTransfer(jawab.kunci_kirim, kecil);
+      jawab.bukti_nama = berkas.name;
+      simpanDraf();
+      status.textContent = `Terunggah: ${berkas.name}`;
+      document.getElementById("g-bukti").hidden = true;
+      if (sudahDiperiksa) periksa(false);
+    } catch (err) {
+      status.textContent = "";
+      notif(err instanceof ErrorApi ? err.message
+            : (err && err.message) || "Bukti gagal diunggah. Coba lagi.", true);
+    }
+  });
 }
 
 /* ---------------- 1. sekolah ---------------- */
@@ -516,6 +618,9 @@ function perbaruiTotal() {
   document.getElementById("kirim-info").innerHTML = total
     ? html`${total} regu · ${rupiah(tagihan)}`
     : `<span class="description">Belum ada regu</span>`;
+  // Kalimat "transfer senilai X" menyebut angka yang sama dengan bar bawah,
+  // jadi ia harus ikut berubah saat jumlah regunya berubah.
+  gambarBayar();
   if (sudahDiperiksa) periksa(false);
 }
 
@@ -753,6 +858,18 @@ function periksa(gulir = true) {
       : "Nama contact person tidak boleh memakai angka" });
   tandai("g-nama-kontak", namaKontakKosong);
 
+  // Cara bayar menahan Kirim sama kerasnya dengan kolom kosong, dan bukti
+  // transfer sama kerasnya dengan cara bayarnya sendiri: RPC menolak keduanya
+  // (migrasi 0121), jadi menahannya di sini cuma membuat penolakan itu
+  // terbaca sebagai kotak merah, bukan sebagai kartu galat sesudah menunggu.
+  if (!jawab.metode_bayar)
+    galat.push({ ke: "bagian-bayar", teks: "Cara pembayaran belum dipilih" });
+  tandai("g-bayar", !jawab.metode_bayar);
+  const buktiKurang = jawab.metode_bayar === "transfer" && !jawab.bukti_transfer;
+  if (buktiKurang)
+    galat.push({ ke: "bagian-bayar", teks: "Bukti transfer belum diunggah" });
+  tandai("g-bukti", buktiKurang);
+
   const digitWa = jawab.kontak_wa.replace(/\D/g, "");
   const waSah = POLA_WA.test(digitWa);
   if (!waSah) galat.push({ ke: "bagian-kontak", teks: "Nomor WA belum sesuai format Indonesia" });
@@ -818,6 +935,10 @@ async function kirim(e) {
       nama_kontak: jawab.nama_kontak,
       regu: jawab.regu,
       kunci_kirim: jawab.kunci_kirim,     // sama saat mencoba lagi
+      metode_bayar: jawab.metode_bayar,
+      // Dikirim apa adanya juga saat tunai; RPC yang membuangnya. Menyaringnya
+      // di sini berarti aturannya hidup di dua tempat.
+      bukti_transfer: jawab.bukti_transfer,
     }, tokenTurnstile);
     sessionStorage.setItem("hrcd_selesai", "1");
     try { localStorage.setItem(KUNCI_HASIL, JSON.stringify(hasil)); } catch {}

--- a/live/style.css
+++ b/live/style.css
@@ -1902,7 +1902,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    tabel lebar kolom Metode cuma 15% jadi ia membungkus jadi dua baris seperti
    sebelumnya. Satu aturan, dua tampilan — tanpa media query yang harus
    ditebak batasnya. */
-.metode-lunas {
+.metode-baris {
   display: inline-flex; align-items: center; justify-content: center;
   flex-wrap: wrap; gap: .35rem;
 }

--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -136,80 +136,80 @@ begin
     perform submit_pendaftaran('SMAN 1 Maja', 'Jln prabuwangi',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Indi homogen', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMK BANGKIT INDONESIA TALAGA', 'Jln, ganeas no 1 kec, talaga',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Prampasu putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Pramapasu Putra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Pramapasu Putri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMAN 1 cirebon', 'Jl siliwangi no 12',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Kandang maung', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('MTs Rancah', 'Jl Cibeureum No. 50',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'SIREUM ATEUL', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'GARUDA MUDA', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'WANOJA SUNDA', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'MOJANG GALUH', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('MA AL-AZHAR KOTA BANJAR', 'Jl. Pesantren No 2 Citangkolo, Desa Kujangsari, Kecamatan Langensari, Kota Banjar',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Skuad Ambyar', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMAN 1 CIHAURBEUTI', 'Jalan kartawijaya no. 600 Pamokolan-Cihaurbeuti,Pamokolan,Ciamis,Kabupaten Ciamis,Jawa Barat 46262',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Bombang Rarang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Bombang Kencana', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('MAS AL-KAUTSAR', 'jln. Pejuang No. 100, Karangpucung wetan, Desa Jajawar, Kecamatan Banjar, Kota Banjar, Provinsi Jawa Barat',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Khalid bin Walid', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Fatimah Azzahra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('Mts Rijalul Hikam', 'Jatinagara',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Brighest Star', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('MA ASALIMIAH', 'jl. Kiayi Haji Salim, No 1 Rt 9 rw 7 Desa Darmacaang, Kec. cikoneng, Kab, Ciamis',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Abang pulan', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Dewi Armina', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMA TERPADU CIKANYERE', 'Kec.Rajadesa,Kab.Ciamis',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'COLOR REMBO', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
         jsonb_build_object('nama_regu', 'PHAIS OREGH', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('MA YPI RIJALUL HIKAM', 'Jatinagara',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Nanya ka urang', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
         jsonb_build_object('nama_regu', 'SagombayFly', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'ZAKORAYFLY', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMA Islam Ainurrafiq', 'Kec. Cigandamekar Kab. Kuningan',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'No Mercy ARQ', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Zombie Ainurrafiq', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMP Islam Ainurrafiq', 'Kec. Cigandamekar Kab. Kuningan',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Oxsigen ARQ', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMKS GALUH RAHAYU', 'Jln Raya Sukaraja, Sindangkasih',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Putera Galuh', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMAI NURUL FIKRI', 'Serang Banten',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Pagoli NFBS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Lastrada NFBS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMA IT AL-FALAH', 'Jl. Raya Citalahab Ds.Mekarjaya Kec.Bungbulang Kab.Garut Kode Pos 44165',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'ADAM MALIK', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMKN 1 Losarang', 'Jalan Raya Pantura Losarang Desa Santing Kel. Jumbleng, Santing, Kec. Losarang, Kabupaten Indramayu, Jawa Barat 45253',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'KIWANA LAS', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
@@ -217,32 +217,32 @@ begin
         jsonb_build_object('nama_regu', 'NYI WANA KULTUR', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
         jsonb_build_object('nama_regu', 'Nyi Wanagri', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
         jsonb_build_object('nama_regu', 'KiWana Tok', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMK Siliwangi AMS Banjarsari', 'Banjarsari,Ciamis, Jawa barat',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Dyah Pitaloka', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pi'),
         jsonb_build_object('nama_regu', 'Prabu Siliwangi', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa'),
         jsonb_build_object('nama_regu', 'Maung Bodas', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMAT RIYADLUL ULUM', 'Condong, Setianegara, Cibereum Kota Tasikmalaya',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Condong Rover Scout', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMPT RIYADLUL ULUM WADDAWAH', 'condong,setianegara,cibereum, kota Tasikmalaya',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Hileud Jengke', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMPN 2 CIPAKU', 'Jalan Desa Cipaku no.5 desa/kec cipaku',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Swag Partners', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'Angel Wings', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'Badhrika Chandra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
         jsonb_build_object('nama_regu', 'Pandawa Lima', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMKN 2 CIAMIS', 'Jl. Sadananya no.21',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Agresi Cakra', 'nama_ketua', 'Ketua Regu', 'golongan', 'penegak_pa')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
     perform submit_pendaftaran('SMPN 1 CIAMIS', 'Jl. Jenderal Sudirman No. 6, Ciamis',
       false, '0800000000', jsonb_build_array(
         jsonb_build_object('nama_regu', 'Disconnect Eror', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pa'),
@@ -251,7 +251,7 @@ begin
         jsonb_build_object('nama_regu', 'Pacebuk Nesa', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'Disconnect Ngelag', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi'),
         jsonb_build_object('nama_regu', 'Alah Siah Boy', 'nama_ketua', 'Ketua Regu', 'golongan', 'penggalang_pi')),
-      0::smallint, null, 'Pembina');
+      0::smallint, null, 'Pembina', p_metode_bayar => 'tunai');
 
     -- Lunasi lalu beri nomor dada. Nominalnya harus PAS seluruh batch —
     -- verifikasi_pembayaran menolak pembayaran sebagian (alur 3.5).

--- a/supabase/migrations/0121_pembayaran_pilihan_pembina.sql
+++ b/supabase/migrations/0121_pembayaran_pilihan_pembina.sql
@@ -187,8 +187,8 @@ begin
   -- kunci_kirim kiriman ini: nama objek Storage bisa ditebak siapa pun yang
   -- pernah melihat satu contohnya, dan tanpa pagar ini satu pendaftaran bisa
   -- menunjuk bukti milik pendaftaran lain.
-  if coalesce(p_metode_bayar, '') not in ('transfer', 'tunai') then
-    raise exception 'cara pembayaran wajib dipilih';
+  if p_metode_bayar is not null and p_metode_bayar not in ('transfer', 'tunai') then
+    raise exception 'cara pembayaran tidak dikenal: %', p_metode_bayar;
   end if;
   v_bukti := nullif(trim(coalesce(p_bukti_transfer, '')), '');
   if p_metode_bayar = 'transfer' then
@@ -286,10 +286,30 @@ begin
 end;
 $fn$;
 
--- Bentuk argumennya berubah, jadi versi delapan-argumen dari 0114 harus
--- DIBUANG. Kalau dibiarkan, PostgREST melihat dua fungsi bernama sama dan
--- menolak panggilannya dengan "could not choose the best candidate function" —
--- form pendaftaran berhenti bekerja tanpa satu baris pun berubah di klien.
+-- ---------------------------------------------------------------------------
+-- KENAPA VERSI INI BELUM MENUNTUT CARA BAYAR, DAN 0122 YANG MENUNTUTNYA
+--
+-- Tiga hal berubah bersama untuk fitur ini — migrasi, Worker gateway, dan form
+-- peserta — dan ketiganya TIDAK mendarat pada detik yang sama. Kalau fungsi ini
+-- langsung menolak kiriman tanpa cara bayar, gateway yang masih berjalan
+-- ditolak setiap kali, dan pendaftaran mati sampai deploy berikutnya selesai.
+-- Bukan jeda yang bisa dijadwalkan: form ini dibuka pembina kapan saja.
+--
+-- Membiarkan bentuk delapan-argumen dari 0114 hidup berdampingan BUKAN
+-- jalannya. Dua fungsi bernama sama membuat PostgREST harus menebak yang mana,
+-- dan tebakan itu bukan sesuatu yang boleh dipertaruhkan pada satu-satunya
+-- pintu pendaftaran. Jadi bentuk lama dibuang di sini, dan penggantinya
+-- menerima kiriman delapan kunci lewat DEFAULT — cara bayarnya tercatat NULL,
+-- persis seperti seluruh pendaftaran sebelum hari ini.
+--
+-- Yang tetap ditegakkan sejak sekarang: transfer WAJIB berbukti, dan buktinya
+-- wajib milik kiriman itu sendiri. Keduanya tidak punya masa peralihan karena
+-- tidak ada klien lama yang pernah mengirimkannya.
+--
+-- `0122` yang menutupnya: sesudah gateway terdeploy, cara bayar yang NULL
+-- ditolak. Jalankan migrasi itu SESUDAH deploy-gateway.yml selesai.
+-- ---------------------------------------------------------------------------
+
 drop function if exists submit_pendaftaran(
   text, text, boolean, text, jsonb, smallint, uuid, text);
 

--- a/supabase/migrations/0121_pembayaran_pilihan_pembina.sql
+++ b/supabase/migrations/0121_pembayaran_pilihan_pembina.sql
@@ -1,0 +1,298 @@
+-- ============================================================================
+-- hrcd-rekap : 0121_pembayaran_pilihan_pembina.sql
+--
+-- Pembina memilih cara membayar saat mendaftar, dan yang transfer mengunggah
+-- buktinya di form itu juga.
+--
+-- ---------------------------------------------------------------------------
+-- DUA "METODE" YANG BERBEDA, DAN JANGAN SAMPAI TERTUKAR
+--
+-- `pembayaran.method` sudah ada sejak 0001. Itu metode yang benar-benar
+-- DITERIMA panitia, dicatat saat menekan Tandai Lunas, dan itulah yang dipakai
+-- menyusun laporan keuangan.
+--
+-- Kolom `pendaftaran.metode_bayar` di sini bukan itu. Ia NIAT pembina, dicatat
+-- sebelum uangnya ada di mana pun. Keduanya sengaja disimpan terpisah karena
+-- keduanya memang bisa berbeda: sekolah memilih Transfer lalu batal dan
+-- membayar tunai di meja, dan yang benar tetap yang di tangan bendahara.
+--
+-- Gunanya niat itu tetap nyata: Meja Pembayaran memakainya sebagai pilihan
+-- awal dropdown metode, jadi jalur yang paling sering benar cukup satu ketukan.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA BUKTI TRANSFER WAJIB
+--
+-- Keputusan pemilik acara. Tanpa bukti, transfer hanya bisa dicocokkan lewat
+-- kode di berita transfer — dan kode yang salah ketik membuat uang masuk tanpa
+-- nama, ketahuan berhari-hari kemudian saat rekening dicocokkan.
+--
+-- Harganya disebut supaya tidak jadi kejutan: sekolah yang MEMILIH transfer
+-- tetapi belum sempat mentransfer tidak bisa mengirim pendaftarannya dulu.
+-- Belum ada layar untuk menyusulkan bukti dengan modal kode pembayaran, jadi
+-- ia harus mengisi form itu lagi nanti. Kalau itu terlalu mahal di lapangan,
+-- yang diubah adalah `check` di bawah DAN validasi di form — bukan salah
+-- satunya saja.
+--
+-- ---------------------------------------------------------------------------
+-- BUCKET `bukti` DAN UNGGAHAN ANONIM
+--
+-- Ini satu-satunya tempat di seluruh sistem yang menerima unggahan dari orang
+-- yang tidak login, jadi pagarnya ditulis sesempit mungkin:
+--
+--   * nama objek WAJIB `<kunci_kirim>/<sesuatu>.jpg` — satu UUID acak yang
+--     lahir di HP pembina. Tidak ada yang bisa menebak folder orang lain.
+--   * INSERT saja. Tidak ada policy update maupun delete untuk anon, jadi
+--     bukti yang sudah masuk tidak bisa ditimpa atau dihapus dari luar.
+--   * tidak ada policy SELECT untuk anon. Yang mengunggah pun tidak bisa
+--     membacanya kembali — bukti pembayaran sekolah lain bukan urusannya.
+--   * batas 1 MB dan hanya image/jpeg, sama dengan bucket `lembar`. Klien
+--     sudah mengecilkan gambarnya lebih dulu lewat `kecilkanFoto()`; batas ini
+--     pagar KEDUA, untuk saat pengecilan itu gagal diam-diam.
+--
+-- Yang TIDAK dijaga, dan disebut supaya tidak jadi kejutan: tidak ada rate
+-- limit di jalur ini. Gateway membatasi 30 pengiriman per IP per menit, tetapi
+-- gambarnya naik langsung ke Storage tanpa melewatinya. Yang menahan
+-- penyalahgunaan cuma batas 1 MB dan tidak adanya hak baca — jadi bucket ini
+-- bisa diisi sampah oleh siapa pun yang mau. Untuk satu acara berisi ratusan
+-- pendaftaran itu risiko yang diterima; kalau suatu saat tidak, unggahannya
+-- dipindahkan lewat Worker, bukan ditambal dengan policy yang lebih rumit.
+--
+-- `submit_pendaftaran` menambahkan pagar yang tidak bisa ditegakkan Storage:
+-- path yang disebut harus berada di dalam folder `kunci_kirim` milik kiriman
+-- itu sendiri. Tanpa itu, satu pendaftaran bisa mengaku memakai bukti milik
+-- pendaftaran lain yang path-nya kebetulan diketahui.
+-- ============================================================================
+
+alter table pendaftaran add column if not exists metode_bayar text;
+alter table pendaftaran add column if not exists bukti_transfer text;
+
+alter table pendaftaran drop constraint if exists pendaftaran_metode_bayar_check;
+alter table pendaftaran add constraint pendaftaran_metode_bayar_check
+  check (metode_bayar is null or metode_bayar in ('transfer', 'tunai'));
+
+-- Baris sebelum migrasi ini tidak punya metode sama sekali, dan
+-- `null is distinct from 'transfer'` bernilai true — jadi mereka lolos tanpa
+-- perlu NOT VALID.
+alter table pendaftaran drop constraint if exists pendaftaran_transfer_berbukti;
+alter table pendaftaran add constraint pendaftaran_transfer_berbukti
+  check (metode_bayar is distinct from 'transfer' or bukti_transfer is not null);
+
+comment on column pendaftaran.metode_bayar is
+  'Cara bayar yang DIPILIH pembina saat mendaftar. Bukan pembayaran.method, '
+  'yang mencatat cara uangnya benar-benar diterima panitia.';
+comment on column pendaftaran.bukti_transfer is
+  'Nama objek di bucket privat `bukti`, selalu berawalan folder kunci_kirim '
+  'kiriman itu sendiri. Wajib ada bila metode_bayar = transfer.';
+
+-- ---------------------------------------------------------------------------
+-- Bucket privat. Pembungkus exception-nya menyalin 0047 dan alasannya sama:
+-- hak atas skema `storage` berbeda antar proyek Supabase, dan gagal di sini
+-- tidak boleh menggagalkan kolom serta RPC yang sudah benar di atas.
+-- ---------------------------------------------------------------------------
+do $blok$
+begin
+  insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  values ('bukti', 'bukti', false, 1048576, array['image/jpeg'])
+  on conflict (id) do update
+    set public = false,
+        file_size_limit = 1048576,
+        allowed_mime_types = array['image/jpeg'];
+  raise notice '0121: bucket `bukti` siap (privat, maks 1 MB, hanya JPEG).';
+exception
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0121: TIDAK BISA membuat bucket lewat migrasi. Buat manual '
+      'di Dashboard > Storage: nama `bukti`, PRIVAT, batas 1 MB (1048576), '
+      'allowed MIME image/jpeg.';
+end;
+$blok$;
+
+do $blok$
+begin
+  execute $pol$
+    create policy bukti_transfer_tulis on storage.objects for insert
+    with check (
+      bucket_id = 'bukti'
+      and name ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/[a-z0-9-]+[.]jpg$'
+    )
+  $pol$;
+  execute $pol$
+    create policy bukti_transfer_baca on storage.objects for select
+    using (bucket_id = 'bukti' and boleh_apa_saja('pembayaran', 'pengaturan'))
+  $pol$;
+  raise notice '0121: policy storage.objects untuk bucket `bukti` terpasang.';
+exception
+  when duplicate_object then
+    raise notice '0121: policy storage.objects sudah ada — dilewati.';
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0121: TIDAK BISA memasang policy storage.objects lewat '
+      'migrasi. Pasang manual di Dashboard > Storage > bukti > Policies, '
+      'salin syaratnya dari kepala migrasi ini.';
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- Salinan terakhir submit_pendaftaran (0114). Yang berubah: dua argumen baru,
+-- satu blok validasi, dan dua kolom di INSERT.
+-- ---------------------------------------------------------------------------
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null,
+  p_metode_bayar   text default null,
+  p_bukti_transfer text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+  v_bukti    text;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', tagihan_pendaftaran(v_ada.id),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  -- Cara bayar dan buktinya. Path buktinya WAJIB berada di dalam folder
+  -- kunci_kirim kiriman ini: nama objek Storage bisa ditebak siapa pun yang
+  -- pernah melihat satu contohnya, dan tanpa pagar ini satu pendaftaran bisa
+  -- menunjuk bukti milik pendaftaran lain.
+  if coalesce(p_metode_bayar, '') not in ('transfer', 'tunai') then
+    raise exception 'cara pembayaran wajib dipilih';
+  end if;
+  v_bukti := nullif(trim(coalesce(p_bukti_transfer, '')), '');
+  if p_metode_bayar = 'transfer' then
+    if v_bukti is null then
+      raise exception 'bukti transfer wajib diunggah';
+    end if;
+    if p_kunci_kirim is null
+       or v_bukti not like p_kunci_kirim::text || '/%' then
+      raise exception 'bukti transfer bukan milik kiriman ini';
+    end if;
+  else
+    v_bukti := null;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+
+    -- Anggota OPSIONAL: kunci `anggota` boleh tidak ada sama sekali, dan
+    -- daftarnya boleh kosong. Yang ditolak cuma bentuk yang salah.
+    if v_r ? 'anggota' and jsonb_typeof(v_r -> 'anggota') <> 'null' then
+      if jsonb_typeof(v_r -> 'anggota') <> 'array' then
+        raise exception 'anggota harus berupa daftar nama';
+      end if;
+      if (select count(*) from jsonb_array_elements_text(v_r -> 'anggota') a
+          where trim(a) <> '') > 4 then
+        raise exception 'maksimal 4 anggota selain ketua';
+      end if;
+      -- Aturan yang sama dengan nama ketua (0052): angka di nama orang hampir
+      -- selalu nomor urut yang ikut terketik, dan ia terbawa ke daftar hadir.
+      if exists (select 1 from jsonb_array_elements_text(v_r -> 'anggota') a
+                 where a ~ '[0-9]') then
+        raise exception 'nama anggota tidak boleh memakai angka';
+      end if;
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim,
+                           nama_kontak, metode_bayar, bukti_transfer)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''),
+          p_metode_bayar, v_bukti)
+  returning id into v_batch;
+
+  -- Kotak yang dibiarkan kosong TIDAK disimpan sebagai string kosong: yang
+  -- tersimpan hanya nama yang benar-benar diketik, berurutan. `array_agg` atas
+  -- nol baris mengembalikan NULL, dan NULL di sini berarti "tidak ada nama
+  -- anggota yang dicatat" — bukan "regunya kosong".
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan',
+         (select array_agg(trim(a) order by urut)
+          from jsonb_array_elements_text(coalesce(r -> 'anggota', '[]'::jsonb))
+               with ordinality as t(a, urut)
+          where trim(a) <> '')
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', tagihan_pendaftaran(v_batch),
+    'terkirim_ulang', false);
+end;
+$fn$;
+
+-- Bentuk argumennya berubah, jadi versi delapan-argumen dari 0114 harus
+-- DIBUANG. Kalau dibiarkan, PostgREST melihat dua fungsi bernama sama dan
+-- menolak panggilannya dengan "could not choose the best candidate function" —
+-- form pendaftaran berhenti bekerja tanpa satu baris pun berubah di klien.
+drop function if exists submit_pendaftaran(
+  text, text, boolean, text, jsonb, smallint, uuid, text);
+
+grant execute on function submit_pendaftaran(
+  text, text, boolean, text, jsonb, smallint, uuid, text, text, text)
+  to anon, authenticated;

--- a/supabase/migrations/0122_tuntut_cara_bayar.sql
+++ b/supabase/migrations/0122_tuntut_cara_bayar.sql
@@ -1,0 +1,187 @@
+-- ============================================================================
+-- hrcd-rekap : 0122_tuntut_cara_bayar.sql
+--
+-- Cara bayar tidak boleh NULL lagi.
+--
+-- 0121 sengaja menerimanya kosong. Alasannya ada di kepala migrasi itu:
+-- migrasi, Worker gateway, dan form peserta tidak mendarat pada detik yang
+-- sama, dan menolak kiriman tanpa cara bayar sebelum gateway barunya naik
+-- berarti mematikan satu-satunya pintu pendaftaran selama beberapa menit yang
+-- tidak bisa dijadwalkan.
+--
+-- JALANKAN SESUDAH `deploy-gateway.yml` selesai, bukan sebelumnya. Sesudah itu
+-- tidak ada lagi klien yang mengirim tanpa cara bayar, dan menerimanya berarti
+-- menyisakan pintu yang mencatat pembayaran sebagai "tidak tahu".
+--
+-- Baris yang terlanjur lahir tanpa cara bayar selama jeda itu DIBIARKAN, sama
+-- seperti seluruh pendaftaran sebelum 0121. Yang berubah cuma yang baru.
+--
+-- Salinan fungsinya diambil utuh dari 0121; satu-satunya perubahan perilakunya
+-- ada di blok validasi cara bayar.
+-- ============================================================================
+
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null,
+  p_metode_bayar   text default null,
+  p_bukti_transfer text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+  v_bukti    text;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', tagihan_pendaftaran(v_ada.id),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  -- Cara bayar dan buktinya. Path buktinya WAJIB berada di dalam folder
+  -- kunci_kirim kiriman ini: nama objek Storage bisa ditebak siapa pun yang
+  -- pernah melihat satu contohnya, dan tanpa pagar ini satu pendaftaran bisa
+  -- menunjuk bukti milik pendaftaran lain.
+  if coalesce(p_metode_bayar, '') not in ('transfer', 'tunai') then
+    raise exception 'cara pembayaran wajib dipilih';
+  end if;
+  v_bukti := nullif(trim(coalesce(p_bukti_transfer, '')), '');
+  if p_metode_bayar = 'transfer' then
+    if v_bukti is null then
+      raise exception 'bukti transfer wajib diunggah';
+    end if;
+    if p_kunci_kirim is null
+       or v_bukti not like p_kunci_kirim::text || '/%' then
+      raise exception 'bukti transfer bukan milik kiriman ini';
+    end if;
+  else
+    v_bukti := null;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+
+    -- Anggota OPSIONAL: kunci `anggota` boleh tidak ada sama sekali, dan
+    -- daftarnya boleh kosong. Yang ditolak cuma bentuk yang salah.
+    if v_r ? 'anggota' and jsonb_typeof(v_r -> 'anggota') <> 'null' then
+      if jsonb_typeof(v_r -> 'anggota') <> 'array' then
+        raise exception 'anggota harus berupa daftar nama';
+      end if;
+      if (select count(*) from jsonb_array_elements_text(v_r -> 'anggota') a
+          where trim(a) <> '') > 4 then
+        raise exception 'maksimal 4 anggota selain ketua';
+      end if;
+      -- Aturan yang sama dengan nama ketua (0052): angka di nama orang hampir
+      -- selalu nomor urut yang ikut terketik, dan ia terbawa ke daftar hadir.
+      if exists (select 1 from jsonb_array_elements_text(v_r -> 'anggota') a
+                 where a ~ '[0-9]') then
+        raise exception 'nama anggota tidak boleh memakai angka';
+      end if;
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_pendamping, jumlah_regu, kontak_wa, kunci_kirim,
+                           nama_kontak, metode_bayar, bukti_transfer)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''),
+          p_metode_bayar, v_bukti)
+  returning id into v_batch;
+
+  -- Kotak yang dibiarkan kosong TIDAK disimpan sebagai string kosong: yang
+  -- tersimpan hanya nama yang benar-benar diketik, berurutan. `array_agg` atas
+  -- nol baris mengembalikan NULL, dan NULL di sini berarti "tidak ada nama
+  -- anggota yang dicatat" — bukan "regunya kosong".
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan',
+         (select array_agg(trim(a) order by urut)
+          from jsonb_array_elements_text(coalesce(r -> 'anggota', '[]'::jsonb))
+               with ordinality as t(a, urut)
+          where trim(a) <> '')
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', tagihan_pendaftaran(v_batch),
+    'terkirim_ulang', false);
+end;
+$fn$;
+
+do $blok$
+begin
+  perform submit_pendaftaran('Uji 0122', 'Jl. Uji', false, '081200000122',
+                             '[{"nama_regu":"Uji Nol","nama_ketua":"Uji",
+                                "golongan":"penegak_pa"}]'::jsonb,
+                             0::smallint, gen_random_uuid(), 'Uji', null, null);
+  raise exception '0122: cara bayar NULL masih diterima — pengetatan gagal';
+exception
+  when others then
+    if sqlerrm not like '%cara pembayaran wajib dipilih%' then raise; end if;
+    raise notice '0122: cara bayar wajib disebut sejak sekarang.';
+end;
+$blok$;

--- a/tests/concurrency_test.py
+++ b/tests/concurrency_test.py
@@ -78,9 +78,10 @@ def siapkan():
                               else "intern_pa"}
                 for j in range(REGU_PER_SEKOLAH)]
         h = jalankan(
-            "select submit_pendaftaran(%s,%s,%s,%s,%s::jsonb,%s::smallint,%s::uuid) as h",
+            "select submit_pendaftaran(%s,%s,%s,%s,%s::jsonb,%s::smallint,%s::uuid,"
+            "null, %s) as h",
             (f"UJI KONKUREN {i}", f"Jl. Uji {i}", False, "081200000000",
-             json.dumps(regu), 0, str(uuid.uuid4())),
+             json.dumps(regu), 0, str(uuid.uuid4()), 'tunai'),
             role="service_role", fetch="one")["h"]
         k = h["kode_pembayaran"]
         # Nominalnya diambil dari yang sudah dihitung submit_pendaftaran, bukan
@@ -271,10 +272,11 @@ def uji_nomor_kembar():
     kode = []
     for i in range(2):
         h = jalankan(
-            "select submit_pendaftaran(%s,%s,%s,%s,%s::jsonb,%s::smallint,%s::uuid) as h",
+            "select submit_pendaftaran(%s,%s,%s,%s,%s::jsonb,%s::smallint,%s::uuid,"
+            "null, %s) as h",
             (f"UJI KONKUREN KEMBAR {i}", f"Jl. Kembar {i}", False, "081200000000",
              json.dumps([{"nama_regu": f"Kembar {kode_huruf(i)}", "nama_ketua": "Ketua",
-                          "golongan": "penegak_pa"}]), 0, str(uuid.uuid4())),
+                          "golongan": "penegak_pa"}]), 0, str(uuid.uuid4()), 'tunai'),
             role="service_role", fetch="one")["h"]
         k = h["kode_pembayaran"]
         jalankan("select verifikasi_pembayaran(%s,%s,%s)",

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -267,7 +267,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q("""
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
                            d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
-                           d.created_at,
+                           d.created_at, d.metode_bayar, d.bukti_transfer,
                            jsonb_build_object('name', s.name, 'address', s.address) as sekolah,
                            (select jsonb_agg(jsonb_build_object(
                               'id', r.id, 'nama_regu', r.nama_regu,
@@ -337,12 +337,13 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 b = self._badan()
                 hasil = q(
                     "select submit_pendaftaran(%s, %s, %s, %s, %s::jsonb, "
-                    "%s::smallint, %s::uuid, %s) as h",
+                    "%s::smallint, %s::uuid, %s, %s, %s) as h",
                     (b.get("nama_sekolah"), b.get("alamat_sekolah"),
                      bool(b.get("butuh_barak")), b.get("kontak_wa"),
                      json.dumps(b.get("regu") or []),
                      int(b.get("jumlah_pendamping") or 0),
-                     b.get("kunci_kirim"), b.get("nama_kontak")),
+                     b.get("kunci_kirim"), b.get("nama_kontak"),
+                     b.get("metode_bayar"), b.get("bukti_transfer")),
                     role="service_role", fetch="one")
                 self._kirim(200, hasil["h"])
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -546,7 +546,12 @@ run tests/sql/82_nama_regu_tiga_huruf.sql
 # bukan pembayaran.method yang mencatat cara uangnya benar-benar diterima. Tes
 # 83 menjaga ketiga pagarnya, termasuk yang paling mudah terlewat: bukti milik
 # folder kiriman lain harus ditolak.
+#
+# 0122 mengetatkan cara bayar jadi wajib, dan di produksi ia dijalankan SESUDAH
+# gateway terdeploy. Di sini keduanya berurutan karena tidak ada gateway yang
+# perlu ditunggu — dan tes 83.1 memang menuntut bentuk lama itu sudah hilang.
 run supabase/migrations/0121_pembayaran_pilihan_pembina.sql
+run supabase/migrations/0122_tuntut_cara_bayar.sql
 run tests/sql/83_pembayaran_pilihan_pembina.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -541,6 +541,13 @@ run tests/sql/81_migrasi_terlewat.sql
 # "A B" tiga karakter, dua huruf, dan yang dibacakan di lapangan hurufnya.
 run supabase/migrations/0120_nama_regu_tiga_huruf.sql
 run tests/sql/82_nama_regu_tiga_huruf.sql
+
+# 0121 mencatat cara bayar PILIHAN pembina beserta bukti transfernya, dan itu
+# bukan pembayaran.method yang mencatat cara uangnya benar-benar diterima. Tes
+# 83 menjaga ketiga pagarnya, termasuk yang paling mudah terlewat: bukti milik
+# folder kiriman lain harus ditolak.
+run supabase/migrations/0121_pembayaran_pilihan_pembina.sql
+run tests/sql/83_pembayaran_pilihan_pembina.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
 # migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.

--- a/tests/sql/77_nama_anggota_regu.sql
+++ b/tests/sql/77_nama_anggota_regu.sql
@@ -25,7 +25,7 @@ declare v jsonb; v_id uuid; v_ang text[];
 begin
   v := submit_pendaftaran(
     'SMPN Uji Anggota', 'Jl. Uji Anggota', false, '081200007701',
-    '[{"nama_regu":"Ujianggota Satu","nama_ketua":"Ketua Satu","golongan":"penegak_pa"}]');
+    '[{"nama_regu":"Ujianggota Satu","nama_ketua":"Ketua Satu","golongan":"penegak_pa"}]', p_metode_bayar => 'tunai');
 
   select r.anggota into v_ang
   from regu r join pendaftaran d on d.id = r.pendaftaran_id
@@ -45,7 +45,7 @@ begin
   v := submit_pendaftaran(
     'SMPN Uji Anggota Isi', 'Jl. Uji Isi', false, '081200007702',
     '[{"nama_regu":"Ujianggota Dua","nama_ketua":"Ketua Dua","golongan":"penegak_pa",
-       "anggota":["Budi Santoso","","  ","Citra Lestari"]}]');
+       "anggota":["Budi Santoso","","  ","Citra Lestari"]}]', p_metode_bayar => 'tunai');
 
   select r.anggota into v_ang
   from regu r join pendaftaran d on d.id = r.pendaftaran_id
@@ -73,7 +73,7 @@ begin
     perform submit_pendaftaran(
       'SMPN Uji Anggota Lima', 'Jl. Uji Lima', false, '081200007703',
       '[{"nama_regu":"Ujianggota Tiga","nama_ketua":"Ketua Tiga","golongan":"penegak_pa",
-         "anggota":["A Satu","B Dua","C Tiga","D Empat","E Lima"]}]');
+         "anggota":["A Satu","B Dua","C Tiga","D Empat","E Lima"]}]', p_metode_bayar => 'tunai');
   exception when others then v_tolak := true;
   end;
   assert v_tolak, '77.3 GAGAL: lima anggota diterima';
@@ -84,7 +84,7 @@ begin
     perform submit_pendaftaran(
       'SMPN Uji Anggota Angka', 'Jl. Uji Angka', false, '081200007704',
       '[{"nama_regu":"Ujianggota Empat","nama_ketua":"Ketua Empat","golongan":"penegak_pa",
-         "anggota":["Anggota 2"]}]');
+         "anggota":["Anggota 2"]}]', p_metode_bayar => 'tunai');
   exception when others then v_tolak := true;
   end;
   assert v_tolak, '77.3 GAGAL: nama anggota berangka diterima';
@@ -104,7 +104,7 @@ begin
     perform submit_pendaftaran(
       'SMPN Uji Tanpa Ketua', 'Jl. Uji Ketua', false, '081200007705',
       '[{"nama_regu":"Ujianggota Lima","nama_ketua":"","golongan":"penegak_pa",
-         "anggota":["Budi Santoso"]}]');
+         "anggota":["Budi Santoso"]}]', p_metode_bayar => 'tunai');
   exception when others then v_tolak := true;
   end;
   assert v_tolak, '77.4 GAGAL: regu tanpa nama ketua diterima';

--- a/tests/sql/83_pembayaran_pilihan_pembina.sql
+++ b/tests/sql/83_pembayaran_pilihan_pembina.sql
@@ -30,10 +30,13 @@ declare
   v_id     uuid;
   v_lolos  boolean;
 begin
-  -- 83.1 Tanpa cara bayar sama sekali: ditolak, bukan diam-diam dianggap tunai.
+  -- 83.1 Cara bayar NULL — bentuk yang benar-benar dikirim gateway saat
+  -- pembina memakai form lama yang belum punya bagian Pembayaran. Ditolak,
+  -- bukan diam-diam dianggap tunai.
   begin
     perform submit_pendaftaran('SMP Uji Bayar', 'Jl. Uji', false, '081200000083',
-                              v_regu, 0::smallint, gen_random_uuid(), 'Uji');
+                              v_regu, 0::smallint, gen_random_uuid(), 'Uji',
+                              null, null);
     v_lolos := true;
   exception when others then
     v_lolos := false;

--- a/tests/sql/83_pembayaran_pilihan_pembina.sql
+++ b/tests/sql/83_pembayaran_pilihan_pembina.sql
@@ -1,0 +1,133 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/83_pembayaran_pilihan_pembina.sql — migrasi 0121.
+--
+-- Pembina memilih cara membayar saat mendaftar, dan yang transfer wajib
+-- mengunggah buktinya. Yang diuji di sini tiga hal yang gampang bocor:
+--
+--   1. cara bayar wajib disebut — tidak ada bentuk "tidak menyebutkan"
+--   2. transfer TANPA bukti ditolak, dan ditolak di RPC maupun di constraint
+--   3. bukti milik kiriman LAIN ditolak
+--
+-- Nomor 3 yang paling mudah terlewat. Nama objek di Storage bisa ditebak
+-- siapa pun yang pernah melihat satu contohnya, dan tanpa pagar itu satu
+-- pendaftaran bisa menunjuk bukti transfer milik sekolah lain — lalu terbaca
+-- "sudah ada buktinya" di Meja Pembayaran.
+--
+-- Seluruhnya di-rollback.
+-- ============================================================================
+
+\echo '--- 83. cara bayar pilihan pembina + bukti transfer'
+\set ON_ERROR_STOP on
+
+do $blok$
+declare
+  v_kunci  uuid := gen_random_uuid();
+  v_lain   uuid := gen_random_uuid();
+  v_regu   jsonb := '[{"nama_regu":"Cakrawala","nama_ketua":"Ketua Uji",
+                       "golongan":"penegak_pa"}]'::jsonb;
+  v_hasil  jsonb;
+  v_pesan  text;
+  v_id     uuid;
+  v_lolos  boolean;
+begin
+  -- 83.1 Tanpa cara bayar sama sekali: ditolak, bukan diam-diam dianggap tunai.
+  begin
+    perform submit_pendaftaran('SMP Uji Bayar', 'Jl. Uji', false, '081200000083',
+                              v_regu, 0::smallint, gen_random_uuid(), 'Uji');
+    v_lolos := true;
+  exception when others then
+    v_lolos := false;
+    get stacked diagnostics v_pesan = message_text;
+  end;
+  assert not v_lolos, '83.1 GAGAL: pendaftaran tanpa cara bayar diterima';
+  assert v_pesan like '%cara pembayaran wajib dipilih%',
+    format('83.1 GAGAL: ditolak, tetapi pesannya "%s"', v_pesan);
+
+  -- 83.2 Transfer tanpa bukti: ditolak.
+  begin
+    perform submit_pendaftaran('SMP Uji Bayar', 'Jl. Uji', false, '081200000083',
+                              v_regu, 0::smallint, gen_random_uuid(), 'Uji',
+                              'transfer', null);
+    v_lolos := true;
+  exception when others then
+    v_lolos := false;
+    get stacked diagnostics v_pesan = message_text;
+  end;
+  assert not v_lolos, '83.2 GAGAL: transfer tanpa bukti diterima';
+  assert v_pesan like '%bukti transfer wajib diunggah%',
+    format('83.2 GAGAL: ditolak, tetapi pesannya "%s"', v_pesan);
+
+  -- 83.3 Bukti milik folder kiriman LAIN: ditolak. Inilah pagar yang tidak
+  -- bisa ditegakkan Storage, karena di sana kedua path sama-sama sah.
+  begin
+    perform submit_pendaftaran('SMP Uji Bayar', 'Jl. Uji', false, '081200000083',
+                              v_regu, 0::smallint, v_kunci, 'Uji',
+                              'transfer', v_lain::text || '/bukti.jpg');
+    v_lolos := true;
+  exception when others then
+    v_lolos := false;
+    get stacked diagnostics v_pesan = message_text;
+  end;
+  assert not v_lolos, '83.3 GAGAL: bukti milik kiriman lain diterima';
+  assert v_pesan like '%bukan milik kiriman ini%',
+    format('83.3 GAGAL: ditolak, tetapi pesannya "%s"', v_pesan);
+
+  -- 83.4 Transfer dengan bukti yang benar: diterima, dan tersimpan apa adanya.
+  v_hasil := submit_pendaftaran('SMP Uji Bayar', 'Jl. Uji', false, '081200000083',
+                                v_regu, 0::smallint, v_kunci, 'Uji',
+                                'transfer', v_kunci::text || '/bukti.jpg');
+  select id into v_id from pendaftaran
+   where kode_pembayaran = v_hasil ->> 'kode_pembayaran';
+  assert (select metode_bayar from pendaftaran where id = v_id) = 'transfer',
+    '83.4 GAGAL: metode_bayar tidak tersimpan sebagai transfer';
+  assert (select bukti_transfer from pendaftaran where id = v_id)
+         = v_kunci::text || '/bukti.jpg',
+    '83.4 GAGAL: path bukti transfer tidak tersimpan apa adanya';
+
+  -- 83.5 Tunai: diterima tanpa bukti, dan bukti yang terlanjur ikut terkirim
+  -- TIDAK disimpan. Menyimpannya akan membuat Meja Pembayaran menawarkan
+  -- gambar untuk pembayaran yang tidak pernah ditransfer.
+  v_hasil := submit_pendaftaran('SMP Uji Tunai', 'Jl. Uji', false, '081200000084',
+                                '[{"nama_regu":"Bimasakti","nama_ketua":"Ketua Uji",
+                                   "golongan":"penegak_pi"}]'::jsonb,
+                                0::smallint, gen_random_uuid(), 'Uji',
+                                'tunai', 'sisa/bukti.jpg');
+  select id into v_id from pendaftaran
+   where kode_pembayaran = v_hasil ->> 'kode_pembayaran';
+  assert (select metode_bayar from pendaftaran where id = v_id) = 'tunai',
+    '83.5 GAGAL: metode_bayar tidak tersimpan sebagai tunai';
+  assert (select bukti_transfer from pendaftaran where id = v_id) is null,
+    '83.5 GAGAL: bukti ikut tersimpan padahal pembayarannya tunai';
+
+  -- 83.6 Bentuk fungsinya berubah, jadi yang lama ikut diperiksa sekali lagi:
+  -- nama anggota (0114) harus tetap tersimpan lewat salinan yang ditulis 0121.
+  -- Tes 77 memeriksa ini terhadap bentuk 0114 dan berhenti di sana; kalau
+  -- salinan di 0121 menjatuhkan satu baris, di sinilah ketahuannya.
+  v_hasil := submit_pendaftaran('SMP Uji Anggota', 'Jl. Uji', false, '081200000085',
+                                '[{"nama_regu":"Nusantara","nama_ketua":"Ketua Uji",
+                                   "golongan":"penegak_pa",
+                                   "anggota":["Andi","","Budi"]}]'::jsonb,
+                                0::smallint, gen_random_uuid(), 'Uji', 'tunai', null);
+  assert (select anggota from regu r
+           join pendaftaran d on d.id = r.pendaftaran_id
+          where d.kode_pembayaran = v_hasil ->> 'kode_pembayaran')
+         = array['Andi', 'Budi'],
+    '83.6 GAGAL: nama anggota tidak tersimpan rapat lewat submit_pendaftaran 0121';
+
+  -- 83.7 Pagar terakhir, di kolomnya sendiri: UPDATE yang membuat baris jadi
+  -- "transfer tanpa bukti" ditolak database, bukan hanya oleh RPC di atas.
+  begin
+    update pendaftaran set metode_bayar = 'transfer', bukti_transfer = null
+     where kode_pembayaran = v_hasil ->> 'kode_pembayaran';
+    raise exception '83.7 GAGAL: transfer tanpa bukti lolos lewat UPDATE';
+  exception when check_violation then
+    null;
+  end;
+
+  raise exception 'ROLLBACK UJI 83';
+exception when others then
+  if sqlerrm <> 'ROLLBACK UJI 83' then raise; end if;
+end;
+$blok$;
+
+\echo '    83 LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -411,6 +411,65 @@ export async function kirimPendaftaran(payload, tokenTurnstile) {
   });
 }
 
+/* ---------------------- BUKTI TRANSFER (migrasi 0121) --------------------
+
+   Satu-satunya unggahan di seluruh sistem yang datang dari orang yang TIDAK
+   login. Karena itu jalannya sengaja beda dari unggahFotoLembar di bawah: ia
+   tidak pernah menyegarkan sesi, dan tidak pernah memakai token siapa pun —
+   anon key saja, persis seperti pembina yang membuka form dari HP-nya.
+
+   Folder pertama WAJIB kunci_kirim, dan itu ditegakkan dua kali: policy
+   storage.objects hanya menerima nama berbentuk `<uuid>/<sesuatu>.jpg`, dan
+   submit_pendaftaran menolak path yang folder-nya bukan kunci_kirim kiriman
+   itu sendiri. Yang pertama menjaga bucket, yang kedua menjaga supaya satu
+   pendaftaran tidak mengaku memakai bukti milik pendaftaran lain.           */
+
+const BUCKET_BUKTI = "bukti";
+
+export function namaObjekBukti(kunciKirim) {
+  const acak = Math.random().toString(36).slice(2, 8);
+  return `${kunciKirim}/bukti-${Date.now()}-${acak}.jpg`;
+}
+
+/** Unggah satu bukti transfer, kembalikan path-nya untuk dikirim ke RPC.
+ *
+ *  Gambarnya sudah dikecilkan pemanggil lewat kecilkanFoto(). Bucket menolak
+ *  apa pun di atas 1 MB dan apa pun yang bukan JPEG — pagar kedua untuk saat
+ *  pengecilan itu gagal diam-diam. */
+export async function unggahBuktiTransfer(kunciKirim, blob) {
+  const path = namaObjekBukti(kunciKirim);
+  // Dev server tidak punya Storage. Path-nya tetap dikembalikan supaya alur
+  // formnya bisa dicoba tanpa Supabase.
+  if (K.mode === "dev") return path;
+
+  await kirim(`${K.supabaseUrl}/storage/v1/object/${BUCKET_BUKTI}/${path}`, {
+    method: "POST",
+    headers: {
+      apikey: K.anonKey,
+      Authorization: `Bearer ${K.anonKey}`,
+      "Content-Type": "image/jpeg",
+      "x-upsert": "false",
+    },
+    body: blob,
+  });
+  return path;
+}
+
+/** Link sementara untuk melihat satu bukti transfer di Meja Pembayaran.
+ *  Alasannya sama dengan tautanFoto(): bucket-nya privat, dan link yang tidak
+ *  kedaluwarsa akan beredar di WhatsApp selamanya. */
+export async function tautanBukti(path) {
+  if (K.mode === "dev" || !path) return null;
+  await pastikanSesiSegar();
+  const j = await kirim(
+    `${K.supabaseUrl}/storage/v1/object/sign/${BUCKET_BUKTI}/${path}`, {
+      method: "POST",
+      headers: kepalaSupabase(),
+      body: JSON.stringify({ expiresIn: 3600 }),
+    });
+  return `${K.supabaseUrl}/storage/v1${j.signedURL || j.signedUrl}`;
+}
+
 /* ============================ MEJA ====================================== */
 
 export async function ringkasanMeja() {
@@ -442,7 +501,7 @@ export async function daftarPendaftaran() {
   if (K.mode === "dev") return baca("/daftar-pendaftaran");
   return baca(null,
     "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping," +
-    "butuh_barak,kontak_wa,created_at," +
+    "butuh_barak,kontak_wa,created_at,metode_bayar,bukti_transfer," +
     "sekolah(name,address)," +
     "regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled)," +
     "pembayaran(amount,method,nomor_kwitansi,verified_at)" +

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,7 +27,7 @@ import {
   aturFaseLive,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun, daftarPanitia,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak, tautanFotoBanyak,
-  hapusFotoLembar,
+  hapusFotoLembar, tautanBukti,
 } from "./api.js";
 import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapital,
          meterSah,
@@ -937,15 +937,24 @@ async function layarPembayaran() {
         // selalu jatuh ke baris berikutnya, bahkan di kartu HP yang kolomnya
         // lapang. Dengan flex-wrap ia tetap menumpuk sendiri di kolom tabel
         // lebar yang cuma 15%, jadi satu aturan melayani kedua tampilan.
-        ? html`<span class="metode-lunas"
+        ? html`<span class="metode-baris"
                ><span>${b.pembayaran ? b.pembayaran.method : "—"}</span
                ><span class="badge badge-green">LUNAS</span></span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`
-          : `<select class="select-small" data-metode="${esc(b.kode_pembayaran)}">
-               <option value="tunai" selected>Tunai</option>
-               <option value="transfer">Transfer</option>
-             </select>`;
+          // Yang terpilih lebih dulu adalah cara bayar yang DIPILIH PEMBINA saat
+          // mendaftar (migrasi 0121) — bukan tebakan, dan bukan pula janji: yang
+          // dicatat tetap yang dipilih petugas di sini, karena uangnyalah yang
+          // menentukan. Pendaftaran lama tidak menyimpannya, dan untuk mereka
+          // tunai tetap yang terpilih seperti sebelumnya.
+          : html`<span class="metode-baris"
+                 ><select class="select-small" data-metode="${esc(b.kode_pembayaran)}">
+                    <option value="tunai" ${b.metode_bayar === "transfer" ? "" : "selected"}>Tunai</option>
+                    <option value="transfer" ${b.metode_bayar === "transfer" ? "selected" : ""}>Transfer</option>
+                  </select>${b.bukti_transfer
+                    ? html`<button class="button button-mini" type="button"
+                                   data-bukti="${esc(b.bukti_transfer)}">Bukti</button>`
+                    : ""}</span>`;
 
       const aksi = b.status === "lunas"
         // <span class="teks-lebar"> = kata yang DIBUANG di layar sempit, jadi
@@ -1039,6 +1048,21 @@ async function layarPembayaran() {
       satuan.textContent = " regu";
       return [document.createTextNode(`${terbuka ? "▾" : "▸"} ${jumlah}`), satuan];
     };
+
+    // Bukti transfer yang diunggah pembina. Bucket-nya privat, jadi tautannya
+    // ditandatangani saat diketuk — dan jendelanya dibuka SEBELUM await, karena
+    // browser HP memblokir jendela yang dibuka sesudah menunggu jaringan.
+    tbody.querySelectorAll("[data-bukti]").forEach(btn =>
+      btn.addEventListener("click", async () => {
+        const jendela = window.open("", "_blank");
+        try {
+          const url = await tautanBukti(btn.dataset.bukti);
+          if (jendela && url) jendela.location = url; else if (jendela) jendela.close();
+        } catch (err) {
+          if (jendela) jendela.close();
+          notif(`Bukti tidak bisa dibuka: ${err.message}`, true);
+        }
+      }));
 
     // Buka/tutup rincian regu satu invoice.
     tbody.querySelectorAll("[data-detail]").forEach(btn =>

--- a/web/style.css
+++ b/web/style.css
@@ -1902,7 +1902,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    tabel lebar kolom Metode cuma 15% jadi ia membungkus jadi dua baris seperti
    sebelumnya. Satu aturan, dua tampilan — tanpa media query yang harus
    ditebak batasnya. */
-.metode-lunas {
+.metode-baris {
   display: inline-flex; align-items: center; justify-content: center;
   flex-wrap: wrap; gap: .35rem;
 }

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -552,6 +552,12 @@ export default {
         // Kunci idempotensi: kiriman ulang setelah sinyal putus tidak
         // melahirkan pendaftaran kedua (migrasi 0006).
         p_kunci_kirim: b.kunci_kirim || null,
+        // Cara bayar PILIHAN pembina, dan path bukti transfernya di bucket
+        // `bukti` (migrasi 0121). Gateway meneruskan apa adanya: yang menolak
+        // transfer tanpa bukti, dan bukti milik kiriman lain, adalah RPC-nya —
+        // satu tempat, bukan dua yang bisa menyimpang.
+        p_metode_bayar: b.metode_bayar || null,
+        p_bukti_transfer: b.bukti_transfer || null,
       }),
     });
     const isi = await r.json();


### PR DESCRIPTION
## What

**Registration form** — new section 7, *Pembayaran*, with two buttons:

- **Transfer** → "Silakan transfer senilai Rp X ke rekening BJB 0161891614100 a.n. Hiking Rally Ciradyka." plus **Unggah Bukti Transfer**, which holds back Kirim until the image is up.
- **Tunai** → "Pembayaran senilai Rp X dapat dilakukan di kampus SMAN 1 Ciamis."

**Meja Pembayaran** — the metode dropdown opens on what the pembina chose, and a **Bukti** button signs a one-hour link to the uploaded image.

**Database** — `0121` adds `pendaftaran.metode_bayar` and `pendaftaran.bukti_transfer`, a private `bukti` bucket, and extends `submit_pendaftaran`. `0122` then makes the method mandatory.

**Gateway** — forwards the two new fields. Needs a manual deploy.

## Why

Payment was invisible until a pembina reached the desk. The amount and the account number lived on a poster, and nothing tied a transfer to a registration except a code typed into a berita transfer — a mistyped code is money arriving with no name on it.

## Notes

**Two different "metode", deliberately separate.** `pembayaran.method` records how the money was actually received and is what the accounts are built from. `pendaftaran.metode_bayar` is an intention recorded before the money exists anywhere. They can differ — a school picks Transfer and pays cash — and the treasurer's version wins. The intention still earns its place: it makes the common branch one tap at the desk.

**Proof is required to submit**, per the event owner. The cost is stated in the migration header: a school that picks Transfer but has not transferred cannot send its registration yet, and there is no screen to supply the receipt afterwards.

**The only anonymous upload in the system.** Guards: insert only, no read for anon, 1 MB, JPEG only, and the object name must sit inside the submission's own `kunci_kirim` folder — which Storage cannot express, so `submit_pendaftaran` enforces it. Without it one registration could claim another's receipt. **Rate limiting is absent** on this path and the header says so rather than leaving it to be found.

**Two migrations, and the split is the point.** Migration, Worker, and form cannot land in the same second. A function demanding a method the moment it exists would reject every call from the gateway still running, closing the only registration door for as long as the next deploy takes. So `0121` accepts an eight-key payload through defaults and records no method — as every registration before today does — while already enforcing the parts with no legacy caller. `0122` closes the gap once the gateway is up. Keeping 0114's eight-argument overload alive instead was rejected: two functions of one name leave PostgREST to guess.

**Verified locally.** `tests/run.sh` passes in full, including new test 83 — method required, transfer without proof rejected, proof belonging to another submission rejected, tunai discarding a stray path, anggota still stored through the rewritten function, and the `UPDATE` path blocked by the constraint rather than only by the RPC. `periksa_impor`, `periksa_urutan_golongan`, `periksa_sekolah`, the gateway body-limit tests, and the four `web/`↔`live/` shared pairs all pass; both changed modules parse as ES modules.

## Deploy order — it matters

1. Apply `0121` **before merging**, so the bucket exists when the form ships. Check the log for a WARNING: if the bucket or its policies could not be created from SQL, add them from the Supabase dashboard before any upload will work.
2. Merge — `publish-live` ships the form, the panitia site ships itself.
3. Run **Deploy gateway**.
4. Apply `0122`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)