### PR TITLE
chore: clear the bukti bucket too when wiping test data

### DIFF
--- a/.github/workflows/apply-migration.yml
+++ b/.github/workflows/apply-migration.yml
@@ -101,19 +101,25 @@ jobs:
             -f "$BERKAS"
 
           if [ "$BERKAS" = "supabase/checks/cleanup_data_uji.sql" ]; then
-            DAFTAR_FOTO="$RUNNER_TEMP/lembar-objects.json"
-            psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
-              -c "select coalesce(json_agg(name order by name), '[]'::json) from storage.objects where bucket_id = 'lembar'" \
-              > "$DAFTAR_FOTO"
+            # DUA bucket, bukan satu. `bukti` menyimpan bukti transfer yang
+            # diunggah pembina (migrasi 0121); barisnya di `pendaftaran` sudah
+            # terhapus oleh SQL di atas, jadi gambarnya tinggal yatim — dan
+            # bukti pembayaran percobaan tidak boleh ikut ke hari-H.
+            for EMBER in lembar bukti; do
+              DAFTAR="$RUNNER_TEMP/$EMBER-objects.json"
+              psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
+                -c "select coalesce(json_agg(name order by name), '[]'::json) from storage.objects where bucket_id = '$EMBER'" \
+                > "$DAFTAR"
 
-            python scripts/delete_storage_objects.py lembar "$DAFTAR_FOTO"
+              python scripts/delete_storage_objects.py "$EMBER" "$DAFTAR"
 
-            SISA_FOTO=$(psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
-              -c "select count(*) from storage.objects where bucket_id = 'lembar'")
-            if [ "$SISA_FOTO" != "0" ]; then
-              echo "Cleanup belum tuntas: masih ada $SISA_FOTO objek di bucket lembar."
-              exit 1
-            fi
-            echo "BUCKET FOTO BERSIH: lembar"
+              SISA=$(psql "$DB_URL" -A -t -v ON_ERROR_STOP=1 \
+                -c "select count(*) from storage.objects where bucket_id = '$EMBER'")
+              if [ "$SISA" != "0" ]; then
+                echo "Cleanup belum tuntas: masih ada $SISA objek di bucket $EMBER."
+                exit 1
+              fi
+              echo "BUCKET BERSIH: $EMBER"
+            done
           fi
           echo "MIGRASI BERHASIL: $BERKAS"

--- a/supabase/checks/cleanup_data_uji.sql
+++ b/supabase/checks/cleanup_data_uji.sql
@@ -4,6 +4,11 @@
 -- MENGHAPUS SELURUH DATA OPERASIONAL PESERTA EDISI AKTIF. Tidak bisa
 -- dibatalkan. Master Asal Sekolah (`sekolah`) tetap disimpan.
 --
+-- Gambar fisiknya dihapus apply-migration.yml sesudah berkas ini jalan, di DUA
+-- bucket: `lembar` (foto slip penilaian) dan `bukti` (bukti transfer yang
+-- diunggah pembina, migrasi 0121). Baris yang merujuk keduanya sudah terhapus
+-- di sini, jadi gambarnya tinggal yatim.
+--
 -- Dijalankan sekali, atas permintaan pemilik, setelah `isi_edisi.sql`
 -- membuktikan bahwa seluruh 16 sekolah di produksi memang sisa pengetesan:
 -- nama bergenerator ("SMA Tabel 054155", "SMK Uji Produksi", "SMP Uji


### PR DESCRIPTION
`cleanup_data_uji.sql` deletes the `pendaftaran` rows, which orphans every transfer receipt uploaded with them. The cleanup step in `apply-migration.yml` only emptied `lembar`, so test receipts would have followed us into the event.

It now loops over **both** buckets and refuses to report success while either still holds an object.

`tests/run.sh` passes; the workflow YAML parses. Master Asal Sekolah is untouched — that is what test 55 has always guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)