### PR TITLE
fix: ikon nota sejajar, tidak lagi menempel di ujung cara bayar

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1759,6 +1759,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-bayar > tbody > tr > td:nth-child(6) .action-row {
     justify-content: flex-start;
   }
+
+  /* Kata cara bayarnya DIPATOK LEBARNYA, supaya lencana LUNAS dan ikon nota
+     sesudahnya jatuh di titik yang sama pada tiap baris. Tanpa ini keduanya
+     menempel di ujung kata, dan katanya cuma ada dua panjang — jadi baris
+     "Transfer" dan baris "Tunai" memulai lencananya di tempat berbeda.
+
+     DIUKUR di layar sungguhan (dev server + 100 pendaftaran), bukan di
+     halaman contoh: "transfer" 52,6px, "tunai" 34,1px. Selisih 18,5px, dan
+     itu persis jarak geser lencana maupun ikonnya.
+
+     3,75rem = 60px: menampung "transfer" dengan sisa ~7px. Kosakatanya
+     TERTUTUP — `pendaftaran_metode_bayar_check` cuma mengizinkan
+     'transfer' dan 'tunai', dan bentuk ketiganya "—" saat pembayarannya
+     belum tercatat. Jadi angka ini tidak bisa dilewati isian tak terduga,
+     dan hanya perlu ditinjau kalau kosakatanya bertambah.
+
+     `min-width`, bukan `width`: kalau suatu saat ada kata yang lebih
+     panjang, ia melebar dan barisnya tetap terbaca — yang hilang cuma
+     kelurusannya, bukan isinya. */
+  .table-bayar > tbody > tr > td > .metode-baris > .metode-kata {
+    min-width: 3.75rem;
+    text-align: left;
+  }
 }
 
 .detail-table-dada { width: 100%; margin: 0; }
@@ -1988,6 +2011,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    tabel lebar kolom Metode cuma 15% jadi ia membungkus jadi dua baris seperti
    sebelumnya. Satu aturan, dua tampilan — tanpa media query yang harus
    ditebak batasnya. */
