### PR TITLE
feat: ask for the total staying over, not the number of pembina

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -500,7 +500,7 @@ export async function ringkasanMeja() {
 export async function daftarPendaftaran() {
   if (K.mode === "dev") return baca("/daftar-pendaftaran");
   return baca(null,
-    "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping," +
+    "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu," +
     "butuh_barak,kontak_wa,created_at,metode_bayar,bukti_transfer," +
     "sekolah(name,address)," +
     "regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled)," +

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -71,7 +71,10 @@ const kosong = () => ({
   jenis_peserta: null,           // "eksternal" atau "internal"
   sekolah: null,                 // {id?, nama, alamat}
   butuh_barak: null,
-  jumlah_pendamping: 0,
+  // Total orang yang menginap, peserta DAN pembina (migrasi 0124). Sampai
+  // 0124 kotak ini cuma menghitung pembina dan susun_barak() yang menambahkan
+  // pesertanya; sekarang angkanya utuh dan rumus itu membacanya apa adanya.
+  jumlah_menginap: 0,
   rincian: {
     penggalang_pa: 0, penggalang_pi: 0,
     penegak_pa: 0, penegak_pi: 0,
@@ -201,7 +204,7 @@ function halaman() {
         <button class="option" id="p-ya" aria-pressed="false" type="button">Ya, perlu</button>
         <button class="option" id="p-tidak" aria-pressed="false" type="button">Tidak perlu</button>
       </div>
-      <div id="isi-pendamping" style="margin-top:.9rem"></div>
+      <div id="isi-menginap" style="margin-top:.9rem"></div>
       <div class="error" id="g-barak" hidden>Pilih salah satu.</div>
     </section>
     `}
@@ -274,7 +277,7 @@ function halaman() {
     jawab.jenis_peserta = jenis;
     jawab.sekolah = jenis === "internal" ? sekolahInternal() : null;
     jawab.butuh_barak = jenis === "internal" ? false : null;
-    jawab.jumlah_pendamping = 0;
+    jawab.jumlah_menginap = 0;
     jawab.rincian = {
       penggalang_pa: 0, penggalang_pi: 0,
       penegak_pa: 0, penegak_pi: 0,
@@ -530,21 +533,21 @@ function gambarBarak() {
     jawab.butuh_barak = ya;
     document.getElementById("p-ya").setAttribute("aria-pressed", String(ya));
     document.getElementById("p-tidak").setAttribute("aria-pressed", String(!ya));
-    const kotak = document.getElementById("isi-pendamping");
+    const kotak = document.getElementById("isi-menginap");
     if (ya) {
       kotak.replaceChildren(h(html`
         <div class="field" style="margin:0">
-          <label for="n-pendamping">Berapa pendamping (pembina/guru) yang ikut menginap?</label>
-          <input type="number" id="n-pendamping" min="0" max="30" inputmode="numeric"
-                 value="${jawab.jumlah_pendamping}">
+          <label for="n-menginap">Total yang menginap (peserta + pembina)?</label>
+          <input type="number" id="n-menginap" min="0" max="200" inputmode="numeric"
+                 value="${jawab.jumlah_menginap}">
           <div class="hint">Boleh 0 kalau belum tahu — bisa diubah saat daftar ulang.</div>
         </div>`));
-      document.getElementById("n-pendamping").addEventListener("input", e => {
-        jawab.jumlah_pendamping = Math.max(0, Number(e.target.value) || 0); simpanDraf();
+      document.getElementById("n-menginap").addEventListener("input", e => {
+        jawab.jumlah_menginap = Math.max(0, Number(e.target.value) || 0); simpanDraf();
       });
     } else {
       kotak.replaceChildren();
-      jawab.jumlah_pendamping = 0;
+      jawab.jumlah_menginap = 0;
     }
     simpanDraf();
     if (sudahDiperiksa) periksa(false);
@@ -930,7 +933,10 @@ async function kirim(e) {
       nama_sekolah: jawab.sekolah.nama,
       alamat_sekolah: jawab.sekolah.alamat,
       butuh_barak: jawab.butuh_barak,
-      jumlah_pendamping: jawab.jumlah_pendamping,
+      // Kunci pada kawat tetap `jumlah_pendamping`: itu kontrak dengan
+      // Worker gateway, dan menggantinya menuntut deploy berbarengan supaya
+      // pendaftaran tidak mati di antaranya. Isinya yang berubah arti.
+      jumlah_pendamping: jawab.jumlah_menginap,
       kontak_wa: jawab.kontak_wa,
       nama_kontak: jawab.nama_kontak,
       regu: jawab.regu,
@@ -1072,7 +1078,7 @@ async function mulai() {
     if (jawab.jenis_peserta === "internal") {
       jawab.sekolah = sekolahInternal();
       jawab.butuh_barak = false;
-      jawab.jumlah_pendamping = 0;
+      jawab.jumlah_menginap = 0;
       jawab.rincian.penggalang_pa = 0;
       jawab.rincian.penggalang_pi = 0;
       jawab.rincian.penegak_pa = 0;

--- a/supabase/checks/seed_data_uji.sql
+++ b/supabase/checks/seed_data_uji.sql
@@ -149,7 +149,7 @@ begin
   on conflict (kunci_sekolah(name)) do nothing;
 
   insert into pendaftaran (sekolah_id, kode_pembayaran, kontak_wa,
-                           jumlah_regu, jumlah_pendamping, butuh_barak, status)
+                           jumlah_regu, jumlah_menginap, butuh_barak, status)
   select s.id,
          'UJI-' || lpad((row_number() over (order by s.name))::text, 3, '0'),
          '08000000000',

--- a/supabase/migrations/0124_jumlah_menginap.sql
+++ b/supabase/migrations/0124_jumlah_menginap.sql
@@ -1,0 +1,356 @@
+-- ============================================================================
+-- hrcd-rekap : 0124_jumlah_menginap.sql
+--
+-- Form pendaftaran berhenti menanyakan jumlah PENDAMPING dan menanyakan TOTAL
+-- yang menginap — peserta beserta pembinanya sekalian.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA INI BUKAN SEKADAR GANTI KALIMAT
+--
+-- `susun_barak()` menghitung kebutuhan satu sekolah sebagai
+-- `regu aktif x 5 + jumlah_pendamping`. Angka lamanya memang cuma pendamping,
+-- jadi pesertanya ditambahkan sendiri oleh rumus itu.
+--
+-- Begitu kotaknya berisi TOTAL, rumus yang sama menghitung pesertanya DUA
+-- KALI. Satu sekolah 4 regu berpendamping 3 berubah dari 23 orang jadi 43, dan
+-- pembagian barak memesan hampir dua kali lipat ruangan yang dibutuhkan. Tidak
+-- ada galat yang muncul — yang muncul kekurangan ruangan pada malam sebelum
+-- lomba, saat semua orang sudah datang.
+--
+-- Karena itu label di layar dan rumus di sini WAJIB berubah bersama, dan itu
+-- seluruh isi migrasi ini.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KOLOMNYA IKUT GANTI NAMA
+--
+-- `jumlah_pendamping` yang berisi total peserta+pembina adalah nama yang
+-- berbohong, dan nama yang berbohong tidak pernah tertangkap tes — ia
+-- tertangkap oleh orang yang membacanya setahun lagi lalu menambahkan `x 5`
+-- sekali lagi, karena "kan ini pendamping".
+--
+-- Yang ikut diganti dan yang tidak:
+--
+--   ikut  : kolom `pendaftaran.jumlah_pendamping` -> `jumlah_menginap`
+--   ikut  : `susun_barak()`, yang berhenti mengalikan lima
+--   ikut  : `ubah_pendamping()` -> `ubah_jumlah_menginap()`, bentuk lama dibuang
+--   ikut  : `submit_pendaftaran()`, karena badan fungsi plpgsql disimpan
+--           sebagai TEKS — `rename column` tidak menyentuhnya, dan fungsi yang
+--           masih menyebut nama lama baru gagal saat dipanggil pembina
+--   TIDAK : nama argumen `p_jumlah_pendamping` pada `submit_pendaftaran`
+--
+-- Argumen itu kontrak dengan Worker gateway. Menggantinya menuntut migrasi dan
+-- deploy Worker yang berbarengan supaya pendaftaran tidak mati di antaranya —
+-- harga yang tidak sebanding untuk satu nama argumen yang tidak pernah dibaca
+-- siapa pun selain worker.js. Yang dibaca manusia adalah kolomnya, dan kolom
+-- itu sekarang benar.
+--
+-- ---------------------------------------------------------------------------
+-- ANGKA LAMA DIBIARKAN
+--
+-- Baris yang sudah ada menyimpan jumlah pendamping, bukan total. Tidak ada
+-- yang mengubahnya di sini: menghitung "berarti totalnya sekian" dari jumlah
+-- regu akan mengarang angka yang tidak pernah dikatakan sekolah mana pun.
+-- Yang sudah mendaftar ditanya ulang saat daftar ulang, lewat
+-- `ubah_jumlah_menginap()`.
+-- ============================================================================
+
+alter table pendaftaran rename column jumlah_pendamping to jumlah_menginap;
+
+comment on column pendaftaran.jumlah_menginap is
+  'Total orang yang menginap di barak — peserta DAN pembina. Sampai 0124 kolom '
+  'ini bernama jumlah_pendamping dan berisi pembinanya saja, dan susun_barak() '
+  'yang menambahkan pesertanya. Sekarang angkanya sudah utuh.';
+
+-- ---------------------------------------------------------------------------
+-- Salinan terakhir susun_barak (0064). Satu-satunya perubahan ada di blok
+-- `for v_b in` — sisanya, termasuk urutan prioritas ruangan, disalin utuh.
+-- ---------------------------------------------------------------------------
+create or replace function susun_barak()
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_b   record;
+  v_r   record;
+  v_sisa integer;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'tidak berhak: pengaturan';
+  end if;
+
+  delete from penempatan_barak;
+
+  -- Kebutuhan per batch = total yang menginap, APA ADANYA. Sampai 0124 baris
+  -- ini menambahkan `regu aktif x 5` karena angkanya cuma pendamping; sekarang
+  -- pesertanya sudah ikut dihitung sekolahnya sendiri, dan mengalikannya lagi
+  -- di sini memesan hampir dua kali lipat ruangan tanpa satu galat pun.
+  for v_b in
+    select d.id, d.jumlah_menginap as butuh
+    from pendaftaran d
+    join regu r on r.pendaftaran_id = d.id
+    where d.butuh_barak and d.status = 'lunas'
+    group by d.id, d.jumlah_menginap
+    having (count(r.id) filter (where not r.is_cancelled)) > 0
+    order by butuh desc
+  loop
+    v_sisa := v_b.butuh;
+
+    -- Urutan prioritas per sisa (temuan review: "pas-dulu" yang lama justru
+    -- memecah sekolah yang sebenarnya muat satu ruangan):
+    --   1) ruangan KOSONG terkecil yang MUAT seluruh sisa  -> 1 sekolah 1 ruangan
+    --   2) ruangan KOSONG terbesar                          -> pecah seminimal mungkin
+    --   3) sisa ruangan BERPENGHUNI terkecil yang muat      -> gabung, terpaksa
+    --   4) sisa ruangan BERPENGHUNI terbesar                -> gabung + pecah
+    while v_sisa > 0 loop
+      select * into v_r from (
+        select ru.id,
+               ru.capacity - coalesce((select sum(p.jumlah_orang)
+                 from penempatan_barak p where p.room_id = ru.id), 0) as longgar,
+               not exists (select 1 from penempatan_barak p
+                           where p.room_id = ru.id) as kosong
+        from room ru
+      ) x
+      where x.longgar > 0
+      order by
+        case
+          when x.kosong and x.longgar >= v_sisa then 1
+          when x.kosong                          then 2
+          when x.longgar >= v_sisa               then 3
+          else 4
+        end,
+        case when x.longgar >= v_sisa then x.longgar end asc,   -- paling pas
+        x.longgar desc                                          -- paling lapang
+      limit 1;
+
+      if v_r.id is null then
+        raise exception 'kapasitas barak kurang % orang untuk batch % — tambah ruangan',
+          v_sisa, v_b.id;
+      end if;
+
+      insert into penempatan_barak (pendaftaran_id, room_id, jumlah_orang)
+      values (v_b.id, v_r.id, least(v_sisa, v_r.longgar));
+      v_sisa := v_sisa - least(v_sisa, v_r.longgar);
+      v_r := null;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Yang mengubah angkanya di meja. Namanya ikut berganti karena yang diubahnya
+-- bukan lagi jumlah pendamping, dan bentuk lamanya DIBUANG: dua nama untuk
+-- satu perbuatan berarti separuh kode memanggil yang tidak lagi diperbaiki.
+-- Tidak ada satu layar pun yang memanggilnya, jadi tidak ada masa peralihan
+-- yang perlu dijaga di sini.
+-- ---------------------------------------------------------------------------
+create or replace function ubah_jumlah_menginap(p_kode text, p_jumlah smallint)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if not boleh('daftar_ulang') then
+    raise exception 'tidak berhak: daftar_ulang';
+  end if;
+  if p_jumlah is null or p_jumlah < 0 then
+    raise exception 'jumlah yang menginap tidak sah';
+  end if;
+  update pendaftaran set jumlah_menginap = p_jumlah
+  where kode_pembayaran = p_kode;
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+end;
+$$;
+
+drop function if exists ubah_pendamping(text, smallint);
+
+grant execute on function ubah_jumlah_menginap(text, smallint) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Salinan terakhir submit_pendaftaran (0122). Satu kata yang berubah: nama
+-- kolom di daftar INSERT. Nama argumennya sengaja tetap — alasannya di kepala
+-- migrasi ini.
+-- ---------------------------------------------------------------------------
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null,
+  p_metode_bayar   text default null,
+  p_bukti_transfer text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+  v_bukti    text;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', tagihan_pendaftaran(v_ada.id),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  -- Cara bayar dan buktinya. Path buktinya WAJIB berada di dalam folder
+  -- kunci_kirim kiriman ini: nama objek Storage bisa ditebak siapa pun yang
+  -- pernah melihat satu contohnya, dan tanpa pagar ini satu pendaftaran bisa
+  -- menunjuk bukti milik pendaftaran lain.
+  if coalesce(p_metode_bayar, '') not in ('transfer', 'tunai') then
+    raise exception 'cara pembayaran wajib dipilih';
+  end if;
+  v_bukti := nullif(trim(coalesce(p_bukti_transfer, '')), '');
+  if p_metode_bayar = 'transfer' then
+    if v_bukti is null then
+      raise exception 'bukti transfer wajib diunggah';
+    end if;
+    if p_kunci_kirim is null
+       or v_bukti not like p_kunci_kirim::text || '/%' then
+      raise exception 'bukti transfer bukan milik kiriman ini';
+    end if;
+  else
+    v_bukti := null;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+
+    -- Anggota OPSIONAL: kunci `anggota` boleh tidak ada sama sekali, dan
+    -- daftarnya boleh kosong. Yang ditolak cuma bentuk yang salah.
+    if v_r ? 'anggota' and jsonb_typeof(v_r -> 'anggota') <> 'null' then
+      if jsonb_typeof(v_r -> 'anggota') <> 'array' then
+        raise exception 'anggota harus berupa daftar nama';
+      end if;
+      if (select count(*) from jsonb_array_elements_text(v_r -> 'anggota') a
+          where trim(a) <> '') > 4 then
+        raise exception 'maksimal 4 anggota selain ketua';
+      end if;
+      -- Aturan yang sama dengan nama ketua (0052): angka di nama orang hampir
+      -- selalu nomor urut yang ikut terketik, dan ia terbawa ke daftar hadir.
+      if exists (select 1 from jsonb_array_elements_text(v_r -> 'anggota') a
+                 where a ~ '[0-9]') then
+        raise exception 'nama anggota tidak boleh memakai angka';
+      end if;
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_menginap, jumlah_regu, kontak_wa, kunci_kirim,
+                           nama_kontak, metode_bayar, bukti_transfer)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''),
+          p_metode_bayar, v_bukti)
+  returning id into v_batch;
+
+  -- Kotak yang dibiarkan kosong TIDAK disimpan sebagai string kosong: yang
+  -- tersimpan hanya nama yang benar-benar diketik, berurutan. `array_agg` atas
+  -- nol baris mengembalikan NULL, dan NULL di sini berarti "tidak ada nama
+  -- anggota yang dicatat" — bukan "regunya kosong".
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan',
+         (select array_agg(trim(a) order by urut)
+          from jsonb_array_elements_text(coalesce(r -> 'anggota', '[]'::jsonb))
+               with ordinality as t(a, urut)
+          where trim(a) <> '')
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', tagihan_pendaftaran(v_batch),
+    'terkirim_ulang', false);
+end;
+$fn$;
+
+-- Pagar terakhir: tidak boleh ada objek tersisa yang masih menyebut nama lama.
+--
+-- Polanya menuntut satu huruf BUKAN pengenal tepat sebelum `jumlah_pendamping`,
+-- supaya `p_jumlah_pendamping` tidak ikut tertangkap. Nama argumen itu memang
+-- masih ada dan memang disengaja — versi pertama pagar ini memakai `like` biasa
+-- dan langsung melaporkan submit_pendaftaran sebagai pelanggar.
+do $blok$
+declare v_sisa text;
+begin
+  select string_agg(p.proname, ', ' order by p.proname) into v_sisa
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public' and p.prokind = 'f'
+    and p.prosrc ~ '(^|[^_[:alnum:]])jumlah_pendamping';
+  if v_sisa is not null then
+    raise exception '0124: fungsi berikut masih menyebut kolom lama dan akan gagal saat dipanggil: %', v_sisa;
+  end if;
+
+  select string_agg(c.relname, ', ' order by c.relname) into v_sisa
+  from pg_class c join pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'public' and c.relkind = 'v'
+    and pg_get_viewdef(c.oid) ~ '(^|[^_[:alnum:]])jumlah_pendamping';
+  if v_sisa is not null then
+    raise exception '0124: view berikut masih menyebut kolom lama: %', v_sisa;
+  end if;
+
+  raise notice '0124: tidak ada lagi yang menyebut jumlah_pendamping sebagai kolom.';
+end;
+$blok$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -266,7 +266,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             elif u.path == "/daftar-pendaftaran":
                 self._kirim(200, q("""
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
-                           d.jumlah_pendamping, d.butuh_barak, d.kontak_wa, d.nama_kontak,
+                           d.jumlah_menginap, d.butuh_barak, d.kontak_wa, d.nama_kontak,
                            d.created_at, d.metode_bayar, d.bukti_transfer,
                            jsonb_build_object('name', s.name, 'address', s.address) as sekolah,
                            (select jsonb_agg(jsonb_build_object(

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -560,6 +560,14 @@ run supabase/migrations/0122_tuntut_cara_bayar.sql
 # membuktikan dirinya AMAN dijalankan di sana — bukan bahwa ia menyelesaikan
 # masalahnya. Yang membuktikan itu satu unggahan sungguhan ke produksi.
 run supabase/migrations/0123_policy_storage_per_peran.sql
+
+# 0124 mengubah arti satu kotak di form: dari jumlah pendamping jadi TOTAL
+# yang menginap. Yang berbahaya bukan labelnya melainkan susun_barak(), yang
+# dulu menambahkan `regu aktif x 5` di atasnya — kalau rumus itu tidak ikut
+# berubah, pesertanya terhitung dua kali tanpa satu galat pun. Tes 84
+# memeriksa jumlah orang yang benar-benar ditempatkan, bukan definisinya.
+run supabase/migrations/0124_jumlah_menginap.sql
+run tests/sql/84_jumlah_menginap.sql
 run tests/sql/83_pembayaran_pilihan_pembina.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh

--- a/tests/sql/84_jumlah_menginap.sql
+++ b/tests/sql/84_jumlah_menginap.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/84_jumlah_menginap.sql — migrasi 0124.
+--
+-- Kotak di form berhenti menghitung pendamping saja dan menghitung TOTAL yang
+-- menginap. Yang diuji di sini bukan labelnya melainkan akibatnya, karena
+-- akibatnya tidak menimbulkan galat apa pun:
+--
+--   `susun_barak()` dulu memesan `regu aktif x 5 + angka itu`. Kalau rumusnya
+--   tidak ikut diubah, peserta terhitung DUA KALI dan pembagian barak memesan
+--   hampir dua kali lipat ruangan. Semuanya berjalan mulus sampai malam
+--   sebelum lomba, saat ruangannya kurang.
+--
+-- Karena itu yang diperiksa adalah JUMLAH ORANG yang benar-benar ditempatkan,
+-- bukan definisi fungsinya. Definisi bisa terbaca benar dan tetap salah.
+--
+-- Seluruhnya di-rollback.
+-- ============================================================================
+
+\echo '--- 84. total yang menginap, bukan jumlah pendamping'
+\set ON_ERROR_STOP on
+
+do $blok$
+declare
+  v_kode   text;
+  v_id     uuid;
+  v_orang  int;
+  v_uid    uuid;
+begin
+  -- susun_barak() dipagari `boleh('pengaturan')`, jadi tesnya harus MENEMPATI
+  -- kursi admin — bukan memanggilnya sebagai superuser tanpa identitas, yang
+  -- akan lulus tanpa pernah menyentuh pagarnya. Akun admin uji dari 01_seed.
+  v_uid := '00000000-0000-0000-0000-00000000000a';
+  assert exists (select 1 from akun_panitia where user_id = v_uid),
+    '84 GAGAL: akun admin uji tidak ada — tes ini tidak menempati kursi apa pun';
+  perform set_config('app.uid', v_uid::text, true);
+
+  -- Empat regu, dan angka menginap 23: dua puluh peserta ditambah tiga
+  -- pembina, persis seperti yang akan diketik pembina di form baru.
+  v_kode := (submit_pendaftaran('SMP Uji Menginap', 'Jl. Uji', true, '081200000084',
+              (select jsonb_agg(jsonb_build_object(
+                 'nama_regu', format('Menginap %s', chr(64 + i)),
+                 'nama_ketua', 'Ketua Uji',
+                 'golongan', 'penegak_pa'))
+               from generate_series(1, 4) i),
+              23::smallint, gen_random_uuid(), 'Uji',
+              'tunai', null)) ->> 'kode_pembayaran';
+
+  select id into v_id from pendaftaran where kode_pembayaran = v_kode;
+  assert (select jumlah_menginap from pendaftaran where id = v_id) = 23,
+    '84.1 GAGAL: angka menginap tidak tersimpan apa adanya';
+
+  update pendaftaran set status = 'lunas' where id = v_id;
+
+  -- Ruangan yang cukup lapang supaya yang diuji pembagiannya, bukan kapasitas.
+  insert into room (name, capacity) values ('UJI 84 A', 200)
+  on conflict do nothing;
+
+  perform susun_barak();
+
+  select coalesce(sum(jumlah_orang), 0) into v_orang
+  from penempatan_barak where pendaftaran_id = v_id;
+
+  -- 43 = 4 regu x 5 + 23, angka yang keluar kalau rumus lamanya dibiarkan.
+  assert v_orang <> 43,
+    '84.2 GAGAL: peserta dihitung dua kali — susun_barak() masih menambahkan '
+    'regu x 5 di atas angka yang sudah memuat peserta';
+  assert v_orang = 23,
+    format('84.2 GAGAL: %s orang ditempatkan, seharusnya 23 — angka yang '
+           'diketik sekolah, apa adanya', v_orang);
+
+  -- 84.3 Yang mengubahnya di meja ikut berganti nama, dan bentuk lamanya
+  -- benar-benar hilang. Dua nama untuk satu perbuatan adalah cara separuh
+  -- kode memanggil yang tidak lagi diperbaiki.
+  perform ubah_jumlah_menginap(v_kode, 30::smallint);
+  assert (select jumlah_menginap from pendaftaran where id = v_id) = 30,
+    '84.3 GAGAL: ubah_jumlah_menginap tidak mengubah angkanya';
+  assert not exists (
+    select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'ubah_pendamping'),
+    '84.3 GAGAL: ubah_pendamping masih ada';
+
+  raise exception 'ROLLBACK UJI 84';
+exception when others then
+  if sqlerrm <> 'ROLLBACK UJI 84' then raise; end if;
+end;
+$blok$;
+
+\echo '    84 LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -500,7 +500,7 @@ export async function ringkasanMeja() {
 export async function daftarPendaftaran() {
   if (K.mode === "dev") return baca("/daftar-pendaftaran");
   return baca(null,
-    "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,jumlah_pendamping," +
+    "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu," +
     "butuh_barak,kontak_wa,created_at,metode_bayar,bukti_transfer," +
     "sekolah(name,address)," +
     "regu(id,nama_regu,nama_ketua,golongan,nomor_dada,kloter_nomor,is_cancelled)," +


### PR DESCRIPTION
## What

The barak question becomes **"Total yang menginap (peserta + pembina)?"**, and everything that read the old number follows:

- `susun_barak()` sizes each school from the number **as given**, no longer `× 5 + it`.
- `pendaftaran.jumlah_pendamping` → **`jumlah_menginap`**.
- `ubah_pendamping()` → `ubah_jumlah_menginap()`; the old name is dropped.
- `submit_pendaftaran()` copied forward with the new column name.
- The field's ceiling goes from 30 to 200 — six regu alone are 30 people before a single pembina.

## Why

This is not a wording change. `susun_barak()` sized a school as `active regu × 5 + jumlah_pendamping`, because the number held only teachers and the formula added the peserta itself.

The moment that box holds a total, the same formula **counts the peserta twice**. A school of four regu with three pembina goes from 23 people to 43, and the allocation reserves nearly double the rooms it needs. Nothing errors. What shows up is a shortage of rooms on the night before the event.

## Notes

**The column is renamed for the same reason.** `jumlah_pendamping` holding a total is a name that lies, and a lying name is never caught by a test — it is caught by whoever reads it a year from now and multiplies by five again, because "this is pendamping, isn't it".

**`submit_pendaftaran` is copied forward, not left alone.** plpgsql stores its body as text, so `RENAME COLUMN` leaves the old name inside it, and a function still naming it fails only when a pembina calls it. The migration ends with a guard that scans every function and view for the old column name and refuses to finish if one survives — it caught `submit_pendaftaran` on the first run.

**`p_jumlah_pendamping` deliberately keeps its name.** It is the contract with the gateway Worker, and renaming it needs a simultaneous migration and Worker deploy so registration does not die in between — too much for a name nothing but `worker.js` ever reads. The form sends the new meaning under the old wire key.

**Existing rows keep their old meaning.** Computing "so the total must be" from the regu count would invent a number no school ever said. Those schools are asked again at daftar ulang, through `ubah_jumlah_menginap()`.

**Verified locally.** `tests/run.sh` passes in full, including new test 84 — which checks the number of people **actually placed in rooms**, not the function's text, and fails explicitly on 43 (the double-counted figure) as well as on anything other than 23. It seats itself as the admin account, since `susun_barak()` is gated on `pengaturan`. `periksa_impor`, `periksa_urutan_golongan`, the four `web/`↔`live/` shared pairs, and both module parses all pass.

## Deploy order

Merge first — the sites stop selecting the old column — then apply `0124`. No gateway deploy: the wire key is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)