### PR TITLE
fix: stop redrawing the kloter ribbon after leaving the screen

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1677,7 +1677,14 @@ async function layarKeberangkatan() {
   `));
 
   const gambarPita = () => {
-    document.getElementById("pita-kloter").replaceChildren(h(papan.map(k => {
+    // Layarnya bisa SUDAH DITINGGALKAN. Menceklis regu memanggil server, dan
+    // sesudah `await` itu petugas mungkin sudah menekan Home — pita kloternya
+    // tidak ada lagi, dan `null.replaceChildren` melempar galat yang muncul
+    // sebagai toast merah "Cannot read properties of null" di layar Home,
+    // seolah Home yang rusak. Yang benar: tidak menggambar apa pun.
+    const pita = document.getElementById("pita-kloter");
+    if (!pita) return;
+    pita.replaceChildren(h(papan.map(k => {
       /* Kloter yang SUDAH berangkat menampilkan JAMNYA, bukan kata
          "berangkat".
 


### PR DESCRIPTION
Ticking a regu on Keberangkatan and then tapping **Home** raised a red toast: `Cannot read properties of null (reading 'replaceChildren')` — on the Home screen, as if Home were broken.

The tick calls the server; after that `await`, `gambarPita()` redraws `#pita-kloter`, which no longer exists once the screen has changed. It now returns instead — the same check the neighbouring `perbaruiPeringatanKontrak()` already made for its own element.

Parses; `periksa_impor` passes. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)