### PR TITLE
fix: redden a wrong-series bib while typing, and lift the toast

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -603,13 +603,39 @@ export function notif(pesan, galat = false) {
   const el = document.body.lastElementChild;
   if (galat) el.querySelector(".notification-close").addEventListener("click", () => el.remove());
 
+  // Papan ketik HP MENUTUPI toast ini. Ia dipatok `position: fixed; bottom`,
+  // dan patokan itu layout viewport — yang TIDAK menyusut saat papan ketik
+  // muncul. Jadi pesan "nomor dada intern adalah 1001-1250" muncul persis di
+  // belakang tombol angka, tepat pada satu-satunya saat ia dibutuhkan.
+  //
+  // visualViewport tahu berapa tinggi yang benar-benar terlihat. Selisihnya
+  // itulah tinggi papan ketik, dan toast-nya diangkat sebanyak itu. Di layar
+  // tanpa papan ketik selisihnya nol, jadi tampilannya tidak berubah sama
+  // sekali. Browser lama tanpa visualViewport melewatkannya begitu saja.
+  const vv = window.visualViewport;
+  const angkat = () => {
+    const tertutup = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+    el.style.bottom = `calc(1.2rem + ${Math.round(tertutup)}px)`;
+  };
+  if (vv) {
+    angkat();
+    vv.addEventListener("resize", angkat);
+    vv.addEventListener("scroll", angkat);
+  }
+  const lepas = () => {
+    if (!vv) return;
+    vv.removeEventListener("resize", angkat);
+    vv.removeEventListener("scroll", angkat);
+  };
+  if (galat) el.querySelector(".notification-close").addEventListener("click", lepas);
+
   // Dipudarkan dulu, baru dibuang setelah transisinya selesai (.35s di gaya).
   // Kalau sudah ditutup manual, el sudah lepas dari halaman dan kedua baris
   // ini tidak melakukan apa-apa — remove() pada simpul yang sudah lepas aman.
   const jeda = galat ? DETIK_NOTIF_GALAT : DETIK_NOTIF;
   setTimeout(() => {
     el.classList.add("pudar");
-    setTimeout(() => el.remove(), 400);
+    setTimeout(() => { lepas(); el.remove(); }, 400);
   }, jeda);
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1508,8 +1508,25 @@ async function layarDaftarUlang() {
     // Loop ketik-Enter (rancangan-b.md 10.1.4): Enter pindah ke regu
     // berikutnya, dan di regu terakhir langsung menyimpan — satu sekolah
     // selesai tanpa memegang mouse.
+    // Deret yang salah memerah SAMBIL DIKETIK, tidak menunggu tombol Simpan.
+    // Kain Intern bertulis 001 sama seperti kain Eksternal, jadi mengetik tiga
+    // angka untuk regu Intern adalah kekeliruan yang paling mungkin terjadi di
+    // meja — dan menahannya sampai Simpan berarti petugas sudah mengetik
+    // sepuluh nomor sebelum tahu yang pertama salah.
+    const tandaiDeret = (inp) => {
+      const isi = inp.value.trim();
+      const angka = Number(isi);
+      const salah = !!isi && rentang && Number.isInteger(angka) && angka > 0
+        && !deretCocok(rentang, inp.dataset.golongan, angka);
+      inp.classList.toggle("input-error", salah);
+    };
+
     tbody.querySelectorAll("[data-dada]").forEach(inp => {
-      inp.addEventListener("input", () => nilaiDada.set(inp.dataset.dada, inp.value));
+      tandaiDeret(inp);
+      inp.addEventListener("input", () => {
+        nilaiDada.set(inp.dataset.dada, inp.value);
+        tandaiDeret(inp);
+      });
       inp.addEventListener("keydown", e => {
         if (e.key !== "Enter") return;
         e.preventDefault();

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -603,13 +603,39 @@ export function notif(pesan, galat = false) {
   const el = document.body.lastElementChild;
   if (galat) el.querySelector(".notification-close").addEventListener("click", () => el.remove());
 
+  // Papan ketik HP MENUTUPI toast ini. Ia dipatok `position: fixed; bottom`,
+  // dan patokan itu layout viewport — yang TIDAK menyusut saat papan ketik
+  // muncul. Jadi pesan "nomor dada intern adalah 1001-1250" muncul persis di
+  // belakang tombol angka, tepat pada satu-satunya saat ia dibutuhkan.
+  //
+  // visualViewport tahu berapa tinggi yang benar-benar terlihat. Selisihnya
+  // itulah tinggi papan ketik, dan toast-nya diangkat sebanyak itu. Di layar
+  // tanpa papan ketik selisihnya nol, jadi tampilannya tidak berubah sama
+  // sekali. Browser lama tanpa visualViewport melewatkannya begitu saja.
+  const vv = window.visualViewport;
+  const angkat = () => {
+    const tertutup = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+    el.style.bottom = `calc(1.2rem + ${Math.round(tertutup)}px)`;
+  };
+  if (vv) {
+    angkat();
+    vv.addEventListener("resize", angkat);
+    vv.addEventListener("scroll", angkat);
+  }
+  const lepas = () => {
+    if (!vv) return;
+    vv.removeEventListener("resize", angkat);
+    vv.removeEventListener("scroll", angkat);
+  };
+  if (galat) el.querySelector(".notification-close").addEventListener("click", lepas);
+
   // Dipudarkan dulu, baru dibuang setelah transisinya selesai (.35s di gaya).
   // Kalau sudah ditutup manual, el sudah lepas dari halaman dan kedua baris
   // ini tidak melakukan apa-apa — remove() pada simpul yang sudah lepas aman.
   const jeda = galat ? DETIK_NOTIF_GALAT : DETIK_NOTIF;
   setTimeout(() => {
     el.classList.add("pudar");
-    setTimeout(() => el.remove(), 400);
+    setTimeout(() => { lepas(); el.remove(); }, 400);
   }, jeda);
 }
 


### PR DESCRIPTION
## The box reddens as it is typed

An Intern bib cloth reads `001` exactly like an external one, so typing three digits for an Intern regu is the likeliest mistake at the desk. Validation existed, but only on **Simpan** — by then the officer had typed ten numbers without learning the first was wrong.

Same rule, same `deretCocok()`, same `input-error` class; only the moment changes. Save still re-checks everything, and the database guard (`nomor_dada_sesuai_deret`) is untouched.

## The toast was behind the keyboard

`.notification` is fixed to the bottom of the **layout** viewport, which does not shrink when the on-screen keyboard opens — so "Nomor dada intern adalah 1001-1250" appeared exactly under the number pad, at the only moment it was needed.

`visualViewport` knows the height actually visible; the difference is the keyboard, and the toast is lifted by that much, updating on resize and scroll. With no keyboard the difference is zero and nothing moves; browsers without `visualViewport` skip it. Listeners are removed when the toast closes, by timeout or by its X.

`util.js` copied to `live/` and verified identical. Both modules parse; `periksa_impor` passes. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)