### PR TITLE
fix: measured one-line Metode, and close dialogs with a corner X

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -616,7 +616,14 @@ export function notif(pesan, galat = false) {
 /** Dialog sederhana pengganti prompt(): punya judul, kartu identitas,
  *  beberapa isian, dan tombol batal yang jelas (temuan review: prompt()
  *  beruntun membingungkan dan batalnya senyap). */
-/** Dialog. `bacaSaja: true` membuang tombol Batal.
+/** Dialog. Membatalkan selalu lewat SILANG di pojok kanan atas, tidak lagi
+ *  lewat tombol "Batal" sebaris dengan tombol aksinya: dua tombol selebar
+ *  layar bertumpuk membuat yang membatalkan dan yang mengerjakan terlihat
+ *  sama penting, dan di HP jari menemukan yang atas lebih dulu.
+ *
+ *  `bacaSaja: true` kini tidak mengubah apa pun — dulu ia membuang tombol
+ *  Batal, dan tombol itu sudah tidak ada untuk siapa pun. Dibiarkan supaya
+ *  belasan pemanggilnya tidak perlu disunting dalam satu commit yang sama.
  *
  *  "Batal" pada dialog yang tidak mengubah apa pun bukan sekadar mubazir: ia
  *  menyiratkan ada sesuatu yang sedang berjalan dan bisa diurungkan. Orang yang
@@ -649,9 +656,9 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     const el = document.body.lastElementChild;
     el.innerHTML = `
       <div class="dialog">
-        ${silangSaja ? `<button class="dialog-silang" data-batal type="button"
-          aria-label="Tutup">&times;</button>` : ""}
-        <h2>${esc(judul)}</h2>
+        <button class="dialog-silang" data-batal type="button"
+          aria-label="Tutup">&times;</button>
+        <h2 style="padding-right:2.2rem">${esc(judul)}</h2>
         ${kartuHtml}
         ${medan.map((m, i) => `
           <div class="field">
@@ -666,8 +673,6 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
         <div class="dialog-error error" hidden></div>
         ${silangSaja ? "" : `
         <div class="option-row">
-          ${bacaSaja ? "" : `<button class="button button-secondary" data-batal
-            type="button">Batal</button>`}
           <button class="button button-primary" data-ok type="button">${esc(labelAksi)}</button>
         </div>`}
       </div>`;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -937,8 +937,14 @@ async function layarPembayaran() {
         // selalu jatuh ke baris berikutnya, bahkan di kartu HP yang kolomnya
         // lapang. Dengan flex-wrap ia tetap menumpuk sendiri di kolom tabel
         // lebar yang cuma 15%, jadi satu aturan melayani kedua tampilan.
-        ? html`<span class="metode-baris" style="flex-wrap:nowrap"
-               ><span>${b.pembayaran ? b.pembayaran.method : "—"}</span
+        // DIUKUR, bukan dikira-kira (pasal 15.9). Di kolom Metode yang lebarnya
+        // 123px — 15% dari lantai 820px — pasangan "Transfer" + lencana LUNAS
+        // memakan 124px apa adanya, jadi ia meluap satu piksel dan membungkus
+        // jadi dua baris. gap .25rem saja sudah muat (122px), tetapi cuma
+        // bersisa 1px; dengan teks metode .9em ia jadi 117px dan punya jarak
+        // yang tidak habis oleh satu huruf yang lebih lebar di HP lain.
+        ? html`<span class="metode-baris" style="flex-wrap:nowrap;gap:.25rem"
+               ><span style="font-size:.9em">${b.pembayaran ? b.pembayaran.method : "—"}</span
                ><span class="badge badge-green">LUNAS</span></span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -616,7 +616,14 @@ export function notif(pesan, galat = false) {
 /** Dialog sederhana pengganti prompt(): punya judul, kartu identitas,
  *  beberapa isian, dan tombol batal yang jelas (temuan review: prompt()
  *  beruntun membingungkan dan batalnya senyap). */
-/** Dialog. `bacaSaja: true` membuang tombol Batal.
+/** Dialog. Membatalkan selalu lewat SILANG di pojok kanan atas, tidak lagi
+ *  lewat tombol "Batal" sebaris dengan tombol aksinya: dua tombol selebar
+ *  layar bertumpuk membuat yang membatalkan dan yang mengerjakan terlihat
+ *  sama penting, dan di HP jari menemukan yang atas lebih dulu.
+ *
+ *  `bacaSaja: true` kini tidak mengubah apa pun — dulu ia membuang tombol
+ *  Batal, dan tombol itu sudah tidak ada untuk siapa pun. Dibiarkan supaya
+ *  belasan pemanggilnya tidak perlu disunting dalam satu commit yang sama.
  *
  *  "Batal" pada dialog yang tidak mengubah apa pun bukan sekadar mubazir: ia
  *  menyiratkan ada sesuatu yang sedang berjalan dan bisa diurungkan. Orang yang
@@ -649,9 +656,9 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     const el = document.body.lastElementChild;
     el.innerHTML = `
       <div class="dialog">
-        ${silangSaja ? `<button class="dialog-silang" data-batal type="button"
-          aria-label="Tutup">&times;</button>` : ""}
-        <h2>${esc(judul)}</h2>
+        <button class="dialog-silang" data-batal type="button"
+          aria-label="Tutup">&times;</button>
+        <h2 style="padding-right:2.2rem">${esc(judul)}</h2>
         ${kartuHtml}
         ${medan.map((m, i) => `
           <div class="field">
@@ -666,8 +673,6 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
         <div class="dialog-error error" hidden></div>
         ${silangSaja ? "" : `
         <div class="option-row">
-          ${bacaSaja ? "" : `<button class="button button-secondary" data-batal
-            type="button">Batal</button>`}
           <button class="button button-primary" data-ok type="button">${esc(labelAksi)}</button>
         </div>`}
       </div>`;


### PR DESCRIPTION
## Metode column, measured not guessed

`Transfer` + the LUNAS badge measured **124px inside a 123px column** — Metode is 15% of the 820px floor — so it overflowed by one pixel and wrapped to two lines.

| variant | width | fits in 123px |
| --- | --- | --- |
| as-is | 124px | no |
| `gap:.25rem` | 122px | yes, by 1px |
| `gap:.25rem` + method at `.9em` | **117px** | yes, by 6px |

The third is shipped: one pixel of slack does not survive a slightly wider glyph on another phone. Measured in Chrome against the real stylesheet, per section 15.9.

## Dialogs close with an X

Cancelling now happens through the X in the top-right corner instead of a full-width **Batal** stacked above the action. Two full-width buttons make cancelling and doing look equally important, and on a phone the thumb reaches the upper one first. The X markup and its style already existed for `silangSaja` dialogs; it is simply always drawn now, and the title gets right padding so it cannot run under it.

`bacaSaja` becomes a no-op and is left in place, documented, rather than editing a dozen callers in the same commit.

`util.js` copied to `live/` and verified identical. Both modules parse; `periksa_impor` passes. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)