### PR TITLE
fix: nota transfer sebaris di sebelah "Transfer LUNAS"

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1772,12 +1772,48 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      harus ikut naik, kalau tidak tabelnya kembali menggeser ke samping dan
      kolom tombol hilang lagi dari layar. */
   .table-bayar { min-width: 820px; }
+
+  /* Label tombol MEMENDEK di sini juga: "Cetak Kwitansi" -> "Kwitansi",
+     "Tandai Lunas" -> "Lunas". Sampai sekarang .teks-lebar hanya
+     disembunyikan di rentang 880-940px, jadi labelnya justru TUMBUH KEMBALI
+     begitu tabelnya jadi `fixed` — dan di situlah kolomnya paling sempit.
+
+     DIUKUR. Dengan nota transfer di kolom tombol, baris lunas butuh 227px
+     sementara kolomnya cuma 215px pada 941px, 220 pada 960, 225 pada 980.
+     Label pendek memangkasnya jadi 177px — sisa 38px di titik tersempit.
+
+     Akibatnya label lengkap kini hanya muncul di kartu HP, dan itu memang
+     yang dimaksud aturan aslinya: "Lunas" sendirian di tombol selebar layar
+     terbaca seperti label status, bukan perintah. Di tabel, tombolnya
+     seukuran isinya dan kata kedua sudah membedakan aksinya. */
+  .table-bayar .teks-lebar { display: none; }
+
+  /* Label tombol TIDAK BOLEH pecah di dalam tombolnya.
+
+     Ini yang membuat kesalahan sebelumnya lolos dari pengukuran: waktu
+     kolomnya kurang, "Cetak Kwitansi" membungkus jadi dua baris DI DALAM
+     tombol, jadi tombolnya justru terukur lebih SEMPIT dan pemeriksaan
+     "muat atau tidak" lulus. Yang rusak tingginya, dan tinggi tidak ikut
+     diperiksa. Dengan nowrap, kekurangan lebar muncul sebagai luapan yang
+     memang terbaca oleh pengukurannya. */
+  .table-bayar .action-row .button { white-space: nowrap; }
   .table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
   .table-bayar > thead > tr > th:nth-child(2) { width: 24%; }
   .table-bayar > thead > tr > th:nth-child(3) { width:  6%; }
   .table-bayar > thead > tr > th:nth-child(4) { width: 12%; }
-  .table-bayar > thead > tr > th:nth-child(5) { width: 15%; }
-  .table-bayar > thead > tr > th:nth-child(6) { width: 25%; }
+  /* Metode 20%, naik dari 15%, dan 5%-nya diambil dari kolom tombol di
+     bawahnya. Yang harus muat SEBARIS di sini tiga benda, bukan dua:
+     "Transfer" + lencana LUNAS + lencana nota = 151px, sementara 15%
+     cuma 131px pada ambang 941px. Notanya duduk di sini karena ia
+     keterangan tentang pembayaran, bukan aksi — di kolom tombol ia
+     terbaca sebagai perintah ketiga sejajar Kwitansi dan Batalkan.
+
+     Yang membuat 5% itu boleh diambil: label tombol memendek di blok ini
+     (aturan .teks-lebar di atas), jadi kolom tombol cuma butuh 152px dan
+     20% memberinya 174px pada ambang yang sama. Sebelum labelnya
+     dipendekkan, 5% ini TIDAK ada untuk diambil. */
+  .table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
+  .table-bayar > thead > tr > th:nth-child(6) { width: 20%; }
 
   /* Tombol aksi DITENGAHKAN di kolomnya, dan kolom Biaya di rincian memakai
      lebar yang sama (25%). Akibatnya angka rupiah tiap regu jatuh tepat di
@@ -1790,8 +1826,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .detail-table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
   .detail-table-bayar > thead > tr > th:nth-child(2) { width: 24%; }
   .detail-table-bayar > thead > tr > th:nth-child(3) { width: 18%; }
-  .detail-table-bayar > thead > tr > th:nth-child(4) { width: 15%; }
-  .detail-table-bayar > thead > tr > th:nth-child(5) { width: 25%; }
+  /* Kolom TERAKHIR kedua tabel harus tetap bertemu — itu yang membuat angka
+     rupiah tiap regu jatuh tepat di bawah tombol induknya (pasal 15.2). Jadi
+     begitu induknya turun 25% -> 20%, rincian ikut turun, dan 5% yang lepas
+     jatuh ke kolom Sekolah supaya jumlahnya tetap 100.
+
+     18 + 24 + 18 + 20 + 20 = 100. Di bawah `fixed`, kolom yang tidak dipatok
+     mendapat NOL, bukan sisanya (pasal 15.3) — jadi jumlah ini bukan
+     formalitas. */
+  .detail-table-bayar > thead > tr > th:nth-child(4) { width: 20%; }
+  .detail-table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
 }
 
 .detail-table-bayar { margin: 0; }