+/* Cara bayar di baris LUNAS. Dulu `style="font-size:.9em"` di dalam app.js;
+   dijadikan kelas supaya lebarnya bisa dipatok di tampilan tabel — lihat blok
+   `min-width: 901px`. */
+.metode-kata { font-size: .9em; }
+
 .metode-baris {
   display: inline-flex; align-items: center; justify-content: center;
   flex-wrap: wrap; gap: .35rem;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -977,7 +977,7 @@ async function layarPembayaran() {
         // meng-escape apa pun yang disisipkan — tombolnya akan TERCETAK
         // sebagai teks. Nilai dari luar tetap lewat esc() satu per satu.
         ? `<span class="metode-baris" style="flex-wrap:nowrap;gap:.25rem"
-           ><span style="font-size:.9em">${esc(b.pembayaran ? b.pembayaran.method : "—")}</span
+           ><span class="metode-kata">${esc(b.pembayaran ? b.pembayaran.method : "—")}</span
            ><span class="badge badge-green">LUNAS</span>${nota}</span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`

--- a/web/style.css
+++ b/web/style.css
@@ -1759,6 +1759,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-bayar > tbody > tr > td:nth-child(6) .action-row {
     justify-content: flex-start;
   }
+
+  /* Kata cara bayarnya DIPATOK LEBARNYA, supaya lencana LUNAS dan ikon nota
+     sesudahnya jatuh di titik yang sama pada tiap baris. Tanpa ini keduanya
+     menempel di ujung kata, dan katanya cuma ada dua panjang — jadi baris
+     "Transfer" dan baris "Tunai" memulai lencananya di tempat berbeda.
+
+     DIUKUR di layar sungguhan (dev server + 100 pendaftaran), bukan di
+     halaman contoh: "transfer" 52,6px, "tunai" 34,1px. Selisih 18,5px, dan
+     itu persis jarak geser lencana maupun ikonnya.
+
+     3,75rem = 60px: menampung "transfer" dengan sisa ~7px. Kosakatanya
+     TERTUTUP — `pendaftaran_metode_bayar_check` cuma mengizinkan
+     'transfer' dan 'tunai', dan bentuk ketiganya "—" saat pembayarannya
+     belum tercatat. Jadi angka ini tidak bisa dilewati isian tak terduga,
+     dan hanya perlu ditinjau kalau kosakatanya bertambah.
+
+     `min-width`, bukan `width`: kalau suatu saat ada kata yang lebih
+     panjang, ia melebar dan barisnya tetap terbaca — yang hilang cuma
+     kelurusannya, bukan isinya. */
+  .table-bayar > tbody > tr > td > .metode-baris > .metode-kata {
+    min-width: 3.75rem;
+    text-align: left;
+  }
 }
 
 .detail-table-dada { width: 100%; margin: 0; }
@@ -1988,6 +2011,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    tabel lebar kolom Metode cuma 15% jadi ia membungkus jadi dua baris seperti
    sebelumnya. Satu aturan, dua tampilan — tanpa media query yang harus
    ditebak batasnya. */
+/* Cara bayar di baris LUNAS. Dulu `style="font-size:.9em"` di dalam app.js;
+   dijadikan kelas supaya lebarnya bisa dipatok di tampilan tabel — lihat blok
+   `min-width: 901px`. */
+.metode-kata { font-size: .9em; }
+
 .metode-baris {
   display: inline-flex; align-items: center; justify-content: center;
   flex-wrap: wrap; gap: .35rem;


### PR DESCRIPTION
## What

Kata cara bayar di baris LUNAS dipatok lebarnya, jadi lencana **LUNAS** dan
ikon **nota** sesudahnya jatuh di titik yang sama pada tiap baris.

## Why

Keduanya menempel di ujung katanya, dan katanya cuma punya dua panjang. Baris
"Transfer" dan baris "Tunai" karena itu memulai lencananya di tempat berbeda,
dan ikonnya ikut bergeser — daftar yang seharusnya terbaca sebagai kolom jadi
bergerigi.

## Diukur di layar sungguhan

Bukan di halaman contoh: **dev server dengan 100 pendaftaran**, dua baris
ditandai lunas — satu transfer, satu tunai.

| | lebar kata | lencana LUNAS | ikon nota |
| --- | ---: | ---: | ---: |
| **sebelum** — transfer | 52,6px | 56,6 | 127,3 |
| **sebelum** — tunai | 34,1px | 38,1 | 108,9 |
| **sesudah** — keduanya | 60px | **64** | **135** |

Selisih 18,5px itu persis lebar selisih katanya, jadi mematok lebar kata
menghapus keduanya sekaligus.

## Notes

- **3,75rem = 60px** menampung "transfer" dengan sisa ~7px. Kosakatanya
  **tertutup** — `pendaftaran_metode_bayar_check` cuma mengizinkan `transfer`
  dan `tunai`, dan bentuk ketiganya `—` saat pembayarannya belum tercatat —
  jadi angka ini tidak bisa dilewati isian tak terduga.
- **`min-width`, bukan `width`**: kalau suatu saat ada kata yang lebih panjang,
  ia melebar dan barisnya tetap terbaca. Yang hilang cuma kelurusannya.
- `style="font-size:.9em"` di dalam `app.js` jadi kelas `.metode-kata`, supaya
  lebarnya diatur dari `style.css` alih-alih ditanam di markup.

## Sapuan 901–1920px

| Lebar | ikon lunas-transfer | ikon lunas-tunai | ikon belum | sisa tersempit |
| ---: | ---: | ---: | ---: | ---: |
| 901–940 | 132 | 132 | 118 | 10px |
| 941 | 132 | 132 | 134 | **9px** |
| 1000 | 132 | 132 | 134 | 21px |
| ≥1100 | 132 | 132 | 134 | 37px |

Semuanya muat sebaris, tanpa gulir mendatar.

```
node --test tests/*.test.mjs -> 216 pass, 1 fail (registration_resend_notice,
                                sudah gagal sebelum rangkaian PR ini)
diff web/style.css live/style.css -> identik
```