### PR TITLE
test: jalankan blok pembangun baris Meja Pembayaran, jangan cuma parse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,15 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    period, ideally under 72 characters.
 2. Add a body when the change needs a *why*. Wrap it at 72 columns and separate
    it from the subject with a blank line.
-3. End every commit message with the co-author trailer:
-   ```
-   Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
-   ```
-4. Keep a commit to one logical change. Do not bundle unrelated edits.
+3. **No authorship trailer, and nothing that names the tool that wrote it.**
+   No `Co-Authored-By: Claude`, no "generated with", no session link, no
+   emoji badge — not in the subject, the body, or a trailer. This replaces the
+   trailer this section used to require; owner's decision, 28 August 2026.
+4. **The same applies to code comments, documentation, and test names.** A
+   comment explains why the code is the way it is. "AI-generated", "written by
+   Claude", or a note about which model produced it explains nothing a reader
+   can act on, and it dates the file the moment the tool changes.
+5. Keep a commit to one logical change. Do not bundle unrelated edits.
 
 ## 3. Creating the pull request
 
@@ -43,10 +47,9 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    it read well on its own.
 4. Structure the body with a **What** section and a **Why** section. Add
    **Notes** only when there is a caveat worth flagging.
-5. End the PR body with:
-   ```
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   ```
+5. **Nothing about how the PR was written.** No "Generated with" footer, no
+   session link, no tool name anywhere in the title or body — see section 2.3.
+   The PR describes the change; who or what typed it is not part of it.
 6. Only create or push a PR when the user has asked for it.
 
 ## 4. Merging to `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,15 @@ Guidance for Claude Code when working in this repository.
    period, ideally under 72 characters.
 2. Add a body when the change needs a *why*. Wrap it at 72 columns and separate
    it from the subject with a blank line.
-3. End every commit message with the co-author trailer:
-   ```
-   Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
-   ```
-4. Keep a commit to one logical change. Do not bundle unrelated edits.
+3. **No authorship trailer, and nothing that names the tool that wrote it.**
+   No `Co-Authored-By: Claude`, no "generated with", no session link, no
+   emoji badge — not in the subject, the body, or a trailer. This replaces the
+   trailer this section used to require; owner's decision, 28 August 2026.
+4. **The same applies to code comments, documentation, and test names.** A
+   comment explains why the code is the way it is. "AI-generated", "written by
+   Claude", or a note about which model produced it explains nothing a reader
+   can act on, and it dates the file the moment the tool changes.
+5. Keep a commit to one logical change. Do not bundle unrelated edits.
 
 ## 3. Creating the pull request
 
@@ -41,10 +45,9 @@ Guidance for Claude Code when working in this repository.
    it read well on its own.
 4. Structure the body with a **What** section and a **Why** section. Add
    **Notes** only when there is a caveat worth flagging.
-5. End the PR body with:
-   ```
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   ```
+5. **Nothing about how the PR was written.** No "Generated with" footer, no
+   session link, no tool name anywhere in the title or body — see section 2.3.
+   The PR describes the change; who or what typed it is not part of it.
 6. Only create or push a PR when the user has asked for it.
 
 ## 4. Merging to `main`