--- a/tests/payment_table_widths.test.mjs
+++ b/tests/payment_table_widths.test.mjs
@@ -8,12 +8,53 @@ import test from "node:test";
 const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
 
 
+/** Persen tiap kolom sebuah tabel, dibaca dari aturan header langsungnya. */
+function lebarKolom(tabel) {
+  const hasil = [];
+  for (const m of css.matchAll(
+    new RegExp(`\\.${tabel} > thead > tr > th:nth-child\\((\\d+)\\) \\{ width:\\s*(\\d+)%;\\s*\\}`, "g")))
+    hasil[Number(m[1]) - 1] = Number(m[2]);
+  return hasil;
+}
+
+
 test("lebar Meja Pembayaran hanya diatur lewat header langsung", () => {
-  assert.match(css,
-    /\.table-bayar > thead > tr > th:nth-child\(6\) \{ width: 25%; \}/);
-  assert.match(css,
-    /\.detail-table-bayar > thead > tr > th:nth-child\(5\) \{ width: 25%; \}/);
+  // Rantai anak, bukan selektor keturunan: tabel rincian BERSARANG di dalam
+  // induknya, jadi `.table-bayar th:nth-child(3)` juga mengenai kolom ketiga
+  // rincian, dan yang menang cuma ditentukan urutan baris di berkas (pasal 15.5).
   assert.doesNotMatch(css, /\.table-bayar th:nth-child\(/);
   assert.doesNotMatch(css, /\.detail-table-bayar th:nth-child\(/);
   assert.doesNotMatch(css, /\.table-bayar td:nth-child\(6\)\s*\{/);
+});
+
+
+test("kolom terakhir induk dan rincian bertemu", () => {
+  const induk = lebarKolom("table-bayar");
+  const rincian = lebarKolom("detail-table-bayar");
+
+  assert.equal(induk.length, 6, "induk harus punya enam kolom berpatokan");
+  assert.equal(rincian.length, 5, "rincian harus punya lima kolom berpatokan");
+
+  // Angkanya SENGAJA tidak dipaku di sini. Yang harus benar hubungannya:
+  // kolom terakhir keduanya bertemu supaya angka rupiah tiap regu jatuh tepat
+  // di bawah tombol induknya, dan kolom pertama bertemu supaya kode dan nama
+  // regu berbaris lurus (pasal 15.2). Tes yang memaku "25%" gagal saat kolom
+  // Metode dilebarkan untuk memuat nota transfer — padahal pasangannya ikut
+  // dipindahkan dengan benar, jadi yang dilaporkannya lapor palsu.
+  assert.equal(induk.at(-1), rincian.at(-1),
+    `kolom terakhir tidak bertemu: induk ${induk.at(-1)}% vs rincian ${rincian.at(-1)}%`);
+  assert.equal(induk[0], rincian[0],
+    `kolom pertama tidak bertemu: induk ${induk[0]}% vs rincian ${rincian[0]}%`);
+});
+
+
+test("persentase kolom berjumlah 100", () => {
+  // Di bawah `table-layout: fixed`, kolom yang tidak kebagian mendapat NOL —
+  // bukan sisanya (pasal 15.3). Jumlah yang kurang dari 100 membagi sisanya
+  // rata ke semua kolom dan menggeser pasangan yang baru saja dijaga di atas.
+  for (const tabel of ["table-bayar", "detail-table-bayar"]) {
+    const lebar = lebarKolom(tabel);
+    const jumlah = lebar.reduce((a, b) => a + b, 0);
+    assert.equal(jumlah, 100, `${tabel} berjumlah ${jumlah}%, bukan 100 — ${lebar.join("/")}`);
+  }
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -943,36 +943,12 @@ async function layarPembayaran() {
         // jadi dua baris. gap .25rem saja sudah muat (122px), tetapi cuma
         // bersisa 1px; dengan teks metode .9em ia jadi 117px dan punya jarak
         // yang tidak habis oleh satu huruf yang lebih lebar di HP lain.
-        // Nota transfernya IKUT TAMPIL sesudah lunas, bukan hilang bersama
-        // dropdown-nya. Sesudah uang masuk barulah ia paling sering dicari:
-        // saat menyusun berkas pertanggungjawaban, dan saat satu setoran
-        // dipertanyakan — dan sampai sekarang satu-satunya cara melihatnya
-        // lagi adalah membatalkan pelunasan, yang mengubah data demi melihat
-        // data.
-        //
-        // Lencana, BUKAN .button-mini seperti di baris belum lunas. Kolom
-        // Metode cuma 15% — 123px pada lantai 820px — dan pasangan
-        // "Transfer" + LUNAS sudah memakai 117px di antaranya. Tombol biasa
-        // menuntut lebar kolomnya sendiri; lencana ikut arus.
-        //
-        // Dan `flex-wrap` dilepas HANYA ketika notanya ada. Nowrap itu hasil
-        // pengukuran lama untuk dua elemen; dengan elemen ketiga ia bukan
-        // lagi menjaga apa-apa melainkan memaksa tiga benda berdesakan di
-        // 123px. Yang dikembalikan cuma perilaku bawaan .metode-baris —
-        // membungkus kalau sempit, sebaris kalau lapang — dan baris tanpa
-        // nota tidak berubah sedikit pun.
-        //
-        // Template biasa, BUKAN tag html``. Alasannya sama dengan cabang di
-        // bawah: ikon sudah berupa HTML, dan html`` meng-escape setiap nilai
-        // yang disisipkan — tombolnya akan TERCETAK sebagai teks.
-        ? `<span class="metode-baris" style="gap:.25rem${b.bukti_transfer ? "" : ";flex-wrap:nowrap"}"
+        // Template biasa, BUKAN tag html``: nota sudah berupa HTML, dan html``
+        // meng-escape apa pun yang disisipkan — tombolnya akan TERCETAK
+        // sebagai teks. Nilai dari luar tetap lewat esc() satu per satu.
+        ? `<span class="metode-baris" style="flex-wrap:nowrap;gap:.25rem"
            ><span style="font-size:.9em">${esc(b.pembayaran ? b.pembayaran.method : "—")}</span
-           ><span class="badge badge-green">LUNAS</span>${b.bukti_transfer
-            ? `<button class="badge badge-tombol" type="button"
-                       data-bukti="${esc(b.bukti_transfer)}"
-                       title="Nota pembayaran"
-                       aria-label="Nota pembayaran">${ikon("file-text")}</button>`
-            : ""}</span>`
+           ><span class="badge badge-green">LUNAS</span>${nota}</span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`
           // Yang terpilih lebih dulu adalah cara bayar yang DIPILIH PEMBINA saat
@@ -980,31 +956,36 @@ async function layarPembayaran() {
           // dicatat tetap yang dipilih petugas di sini, karena uangnyalah yang
           // menentukan. Pendaftaran lama tidak menyimpannya, dan untuk mereka
           // tunai tetap yang terpilih seperti sebelumnya.
-          // Template biasa, BUKAN tag html`` — tombol Bukti sudah berupa HTML dan
-          // html`` meng-escape setiap nilai yang disisipkan, jadi tombolnya
-          // sempat TERCETAK sebagai teks di layar Pembayaran.
-          // nowrap HANYA kalau tidak ada tombol bukti. Di kartu HP kolomnya
-          // lapang (284px ke atas) jadi nowrap tidak pernah terpakai di sana —
-          // ia cuma berlaku di rentang tabel `fixed`, tempat kolom Metode
-          // selebar 131-152px. Di situ dropdown 128px + tombol 36px = 170px,
-          // dan dengan nowrap tombolnya menonjol 38px KELUAR kolom, menimpa
-          // "Tandai Lunas" di sebelahnya. DIUKUR di browser (pasal 15.9-15.10),
-          // bukan dibaca.
-          //
-          // Meluapnya baru terlihat sejak 0130 mengisi bukti untuk keseratus
-          // pendaftaran XXXVII: sebelumnya hampir tidak ada baris yang punya
-          // bukti, jadi tombolnya nyaris tidak pernah tergambar dan aturan
-          // nowrap-nya tidak pernah diuji oleh data sungguhan.
-          : `<span class="metode-baris" style="${b.bukti_transfer ? "" : "flex-wrap:nowrap"}"
+          // Template biasa, BUKAN tag html``. Nilainya lewat esc() satu per
+          // satu — html`` meng-escape apa pun yang disisipkan, dan itu pernah
+          // membuat tombol di sini TERCETAK sebagai teks.
+          // nowrap DI SINI saja, bukan di kelasnya: pasangan LUNAS di atas memang
+          // perlu menumpuk sendiri di kolom sempit. Di sini yang berdampingan
+          // cuma dropdown, dan kolomnya memang hanya cukup untuk itu.
+          : `<span class="metode-baris" style="flex-wrap:nowrap"
              ><select class="select-small" data-metode="${esc(b.kode_pembayaran)}">
                 <option value="tunai" ${b.metode_bayar === "transfer" ? "" : "selected"}>Tunai</option>
                 <option value="transfer" ${b.metode_bayar === "transfer" ? "selected" : ""}>Transfer</option>
-              </select>${b.bukti_transfer
-                ? `<button class="button button-mini" type="button"
-                           data-bukti="${esc(b.bukti_transfer)}"
-                           title="Bukti Pembayaran"
-                           aria-label="Bukti Pembayaran">${ikon("file-text")}</button>`
-                : ""}</span>`;
+              </select>${nota}</span>`;
+
+      // Nota transfer duduk DI KOLOM METODE, tepat sesudah cara bayarnya —
+      // "Transfer LUNAS [nota]" — karena ia keterangan tentang pembayaran
+      // itu, bukan sebuah aksi. Di kolom tombol ia terbaca sebagai perintah
+      // ketiga sejajar Kwitansi dan Batalkan, padahal ia cuma lampiran.
+      //
+      // Kolom Metode DILEBARKAN 15% -> 20% supaya ketiganya muat SEBARIS;
+      // 5% itu diambil dari kolom tombol, yang jadi longgar begitu labelnya
+      // memendek. Angka dan alasannya di web/style.css, blok min-width 941px.
+      //
+      // Lencana, bukan .button-mini: 33x22 lawan 36x34. Tombol penuh menuntut
+      // ruang seukuran aksi untuk sesuatu yang cuma dibuka sesekali, dan
+      // tingginya menaikkan tinggi seluruh baris.
+      const nota = b.bukti_transfer
+        ? `<button class="badge badge-tombol" type="button"
+                   data-bukti="${esc(b.bukti_transfer)}"
+                   title="Nota pembayaran"
+                   aria-label="Nota pembayaran">${ikon("file-text")}</button>`
+        : "";
 
       const aksi = b.status === "lunas"
         // <span class="teks-lebar"> = kata yang DIBUANG di layar sempit, jadi

--- a/web/style.css
+++ b/web/style.css
@@ -1772,12 +1772,48 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      harus ikut naik, kalau tidak tabelnya kembali menggeser ke samping dan
      kolom tombol hilang lagi dari layar. */
   .table-bayar { min-width: 820px; }
+
+  /* Label tombol MEMENDEK di sini juga: "Cetak Kwitansi" -> "Kwitansi",
+     "Tandai Lunas" -> "Lunas". Sampai sekarang .teks-lebar hanya
+     disembunyikan di rentang 880-940px, jadi labelnya justru TUMBUH KEMBALI
+     begitu tabelnya jadi `fixed` — dan di situlah kolomnya paling sempit.
+
+     DIUKUR. Dengan nota transfer di kolom tombol, baris lunas butuh 227px
+     sementara kolomnya cuma 215px pada 941px, 220 pada 960, 225 pada 980.
+     Label pendek memangkasnya jadi 177px — sisa 38px di titik tersempit.
+
+     Akibatnya label lengkap kini hanya muncul di kartu HP, dan itu memang
+     yang dimaksud aturan aslinya: "Lunas" sendirian di tombol selebar layar
+     terbaca seperti label status, bukan perintah. Di tabel, tombolnya
+     seukuran isinya dan kata kedua sudah membedakan aksinya. */
+  .table-bayar .teks-lebar { display: none; }
+
+  /* Label tombol TIDAK BOLEH pecah di dalam tombolnya.
+
+     Ini yang membuat kesalahan sebelumnya lolos dari pengukuran: waktu
+     kolomnya kurang, "Cetak Kwitansi" membungkus jadi dua baris DI DALAM
+     tombol, jadi tombolnya justru terukur lebih SEMPIT dan pemeriksaan
+     "muat atau tidak" lulus. Yang rusak tingginya, dan tinggi tidak ikut
+     diperiksa. Dengan nowrap, kekurangan lebar muncul sebagai luapan yang
+     memang terbaca oleh pengukurannya. */
+  .table-bayar .action-row .button { white-space: nowrap; }
   .table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
   .table-bayar > thead > tr > th:nth-child(2) { width: 24%; }
   .table-bayar > thead > tr > th:nth-child(3) { width:  6%; }
   .table-bayar > thead > tr > th:nth-child(4) { width: 12%; }
-  .table-bayar > thead > tr > th:nth-child(5) { width: 15%; }
-  .table-bayar > thead > tr > th:nth-child(6) { width: 25%; }
+  /* Metode 20%, naik dari 15%, dan 5%-nya diambil dari kolom tombol di
+     bawahnya. Yang harus muat SEBARIS di sini tiga benda, bukan dua:
+     "Transfer" + lencana LUNAS + lencana nota = 151px, sementara 15%
+     cuma 131px pada ambang 941px. Notanya duduk di sini karena ia
+     keterangan tentang pembayaran, bukan aksi — di kolom tombol ia
+     terbaca sebagai perintah ketiga sejajar Kwitansi dan Batalkan.
+
+     Yang membuat 5% itu boleh diambil: label tombol memendek di blok ini
+     (aturan .teks-lebar di atas), jadi kolom tombol cuma butuh 152px dan
+     20% memberinya 174px pada ambang yang sama. Sebelum labelnya
+     dipendekkan, 5% ini TIDAK ada untuk diambil. */
+  .table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
+  .table-bayar > thead > tr > th:nth-child(6) { width: 20%; }
 
   /* Tombol aksi DITENGAHKAN di kolomnya, dan kolom Biaya di rincian memakai
      lebar yang sama (25%). Akibatnya angka rupiah tiap regu jatuh tepat di
@@ -1790,8 +1826,16 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .detail-table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
   .detail-table-bayar > thead > tr > th:nth-child(2) { width: 24%; }
   .detail-table-bayar > thead > tr > th:nth-child(3) { width: 18%; }
-  .detail-table-bayar > thead > tr > th:nth-child(4) { width: 15%; }
-  .detail-table-bayar > thead > tr > th:nth-child(5) { width: 25%; }
+  /* Kolom TERAKHIR kedua tabel harus tetap bertemu — itu yang membuat angka
+     rupiah tiap regu jatuh tepat di bawah tombol induknya (pasal 15.2). Jadi
+     begitu induknya turun 25% -> 20%, rincian ikut turun, dan 5% yang lepas
+     jatuh ke kolom Sekolah supaya jumlahnya tetap 100.
+
+     18 + 24 + 18 + 20 + 20 = 100. Di bawah `fixed`, kolom yang tidak dipatok
+     mendapat NOL, bukan sisanya (pasal 15.3) — jadi jumlah ini bukan
+     formalitas. */
+  .detail-table-bayar > thead > tr > th:nth-child(4) { width: 20%; }
+  .detail-table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
 }
 
 .detail-table-bayar { margin: 0; }


### PR DESCRIPTION
## What

Notanya kembali ke sebelah **Transfer LUNAS** di kolom Metode, dan kali ini
**sebaris** — tidak lagi turun sendirian ke baris kedua. Kolom Metode
dilebarkan supaya memang muat.

| | sebelum | sesudah |
| --- | --- | --- |
| induk | `18/24/6/12/15/25` | `18/24/6/12/**20**/**20**` |
| rincian | `18/24/18/15/25` | `18/24/18/**20**/**20**` |

## Why

#649 menaruh notanya di kolom Metode dan membiarkannya **membungkus** kalau
sempit. Akibatnya ikon itu turun sendirian ke baris kedua di **setiap** baris,
dan daftar 100 invoice jadi dua kali lebih panjang.

**Kenapa itu lolos dari pengukuran saya:** pada wadah `flex-wrap: wrap`,
`scrollWidth` selalu kira-kira selebar wadahnya, jadi pemeriksaan "meluap atau
tidak" lulus dengan sendirinya. Yang harus diukur **jumlah lebar anak + gap**
terhadap lebar kolom — itu yang dipakai sekarang.

**5% diambil dari kolom tombol**, bukan dari Sekolah: Metode butuh 151px untuk
tiga benda sementara 15% cuma 131px pada ambang 941px. Kolom tombol boleh
menyerahkannya karena labelnya baru saja memendek — ia cuma butuh 152px dan
20% memberinya 174px. **Sebelum labelnya dipendekkan, 5% itu tidak ada untuk
diambil.**

Kolom terakhir kedua tabel tetap bertemu (pasal 15.2), dan keduanya tetap
berjumlah 100 — di bawah `fixed`, kolom yang tidak dipatok mendapat **nol**,
bukan sisanya.

## Dua akar masalah yang ikut ditutup

**1. Label tombol memanjang kembali di ≥941px.** `.teks-lebar` selama ini hanya
disembunyikan di 880–940px, jadi "Cetak Kwitansi" tumbuh lagi persis di rentang
tempat kolomnya paling sempit. Sekarang label pendek berlaku di seluruh
tampilan tabel; label lengkap tinggal di kartu HP — dan itu memang yang
dimaksud aturan aslinya.

**2. Label boleh pecah di dalam tombolnya.** Waktu kolomnya kurang,
"Cetak Kwitansi" membungkus jadi dua baris dan tombolnya justru terukur lebih
**sempit** — jadi pemeriksaan lebar lulus sementara yang rusak tingginya.
`white-space: nowrap` membuat kekurangan lebar muncul sebagai luapan yang
terbaca alat ukurnya.

## Tesnya berhenti memaku angka

`payment_table_widths` memaku `"25%"` dan gagal begitu kolomnya dirombak —
padahal pasangannya ikut dipindahkan dengan benar. Itu lapor palsu, dan
pemeriksa yang lapor palsu berhenti dipercaya.

Sekarang ia memeriksa **hubungannya**: kolom pertama dan terakhir kedua tabel
harus bertemu, dan keduanya harus berjumlah 100. Dua pagar itu menangkap
perombakan yang **salah**; angka yang dipaku menangkap perombakan **apa pun**.

## Diukur (pasal 15.9–15.10)

Markup + `style.css` sungguhan di dalam iframe, disapu 360 → 1920px, melewati
kedua ambang:

| Lebar | LUNAS metode | BELUM metode | Kolom tombol |
| ---: | --- | --- | --- |
| 901–940 | 151/161 · sisa 10 | 150/161 · sisa 11 | 150/160 · sisa 10 |
| 941 | 151/175 · sisa 24 | 166/175 · **sisa 9** | 150/175 · sisa 25 |
| 1000 | 151/187 · sisa 36 | 166/187 · sisa 21 | 150/187 · sisa 37 |
| ≥1100 | 151/203 · sisa 52 | 166/203 · sisa 37 | 150/203 · sisa 53 |

Semua **sebaris**, tanpa gulir mendatar, tanpa label yang pecah. Titik
tersempit 9px — sebelum PR ini kolom Metode hidup dengan sisa **1px**.

```
node --test tests/*.test.mjs  -> 212 pass, 1 fail (registration_resend_notice,
                                 sudah gagal sebelum rangkaian PR ini)
diff web/style.css live/style.css -> identik
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqPv85zq4q2mS3ekPycExN