### PR TITLE
fix: dev database bisa dibangun lagi — mati sejak migrasi 0118

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -58,11 +58,25 @@ values (37, 10, 10, 100, 20, 0);
 -- Saklar hari-H: satu baris.
 insert into status_acara (id) values (true);
 
+-- Baris acuan di bawah semuanya `on conflict do nothing`, dan itu bukan
+-- kehati-hatian berlebih: berkas ini dijalankan pada DUA urutan yang berbeda.
+-- tests/run.sh menjalankannya di TENGAH daftar migrasi, sementara
+-- tests/dev_database.sh menjalankannya SESUDAH semuanya — dan beberapa
+-- migrasi memasukkan baris yang sama (0093, 0105, 0119 untuk kloter; 0116
+-- untuk stok nomor dada Intern, yang memang sudah memakai penjaga yang sama).
+--
+-- Tanpa penjaga ini, seed berhenti dengan "duplicate key" pada urutan kedua,
+-- dan yang gagal bukan cuma seed-nya: seluruh langkah sesudahnya tidak
+-- pernah dijalankan, jadi dev server tidak bisa dipakai sama sekali.
+
 -- 40 kloter (30 dasar + 31-40 cadangan).
-insert into kloter (nomor) select generate_series(1, 40);
+insert into kloter (nomor) select generate_series(1, 40)
+on conflict (nomor) do nothing;
 
 -- Stok nomor dada fisik. DUA deret, karena kainnya dicetak dua set yang
 -- sama-sama mulai dari 001: Eksternal 1-500, Intern 1001-1250 (migrasi 0116).
 -- Batas antaranya `edisi.nomor_dada_intern_mulai`.
-insert into nomor_dada_stok (nomor) select generate_series(1, 500);
-insert into nomor_dada_stok (nomor) select generate_series(1001, 1250);
+insert into nomor_dada_stok (nomor) select generate_series(1, 500)
+on conflict (nomor) do nothing;
+insert into nomor_dada_stok (nomor) select generate_series(1001, 1250)
+on conflict (nomor) do nothing;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -43,32 +43,88 @@ run tests/sql/00_harness.sql
 # menambalnya dengan mengedit 0076 — migrasi yang sudah diterapkan ke produksi
 # tidak pernah diedit (final-architecture.md bagian 2).
 #
-# SYARAT MASUK LEWATI_DULU: migrasinya tidak boleh memuat DDL. 0076 memenuhinya
-# — isinya satu blok `do` berisi UPDATE dan INSERT saja. Migrasi yang menambah
-# kolom SEKALIGUS mengisi data per edisi tidak boleh dilewati: seluruh migrasi
-# sesudahnya akan berjalan di atas tabel yang kolomnya belum ada, persis
-# kerusakan yang diceritakan alinea pertama. 0037, 0039 dan 0054 menambah
-# kolom, jadi ketiganya diulang dan tidak pernah dilewati.
-LEWATI_DULU="0076_bidai_dan_lomba_soal"
+# SYARAT MASUK LEWATI_DULU, dan bunyinya lebih tepat begini: migrasi yang
+# dilewati tidak boleh meninggalkan SESUATU YANG DIPAKAI migrasi sesudahnya.
+#
+# Versi pertama syarat ini berbunyi "tidak boleh memuat DDL", dan itu terlalu
+# lebar. Yang benar-benar merusak kolom atau tabel yang belum ada saat migrasi
+# berikutnya membacanya — 0037, 0039 dan 0054 menambah kolom, jadi ketiganya
+# diulang dan tidak pernah dilewati. Sebuah `create or replace function` yang
+# tidak dipanggil siapa pun di antara dua titik itu TIDAK merusak apa pun: yang
+# ada sementara versi lamanya, dan pengulangannya memasang versi barunya.
+#
+# Yang wajib diperiksa sebelum menambah nama ke daftar ini, satu per satu:
+#
+#   1. Apa yang ditinggalkannya — kolom/tabel (JANGAN dilewati) atau fungsi,
+#      view, komentar (boleh, kalau syarat 2 terpenuhi)?
+#   2. Adakah migrasi SESUDAHNYA sampai seed.sql yang memakainya? Cari
+#      namanya di supabase/migrations dengan nomor lebih besar.
+#
+# 0076 : satu blok `do` berisi UPDATE dan INSERT saja, tanpa DDL.
+# 0118 : `create or replace function perkiraan_berangkat_kloter` + dua
+#        `comment on`. Diperiksa 28 Agustus 2026 — yang menyebutnya sesudah
+#        0118 cuma 0119, dan itu pun cuma di dalam KOMENTAR ("sudah
+#        digantikan 0118"), bukan pemanggilan. Jadi tidak ada yang membacanya
+#        di antara dua titik itu.
+#
+# KENAPA 0118 HARUS DITUNDA. Blok penutupnya bukan sekadar `raise notice`
+# melainkan dua `assert` atas jam berangkat kloter pertama dan terakhir. Di
+# sini tabel `edisi` masih KOSONG, jadi ketiga nilainya NULL, `assert NULL`
+# gagal, dan skripnya berhenti di situ — seluruh migrasi 0119-0130 tidak
+# pernah dijalankan. Itulah yang membuat dev server tidak bisa dipakai sama
+# sekali sejak 0118 mendarat, dan kenapa layar Meja Pembayaran yang rusak
+# 28 Agustus 2026 baru ketahuan oleh petugas di lapangan: tidak ada satu pun
+# cara membuka layarnya di laptop.
+# 0129 dan 0130 ditunda karena alasan ketiga lagi, dan ia yang paling sunyi:
+# keduanya memakai `edisi_aktif()`. Di glob nilainya NULL, jadi
+#   'HRCD' || edisi_aktif() || '-' || ...
+# seluruhnya jadi NULL — dan `exit when not exists (... = NULL)` langsung
+# keluar pada putaran pertama, karena perbandingan dengan NULL tidak pernah
+# benar. Yang menghentikan skripnya bukan logika kodenya melainkan
+# not-null constraint kolom kode_pembayaran, beberapa baris sesudahnya.
+#
+# Keduanya tidak meninggalkan DDL yang dipakai siapa pun: tabel sementaranya
+# dibuang sendiri di ujung berkasnya, dan sisanya INSERT dan UPDATE.
+LEWATI_DULU="0076_bidai_dan_lomba_soal 0118_jeda_kloter_maksimal
+             0129_impor_pendaftaran_xxxvii 0130_bukti_transfer_link_drive"
 ULANG="0032_konfigurasi_xxxvii 0033_nama_pos_xxxvii 0034_nama_pos_final
        0035_tangga_menaksir 0036_kriteria_bidai 0037_petunjuk_kolom
        0038_petunjuk_menaksir 0039_judul_isian 0054_kolom_lomba
        0076_bidai_dan_lomba_soal 0091_intern_golongan
