### PR TITLE
fix: stop asking anon which pos it works at

### DIFF
--- a/supabase/migrations/0123_policy_storage_per_peran.sql
+++ b/supabase/migrations/0123_policy_storage_per_peran.sql
@@ -1,0 +1,98 @@
+-- ============================================================================
+-- hrcd-rekap : 0123_policy_storage_per_peran.sql
+--
+-- Unggahan bukti transfer oleh pembina ditolak "permission denied for function
+-- pos_saya", dan tidak ada satu pun yang salah pada policy buktinya sendiri.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG SEBENARNYA TERJADI
+--
+-- `storage.objects` sekarang punya empat policy: tiga milik bucket `lembar`
+-- (0047, ditulis ulang 0064, ditambah 0081) dan dua milik bucket `bukti`
+-- (0121). Tidak satu pun di antaranya menyebut peran, jadi SEMUANYA berlaku
+-- untuk PUBLIC — termasuk `anon`.
+--
+-- Policy permissive di-OR-kan, tetapi OR itu tetap harus MENGEVALUASI setiap
+-- syaratnya. Syarat milik `lembar` memanggil `peran()` dan `pos_saya()`, dan
+-- `anon` tidak berhak menjalankan keduanya. Evaluasinya tidak menghasilkan
+-- "false" melainkan GALAT, dan galat itu membatalkan seluruh INSERT sebelum
+-- syarat bucket `bukti` — yang sebenarnya lolos — sempat dibaca.
+--
+-- Jadi yang ditolak bukan pembinanya, melainkan pertanyaannya: anon ditanyai
+-- "pos berapa kamu?" pada saat mengunggah bukti pembayaran.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA JAWABANNYA `TO`, BUKAN MEMBERI HAK EXECUTE KEPADA anon
+--
+-- Menambahkan `grant execute on function pos_saya, peran to anon` akan
+-- menyelesaikan galatnya dan membuka dua fungsi yang membaca identitas panitia
+-- kepada seluruh internet — untuk alasan yang tidak ada hubungannya dengan
+-- keduanya. Yang benar adalah tidak menanyakannya sejak awal.
+--
+-- `alter policy ... to <peran>` mempersempit policy ke peran yang memang
+-- dituju. Policy yang tidak berlaku untuk sebuah peran TIDAK dievaluasi sama
+-- sekali untuk peran itu, jadi `anon` tidak pernah lagi menyentuh `pos_saya()`.
+--
+--   lembar  -> `authenticated` saja. Tidak pernah ada petugas anonim.
+--   bukti   -> tulis: `anon` DAN `authenticated`, karena pembina mengunggah
+--              tanpa login sementara panitia yang membantu di meja SUDAH
+--              login, dan keduanya mengunggah bukti yang sama.
+--              baca:  `authenticated` saja — syaratnya memanggil
+--              `boleh_apa_saja()`, dan itu pertanyaan yang sama tidak sahnya
+--              untuk anon.
+--
+-- ---------------------------------------------------------------------------
+-- PELAJARAN YANG LEBIH BESAR DARIPADA BUG INI
+--
+-- Menambahkan policy ke tabel yang SUDAH punya policy bukan tindakan yang
+-- berdiri sendiri: peran baru yang diberi jalan masuk akan ikut mengevaluasi
+-- seluruh syarat lama. Tes lokal tidak menangkapnya karena `storage` tidak ada
+-- di database uji, dan `psql` menerapkan migrasinya sebagai superuser yang
+-- boleh menjalankan fungsi apa pun. Yang menangkapnya adalah satu unggahan
+-- sungguhan dari HP.
+-- ============================================================================
+
+do $blok$
+begin
+  execute 'alter policy foto_lembar_baca  on storage.objects to authenticated';
+  execute 'alter policy foto_lembar_tulis on storage.objects to authenticated';
+  raise notice '0123: policy bucket `lembar` dipersempit ke authenticated.';
+exception
+  when undefined_object then
+    raise notice '0123: policy bucket `lembar` tidak ada — dilewati.';
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0123: TIDAK BISA mengubah policy storage.objects lewat '
+      'migrasi. Di Dashboard > Storage > Policies, setel policy lembar ke '
+      'peran `authenticated`.';
+end;
+$blok$;
+
+-- Terpisah dari blok di atas: 0081 menambahkannya belakangan, dan proyek yang
+-- belum menerapkannya tidak boleh membuat kedua policy sebelumnya ikut batal.
+do $blok$
+begin
+  execute 'alter policy foto_lembar_hapus on storage.objects to authenticated';
+  raise notice '0123: policy hapus bucket `lembar` dipersempit ke authenticated.';
+exception
+  when undefined_object then
+    raise notice '0123: policy foto_lembar_hapus tidak ada — dilewati.';
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0123: policy foto_lembar_hapus tidak bisa dipersempit.';
+end;
+$blok$;
+
+do $blok$
+begin
+  execute 'alter policy bukti_transfer_tulis on storage.objects to anon, authenticated';
+  execute 'alter policy bukti_transfer_baca  on storage.objects to authenticated';
+  raise notice '0123: bukti transfer boleh diunggah anon maupun panitia.';
+exception
+  when undefined_object then
+    raise warning '0123: policy bucket `bukti` tidak ada — terapkan 0121 dulu.';
+  when insufficient_privilege or undefined_table or invalid_schema_name then
+    raise warning '0123: TIDAK BISA mengubah policy storage.objects lewat '
+      'migrasi. Di Dashboard > Storage > Policies, setel bukti_transfer_tulis '
+      'ke peran `anon` dan `authenticated`, dan bukti_transfer_baca ke '
+      '`authenticated`.';
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -552,6 +552,14 @@ run tests/sql/82_nama_regu_tiga_huruf.sql
 # perlu ditunggu — dan tes 83.1 memang menuntut bentuk lama itu sudah hilang.
 run supabase/migrations/0121_pembayaran_pilihan_pembina.sql
 run supabase/migrations/0122_tuntut_cara_bayar.sql
