### PR TITLE
feat: store regu names in capitals, and centre the upload button

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -392,7 +392,9 @@ function gambarBayar() {
                   aria-label="Hapus bukti transfer">${ikon("x")}</button>
         </div>
         <div class="description">${esc(jawab.bukti_nama || "")}</div>` : ""}
-      <label class="button button-primary" style="margin-top:.2rem">
+      <label class="button button-primary"
+             style="margin-top:.2rem;display:inline-flex;align-items:center;
+                    justify-content:center;width:100%">
         <input type="file" id="bukti" accept="image/*" hidden>
         ${ikon("camera")} ${sudah ? "Ganti Bukti" : "Unggah Bukti"}
       </label>
@@ -712,7 +714,8 @@ function gambarRegu() {
         <div class="field" style="margin:0">
           <label for="r-nama-${i}">Nama Regu</label>
           <input type="text" id="r-nama-${i}" value="${esc(r.nama_regu)}"
-                 maxlength="${NAMA_MAKS}" placeholder="contoh: Rajawali">
+                 maxlength="${NAMA_MAKS}" placeholder="contoh: Rajawali"
+                 style="text-transform:uppercase">
           <div class="error" id="r-nama-galat-${i}" hidden>Nama regu wajib diisi.</div>
         </div>
         <div class="field" style="margin:0">
@@ -824,7 +827,11 @@ function gambarRegu() {
 
   jawab.regu.forEach((r, i) => {
     document.getElementById(`r-nama-${i}`).addEventListener("input", e => {
-      r.nama_regu = e.target.value.trim(); simpanDraf();
+      // Kapital sejak di sini, bukan cuma di layar: yang dikirim, yang tercetak
+      // di konfirmasi, dan yang dibacakan di lapangan harus satu bentuk yang
+      // sama. Database menegakkannya lagi lewat trigger (migrasi 0126) untuk
+      // nama yang diketik panitia dari layar meja.
+      r.nama_regu = e.target.value.trim().toUpperCase(); simpanDraf();
       cekRegu(i);
       periksaNamaKeServer();
       if (sudahDiperiksa) periksa(false);

--- a/supabase/migrations/0126_nama_regu_kapital.sql
+++ b/supabase/migrations/0126_nama_regu_kapital.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- hrcd-rekap : 0126_nama_regu_kapital.sql
+--
+-- Nama regu selalu KAPITAL, di mana pun ia muncul.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DI DATABASE, BUKAN DI LAYAR
+--
+-- Nama regu tampil di belasan tempat: form pendaftaran, konfirmasi, pesan
+-- WhatsApp, Meja Pembayaran, Meja Daftar Ulang, papan Keberangkatan, lembar
+-- input nilai per pos, blangko cetak, Live Score, dan rekap yang terbit ke
+-- halaman peserta. Menyeragamkannya dengan `text-transform: uppercase` berarti
+-- menambal belasan tempat, melewatkan sebagian, dan sama sekali tidak menyentuh
+-- yang BUKAN layar — pesan WhatsApp dan berkas JSON yang terbit adalah teks
+-- biasa, bukan HTML.
+--
+-- Kalau datanya sendiri kapital, ketiga belas tempat itu benar tanpa satu baris
+-- pun ditambahkan, sekarang maupun tahun depan.
+--
+-- ---------------------------------------------------------------------------
+-- APA YANG TIDAK BERUBAH
+--
+-- Indeks nama unik memakai bentuk yang sudah dinormalkan (huruf kecil, spasi
+-- dirapatkan), jadi mengubah huruf besar-kecil TIDAK melahirkan tabrakan baru
+-- dan tidak pula menghapus tabrakan lama.
+--
+-- `regu_nama_panjang` menghitung karakter dan `regu_nama_regu_tiga_huruf`
+-- menghitung huruf; `upper()` tidak mengubah jumlah keduanya.
+--
+-- Nama KETUA dan nama ANGGOTA sengaja TIDAK ikut dikapitalkan. Yang dibacakan
+-- di lapangan dan dicetak besar di blangko adalah nama regu; nama orang ditulis
+-- sebagaimana orangnya menulisnya.
+-- ============================================================================
+
+update regu set nama_regu = upper(nama_regu) where nama_regu <> upper(nama_regu);
+
+create or replace function regu_nama_kapital()
+returns trigger
+language plpgsql
+set search_path = public
+as $fn$
+begin
+  new.nama_regu := upper(new.nama_regu);
+  return new;
+end;
+$fn$;
+
+comment on function regu_nama_kapital() is
+  'Nama regu disimpan kapital supaya seluruh layar, cetakan, pesan WhatsApp, '
+  'dan berkas terbit menampilkannya seragam tanpa menambal satu per satu.';
+
+drop trigger if exists regu_kapital on regu;
+create trigger regu_kapital
+  before insert or update of nama_regu on regu
+  for each row execute function regu_nama_kapital();
+
+do $blok$
+declare v_sisa int;
+begin
+  select count(*) into v_sisa from regu where nama_regu <> upper(nama_regu);
+  if v_sisa > 0 then
+    raise exception '0126: masih ada % nama regu yang belum kapital', v_sisa;
+  end if;
+  raise notice '0126: seluruh nama regu kapital, dan trigger menjaga yang baru.';
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -574,6 +574,13 @@ run tests/sql/84_jumlah_menginap.sql
 # terlalu mahal — rinciannya di kepala migrasinya. Seperti 0123, skema
 # `storage` tidak ada di database uji.
 run supabase/migrations/0125_bukti_transfer_tanpa_policy_ganti.sql
+
+# 0126 menyimpan nama regu KAPITAL, supaya belasan tempat yang menampilkannya
+# — termasuk pesan WhatsApp dan berkas terbit, yang bukan HTML — seragam
+# tanpa ditambal satu per satu. Tes 85 menguji dua jalur: pendaftaran, dan
+# penulisan langsung dari layar meja yang hanya dijaga trigger.
+run supabase/migrations/0126_nama_regu_kapital.sql
+run tests/sql/85_nama_regu_kapital.sql
 run tests/sql/83_pembayaran_pilihan_pembina.sql
 run tests/sql/77_nama_anggota_regu.sql
 # Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh

--- a/tests/sql/85_nama_regu_kapital.sql
+++ b/tests/sql/85_nama_regu_kapital.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/85_nama_regu_kapital.sql — migrasi 0126.
+--
+-- Nama regu disimpan kapital supaya seluruh layar, cetakan, pesan WhatsApp,
+-- dan berkas terbit seragam tanpa menambal satu per satu. Yang diuji: jalur
+-- pendaftaran DAN penulisan langsung, karena panitia juga mengetik nama dari
+-- layar meja — dan trigger inilah satu-satunya yang menjaga jalur itu.
+-- ============================================================================
+
+\echo '--- 85. nama regu selalu kapital'
+\set ON_ERROR_STOP on
+
+do $blok$
+declare
+  v_hasil jsonb;
+  v_id    uuid;
+  v_nama  text;
+begin
+  v_hasil := submit_pendaftaran('SMP Uji Kapital', 'Jl. Uji', false, '081200000085',
+               '[{"nama_regu":"Rajawali Muda","nama_ketua":"Andi Saputra",
+                  "golongan":"penegak_pa"}]'::jsonb,
+               0::smallint, gen_random_uuid(), 'Uji', 'tunai', null);
+  select r.id, r.nama_regu into v_id, v_nama
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_hasil ->> 'kode_pembayaran';
+  assert v_nama = 'RAJAWALI MUDA',
+    format('85.1 GAGAL: tersimpan "%s", seharusnya RAJAWALI MUDA', v_nama);
+
+  -- Nama orang TIDAK ikut dikapitalkan.
+  assert (select nama_ketua from regu where id = v_id) = 'Andi Saputra',
+    '85.1 GAGAL: nama ketua ikut dikapitalkan';
+
+  -- 85.2 Jalur meja: UPDATE langsung juga dijaga trigger.
+  update regu set nama_regu = 'elang senja' where id = v_id;
+  assert (select nama_regu from regu where id = v_id) = 'ELANG SENJA',
+    '85.2 GAGAL: UPDATE dari layar meja lolos tanpa dikapitalkan';
+
+  raise exception 'ROLLBACK UJI 85';
+exception when others then
+  if sqlerrm <> 'ROLLBACK UJI 85' then raise; end if;
+end;
+$blok$;
+
+\echo '    85 LULUS'


### PR DESCRIPTION
## What

- `0126` uppercases every `regu.nama_regu` and adds a trigger keeping new and edited ones capital.
- The form types in capitals and sends them that way.
- The **Unggah Bukti** button is centred again.

## Why

Regu names appear in a dozen places — form, confirmation, WhatsApp message, payment desk, daftar ulang, departure board, per-pos scoring sheet, printed blangko, Live Score, published rekap. CSS would mean patching a dozen places, missing some, and not touching the ones that are not screens: the WhatsApp text and the published JSON are plain text.

With the data itself capital, all of them are right without a line added.

## Notes

**Names of people are not touched** — ketua and anggota stay as written. What is read out at the field and printed large on the blangko is the regu name.

**Nothing else shifts:** the unique index uses a normalised lower-case key, so case changes create no new collisions; the 20-character and three-letter limits count characters and letters, which `upper()` leaves alone.

**The button** sat left-aligned because `.field label` outranks `.button` on specificity, so the flex centring never applied. Restored inline, where no selector can outrank it.

**Verified locally:** `tests/run.sh` passes in full, including test 85 — which checks both the registration path and a direct `UPDATE` from a desk screen, the path only the trigger guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)