### PR TITLE
feat: Bukti becomes a camera icon beside the dropdown

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -950,13 +950,19 @@ async function layarPembayaran() {
           // Template biasa, BUKAN tag html`` — tombol Bukti sudah berupa HTML dan
           // html`` meng-escape setiap nilai yang disisipkan, jadi tombolnya
           // sempat TERCETAK sebagai teks di layar Pembayaran.
-          : `<span class="metode-baris"
+          // nowrap DI SINI saja, bukan di kelasnya: pasangan LUNAS di atas memang
+          // perlu menumpuk sendiri di kolom sempit. Di sini yang berdampingan
+          // cuma dropdown dan satu ikon, dan tombol yang jatuh ke baris
+          // berikutnya membuat kartunya setinggi dua baris tanpa alasan.
+          : `<span class="metode-baris" style="flex-wrap:nowrap"
              ><select class="select-small" data-metode="${esc(b.kode_pembayaran)}">
                 <option value="tunai" ${b.metode_bayar === "transfer" ? "" : "selected"}>Tunai</option>
                 <option value="transfer" ${b.metode_bayar === "transfer" ? "selected" : ""}>Transfer</option>
               </select>${b.bukti_transfer
                 ? `<button class="button button-mini" type="button"
-                           data-bukti="${esc(b.bukti_transfer)}">Bukti</button>`
+                           data-bukti="${esc(b.bukti_transfer)}"
+                           title="Lihat bukti transfer"
+                           aria-label="Lihat bukti transfer">${ikon("camera")}</button>`
                 : ""}</span>`;
 
       const aksi = b.status === "lunas"


### PR DESCRIPTION
On a phone card the word **Bukti** made the pair too wide, so the button dropped to its own line and every transfer row stood two lines tall. It is now a camera icon — the same one the pembina pressed to upload it — with `title` and `aria-label` carrying the meaning.

`flex-wrap: nowrap` is set on this pair only, inline. The LUNAS pair above it genuinely needs to stack in a narrow column, which is why the class itself still wraps.

Parses; `periksa_impor` passes. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)