+
+# 0123 mempersempit policy storage.objects ke peran yang memang dituju.
+# Tanpa itu unggahan anon ikut mengevaluasi syarat bucket `lembar` yang
+# memanggil pos_saya(), dan galat hak akses membatalkan seluruh INSERT.
+# Di database uji skema `storage` tidak ada, jadi migrasi ini hanya
+# membuktikan dirinya AMAN dijalankan di sana — bukan bahwa ia menyelesaikan
+# masalahnya. Yang membuktikan itu satu unggahan sungguhan ke produksi.
+run supabase/migrations/0123_policy_storage_per_peran.sql
 run tests/sql/83_pembayaran_pilihan_pembina.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh


### PR DESCRIPTION
## What

`0123` narrows every `storage.objects` policy to the roles it is actually for:

| policy | bucket | roles |
| --- | --- | --- |
| `foto_lembar_baca` / `_tulis` / `_hapus` | lembar | `authenticated` |
| `bukti_transfer_tulis` | bukti | `anon`, `authenticated` |
| `bukti_transfer_baca` | bukti | `authenticated` |

## Why

Uploading a transfer receipt failed with **`permission denied for function pos_saya`**, and nothing was wrong with the bukti policy.

None of the five policies named a role, so all applied to `PUBLIC`. Permissive policies are OR-ed — but the OR still has to *evaluate* each condition, and the lembar ones call `peran()` and `pos_saya()`, which `anon` may not execute. That does not evaluate to false; it raises, and the raise aborts the whole `INSERT` before the bukti condition — which would have passed — is ever read.

What was rejected was not the pembina but the question: anon was asked which pos it works at, while uploading a payment receipt.

## Notes

**Why `TO` and not a grant.** `grant execute on function pos_saya, peran to anon` also clears the error, and opens two functions that read panitia identity to the whole internet for a reason unrelated to either. A policy that does not apply to a role is never evaluated for it, so the right move is to stop asking.

**Both roles upload receipts**, per the event owner: a pembina uploads without logging in, a panitia helping at the desk is logged in, and it is the same receipt.

**Not reproducible locally, and the migration says so.** The test database has no `storage` schema, and `psql` applies migrations as a superuser that may call anything. `tests/run.sh` passes and this migration proves only that it is safe to run there — it takes the `undefined_object` branch. What caught the bug was one upload from a phone; what confirms the fix is another.

The bigger lesson is recorded in the migration header: adding a policy to a table that already has policies is not a standalone act — a newly admitted role starts evaluating every older condition too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)