### PR TITLE
chore: 'Belum dihubungkan', not 'Belum tertaut'

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5992,7 +5992,7 @@ async function layarFoto() {
       </div>
     </div>
     <div class="card">
-      <h2>Belum tertaut <span class="badge" id="foto-belum">0</span></h2>
+      <h2>Belum dihubungkan <span class="badge" id="foto-belum">0</span></h2>
       <div class="grid-foto" id="foto-grid"></div>
     </div>
   `));


### PR DESCRIPTION
The Foto Jawaban heading now reads **Belum dihubungkan**.

Only the visible heading changes; identifiers like `daftarFotoBelumTaut` and `tautkanFoto` keep their names — they are code, read by maintainers, not by panitia.

Parses. No SQL, no gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)