### PR TITLE
feat: receipt icon for Bukti Pembayaran, not a camera

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -867,6 +867,11 @@ const IKON = {
     '<circle cx="12" cy="12" r="10" /> <path d="m9 12 2 2 4-4" />',
   "clipboard-list":
     '<rect width="8" height="4" x="8" y="2" rx="1" ry="1" /> <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /> <path d="M12 11h4" /> <path d="M12 16h4" /> <path d="M8 11h.01" /> <path d="M8 16h.01" />',
+  // Nota: kertas bergerigi di bawah. Dipakai layar Pembayaran untuk membuka
+  // bukti transfer yang diunggah pembina — kamera sempat dipakai dan salah
+  // membaca: yang dibuka bukan kameranya, melainkan struknya.
+  "receipt":
+    '<path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1-2-1Z" /> <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" /> <path d="M12 17.5v-11" />',
   "credit-card":
     '<rect width="20" height="14" x="2" y="5" rx="2" /> <line x1="2" x2="22" y1="10" y2="10" />',
   "flag":

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -961,8 +961,8 @@ async function layarPembayaran() {
               </select>${b.bukti_transfer
                 ? `<button class="button button-mini" type="button"
                            data-bukti="${esc(b.bukti_transfer)}"
-                           title="Lihat bukti transfer"
-                           aria-label="Lihat bukti transfer">${ikon("camera")}</button>`
+                           title="Bukti Pembayaran"
+                           aria-label="Bukti Pembayaran">${ikon("receipt")}</button>`
                 : ""}</span>`;
 
       const aksi = b.status === "lunas"

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -867,6 +867,11 @@ const IKON = {
     '<circle cx="12" cy="12" r="10" /> <path d="m9 12 2 2 4-4" />',
   "clipboard-list":
     '<rect width="8" height="4" x="8" y="2" rx="1" ry="1" /> <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /> <path d="M12 11h4" /> <path d="M12 16h4" /> <path d="M8 11h.01" /> <path d="M8 16h.01" />',
+  // Nota: kertas bergerigi di bawah. Dipakai layar Pembayaran untuk membuka
+  // bukti transfer yang diunggah pembina — kamera sempat dipakai dan salah
+  // membaca: yang dibuka bukan kameranya, melainkan struknya.
+  "receipt":
+    '<path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1-2-1Z" /> <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" /> <path d="M12 17.5v-11" />',
   "credit-card":
     '<rect width="20" height="14" x="2" y="5" rx="2" /> <line x1="2" x2="22" y1="10" y2="10" />',
   "flag":


### PR DESCRIPTION
A camera says the button takes a photo. What it opens is the slip the pembina already sent, so it is a receipt icon now, and the hover reads **Bukti Pembayaran** (`title` and `aria-label`).

`receipt` is added to the shared `IKON` map in `web/js/util.js` and copied to `live/js/util.js` in the same commit, as `shared-files.yml` requires — the pair is verified identical.

Both modules parse; `periksa_impor` passes. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)