### PR TITLE
fix: kolom Metode dan kolom tombol Meja Pembayaran rata kiri

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1720,6 +1720,47 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   }
 }
 
+/* ---------------------------------------------------------------------------
+   MEJA PEMBAYARAN: KOLOM METODE DAN KOLOM TOMBOL RATA KIRI
+
+   Berlaku di KEDUA rentang tabel — 901-940 yang `auto` dan >=941 yang
+   `fixed` — karena yang diperbaikinya sama di keduanya, dan aturan yang sama
+   ditulis dua kali pada akhirnya berbeda di salah satunya (pasal 15.6).
+
+   Sampai sekarang keduanya DITENGAHKAN, dan itu terlihat rapi hanya selama
+   isi tiap baris sama panjang. Ia tidak pernah sama panjang:
+
+     "Transfer LUNAS [nota]"  lawan  "Tunai LUNAS"
+     "Kwitansi Batalkan"      lawan  "Lunas"
+
+   Isi yang lebih pendek ditengahkan berarti tepi kirinya MASUK ke dalam, jadi
+   tiap baris memulai di tempat yang berbeda. Mata yang menyusuri daftar 100
+   invoice kehilangan garis tegaknya dan harus mencari ulang tiap baris —
+   persis alasan yang sudah tertulis untuk kartu HP di bawah, tempat tombolnya
+   sudah rata kiri sejak dicoba di HP sungguhan.
+
+   Catatan lama menyebut tampilan tabel berbeda karena "tombolnya mengisi satu
+   KOLOM, bukan satu baris". Itu benar untuk lebar kolomnya, bukan untuk isinya:
+   yang mengisi kolom tetap sepasang tombol yang panjangnya berubah-ubah.
+
+   Kolom Biaya di tabel rincian tetap RATA KANAN dan tetap selebar kolom tombol
+   (pasal 15.2), jadi angka rupiahnya tetap berakhir di tepi yang sama. Yang
+   berpindah tepi kiri tombolnya, bukan tepi kanan kolomnya. */
+@media (min-width: 901px) {
+  /* Menang atas kelas .text-center di markup-nya lewat kekhususan, bukan lewat
+     urutan — jadi ia tetap benar di mana pun blok ini diletakkan (pasal 15.12). */
+  .table-bayar > thead > tr > th:nth-child(5),
+  .table-bayar > tbody > tr > td:nth-child(5),
+  .table-bayar > tbody > tr > td:nth-child(6) { text-align: left; }
+  /* Dua pembungkus lentur di dalamnya ikut, kalau tidak `text-align` saja
+     tidak menggerakkan apa pun: keduanya flex, dan yang menentukan letak
+     anaknya `justify-content`. */
+  .table-bayar > tbody > tr > td > .metode-baris,
+  .table-bayar > tbody > tr > td:nth-child(6) .action-row {
+    justify-content: flex-start;
+  }
+}
+
 .detail-table-dada { width: 100%; margin: 0; }
 /* Padding sel disamakan dengan tabel induk (.table td), kalau tidak isinya
    bergeser beberapa piksel dan kesejajarannya hilang lagi. */
@@ -1815,12 +1856,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
   .table-bayar > thead > tr > th:nth-child(6) { width: 20%; }
 
-  /* Tombol aksi DITENGAHKAN di kolomnya, dan kolom Biaya di rincian memakai
-     lebar yang sama (25%). Akibatnya angka rupiah tiap regu jatuh tepat di
-     bawah tombol "Tandai Lunas" — itu jumlah yang sedang dihitung petugas
-     saat jarinya sudah di atas tombol itu. */
-  .table-bayar > tbody > tr > td:nth-child(6) { text-align: center; }
-  .table-bayar > tbody > tr > td:nth-child(6) .action-row { justify-content: center; }
+  /* Perataan kolom Metode dan kolom tombol TIDAK diatur di sini melainkan di
+     blok `min-width: 901px` di bawah — ia berlaku untuk KEDUA rentang tabel,
+     dan aturan yang sama ditulis dua kali pada akhirnya berbeda di salah
+     satunya (pasal 15.6). */
 
   .detail-table-bayar { width: 100%; }
   .detail-table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
