### PR TITLE
test: resend notice berhenti memaku ejaan, periksa maksudnya

### DIFF
--- a/tests/registration_resend_notice.test.mjs
+++ b/tests/registration_resend_notice.test.mjs
@@ -15,5 +15,20 @@ test("hasil kirim ulang menampilkan keadaan data yang sudah tercatat", () => {
   assert.match(sukses, /hasil\.terkirim_ulang \? "" : "hidden"/);
   assert.match(sukses, /sudah tercatat dari kiriman sebelumnya/);
   assert.match(sukses, /Perubahan setelah kiriman pertama tidak ikut tersimpan/);
-  assert.match(sukses, /tercatat berisi \$\{hasil\.jumlah_regu\} regu/);
+  // Jumlah regunya DISEBUT di kalimat itu. Yang diperiksa cuma bahwa
+  // `jumlah_regu` benar-benar disisipkan ke sana — BUKAN ekspresi persisnya.
+  //
+  // Versi pertama memaku `${hasil.jumlah_regu}` apa adanya, lalu gagal begitu
+  // 031755e membungkusnya jadi `${esc(hasil.jumlah_regu)}`. Pembungkus itu
+  // benar dan memang perlu: commit itu mengubah sukses() dari tag html``
+  // menjadi template biasa — karena html`` meng-escape SETIAP nilai yang
+  // disisipkan, jadi HTML yang dibangun dengannya lalu disisipkan ke html``
+  // lain keluar sebagai TEKS yang terlihat di layar. Di template biasa,
+  // yang di-escape tiap nilai luar satu per satu.
+  //
+  // Jadi yang gagal bukan kodenya melainkan tesnya, dan ia gagal selama
+  // berhari-hari sambil benar. Tes yang memaku bentuk penulisan menghukum
+  // perbaikan yang sah, lalu diabaikan karena "memang merah dari dulu" —
+  // dan sesudah itu ia tidak lagi menjaga apa pun.
+  assert.match(sukses, /tercatat berisi \$\{[^}]*jumlah_regu[^}]*\} regu/);
 });


### PR DESCRIPTION
## What

`registration_resend_notice` berhenti memaku ekspresi persis di sumber, dan
memeriksa maksud kalimatnya: jumlah regu memang disisipkan ke sana.

```diff
-  assert.match(sukses, /tercatat berisi \$\{hasil\.jumlah_regu\} regu/);
+  assert.match(sukses, /tercatat berisi \$\{[^}]*jumlah_regu[^}]*\} regu/);
```

## Why

**Tes ini gagal berhari-hari sambil benar — yang salah tesnya, bukan kodenya.**

Ia memaku `${hasil.jumlah_regu}` apa adanya, lalu gagal begitu `031755e`
membungkusnya jadi `${esc(hasil.jumlah_regu)}`. Pembungkus itu **perlu**:
commit tersebut mengubah `sukses()` dari tag `` html`` `` menjadi template
biasa, karena `` html`` `` meng-escape **setiap** nilai yang disisipkan — jadi
HTML yang dibangun dengannya lalu disisipkan ke `` html`` `` lain keluar
sebagai teks yang terlihat di layar. Itu bug yang benar-benar terjadi:
konfirmasi pendaftaran sempat menampilkan `<p class="description">` sebagai
tulisan.

Jadi tesnya menghukum perbaikan yang sah.

## Notes

- **Dibuktikan masih bergigi.** Dengan angkanya diganti kata "beberapa",
  tesnya gagal — jadi pelonggarannya tidak membuatnya jadi hiasan.
- Tes yang memaku bentuk penulisan lalu diabaikan karena "memang merah dari
  dulu" berhenti menjaga apa pun. Merahnya sendiri juga punya harga: setiap
  laporan tes minggu ini harus dibubuhi "satu gagal, tapi yang itu memang
  sudah gagal" — kalimat yang menyembunyikan kegagalan yang benar-benar baru.
- Tidak ada kode layar yang disentuh, jadi bagian 17 tidak menuntut layarnya
  dibuka untuk perubahan ini.

## Hasil

```
node --test tests/*.test.mjs -> 217 pass, 0 fail
```

Pertama kali seluruh rangkaian hijau.