### PR TITLE
fix: exclude deployment artifacts from static assets

### DIFF
--- a/web/.assetsignore
+++ b/web/.assetsignore
@@ -1,0 +1,2 @@
+.wrangler/
+wrangler.toml


### PR DESCRIPTION
## What\n\n- exclude Wrangler's local cache directory from public static assets\n- exclude the Wrangler deployment configuration from public static assets\n\n## Why\n\nA manual production deployment exposed deployment metadata and configuration as public static files. These files are not part of the panitia site and must not be included in future asset manifests.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)