### PR TITLE
fix: folded-page icon, and keep Transfer beside LUNAS

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -867,11 +867,12 @@ const IKON = {
     '<circle cx="12" cy="12" r="10" /> <path d="m9 12 2 2 4-4" />',
   "clipboard-list":
     '<rect width="8" height="4" x="8" y="2" rx="1" ry="1" /> <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /> <path d="M12 11h4" /> <path d="M12 16h4" /> <path d="M8 11h.01" /> <path d="M8 16h.01" />',
-  // Nota: kertas bergerigi di bawah. Dipakai layar Pembayaran untuk membuka
-  // bukti transfer yang diunggah pembina — kamera sempat dipakai dan salah
-  // membaca: yang dibuka bukan kameranya, melainkan struknya.
-  "receipt":
-    '<path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1-2-1Z" /> <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" /> <path d="M12 17.5v-11" />',
+  // Kertas berlipat sudut, dipakai layar Pembayaran untuk membuka bukti
+  // transfer. Dua ikon lain sudah dicoba dan dibuang: kamera terbaca "ambil
+  // foto", dan struk bergerigi punya lengkung S di tengahnya yang pada ukuran
+  // ikon terbaca sebagai LAMBANG DOLAR.
+  "file-text":
+    '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /> <path d="M14 2v4a2 2 0 0 0 2 2h4" /> <path d="M16 13H8" /> <path d="M16 17H8" /> <path d="M10 9H8" />',
   "credit-card":
     '<rect width="20" height="14" x="2" y="5" rx="2" /> <line x1="2" x2="22" y1="10" y2="10" />',
   "flag":

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -937,7 +937,7 @@ async function layarPembayaran() {
         // selalu jatuh ke baris berikutnya, bahkan di kartu HP yang kolomnya
         // lapang. Dengan flex-wrap ia tetap menumpuk sendiri di kolom tabel
         // lebar yang cuma 15%, jadi satu aturan melayani kedua tampilan.
-        ? html`<span class="metode-baris"
+        ? html`<span class="metode-baris" style="flex-wrap:nowrap"
                ><span>${b.pembayaran ? b.pembayaran.method : "—"}</span
                ><span class="badge badge-green">LUNAS</span></span>`
         : b.status === "batal"
@@ -962,7 +962,7 @@ async function layarPembayaran() {
                 ? `<button class="button button-mini" type="button"
                            data-bukti="${esc(b.bukti_transfer)}"
                            title="Bukti Pembayaran"
-                           aria-label="Bukti Pembayaran">${ikon("receipt")}</button>`
+                           aria-label="Bukti Pembayaran">${ikon("file-text")}</button>`
                 : ""}</span>`;
 
       const aksi = b.status === "lunas"

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -867,11 +867,12 @@ const IKON = {
     '<circle cx="12" cy="12" r="10" /> <path d="m9 12 2 2 4-4" />',
   "clipboard-list":
     '<rect width="8" height="4" x="8" y="2" rx="1" ry="1" /> <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /> <path d="M12 11h4" /> <path d="M12 16h4" /> <path d="M8 11h.01" /> <path d="M8 16h.01" />',
-  // Nota: kertas bergerigi di bawah. Dipakai layar Pembayaran untuk membuka
-  // bukti transfer yang diunggah pembina — kamera sempat dipakai dan salah
-  // membaca: yang dibuka bukan kameranya, melainkan struknya.
-  "receipt":
-    '<path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1-2-1Z" /> <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" /> <path d="M12 17.5v-11" />',
+  // Kertas berlipat sudut, dipakai layar Pembayaran untuk membuka bukti
+  // transfer. Dua ikon lain sudah dicoba dan dibuang: kamera terbaca "ambil
+  // foto", dan struk bergerigi punya lengkung S di tengahnya yang pada ukuran
+  // ikon terbaca sebagai LAMBANG DOLAR.
+  "file-text":
+    '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /> <path d="M14 2v4a2 2 0 0 0 2 2h4" /> <path d="M16 13H8" /> <path d="M16 17H8" /> <path d="M10 9H8" />',
   "credit-card":
     '<rect width="20" height="14" x="2" y="5" rx="2" /> <line x1="2" x2="22" y1="10" y2="10" />',
   "flag":


### PR DESCRIPTION
Two fixes on the payment desk.

**The icon.** The receipt glyph has an S-curve through its middle that at icon size reads as a **dollar sign**. Replaced with a folded-corner page with ruled lines — invoice, without saying money. That is the third icon tried here and the migration comment in `util.js` records why the other two were dropped, so nobody puts a camera back.

**Transfer beside LUNAS.** They wrapped onto two lines in a narrow column. The `.metode-baris` class still wraps by default because other pairs need it; `nowrap` is set inline on this pair, exactly as it already was on the unpaid one.

`util.js` is copied to `live/` in the same commit and verified identical. Both modules parse. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)