### PR TITLE
feat: regu menyimpan kelas atau organisasi asalnya

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0118`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0131`
+sampai migrasi `0118`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0132`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0131`.
+`0119`-`0132`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-131 migrasi, `0001` sampai `0131`, dijalankan berurutan tanpa lubang penomoran.
+132 migrasi, `0001` sampai `0132`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0118`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0132`
+sampai migrasi `0133`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0133`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0132`.
+`0119`-`0133`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-132 migrasi, `0001` sampai `0132`, dijalankan berurutan tanpa lubang penomoran.
+133 migrasi, `0001` sampai `0133`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0132_impor_pendaftaran_xxxvii_lanjutan.sql
+++ b/supabase/migrations/0132_impor_pendaftaran_xxxvii_lanjutan.sql
@@ -1,0 +1,240 @@
+-- ============================================================================
+-- hrcd-rekap : 0132_impor_pendaftaran_xxxvii_lanjutan.sql
+--
+-- Memasukkan jawaban Google Form HRCD XXXVII mulai baris 143
+-- (28 Agustus 2026 14:01:17, Bunga Patroman) sampai baris 149.
+--
+-- Dua baris adalah kiriman ulang, bukan regu baru. Baris 143 diulang lebih
+-- rapi pada baris 145 dengan lima anggota Bunga Patroman yang sama; baris 146
+-- diulang pada baris 148 dengan lima anggota ROMUSA yang sama. Versi terakhir
+-- dipakai, sehingga tujuh baris sumber menjadi lima respons unik.
+--
+-- Baris yang sudah telanjur dimasukkan lewat form aktif dilengkapi, bukan
+-- dibuat lagi. Nama dan nomor regu yang sudah mempunyai nomor dada tidak
+-- diubah. Satu pendaftaran manual dapat memuat beberapa regu; karena satu nota
+-- hanya mempunyai satu kolom bukti, link baris terakhir dalam pendaftaran
+-- gabungan menjadi link nota itu secara deterministik.
+--
+-- Aman dijalankan ulang: baris baru memakai kunci_kirim deterministik. Status
+-- pembayaran, nomor dada, kloter, dan keadaan operasional lain tidak disentuh.
+-- ============================================================================
+
+create temporary table impor_form_lanjutan (
+  baris       integer primary key,
+  sekolah     text    not null,
+  nama_regu   text    not null,
+  golongan    text    not null,
+  nama_ketua  text    not null,
+  anggota     text[]  not null,
+  kontak_wa   text    not null,
+  nama_kontak text,
+  bukti       text    not null
+);
+
+insert into impor_form_lanjutan
+  (baris, sekolah, nama_regu, golongan, nama_ketua, anggota,
+   kontak_wa, nama_kontak, bukti) values
+  (144, 'MAN 2 Ciamis', 'CAKRAWIRA', 'penegak_pa',
+   'IKBAL MAULANA',
+   array['MUHAMMAD FAUZAN KAMIL MUBAROK', 'ADE ILHAM FATHUL BARRI', 'ALDI AKBAR FIRMANSYAH', 'RIZKY DENDY RAMADHAN'],
+   '085927721993', 'Yudi',
+   'https://drive.google.com/file/d/1ycMKHUfKbw6pv_Ngw5YlxRjiiYxXdTYD/view'),
+  (145, 'SMAN 1 Banjar', 'Bunga Patroman', 'penegak_pi',
+   'Aulia Ramadhani Putri',
+   array['Nabila Rizqia Rahmat', 'Davina Dzikra Nurfawwaza', 'Naura Anindya Putri', 'Tasya Tanti Apriliani'],
+   '085220567876', null,
+   'https://drive.google.com/file/d/1iDiDnAryQbINrS4MHN40J9WhepFQQDsg/view'),
+  (147, 'MAN 1 Ciamis', 'Spartan scout 666', 'penegak_pa',
+   'M. Dhieka Rahmat Ghazali',
+   array['Muhammad Dzakwan Aushof', 'Muhamad Fakhrul Musyaffa', 'Fadlan Ikbalurrahman', 'Rafif Fauzan Athallah'],
+   '083130965734', null,
+   'https://drive.google.com/file/d/1f6TmDTH-8nhTs5P5io97oJY2t8aoLxQE/view'),
+  (148, 'SMAN 2 Ciamis', 'ROMUSA', 'penegak_pi',
+   'Tresnawati Maulidia',
+   array['Fitria Septiana', 'Seni Nur Septiani', 'Natara Qalbi Alfaathir', 'Qisty Aulia Anwar'],
+   '082262634124', null,
+   'https://drive.google.com/file/d/1mTQcspEgkKUcZZRKyNvIgCUwNy5c7I7c/view'),
+  (149, 'SMAN 2 Ciamis', 'SRIKANDI NUSANTARA', 'penegak_pi',
+   'SITI NURHIDAYAH',
+   array['MAHARANI RAJWA ALMIRA', 'BRAINY QURRA A''YUN', 'LISANA SHIDQI ALIYYA', 'AULIA ALTAFUNYSA'],
+   '082262634124', 'Ibu Nurislah',
+   'https://drive.google.com/file/d/1yF0qNcwQfEvT4L1-sM6EpiMyGqWNXHPS/view');
+
+create temporary table impor_sekolah_lanjutan (nama text primary key);
+
+insert into impor_sekolah_lanjutan (nama)
+select distinct sekolah from impor_form_lanjutan;
+
+create temporary table impor_hasil_lanjutan (
+  baris          integer primary key references impor_form_lanjutan (baris),
+  pendaftaran_id uuid not null
+);
+
+do $blok$
+declare
+  v_s record;
+  v_n integer := 0;
+begin
+  for v_s in select * from impor_sekolah_lanjutan order by nama loop
+    if not exists (
+      select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah(v_s.nama)
+    ) then
+      insert into sekolah (name, address) values (v_s.nama, '');
+      v_n := v_n + 1;
+      raise notice '0132: sekolah baru - %', v_s.nama;
+    end if;
+  end loop;
+  raise notice '0132: % sekolah baru dibuat.', v_n;
+end;
+$blok$;
+
+do $blok$
+declare
+  v_f       record;
+  v_batch   uuid;
+  v_sek     uuid;
+  v_kunci   uuid;
+  v_kode    text;
+  v_pakai   record;
+  v_baru    integer := 0;
+  v_ada     integer := 0;
+begin
+  for v_f in select * from impor_form_lanjutan order by baris loop
+    v_batch := null;
+    v_kunci := md5('hrcd-xxxvii-form-' || v_f.baris)::uuid;
+
+    select id into v_sek from sekolah
+     where kunci_sekolah(name) = kunci_sekolah(v_f.sekolah);
+    if v_sek is null then
+      raise exception '0132: sekolah % tidak ketemu setelah dibuat', v_f.sekolah;
+    end if;
+
+    select id into v_batch from pendaftaran where kunci_kirim = v_kunci;
+
+    if v_batch is null then
+      select r.pendaftaran_id into v_batch
+      from regu r
+      join pendaftaran d on d.id = r.pendaftaran_id
+      join sekolah s on s.id = d.sekolah_id
+      where not r.is_cancelled
+        and lower(regexp_replace(trim(r.nama_regu), '\s+', ' ', 'g'))
+          = lower(regexp_replace(trim(v_f.nama_regu), '\s+', ' ', 'g'))
+        and r.golongan = v_f.golongan
+        and (kunci_sekolah(s.name) = kunci_sekolah(v_f.sekolah)
+             or d.kontak_wa = v_f.kontak_wa);
+
+      if v_batch is not null then
+        v_ada := v_ada + 1;
+      elsif exists (
+        select 1 from regu r
+        where not r.is_cancelled
+          and lower(regexp_replace(trim(r.nama_regu), '\s+', ' ', 'g'))
+            = lower(regexp_replace(trim(v_f.nama_regu), '\s+', ' ', 'g'))
+      ) then
+        select s.name as sekolah, r.golongan, r.nama_ketua, r.anggota,
+               d.kontak_wa
+          into v_pakai
+          from regu r
+          join pendaftaran d on d.id = r.pendaftaran_id
+          join sekolah s on s.id = d.sekolah_id
+         where not r.is_cancelled
+           and lower(regexp_replace(trim(r.nama_regu), '\s+', ' ', 'g'))
+             = lower(regexp_replace(trim(v_f.nama_regu), '\s+', ' ', 'g'));
+
+        raise exception '0132: nama % baris % sudah dipakai <% / % / % / % / %>; sumber <% / % / % / % / %>',
+          v_f.nama_regu, v_f.baris,
+          v_pakai.sekolah, v_pakai.golongan, v_pakai.nama_ketua,
+          v_pakai.anggota, v_pakai.kontak_wa,
+          v_f.sekolah, v_f.golongan, v_f.nama_ketua,
+          v_f.anggota, v_f.kontak_wa;
+      end if;
+    end if;
+
+    if v_batch is null then
+      loop
+        v_kode := 'HRCD' || edisi_aktif() || '-' ||
+                  upper(substr(md5(gen_random_uuid()::text), 1, 6));
+        exit when not exists (
+          select 1 from pendaftaran where kode_pembayaran = v_kode
+        );
+      end loop;
+
+      insert into pendaftaran (
+        sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+        jumlah_regu, kontak_wa, kunci_kirim, nama_kontak,
+        metode_bayar, bukti_transfer
+      ) values (
+        v_sek, v_kode, false, 0, 1, v_f.kontak_wa, v_kunci,
+        v_f.nama_kontak, 'transfer', v_f.bukti
+      ) returning id into v_batch;
+
+      insert into regu (
+        pendaftaran_id, nama_regu, nama_ketua, golongan, anggota
+      ) values (
+        v_batch, v_f.nama_regu, v_f.nama_ketua, v_f.golongan,
+        nullif(v_f.anggota, '{}')
+      );
+      v_baru := v_baru + 1;
+    else
+      update pendaftaran
+         set sekolah_id     = v_sek,
+             kontak_wa      = v_f.kontak_wa,
+             nama_kontak    = coalesce(nama_kontak, v_f.nama_kontak),
+             metode_bayar   = 'transfer',
+             bukti_transfer = v_f.bukti
+       where id = v_batch;
+
+      update regu
+         set nama_regu  = case
+                            when nomor_dada is null then v_f.nama_regu
+                            else nama_regu
+                          end,
+             nama_ketua = v_f.nama_ketua,
+             anggota    = nullif(v_f.anggota, '{}')
+       where pendaftaran_id = v_batch
+         and not is_cancelled
+         and lower(regexp_replace(trim(nama_regu), '\s+', ' ', 'g'))
+           = lower(regexp_replace(trim(v_f.nama_regu), '\s+', ' ', 'g'));
+    end if;
+
+    insert into impor_hasil_lanjutan (baris, pendaftaran_id)
+    values (v_f.baris, v_batch);
+  end loop;
+
+  raise notice '0132: % pendaftaran dibuat, % yang sudah ada dilengkapi.',
+    v_baru, v_ada;
+end;
+$blok$;
+
+do $blok$
+declare
+  v_n integer;
+begin
+  select count(*) into v_n
+  from impor_form_lanjutan f
+  join impor_hasil_lanjutan h on h.baris = f.baris
+  join pendaftaran d
+    on d.id = h.pendaftaran_id
+   and d.metode_bayar = 'transfer'
+   and d.bukti_transfer like 'https://drive.google.com/file/d/%/view'
+  join regu r
+    on r.pendaftaran_id = d.id
+   and r.golongan = f.golongan
+   and r.nama_ketua = f.nama_ketua
+   and r.anggota = f.anggota
+   and not r.is_cancelled
+  join sekolah s
+    on s.id = d.sekolah_id
+   and kunci_sekolah(s.name) = kunci_sekolah(f.sekolah);
+
+  if v_n <> (select count(*) from impor_form_lanjutan) then
+    raise exception '0132: baru % dari % respons unik yang terpasang lengkap',
+      v_n, (select count(*) from impor_form_lanjutan);
+  end if;
+  raise notice '0132: % respons unik terpasang lengkap.', v_n;
+end;
+$blok$;
+
+drop table impor_hasil_lanjutan;
+drop table impor_form_lanjutan;
+drop table impor_sekolah_lanjutan;

