### PR TITLE
feat: impor 100 pendaftaran HRCD XXXVII dari Google Form

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -5,7 +5,10 @@ ini, bukan rencana. Kalau `desain-sistem.md` atau `rancangan-b.md` berbeda dari
 dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
-Terakhir diperiksa terhadap kode: **27 Agustus 2026**, sampai migrasi `0118`.
+Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
+sampai migrasi `0118`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0129`
+— hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
+`0119`-`0129`.
 
 ---
 
@@ -62,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-118 migrasi, `0001` sampai `0118`, dijalankan berurutan tanpa lubang penomoran.
+129 migrasi, `0001` sampai `0129`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -104,6 +104,55 @@ tidak tercampur dengan yang benar-benar butuh jawaban orang.
 
 ---
 
+## E. Sekolah baru dari pendaftaran XXXVII — alamatnya belum dicari
+
+Tiga belas sekolah ini masuk lewat migrasi `0129`, dari jawaban Google Form
+HRCD XXXVII. Mereka **sudah ada di tabel `sekolah` produksi dengan alamat
+kosong**, dan itu tidak menghalangi apa pun: pendaftaran, kloter, dan blangko
+tidak membaca alamat. Yang membacanya cuma surat.
+
+Bedanya dengan bagian A sampai D, dan ini yang membuat mereka ditulis
+terpisah: yang di atas sudah **disisir dan buntu**, yang di sini **belum
+dicari sama sekali**. Keduanya butuh pekerjaan yang berbeda — yang di atas
+butuh satu kalimat dari pembina, yang di sini butuh setengah jam di Data
+Referensi Kemendikdasmen.
+
+Mereka juga sengaja **belum masuk `tools/data/sekolah_nama.json` maupun
+`sekolah_alamat.json`**. Kedua berkas itu hasil kurasi edisi XXXIII-XXXVI
+(runbook bagian 2), dan menambahkan baris tanpa NPSN, tanpa alamat, dan tanpa
+sumber ke dalamnya menurunkan mutu daftar yang justru jadi acuan. Yang benar
+urutannya terbalik: cari alamatnya dulu menurut runbook bagian 6, baru
+tuliskan barisnya lengkap sekaligus.
+
+| Sekolah | Regu | Petunjuk dari form (kwartir ranting / cabang) |
+| --- | ---: | --- |
+| **MA Bahrul Anwar** | 6 | Cipaku / Ciamis |
+| **MTs Bahrul Anwar** | 5 | Cipaku / Ciamis |
+| **MTs Mujahidin** | 6 | Cipaku / Ciamis |
+| **MA Mujahidin** | 4 | Cipaku / Ciamis |
+| **MTsN 1 Ciamis** | 6 | Ciamis / Ciamis |
+| **SMPN 3 Kawali** | 5 | Kawali / Ciamis |
+| **SMPN 1 Kawali** | 4 | Kawali / Ciamis |
+| **SMK As-Sulthoniah** | 3 | Cipaku / Ciamis — alamat SUDAH ada, dari pemilik acara |
+| **MA Sirnarasa** | 1 | Panjalu / Ciamis |
+| **MA IPHI Pamarican** | 1 | Pamarican / Ciamis |
+| **SMA IT Nurul Huda** | 1 | Pamarican / Ciamis |
+| **SMPN 2 Kawali** | 1 | Kawali / Ciamis |
+| **SMPN 3 Baregbeg** | 1 | Baregbeg / Ciamis |
+
+Kolom petunjuk diambil apa adanya dari form dan **bukan alamat** — runbook
+bagian 1 sudah menyebutnya arah, bukan sumber kebenaran. Ia dipasang di sini
+supaya yang mencari tahu harus mulai dari kecamatan mana.
+
+`SMK As-Sulthoniah` pengecualiannya: alamatnya sudah terisi di `0129` dari
+jawaban pemilik acara — Dusun Desa RT 014/007, Jalatrang, Kec. Cipaku, Kab.
+Ciamis. Yang tersisa untuknya cuma NPSN.
+
+**Kolom Regu di atas adalah harganya kalau salah.** Enam regu MA Bahrul Anwar
+berarti enam undangan yang nyasar; satu regu SMPN 2 Kawali, satu. Kerjakan
+dari atas.
+---
+
 ## Yang bukan soal sekolah
 
 **`SMK Bhakti Kencana` masih satu klaster berisi dua sekolah** — satu di Kota

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -127,7 +127,7 @@ export function pesanRamah(m) {
   if (/regu_nama_unik|duplicate key value violates unique constraint "regu_nama/i.test(t))
     return "Nama regu itu sudah dipakai regu lain. Pilih nama yang berbeda.";
   if (/regu_nama_panjang/i.test(t))
-    return "Nama regu paling panjang 20 karakter.";
+    return "Nama regu paling panjang 25 karakter.";
   if (/nama_regu_tanpa_angka/i.test(t))
     return "Nama regu tidak boleh memakai angka.";
   if (/nama_ketua_tanpa_angka/i.test(t))

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -128,6 +128,8 @@ export function pesanRamah(m) {
     return "Nama regu itu sudah dipakai regu lain. Pilih nama yang berbeda.";
   if (/regu_nama_panjang/i.test(t))
     return "Nama regu paling panjang 25 karakter.";
+  if (/nama_regu_angka_di_belakang/i.test(t))
+    return "Angka di nama regu hanya boleh di belakang, misal: Cakra 1.";
   if (/nama_regu_tanpa_angka/i.test(t))
     return "Nama regu tidak boleh memakai angka.";
   if (/nama_ketua_tanpa_angka/i.test(t))

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -131,11 +131,17 @@ const golonganForm = () => internal() ? GOLONGAN_INTERNAL : GOLONGAN;
 const labelGolongan = k => golonganForm().find(g => g.kode === k)?.label
   ?? [...GOLONGAN, ...GOLONGAN_INTERNAL].find(g => g.kode === k).label;
 
-/* ---------- nama regu: 20 karakter, dan tidak boleh kembar (0051) ----------
+/* ---------- nama regu: 25 karakter, dan tidak boleh kembar ----------------
 
-   20 diturunkan dari kolom Nama Regu pada form tabel per pos: 48mm pada huruf
-   10pt memuat ~21 karakter kapital. Lebih dari itu terpotong DIAM-DIAM di
-   kertas cadangan, yang justru dipakai saat internet mati.
+   20 (0051) diturunkan dari kolom Nama Regu pada blangko pos. Kolom itu sejak
+   itu justru dipersempit jadi 44mm atas keputusan panitia — lebih baik nama
+   terpotong sedikit daripada kotak nilai yang sempit — jadi yang dijaga 20
+   sudah tidak dijaga oleh 20, dan 0127 menaikkannya ke 25. Yang membuat
+   pemotongan itu aman: baris dikenali dari NOMOR DADA, bukan dari namanya.
+
+   Angka ini WAJIB sama dengan check `regu_nama_panjang` di database. Kalau ia
+   lebih kecil, pembina tidak bisa mengetik nama yang sebenarnya diterima dan
+   tidak ada galat apa pun yang muncul — hurufnya cuma berhenti masuk.
 
    Kembar ditolak di seluruh edisi karena nama juara dibacakan di depan
    lapangan, dan nama yang sudah pernah disebut kehilangan momennya.
@@ -144,7 +150,7 @@ const labelGolongan = k => golonganForm().find(g => g.kode === k)?.label
    besar-kecil diabaikan, spasi beruntun dirapatkan. Pembatas yang bisa
    dilewati dengan menekan Caps Lock bukan pembatas.                        */
 
-const NAMA_MAKS = 20;
+const NAMA_MAKS = 25;
 
 /* Angka di kolom nama selalu berarti salah satu dari dua hal: kolomnya
    tertukar (nomor WA diketik di kotak Nama), atau regunya dinomori sendiri

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -161,6 +161,25 @@ const NAMA_MAKS = 25;
    — dan menolak semuanya demi menolak angka akan menolak lebih banyak nama
    asli daripada kesalahan yang dicegahnya. */
 const ADA_ANGKA = /[0-9]/;
+
+/* Nama REGU melonggar di 0128: angka boleh, tapi hanya sebagai ekor. Yang
+   dilepas cuma larangan menomori regu — SMKN 2 Ciamis mengirim enam regu dan
+   menyebutnya CAKRA 1..4 dan AGRESI 1..3, dan itu memang nama yang mereka
+   pakai. Yang TETAP dijaga bentuk khas kolom tertukar: angka di depan tanpa
+   nama sama sekali.
+
+   Harus sama persis dengan check `regu_nama_regu_angka_di_belakang`. Kalau di
+   sini lebih ketat, pembina berhenti mengetik pada aturan yang database
+   sebenarnya sudah terima, dan tidak ada galat apa pun yang muncul.
+
+     diterima   CAKRA 1, AGRESI 3, RAJAWALI
+     ditolak    08477484      (nomor WA nyasar ke kotak nama)
+     ditolak    SMA 2 CIAMIS  (angka di tengah)
+
+   ADA_ANGKA di atas TETAP dipakai lima tempat lain, dan semuanya nama ORANG.
+   Tidak ada yang bernama "Nur Aisyah 2", jadi di sana angka tetap berarti
+   kolom tertukar. */
+const NAMA_REGU_SAH = /^[^0-9]+[0-9]*$/;
 const normalNama = (t) => String(t || "").trim().toLowerCase().replace(/\s+/g, " ");
 
 /* Batas BAWAH nama regu (0120). Yang dihitung hurufnya, bukan panjang
@@ -796,7 +815,8 @@ function gambarRegu() {
   const masalahNama = (i) => {
     const n = normalNama(jawab.regu[i].nama_regu);
     if (!n) return "Nama regu wajib diisi.";
-    if (ADA_ANGKA.test(n)) return "Nama regu tidak boleh memakai angka.";
+    if (!NAMA_REGU_SAH.test(n))
+      return "Angka di nama regu hanya boleh di belakang, misal: Cakra 1.";
     if (!cukupHuruf(n)) return `Nama regu minimal ${HURUF_MIN} huruf.`;
     if (jawab.regu.some((x, j) => j < i && normalNama(x.nama_regu) === n))
       return "Nama ini sudah dipakai regu lain di form ini.";

--- a/live/style.css
+++ b/live/style.css
@@ -1405,8 +1405,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dan kolom penilaian menerima apa pun yang tersisa — pada Pos 5 itu
      menyisakan 16mm untuk judul "KREATIVITAS", yang tumpah keluar kertas.
 
-     Nama regu 44mm karena 0051 membatasinya 20 karakter, dan 20 kapital 10pt
-     memang selebar itu. Organisasi diberi lebar yang sama dan dipotong
+     Nama regu 44mm, dan angka itu SUDAH di bawah nama terpanjang yang
+     database terima — 25 karakter sejak 0127, ~57mm pada 10pt kapital.
+     Memotong adalah pilihan, bukan kelalaian: yang dibeli dengan milimeter
+     itu kotak penilaian, dan baris tetap dikenali dari nomor dada di kolom
+     pertama. Organisasi diberi lebar yang sama dan dipotong
      elipsis di situ: nama sekolah bisa sepanjang apa pun, dan lembar ini
      dibaca untuk MENCOCOKKAN baris, bukan untuk membaca nama sekolah utuh —
      nomor dada di kolom pertama yang jadi kuncinya.

--- a/supabase/migrations/0127_nama_regu_dua_puluh_lima.sql
+++ b/supabase/migrations/0127_nama_regu_dua_puluh_lima.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- hrcd-rekap : 0127_nama_regu_dua_puluh_lima.sql
+--
+-- Batas atas nama regu naik dari 20 ke 25 karakter.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Keputusan pemilik acara, dan yang memicunya nyata: 100 regu yang mendaftar
+-- lewat Google Form XXXVII masuk lewat 0128, dan tiga di antaranya melewati
+-- 20 — "COBOY GEULIS PASUNDAN" (21), "WIJAYA KUSUMA NAWASENA" (22),
+-- "LAKSAMANA MALA HAYATI" (21). Form Google tidak tahu pagar kita, jadi nama
+-- itu sudah beredar di sekolahnya sebelum sistem ini pernah melihatnya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA 25 TIDAK MENGKHIANATI ALASAN 20
+--
+-- 0051 menurunkan 20 dari lebar kolom Nama Regu di blangko pos: 48mm pada
+-- 10pt memuat ~21 karakter kapital, jadi 20 memberi satu karakter jarak, dan
+-- alasannya "supaya nama tidak terpotong DIAM-DIAM di kertas cadangan".
+--
+-- Angka 48mm itu sudah tidak berlaku. Kolomnya kini **44mm** — dipersempit
+-- dengan sengaja, dan alasannya ditulis panjang di `web/style.css`: panitia
+-- memilih kotak nilai yang lebar daripada nama yang utuh, dan 44mm memang
+-- SUDAH di bawah kebutuhan nama 20 karakter. Blangko itu karena itu sudah
+-- memotong hari ini, pada nama yang lolos pagar 20, dan elipsisnya adalah
+-- jaring pengaman yang disengaja — bukan kecelakaan.
+--
+-- Jadi yang dijaga 20 sudah tidak dijaga oleh 20. Yang membuat pemotongan itu
+-- tidak berbahaya juga sudah ditulis di sana: regu dikenali dari NOMOR DADA
+-- di kolom pertama, bukan dari namanya.
+--
+-- Yang TIDAK ikut berubah, dan sengaja: lebar kolomnya. Melebarkannya
+-- mengambil milimeter dari kolom penilaian — 23mm per kotak di Pos 3 yang
+-- punya tujuh — dan itu keputusan panitia yang tidak diminta siapa pun untuk
+-- dibatalkan.
+--
+-- ---------------------------------------------------------------------------
+-- YANG IKUT BERUBAH
+--
+--   `regu_nama_panjang`                    check 1..20  -> 1..25
+--   `NAMA_MAKS` di live/js/daftar.js       20 -> 25 (maxlength kotak isian)
+--   pesan galat di web/js/api.js + live/   "paling panjang 20" -> 25
+--
+-- Ketiganya WAJIB bergerak bersama. Kotak isian yang masih `maxlength="20"`
+-- membuat pembina tidak bisa mengetik nama yang database sebenarnya terima,
+-- dan tidak ada galat apa pun yang muncul — hurufnya cuma berhenti masuk.
+--
+-- `regu_nama_regu_tiga_huruf` (0120) tidak disentuh: itu batas BAWAH, dan ia
+-- menghitung HURUF sedangkan yang di sini menghitung KARAKTER.
+-- ============================================================================
+
+alter table regu drop constraint if exists regu_nama_panjang;
+alter table regu add constraint regu_nama_panjang
+  check (length(trim(nama_regu)) between 1 and 25);
+
+comment on constraint regu_nama_panjang on regu is
+  'Nama regu 1-25 karakter. Sampai 0127 batasnya 20, diturunkan dari lebar '
+  'kolom blangko pos yang sejak itu justru dipersempit jadi 44mm dan memotong '
+  'dengan elipsis atas keputusan panitia. Batas bawahnya terpisah: '
+  'regu_nama_regu_tiga_huruf (0120), yang menghitung huruf, bukan karakter.';
+
+do $blok$
+declare v_n integer;
+begin
+  select count(*) into v_n from regu where length(trim(nama_regu)) > 20;
+  raise notice '0127: batas nama regu 25 karakter terpasang; % nama yang ada melewati 20.', v_n;
+end;
+$blok$;

--- a/supabase/migrations/0128_nama_regu_angka_di_belakang.sql
+++ b/supabase/migrations/0128_nama_regu_angka_di_belakang.sql
@@ -1,0 +1,99 @@
+-- ============================================================================
+-- hrcd-rekap : 0128_nama_regu_angka_di_belakang.sql
+--
+-- Nama regu boleh memuat angka, TAPI hanya sebagai ekor: "CAKRA 1" diterima,
+-- "08477484" dan "SMA 2 CIAMIS" tidak.
+--
+-- Hanya `regu.nama_regu` yang melonggar. `nama_ketua`, `regu.anggota`, dan
+-- `pendaftaran.nama_kontak` tetap menolak angka mana pun -- alasannya di
+-- bawah, dan ia berbeda dari alasan nama regu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Keputusan pemilik acara, dipicu enam regu SMKN 2 Ciamis yang mendaftar lewat
+-- Google Form XXXVII: CAKRA 1, CAKRA 2, CAKRA 4, AGRESI 1, AGRESI 2, AGRESI 3.
+-- Satu sekolah mengirim enam regu dan menomorinya untuk membedakan -- cara
+-- yang wajar, dan sudah dipakai sebelum sistem ini pernah melihat namanya.
+--
+-- 0052 melarang seluruh angka, dengan dua alasan. Yang ini menerima alasan
+-- pertama seutuhnya dan melepas yang kedua:
+--
+--   1. KOLOM TERTUKAR -- nomor WhatsApp diketik di kotak Nama. Ini yang
+--      dijaga, dan bentuknya khas: angkanya di DEPAN dan tidak ada nama sama
+--      sekali. "08477484" tetap ditolak, dan itulah seluruh isi migrasi ini.
+--
+--   2. REGU DINOMORI SENDIRI -- "REGU 1", "REGU 2", bersaing dengan nomor
+--      dada di lembar yang sama. Ini yang dilepas: pemilik acara memutuskan
+--      pembina boleh menomori regunya, karena "CAKRA 1" dan "CAKRA 2" memang
+--      dua regu berbeda dari satu sekolah dan tidak ada nama lain yang mereka
+--      pakai.
+--
+-- ---------------------------------------------------------------------------
+-- BENTUKNYA
+--
+--   trim(nama_regu) ~ '^[^0-9]+[0-9]*$'
+--
+-- Dibaca: satu atau lebih karakter BUKAN angka, lalu angka sebanyak apa pun
+-- di ujung, lalu habis. Tiga akibatnya, dan ketiganya disengaja:
+--
+--   diterima   CAKRA 1, AGRESI 3, RAJAWALI, ELANG-2
+--   ditolak    08477484        angka di depan, tidak ada namanya
+--   ditolak    SMA 2 CIAMIS    angka di TENGAH -- bukan penomoran regu,
+--                              hampir selalu isian yang nyasar
+--
+-- Nama yang cuma angka juga sudah ditolak oleh `regu_nama_regu_tiga_huruf`
+-- (0120), yang menuntut minimal tiga HURUF. Dua pagar itu tidak tumpang
+-- tindih: 0120 menghitung huruf, yang ini mengatur letaknya.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA KOLOM NAMA ORANG TIDAK IKUT
+--
+-- Alasan kedua di atas cuma berlaku untuk nama regu. Tidak ada seorang pun
+-- bernama "Nur Aisyah 2", jadi angka di kolom nama orang tetap berarti kolom
+-- tertukar, dan pelonggaran yang sama di sana hanya membuka kembali kekeliruan
+-- yang baru ketahuan di meja daftar ulang saat pembinanya sudah pulang.
+--
+-- ---------------------------------------------------------------------------
+-- YANG WAJIB IKUT BERUBAH
+--
+--   `ADA_ANGKA` di live/js/daftar.js -- dipakai enam tempat, dan HANYA yang
+--   memeriksa nama regu yang boleh berganti. Lima sisanya nama orang.
+--   Pesan galat di web/js/api.js + salinan live/.
+--
+-- Form yang masih menolak "CAKRA 1" sambil diketik membuat pembina berhenti
+-- mengetik pada aturan yang database sebenarnya sudah terima -- dan tidak ada
+-- galat apa pun yang muncul di sisi kita.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Berhenti lebih dulu kalau ada nama yang bahkan aturan baru ini tolak, dengan
+-- menyebut pelanggarnya. Aturan yang MELONGGAR memang tidak mungkin menolak
+-- baris yang tadinya lolos -- tapi berkas ini juga dijalankan di database yang
+-- pernah menerima nama lewat jalur lain, dan pesan Postgres hanya menyebut
+-- satu baris.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_sisa text;
+begin
+  select string_agg(nama_regu, ', ') into v_sisa
+  from regu
+  where not is_cancelled and trim(nama_regu) !~ '^[^0-9]+[0-9]*$';
+
+  if v_sisa is not null then
+    raise exception '0128: nama regu berikut tetap tidak sah -- angkanya bukan di belakang: %', v_sisa;
+  end if;
+  raise notice '0128: data yang ada lolos aturan angka-di-belakang.';
+end;
+$blok$;
+
+alter table regu drop constraint if exists regu_nama_regu_tanpa_angka;
+alter table regu drop constraint if exists regu_nama_regu_angka_di_belakang;
+alter table regu add constraint regu_nama_regu_angka_di_belakang
+  check (trim(nama_regu) ~ '^[^0-9]+[0-9]*$');
+
+comment on constraint regu_nama_regu_angka_di_belakang on regu is
+  'Angka boleh, tapi hanya sebagai ekor: "CAKRA 1" ya, "08477484" dan '
+  '"SMA 2 CIAMIS" tidak. Sampai 0128 aturannya melarang angka mana pun; yang '
+  'dilepas cuma larangan menomori regu, bukan pagar terhadap nomor WA yang '
+  'nyasar ke kotak nama. Kolom nama ORANG tetap menolak angka apa pun (0052).';

--- a/supabase/migrations/0129_impor_pendaftaran_xxxvii.sql
+++ b/supabase/migrations/0129_impor_pendaftaran_xxxvii.sql
@@ -1,0 +1,678 @@
+-- ============================================================================
+-- hrcd-rekap : 0129_impor_pendaftaran_xxxvii.sql
+--
+-- Memasukkan 100 regu yang mendaftar lewat Google Form HRCD XXXVII ke tabel
+-- `pendaftaran` dan `regu`. Sumbernya berkas jawaban form
+-- `FORM_PENDAFTARAN_HRCD_XXXVII_Jawaban.xlsx`, 100 baris, isian terakhir
+-- 21 Agustus 2026.
+--
+-- ---------------------------------------------------------------------------
+-- SATU BARIS FORM = SATU PENDAFTARAN
+--
+-- Formnya diisi per REGU, bukan per sekolah, jadi tiap baris jadi satu
+-- `pendaftaran` berisi satu regu dengan kode pembayarannya sendiri. Itu
+-- keputusan pemilik acara, bukan bawaan datanya: menggabungkan enam regu satu
+-- sekolah jadi satu kode akan menagih satu pembina untuk regu yang bukan
+-- urusannya, dan di data ini tujuh sekolah memang mengirim regunya lewat dua
+-- nomor pembina yang berbeda.
+--
+-- ---------------------------------------------------------------------------
+-- SEMUANYA BELUM MEMBAYAR
+--
+-- Kolom `status` dibiarkan pada bawaannya, `menunggu_pembayaran`. Form memang
+-- meminta bukti transfer dan hampir semua mengunggahnya, tapi berkasnya ada di
+-- Google Drive, bukan di Storage kita -- dan yang menentukan lunas adalah meja
+-- pembayaran, bukan adanya lampiran. `metode_bayar` dan `bukti_transfer`
+-- karena itu dibiarkan NULL; keduanya diisi saat berkasnya dipindahkan.
+--
+-- Nomor dada dan kloter juga NULL: keduanya lahir di `daftar_ulang_batch`,
+-- bukan di sini.
+--
+-- ---------------------------------------------------------------------------
+-- BISA DIJALANKAN ULANG
+--
+-- Tiap baris membawa `kunci_kirim` yang dihitung dari nomor barisnya di
+-- spreadsheet -- `md5('hrcd-xxxvii-form-<baris>')::uuid` -- dan `pendaftaran`
+-- punya unique index atas kolom itu sejak 0006. Menjalankan migrasi ini dua
+-- kali tidak melahirkan seratus pendaftaran kedua; yang sudah ada dilewati.
+--
+-- Kode pembayarannya TIDAK dihitung dari nomor baris. Ia diundi seperti di
+-- `submit_pendaftaran`, dengan pengulangan sampai tidak bentrok, supaya kode
+-- yang sudah beredar di produksi tidak mungkin tertimpa.
+--
+-- ---------------------------------------------------------------------------
+-- SEKOLAH
+--
+-- 28 sekolah, dari 43 tulisan berbeda di form. Penyamaannya memakai
+-- `kunci()` Python di `tools/normalize_sekolah.py`, hasilnya dibaca orang, lalu
+-- nama bakunya ditulis tangan di sini -- persis urutan yang diminta
+-- runbook-sekolah.md bagian 12.2. Menyerahkan pencocokan itu ke
+-- `kunci_sekolah()` database sudah pernah dicoba di 0061 dan meloloskan enam
+-- sekolah tanpa dibakukan.
+--
+-- Empat tulisan disatukan tangan, karena kunci mana pun tidak boleh cukup
+-- rakus untuk menyatukannya sendiri:
+--
+--   'sman negeri 1 sukadana'           -> SMAN 1 Sukadana
+--   'SMA NEGERI 2 CIA'                 -> SMAN 2 Ciamis    (ketikan terpotong)
+--   'SMPN1 a CIKONENG'                 -> SMPN 1 Cikoneng
+--   'Jalatrang' / 'Jalatrang Cipaku'   -> SMK As-Sulthoniah
+--
+-- Yang terakhir bukan salah ketik melainkan dua kolom yang tertukar: Jalatrang
+-- adalah DESA tempat sekolahnya berada, dan nama sekolahnya justru ditulis di
+-- kolom Gugus Depan. Dipastikan ke pemilik acara beserta alamat lengkapnya.
+--
+-- 13 sekolah belum ada di daftar kurasi dan lahir di sini dengan alamat
+-- KOSONG. Alamatnya tidak dikarang dari kolom Kwartir Ranting form -- runbook
+-- bagian 1 menyebut kolom itu petunjuk arah, bukan sumber kebenaran. Daftar
+-- kerjanya ada di docs/sekolah-belum-tuntas.md.
+--
+-- ---------------------------------------------------------------------------
+-- DUA PAGAR YANG FORM GOOGLE TIDAK TAHU
+--
+-- `regu` punya tiga pagar atas nama regu, dan Google Form tidak tahu satu pun:
+-- maksimal 20 karakter dan tidak boleh kembar (0051), serta tidak boleh
+-- memuat angka (0052). Sebelas regu di sini melanggar salah satunya, dan
+-- namanya sudah beredar di sekolahnya sebelum sistem ini melihatnya.
+--
+-- Dua pagar dilonggarkan lebih dulu, atas keputusan pemilik acara, dan
+-- alasannya ada di kepala masing-masing migrasi:
+--
+--   0127  batas panjang 20 -> 25    menampung COBOY GEULIS PASUNDAN (21),
+--                                   WIJAYA KUSUMA NAWASENA (22),
+--                                   LAKSAMANA MALA HAYATI (21)
+--   0128  angka boleh di EKOR       menampung CAKRA 1/2/4 dan AGRESI 1/2/3,
+--                                   enam regu SMKN 2 Ciamis
+--
+-- KEDUANYA WAJIB dijalankan lebih dulu. Berkas ini sendirian di database yang
+-- masih berbatas 20 gagal di regu keempat, dan yang masih menolak angka gagal
+-- di regu ke-74.
+--
+-- Nama kembar tidak bisa diselesaikan dengan melonggarkan pagar: nama juara
+-- dibacakan di depan lapangan, dan nama yang sudah disebut kehilangan
+-- momennya. Dua pasang, dan yang mendaftar lebih dulu berhak atas namanya --
+-- persis yang akan terjadi kalau mereka melewati form kita, karena
+-- nama_regu_dipakai() memblokir yang belakangan SAMBIL DIKETIK:
+--
+--   GARUDA   MTs Al-Hasan Banjarsari  21 Agt  -> tetap GARUDA
+--            SMPN 1 Cipaku            27 Agt  -> GARUDA CIPAKU
+--   TERATAI  MTs Al-Hasan Banjarsari  21 Agt  -> tetap TERATAI
+--            MTs Bahrul Anwar         27 Agt  -> TERATAI BAHRUL ANWAR
+--
+-- Ekor nama sekolah adalah keputusan pemilik acara. Kedua pembina perlu
+-- diberi tahu: yang tercetak di blangko dan dibacakan di lapangan adalah nama
+-- yang di sini, bukan yang mereka tulis di form.
+--
+-- ---------------------------------------------------------------------------
+-- YANG TIDAK DITANYAKAN FORM
+--
+-- Form XXXVII tidak menanyakan barak maupun jumlah yang menginap, jadi
+-- `butuh_barak` false dan `jumlah_menginap` 0 untuk seluruh baris. Keduanya
+-- ditanyakan ulang di meja daftar ulang lewat `ubah_jumlah_menginap()`.
+--
+-- Form juga tidak menanyakan siapa ketua regunya. Yang dipakai sebagai
+-- `nama_ketua` adalah "Nama Lengkap Anggota 1", dan empat sisanya masuk
+-- `regu.anggota` berurutan. Seluruh 100 regu mengisi kelimanya.
+--
+-- Sepuluh regu tidak mengisi Contact Person Pembina -- MTs Al-Hasan Banjarsari
+-- (4), SMPN 3 Kawali (5), SMPN 2 Kawali (1). `kontak_wa` NOT NULL, jadi
+-- ketiganya diberi penanda 'belum ada' yang terbaca sebagai kekosongan di
+-- layar, bukan sebagai nomor yang gagal dihubungi. Nomornya dikejar terpisah.
+-- ---------------------------------------------------------------------------
+-- DUA TABEL SEMENTARA, DIBUANG DENGAN TANGAN
+--
+-- Keduanya sengaja TIDAK memakai `on commit drop`. Produksi menjalankan
+-- migrasi lewat `psql --single-transaction`, jadi di sana klausa itu benar;
+-- `tests/run.sh` tidak, dan di autocommit `create temporary table ... on
+-- commit drop` membuang tabelnya seketika di ujung statement yang membuatnya.
+-- Berkas ini pertama kali ditulis begitu dan gagal di baris berikutnya dengan
+-- 'relation "impor_form" does not exist' -- hanya di laptop, bukan di
+-- produksi. Yang dibuang di ujung berkas ini adalah gantinya, dan ia benar di
+-- kedua cara menjalankan.
+-- ============================================================================
+
+create temporary table impor_form (
+  baris       integer primary key,
+  sekolah     text    not null,
+  nama_regu   text    not null,
+  golongan    text    not null,
+  nama_ketua  text    not null,
+  anggota     text[]  not null,
+  kontak_wa   text    not null,
+  nama_kontak text
+);
+
+insert into impor_form (baris, sekolah, nama_regu, golongan, nama_ketua,
+                        anggota, kontak_wa, nama_kontak) values
+  (2, 'MTs Al-Hasan Banjarsari', 'GARUDA', 'penggalang_pa',
+   'YOKI RAMADHI',
+   array['ALDI AMU MUROZAQ', 'MAHER GIBRAN ALGHIFARY', 'DIKA NURPRADANA', 'KAMAJAYA SUKMA PAWITRA'],
+   'belum ada', null),
+  (3, 'MTs Al-Hasan Banjarsari', 'TERATAI', 'penggalang_pi',
+   'RIFFA''A NUR AZIZAH',
+   array['DARIS SETIA NINGSIH', 'ZAHRA AUDIA', 'DEVI PUSWITA', 'KEULIS NUR AZIZAH AZZAHRA'],
+   'belum ada', null),
+  (4, 'MTs Al-Hasan Banjarsari', 'EDELWEIS A', 'penggalang_pi',
+   'AYUNIA CHARLIANTI',
+   array['DEBIYLA ZAHRA MEYFA', 'SYIFA NUR LATIFAH', 'DINARA SYAFIRA', 'SABILA NILNAMUNA'],
+   'belum ada', null),
+  (5, 'MTs Al-Hasan Banjarsari', 'ELANG', 'penggalang_pa',
+   'HAZIQ ARYA PRATAMA',
+   array['WILLY ALFIKRI', 'MUHAMMAD DZIKRI MAULANA', 'ADAM GHANI KAUTSAR', 'MUHAMMAD HASBI ABDILLAH'],
+   'belum ada', null),
+  (6, 'SMPN 2 Kawali', 'ASTER PRADOEKA', 'penggalang_pi',
+   'Fitya Najiyah Rahmadan',
+   array['Salsa Syakila Zahra', 'Agni Nurhasanah', 'Zahira', 'Widad Dwi Razwanti'],
+   'belum ada', null),
+  (7, 'SMPN 3 Kawali', 'ALAMANDA', 'penggalang_pi',
+   'SANI AULIA RAMADHAN',
+   array['ALYA NUR NABILAH', 'MESYA ROSLIANI', 'SINTYA NUR AMANAH', 'SITI MAESAROH'],
+   'belum ada', null),
+  (8, 'SMPN 3 Kawali', 'CAMELIA', 'penggalang_pi',
+   'DIANDRA ANNISA NAWA NUGRAHA',
+   array['HILDA HIDAYAH', 'KHANZA HUMAIRA BILQIS', 'SILVI MAULIDA', 'ZAHRA NUR AZIZAH'],
+   'belum ada', null),
+  (9, 'SMPN 3 Kawali', 'ASTER', 'penggalang_pi',
+   'SOLIHATUNNISA',
+   array['KESYA SHLAAWATI', 'NATASYA ASYIFA PUTRI', 'AYRA RAHMA JULIYANTI', 'SYIFATUL KAMILAH'],
+   'belum ada', null),
+  (10, 'SMPN 3 Kawali', 'CARACAL', 'penggalang_pa',
+   'DESTA AKSIOMA MUSTOFA',
+   array['MUHAMMAD FAUZAN AL GHIFARI', 'DYAN RACHMAT KOMARI', 'MUHAMMAD NAUFAL ARIF ADISANTIKA', 'GILANG FERDIANSAH RAMADAN'],
+   'belum ada', null),
+  (11, 'SMPN 3 Kawali', 'MAUNG', 'penggalang_pa',
+   'ADITYA RAHMAN SAPUTRA',
+   array['AGUS SUPRIATNA', 'DAFA BILFAQIH ABYAN', 'MAHESA PURTA ASUARI', 'PASYA FADILLA'],
+   'belum ada', null),
+  (12, 'MTsN 1 Ciamis', 'TIMUN MAS', 'penggalang_pi',
+   'KIKIS RINDU APRILLIA',
+   array['AZKA SELVA NUR FADILLAH', 'AYU INTAN NURAENI', 'ARNI MEILANI', 'SITI NURHASANAH'],
+   '088971832802', null),
+  (13, 'MTsN 1 Ciamis', 'THE JALANGKUNG', 'penggalang_pa',
+   'NAUFAL ZATNIKA',
+   array['EVAN MUHAMAD FADIL', 'MUH ZIDAN ZAKI BUDIAWAN', 'REVAN PERMANA', 'TIO FAUQO SYAHID'],
+   '088971832802', null),
+  (14, 'SMPN 1 Cimaragas', 'PANCA PUSPITA', 'penggalang_pi',
+   'ADE RISMAYANTI',
+   array['SITI MUDRIKAH', 'ANGGUN FEBBY ARIANY', 'SISKA VARLIANA PUTRI', 'ROSELLA'],
+   '085860555358', null),
+  (15, 'SMPN 1 Cimaragas', 'MATAHARI', 'penggalang_pi',
+   'ADIA RAFA FATHINA',
+   array['PUTRI SALSABILA NUR AZIZAH', 'APRILIA PUTRI LESTARI', 'AQILA KAYALANI', 'NADYA GALUH MULYANI'],
+   '085322800405', null),
+  (16, 'MTsN 1 Ciamis', 'MARIO BROSS GEULIS', 'penggalang_pi',
+   'WINARNI NURRIZQIAH',
+   array['SHINY QURRATU QALBI', 'SYAKIRA HASYA JANEETA', 'ALIN NAWAL K', 'PUTRI BILQIS'],
+   '088971832802', null),
+  (17, 'SMPN 1 Kawali', 'JALAK DEWATA', 'penggalang_pa',
+   'Dimas Bagja Ar Rasyid',
+   array['Achmad Rizal Mutaqin', 'Athif Falihul Faiq Cherdiana', 'Rafka Rafasya Pratama', 'Rizqi Adhitya Pramudita'],
+   '08988777900', null),
+  (18, 'MTsN 1 Ciamis', 'CRAZY BOYS', 'penggalang_pa',
+   'ALBANI MUHAMMAD NASIR',
+   array['YAZID FATHUROHMAN MUBAROK', 'MUHAMAD BARIZ HIELMI', 'DAFIAN APRILIO', 'DEFASA SATRIA MAULANA'],
+   '088971832802', null),
+  (19, 'MTsN 1 Ciamis', 'COBOY GEULIS PASUNDAN', 'penggalang_pi',
+   'ZAHIRA NURUL ''AINI',
+   array['RARA FANY FAUZIAH', 'NAIRA SYAHLA AJAHRA', 'MALA NURULFADILAH', 'HILYANI RAISA SUCIANI QOLBY'],
+   '088971832802', null),
+  (20, 'SMPN 1 Kawali', 'WIJAYA KUSUMA NAWASENA', 'penggalang_pi',
+   'Alia Shofia Maulida',
+   array['Aisyah Citra Nila Kusumah', 'Aqila Putri Ginsa', 'Nazwa Dalilah', 'Sefira Sajidah Zahra'],
+   '087828486646', null),
+  (21, 'SMPN 1 Kawali', 'VIOLET NISKALA', 'penggalang_pi',
+   'Khalisa Shafa Ghaissani',
+   array['Alfira Klarisa Putri', 'Ilma Firda Hasbiya', 'Kaila Najla Humaira', 'Melani Triesahapsari'],
+   '087828486646', null),
+  (22, 'SMPN 1 Kawali', 'JAGUAR WISESA', 'penggalang_pa',
+   'Muhammad Fakhri Nizam Ali',
+   array['Devaleskha Tysta Khalfani', 'Nanda Nektar An-Nahl', 'Raqilla Idraki Lattanzio', 'Taufik Khoirul Fajar'],
+   '08988777900', null),
+  (23, 'SMPN 1 Ciamis', 'BOUGENVILE', 'penggalang_pi',
+   'Shafa Milana Anggraeni Setiawan',
+   array['Novidha Anastasya Putri', 'Azkiya Kirey Anzio', 'Agnya Nur Fadillah', 'Syifa Zakiyya Filardha Razqi'],
+   '08112292012', 'ibu Fitri latuperisa'),
+  (24, 'MA Sirnarasa', 'CAKRA NUSA', 'penegak_pa',
+   'MUHAMMAD FIKRI PRATAMA',
+   array['ABDAN NASIR BAHRAWI', 'HILMY FARRAS FATIH', 'MUHAMMAD RIZQY ATTALA ROSADI', 'MUHAMMAD ZUFAR FAIQ K'],
+   '089518698998', null),
+  (25, 'SMAN 1 Baregbeg', 'RHINO', 'penegak_pa',
+   'FANZI HAERUDIN',
+   array['RAFKA MAULI RESTU SYAPUTRA', 'FADEL MUHAMMAD FAUZI', 'SUNAN ANGKAWIJAYA', 'RADITIYA RUHIYAT SAPUTRA'],
+   '085223168786', null),
+  (26, 'SMAN 1 Sukadana', 'AVARSA', 'penegak_pi',
+   'Indah Nurhusna',
+   array['Haira Salsyabila', 'Tiara Qianisa Putri', 'Nurul Meilahafifah', 'Sinta Nuraini'],
+   '082318383182', null),
+  (27, 'SMAN 1 Sukadana', 'ANYELIR', 'penegak_pi',
+   'Alexandriani Siratuyunin',
+   array['Silvi Nuraeni', 'Dara Nukeu Pebrianti', 'Sri Putri Lestari', 'Andin Keisya Putri'],
+   '082318383182', null),
+  (28, 'SMAN 1 Sukadana', 'MOLDA', 'penegak_pi',
+   'MEILANI AWALIYAH',
+   array['OKTAVIANI AZZAHRA', 'LEANI INSANI PUTRI', 'DESPITA TRI HANDAYANI', 'SITI SALMAH KHAIRUNNISA'],
+   '082318383182', null),
+  (29, 'SMAN 1 Sukadana', 'NGABRET', 'penegak_pi',
+   'Imelda Yustanza',
+   array['Zaskia Maulida', 'Shifa Nurul Aulia', 'Salsabila Azzahra', 'Anggun Alviani'],
+   '082318383182', null),
+  (30, 'SMAN 1 Sukadana', 'AGREMA', 'penegak_pi',
+   'ICHA HAPIPAH',
+   array['AISYATUL HUSNA', 'KIKI AZA AMELIA', 'ATIKA BALQIS AZIZAH', 'RAHMA AZILA PUTRI'],
+   '082318383182', 'ka erna yuliana'),
+  (31, 'SMAN 1 Sukadana', 'NISKALA', 'penegak_pi',
+   'ISMAJATI',
+   array['Sarah Aulya Zahra', 'Risnina Aprilia Diany', 'Risma Nur Afifah', 'Lulu Aulia Juniar'],
+   '08231838182', null),
+  (32, 'SMAN 1 Sukadana', 'BANGKONG LUNCAT', 'penegak_pa',
+   'Anil Nirwana Juniar',
+   array['Adhitya Afrilianto Gunawan', 'Yuda Prasetiyo', 'Aan Nurfaturohman', 'Miptah Parid'],
+   '082318383182', null),
+  (33, 'SMAN 1 Sukadana', 'KAUM GABUT', 'penegak_pa',
+   'MUHAMMAD AZKA AULIA',
+   array['FAUZAN ZULKIFLI HASAN', 'ADITYA MUHAMMAD REZKY', 'RENO MEIZA ADRIAN', 'TEMMY TRI AWALUDIN'],
+   '082318383182', null),
+  (34, 'SMAN 1 Sukadana', 'GUNDAL GANDIL', 'penegak_pa',
+   'Dika nugraha',
+   array['Evan rofiqulvian', 'Haikal hamdi', 'Raka nurcahya fadila', 'Aditya muhamad dafa'],
+   '082318383182', null),
+  (35, 'SMAN 1 Sukadana', 'EDELWEIS B', 'penegak_pi',
+   'Nindia putri juniar',
+   array['Salsabila Juliani', 'Fina jaoharotul huda', 'Nita', 'Rifa Salma azahra'],
+   '082318383182', null),
+  (36, 'SMPN 1 Ciamis', 'BUNGA TELANG', 'penggalang_pi',
+   'Adzkya Qanayya Rakhmat Mulyana',
+   array['Rd.roro edlyn elgiva w.', 'Ica cahyani', 'Anisya''ban Khoirul anam', 'Chika ayunda rahma'],
+   '0811200292011', null),
+  (37, 'SMPN 1 Cikoneng', 'BANTENG', 'penggalang_pa',
+   'SYAFIQ ARIEF NUGRAHA',
+   array['ZAKIY MUHAMMAD TAZKIYYA', 'MUHAMAD RIFKI', 'ADITIA DWI PUTRA', 'DADANG DARUSMAN'],
+   '081321692092', null),
+  (38, 'SMPN 1 Cikoneng', 'RAFLESIA', 'penggalang_pi',
+   'BELA NURAENI',
+   array['ZAHIRA SITI FATITUZZAHRO', 'KEISHA NUR QAIREEN', 'ADELLIA RAMADHANI FATIMAH', 'SAHIRA FARRAS GHAISANI'],
+   '081321692092', null),
+  (39, 'SMAN 1 Panawangan', 'RIMBA BOY', 'penegak_pa',
+   'ANGGI HENDRIANA',
+   array['ARI MULYA GUMILAR', 'DENNIS ZAIDAN FATURRACHMAN', 'SANDRA MALIK', 'SHANDIKA FEBRIYANA'],
+   '081312250007', null),
+  (40, 'SMAN 1 Panawangan', 'WIRAGA', 'penegak_pa',
+   'Raka nur fahrizka',
+   array['Irawan Riswanto', 'Fahrul Fauzi', 'Muhammad Dzikri N.H', 'Rayi nur fahrizka'],
+   '081312250007', null),
+  (41, 'SMAN 1 Sukadana', 'CENDANA', 'penegak_pi',
+   'desy wulanika',
+   array['lyris Khoirunnisa', 'nuryza aprilyani', 'decha fadillah shilvana', 'nida aulia'],
+   '082318383182', null),
+  (42, 'MTs Mujahidin', 'LIMA ELANG TANGGUH', 'penggalang_pa',
+   'Nanda Najiullah Arham',
+   array['Rafa Arkana Hamizan', 'Muhamad Fahri', 'M. Fazri Setiawan', 'Badri Maulana'],
+   '081320073291', null),
+  (43, 'MTs Mujahidin', 'LIMA ELANG GAGAH', 'penggalang_pa',
+   'GALIH PURNAMA RAMADHAN',
+   array['FARDA RIDHO RAMADHAN', 'NURSIDIK RAMDANI', 'RAKHA SYAFIQ ABDULLAH', 'IRFAN HANDIANA'],
+   '081320073291', null),
+  (44, 'MTs Mujahidin', 'LIMA ELANG BERANI', 'penggalang_pa',
+   'FIRDIAN MAULANA',
+   array['SEPTA DWINUGRAHA PUTRA', 'FAQIH DHIYAULHAQ SYAHPUTRA', 'AZKA N. ARIFIN', 'ADE AGUSTIANA'],
+   '081320073291', null),
+  (45, 'MTs Mujahidin', 'LIMA ELANG CERDIK', 'penggalang_pa',
+   'KAFFA FAWWAZ AL TAMIS',
+   array['DIFFA NAFIZ AUFAR', 'AGUNG IKHWAN NAFIZ', 'TAUFAN ADZIM H. FAYYAZ', 'RAFFA ADYTIA NUGRAHA'],
+   '081320073291', null),
+  (46, 'MTs Mujahidin', 'LIMA MATAHARI HEBAT', 'penggalang_pi',
+   'REYSHA ALICE SALSABILA',
+   array['NAYLA WULAN GERHANA', 'TASYA AULIYA NISAUZZAKIYAH', 'IZDIHAR SERIYUSLI', 'FITRI KHOIRUNNISA'],
+   '081320073291', null),
+  (47, 'MTs Mujahidin', 'LIMA MATAHARI CANTIK', 'penggalang_pi',
+   'CLARESA PUTRI SITI KHOJANAH',
+   array['VERA NUR RAHAYU', 'DESWITA NADILA CANTIKA', 'AVISA TAZKIYATUN NISA', 'RAYA NURUL AKILA'],
+   '081320073291', null),
+  (48, 'SMAN 1 Sukadana', 'KECET KECET', 'penegak_pa',
+   'Azam Muhammad Zildan',
+   array['Eka Julian Pratama', 'Adi Febrian', 'Restu Agustian', 'Satria Daffa Yunansyah'],
+   '082318383182', null),
+  (49, 'SMAN 1 Panawangan', 'NEBULA', 'penegak_pi',
+   'anisa nur syamsyah',
+   array['Rahmawati Oktaviani', 'Sri Agustina', 'Amanda nafisa fitri', 'Laila nur fitriasari'],
+   '081312250007', null),
+  (50, 'MA Mujahidin', 'NARARA', 'penegak_pi',
+   'ATIA TUNNISA',
+   array['SRI ASIH', 'KEYLA AZZAHRA PEBRIANTI', 'VIDYA WARDATUL ''AINI', 'NADIA INDRIANI'],
+   '081323765964', null),
+  (51, 'MA Mujahidin', 'EX GARUDA', 'penegak_pa',
+   'AGUNG AKBAR SIDIK',
+   array['FAHRI FAIZ FARHANI', 'MUHAMMAD SAEFUL DAFA', 'IHSAN NASULLOH', 'NYCEP YUDISTIRA'],
+   '081211304457', null),
+  (52, 'MA Mujahidin', 'PIIT BONDOL', 'penegak_pa',
+   'MUHAMAD BAYU SETIAWAN',
+   array['SHEVA FAUJAN HILMI', 'RO''UP SOLEHUDIN', 'RAUHAN HERDIANSYAH', 'IMAM NURJAMIL'],
+   '081211304457', null),
+  (53, 'MA Mujahidin', 'SATWIKA', 'penegak_pi',
+   'DIAN SRI MULYANI',
+   array['AULIA SALSABILA', 'RISMA', 'PUTRI SITI ATIAH', 'SUCI AYU LESTARI'],
+   '081323765964', null),
+  (54, 'MTsN 1 Ciamis', 'SRIKANDI DENIM', 'penggalang_pi',
+   'ANNISA AMELIA QOLBI',
+   array['RAINA ALMUKHSANATUNNISA', 'ADILA MAULIDA SANUSI', 'SITI SILKA KUMALA', 'YANTI KUMALA'],
+   '088971832802', null),
+  (55, 'SMAN 1 Kawali', 'RANGGAYUNAN', 'penegak_pa',
+   'Rifki kosasih',
+   array['Al Firyal Azhar', 'Ari Afrizal Nuryana', 'Daffa Khaerul Iman', 'Lionel Alfon Nicola'],
+   '082119352827', null),
+  (56, 'SMAN 1 Kawali', 'CITRARESMI', 'penegak_pi',
+   'ADINDA SYAIMA RAIHANUNNISA',
+   array['SALSABILA SETIANI', 'ISTI AGUSTIN', 'NAZWA ASRIAH KUSNADI', 'HILDA NUR AISAH'],
+   '082119352827', null),
+  (57, 'SMAN 1 Kawali', 'DEWI UMMA', 'penegak_pi',
+   'AKILA LATIFA SYAWALIAH',
+   array['FRANSISCA INDRIYANI', 'NASYWA LAILATUL HUSNA', 'ADINDA RIZQYATUL MUBAROKAH', 'TINA AMELIA RAHMA'],
+   '082119352827', null),
+  (58, 'SMAN 1 Kawali', 'RATU DEWATA', 'penegak_pi',
+   'NUNIK NURSOBAH',
+   array['DEWI ANDINI', 'RAHMA ANGGI WIGUNA', 'NAJLA RAISYA TSABITAH', 'NABILA LATHIFATUNNISA'],
+   '082119352827', null),
+  (59, 'SMAN 1 Kawali', 'DEWI LARA', 'penegak_pi',
+   'IIS ISTIANAH',
+   array['ALLISTYA RAIYA RAMAWATI', 'HAIFA NUR FADILA', 'DZALFA FATIMATUL KAMILA', 'RAISYA CAMEELA EL MAHROM'],
+   '082119352827', null),
+  (60, 'SMAN 2 Ciamis', 'BANCET HEJO', 'penegak_pa',
+   'Asep Nugraha',
+   array['Fauzian Rizki Firdaus', 'Muhammad Rafli', 'Arif Rahman Firdaus', 'Damar Wulan Wijaya'],
+   '082262634124', 'Ibu Nurislah'),
+  (61, 'SMAN 2 Ciamis', 'REGU SERAYA', 'penegak_pi',
+   'Kirana Ramadani Putri',
+   array['Lisda Nurhidayah', 'Chelsea Kirana Maharani', 'Alya Haya Nafiisah', 'Maulida siti rundati'],
+   '082262634124', null),
+  (62, 'SMAN 1 Kawali', 'SINGACALA', 'penegak_pa',
+   'ADIT RADITYA',
+   array['RIZQY FEBRIAN ARRASYID', 'ANDIKA GEOPANO', 'PASHA MAULANA EL-HAQ', 'ZAMZAM MUBAROK UDHMA'],
+   '082119352827', null),
+  (63, 'SMA IT Nurul Huda', 'SERSANT', 'penegak_pa',
+   'ABDUL AZIZ RAMDANI',
+   array['WILDAN HILMIANSYAH', 'GILANG RAMADAN', 'YOSEP DARMAWAN', 'WILDAN MAULANA HILMANSYAH'],
+   '081312042034', null),
+  (64, 'MA Bahrul Anwar', 'JOKO TINGKIR', 'penegak_pa',
+   'AGNI M ABDU ROSID',
+   array['AHMAD JAELANI', 'EFILIAN ILHAM R', 'M RIZQI ZIYAD S', 'ARROFI SIHABUL M'],
+   '082319605067', null),
+  (65, 'MA Bahrul Anwar', 'LASKAR TANI', 'penegak_pa',
+   'YUDA KAMIL P',
+   array['M HUSNI MUBAROK', 'AHMAD FAUZI GIBRAN', 'IRFAN MAULIDI', 'FABBY NUR AKMAL J'],
+   '082319605067', null),
+  (66, 'MA Bahrul Anwar', 'ASTRA JINGGA', 'penegak_pa',
+   'AZMI ZAIDAN ZS',
+   array['AKBAR PURNAMA S', 'M ILHAM S', 'RANDHIKA M FAUZI', 'AHMAD HIDAYAT'],
+   '082319605067', null),
+  (67, 'MA Bahrul Anwar', 'ROJALI', 'penegak_pa',
+   'M ZAIDAN A',
+   array['ZIKRI MAULANA', 'ALDI ROSDIANSYAH', 'M AQIL ABDUL M', 'M RAVI NUR AZI'],
+   '082319605067', null),
+  (68, 'MA Bahrul Anwar', 'SEKAR WIDYA', 'penegak_pi',
+   'RINI FITRIANI',
+   array['ISNA KAMALIATUL M', 'ROSA RIKA N', 'ZASKIA CAHYA', 'AIRA FITRI YANI'],
+   '082319605067', null),
+  (69, 'MA Bahrul Anwar', 'CENDANA B', 'penegak_pi',
+   'IRNA INDAH HAYATI',
+   array['WITRI SALSA R', 'DINI WAHYUNI', 'ZIHAN HASYRI A', 'HUSNA CHOIRUN N'],
+   '082319605067', null),
+  (70, 'SMK As-Sulthoniah', 'MANGGALA', 'penegak_pi',
+   'Meylana Septiani',
+   array['Nuraeni', 'Mega Aulis', 'Keisha Rahmadina', 'Anit Anita Tiarawati'],
+   '081213097843', null),
+  (71, 'SMK As-Sulthoniah', 'TUTUT', 'penegak_pi',
+   'Asep Andi Maulana',
+   array['Deris Khoerusadiq', 'Ahmad Fahri Alfi Fauzan', 'Febriansyah Muharom', 'Fikri Nakhlak Rafi'],
+   '081213097843', null),
+  (72, 'SMPN 1 Cipaku', 'REGU MATAHARI B', 'penggalang_pi',
+   'Rifka Kayla azzahra',
+   array['Luthfia Nur maulida', 'Raisya nurfadilah', 'Layla Nur fathonah', 'Raeesa amanda putri'],
+   '085659503086', 'Puteri dewi ang gini'),
+  (73, 'SMK As-Sulthoniah', 'EDELWEIS', 'penegak_pi',
+   'Apwa Maupatul Pauzah',
+   array['Syarah Heryani', 'Shalwa Nurul Hidayah', 'Deasifa Damayanti', 'Mutiara Ardilah Nurfala'],
+   '081213097843', null),
+  (74, 'SMPN 1 Cipaku', 'GARUDA CIPAKU', 'penggalang_pa',
+   'Fathan Fadlika Maulidan',
+   array['Muhamad Adrian Putra Khoeruman', 'Muhammad Rafi Nurohmat', 'Fery Marwan Septian', 'Arfandi Khairul Adam'],
+   '085794019830', 'andre ramandra'),
+  (75, 'SMKN 2 Ciamis', 'CAKRA 1', 'penegak_pi',
+   'Syifa Khoerunisa',
+   array['Sifa Januarista', 'Agni Nurul Jannah', 'Nur Farjanah', 'Annisa Wulandari'],
+   '08112113126', 'Dewi Aryanti'),
+  (76, 'SMKN 1 Rancah', 'KIRANA', 'penegak_pi',
+   'RIKA NUR AYUNINGSIH',
+   array['AMELIA BUNGA SAFITRI', 'YENI NURA''ENI', 'YASMIN PUTRI KHUMAIRAH', 'RAHMAWATI'],
+   '085212553553', null),
+  (77, 'SMKN 1 Rancah', 'SURALAKSANA', 'penegak_pa',
+   'REYHAN ADHIRA FEBRIAN',
+   array['RIFKY RAMDANI', 'ADE ALI RIDZWAN', 'JAYA RAMDANI', 'IPNU OKTA SAPUTRA'],
+   '085321081547', null),
+  (78, 'MTs Bahrul Anwar', 'SYUDUDU', 'penggalang_pa',
+   'M FARHAN',
+   array['MAURIZ HUSNI M', 'AZMI ALIF HILMI', 'M IJAD BADRUJAMAN', 'ARVIN NUGRAHA'],
+   '082319605067', null),
+  (79, 'MTs Bahrul Anwar', 'PASUKAN SATRIA', 'penggalang_pa',
+   'ASEP MAULANA',
+   array['AGIS RIADI H', 'FAISAL ABDUL H', 'AZKA DARMAWAN', 'NAJA ZAINURROHMAN'],
+   '082319605067', null),
+  (80, 'MTs Bahrul Anwar', 'SCARLET', 'penggalang_pa',
+   'AZZAM FADL ABQORY',
+   array['HILMI NIZAR M', 'M YASIR AL-BANA', 'LU''LU ABDUL LATIF', 'DAES PADIL PRATAMA'],
+   '082319605067', null),
+  (81, 'SMKN 2 Ciamis', 'CAKRA 4', 'penegak_pi',
+   'Aira Nanda Heraldine',
+   array['Siska Aulia', 'Nova Nuraeni', 'Salsa Rahmawati', 'Lisna Setiawati'],
+   '08112113126', 'Dewi Ariyanti'),
+  (82, 'MTs Bahrul Anwar', 'KENANGA', 'penggalang_pi',
+   'EUIS SITI NURROHMAH',
+   array['SINTA SAMSIATU ROHMAH', 'RATIH QIBTYAH H', 'NISWAH KHOIROTUN H', 'NAZMI GILDA A'],
+   '082319605067', null),
+  (83, 'MTs Bahrul Anwar', 'TERATAI BAHRUL ANWAR', 'penggalang_pi',
+   'BALQIS LAELA S',
+   array['FATIMAH AZZAHRA', 'HANI LAELATUL H', 'AMELIA RAHMA N', 'ALMA ZAKIATUL F'],
+   '082319605067', null),
+  (84, 'SMAN 2 Ciamis', 'MENTARI STECU', 'penegak_pi',
+   'NABILA NURFELLIA',
+   array['AMIRAH HAIRANI SYARIEF', 'SILVI ANGGRAINI PUTRI', 'AIRA PUTRI AMARA', 'REGINA AULIA PUTRI'],
+   '082262634124', null),
+  (85, 'MA IPHI Pamarican', 'EL - FAQIH', 'penegak_pa',
+   'Naufal Ari Fahreza',
+   array['Ihsan Maulana', 'Rahmat Khoyrur Rizqi', 'Raihan Amdar Kanastren', 'Adelpi Rosadi'],
+   '081323643027', null),
+  (86, 'SMKN 2 Ciamis', 'AGRESI 1', 'penegak_pa',
+   'EQBAL FARIS AL-GHIFARI',
+   array['DENDA ERLANGGA', 'M.FAJAR MAULANA', 'ELVAN ARSYAVINE', 'M RIZALUL HAQ'],
+   '087884243026', null),
+  (87, 'SMKN 2 Ciamis', 'AGRESI 3', 'penegak_pa',
+   'RIFKI MUHAMMAD SYAMSI',
+   array['MUHAMAD MULQI HAJAZI', 'ARIS RIZKI FADILAH', 'FAZRIN FADRIYANSYAH', 'ANDIKA SYIFA NURROHMAN'],
+   '087884243026', null),
+  (88, 'SMAN 2 Ciamis', 'KECEBONG', 'penegak_pi',
+   'Lisna nurinayah',
+   array['Almira firdiani cahya', 'Annabella Raina syaban', 'Dara safittri Azzahra', 'Raisya setya'],
+   '082262634124', 'Nurislah'),
+  (89, 'SMKN 1 Banjar', 'SATRIA CAKRAWALA', 'penegak_pa',
+   'SEPTIAN ABDURAHMAN',
+   array['DAVA AZIZ NURRAHMAN', 'MOHAMAD FACHRY SEPTIAN RAMDANI', 'DANDI JULIANA NUGRAHA', 'ERIX PRASETYO NUGRAHA'],
+   '082320615528', null),
+  (90, 'SMKN 1 Banjar', 'PUTRI KANJEUNG', 'penegak_pi',
+   'YUDITH DWI ARYANI',
+   array['PUPUT MELATI AMELINA', 'ZAHRATU SIPA', 'DINDA AULIA', 'TIARA OKTAVIANI'],
+   '082320615528', null),
+  (91, 'SMKN 1 Banjar', 'CAKRA DYNATA', 'penegak_pa',
+   'DHINAR DHIYAAUL HAQ',
+   array['RAYHAN AKBAR ENDRIANSYAH', 'IKHSAN SURYA NUGRAHA', 'MUHAMMAD AZRIL GINANJAR', 'REHAN NUR''ALAMSYAH'],
+   '082320615528', null),
+  (92, 'SMKN 2 Ciamis', 'CAKRA 2', 'penegak_pi',
+   'Silfa Aima',
+   array['Zulfa Fauziah', 'Syifa Apriliani Padila', 'Asila', 'Wulan Nurfadila'],
+   '08112113126', 'Dewy Ariyanti'),
+  (93, 'SMKN 1 Banjar', 'ROYAL RANGERS', 'penegak_pi',
+   'DIAH AYU LESTARI',
+   array['NOVI YULIANI', 'ELA SETIAWATI', 'AIRIN ASY SYIFA', 'ALFIANA NUR MAHMUDAH'],
+   '082320615528', null),
+  (94, 'SMAN 2 Ciamis', 'WIRA KENCANA', 'penegak_pa',
+   'Rafka Aditia Dariyat',
+   array['Risqy Azhar Fadhilah', 'Sazki Syifaur Rohim', 'Zahran Izyan Ahmad Luthfii', 'Moch Rafa Fadillah'],
+   '081222948065', null),
+  (95, 'SMAN 2 Ciamis', 'PABUDU', 'penegak_pi',
+   'Dewi Sri Juliya',
+   array['Ita Nursipa Hidayati', 'Keysha Fiarrayyan Rahmadani', 'Tuti Aiynul Hamdiyah', 'Aurel Putri Andani'],
+   '082262634124', null),
+  (96, 'SMKN 2 Ciamis', 'AGRESI 2', 'penegak_pa',
+   'ANDRA ALTAVIAN',
+   array['ZAKI MUBAROK', 'M.HUSNI PUTRA PRATAMA', 'RIZKY FADIEL MAULANA', 'AZMI NAILFAHD'],
+   '087884243026', null),
+  (97, 'SMAN 2 Ciamis', 'PURBALINGGA', 'penegak_pa',
+   'Rikza Haikal Ainursyam',
+   array['Rizki Rauffaturohman', 'Arif Farhan Nulhakim', 'Ahmad Hidayat Nurul Akbar', 'Lintang Faishal Alfikri'],
+   '081222948065', null),
+  (98, 'SMAN 1 Cihaurbeuti', 'LAKSAMANA MALA HAYATI', 'penegak_pi',
+   'Sry Fanny Agustin',
+   array['Nayla Salsabila', 'Alifia Tiara Sakhi', 'Heisya Putri Juani', 'Dilla Azzahra'],
+   '085246366971', 'Kak Nina'),
+  (99, 'SMAN 1 Cihaurbeuti', 'PRABU SILIWANGI', 'penegak_pa',
+   'Fathir Hasya Al khalifi',
+   array['Syafiq Muhammad Fauzi', 'Yandi Muhammad Hamzah', 'Sandi nur Aziz', 'Muhammad Syauqi Ebany Alzam'],
+   '085246366971', 'Kak Nina'),
+  (100, 'SMAN 3 Ciamis', 'WONDAMA', 'penegak_pa',
+   'Hasbi aviona',
+   array['Dafin adilla putra perdana', 'Ilham maulana', 'Marshya tri maulana', 'Septian Alam Ramadhan'],
+   '082317958637', null),
+  (101, 'SMPN 3 Baregbeg', 'ELANG HITAM', 'penggalang_pa',
+   'MUHAMMAD IQBAL AL FIKRI',
+   array['SANDI KHOERURRIZKI AMMRULLAH', 'IQBAL KHARISMA JULIANA', 'WILDAN MUHAMMAD MUHTAR', 'DANI PERMANA'],
+   '081224915746', null);
+
+-- ---------------------------------------------------------------------------
+-- Sekolah yang belum ada dibuat di sini. Pencariannya lewat kunci_sekolah()
+-- supaya ejaan yang beda tanda baca mendarat di baris yang sama, dan alamat
+-- yang sudah ada TIDAK ditimpa (runbook bagian 12.1).
+-- ---------------------------------------------------------------------------
+create temporary table impor_sekolah (nama text primary key, alamat text not null);
+
+insert into impor_sekolah (nama, alamat) values
+  ('MA Bahrul Anwar', ''),
+  ('MA IPHI Pamarican', ''),
+  ('MA Mujahidin', ''),
+  ('MA Sirnarasa', ''),
+  ('MTs Al-Hasan Banjarsari', ''),
+  ('MTs Bahrul Anwar', ''),
+  ('MTs Mujahidin', ''),
+  ('MTsN 1 Ciamis', ''),
+  ('SMA IT Nurul Huda', ''),
+  ('SMAN 1 Baregbeg', ''),
+  ('SMAN 1 Cihaurbeuti', ''),
+  ('SMAN 1 Kawali', ''),
+  ('SMAN 1 Panawangan', ''),
+  ('SMAN 1 Sukadana', ''),
+  ('SMAN 2 Ciamis', ''),
+  ('SMAN 3 Ciamis', ''),
+  ('SMK As-Sulthoniah', 'Dusun Desa RT 014/007, Jalatrang, Kec. Cipaku, Kab. Ciamis, Jawa Barat'),
+  ('SMKN 1 Banjar', ''),
+  ('SMKN 1 Rancah', ''),
+  ('SMKN 2 Ciamis', ''),
+  ('SMPN 1 Ciamis', ''),
+  ('SMPN 1 Cikoneng', ''),
+  ('SMPN 1 Cimaragas', ''),
+  ('SMPN 1 Cipaku', ''),
+  ('SMPN 1 Kawali', ''),
+  ('SMPN 2 Kawali', ''),
+  ('SMPN 3 Baregbeg', ''),
+  ('SMPN 3 Kawali', '');
+
+do $blok$
+declare
+  v_s   record;
+  v_ada uuid;
+  v_n   integer := 0;
+begin
+  for v_s in select * from impor_sekolah order by nama loop
+    select id into v_ada from sekolah
+     where kunci_sekolah(name) = kunci_sekolah(v_s.nama);
+    if v_ada is null then
+      insert into sekolah (name, address) values (v_s.nama, v_s.alamat);
+      v_n := v_n + 1;
+      raise notice '0129: sekolah baru - % <%>', v_s.nama, v_s.alamat;
+    end if;
+  end loop;
+  raise notice '0129: % sekolah baru dibuat.', v_n;
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- Satu pendaftaran per baris form, beserta regunya.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_f     record;
+  v_batch uuid;
+  v_kode  text;
+  v_sek   uuid;
+  v_kunci uuid;
+  v_baru  integer := 0;
+  v_lewat integer := 0;
+begin
+  for v_f in select * from impor_form order by baris loop
+    v_kunci := md5('hrcd-xxxvii-form-' || v_f.baris)::uuid;
+
+    if exists (select 1 from pendaftaran where kunci_kirim = v_kunci) then
+      v_lewat := v_lewat + 1;
+      continue;
+    end if;
+
+    select id into v_sek from sekolah
+     where kunci_sekolah(name) = kunci_sekolah(v_f.sekolah);
+    if v_sek is null then
+      raise exception '0129: sekolah % tidak ketemu setelah dibuat', v_f.sekolah;
+    end if;
+
+    loop
+      v_kode := 'HRCD' || edisi_aktif() || '-' ||
+                upper(substr(md5(gen_random_uuid()::text), 1, 6));
+      exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+    end loop;
+
+    insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                             jumlah_menginap, jumlah_regu, kontak_wa,
+                             kunci_kirim, nama_kontak)
+    values (v_sek, v_kode, false, 0, 1, v_f.kontak_wa, v_kunci, v_f.nama_kontak)
+    returning id into v_batch;
+
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota)
+    values (v_batch, v_f.nama_regu, v_f.nama_ketua, v_f.golongan,
+            nullif(v_f.anggota, '{}'));
+
+    v_baru := v_baru + 1;
+  end loop;
+
+  raise notice '0129: % pendaftaran dibuat, % dilewati karena sudah ada.',
+    v_baru, v_lewat;
+end;
+$blok$;
+
+-- ---------------------------------------------------------------------------
+-- Pagar: yang dihitung bukan "migrasi berjalan" melainkan seratus baris form
+-- itu benar-benar punya regunya di database. Menjalankan ulang harus
+-- menghasilkan angka yang sama persis.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_n integer;
+begin
+  select count(*) into v_n
+  from impor_form f
+  join pendaftaran d on d.kunci_kirim = md5('hrcd-xxxvii-form-' || f.baris)::uuid
+  join regu r on r.pendaftaran_id = d.id
+  where r.nama_regu = f.nama_regu and r.golongan = f.golongan;
+
+  if v_n <> (select count(*) from impor_form) then
+    raise exception '0129: % dari % baris form tidak punya regu yang cocok',
+      (select count(*) from impor_form) - v_n, (select count(*) from impor_form);
+  end if;
+  raise notice '0129: % baris form terpasang lengkap.', v_n;
+end;
+$blok$;
+
+drop table impor_form;
+drop table impor_sekolah;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -598,4 +598,11 @@ run tests/sql/55_cleanup_preserves_schools.sql
 run supabase/migrations/0127_nama_regu_dua_puluh_lima.sql
 run tests/sql/86_nama_regu_dua_puluh_lima.sql
 
+# 0128 membuka angka di nama regu, tapi HANYA sebagai ekor: enam regu SMKN 2
+# Ciamis mendaftar sebagai CAKRA 1..4 dan AGRESI 1..3. Tes 22 di atas tetap
+# menguji larangan lama di tempatnya sendiri; tes 87 menguji aturan barunya,
+# termasuk bahwa nomor WA yang nyasar ke kotak nama masih ditolak.
+run supabase/migrations/0128_nama_regu_angka_di_belakang.sql
+run tests/sql/87_nama_regu_angka_di_belakang.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -605,4 +605,12 @@ run tests/sql/86_nama_regu_dua_puluh_lima.sql
 run supabase/migrations/0128_nama_regu_angka_di_belakang.sql
 run tests/sql/87_nama_regu_angka_di_belakang.sql
 
+# 0129 memasukkan 100 regu dari jawaban Google Form. Ditaruh PALING AKHIR, di
+# belakang 55, karena ia satu-satunya migrasi yang membawa data operasional:
+# di tengah daftar, seratus pendaftaran itu ikut terbaca tes-tes sesudahnya
+# yang menghitung baris. Yang dibuktikan di sini cuma bahwa migrasinya jalan
+# bersih di atas skema yang sudah lengkap — pagar di dalamnya sendiri yang
+# menghitung apakah keseratus barisnya benar-benar terpasang.
+run supabase/migrations/0129_impor_pendaftaran_xxxvii.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -591,4 +591,11 @@ run supabase/checks/live_json.sql
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.
 run tests/sql/55_cleanup_preserves_schools.sql
 
+# 0127 menaikkan batas nama regu 20 -> 25 karakter, karena tiga regu XXXVII
+# mendaftar lewat Google Form dengan nama yang melewatinya. Tes 21 di atas
+# sengaja DIBIARKAN menguji batas 20: ia berjalan sebelum migrasi ini, dan
+# itulah yang benar pada titik itu. Tes 86 menguji batas barunya.
+run supabase/migrations/0127_nama_regu_dua_puluh_lima.sql
+run tests/sql/86_nama_regu_dua_puluh_lima.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/sql/86_nama_regu_dua_puluh_lima.sql
+++ b/tests/sql/86_nama_regu_dua_puluh_lima.sql
@@ -1,0 +1,65 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/86_nama_regu_dua_puluh_lima.sql
+--
+-- Batas atas nama regu 25 karakter (0127). Tes 21 menguji batas LAMA di
+-- tempatnya sendiri — ia berjalan sebelum 0127 dan memang harus tetap
+-- menolak 21 karakter di sana, karena itulah yang benar pada saat itu.
+--
+-- Yang diuji di sini tiga hal, dan yang ketiga yang paling mudah lupa:
+--   86.1  25 karakter DITERIMA
+--   86.2  26 karakter DITOLAK
+--   86.3  batas bawah tiga huruf (0120) masih berlaku
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into sekolah (name, address) values ('SMPN Uji 86', 'Ciamis');
+insert into pendaftaran (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa)
+select id, 'HRCD37-T86001', 1, '081200000086' from sekolah where name = 'SMPN Uji 86';
+
+-- 86.1  Tepat 25 karakter diterima.
+insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+select id, 'ABCDEFGHIJ KLMNO PQRSTUV', 'Uji Ketua', 'penggalang_pa'
+from pendaftaran where kode_pembayaran = 'HRCD37-T86001';
+
+do $blok$
+begin
+  if not exists (select 1 from regu
+                 where nama_regu = 'ABCDEFGHIJ KLMNO PQRSTUV') then
+    raise exception '86.1 GAGAL: nama 25 karakter tidak tersimpan';
+  end if;
+  raise notice '86.1 LULUS: nama 25 karakter diterima.';
+end;
+$blok$;
+
+-- 86.2  Dua puluh enam karakter ditolak.
+do $blok$
+begin
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    select id, 'ABCDEFGHIJ KLMNO PQRSTUVWX', 'Uji Ketua', 'penggalang_pi'
+    from pendaftaran where kode_pembayaran = 'HRCD37-T86001';
+    raise exception '86.2 GAGAL: nama 26 karakter diterima';
+  exception when check_violation then
+    raise notice '86.2 LULUS: nama 26 karakter ditolak.';
+  end;
+end;
+$blok$;
+
+-- 86.3  Batas bawah 0120 tidak ikut longgar.
+do $blok$
+begin
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    select id, 'A B', 'Uji Ketua', 'penegak_pa'
+    from pendaftaran where kode_pembayaran = 'HRCD37-T86001';
+    raise exception '86.3 GAGAL: nama dua huruf diterima';
+  exception when check_violation then
+    raise notice '86.3 LULUS: batas bawah tiga huruf masih berlaku.';
+  end;
+end;
+$blok$;
+
+rollback;

--- a/tests/sql/87_nama_regu_angka_di_belakang.sql
+++ b/tests/sql/87_nama_regu_angka_di_belakang.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/87_nama_regu_angka_di_belakang.sql
+--
+-- Angka di nama regu boleh, tapi hanya di belakang (0128).
+--
+-- Tes 22 menguji larangan LAMA di tempatnya sendiri, sebelum migrasi ini, dan
+-- memang harus tetap menolak "REGU 1" di sana.
+--
+--   87.1  "CAKRA 1" diterima          -- yang dibuka
+--   87.2  "08477484" ditolak          -- nomor WA nyasar, yang tetap dijaga
+--   87.3  "SMA 2 CIAMIS" ditolak      -- angka di tengah
+--   87.4  nama KETUA berangka tetap ditolak -- pelonggaran tidak menular
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into sekolah (name, address) values ('SMKN Uji 87', 'Ciamis');
+insert into pendaftaran (sekolah_id, kode_pembayaran, jumlah_regu, kontak_wa)
+select id, 'HRCD37-T87001', 1, '081200000087' from sekolah where name = 'SMKN Uji 87';
+
+-- 87.1  Angka sebagai ekor diterima.
+insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+select id, 'CAKRA 1', 'Uji Ketua', 'penegak_pi'
+from pendaftaran where kode_pembayaran = 'HRCD37-T87001';
+
+do $blok$
+begin
+  if not exists (select 1 from regu where nama_regu = 'CAKRA 1') then
+    raise exception '87.1 GAGAL: "CAKRA 1" tidak tersimpan';
+  end if;
+  raise notice '87.1 LULUS: angka sebagai ekor diterima.';
+end;
+$blok$;
+
+-- 87.2  Nomor yang nyasar ke kotak nama tetap ditolak. Yang menangkapnya bisa
+--       check ini ATAU batas tiga huruf (0120) — keduanya benar, dan tes ini
+--       sengaja tidak memilih salah satunya: yang diuji bahwa ia TIDAK MASUK.
+do $blok$
+begin
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    select id, '08477484', 'Uji Ketua', 'penegak_pa'
+    from pendaftaran where kode_pembayaran = 'HRCD37-T87001';
+    raise exception '87.2 GAGAL: nama yang seluruhnya angka diterima';
+  exception when check_violation then
+    raise notice '87.2 LULUS: nomor yang nyasar ke kotak nama ditolak.';
+  end;
+end;
+$blok$;
+
+-- 87.3  Angka di TENGAH ditolak.
+do $blok$
+begin
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    select id, 'SMA 2 CIAMIS', 'Uji Ketua', 'penggalang_pa'
+    from pendaftaran where kode_pembayaran = 'HRCD37-T87001';
+    raise exception '87.3 GAGAL: angka di tengah nama diterima';
+  exception when check_violation then
+    raise notice '87.3 LULUS: angka di tengah nama ditolak.';
+  end;
+end;
+$blok$;
+
+-- 87.4  Nama ORANG tetap menolak angka apa pun — termasuk di belakang.
+do $blok$
+begin
+  begin
+    insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
+    select id, 'ELANG SENJA', 'Uji Ketua 2', 'penggalang_pi'
+    from pendaftaran where kode_pembayaran = 'HRCD37-T87001';
+    raise exception '87.4 GAGAL: nama ketua berangka diterima';
+  exception when check_violation then
+    raise notice '87.4 LULUS: nama ketua berangka tetap ditolak.';
+  end;
+end;
+$blok$;
+
+rollback;

--- a/tools/periksa_sekolah.py
+++ b/tools/periksa_sekolah.py
@@ -77,6 +77,14 @@ BUKAN_JALAN = re.compile(r'\b(Kecamatan|Kec)\b\.?', re.I)
 AWALAN_SALAH = re.compile(r'^(Desa|Kelurahan|Kel)\b\.?', re.I)
 
 
+# Judul bagian E di docs/sekolah-belum-tuntas.md. Pemeriksaan 7 berhenti di
+# sini: yang di bawahnya sekolah yang alamatnya belum dicari sama sekali,
+# bukan daftar kerja atas sekolah_alamat.json. Ditulis sebagai konstanta
+# supaya judul yang berganti gagal keras, bukan diam-diam melebarkan cakupan
+# pemeriksaan sampai melaporkan tiga belas sekolah sebagai pelanggar.
+BAGIAN_XXXVII = "## E. Sekolah baru dari pendaftaran XXXVII"
+
+
 def muat(nama):
     berkas = AKAR / "tools" / "data" / nama
     if not berkas.exists():
@@ -154,8 +162,23 @@ def main():
     if not doc.exists():
         salah.append("docs/sekolah-belum-tuntas.md tidak ada")
     else:
+        isi = doc.read_text(encoding="utf-8")
+        # Yang dibandingkan HANYA bagian A-D. Bagian E daftar yang lain sama
+        # sekali: sekolah yang masuk lewat pendaftaran XXXVII dan alamatnya
+        # BELUM DICARI, jadi ia memang tidak punya baris di sekolah_alamat.json
+        # dan tidak boleh dituntut punya. Tanpa potongan ini pemeriksaan
+        # melaporkan ketiga belasnya sebagai "sudah tinggi tapi masih
+        # terdaftar" — lapor palsu, dan pemeriksa yang lapor palsu berhenti
+        # dipercaya.
+        batas = isi.find(BAGIAN_XXXVII)
+        if batas == -1:
+            salah.append(
+                f"docs/sekolah-belum-tuntas.md: judul {BAGIAN_XXXVII!r} hilang — "
+                "periksa apakah bagiannya diganti nama atau dihapus")
+        else:
+            isi = isi[:batas]
         # Tiap baris tabel berbentuk: | **Nama Sekolah** | ...
-        didaftar = set(re.findall(r'^\| \*\*(.+?)\*\* \|', doc.read_text(encoding="utf-8"), re.M))
+        didaftar = set(re.findall(r'^\| \*\*(.+?)\*\* \|', isi, re.M))
         belum = {a["nama"] for a in alamat if a.get("keyakinan") != "tinggi"}
         for n in sorted(belum - didaftar):
             salah.append(f"{n}: keyakinan belum 'tinggi' tapi tidak ada di docs/sekolah-belum-tuntas.md")

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -127,7 +127,7 @@ export function pesanRamah(m) {
   if (/regu_nama_unik|duplicate key value violates unique constraint "regu_nama/i.test(t))
     return "Nama regu itu sudah dipakai regu lain. Pilih nama yang berbeda.";
   if (/regu_nama_panjang/i.test(t))
-    return "Nama regu paling panjang 20 karakter.";
+    return "Nama regu paling panjang 25 karakter.";
   if (/nama_regu_tanpa_angka/i.test(t))
     return "Nama regu tidak boleh memakai angka.";
   if (/nama_ketua_tanpa_angka/i.test(t))

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -128,6 +128,8 @@ export function pesanRamah(m) {
     return "Nama regu itu sudah dipakai regu lain. Pilih nama yang berbeda.";
   if (/regu_nama_panjang/i.test(t))
     return "Nama regu paling panjang 25 karakter.";
+  if (/nama_regu_angka_di_belakang/i.test(t))
+    return "Angka di nama regu hanya boleh di belakang, misal: Cakra 1.";
   if (/nama_regu_tanpa_angka/i.test(t))
     return "Nama regu tidak boleh memakai angka.";
   if (/nama_ketua_tanpa_angka/i.test(t))

--- a/web/style.css
+++ b/web/style.css
@@ -1405,8 +1405,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dan kolom penilaian menerima apa pun yang tersisa — pada Pos 5 itu
      menyisakan 16mm untuk judul "KREATIVITAS", yang tumpah keluar kertas.
 
-     Nama regu 44mm karena 0051 membatasinya 20 karakter, dan 20 kapital 10pt
-     memang selebar itu. Organisasi diberi lebar yang sama dan dipotong
+     Nama regu 44mm, dan angka itu SUDAH di bawah nama terpanjang yang
+     database terima — 25 karakter sejak 0127, ~57mm pada 10pt kapital.
+     Memotong adalah pilihan, bukan kelalaian: yang dibeli dengan milimeter
+     itu kotak penilaian, dan baris tetap dikenali dari nomor dada di kolom
+     pertama. Organisasi diberi lebar yang sama dan dipotong
      elipsis di situ: nama sekolah bisa sepanjang apa pun, dan lembar ini
      dibaca untuk MENCOCOKKAN baris, bukan untuk membaca nama sekolah utuh —
      nomor dada di kolom pertama yang jadi kuncinya.


### PR DESCRIPTION
## What

Memasukkan 100 regu yang mendaftar lewat Google Form HRCD XXXVII ke
`pendaftaran` dan `regu`, beserta dua pelonggaran pagar nama regu yang
datanya tuntut.

Tiga migrasi, berurutan dan tidak boleh ditukar:

| Migrasi | Isi |
| --- | --- |
| `0127` | batas panjang nama regu 20 → 25 karakter |
| `0128` | angka boleh di nama regu, tapi hanya sebagai EKOR |
| `0129` | impor 100 pendaftaran + 13 sekolah baru |

**Bentuk datanya.** Satu baris form = satu `pendaftaran` berisi satu regu
dengan kode pembayarannya sendiri. Anggota 1 → `nama_ketua`, anggota 2–5 →
`regu.anggota`. Tingkatan + Jenis Kelamin → `golongan` (29 penegak pa,
31 penegak pi, 18 penggalang pa, 22 penggalang pi). Nomor dada dan kloter
tetap NULL — keduanya lahir di `daftar_ulang_batch`.

**Semuanya `menunggu_pembayaran`**, dan gambar (bukti transfer, formulir,
surat tugas) belum dipindahkan dari Google Drive — menyusul.

**28 sekolah dari 44 tulisan berbeda.** 13 di antaranya baru dan lahir dengan
alamat kosong; daftar kerjanya di `docs/sekolah-belum-tuntas.md` bagian E.

## Why

Datanya dikumpulkan lewat Google Form, yang tidak tahu satu pun pagar kita.
Sebelas regu melanggar salah satunya, dan namanya sudah beredar di sekolahnya
sebelum sistem ini melihatnya:

- **Tiga nama > 20 karakter.** Angka 20 diturunkan 0051 dari kolom blangko pos
  48mm. Kolom itu sejak itu dipersempit jadi **44mm** atas keputusan panitia —
  sudah di bawah kebutuhan nama 20 karakter, dan memotong dengan elipsis hari
  ini. Yang dijaga 20 sudah tidak dijaga oleh 20. Lebar kolomnya sengaja tidak
  ikut berubah: melebarkannya mengambil milimeter dari kotak penilaian.
- **Enam nama berangka** — CAKRA 1/2/4 dan AGRESI 1/2/3, enam regu SMKN 2
  Ciamis. 0052 melarang angka karena dua hal; yang dijaga (nomor WA nyasar ke
  kotak nama) tetap, yang dilepas (regu dinomori sendiri) diputuskan pemilik
  acara.
- **Dua nama kembar** — GARUDA dan TERATAI. Yang mendaftar lebih dulu berhak
  atas namanya, persis seperti `nama_regu_dipakai()` memblokir yang belakangan
  sambil diketik. Yang belakangan diberi ekor sekolah: GARUDA CIPAKU,
  TERATAI BAHRUL ANWAR.

## Notes

- **`0129` bisa dijalankan ulang.** Tiap baris membawa `kunci_kirim` dari nomor
  barisnya di spreadsheet; jalan kedua kalinya melaporkan "0 dibuat, 100
  dilewati". Kode pembayarannya tetap diundi, jadi kode yang sudah beredar
  tidak mungkin tertimpa.
- **Sepuluh regu tanpa nomor pembina** — MTs Al-Hasan Banjarsari (4),
  SMPN 3 Kawali (5), SMPN 2 Kawali (1). `kontak_wa` diisi penanda
  `belum ada`. Nomornya perlu dikejar.
- **Dua pembina perlu diberi tahu** bahwa nama regunya berubah: SMPN 1 Cipaku
  (GARUDA → GARUDA CIPAKU) dan MTs Bahrul Anwar (TERATAI → TERATAI BAHRUL
  ANWAR).
- **`Jalatrang` bukan sekolah** melainkan desa — tiga regu menulis nama
  sekolahnya di kolom Gugus Depan. Sekolahnya SMK As-Sulthoniah, alamat
  lengkapnya dari pemilik acara.
- **Pemeriksaan 7 `tools/periksa_sekolah.py` dipersempit ke bagian A–D** dari
  `sekolah-belum-tuntas.md`. Bagian E daftar yang lain: sekolah yang alamatnya
  belum dicari sama sekali, jadi ia memang tidak punya baris di
  `sekolah_alamat.json` dan tidak boleh dituntut punya.
- **`docs/final-architecture.md` disegarkan penomorannya saja** ke `0129`.
  Dokumen itu sudah tertinggal di `0118` sebelum PR ini; isinya belum dibaca
  ulang terhadap `0119`–`0129`.
- **Satu tes JS gagal dan itu sudah gagal di `main`**:
  `registration_resend_notice` — soal `esc(hasil.jumlah_regu)` di `sukses()`,
  tidak bersinggungan dengan PR ini.

## Dijalankan lokal

```
bash tests/run.sh                 -> SEMUA TES LULUS (0129: 100 baris form terpasang lengkap)
node --test tests/*.test.mjs      -> 209 pass, 1 fail (yang sudah gagal di main)
python tools/periksa_impor.py     -> lulus
python tools/periksa_sekolah.py   -> lulus
diff web/{style.css,js/api.js} live/  -> identik
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqPv85zq4q2mS3ekPycExN