@@ -2783,9 +2822,10 @@ input.small-input { text-align: center; }
   /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
      dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya
      rata kiri, dan sepasang tombol yang menyendiri di tengah memutus garis
-     baca tegak yang dipakai mata menyusuri kartu demi kartu. Tampilan tabel
-     lebar tetap tengah (lihat .table-bayar td:nth-child(6)): di sana tombolnya
-     mengisi satu KOLOM, bukan satu baris. */
+     baca tegak yang dipakai mata menyusuri kartu demi kartu. Sejak alasan itu
+     ternyata berlaku sama di tampilan tabel, keduanya rata kiri — lihat blok
+     `min-width: 901px`. Aturan ini tetap ada karena kartu HP punya jalur
+     tata letaknya sendiri (grid per sel) dan tidak tersentuh blok itu. */
   .table-bayar tbody tr[data-baris] > td:last-child .action-row {
     justify-content: flex-start;
   }

--- a/tests/payment_table_widths.test.mjs
+++ b/tests/payment_table_widths.test.mjs
@@ -58,3 +58,26 @@ test("persentase kolom berjumlah 100", () => {
     assert.equal(jumlah, 100, `${tabel} berjumlah ${jumlah}%, bukan 100 — ${lebar.join("/")}`);
   }
 });
+
+
+test("kolom Metode dan kolom tombol rata kiri di tampilan tabel", () => {
+  // Ditengahkan, isi yang lebih pendek tepi kirinya masuk ke dalam, jadi tiap
+  // baris memulai di tempat yang berbeda — "Transfer LUNAS [nota]" lawan
+  // "Tunai LUNAS", "Kwitansi Batalkan" lawan "Lunas". Mata yang menyusuri 100
+  // invoice kehilangan garis tegaknya dan harus mencari ulang tiap baris.
+  //
+  // `text-align` saja tidak cukup: kedua pembungkusnya flex, dan yang
+  // menentukan letak anaknya `justify-content`. Aturan yang hilang salah
+  // satunya tidak menggerakkan apa pun, dan tidak ada galat yang muncul.
+  const blok = css.slice(css.indexOf("@media (min-width: 901px) {"));
+  assert.notEqual(blok.length, 0, "blok perataan min-width: 901px tidak ada");
+
+  assert.match(blok, /\.table-bayar > tbody > tr > td:nth-child\(5\),/);
+  assert.match(blok, /\.table-bayar > tbody > tr > td:nth-child\(6\) \{ text-align: left; \}/);
+  assert.match(blok, /\.table-bayar > tbody > tr > td > \.metode-baris,/);
+  assert.match(blok, /\.action-row \{\s*justify-content: flex-start;/);
+
+  // Dan tidak boleh ada yang menengahkannya kembali di tempat lain.
+  assert.doesNotMatch(css,
+    /\.table-bayar > tbody > tr > td:nth-child\(6\)[^{]*\{[^}]*text-align: center/);
+});

--- a/web/style.css
+++ b/web/style.css
@@ -1720,6 +1720,47 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   }
 }
 