--- a/supabase/migrations/0133_kelas_organisasi_regu.sql
+++ b/supabase/migrations/0133_kelas_organisasi_regu.sql
@@ -1,0 +1,296 @@
+-- ============================================================================
+-- hrcd-rekap : 0133_kelas_organisasi_regu.sql
+--
+-- Regu menyimpan KELAS atau ORGANISASI asalnya, satu per regu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA, DAN KENAPA PER REGU
+--
+-- Regu Eksternal dibedakan oleh sekolahnya: "SMPN 3 Kawali" cukup untuk tahu
+-- regu itu datang dari mana. Regu Intern semuanya dari SATU sekolah — tuan
+-- rumah — jadi kolom sekolah mengatakan hal yang sama untuk keenam puluh
+-- sekian regu, dan tidak membedakan apa pun.
+--
+-- Yang membedakan mereka kelas atau organisasinya: XI-1, XII-4, OSIS,
+-- Paskibra. Sampai sekarang itu tidak dicatat di mana pun, jadi panitia yang
+-- memanggil regu Intern di lapangan tidak punya cara menyebut asalnya selain
+-- nama regunya sendiri.
+--
+-- Per REGU, bukan per pendaftaran: satu kiriman Intern memuat regu dari
+-- beberapa kelas sekaligus — itulah bentuk pendaftaran tuan rumah, satu
+-- pembina mendaftarkan seluruh angkatan. Satu kotak untuk seluruh kiriman
+-- memaksa mereka memilih satu kelas untuk mewakili semuanya, dan yang
+-- tersimpan jadi keterangan yang salah untuk sebagian besar barisnya.
+--
+-- ---------------------------------------------------------------------------
+-- BOLEH KOSONG, DAN TIDAK DIPAGARI KE INTERN SAJA
+--
+-- Kolomnya NULL untuk seluruh regu yang sudah ada, dan tetap boleh NULL
+-- sesudahnya. Form hanya menawarkan kotaknya pada jalur Intern; yang menjaga
+-- itu form, bukan constraint.
+--
+-- Sengaja: `check (golongan like 'intern%' or kelas_organisasi is null)`
+-- terdengar rapi sampai satu regu Eksternal ternyata memang punya organisasi
+-- yang perlu dicatat — dan saat itu yang menolaknya bukan keputusan panitia
+-- melainkan satu baris yang ditulis hari ini tanpa alasan yang kuat. Yang
+-- dijaga di sini cuma panjangnya.
+--
+-- ---------------------------------------------------------------------------
+-- KOMPATIBEL DENGAN FORM YANG SEDANG BERJALAN
+--
+-- Tanda tangan `submit_pendaftaran` TIDAK berubah. Kelas/organisasi dibaca
+-- dari kunci baru DI DALAM tiap elemen `p_regu`, jadi:
+--
+--   form lama (yang tersaji sekarang)  -> kuncinya tidak ada -> NULL
+--   form baru                          -> kuncinya terbaca dan tersimpan
+--
+-- Itu yang membuat migrasi ini aman diterapkan LEBIH DULU, di tengah acara,
+-- tanpa menunggu form-nya ikut terbit. Urutannya memang harus begitu:
+-- kalau form-nya terbit duluan, kotak yang diisi pembina dibuang diam-diam
+-- oleh RPC yang belum mengenal kuncinya.
+--
+-- Gateway Worker tidak perlu ikut di-deploy — ia meneruskan `b.regu` apa
+-- adanya (`p_regu: b.regu`), tanpa menyaring kuncinya satu per satu.
+-- ============================================================================
+
+alter table regu add column if not exists kelas_organisasi text;
+
+alter table regu drop constraint if exists regu_kelas_organisasi_panjang;
+alter table regu add constraint regu_kelas_organisasi_panjang
+  check (kelas_organisasi is null or length(kelas_organisasi) <= 80);
+
+comment on column regu.kelas_organisasi is
+  'Kelas atau organisasi asal regu — XI-1, OSIS, Paskibra. Diisi jalur Intern, '
+  'tempat kolom sekolah tidak membedakan apa pun karena semuanya tuan rumah. '
+  'NULL untuk regu yang mendaftar sebelum 0133 dan untuk yang tidak mengisinya.';
+
+-- ---------------------------------------------------------------------------
+-- Salinan terakhir submit_pendaftaran (0124). Yang berubah HANYA daftar kolom
+-- pada INSERT regu di bawah, beserta satu ekspresi yang membacanya. Selebihnya
+-- disalin utuh — termasuk seluruh validasi dan komentarnya — karena badan
+-- fungsi plpgsql disimpan sebagai TEKS: yang tidak ikut disalin, hilang.
+-- ---------------------------------------------------------------------------
+create or replace function submit_pendaftaran(
+  p_nama_sekolah   text,
+  p_alamat_sekolah text,
+  p_butuh_barak    boolean,
+  p_kontak_wa      text,
+  p_regu           jsonb,
+  p_jumlah_pendamping smallint default 0,
+  p_kunci_kirim    uuid default null,
+  p_nama_kontak    text default null,
+  p_metode_bayar   text default null,
+  p_bukti_transfer text default null
+) returns jsonb
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare
+  v_sekolah  uuid;
+  v_batch    uuid;
+  v_kode     text;
+  v_n        int;
+  v_r        jsonb;
+  v_ada      pendaftaran%rowtype;
+  v_bukti    text;
+begin
+  if p_kunci_kirim is not null then
+    select * into v_ada from pendaftaran where kunci_kirim = p_kunci_kirim;
+    if found then
+      return jsonb_build_object(
+        'kode_pembayaran', v_ada.kode_pembayaran,
+        'jumlah_regu', v_ada.jumlah_regu,
+        'total_tagihan', tagihan_pendaftaran(v_ada.id),
+        'terkirim_ulang', true);
+    end if;
+  end if;
+
+  v_n := jsonb_array_length(p_regu);
+  if v_n is null or v_n < 1 then
+    raise exception 'minimal satu regu';
+  end if;
+  if v_n > 30 then
+    raise exception 'maksimal 30 regu per pendaftaran';
+  end if;
+  if p_kontak_wa is null or length(trim(p_kontak_wa)) < 8 then
+    raise exception 'kontak WA wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_sekolah), '') = '' then
+    raise exception 'nama sekolah wajib diisi';
+  end if;
+
+  -- Cara bayar dan buktinya. Path buktinya WAJIB berada di dalam folder
+  -- kunci_kirim kiriman ini: nama objek Storage bisa ditebak siapa pun yang
+  -- pernah melihat satu contohnya, dan tanpa pagar ini satu pendaftaran bisa
+  -- menunjuk bukti milik pendaftaran lain.
+  if coalesce(p_metode_bayar, '') not in ('transfer', 'tunai') then
+    raise exception 'cara pembayaran wajib dipilih';
+  end if;
+  v_bukti := nullif(trim(coalesce(p_bukti_transfer, '')), '');
+  if p_metode_bayar = 'transfer' then
+    if v_bukti is null then
+      raise exception 'bukti transfer wajib diunggah';
+    end if;
+    if p_kunci_kirim is null
+       or v_bukti not like p_kunci_kirim::text || '/%' then
+      raise exception 'bukti transfer bukan milik kiriman ini';
+    end if;
+  else
+    v_bukti := null;
+  end if;
+
+  for v_r in select * from jsonb_array_elements(p_regu) loop
+    if coalesce(trim(v_r ->> 'nama_regu'), '') = '' then
+      raise exception 'nama regu wajib diisi';
+    end if;
+    if coalesce(trim(v_r ->> 'nama_ketua'), '') = '' then
+      raise exception 'nama ketua wajib diisi';
+    end if;
+    if coalesce(v_r ->> 'golongan', '') not in (
+      'penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi',
+      'intern_pa', 'intern_pi'
+    ) then
+      raise exception 'golongan tidak dikenal: %', coalesce(v_r ->> 'golongan', '(kosong)');
+    end if;
+
+    -- Kelas/organisasi OPSIONAL, dan yang ditolak cuma yang terlalu panjang.
+    -- Batasnya sama dengan `maxlength` kotaknya di form, jadi yang lolos di
+    -- layar juga lolos di sini — pembina tidak pernah menemui penolakan yang
+    -- tidak bisa ia lihat sebabnya.
+    if length(coalesce(trim(v_r ->> 'kelas_organisasi'), '')) > 80 then
+      raise exception 'kelas/organisasi maksimal 80 karakter';
+    end if;
+
+    -- Anggota OPSIONAL: kunci `anggota` boleh tidak ada sama sekali, dan
+    -- daftarnya boleh kosong. Yang ditolak cuma bentuk yang salah.
+    if v_r ? 'anggota' and jsonb_typeof(v_r -> 'anggota') <> 'null' then
+      if jsonb_typeof(v_r -> 'anggota') <> 'array' then
+        raise exception 'anggota harus berupa daftar nama';
+      end if;
+      if (select count(*) from jsonb_array_elements_text(v_r -> 'anggota') a
+          where trim(a) <> '') > 4 then
+        raise exception 'maksimal 4 anggota selain ketua';
+      end if;
+      -- Aturan yang sama dengan nama ketua (0052): angka di nama orang hampir
+      -- selalu nomor urut yang ikut terketik, dan ia terbawa ke daftar hadir.
+      if exists (select 1 from jsonb_array_elements_text(v_r -> 'anggota') a
+                 where a ~ '[0-9]') then
+        raise exception 'nama anggota tidak boleh memakai angka';
+      end if;
+    end if;
+  end loop;
+
+  select id into v_sekolah from sekolah
+   where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+
+  if v_sekolah is null then
+    insert into sekolah (name, address)
+    values (trim(p_nama_sekolah), trim(coalesce(p_alamat_sekolah, '')))
+    on conflict (kunci_sekolah(name)) do nothing
+    returning id into v_sekolah;
+
+    if v_sekolah is null then
+      select id into v_sekolah from sekolah
+       where kunci_sekolah(name) = kunci_sekolah(p_nama_sekolah);
+    end if;
+  end if;
+
+  loop
+    v_kode := 'HRCD' || edisi_aktif() || '-' ||
+              upper(substr(md5(gen_random_uuid()::text), 1, 6));
+    exit when not exists (select 1 from pendaftaran where kode_pembayaran = v_kode);
+  end loop;
+
+  insert into pendaftaran (sekolah_id, kode_pembayaran, butuh_barak,
+                           jumlah_menginap, jumlah_regu, kontak_wa, kunci_kirim,
+                           nama_kontak, metode_bayar, bukti_transfer)
+  values (v_sekolah, v_kode, coalesce(p_butuh_barak, false),
+          greatest(coalesce(p_jumlah_pendamping, 0), 0), v_n, trim(p_kontak_wa),
+          p_kunci_kirim, nullif(trim(coalesce(p_nama_kontak, '')), ''),
+          p_metode_bayar, v_bukti)
+  returning id into v_batch;
+
+  -- Kotak yang dibiarkan kosong TIDAK disimpan sebagai string kosong: yang
+  -- tersimpan hanya nama yang benar-benar diketik, berurutan. `array_agg` atas
+  -- nol baris mengembalikan NULL, dan NULL di sini berarti "tidak ada nama
+  -- anggota yang dicatat" — bukan "regunya kosong".
+  --
+  -- `kelas_organisasi` mengikuti aturan yang sama: kotak kosong disimpan NULL,
+  -- bukan string kosong. Dua bentuk untuk satu keadaan berarti setiap
+  -- pembacanya harus memeriksa keduanya, dan yang lupa memeriksa salah satunya
+  -- menggambar baris kosong yang terlihat seperti data.
+  insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan, anggota,
+                    kelas_organisasi)
+  select v_batch, trim(r ->> 'nama_regu'), trim(r ->> 'nama_ketua'), r ->> 'golongan',
+         (select array_agg(trim(a) order by urut)
+          from jsonb_array_elements_text(coalesce(r -> 'anggota', '[]'::jsonb))
+               with ordinality as t(a, urut)
+          where trim(a) <> ''),
+         nullif(trim(coalesce(r ->> 'kelas_organisasi', '')), '')
+  from jsonb_array_elements(p_regu) r;
+
+  return jsonb_build_object(
+    'kode_pembayaran', v_kode,
+    'jumlah_regu', v_n,
+    'total_tagihan', tagihan_pendaftaran(v_batch),
+    'terkirim_ulang', false);
+end;
+$fn$;
+
+-- ---------------------------------------------------------------------------
+-- Pagar: kunci baru benar-benar tersimpan, dan kiriman TANPA kunci itu tetap
+-- diterima. Yang kedua yang penting hari ini — form yang sedang tersaji belum
+-- mengirimnya, dan pembina sedang mendaftar saat migrasi ini berjalan.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_kunci uuid := gen_random_uuid();
+  v_kunci2 uuid := gen_random_uuid();
+  v_kode  text;
+  v_isi   text;
+begin
+  select (submit_pendaftaran(
+    'SMA Negeri 1 Ciamis', '', false, '081200000133',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'UJI KELAS 0133', 'nama_ketua', 'Uji Ketua',
+      'golongan', 'intern_pa', 'kelas_organisasi', '  XI-1  ')),
+    0::smallint, v_kunci, null, 'tunai', null) ->> 'kode_pembayaran')
+  into v_kode;
+
+  select r.kelas_organisasi into v_isi
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_kode;
+
+  if v_isi is distinct from 'XI-1' then
+    raise exception '0133: kelas/organisasi tersimpan sebagai % — seharusnya XI-1 (dan spasinya dibuang)', coalesce(v_isi, '<NULL>');
+  end if;
+
+  -- Kiriman tanpa kuncinya sama sekali: bentuk yang dipakai form yang sedang
+  -- tersaji. Ia harus tetap diterima, dan kolomnya NULL.
+  select (submit_pendaftaran(
+    'SMA Negeri 1 Ciamis', '', false, '081200000133',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'UJI TANPA KELAS 0133', 'nama_ketua', 'Uji Ketua',
+      'golongan', 'intern_pi')),
+    0::smallint, v_kunci2, null, 'tunai', null) ->> 'kode_pembayaran')
+  into v_kode;
+
+  select coalesce(r.kelas_organisasi, '<NULL>') into v_isi
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_kode;
+
+  if v_isi <> '<NULL>' then
+    raise exception '0133: kiriman tanpa kelas/organisasi menyimpan %', v_isi;
+  end if;
+
+  -- Bersihkan kedua pendaftaran uji. Migrasi ini berjalan di produksi saat
+  -- acara berlangsung; meninggalkan dua regu karangan di sana berarti dua
+  -- baris palsu di Meja Pembayaran dan dua nama yang menyandera indeks
+  -- `regu_nama_unik` selamanya.
+  delete from regu where pendaftaran_id in (
+    select id from pendaftaran where kunci_kirim in (v_kunci, v_kunci2));
+  delete from pendaftaran where kunci_kirim in (v_kunci, v_kunci2);
+
+  raise notice '0133: kelas/organisasi tersimpan per regu; kiriman tanpa kuncinya tetap diterima.';
+end;
+$blok$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -618,6 +618,18 @@ run supabase/migrations/0129_impor_pendaftaran_xxxvii.sql
 # tempatnya tepat di belakangnya, bukan di kelompok migrasi mana pun.
 run supabase/migrations/0130_bukti_transfer_link_drive.sql
 
