### PR TITLE
fix: print contest forms without registered teams

### DIFF
--- a/tests/print_cleanup.test.mjs
+++ b/tests/print_cleanup.test.mjs
@@ -30,3 +30,17 @@ test("pos tanpa blangko tidak meninggalkan printout kosong", () => {
   assert.ok(posisiKosong < posisiPasang,
     "printout dipasang sebelum diketahui bahwa tidak ada blangko");
 });
+
+
+test("form per lomba tidak bergantung pada adanya baris regu", () => {
+  const awal = app.indexOf("const cetak = (slip) => {");
+  const akhir = app.indexOf('document.getElementById("cetak-lembar")', awal);
+  const cetak = app.slice(awal, akhir);
+  const posisiBlangko = cetak.indexOf("if (slip) {");
+  const posisiPagarBaris = cetak.indexOf("if (!tampil.length)");
+
+  assert.notEqual(posisiBlangko, -1);
+  assert.notEqual(posisiPagarBaris, -1);
+  assert.ok(posisiBlangko < posisiPagarBaris,
+    "form per lomba masih ditolak sebelum cabang cetaknya dijalankan");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4598,16 +4598,40 @@ async function layarInputPos() {
 
   /* ---------- cetak lembar kosong ---------- */
 
-  // Yang dicetak adalah baris yang SEDANG TAMPIL, bukan selalu semuanya.
+  // Form Tabel mencetak baris yang SEDANG TAMPIL, bukan selalu semuanya.
   // Dua kebutuhan berbeda terlayani satu tombol: sebelum lomba cetak "Semua"
   // untuk lembar kosong, dan di tengah lomba saring "Belum lengkap" dulu
   // supaya kertas susulan hanya memuat regu yang memang belum dinilai.
+  //
+  // Form per Lomba tidak membaca baris sama sekali. Ia adalah master kosong
+  // yang bentuk dan jumlah halamannya ditentukan konfigurasi lomba di pos;
+  // belum adanya satu pun regu tidak boleh menghalangi pencetakannya.
   /* TIDAK async, dan itu disengaja. `window.print()` di bawah harus tetap
      berada dalam giliran event tap — Safari iPhone memblokirnya kalau ada
      `await` lebih dulu, dan yang terlihat cuma tombol yang tidak melakukan
      apa-apa. Fungsi biasa membuat pelanggarannya jadi galat sintaks, bukan
      bug yang cuma muncul di iPhone orang lain. */
   const cetak = (slip) => {
+    if (slip) {
+      // Yang dicetak MASTER, bukan tumpukannya — jadi daftar ulang yang belum
+      // ditutup tidak berpengaruh di sini, dan jumlah regu yang sedang tampil
+      // pun tidak. Blangkonya kosong; berapa banyak yang dibutuhkan diputuskan
+      // di mesin fotokopi, bukan di layar ini.
+      const n = siapkanCetakBlangko(pos, kolom);
+      // Nol berarti pos ini seluruhnya lomba soal — dijawab di lembar soalnya
+      // sendiri, jadi tidak ada blangko yang perlu dicetak. Tanpa cabang ini
+      // browser membuka dialog cetak untuk halaman kosong, dan yang menekan
+      // tombolnya menyimpulkan bahwa pencetakannya rusak.
+      if (!n) {
+        notif("Pos ini seluruhnya lomba soal — dijawab di lembar soalnya "
+              + "sendiri, jadi tidak ada blangko yang perlu dicetak.", true);
+        return;
+      }
+      notif(`${n} master A5 melintang, satu per lomba.`);
+      window.print();
+      return;
+    }
+
     const tampil = [...tbody.children].filter(tr => !tr.hidden)
       .map(tr => lembar.find(r => Number(r.nomor_dada) === Number(tr.dataset.dada)))
       .filter(Boolean);
@@ -4642,25 +4666,7 @@ async function layarInputPos() {
         n => peta.get(n) || { nomor_dada: n, kosong: true });
     }
 
-    if (slip) {
-      // Yang dicetak MASTER, bukan tumpukannya — jadi daftar ulang yang belum
-      // ditutup tidak berpengaruh di sini, dan jumlah regu yang sedang tampil
-      // pun tidak. Blangkonya kosong; berapa banyak yang dibutuhkan diputuskan
-      // di mesin fotokopi, bukan di layar ini.
-      const n = siapkanCetakBlangko(pos, kolom);
-      // Nol berarti pos ini seluruhnya lomba soal — dijawab di lembar soalnya
-      // sendiri, jadi tidak ada blangko yang perlu dicetak. Tanpa cabang ini
-      // browser membuka dialog cetak untuk halaman kosong, dan yang menekan
-      // tombolnya menyimpulkan bahwa pencetakannya rusak.
-      if (!n) {
-        notif("Pos ini seluruhnya lomba soal — dijawab di lembar soalnya "
-              + "sendiri, jadi tidak ada blangko yang perlu dicetak.", true);
-        return;
-      }
-      notif(`${n} master A5 melintang, satu per lomba.`);
-    } else {
-      siapkanCetakLembarPos(pos, kolom, semua);
-    }
+    siapkanCetakLembarPos(pos, kolom, semua);
     window.print();
   };
 


### PR DESCRIPTION
## What\n\n- let Form per Lomba build its fixed print masters before checking table rows\n- keep the empty-row guard for Form Tabel only\n- add a regression test for printing with zero registered teams\n\n## Why\n\nForm per Lomba is fixed by the configured contests at each pos and must be printable before any team registers.\n\n## Notes\n\nThe 20 focused print tests pass. The repository-wide Node suite currently has two pre-existing failures in final architecture and registration resend assertions; neither is touched by this PR.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)