+/* ---------------------------------------------------------------------------
+   MEJA PEMBAYARAN: KOLOM METODE DAN KOLOM TOMBOL RATA KIRI
+
+   Berlaku di KEDUA rentang tabel — 901-940 yang `auto` dan >=941 yang
+   `fixed` — karena yang diperbaikinya sama di keduanya, dan aturan yang sama
+   ditulis dua kali pada akhirnya berbeda di salah satunya (pasal 15.6).
+
+   Sampai sekarang keduanya DITENGAHKAN, dan itu terlihat rapi hanya selama
+   isi tiap baris sama panjang. Ia tidak pernah sama panjang:
+
+     "Transfer LUNAS [nota]"  lawan  "Tunai LUNAS"
+     "Kwitansi Batalkan"      lawan  "Lunas"
+
+   Isi yang lebih pendek ditengahkan berarti tepi kirinya MASUK ke dalam, jadi
+   tiap baris memulai di tempat yang berbeda. Mata yang menyusuri daftar 100
+   invoice kehilangan garis tegaknya dan harus mencari ulang tiap baris —
+   persis alasan yang sudah tertulis untuk kartu HP di bawah, tempat tombolnya
+   sudah rata kiri sejak dicoba di HP sungguhan.
+
+   Catatan lama menyebut tampilan tabel berbeda karena "tombolnya mengisi satu
+   KOLOM, bukan satu baris". Itu benar untuk lebar kolomnya, bukan untuk isinya:
+   yang mengisi kolom tetap sepasang tombol yang panjangnya berubah-ubah.
+
+   Kolom Biaya di tabel rincian tetap RATA KANAN dan tetap selebar kolom tombol
+   (pasal 15.2), jadi angka rupiahnya tetap berakhir di tepi yang sama. Yang
+   berpindah tepi kiri tombolnya, bukan tepi kanan kolomnya. */
+@media (min-width: 901px) {
+  /* Menang atas kelas .text-center di markup-nya lewat kekhususan, bukan lewat
+     urutan — jadi ia tetap benar di mana pun blok ini diletakkan (pasal 15.12). */
+  .table-bayar > thead > tr > th:nth-child(5),
+  .table-bayar > tbody > tr > td:nth-child(5),
+  .table-bayar > tbody > tr > td:nth-child(6) { text-align: left; }
+  /* Dua pembungkus lentur di dalamnya ikut, kalau tidak `text-align` saja
+     tidak menggerakkan apa pun: keduanya flex, dan yang menentukan letak
+     anaknya `justify-content`. */
+  .table-bayar > tbody > tr > td > .metode-baris,
+  .table-bayar > tbody > tr > td:nth-child(6) .action-row {
+    justify-content: flex-start;
+  }
+}
+
 .detail-table-dada { width: 100%; margin: 0; }
 /* Padding sel disamakan dengan tabel induk (.table td), kalau tidak isinya
    bergeser beberapa piksel dan kesejajarannya hilang lagi. */
@@ -1815,12 +1856,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
   .table-bayar > thead > tr > th:nth-child(6) { width: 20%; }
 
-  /* Tombol aksi DITENGAHKAN di kolomnya, dan kolom Biaya di rincian memakai
-     lebar yang sama (25%). Akibatnya angka rupiah tiap regu jatuh tepat di
-     bawah tombol "Tandai Lunas" — itu jumlah yang sedang dihitung petugas
-     saat jarinya sudah di atas tombol itu. */
-  .table-bayar > tbody > tr > td:nth-child(6) { text-align: center; }
-  .table-bayar > tbody > tr > td:nth-child(6) .action-row { justify-content: center; }
+  /* Perataan kolom Metode dan kolom tombol TIDAK diatur di sini melainkan di
+     blok `min-width: 901px` di bawah — ia berlaku untuk KEDUA rentang tabel,
+     dan aturan yang sama ditulis dua kali pada akhirnya berbeda di salah
+     satunya (pasal 15.6). */
 
   .detail-table-bayar { width: 100%; }
   .detail-table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
@@ -2783,9 +2822,10 @@ input.small-input { text-align: center; }
   /* Cetak Kwitansi + Batalkan RATA KIRI di kartu HP — sempat ditengahkan dan
      dikembalikan setelah dicoba di HP sungguhan. Seluruh isi kartu lainnya
      rata kiri, dan sepasang tombol yang menyendiri di tengah memutus garis
-     baca tegak yang dipakai mata menyusuri kartu demi kartu. Tampilan tabel
-     lebar tetap tengah (lihat .table-bayar td:nth-child(6)): di sana tombolnya
-     mengisi satu KOLOM, bukan satu baris. */
+     baca tegak yang dipakai mata menyusuri kartu demi kartu. Sejak alasan itu
+     ternyata berlaku sama di tampilan tabel, keduanya rata kiri — lihat blok
+     `min-width: 901px`. Aturan ini tetap ada karena kartu HP punya jalur
+     tata letaknya sendiri (grid per sel) dan tidak tersentuh blok itu. */
   .table-bayar tbody tr[data-baris] > td:last-child .action-row {
     justify-content: flex-start;
   }