+# 0133 memberi regu kolom kelas/organisasi, dipakai jalur Intern. Pagar di
+# dalamnya MENGIRIM dua pendaftaran uji lewat submit_pendaftaran lalu
+# menghapusnya lagi — salah satunya untuk membuktikan kiriman TANPA kunci
+# baru itu tetap diterima.
+#
+# Ia berjalan SEBELUM 0131 dan 0132 di daftar ini, bukan sesudahnya, dan itu
+# justru pembuktian tambahan: keduanya mengimpor lewat submit_pendaftaran
+# tanpa mengirim kunci `kelas_organisasi` sama sekali, dan tetap lulus di atas
+# fungsi yang sudah diganti 0133. Itu persis keadaan produksi saat migrasi ini
+# diterapkan — form yang tersaji belum mengirim kuncinya.
+run supabase/migrations/0133_kelas_organisasi_regu.sql
+
 # 0131 meneruskan impor mulai baris 102 sampai akhir workbook. Tiga kiriman
 # ulang dilewati, sehingga pagarnya menuntut 38 pendaftaran unik; baris yang
 # telanjur dimasukkan lewat form baru dicocokkan dan dilengkapi notanya.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -623,4 +623,9 @@ run supabase/migrations/0130_bukti_transfer_link_drive.sql
 # telanjur dimasukkan lewat form baru dicocokkan dan dilengkapi notanya.
 run supabase/migrations/0131_impor_pendaftaran_xxxvii_susulan.sql
 