--- a/tests/payment_rows_render.test.mjs
+++ b/tests/payment_rows_render.test.mjs
@@ -1,0 +1,137 @@
+// Baris Meja Pembayaran benar-benar TERBANGUN, bukan sekadar ter-parse.
+//
+// KENAPA TES INI ADA
+//
+// 28 Agustus 2026 layar Meja Pembayaran kosong di produksi: saringan, kotak
+// cari, dan "39 invoice · 40 regu" tergambar, lalu tidak ada satu baris pun.
+// Sebabnya satu deklarasi yang pindah tempat — `const nota` berakhir di BAWAH
+// `const metode`, padahal `metode` menyisipkan `${nota}` ke dalam template-nya.
+// `const` yang disentuh sebelum barisnya dijalankan melempar ReferenceError,
+// bukan undefined, jadi SELURUH baris gagal dirender sekaligus.
+//
+// Yang membuatnya lolos, dan kenapa tes ini berbentuk begini:
+//
+//   * `node --check` LULUS. Temporal dead zone itu galat saat DIJALANKAN,
+//     bukan saat di-parse — celah yang sama persis dengan yang ditutup
+//     tools/periksa_impor.py untuk import yang hilang.
+//   * Angka "39 invoice" tetap benar, karena ia dihitung dari data yang sudah
+//     diterima, bukan dari barisnya. Layarnya terbaca seperti daftar yang
+//     memang kosong, bukan seperti kerusakan.
+//   * Seluruh pengukuran tata letak hari itu dikerjakan di halaman contoh
+//     berisi markup STATIS. Tidak ada satu langkah pun yang menjalankan
+//     app.js.
+//
+// Jadi yang diuji di sini bukan hasil HTML-nya melainkan bahwa blok itu
+// SELESAI DIJALANKAN untuk keempat bentuk baris yang ada. Pemeriksaan isinya
+// dibuat longgar dengan sengaja: yang mahal kalau salah baris yang hilang,
+// bukan kelas CSS yang berganti nama.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+
+/** Potong blok `baris.map(b => { ... }).join("")` dari layarPembayaran(). */
+function blokPembangunBaris() {
+  const mulai = app.indexOf("tbody.replaceChildren(h(baris.map(b => {");
+  assert.notEqual(mulai, -1,
+    "blok pembangun baris Meja Pembayaran tidak ditemukan — kalau bentuknya " +
+    "berubah, sesuaikan potongan ini, JANGAN hapus tesnya");
+  const akhir = app.indexOf('}).join("")));', mulai);
+  assert.notEqual(akhir, -1, "ujung blok pembangun baris tidak ditemukan");
+
+  return app.slice(mulai, akhir)
+    .replace("tbody.replaceChildren(h(baris.map(b => {", "const HASIL = baris.map(b => {")
+    + '}).join(""); return HASIL;';
+}
+
+
+/* Tiruan seadanya. Yang ditiru cuma yang DIPANGGIL blok itu; kalau ia mulai
+   memanggil yang lain, tes ini gagal dengan "x is not defined" — dan itu
+   memang laporan yang benar, bukan gangguan. */
+const esc = (t) => String(t ?? "").replace(/[&<>"']/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+const html = (s, ...v) =>
+  s.reduce((a, p, i) => a + p + (i < v.length ? esc(v[i]) : ""), "");
+
+const TIRUAN = {
+  esc,
+  html,
+  ikon: () => "<svg></svg>",
+  rupiah: (n) => "Rp " + Number(n).toLocaleString("id-ID"),
+  reguAktif: (b) => b.regu.filter((r) => !r.batal),
+  totalBiaya: () => 175000,
+  biayaRegu: () => 175000,
+  GOLONGAN_LABEL: { penegak_pa: "Penegak PA", penggalang_pi: "Penggalang PI" },
+  EDISI: { biaya_per_regu: 175000 },
+  dibuka: new Set(),
+};
+
+// Keempat bentuk yang benar-benar ada di layar, termasuk yang batal — dan
+// satu lunas TANPA bukti, karena cabang tanpa nota punya tata letaknya sendiri.
+const BARIS = [
+  { kode_pembayaran: "HRCD37-AAA111", status: "lunas", metode_bayar: "transfer",
+    bukti_transfer: "https://drive.google.com/file/d/XYZ/view",
+    pembayaran: { method: "transfer" }, sekolah: { name: "MA Bahrul Anwar" },
+    regu: [{ nama_regu: "ASTRA JINGGA", nama_ketua: "Azmi", golongan: "penegak_pa", batal: false }] },
+  { kode_pembayaran: "HRCD37-BBB222", status: "lunas", metode_bayar: null,
+    bukti_transfer: null, pembayaran: { method: "tunai" },
+    sekolah: { name: "SMPN 1 Cimaragas" },
+    regu: [{ nama_regu: "MATAHARI", nama_ketua: "Adia", golongan: "penggalang_pi", batal: false }] },
+  { kode_pembayaran: "HRCD37-CCC333", status: "menunggu_pembayaran",
+    metode_bayar: "transfer", bukti_transfer: "https://drive.google.com/file/d/ABC/view",
+    pembayaran: null, sekolah: { name: "MTs Al-Hasan Banjarsari" },
+    regu: [{ nama_regu: "GARUDA", nama_ketua: "Yoki", golongan: "penegak_pa", batal: false }] },
+  { kode_pembayaran: "HRCD37-DDD444", status: "batal", metode_bayar: null,
+    bukti_transfer: null, pembayaran: null, sekolah: { name: "SMPN 3 Kawali" },
+    regu: [{ nama_regu: "ALAMANDA", nama_ketua: "Sani", golongan: "penggalang_pi", batal: true }] },
+];
+
+
+function bangun(baris = BARIS) {
+  const nama = Object.keys(TIRUAN);
+  // eslint-disable-next-line no-new-func
+  const jalan = new Function("baris", ...nama, blokPembangunBaris());
+  return jalan(baris, ...nama.map((n) => TIRUAN[n]));
+}
+
+
+test("blok pembangun baris berjalan sampai selesai untuk keempat bentuk", () => {
+  // Kalau ada `const` yang dipakai sebelum dideklarasikan, panggilan ini
+  // melempar ReferenceError di sini — bukan diam-diam di HP petugas.
+  const keluaran = bangun();
+  const jumlah = (pola) => (keluaran.match(pola) || []).length;
+
+  assert.equal(jumlah(/<tr class="invoice-row"/g), 4, "empat baris invoice");
+  assert.equal(jumlah(/badge-green">LUNAS/g), 2, "dua lencana LUNAS");
+  assert.equal(jumlah(/badge-red">BATAL/g), 1, "satu lencana BATAL");
+  assert.equal(jumlah(/data-metode=/g), 1, "satu dropdown cara bayar");
+});
+
+
+test("tombol nota muncul hanya untuk baris yang punya buktinya", () => {
+  const keluaran = bangun();
+  assert.equal((keluaran.match(/data-bukti=/g) || []).length, 2,
+    "dua tombol nota: satu baris lunas, satu baris belum lunas");
+
+  const tanpaBukti = bangun(BARIS.map((b) => ({ ...b, bukti_transfer: null })));
+  assert.equal((tanpaBukti.match(/data-bukti=/g) || []).length, 0,
+    "tanpa bukti, tombolnya tidak digambar sama sekali");
+});
+
+
+test("tombol nota duduk di kolom Metode, bukan di kolom tombol", () => {
+  // Ditetapkan pemilik acara: notanya di sebelah "Transfer LUNAS", karena ia
+  // keterangan tentang pembayaran — bukan aksi ketiga sejajar Kwitansi dan
+  // Batalkan.
+  const rapat = bangun().replace(/\s+/g, " ");
+  assert.match(rapat, /badge-green">LUNAS<\/span><button[^>]*data-bukti/,
+    "di baris lunas, nota harus tepat sesudah lencana LUNAS");
+  assert.match(rapat, /<\/select><button[^>]*data-bukti/,
+    "di baris belum lunas, nota harus tepat sesudah dropdown cara bayar");
+  assert.doesNotMatch(rapat, /data-batal-bayar=[^>]*>Batalkan<\/button> <button[^>]*data-bukti/,
+    "nota tidak boleh kembali ke kolom tombol");
+});


### PR DESCRIPTION
## What

Tes baru yang **memotong blok `baris.map(b => {...})` dari `app.js` dan
menjalankannya** dengan data tiruan untuk keempat bentuk baris: lunas bernota,
lunas tanpa nota, belum lunas bernota, dan batal.

Sekalian: aturan kerja berhenti menandai commit dan PR dengan nama alat yang
menulisnya — `CLAUDE.md` dan `AGENTS.md` bagian 2.3, 2.4, dan 3.5.

## Why

Layar Meja Pembayaran kosong di produksi karena `const nota` dipakai sebelum
dideklarasikan. **Tidak ada satu pun langkah verifikasi yang menangkapnya:**

- `node --check` lulus — temporal dead zone itu galat saat **dijalankan**,
  bukan saat di-parse.
- Seluruh pengukuran tata letak dikerjakan di halaman contoh berisi markup
  **statis**, bukan di layar yang dirender `app.js`.
- Angka "39 invoice · 40 regu" tetap benar, karena ia dihitung dari data yang
  sudah diterima — layarnya terbaca seperti daftar yang memang kosong.

Yang menemukannya petugas yang membuka layarnya **saat acara berjalan**. Itu
tempat paling mahal untuk menemukannya.

**Dibuktikan menangkap.** Dengan deklarasinya dikembalikan ke tempat salahnya,
ketiga tesnya gagal:

```
ReferenceError: Cannot access 'nota' before initialization
```

Tanpa bukti itu, tes seperti ini cuma hiasan yang menambah rasa aman palsu.

## Notes

- Pemeriksaan isinya sengaja **longgar** — jumlah baris, lencana, dropdown, dan
  letak tombol nota. Yang mahal kalau salah baris yang hilang, bukan kelas CSS
  yang berganti nama.
- Tiruannya hanya memuat yang benar-benar **dipanggil** blok itu. Kalau ia
  mulai memanggil yang lain, tesnya gagal dengan "x is not defined" — dan itu
  laporan yang benar, bukan gangguan.
- Saya sempat menulis pemeriksa TDZ statis untuk seluruh berkas JS lalu
  **membuangnya**: ia melaporkan 10 temuan yang semuanya palsu (badan arrow
  menunda pemanggilan, parameter yang menaungi nama yang sama). Pemeriksa yang
  lapor palsu berhenti dipercaya, lalu berhenti dibaca.
- `tests/dev_database.sh` **gagal di migrasi 0118**, jadi layar ini belum bisa
  dibuka sungguhan di lokal. Itu lubang yang tersisa dan belum saya tutup di
  PR ini.

## Aturan penulisan yang berubah

Trailer co-author dan footer "Generated with" dibuang, dan larangannya
diperluas ke komentar kode serta dokumen. Riwayat repo dibaca maintainer
berikutnya — anggota ambalan SMA — dan penanda alat tidak menjelaskan apa pun
yang bisa mereka pakai, sekaligus basi begitu alatnya berganti.

```
node --test tests/*.test.mjs  -> 216 pass, 1 fail (registration_resend_notice,
                                 sudah gagal sebelum rangkaian PR ini)
diff CLAUDE.md AGENTS.md      -> hanya paragraf pengantar (bagian 7.7)
```