-       0093_configure_fifo_capacity"
+       0093_configure_fifo_capacity 0118_jeda_kloter_maksimal"
 
-# Yang dilewati WAJIB ada di ULANG. Kalau tidak, ia tidak dijalankan sama
-# sekali — kerusakan yang sama dengan berhenti di 0011, dan sama diamnya.
+# Yang dilewati WAJIB dijalankan lagi di suatu tempat. Kalau tidak, ia tidak
+# dijalankan sama sekali — kerusakan yang sama dengan berhenti di 0011, dan
+# sama diamnya.
+#
+# Ada DUA cara menjalankannya lagi, dan pagar ini menerima keduanya:
+#   * masuk daftar ULANG, yang diputar tepat sesudah seed.sql, atau
+#   * satu baris `run supabase/migrations/<nama>.sql` tersendiri di bawah,
+#     untuk yang harus PALING AKHIR — 0129 dan 0130 begitu, karena keduanya
+#     membawa data operasional dan tidak boleh terbaca langkah sesudahnya.
+#
+# Versi pertama pagar ini hanya memeriksa ULANG, jadi ia menolak cara kedua
+# walau migrasinya benar-benar dijalankan sepuluh baris kemudian.
 for m in $LEWATI_DULU; do
-  case " $(echo $ULANG) " in
-    *" $m "*) ;;
-    *) echo "dev_database.sh: $m ada di LEWATI_DULU tapi tidak di ULANG — ia tidak akan pernah dijalankan." >&2
-       exit 1 ;;
-  esac
+  diulang=""
+  case " $(echo $ULANG) " in *" $m "*) diulang="ya" ;; esac
+  grep -q "^run supabase/migrations/$m[.]sql$" "$0" && diulang="ya"
+  if [ -z "$diulang" ]; then
+    echo "dev_database.sh: $m ada di LEWATI_DULU tapi tidak pernah dijalankan lagi — tambahkan ke ULANG atau beri baris run sendiri." >&2
+    exit 1
+  fi
 done
 
 for m in "$ROOT"/supabase/migrations/*.sql; do
   nama="$(basename "$m")"
-  case " $LEWATI_DULU " in *" ${nama%.sql} "*) echo "-- (ditunda) $nama"; continue ;; esac
+  # `$(echo ...)` MELIPAT baris barunya jadi spasi, dan itu bukan gaya
+  # penulisan. Pola di bawah menuntut SPASI di kedua sisi nama; kalau
+  # LEWATI_DULU ditulis dua baris, yang di ujung baris pertama diapit spasi
+  # dan BARIS BARU, jadi ia tidak pernah cocok dan migrasinya tetap
+  # dijalankan di sini — diam-diam, karena tidak ada yang melaporkan
+  # kegagalan mencocokkan. Pemeriksa ULANG di atas sudah memakai bentuk ini;
+  # yang di sini tertinggal sampai daftarnya benar-benar jadi dua baris.
+  case " $(echo $LEWATI_DULU) " in *" ${nama%.sql} "*) echo "-- (ditunda) $nama"; continue ;; esac
   run "supabase/migrations/$nama"
 done
 run supabase/seed.sql
@@ -142,5 +198,18 @@ run supabase/migrations/0058_peran_per_pekerjaan.sql
 # ia periksa — `(peran = 'juri_pos') = (pos is not null)` — baru saja dipasang
 # kembali oleh 0058 satu baris di atas.
 run supabase/migrations/0075_koordinator_pos.sql
+
+# 0129 dan 0130 PALING AKHIR, sama seperti di tests/run.sh, dan alasannya
+# sama: keduanya satu-satunya migrasi yang membawa DATA OPERASIONAL. Di
+# tengah daftar, seratus pendaftaran itu ikut terbaca langkah sesudahnya —
+# dan 01_seed_uji.sql membuat regu dengan nama karangan yang bisa menabrak
+# `regu_nama_unik`, indeks yang berlaku SELURUH edisi.
+#
+# Keduanya sengaja IKUT di dev, bukan dilewati begitu saja: layar Meja
+# Pembayaran yang berisi empat baris uji tidak menunjukkan apa pun tentang
+# layar yang berisi seratus, dan justru di layar seratus baris itulah
+# kerusakan 28 Agustus 2026 terlihat.
+run supabase/migrations/0129_impor_pendaftaran_xxxvii.sql
+run supabase/migrations/0130_bukti_transfer_link_drive.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"


### PR DESCRIPTION
## What

`tests/dev_database.sh` bisa dijalankan sampai selesai lagi, dan hasilnya
database dev berisi **100 pendaftaran sungguhan** — sama seperti produksi.

## Why

Skripnya berhenti di `0118` sejak migrasi itu mendarat, dan **selama itu tidak
ada cara membuka layar mana pun di laptop.** Itulah yang membuat layar Meja
Pembayaran yang kosong baru ketahuan oleh petugas di lapangan, saat acara
berjalan.

Tiga migrasi menghentikannya, ketiganya bentuk yang sama — menuntut edisi
aktif, dijalankan sebelum `seed.sql` membuatnya:

| | Yang terjadi |
| --- | --- |
| `0118` | Dua `assert` atas jam berangkat kloter. `edisi` masih kosong → ketiga nilainya NULL → `assert NULL` gagal → **0119–0130 tidak pernah dijalankan.** |
| `0129` | `edisi_aktif()` NULL → seluruh kode pembayaran jadi NULL, dan `exit when not exists (... = NULL)` keluar pada putaran pertama karena perbandingan dengan NULL tidak pernah benar. Yang menghentikannya not-null constraint. |
| `0130` | Sama, dan ia menuntut `0129` sudah jalan. |

Ketiganya ditunda lalu dijalankan ulang. `0129`/`0130` **paling akhir**, sama
seperti di `tests/run.sh`: keduanya membawa data operasional, dan
`01_seed_uji.sql` membuat regu bernama karangan yang bisa menabrak
`regu_nama_unik`.

Keduanya sengaja **ikut** di dev, bukan dilewati. Layar berisi empat baris uji
tidak menunjukkan apa pun tentang layar berisi seratus — dan justru di layar
seratus baris itulah kerusakannya terlihat.

## Dua jebakan di skripnya sendiri

**`LEWATI_DULU` multi-baris tidak pernah cocok.** Polanya menuntut spasi di
kedua sisi nama, sementara yang di ujung baris pertama diapit spasi dan **baris
baru**. Migrasinya tetap dijalankan, diam-diam. Pemeriksa `ULANG` di sebelahnya
sudah memakai `$(echo ...)` untuk melipatnya; yang ini tertinggal sampai
daftarnya benar-benar jadi dua baris.

**Pagar "yang dilewati wajib dijalankan lagi" hanya memeriksa `ULANG`,** jadi
ia menolak migrasi yang dijalankan lewat baris `run` tersendiri — padahal itu
yang dibutuhkan `0129`/`0130`. Sekarang ia menerima kedua cara.

## Syarat LEWATI_DULU diperbaiki bunyinya

Dulu "tidak boleh memuat DDL", dan itu terlalu lebar. Yang benar-benar merusak
**kolom atau tabel** yang belum ada saat migrasi berikutnya membacanya. Sebuah
`create or replace function` yang tidak dipanggil siapa pun di antara dua titik
itu tidak merusak apa pun — diperiksa untuk `0118`: yang menyebutnya sesudah
itu cuma `0119`, dan itu pun di dalam komentar.

## Seed jadi tidak bergantung urutan

`seed.sql` dijalankan pada **dua urutan berbeda** — di tengah daftar oleh
`run.sh`, di belakang semuanya oleh `dev_database.sh` — sementara `0093`,
`0105`, `0119` memasukkan kloter dan `0116` memasukkan stok nomor dada yang
sama. Insert kloter dan stok diberi `on conflict do nothing`, penjaga yang
sudah dipakai `0116`.

## Dijalankan lokal

```
bash tests/dev_database.sh  -> "hrcd_dev siap", 100 pendaftaran + 100 bukti
bash tests/run.sh           -> SEMUA TES LULUS
node --test tests/*.test.mjs -> 216 pass, 1 fail (registration_resend_notice,
                                sudah gagal sebelum rangkaian PR ini)
```

Dan yang paling penting: dengan ini layar Meja Pembayaran **benar-benar dibuka
di browser**, berisi 100 invoice, sebelum PR berikutnya di-merge.