+# 0132 meneruskan lagi mulai baris 143. Dua kiriman ulang dilewati, sehingga
+# tujuh baris sumber menjadi lima regu unik; data yang sudah masuk lewat form
+# aktif dicocokkan tanpa mengubah nama atau nomor regu yang sudah bernomor.
+run supabase/migrations/0132_impor_pendaftaran_xxxvii_lanjutan.sql
+
 echo "SEMUA TES LULUS"


### PR DESCRIPTION
## What

Kolom baru `regu.kelas_organisasi`, dan `submit_pendaftaran` menyimpannya dari
kunci baru **di dalam tiap elemen** `p_regu`.

Ini bagian **database** dari permintaan "Kelas / Organisasi" di form Internal.
Bagian formnya menyusul di PR terpisah — urutannya penting, lihat di bawah.

## Why

Regu Eksternal dibedakan oleh sekolahnya. Regu Intern semuanya dari **satu**
sekolah — tuan rumah — jadi kolom sekolah mengatakan hal yang sama untuk keenam
puluh sekian regu dan tidak membedakan apa pun. Yang membedakan mereka kelas
atau organisasinya: XI-1, XII-4, OSIS, Paskibra — dan itu tidak dicatat di mana
pun.

**Per regu, bukan per pendaftaran.** Satu kiriman Intern memuat regu dari
beberapa kelas sekaligus; itulah bentuk pendaftaran tuan rumah, satu pembina
mendaftarkan seluruh angkatan. Satu kotak untuk seluruh kiriman memaksa mereka
memilih satu kelas untuk mewakili semuanya, dan yang tersimpan jadi keterangan
yang salah untuk sebagian besar barisnya.