### PR DESCRIPTION
## What

Kolom **Metode** dan **kolom tombol** di Meja Pembayaran kini rata kiri di
tampilan tabel, jadi tiap baris memulai di tempat yang sama.

Header `METODE` ikut rata kiri supaya ia duduk tepat di atas isinya.

## Why

Keduanya ditengahkan, dan itu terlihat rapi hanya selama isi tiap baris sama
panjang. Ia tidak pernah sama panjang:

```
"Transfer LUNAS [nota]"   lawan   "Tunai LUNAS"
"Kwitansi Batalkan"       lawan   "Lunas"
```

Isi yang lebih pendek ditengahkan berarti **tepi kirinya masuk ke dalam**, jadi
tiap baris memulai di tempat yang berbeda. Mata yang menyusuri daftar 100
invoice kehilangan garis tegaknya dan harus mencari ulang tiap baris.

Alasan itu **sudah tertulis di berkas ini** untuk kartu HP — "sepasang tombol
yang menyendiri di tengah memutus garis baca tegak yang dipakai mata menyusuri
kartu demi kartu" — dan ternyata berlaku sama persis di tampilan tabel. Catatan
lama menyebut tabel berbeda karena "tombolnya mengisi satu KOLOM, bukan satu
baris"; itu benar untuk lebar kolomnya, bukan untuk isinya. Catatannya ikut
dibetulkan.

## Notes

- **Satu blok `min-width: 901px`**, berlaku untuk KEDUA rentang tabel — bukan
  disalin ke blok 901–940 dan blok 941 masing-masing. Aturan yang sama ditulis
  dua kali pada akhirnya berbeda di salah satunya (pasal 15.6).
- Kekhususannya cukup untuk mengalahkan kelas `.text-center` di markup-nya,
  jadi ia tidak bergantung pada urutan baris di berkas (pasal 15.12).
- **`text-align` saja tidak menggerakkan apa pun** — kedua pembungkusnya flex,
  dan yang menentukan letak anaknya `justify-content`. Tesnya menjaga keduanya,
  karena aturan yang hilang salah satunya tidak memunculkan galat apa pun.
- **Kartu HP tidak tersentuh**: ia punya jalur tata letaknya sendiri (grid per
  sel) dan tombolnya memang sudah rata kiri sejak dulu.
- **Kolom Biaya di tabel rincian tetap rata kanan** dan tetap selebar kolom
  tombol (pasal 15.2), jadi angka rupiahnya tetap berakhir di tepi yang sama.
  Yang berpindah tepi **kiri** tombolnya, bukan tepi kanan kolomnya.

## Diukur (pasal 15.9–15.10)

Jarak tepi kiri isi ke tepi dalam selnya, ketiga baris contoh, kedua kolom:

| Lebar | Metode (lunas / tunai / belum) | Tombol (lunas / tunai / belum) | Muat sebaris | Gulir mendatar |
| ---: | --- | --- | --- | --- |
| 901 | 0 / 0 / 0 | 0 / 0 / 0 | ok | tidak |
| 940 | 0 / 0 / 0 | 0 / 0 / 0 | ok | tidak |
| 941 | 0 / 0 / 0 | 0 / 0 / 0 | ok | tidak |
| 1000 | 0 / 0 / 0 | 0 / 0 / 0 | ok | tidak |
| 1100 | 0 / 0 / 0 | 0 / 0 / 0 | ok | tidak |
| 1920 | 0 / 0 / 0 | 0 / 0 / 0 | ok | tidak |

```
node --test tests/*.test.mjs  -> 213 pass, 1 fail (registration_resend_notice,
                                 sudah gagal sebelum rangkaian PR ini)
diff web/style.css live/style.css -> identik
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqPv85zq4q2mS3ekPycExN