### PR TITLE
feat: nota transfer ikut tampil di baris yang sudah lunas

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -943,9 +943,36 @@ async function layarPembayaran() {
         // jadi dua baris. gap .25rem saja sudah muat (122px), tetapi cuma
         // bersisa 1px; dengan teks metode .9em ia jadi 117px dan punya jarak
         // yang tidak habis oleh satu huruf yang lebih lebar di HP lain.
-        ? html`<span class="metode-baris" style="flex-wrap:nowrap;gap:.25rem"
-               ><span style="font-size:.9em">${b.pembayaran ? b.pembayaran.method : "—"}</span
-               ><span class="badge badge-green">LUNAS</span></span>`
+        // Nota transfernya IKUT TAMPIL sesudah lunas, bukan hilang bersama
+        // dropdown-nya. Sesudah uang masuk barulah ia paling sering dicari:
+        // saat menyusun berkas pertanggungjawaban, dan saat satu setoran
+        // dipertanyakan — dan sampai sekarang satu-satunya cara melihatnya
+        // lagi adalah membatalkan pelunasan, yang mengubah data demi melihat
+        // data.
+        //
+        // Lencana, BUKAN .button-mini seperti di baris belum lunas. Kolom
+        // Metode cuma 15% — 123px pada lantai 820px — dan pasangan
+        // "Transfer" + LUNAS sudah memakai 117px di antaranya. Tombol biasa
+        // menuntut lebar kolomnya sendiri; lencana ikut arus.
+        //
+        // Dan `flex-wrap` dilepas HANYA ketika notanya ada. Nowrap itu hasil
+        // pengukuran lama untuk dua elemen; dengan elemen ketiga ia bukan
+        // lagi menjaga apa-apa melainkan memaksa tiga benda berdesakan di
+        // 123px. Yang dikembalikan cuma perilaku bawaan .metode-baris —
+        // membungkus kalau sempit, sebaris kalau lapang — dan baris tanpa
+        // nota tidak berubah sedikit pun.
+        //
+        // Template biasa, BUKAN tag html``. Alasannya sama dengan cabang di
+        // bawah: ikon sudah berupa HTML, dan html`` meng-escape setiap nilai
+        // yang disisipkan — tombolnya akan TERCETAK sebagai teks.
+        ? `<span class="metode-baris" style="gap:.25rem${b.bukti_transfer ? "" : ";flex-wrap:nowrap"}"
+           ><span style="font-size:.9em">${esc(b.pembayaran ? b.pembayaran.method : "—")}</span
+           ><span class="badge badge-green">LUNAS</span>${b.bukti_transfer
+            ? `<button class="badge badge-tombol" type="button"
+                       data-bukti="${esc(b.bukti_transfer)}"
+                       title="Nota pembayaran"
+                       aria-label="Nota pembayaran">${ikon("file-text")}</button>`
+            : ""}</span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`
           // Yang terpilih lebih dulu adalah cara bayar yang DIPILIH PEMBINA saat
@@ -956,11 +983,19 @@ async function layarPembayaran() {
           // Template biasa, BUKAN tag html`` — tombol Bukti sudah berupa HTML dan
           // html`` meng-escape setiap nilai yang disisipkan, jadi tombolnya
           // sempat TERCETAK sebagai teks di layar Pembayaran.
-          // nowrap DI SINI saja, bukan di kelasnya: pasangan LUNAS di atas memang
-          // perlu menumpuk sendiri di kolom sempit. Di sini yang berdampingan
-          // cuma dropdown dan satu ikon, dan tombol yang jatuh ke baris
-          // berikutnya membuat kartunya setinggi dua baris tanpa alasan.
-          : `<span class="metode-baris" style="flex-wrap:nowrap"
+          // nowrap HANYA kalau tidak ada tombol bukti. Di kartu HP kolomnya
+          // lapang (284px ke atas) jadi nowrap tidak pernah terpakai di sana —
+          // ia cuma berlaku di rentang tabel `fixed`, tempat kolom Metode
+          // selebar 131-152px. Di situ dropdown 128px + tombol 36px = 170px,
+          // dan dengan nowrap tombolnya menonjol 38px KELUAR kolom, menimpa
+          // "Tandai Lunas" di sebelahnya. DIUKUR di browser (pasal 15.9-15.10),
+          // bukan dibaca.
+          //
+          // Meluapnya baru terlihat sejak 0130 mengisi bukti untuk keseratus
+          // pendaftaran XXXVII: sebelumnya hampir tidak ada baris yang punya
+          // bukti, jadi tombolnya nyaris tidak pernah tergambar dan aturan
+          // nowrap-nya tidak pernah diuji oleh data sungguhan.
+          : `<span class="metode-baris" style="${b.bukti_transfer ? "" : "flex-wrap:nowrap"}"
              ><select class="select-small" data-metode="${esc(b.kode_pembayaran)}">
                 <option value="tunai" ${b.metode_bayar === "transfer" ? "" : "selected"}>Tunai</option>
                 <option value="transfer" ${b.metode_bayar === "transfer" ? "selected" : ""}>Transfer</option>


### PR DESCRIPTION
## What

Tombol **nota pembayaran** kini ikut tampil di baris yang sudah **LUNAS**, tidak
lagi hilang bersama dropdown cara bayarnya. Di baris lunas ia digambar sebagai
lencana kecil di sebelah badge LUNAS; diketuk, ia membuka nota transfernya —
sekarang link Drive (`0130`), nanti berkas di Storage tanpa perlu diubah lagi.

Sekalian memperbaiki **satu cacat tampilan** yang ketahuan saat mengukur.

## Why

Sesudah uang masuk barulah notanya paling sering dicari: saat menyusun berkas
pertanggungjawaban, dan saat satu setoran dipertanyakan. Sampai sekarang
satu-satunya cara melihatnya lagi adalah **membatalkan pelunasan** — mengubah
data demi melihat data.

**Lencana, bukan `.button-mini`.** Kolom Metode cuma 15%, dan pasangan
"Transfer" + LUNAS sudah memakai 117px dari 123px yang tersedia. Lencana ikut
arus; tombol menuntut lebar kolomnya sendiri.

### Cacat yang ikut ketahuan

Baris **belum lunas** yang punya bukti **meluap 38px keluar kolom Metode dan
menimpa "Tandai Lunas"** di sebelahnya — dropdown 128px + tombol 36px = 170px
dipaksa sebaris oleh `flex-wrap:nowrap` di kolom selebar 140px.

Itu bukan cacat baru, tapi **baru terlihat sejak `0130`** mengisi bukti untuk
keseratus pendaftaran XXXVII: sebelumnya hampir tidak ada baris yang punya
bukti, jadi tombolnya nyaris tidak pernah tergambar dan aturan `nowrap`-nya
tidak pernah diuji data sungguhan.

Kedua cabang kini melepas `nowrap` **hanya ketika tombolnya ada**, jadi keduanya
kembali ke perilaku bawaan `.metode-baris` — membungkus kalau sempit, sebaris
kalau lapang. **Baris tanpa nota tidak berubah sedikit pun**, jadi pengukuran
lama untuk dua elemen tetap berlaku di sana.

## Notes

- Handler-nya tidak perlu ditambah: `tbody.querySelectorAll("[data-bukti]")`
  sudah mengikat semua tombol bernama itu, termasuk yang baru.
- Cabang lunas berpindah dari tag `` html`` `` ke template biasa dengan `esc()`
  eksplisit — sama seperti cabang di bawahnya, dan alasannya sama: ikon sudah
  berupa HTML, dan `` html`` `` akan meng-escape-nya jadi teks yang TERCETAK di
  layar.
- Satu tes JS gagal dan **sudah gagal sebelum rangkaian PR ini**:
  `registration_resend_notice`.

## Diukur, bukan dibaca (pasal 15.9–15.10)

Halaman contoh berisi markup sungguhan + `style.css` sungguhan, dimuat di dalam
iframe yang lebarnya disapu **360px → 1920px** (melewati kedua ambang, 901 dan
941):

| Yang diperiksa | Hasil |
| --- | --- |
| `isi.scrollWidth − td.clientWidth` ketiga sel | **≤ 0 di seluruh rentang** — tidak ada yang meluap |
| Tombol nota vs tombol Kwitansi (`getBoundingClientRect`) | **tidak pernah bertembusan** |
| `wrapper.scrollWidth > clientWidth` | **tidak ada gulir mendatar** |
| Baris tanpa nota | tinggi & luapnya **identik dengan sebelum perubahan** |

Sebelum perbaikan, pada 1000px: `meluapPx: 30`, `tombolKananLewatKolom: 38`.

```
node --test tests/*.test.mjs   -> 210 pass, 1 fail (yang sudah gagal di main)
node --input-type=module --check < web/js/app.js  -> parse OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqPv85zq4q2mS3ekPycExN