## Kenapa migrasinya duluan, dan formnya belakangan

Tanda tangan `submit_pendaftaran` **tidak berubah** — kuncinya dibaca dari
dalam `p_regu`. Jadi:

| | |
| --- | --- |
| form yang tersaji sekarang | kuncinya tidak ada → `NULL`, kiriman tetap diterima |
| form baru (PR berikutnya) | kuncinya terbaca dan tersimpan |

Kalau urutannya dibalik, kotak yang diisi pembina **dibuang diam-diam** oleh
RPC yang belum mengenal kuncinya. Gateway Worker tidak perlu ikut di-deploy —
ia meneruskan `b.regu` apa adanya.

## Notes

- **Tidak dipagari ke Intern saja.** Form yang menjaga itu, bukan constraint.
  `check (golongan like 'intern%' or ... is null)` terdengar rapi sampai satu
  regu Eksternal ternyata memang punya organisasi yang perlu dicatat — dan yang
  menolaknya saat itu bukan keputusan panitia melainkan satu baris yang ditulis
  hari ini tanpa alasan kuat. Yang dijaga cuma panjangnya, 80 karakter, sama
  dengan `maxlength` kotaknya nanti.
- **Kotak kosong disimpan `NULL`, bukan string kosong** — aturan yang sama
  dengan `anggota`. Dua bentuk untuk satu keadaan berarti setiap pembacanya
  harus memeriksa keduanya.
- Dinomori **0133**, bukan 0132: nomor itu keburu dipakai impor pendaftaran
  lanjutan yang mendarat lebih dulu.

## Pagar di dalam migrasinya

Ia **mengirim dua pendaftaran uji lewat RPC-nya sendiri** lalu menghapusnya
lagi:

1. dengan kunci baru → harus tersimpan, dan spasinya dibuang (`"  XI-1  "` →
   `XI-1`)
2. **tanpa kunci itu sama sekali** → harus tetap diterima, kolomnya `NULL`

Yang kedua yang penting hari ini: pembina sedang mendaftar saat migrasi ini
berjalan. Keduanya dihapus lagi supaya tidak meninggalkan baris palsu di Meja
Pembayaran maupun nama yang menyandera `regu_nama_unik`.

Pembuktian tambahan datang dari urutan di `tests/run.sh`: `0131` dan `0132`
mengimpor lewat `submit_pendaftaran` **tanpa** kunci baru itu, dan keduanya
lulus di atas fungsi yang sudah diganti — persis keadaan produksi.

```
bash tests/run.sh            -> SEMUA TES LULUS
                                0133: kelas/organisasi tersimpan per regu;
                                kiriman tanpa kuncinya tetap diterima
node --test tests/*.test.mjs -> 218 pass, 0 fail
```