### PR TITLE
feat: layar Data Peserta — panitia membetulkan yang salah diketik pembina

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0134`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0134`
+sampai migrasi `0135`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0135`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0134`.
+`0119`-`0135`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-134 migrasi, `0001` sampai `0134`, dijalankan berurutan tanpa lubang penomoran.
+135 migrasi, `0001` sampai `0135`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -189,6 +189,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | --- | --- | --- |
 | `#/home` | Home | menu + **empat** lencana: dua antrean (menunggu pembayaran, lunas belum bernomor) dan dua kemajuan berantai (Keberangkatan `berangkat/siap`, Kedatangan `datang/berangkat`) |
 | `#/foto` | Foto Jawaban | foto borongan per lomba di pos, lalu tautkan nomor dada |
+| `#/data-peserta` | Data Peserta | betulkan yang salah diketik pembina: kontak, nama regu, ketua, anggota, kelas/organisasi |
 | `#/pembayaran` | Meja Pembayaran | tabel semua invoice, tandai lunas, cetak kwitansi |
 | `#/daftar-ulang` | Meja Daftar Ulang | isi nomor dada per regu, tukar nomor rusak |
 | `#/cetak-kloter` | Daftar Kloter | lembar per kloter untuk petugas start |

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -520,6 +520,43 @@ export async function daftarPendaftaran() {
     "&regu.order=nama_regu.asc&order=created_at.asc");
 }
 
+/** Bahan layar Data Peserta: yang BISA DIBETULKAN, dan tidak lebih.
+ *
+ *  Sengaja tidak memakai daftarPendaftaran() walau dua-duanya membaca tabel
+ *  yang sama. Layar itu perlu tagihan, metode bayar, dan kwitansi; layar ini
+ *  perlu nama anggota dan kelas/organisasi. Satu bentuk untuk keduanya berarti
+ *  tiap layar mengirimkan kolom yang tidak dipakainya ke ratusan baris — dan
+ *  yang lebih mahal, tiap perubahan pada salah satunya menyentuh keduanya. */
+export async function dataPeserta() {
+  if (K.mode === "dev") return baca("/data-peserta");
+  return baca(null,
+    "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,kontak_wa," +
+    "nama_kontak,created_at,sekolah(name)," +
+    "regu(id,nama_regu,nama_ketua,golongan,anggota,kelas_organisasi," +
+    "nomor_dada,is_cancelled)" +
+    "&regu.order=nama_regu.asc&order=created_at.asc");
+}
+
+/** Betulkan kontak pembina satu pendaftaran (migrasi 0135). Nama dan nomor
+ *  dikirim BERSAMA: yang mengganti nomor hampir selalu mengganti orangnya. */
+export async function ubahKontakPendaftaran(kode, namaKontak, kontakWa) {
+  return rpc("ubah_kontak_pendaftaran", {
+    p_kode: kode, p_nama_kontak: namaKontak || null, p_kontak_wa: kontakWa,
+  });
+}
+
+/** Betulkan identitas satu regu (migrasi 0135). Golongan, sekolah, nomor dada
+ *  dan status bayar TIDAK di sini — masing-masing punya jalurnya sendiri. */
+export async function ubahIdentitasRegu(reguId, data) {
+  return rpc("ubah_identitas_regu", {
+    p_regu_id: reguId,
+    p_nama_regu: data.nama_regu,
+    p_nama_ketua: data.nama_ketua,
+    p_anggota: data.anggota || [],
+    p_kelas_organisasi: data.kelas_organisasi || null,
+  });
+}
+
 export const verifikasiPembayaran = (kode, nominal, metode) =>
   rpc("verifikasi_pembayaran", { p_kode: kode, p_nominal: nominal, p_metode: metode });
 

--- a/live/style.css
+++ b/live/style.css
@@ -1835,6 +1835,65 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kolom dilebarkan, angka ini ikut naik — DAN ambang kartu 900px di bawah
      harus ikut naik, kalau tidak tabelnya kembali menggeser ke samping dan
      kolom tombol hilang lagi dari layar. */
+
+  /* ---- Data Peserta ----
+
+     `table-layout: fixed`, dan alasannya SATU: membuka baris rincian tidak
+     boleh menggeser kolom induknya.
+
+     Dengan `auto`, lebar tiap kolom dihitung dari SELURUH isi tabel — baris
+     rincian yang baru muncul ikut dihitung, dan enam kolom di atasnya
+     bergeser semua. Petugas yang menekan satu tombol melihat seluruh tabel
+     melompat, lalu harus mencari lagi baris yang tadi dilihatnya. Itu keluhan
+     yang dilaporkan langsung, dan `fixed` yang menyelesaikannya: lebar kolom
+     ditentukan patokan di bawah, bukan isinya, jadi yang berubah saat rincian
+     dibuka cuma tingginya.
+
+     Persentasenya WAJIB berjumlah 100 di kedua tabel. Di bawah `fixed`, kolom
+     yang tidak dipatok mendapat NOL — bukan sisanya (pasal 15.3).
+
+       induk    14 + 15 + 22 +  8 + 20 + 21              = 100
+       rincian  14 + 11 + 13 + 15 + 12 + 12 + 12 + 11    = 100
+
+     Keduanya TIDAK dipasangkan kolom per kolom, dan itu beda dari tabel
+     Pembayaran (pasal 15.2). Di sana kolom terakhir keduanya harus bertemu
+     supaya angka rupiah tiap regu jatuh di bawah tombolnya. Di sini rinciannya
+     bicara hal lain sama sekali — satu baris per regu, kolomnya Ketua dan
+     Anggota — dan tidak ada angka yang perlu berbaris tegak.
+
+     1120px = delapan kolom rincian yang masing-masing memuat satu kotak nama.
+     Di bawah itu pembungkusnya menggulir mendatar, bukan memampatkan kotaknya
+     sampai nama tidak terbaca. Di bawah 900px ia sudah jadi kartu dan seluruh
+     angka di sini tidak berlaku. */
+  .table-peserta, .detail-table-peserta { table-layout: fixed; }
+  .table-peserta { min-width: 1120px; }
+  .detail-table-peserta { width: 100%; }
+
+  .table-peserta > thead > tr > th:nth-child(1) { width: 14%; }
+  .table-peserta > thead > tr > th:nth-child(2) { width: 15%; }
+  .table-peserta > thead > tr > th:nth-child(3) { width: 22%; }
+  .table-peserta > thead > tr > th:nth-child(4) { width:  8%; }
+  .table-peserta > thead > tr > th:nth-child(5) { width: 20%; }
+  .table-peserta > thead > tr > th:nth-child(6) { width: 21%; }
+
+  .detail-table-peserta > thead > tr > th:nth-child(1) { width: 14%; }
+  .detail-table-peserta > thead > tr > th:nth-child(2) { width: 11%; }
+  .detail-table-peserta > thead > tr > th:nth-child(3) { width: 13%; }
+  .detail-table-peserta > thead > tr > th:nth-child(4) { width: 15%; }
+  .detail-table-peserta > thead > tr > th:nth-child(5) { width: 12%; }
+  .detail-table-peserta > thead > tr > th:nth-child(6) { width: 12%; }
+  .detail-table-peserta > thead > tr > th:nth-child(7) { width: 12%; }
+  .detail-table-peserta > thead > tr > th:nth-child(8) { width: 11%; }
+
+  /* Kotak isian mengisi selnya. Tanpa ini `.small-input` memakai lebar bawaan
+     input dan meluap keluar kolom yang sudah dipatok. */
+  .table-peserta .small-input,
+  .detail-table-peserta .small-input { width: 100%; min-width: 0; }
+  /* Nama sekolah satu-satunya isi yang panjangnya tak terduga — ia yang
+     mengalah dan membungkus, seperti di tabel Pembayaran. */
+  .table-peserta > tbody > tr > td:nth-child(3) {
+    white-space: normal; overflow-wrap: break-word;
+  }
   .table-bayar { min-width: 820px; }
 
   /* Label tombol MEMENDEK di sini juga: "Cetak Kwitansi" -> "Kwitansi",

--- a/supabase/migrations/0135_ubah_data_peserta.sql
+++ b/supabase/migrations/0135_ubah_data_peserta.sql
@@ -1,0 +1,215 @@
+-- ============================================================================
+-- hrcd-rekap : 0135_ubah_data_peserta.sql
+--
+-- Dua RPC yang membuat data pendaftaran BISA DIBETULKAN dari layar panitia:
+-- kontak pembina, dan identitas tiap regu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA
+--
+-- Sampai sekarang segala yang diketik pembina di form pendaftaran adalah
+-- keadaan akhir. Nomor WA salah satu digit, nama anggota tertukar, nama ketua
+-- salah eja — tidak ada satu layar pun yang bisa membetulkannya, dan satu-
+-- satunya jalan membatalkan pendaftaran lalu meminta mereka mengisi ulang.
+--
+-- Itu bukan jalan yang dipakai orang: yang benar-benar terjadi, panitia
+-- mencatat betulannya di kertas lain, dan sejak saat itu database berbeda dari
+-- kenyataan tanpa ada yang tahu bagian mana.
+--
+-- ---------------------------------------------------------------------------
+-- HAKNYA `pendaftaran`, BUKAN FITUR BARU
+--
+-- `boleh('pendaftaran')` — hak yang sudah ada, dipegang admin dan registrasi
+-- (paket_peran, 0075). Membetulkan data pendaftaran adalah pekerjaan yang
+-- sama dengan menerima pendaftaran; memberinya kunci sendiri berarti satu
+-- centang lagi yang harus diingat panitia, untuk pemisahan yang tidak pernah
+-- diminta siapa pun.
+--
+-- ---------------------------------------------------------------------------
+-- YANG TIDAK BISA DIUBAH DARI SINI, DAN KENAPA
+--
+--   golongan      — menentukan harga (0110) dan blangko mana yang dicetak.
+--                   Salah golongan berarti pendaftaran yang salah, bukan salah
+--                   ketik; batalkan dan daftar ulang.
+--   sekolah       — sama, dan ia dipakai kunci pencarian di banyak layar.
+--   nomor dada    — punya jalurnya sendiri (tukar_nomor, 0041) yang menjaga
+--                   stok dan pensiunnya.
+--   status bayar  — punya Meja Pembayaran.
+--
+-- Yang tersisa memang cuma tulisan: nama dan nomor telepon.
+--
+-- ---------------------------------------------------------------------------
+-- RIWAYATNYA TERCATAT SENDIRI
+--
+-- `regu` dan `pendaftaran` dua-duanya punya trigger `record_history` (0042),
+-- jadi tiap perubahan di sini masuk riwayat tanpa satu baris tambahan. Itu
+-- yang membuat layar ini aman diberikan: yang mengubah, kapan, dan dari apa
+-- ke apa semuanya tersimpan.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kontak pembina.
+--
+-- Nomor WA dan nama contact person adalah SATU pasang — keduanya diubah
+-- bersama, karena yang mengganti nomor hampir selalu mengganti orangnya juga.
+-- Dua RPC terpisah berarti satu di antaranya bisa gagal dan meninggalkan nama
+-- lama di sebelah nomor baru.
+-- ---------------------------------------------------------------------------
+create or replace function ubah_kontak_pendaftaran(
+  p_kode        text,
+  p_nama_kontak text,
+  p_kontak_wa   text
+) returns void
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare v_wa text;
+begin
+  if not boleh('pendaftaran') then
+    raise exception 'tidak berhak: pendaftaran';
+  end if;
+
+  -- Satu bentuk saja yang disimpan: 08xxxxxxxxxx. Yang diketik orang ada
+  -- empat — "+62 812-...", "62812...", "0812..." dan kadang "812..." — dan
+  -- keempatnya nomor yang SAMA. Disimpan apa adanya, pencarian nomor tidak
+  -- pernah menemukan yang ditulis dengan gaya lain, dan tautan WhatsApp
+  -- panitia mendarat di nomor yang tidak ada.
+  v_wa := regexp_replace(coalesce(p_kontak_wa, ''), '[^0-9]', '', 'g');
+  if v_wa like '62%'     then v_wa := '0' || substr(v_wa, 3); end if;
+  if v_wa like '8%'      then v_wa := '0' || v_wa;            end if;
+  if length(v_wa) < 8 then
+    raise exception 'nomor WA belum lengkap';
+  end if;
+
+  -- Nama boleh dikosongkan — sebagian pendaftaran lama memang tidak punya
+  -- (kolomnya baru ada sejak 0013). Yang tidak boleh: angka di dalamnya,
+  -- aturan yang sama dengan nama orang mana pun (0052).
+  if coalesce(p_nama_kontak, '') ~ '[0-9]' then
+    raise exception 'nama contact person tidak boleh memakai angka';
+  end if;
+
+  update pendaftaran
+     set kontak_wa   = v_wa,
+         nama_kontak = nullif(trim(coalesce(p_nama_kontak, '')), '')
+   where kode_pembayaran = p_kode;
+
+  if not found then
+    raise exception 'kode pembayaran tidak dikenal: %', p_kode;
+  end if;
+end;
+$fn$;
+
+grant execute on function ubah_kontak_pendaftaran(text, text, text) to authenticated;
+
+comment on function ubah_kontak_pendaftaran(text, text, text) is
+  'Betulkan nama dan nomor WA pembina satu pendaftaran. Nomornya dinormalkan '
+  'ke satu bentuk 08xxxxxxxxxx, jadi "+62 812-3456", "62812..." dan "812..." '
+  'mendarat sama. Riwayatnya tercatat trigger record_history (0042).';
+
+-- ---------------------------------------------------------------------------
+-- 2. Identitas satu regu.
+--
+-- Seluruh validasinya SAMA PERSIS dengan submit_pendaftaran, dan itu
+-- disengaja: dua pintu masuk untuk satu tabel yang aturannya berbeda berarti
+-- data yang lolos lewat pintu kedua akan ditolak pintu pertama, dan yang
+-- menemukannya pembina yang mendaftar tahun depan.
+-- ---------------------------------------------------------------------------
+create or replace function ubah_identitas_regu(
+  p_regu_id          uuid,
+  p_nama_regu        text,
+  p_nama_ketua       text,
+  p_anggota          text[],
+  p_kelas_organisasi text default null
+) returns void
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare v_anggota text[];
+begin
+  if not boleh('pendaftaran') then
+    raise exception 'tidak berhak: pendaftaran';
+  end if;
+
+  if coalesce(trim(p_nama_regu), '') = '' then
+    raise exception 'nama regu wajib diisi';
+  end if;
+  if coalesce(trim(p_nama_ketua), '') = '' then
+    raise exception 'nama ketua wajib diisi';
+  end if;
+  if p_nama_ketua ~ '[0-9]' then
+    raise exception 'nama ketua tidak boleh memakai angka';
+  end if;
+
+  -- Kotak kosong DIBUANG, bukan disimpan sebagai string kosong — aturan yang
+  -- sama dengan submit_pendaftaran. Urutannya dipertahankan.
+  select array_agg(a order by urut) into v_anggota
+  from unnest(coalesce(p_anggota, array[]::text[])) with ordinality as t(a, urut)
+  where trim(coalesce(a, '')) <> '';
+
+  if coalesce(array_length(v_anggota, 1), 0) > 4 then
+    raise exception 'maksimal 4 anggota selain ketua';
+  end if;
+  if exists (select 1 from unnest(coalesce(v_anggota, array[]::text[])) a
+             where a ~ '[0-9]') then
+    raise exception 'nama anggota tidak boleh memakai angka';
+  end if;
+
+  update regu
+     set nama_regu        = trim(p_nama_regu),
+         nama_ketua       = trim(p_nama_ketua),
+         anggota          = (select array_agg(trim(a) order by urut)
+                             from unnest(coalesce(v_anggota, array[]::text[]))
+                                  with ordinality as t(a, urut)),
+         kelas_organisasi = nullif(trim(coalesce(p_kelas_organisasi, '')), '')
+   where id = p_regu_id;
+
+  if not found then
+    raise exception 'regu tidak dikenal';
+  end if;
+end;
+$fn$;
+
+grant execute on function ubah_identitas_regu(uuid, text, text, text[], text)
+  to authenticated;
+
+comment on function ubah_identitas_regu(uuid, text, text, text[], text) is
+  'Betulkan nama regu, ketua, anggota, dan kelas/organisasi satu regu. '
+  'Golongan, sekolah, nomor dada, dan status bayar SENGAJA tidak di sini — '
+  'masing-masing punya jalurnya sendiri, dan yang salah di antaranya bukan '
+  'salah ketik melainkan pendaftaran yang salah. Constraint tabelnya yang '
+  'menegakkan nama kapital (0126), tanpa angka di depan (0128), tidak kembar '
+  '(0051), dan kelas tanpa simbol (0134).';
+
+-- ---------------------------------------------------------------------------
+-- Pagar di SINI cuma membuktikan pintunya terkunci: kedua fungsi ada, dan
+-- keduanya menolak pemanggil tanpa hak. Migrasi berjalan tanpa kursi
+-- pengguna — `boleh()` selalu false di sini — jadi jalur POSITIFnya tidak bisa
+-- diuji dari dalam berkas ini.
+--
+-- Itu bukan kekurangan yang ditambal, melainkan pembagian yang benar: yang
+-- menguji hak harus MENEMPATI KURSI (CLAUDE.md 13.8), dan yang bisa
+-- menempati kursi cuma harness tes. Jalur positifnya di
+-- tests/sql/88_ubah_data_peserta.sql, yang menjalankan keduanya sebagai akun
+-- registrasi lalu memeriksa hasilnya baris demi baris.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare v_ditolak integer := 0;
+begin
+  begin
+    perform ubah_kontak_pendaftaran('TIDAK-ADA', 'Bu Uji', '081200000000');
+  exception when others then
+    if sqlerrm like 'tidak berhak%' then v_ditolak := v_ditolak + 1; end if;
+  end;
+
+  begin
+    perform ubah_identitas_regu(gen_random_uuid(), 'UJI', 'Uji', null, null);
+  exception when others then
+    if sqlerrm like 'tidak berhak%' then v_ditolak := v_ditolak + 1; end if;
+  end;
+
+  if v_ditolak <> 2 then
+    raise exception '0135: baru % dari 2 RPC yang menolak pemanggil tanpa hak', v_ditolak;
+  end if;
+  raise notice '0135: kedua RPC ada dan menolak pemanggil tanpa hak pendaftaran.';
+end;
+$blok$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -39,6 +39,10 @@ DSN = " ".join([
 ])
 PORT = 8787
 
+# Argumen yang bertipe text[] di Postgres, bukan jsonb. Dipisah karena
+# keduanya sampai ke sini sebagai list JSON yang sama persis.
+ARRAY_TEKS = {"p_anggota"}
+
 # RPC yang boleh dipanggil layar, beserta urutan argumennya.
 RPC = {
     "verifikasi_pembayaran": ["p_kode", "p_nominal", "p_metode"],
@@ -56,6 +60,9 @@ RPC = {
     "kunci_nilai_pos":       ["p_nomor_dada", "p_pos"],
     "buka_kunci_nilai_pos":  ["p_nomor_dada", "p_pos", "p_alasan"],
     "catat_closing":         ["p_nomor_dada", "p_jam_datang", "p_anggota_hadir", "p_catatan"],
+    "ubah_kontak_pendaftaran": ["p_kode", "p_nama_kontak", "p_kontak_wa"],
+    "ubah_identitas_regu":   ["p_regu_id", "p_nama_regu", "p_nama_ketua",
+                              "p_anggota", "p_kelas_organisasi"],
     "atur_fase_live":        ["p_fase"],
     "atur_planning_berangkat": ["p_pertama", "p_terakhir"],
     "susun_barak":           [],
@@ -263,6 +270,29 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "order by nomor_dada",
                     (p.get("pos") or 0, p.get("dada") or "", p.get("dada") or ""),
                     uid=p.get("uid")))
+            elif u.path == "/data-peserta":
+                # Bahan layar Data Peserta. Kolomnya BEDA dari
+                # /daftar-pendaftaran: yang di sini nama anggota dan
+                # kelas/organisasi, bukan tagihan dan kwitansi.
+                self._kirim(200, q("""
+                    select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
+                           d.kontak_wa, d.nama_kontak, d.created_at,
+                           jsonb_build_object('name', s.name) as sekolah,
+                           coalesce((select jsonb_agg(jsonb_build_object(
+                                       'id', r.id, 'nama_regu', r.nama_regu,
+                                       'nama_ketua', r.nama_ketua,
+                                       'golongan', r.golongan,
+                                       'anggota', r.anggota,
+                                       'kelas_organisasi', r.kelas_organisasi,
+                                       'nomor_dada', r.nomor_dada,
+                                       'is_cancelled', r.is_cancelled)
+                                     order by r.nama_regu)
+                             from regu r where r.pendaftaran_id = d.id),
+                            '[]'::jsonb) as regu
+                    from pendaftaran d join sekolah s on s.id = d.sekolah_id
+                    order by d.created_at
+                """, uid=p.get("uid")))
+
             elif u.path == "/daftar-pendaftaran":
                 self._kirim(200, q("""
                     select d.id, d.kode_pembayaran, d.status, d.jumlah_regu,
@@ -423,7 +453,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 nilai = []
                 for k in urutan:
                     v = args.get(k)
-                    if isinstance(v, (dict, list)):
+                    # Daftar yang tujuannya text[] diteruskan sebagai LIST
+                    # Python — psycopg2 mengubahnya jadi array Postgres. Kalau
+                    # ikut di-json.dumps seperti jsonb, yang sampai ke fungsi
+                    # teks '["a","b"]' dan Postgres menolaknya dengan
+                    # "malformed array literal". PostgREST di produksi memang
+                    # sudah memetakannya sendiri; yang perlu diajari cuma
+                    # tiruan ini.
+                    if isinstance(v, list) and k in ARRAY_TEKS:
+                        pass
+                    elif isinstance(v, (dict, list)):
                         v = json.dumps(v)
                     nilai.append(v)
                 # Postgres tidak meng-coerce integer->smallint saat memilih

--- a/tests/payment_rows_render.test.mjs
+++ b/tests/payment_rows_render.test.mjs
@@ -36,7 +36,13 @@ const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8")
 
 /** Potong blok `baris.map(b => { ... }).join("")` dari layarPembayaran(). */
 function blokPembangunBaris() {
-  const mulai = app.indexOf("tbody.replaceChildren(h(baris.map(b => {");
+  // Dicari MULAI DARI layarPembayaran(), bukan dari awal berkas. Layar Data
+  // Peserta memakai potongan pembuka yang sama persis dan berada lebih dulu
+  // di app.js — tanpa jangkar ini, tes Pembayaran diam-diam menguji blok milik
+  // layar lain. Yang menemukannya tes ini sendiri, saat layar itu ditambahkan.
+  const layar = app.indexOf("async function layarPembayaran() {");
+  assert.notEqual(layar, -1, "layarPembayaran() tidak ditemukan di app.js");
+  const mulai = app.indexOf("tbody.replaceChildren(h(baris.map(b => {", layar);
   assert.notEqual(mulai, -1,
     "blok pembangun baris Meja Pembayaran tidak ditemukan — kalau bentuknya " +
     "berubah, sesuaikan potongan ini, JANGAN hapus tesnya");

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -635,6 +635,12 @@ run supabase/migrations/0133_kelas_organisasi_regu.sql
 # utuh), satu bersimbol (harus ditolak), lalu keduanya dihapus lagi.
 run supabase/migrations/0134_kelas_organisasi_tanpa_simbol.sql
 
+# 0135 membuat data pendaftaran bisa DIBETULKAN dari layar panitia — peserta
+# salah ketik, panitia membantu. Pagarnya mendaftar satu regu lewat RPC-nya
+# sendiri, mengubahnya, memeriksa hasilnya, lalu menghapusnya lagi.
+run supabase/migrations/0135_ubah_data_peserta.sql
+run tests/sql/88_ubah_data_peserta.sql
+
 # 0131 meneruskan impor mulai baris 102 sampai akhir workbook. Tiga kiriman
 # ulang dilewati, sehingga pagarnya menuntut 38 pendaftaran unik; baris yang
 # telanjur dimasukkan lewat form baru dicocokkan dan dilengkapi notanya.

--- a/tests/sql/88_ubah_data_peserta.sql
+++ b/tests/sql/88_ubah_data_peserta.sql
@@ -1,0 +1,139 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/88_ubah_data_peserta.sql
+--
+-- Panitia membetulkan data yang salah diketik pembina (migrasi 0135).
+--
+-- Migrasinya sendiri hanya bisa membuktikan pintunya TERKUNCI: ia berjalan
+-- tanpa kursi pengguna, jadi `boleh()` selalu false di sana. Jalur positifnya
+-- di sini, dijalankan sebagai akun registrasi sungguhan — yang menguji hak
+-- harus menempati kursi (CLAUDE.md 13.8).
+--
+--   88.1  kontak pembina bisa dibetulkan, nomornya dinormalkan
+--   88.2  identitas regu bisa dibetulkan, kotak anggota kosong dibuang
+--   88.3  nama regu bisa diganti — dan yang kembar tetap ditolak
+--   88.4  validasi lama ikut berlaku lewat pintu baru ini
+--   88.5  mencabut centang `pendaftaran` menutup keduanya
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+do $blok$
+declare
+  v_registrasi uuid := '00000000-0000-0000-0000-0000000000b1';
+  v_kunci uuid := gen_random_uuid();
+  v_lain  uuid := gen_random_uuid();
+  v_kode  text;
+  v_kode2 text;
+  v_regu  uuid;
+  v_teks  text;
+  v_pesan text;
+begin
+  perform set_config('app.uid', v_registrasi::text, true);
+
+  -- Dua pendaftaran: satu yang dibetulkan, satu lagi yang namanya dipakai
+  -- untuk menguji tabrakan nama regu.
+  select (submit_pendaftaran(
+    'SMA Negeri 1 Ciamis', '', false, '081200000088',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'UJI EDIT DELAPAN', 'nama_ketua', 'Ketua Lama',
+      'golongan', 'intern_pa', 'kelas_organisasi', 'XI IPA 1',
+      'anggota', jsonb_build_array('Anggota Satu', 'Anggota Dua'))),
+    0::smallint, v_kunci, 'Bu Lama', 'tunai', null) ->> 'kode_pembayaran')
+  into v_kode;
+
+  select (submit_pendaftaran(
+    'SMA Negeri 1 Ciamis', '', false, '081200000088',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'UJI EDIT SEMBILAN', 'nama_ketua', 'Ketua Lain',
+      'golongan', 'intern_pi')),
+    0::smallint, v_lain, null, 'tunai', null) ->> 'kode_pembayaran')
+  into v_kode2;
+
+  select r.id into v_regu
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_kode;
+
+  -- 88.1  Kontak pembina. Nomornya sengaja ditulis dengan +62, spasi, dan
+  --       tanda hubung — bentuk yang benar-benar dikirim orang dari HP.
+  perform ubah_kontak_pendaftaran(v_kode, 'Bu Baru', '+62 812-9999-0000');
+  select nama_kontak || ' / ' || kontak_wa into v_teks
+  from pendaftaran where kode_pembayaran = v_kode;
+  assert v_teks = 'Bu Baru / 081299990000',
+    format('88.1 GAGAL: kontak jadi %s', v_teks);
+  raise notice '88.1 LULUS: kontak dibetulkan, nomornya dinormalkan.';
+
+  -- 88.2  Identitas regu. Kotak anggota kosong di TENGAH harus dibuang, bukan
+  --       disimpan sebagai string kosong — aturan yang sama dengan pendaftaran.
+  perform ubah_identitas_regu(v_regu, 'UJI EDIT DELAPAN', 'Ketua Baru',
+                              array['Anggota Satu', '', 'Anggota Tiga'], 'XII IPS 2');
+  select nama_ketua || ' / ' || array_to_string(anggota, ',') || ' / ' || kelas_organisasi
+    into v_teks from regu where id = v_regu;
+  assert v_teks = 'Ketua Baru / Anggota Satu,Anggota Tiga / XII IPS 2',
+    format('88.2 GAGAL: regu jadi %s', v_teks);
+  raise notice '88.2 LULUS: identitas regu dibetulkan, kotak kosong dibuang.';
+
+  -- 88.3  Nama regu memang boleh diganti — itu salah ketik yang paling sering
+  --       diminta. Yang tidak boleh: bertabrakan dengan regu lain, karena nama
+  --       juara dibacakan di lapangan (0051).
+  perform ubah_identitas_regu(v_regu, 'UJI EDIT SEPULUH', 'Ketua Baru',
+                              array['Anggota Satu'], 'XII IPS 2');
+  select nama_regu into v_teks from regu where id = v_regu;
+  assert v_teks = 'UJI EDIT SEPULUH',
+    format('88.3 GAGAL: nama regu jadi %s', v_teks);
+
+  begin
+    perform ubah_identitas_regu(v_regu, 'UJI EDIT SEMBILAN', 'Ketua Baru',
+                                null, null);
+    assert false, '88.3 GAGAL: nama regu kembar diterima';
+  exception when unique_violation then
+    null;
+  end;
+  raise notice '88.3 LULUS: nama regu bisa diganti; yang kembar ditolak.';
+
+  -- 88.4  Validasi lama ikut lewat pintu baru: angka di nama orang, dan
+  --       simbol di kelas/organisasi.
+  begin
+    perform ubah_identitas_regu(v_regu, 'UJI EDIT SEPULUH', 'Ketua 2', null, null);
+    assert false, '88.4 GAGAL: nama ketua berangka diterima';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like '%angka%', format('88.4 GAGAL: pesannya %s', v_pesan);
+
+  begin
+    perform ubah_identitas_regu(v_regu, 'UJI EDIT SEPULUH', 'Ketua Baru',
+                                null, 'XI-1');
+    assert false, '88.4 GAGAL: kelas bersimbol diterima';
+  exception when check_violation then
+    null;
+  end;
+  raise notice '88.4 LULUS: validasi lama ikut berlaku lewat pintu baru.';
+
+  -- 88.5  Centang dicabut, pintunya tertutup — panggilan yang SAMA PERSIS
+  --       dijalankan dua kali dan yang berubah cuma satu baris akun_hak.
+  delete from akun_hak where user_id = v_registrasi and fitur = 'pendaftaran';
+
+  begin
+    perform ubah_kontak_pendaftaran(v_kode, 'Bu Baru', '081299990000');
+    assert false, '88.5 GAGAL: kontak masih bisa diubah tanpa centang';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like 'tidak berhak%',
+    format('88.5 GAGAL: pesannya %s, bukan "tidak berhak"', v_pesan);
+
+  begin
+    perform ubah_identitas_regu(v_regu, 'UJI EDIT SEPULUH', 'Ketua Baru', null, null);
+    assert false, '88.5 GAGAL: regu masih bisa diubah tanpa centang';
+  exception when others then
+    v_pesan := sqlerrm;
+  end;
+  assert v_pesan like 'tidak berhak%',
+    format('88.5 GAGAL: pesannya %s, bukan "tidak berhak"', v_pesan);
+  raise notice '88.5 LULUS: mencabut centang pendaftaran menutup keduanya.';
+end;
+$blok$;
+
+rollback;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -520,6 +520,43 @@ export async function daftarPendaftaran() {
     "&regu.order=nama_regu.asc&order=created_at.asc");
 }
 
+/** Bahan layar Data Peserta: yang BISA DIBETULKAN, dan tidak lebih.
+ *
+ *  Sengaja tidak memakai daftarPendaftaran() walau dua-duanya membaca tabel
+ *  yang sama. Layar itu perlu tagihan, metode bayar, dan kwitansi; layar ini
+ *  perlu nama anggota dan kelas/organisasi. Satu bentuk untuk keduanya berarti
+ *  tiap layar mengirimkan kolom yang tidak dipakainya ke ratusan baris — dan
+ *  yang lebih mahal, tiap perubahan pada salah satunya menyentuh keduanya. */
+export async function dataPeserta() {
+  if (K.mode === "dev") return baca("/data-peserta");
+  return baca(null,
+    "pendaftaran?select=id,kode_pembayaran,status,jumlah_regu,kontak_wa," +
+    "nama_kontak,created_at,sekolah(name)," +
+    "regu(id,nama_regu,nama_ketua,golongan,anggota,kelas_organisasi," +
+    "nomor_dada,is_cancelled)" +
+    "&regu.order=nama_regu.asc&order=created_at.asc");
+}
+
+/** Betulkan kontak pembina satu pendaftaran (migrasi 0135). Nama dan nomor
+ *  dikirim BERSAMA: yang mengganti nomor hampir selalu mengganti orangnya. */
+export async function ubahKontakPendaftaran(kode, namaKontak, kontakWa) {
+  return rpc("ubah_kontak_pendaftaran", {
+    p_kode: kode, p_nama_kontak: namaKontak || null, p_kontak_wa: kontakWa,
+  });
+}
+
+/** Betulkan identitas satu regu (migrasi 0135). Golongan, sekolah, nomor dada
+ *  dan status bayar TIDAK di sini — masing-masing punya jalurnya sendiri. */
+export async function ubahIdentitasRegu(reguId, data) {
+  return rpc("ubah_identitas_regu", {
+    p_regu_id: reguId,
+    p_nama_regu: data.nama_regu,
+    p_nama_ketua: data.nama_ketua,
+    p_anggota: data.anggota || [],
+    p_kelas_organisasi: data.kelas_organisasi || null,
+  });
+}
+
 export const verifikasiPembayaran = (kode, nominal, metode) =>
   rpc("verifikasi_pembayaran", { p_kode: kode, p_nominal: nominal, p_metode: metode });
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -11,6 +11,7 @@
 import {
   sesi, masuk, keluar, gantiPasswordSendiri, ErrorApi,
   infoEdisi, infoPengaturanKloter, aturPlanningBerangkat, ringkasanMeja, daftarPendaftaran,
+  dataPeserta, ubahKontakPendaftaran, ubahIdentitasRegu,
   verifikasiPembayaran, batalkanVerifikasi, daftarUlang, tukarNomor,
   daftarKloter, tandaiKloterDicetak, pindahKloter, daftarSisipan,
   cariRegu, catatFinish, infoPenalti,
@@ -527,6 +528,16 @@ async function layarHome() {
          target="_blank" rel="noopener">
         <div class="function-name">${ikonKotak("clipboard-list", "biru")} Pendaftaran</div>
       </a>` : ""}
+      <!-- Data Peserta duduk tepat di sebelah Pendaftaran, dan itu bukan
+           soal tata letak: keduanya satu pekerjaan yang sama dibelah dua oleh
+           waktu. Yang satu menerima apa yang diketik pembina, yang satu
+           membetulkannya waktu pembina menelepon karena salah ketik. Haknya
+           pun sama: hak pendaftaran. (Tanpa backtick di komentar ini — ia
+           berada DI DALAM template literal, dan satu backtick menutupnya.) -->
+      ${bolehLihat("pendaftaran") ? `
+      <a href="#/data-peserta">
+        <div class="function-name">${ikonKotak("id-card", "toska")} Data Peserta</div>
+      </a>` : ""}
       ${bolehLihat("pembayaran") ? `
       <a href="#/pembayaran">
         <div class="function-name">${ikonKotak("credit-card", "hijau")} Pembayaran ${lencana(r ? r.menunggu_pembayaran : null)}</div>
@@ -841,6 +852,241 @@ const cocokCari = (b, cari) => !cari
 const reguAktif = (b) => (b.regu || []).filter(r => !r.is_cancelled);
 
 /* ============================ MEJA PEMBAYARAN ============================ */
+
+/* ============================ DATA PESERTA ==============================
+
+   Membetulkan yang salah diketik pembina. Peserta mendaftar sendiri lewat
+   form di situs peserta, dan sebagian salah ketik — nomor WA kurang satu
+   digit, nama anggota tertukar, nama ketua salah eja. Sampai layar ini ada,
+   satu-satunya jalan membatalkan pendaftaran lalu meminta mereka mengisi
+   ulang, dan yang benar-benar terjadi: panitia mencatat betulannya di kertas
+   lain, dan database berbeda dari kenyataan tanpa ada yang tahu bagian mana.
+
+   YANG BISA DIUBAH DI SINI cuma tulisan: kontak pembina, dan identitas tiap
+   regu. Golongan, sekolah, nomor dada, dan status bayar sengaja tidak —
+   masing-masing punya jalurnya sendiri, dan yang salah di antaranya bukan
+   salah ketik melainkan pendaftaran yang salah. Alasan lengkapnya di kepala
+   migrasi 0135.
+
+   KARTU, BUKAN TABEL. Layar Pembayaran menampilkan angka yang dibaca sekilas,
+   jadi tabel enam kolom benar di sana. Yang di sini isian yang diketik, dan
+   isian di dalam sel tabel `fixed` selebar 15% tidak bisa dipakai. Alat cari
+   dan saringannya tetap sama persis (alatTabel), jadi kebiasaan panitia tidak
+   berubah.
+
+   ISIANNYA BARU DIGAMBAR SAAT KARTUNYA DIBUKA. 250 pendaftaran x 7 kotak per
+   regu adalah ribuan elemen form yang tidak ada gunanya sampai satu di antara
+   mereka disentuh. Yang tergambar duluan cuma barisnya. */
+async function layarDataPeserta() {
+  if (!EDISI) { layarButuhEdisi("Data Peserta"); return; }
+  pasangKepala("Data Peserta", true);
+  LAYAR.replaceChildren(h(pemuat()));
+
+  const layarIni = location.hash;
+  let semua;
+  try { semua = await dataPeserta(); }
+  catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarDataPeserta)); return; }
+  if (location.hash !== layarIni) return;
+
+  const dibuka = new Set();
+
+  const reguAktifDp = (b) => (b.regu || []).filter(r => !r.is_cancelled);
+  const internDp = (b) => reguAktifDp(b).some(r => String(r.golongan || "").startsWith("intern"));
+
+  LAYAR.replaceChildren(h(`
+    <div class="card">
+      ${alatTabel({
+        saringan: [
+          { kode: "semua", label: "Semua" },
+          { kode: "eksternal", label: "Eksternal", pendek: "Luar" },
+          { kode: "intern", label: "Intern" },
+        ],
+        saringAktif: "semua",
+        jumlah: semua.length,
+        cariContoh: "Cari kode, sekolah, regu, ketua, atau nomor WA…",
+      })}
+      <div id="isi-peserta"></div>
+    </div>
+  `));
+
+  const gambar = (cari = "", saring = "semua") => {
+    const cocok = semua.filter(b => {
+      if (saring === "intern" && !internDp(b)) return false;
+      if (saring === "eksternal" && internDp(b)) return false;
+      if (!cari) return true;
+      const kumpul = [
+        b.kode_pembayaran, b.sekolah?.name, b.kontak_wa, b.nama_kontak,
+        ...reguAktifDp(b).flatMap(r => [r.nama_regu, r.nama_ketua,
+                                        r.kelas_organisasi, ...(r.anggota || [])]),
+      ].filter(Boolean).join(" ").toLowerCase();
+      return kumpul.includes(cari);
+    });
+
+    const kotak = document.getElementById("isi-peserta");
+    document.getElementById("tabel-jumlah").textContent =
+      `${cocok.length} pendaftaran · `
+      + `${cocok.reduce((n, b) => n + reguAktifDp(b).length, 0)} regu`;
+
+    if (!cocok.length) {
+      kotak.replaceChildren(h(`<p class="table-empty">Tidak ada yang cocok.</p>`));
+      return;
+    }
+
+    kotak.replaceChildren(h(cocok.map(b => {
+      const kode = esc(b.kode_pembayaran);
+      const aktif = reguAktifDp(b);
+      const terbuka = dibuka.has(b.kode_pembayaran);
+      return `
+      <div class="regu-card" id="dp-${kode}">
+        <div class="action-row" style="justify-content:space-between;align-items:baseline">
+          <div>
+            <strong class="mono">${kode}</strong>
+            <span style="margin-left:.5rem">${esc(b.sekolah?.name || "—")}</span>
+          </div>
+          <button class="button-detail" type="button" data-buka="${kode}"
+                  aria-expanded="${terbuka}">${terbuka ? "▾" : "▸"} ${aktif.length}<span
+                  class="satuan-regu"> regu</span></button>
+        </div>
+        <div class="sub" style="margin-top:.15rem">
+          ${esc(b.nama_kontak || "tanpa nama kontak")} · ${esc(b.kontak_wa || "—")}
+        </div>
+        ${!terbuka ? "" : isiUbah(b, aktif)}
+      </div>`;
+    }).join("")));
+
+    kotak.querySelectorAll("[data-buka]").forEach(btn =>
+      btn.addEventListener("click", () => {
+        const k = btn.dataset.buka;
+        if (dibuka.has(k)) dibuka.delete(k); else dibuka.add(k);
+        gambar(cari, saring);
+      }));
+
+    pasangUbah(cocok, () => gambar(cari, saring));
+  };
+
+  /* Isian satu pendaftaran: kontak di atas, lalu satu blok per regu. Tiap blok
+     punya tombol Simpan sendiri — satu tombol untuk seluruh kartu berarti satu
+     nama regu yang kembar menggagalkan penyimpanan lima regu lain yang sudah
+     benar, dan petugas tidak tahu mana yang tersimpan. */
+  const isiUbah = (b, aktif) => {
+    const kode = esc(b.kode_pembayaran);
+    return `
+      <div style="margin-top:.7rem;border-top:1.5px solid var(--garis);padding-top:.7rem">
+        <div class="two-column">
+          <div class="field" style="margin:0">
+            <label for="dp-nama-${kode}">Contact Person</label>
+            <input type="text" id="dp-nama-${kode}" value="${esc(b.nama_kontak || "")}"
+                   placeholder="contoh: Bu Rina">
+          </div>
+          <div class="field" style="margin:0">
+            <label for="dp-wa-${kode}">Nomor WhatsApp</label>
+            <input type="tel" id="dp-wa-${kode}" inputmode="numeric"
+                   value="${esc(b.kontak_wa || "")}" placeholder="contoh: 08123456789">
+          </div>
+        </div>
+        <div class="action-row" style="margin-top:.5rem">
+          <button class="button button-secondary button-mini" type="button"
+                  data-simpan-kontak="${kode}">Simpan kontak</button>
+        </div>
+
+        ${aktif.map(r => blokRegu(r)).join("")}
+      </div>`;
+  };
+
+  const blokRegu = (r) => {
+    const id = esc(r.id);
+    const intern = String(r.golongan || "").startsWith("intern");
+    const ang = [0, 1, 2, 3].map(k => (r.anggota || [])[k] || "");
+    return `
+      <div class="regu-card" style="margin-top:.6rem" id="dp-regu-${id}">
+        <span class="badge badge-green">${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}${
+          r.nomor_dada ? ` · ${esc(dada3(r.nomor_dada))}` : ""}</span>
+        ${!intern ? "" : `
+        <div class="field" style="margin:.45rem 0 .7rem">
+          <label for="dp-kelas-${id}">Kelas / Organisasi</label>
+          <input type="text" id="dp-kelas-${id}" maxlength="80"
+                 value="${esc(r.kelas_organisasi || "")}"
+                 placeholder="contoh: XI IPA 4 atau OSIS">
+        </div>`}
+        <div class="two-column">
+          <div class="field" style="margin:0">
+            <label for="dp-regu-nama-${id}">Nama Regu</label>
+            <input type="text" id="dp-regu-nama-${id}" maxlength="25"
+                   value="${esc(r.nama_regu || "")}" style="text-transform:uppercase">
+          </div>
+          <div class="field" style="margin:0">
+            <label for="dp-ketua-${id}">Nama Ketua</label>
+            <input type="text" id="dp-ketua-${id}" value="${esc(r.nama_ketua || "")}">
+          </div>
+        </div>
+        <div class="field" style="margin-top:.5rem">
+          <label for="dp-ang-${id}-0">Nama Anggota (opsional)</label>
+          ${ang.map((a, k) => `
+            <input type="text" id="dp-ang-${id}-${k}" value="${esc(a)}"
+                   style="margin-top:.35rem" placeholder="Nama Anggota ${k + 1}">`).join("")}
+        </div>
+        <div class="action-row" style="margin-top:.5rem">
+          <button class="button button-secondary button-mini" type="button"
+                  data-simpan-regu="${id}">Simpan regu</button>
+        </div>
+      </div>`;
+  };
+
+  /* Sesudah tersimpan, data DI MEMORI ikut diperbarui lalu tabelnya digambar
+     ulang. Tanpa itu baris ringkasnya masih menyebut nomor lama sampai layar
+     dimuat ulang, dan petugas menyimpulkan simpanannya tidak masuk. */
+  const pasangUbah = (cocok, gambarUlang) => {
+    LAYAR.querySelectorAll("[data-simpan-kontak]").forEach(btn =>
+      btn.addEventListener("click", async () => {
+        const kode = btn.dataset.simpanKontak;
+        const b = semua.find(x => x.kode_pembayaran === kode);
+        const nama = document.getElementById(`dp-nama-${kode}`).value.trim();
+        const wa = document.getElementById(`dp-wa-${kode}`).value.trim();
+        btn.disabled = true;
+        try {
+          await ubahKontakPendaftaran(kode, nama, wa);
+          b.nama_kontak = nama || null;
+          b.kontak_wa = wa.replace(/\D/g, "").replace(/^62/, "0");
+          notif("Kontak tersimpan.");
+          gambarUlang();
+        } catch (e) {
+          notif(e instanceof ErrorApi ? e.message : "Kontak gagal disimpan.", true);
+          btn.disabled = false;
+        }
+      }));
+
+    LAYAR.querySelectorAll("[data-simpan-regu]").forEach(btn =>
+      btn.addEventListener("click", async () => {
+        const id = btn.dataset.simpanRegu;
+        const r = semua.flatMap(x => x.regu || []).find(x => String(x.id) === id);
+        const ambil = (s) => (document.getElementById(s)?.value || "").trim();
+        const data = {
+          nama_regu: ambil(`dp-regu-nama-${id}`).toUpperCase(),
+          nama_ketua: ambil(`dp-ketua-${id}`),
+          anggota: [0, 1, 2, 3].map(k => ambil(`dp-ang-${id}-${k}`)).filter(Boolean),
+          kelas_organisasi: ambil(`dp-kelas-${id}`),
+        };
+        btn.disabled = true;
+        try {
+          await ubahIdentitasRegu(id, data);
+          Object.assign(r, {
+            nama_regu: data.nama_regu, nama_ketua: data.nama_ketua,
+            anggota: data.anggota.length ? data.anggota : null,
+            kelas_organisasi: data.kelas_organisasi || null,
+          });
+          notif("Regu tersimpan.");
+          gambarUlang();
+        } catch (e) {
+          notif(e instanceof ErrorApi ? e.message : "Regu gagal disimpan.", true);
+          btn.disabled = false;
+        }
+      }));
+  };
+
+  gambar();
+  pasangAlatTabel(gambar);
+}
+
 
 async function layarPembayaran() {
   if (!EDISI) { layarButuhEdisi("Meja Pembayaran"); return; }
@@ -6410,6 +6656,7 @@ async function layarFoto() {
 const RUTE = {
   "#/home": layarHome,
   "#/foto": layarFoto,
+  "#/data-peserta": layarDataPeserta,
   "#/pembayaran": layarPembayaran,
   "#/daftar-ulang": layarDaftarUlang,
   "#/cetak-kloter": layarCetakKloter,

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -855,28 +855,43 @@ const reguAktif = (b) => (b.regu || []).filter(r => !r.is_cancelled);
 
 /* ============================ DATA PESERTA ==============================
 
-   Membetulkan yang salah diketik pembina. Peserta mendaftar sendiri lewat
-   form di situs peserta, dan sebagian salah ketik — nomor WA kurang satu
-   digit, nama anggota tertukar, nama ketua salah eja. Sampai layar ini ada,
-   satu-satunya jalan membatalkan pendaftaran lalu meminta mereka mengisi
-   ulang, dan yang benar-benar terjadi: panitia mencatat betulannya di kertas
-   lain, dan database berbeda dari kenyataan tanpa ada yang tahu bagian mana.
+   Membetulkan yang salah diketik pembina. Peserta mendaftar sendiri lewat form
+   di situs peserta, dan sebagian salah ketik — nomor WA kurang satu digit, nama
+   anggota tertukar, nama ketua salah eja. Sampai layar ini ada, satu-satunya
+   jalan membatalkan pendaftaran lalu meminta mereka mengisi ulang, dan yang
+   benar-benar terjadi: panitia mencatat betulannya di kertas lain, dan database
+   berbeda dari kenyataan tanpa ada yang tahu bagian mana.
 
-   YANG BISA DIUBAH DI SINI cuma tulisan: kontak pembina, dan identitas tiap
-   regu. Golongan, sekolah, nomor dada, dan status bayar sengaja tidak —
-   masing-masing punya jalurnya sendiri, dan yang salah di antaranya bukan
+   BENTUKNYA SAMA DENGAN MEJA PEMBAYARAN: satu baris per pendaftaran, tombol
+   jumlah regu membuka baris rinciannya. Yang berbeda cuma isinya — di sini
+   setiap sel yang boleh dibetulkan adalah kotak isian.
+
+   DISIMPAN SAAT KOTAKNYA DITINGGALKAN, tanpa tombol Simpan. Satu tombol per
+   baris berarti petugas yang membetulkan satu huruf harus mencari tombolnya
+   dulu, dan yang lupa menekannya kehilangan suntingannya tanpa tahu. Kotaknya
+   berkedip hijau sesudah tersimpan — cara yang sama dengan layar Input Nilai
+   Pos, jadi tidak ada kebiasaan baru yang perlu dipelajari.
+
+   YANG TIDAK ADA DI SINI: golongan, sekolah, nomor dada, status bayar.
+   Masing-masing punya jalurnya sendiri, dan yang salah di antaranya bukan
    salah ketik melainkan pendaftaran yang salah. Alasan lengkapnya di kepala
-   migrasi 0135.
+   migrasi 0135. */
 
-   KARTU, BUKAN TABEL. Layar Pembayaran menampilkan angka yang dibaca sekilas,
-   jadi tabel enam kolom benar di sana. Yang di sini isian yang diketik, dan
-   isian di dalam sel tabel `fixed` selebar 15% tidak bisa dipakai. Alat cari
-   dan saringannya tetap sama persis (alatTabel), jadi kebiasaan panitia tidak
-   berubah.
+/** "17 Agu 26 16:55" — pendek karena ia satu kolom di antara enam, dan yang
+ *  dicari orang di sana urutan kedatangan, bukan tanggal lengkapnya. WIB,
+ *  sama seperti tanggalPanjang(): menjelang tengah malam tanggal alat dan
+ *  tanggal WIB bisa menunjuk hari yang berbeda. */
+const FMT_DP = new Intl.DateTimeFormat("id-ID", {
+  timeZone: "Asia/Jakarta", day: "numeric", month: "short",
+  year: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false,
+});
+const tanggalRingkas = (t) => {
+  if (!t) return "—";
+  const b = {};
+  for (const x of FMT_DP.formatToParts(new Date(t))) b[x.type] = x.value;
+  return `${b.day} ${b.month.replace(".", "")} ${b.year} ${b.hour}:${b.minute}`;
+};
 
-   ISIANNYA BARU DIGAMBAR SAAT KARTUNYA DIBUKA. 250 pendaftaran x 7 kotak per
-   regu adalah ribuan elemen form yang tidak ada gunanya sampai satu di antara
-   mereka disentuh. Yang tergambar duluan cuma barisnya. */
 async function layarDataPeserta() {
   if (!EDISI) { layarButuhEdisi("Data Peserta"); return; }
   pasangKepala("Data Peserta", true);
@@ -889,9 +904,8 @@ async function layarDataPeserta() {
   if (location.hash !== layarIni) return;
 
   const dibuka = new Set();
-
-  const reguAktifDp = (b) => (b.regu || []).filter(r => !r.is_cancelled);
-  const internDp = (b) => reguAktifDp(b).some(r => String(r.golongan || "").startsWith("intern"));
+  const aktifDp = (b) => (b.regu || []).filter(r => !r.is_cancelled);
+  const internDp = (b) => aktifDp(b).some(r => String(r.golongan || "").startsWith("intern"));
 
   LAYAR.replaceChildren(h(`
     <div class="card">
@@ -905,182 +919,195 @@ async function layarDataPeserta() {
         jumlah: semua.length,
         cariContoh: "Cari kode, sekolah, regu, ketua, atau nomor WA…",
       })}
-      <div id="isi-peserta"></div>
+      <div class="table-wrapper">
+        <table class="table data-table table-peserta">
+          <thead>
+            <tr>
+              <th>Tanggal</th><th>Kode Bayar</th><th>Asal Sekolah</th>
+              <th class="text-center">Regu</th><th>Contact Person</th><th>WhatsApp</th>
+            </tr>
+          </thead>
+          <tbody id="isi-tabel"></tbody>
+        </table>
+      </div>
     </div>
   `));
 
   const gambar = (cari = "", saring = "semua") => {
-    const cocok = semua.filter(b => {
+    const baris = semua.filter(b => {
       if (saring === "intern" && !internDp(b)) return false;
       if (saring === "eksternal" && internDp(b)) return false;
       if (!cari) return true;
-      const kumpul = [
+      return [
         b.kode_pembayaran, b.sekolah?.name, b.kontak_wa, b.nama_kontak,
-        ...reguAktifDp(b).flatMap(r => [r.nama_regu, r.nama_ketua,
-                                        r.kelas_organisasi, ...(r.anggota || [])]),
-      ].filter(Boolean).join(" ").toLowerCase();
-      return kumpul.includes(cari);
+        ...aktifDp(b).flatMap(r => [r.nama_regu, r.nama_ketua, r.kelas_organisasi,
+                                    ...(r.anggota || [])]),
+      ].filter(Boolean).join(" ").toLowerCase().includes(cari);
     });
 
-    const kotak = document.getElementById("isi-peserta");
     document.getElementById("tabel-jumlah").textContent =
-      `${cocok.length} pendaftaran · `
-      + `${cocok.reduce((n, b) => n + reguAktifDp(b).length, 0)} regu`;
+      `${baris.length} pendaftaran · ${baris.reduce((n, b) => n + aktifDp(b).length, 0)} regu`;
 
-    if (!cocok.length) {
-      kotak.replaceChildren(h(`<p class="table-empty">Tidak ada yang cocok.</p>`));
+    const tbody = document.getElementById("isi-tabel");
+    if (!baris.length) {
+      tbody.replaceChildren(h(`<tr><td colspan="6" class="table-empty">
+        Tidak ada yang cocok.</td></tr>`));
       return;
     }
 
-    kotak.replaceChildren(h(cocok.map(b => {
+    /* Template BIASA, bukan tag html`` — baris rincian sudah berupa HTML jadi,
+       dan html`` meng-escape setiap nilai yang disisipkan. Nilai dari luar
+       tetap lewat esc() satu per satu. */
+    tbody.replaceChildren(h(baris.map(b => {
       const kode = esc(b.kode_pembayaran);
-      const aktif = reguAktifDp(b);
+      const aktif = aktifDp(b);
       const terbuka = dibuka.has(b.kode_pembayaran);
       return `
-      <div class="regu-card" id="dp-${kode}">
-        <div class="action-row" style="justify-content:space-between;align-items:baseline">
-          <div>
-            <strong class="mono">${kode}</strong>
-            <span style="margin-left:.5rem">${esc(b.sekolah?.name || "—")}</span>
-          </div>
-          <button class="button-detail" type="button" data-buka="${kode}"
-                  aria-expanded="${terbuka}">${terbuka ? "▾" : "▸"} ${aktif.length}<span
-                  class="satuan-regu"> regu</span></button>
-        </div>
-        <div class="sub" style="margin-top:.15rem">
-          ${esc(b.nama_kontak || "tanpa nama kontak")} · ${esc(b.kontak_wa || "—")}
-        </div>
-        ${!terbuka ? "" : isiUbah(b, aktif)}
-      </div>`;
+        <tr class="invoice-row" data-baris="${kode}">
+          <td class="mono" data-label="Tanggal">${esc(tanggalRingkas(b.created_at))}</td>
+          <td class="mono" data-label="Kode Bayar">${kode}</td>
+          <td data-label="Asal Sekolah"><strong>${esc(b.sekolah?.name || "—")}</strong></td>
+          <td class="text-center" data-label="Regu">
+            <button class="button-detail" type="button" data-detail="${kode}"
+                    aria-expanded="${terbuka}"
+                    aria-label="Lihat ${aktif.length} regu"><span class="panah">${
+              terbuka ? "▾" : "▸"}</span> ${aktif.length}<span
+                    class="satuan-regu"> regu</span></button>
+          </td>
+          <td data-label="Contact Person">
+            <input type="text" class="small-input" data-kontak-nama="${kode}"
+                   value="${esc(b.nama_kontak || "")}" placeholder="contoh: Aji"></td>
+          <td data-label="WhatsApp">
+            <input type="tel" class="small-input" inputmode="numeric"
+                   data-kontak-wa="${kode}" value="${esc(b.kontak_wa || "")}"
+                   placeholder="08123456789"></td>
+        </tr>
+        ${!aktif.length ? "" : `
+        <tr class="detail-row" data-detail-untuk="${kode}" ${terbuka ? "" : "hidden"}>
+          <td colspan="6" class="detail-cell-flush">
+            <table class="detail-table detail-table-peserta">
+              <thead>
+                <tr><th>Regu</th><th>Kategori</th><th>Kelas</th><th>Ketua</th>
+                    <th>Anggota 1</th><th>Anggota 2</th><th>Anggota 3</th><th>Anggota 4</th></tr>
+              </thead>
+              <tbody>
+                ${aktif.map(r => barisRegu(r)).join("")}
+              </tbody>
+            </table>
+          </td>
+        </tr>`}`;
     }).join("")));
 
-    kotak.querySelectorAll("[data-buka]").forEach(btn =>
-      btn.addEventListener("click", () => {
-        const k = btn.dataset.buka;
-        if (dibuka.has(k)) dibuka.delete(k); else dibuka.add(k);
-        gambar(cari, saring);
-      }));
-
-    pasangUbah(cocok, () => gambar(cari, saring));
+    pasangBaris(() => gambar(cari, saring));
   };
 
-  /* Isian satu pendaftaran: kontak di atas, lalu satu blok per regu. Tiap blok
-     punya tombol Simpan sendiri — satu tombol untuk seluruh kartu berarti satu
-     nama regu yang kembar menggagalkan penyimpanan lima regu lain yang sudah
-     benar, dan petugas tidak tahu mana yang tersimpan. */
-  const isiUbah = (b, aktif) => {
-    const kode = esc(b.kode_pembayaran);
-    return `
-      <div style="margin-top:.7rem;border-top:1.5px solid var(--garis);padding-top:.7rem">
-        <div class="two-column">
-          <div class="field" style="margin:0">
-            <label for="dp-nama-${kode}">Contact Person</label>
-            <input type="text" id="dp-nama-${kode}" value="${esc(b.nama_kontak || "")}"
-                   placeholder="contoh: Bu Rina">
-          </div>
-          <div class="field" style="margin:0">
-            <label for="dp-wa-${kode}">Nomor WhatsApp</label>
-            <input type="tel" id="dp-wa-${kode}" inputmode="numeric"
-                   value="${esc(b.kontak_wa || "")}" placeholder="contoh: 08123456789">
-          </div>
-        </div>
-        <div class="action-row" style="margin-top:.5rem">
-          <button class="button button-secondary button-mini" type="button"
-                  data-simpan-kontak="${kode}">Simpan kontak</button>
-        </div>
+  /* Satu baris rincian = satu regu. Ketua DAN empat anggota, karena satu regu
+     lima orang: ketuanya salah satu dari kelima, bukan orang keenam. Kolom
+     "Anggota 5" karena itu tidak ada — constraint regu_anggota_maks_empat
+     menolaknya, dan yang menolak lebih dulu seharusnya layar ini.
 
-        ${aktif.map(r => blokRegu(r)).join("")}
-      </div>`;
-  };
-
-  const blokRegu = (r) => {
+     Kelas punya kolomnya sendiri, dan kotaknya cuma digambar untuk regu
+     Intern — regu Eksternal dibedakan oleh sekolahnya, dan kolom ini kosong
+     untuk mereka. Digambar "—", bukan kotak yang tidak bisa diisi: kotak
+     kosong yang menolak ketikan terbaca seperti kerusakan. */
+  const barisRegu = (r) => {
     const id = esc(r.id);
     const intern = String(r.golongan || "").startsWith("intern");
     const ang = [0, 1, 2, 3].map(k => (r.anggota || [])[k] || "");
     return `
-      <div class="regu-card" style="margin-top:.6rem" id="dp-regu-${id}">
-        <span class="badge badge-green">${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}${
-          r.nomor_dada ? ` · ${esc(dada3(r.nomor_dada))}` : ""}</span>
-        ${!intern ? "" : `
-        <div class="field" style="margin:.45rem 0 .7rem">
-          <label for="dp-kelas-${id}">Kelas / Organisasi</label>
-          <input type="text" id="dp-kelas-${id}" maxlength="80"
-                 value="${esc(r.kelas_organisasi || "")}"
-                 placeholder="contoh: XI IPA 4 atau OSIS">
-        </div>`}
-        <div class="two-column">
-          <div class="field" style="margin:0">
-            <label for="dp-regu-nama-${id}">Nama Regu</label>
-            <input type="text" id="dp-regu-nama-${id}" maxlength="25"
-                   value="${esc(r.nama_regu || "")}" style="text-transform:uppercase">
-          </div>
-          <div class="field" style="margin:0">
-            <label for="dp-ketua-${id}">Nama Ketua</label>
-            <input type="text" id="dp-ketua-${id}" value="${esc(r.nama_ketua || "")}">
-          </div>
-        </div>
-        <div class="field" style="margin-top:.5rem">
-          <label for="dp-ang-${id}-0">Nama Anggota (opsional)</label>
-          ${ang.map((a, k) => `
-            <input type="text" id="dp-ang-${id}-${k}" value="${esc(a)}"
-                   style="margin-top:.35rem" placeholder="Nama Anggota ${k + 1}">`).join("")}
-        </div>
-        <div class="action-row" style="margin-top:.5rem">
-          <button class="button button-secondary button-mini" type="button"
-                  data-simpan-regu="${id}">Simpan regu</button>
-        </div>
-      </div>`;
+      <tr data-regu="${id}">
+        <td data-label="Regu">
+          <input type="text" class="small-input" data-f="nama_regu" data-id="${id}"
+                 maxlength="25" style="text-transform:uppercase"
+                 value="${esc(r.nama_regu || "")}"></td>
+        <td data-label="Kategori">
+          <span class="badge badge-green">${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}</span></td>
+        <td data-label="Kelas">${!intern ? "—" : `
+          <input type="text" class="small-input" data-f="kelas_organisasi" data-id="${id}"
+                 maxlength="80" value="${esc(r.kelas_organisasi || "")}"
+                 placeholder="XI IPA 4">`}</td>
+        <td data-label="Ketua">
+          <input type="text" class="small-input" data-f="nama_ketua" data-id="${id}"
+                 value="${esc(r.nama_ketua || "")}"></td>
+        ${ang.map((a, k) => `
+        <td data-label="Anggota ${k + 1}">
+          <input type="text" class="small-input" data-f="anggota${k}" data-id="${id}"
+                 value="${esc(a)}"></td>`).join("")}
+      </tr>`;
   };
 
-  /* Sesudah tersimpan, data DI MEMORI ikut diperbarui lalu tabelnya digambar
-     ulang. Tanpa itu baris ringkasnya masih menyebut nomor lama sampai layar
-     dimuat ulang, dan petugas menyimpulkan simpanannya tidak masuk. */
-  const pasangUbah = (cocok, gambarUlang) => {
-    LAYAR.querySelectorAll("[data-simpan-kontak]").forEach(btn =>
-      btn.addEventListener("click", async () => {
-        const kode = btn.dataset.simpanKontak;
-        const b = semua.find(x => x.kode_pembayaran === kode);
-        const nama = document.getElementById(`dp-nama-${kode}`).value.trim();
-        const wa = document.getElementById(`dp-wa-${kode}`).value.trim();
-        btn.disabled = true;
-        try {
-          await ubahKontakPendaftaran(kode, nama, wa);
-          b.nama_kontak = nama || null;
-          b.kontak_wa = wa.replace(/\D/g, "").replace(/^62/, "0");
-          notif("Kontak tersimpan.");
-          gambarUlang();
-        } catch (e) {
-          notif(e instanceof ErrorApi ? e.message : "Kontak gagal disimpan.", true);
-          btn.disabled = false;
-        }
+  /* Disimpan saat kotaknya ditinggalkan (change), bukan tiap ketukan huruf:
+     satu nama yang diketik pelan akan jadi belasan permintaan, dan tiap
+     permintaan menulis satu baris riwayat. */
+  const pasangBaris = (gambarUlang) => {
+    const tbody = document.getElementById("isi-tabel");
+
+    tbody.querySelectorAll("[data-detail]").forEach(btn =>
+      btn.addEventListener("click", () => {
+        const k = btn.dataset.detail;
+        if (dibuka.has(k)) dibuka.delete(k); else dibuka.add(k);
+        const row = tbody.querySelector(`[data-detail-untuk="${CSS.escape(k)}"]`);
+        if (row) row.hidden = !dibuka.has(k);
+        btn.setAttribute("aria-expanded", String(dibuka.has(k)));
+        // Panahnya saja yang diganti, JUMLAHNYA jangan. Versi pertama menulis
+        // ke firstChild.nodeValue — dan simpul pertama itu memuat "▸ 1",
+        // bukan panahnya sendiri, jadi angkanya ikut terhapus dan tombolnya
+        // berbunyi "-". Sekarang panahnya punya simpulnya sendiri.
+        btn.querySelector(".panah").textContent = dibuka.has(k) ? "▾" : "▸";
       }));
 
-    LAYAR.querySelectorAll("[data-simpan-regu]").forEach(btn =>
-      btn.addEventListener("click", async () => {
-        const id = btn.dataset.simpanRegu;
-        const r = semua.flatMap(x => x.regu || []).find(x => String(x.id) === id);
-        const ambil = (s) => (document.getElementById(s)?.value || "").trim();
-        const data = {
-          nama_regu: ambil(`dp-regu-nama-${id}`).toUpperCase(),
-          nama_ketua: ambil(`dp-ketua-${id}`),
-          anggota: [0, 1, 2, 3].map(k => ambil(`dp-ang-${id}-${k}`)).filter(Boolean),
-          kelas_organisasi: ambil(`dp-kelas-${id}`),
-        };
-        btn.disabled = true;
-        try {
-          await ubahIdentitasRegu(id, data);
-          Object.assign(r, {
-            nama_regu: data.nama_regu, nama_ketua: data.nama_ketua,
-            anggota: data.anggota.length ? data.anggota : null,
-            kelas_organisasi: data.kelas_organisasi || null,
-          });
-          notif("Regu tersimpan.");
-          gambarUlang();
-        } catch (e) {
-          notif(e instanceof ErrorApi ? e.message : "Regu gagal disimpan.", true);
-          btn.disabled = false;
-        }
-      }));
+    const kedip = (el) => {
+      el.classList.add("saved");
+      setTimeout(() => el.classList.remove("saved"), 1200);
+    };
+
+    const simpanKontak = async (kode, el) => {
+      const b = semua.find(x => x.kode_pembayaran === kode);
+      const nama = tbody.querySelector(`[data-kontak-nama="${CSS.escape(kode)}"]`).value.trim();
+      const wa = tbody.querySelector(`[data-kontak-wa="${CSS.escape(kode)}"]`).value.trim();
+      if (nama === (b.nama_kontak || "") && wa === (b.kontak_wa || "")) return;
+      try {
+        await ubahKontakPendaftaran(kode, nama, wa);
+        b.nama_kontak = nama || null;
+        b.kontak_wa = wa.replace(/\D/g, "").replace(/^62/, "0");
+        tbody.querySelector(`[data-kontak-wa="${CSS.escape(kode)}"]`).value = b.kontak_wa;
+        kedip(el);
+      } catch (e) {
+        notif(e instanceof ErrorApi ? e.message : "Kontak gagal disimpan.", true);
+        gambarUlang();
+      }
+    };
+
+    const simpanRegu = async (id, el) => {
+      const r = semua.flatMap(x => x.regu || []).find(x => String(x.id) === id);
+      const ambil = (f) => (tbody.querySelector(
+        `[data-f="${f}"][data-id="${CSS.escape(id)}"]`)?.value || "").trim();
+      const data = {
+        nama_regu: ambil("nama_regu").toUpperCase(),
+        nama_ketua: ambil("nama_ketua"),
+        anggota: [0, 1, 2, 3].map(k => ambil(`anggota${k}`)).filter(Boolean),
+        kelas_organisasi: ambil("kelas_organisasi"),
+      };
+      try {
+        await ubahIdentitasRegu(id, data);
+        Object.assign(r, {
+          nama_regu: data.nama_regu, nama_ketua: data.nama_ketua,
+          anggota: data.anggota.length ? data.anggota : null,
+          kelas_organisasi: data.kelas_organisasi || null,
+        });
+        kedip(el);
+      } catch (e) {
+        notif(e instanceof ErrorApi ? e.message : "Regu gagal disimpan.", true);
+        gambarUlang();
+      }
+    };
+
+    tbody.querySelectorAll("[data-kontak-nama],[data-kontak-wa]").forEach(inp =>
+      inp.addEventListener("change", () =>
+        simpanKontak(inp.dataset.kontakNama || inp.dataset.kontakWa, inp)));
+
+    tbody.querySelectorAll("[data-f][data-id]").forEach(inp =>
+      inp.addEventListener("change", () => simpanRegu(inp.dataset.id, inp)));
   };
 
   gambar();

--- a/web/style.css
+++ b/web/style.css
@@ -1835,6 +1835,65 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      kolom dilebarkan, angka ini ikut naik — DAN ambang kartu 900px di bawah
      harus ikut naik, kalau tidak tabelnya kembali menggeser ke samping dan
      kolom tombol hilang lagi dari layar. */
+
+  /* ---- Data Peserta ----
+
+     `table-layout: fixed`, dan alasannya SATU: membuka baris rincian tidak
+     boleh menggeser kolom induknya.
+
+     Dengan `auto`, lebar tiap kolom dihitung dari SELURUH isi tabel — baris
+     rincian yang baru muncul ikut dihitung, dan enam kolom di atasnya
+     bergeser semua. Petugas yang menekan satu tombol melihat seluruh tabel
+     melompat, lalu harus mencari lagi baris yang tadi dilihatnya. Itu keluhan
+     yang dilaporkan langsung, dan `fixed` yang menyelesaikannya: lebar kolom
+     ditentukan patokan di bawah, bukan isinya, jadi yang berubah saat rincian
+     dibuka cuma tingginya.
+
+     Persentasenya WAJIB berjumlah 100 di kedua tabel. Di bawah `fixed`, kolom
+     yang tidak dipatok mendapat NOL — bukan sisanya (pasal 15.3).
+
+       induk    14 + 15 + 22 +  8 + 20 + 21              = 100
+       rincian  14 + 11 + 13 + 15 + 12 + 12 + 12 + 11    = 100
+
+     Keduanya TIDAK dipasangkan kolom per kolom, dan itu beda dari tabel
+     Pembayaran (pasal 15.2). Di sana kolom terakhir keduanya harus bertemu
+     supaya angka rupiah tiap regu jatuh di bawah tombolnya. Di sini rinciannya
+     bicara hal lain sama sekali — satu baris per regu, kolomnya Ketua dan
+     Anggota — dan tidak ada angka yang perlu berbaris tegak.
+
+     1120px = delapan kolom rincian yang masing-masing memuat satu kotak nama.
+     Di bawah itu pembungkusnya menggulir mendatar, bukan memampatkan kotaknya
+     sampai nama tidak terbaca. Di bawah 900px ia sudah jadi kartu dan seluruh
+     angka di sini tidak berlaku. */
+  .table-peserta, .detail-table-peserta { table-layout: fixed; }
+  .table-peserta { min-width: 1120px; }
+  .detail-table-peserta { width: 100%; }
+
+  .table-peserta > thead > tr > th:nth-child(1) { width: 14%; }
+  .table-peserta > thead > tr > th:nth-child(2) { width: 15%; }
+  .table-peserta > thead > tr > th:nth-child(3) { width: 22%; }
+  .table-peserta > thead > tr > th:nth-child(4) { width:  8%; }
+  .table-peserta > thead > tr > th:nth-child(5) { width: 20%; }
+  .table-peserta > thead > tr > th:nth-child(6) { width: 21%; }
+
+  .detail-table-peserta > thead > tr > th:nth-child(1) { width: 14%; }
+  .detail-table-peserta > thead > tr > th:nth-child(2) { width: 11%; }
+  .detail-table-peserta > thead > tr > th:nth-child(3) { width: 13%; }
+  .detail-table-peserta > thead > tr > th:nth-child(4) { width: 15%; }
+  .detail-table-peserta > thead > tr > th:nth-child(5) { width: 12%; }
+  .detail-table-peserta > thead > tr > th:nth-child(6) { width: 12%; }
+  .detail-table-peserta > thead > tr > th:nth-child(7) { width: 12%; }
+  .detail-table-peserta > thead > tr > th:nth-child(8) { width: 11%; }
+
+  /* Kotak isian mengisi selnya. Tanpa ini `.small-input` memakai lebar bawaan
+     input dan meluap keluar kolom yang sudah dipatok. */
+  .table-peserta .small-input,
+  .detail-table-peserta .small-input { width: 100%; min-width: 0; }
+  /* Nama sekolah satu-satunya isi yang panjangnya tak terduga — ia yang
+     mengalah dan membungkus, seperti di tabel Pembayaran. */
+  .table-peserta > tbody > tr > td:nth-child(3) {
+    white-space: normal; overflow-wrap: break-word;
+  }
   .table-bayar { min-width: 820px; }
 
   /* Label tombol MEMENDEK di sini juga: "Cetak Kwitansi" -> "Kwitansi",


### PR DESCRIPTION
## What

Ubin baru **Data Peserta**, tepat di sebelah Pendaftaran, dengan gaya cari +
saringan yang sama persis dengan Meja Pembayaran.

Isinya bisa **disunting**:

| | |
| --- | --- |
| kontak pembina | nama contact person + nomor WA |
| tiap regu | nama regu, nama ketua, empat anggota, kelas/organisasi |

## Why

Peserta mendaftar sendiri lewat form, dan sebagian salah ketik. Sampai sekarang
**tidak ada satu layar pun yang bisa membetulkannya** — satu-satunya jalan
membatalkan pendaftaran lalu meminta mereka mengisi ulang.

Yang benar-benar terjadi bukan itu: panitia mencatat betulannya di kertas lain,
dan sejak saat itu database berbeda dari kenyataan **tanpa ada yang tahu bagian
mana**.

**Nama regu ikut bisa diubah** — itu justru yang paling sering diminta — dan
yang kembar tetap ditolak indeks `0051`, karena nama juara dibacakan di
lapangan.

**Golongan, sekolah, nomor dada, dan status bayar sengaja tidak**: masing-masing
punya jalurnya sendiri, dan yang salah di antaranya bukan salah ketik melainkan
pendaftaran yang salah.

## Notes

- **Haknya `pendaftaran`, bukan fitur baru.** Membetulkan data pendaftaran
  adalah pekerjaan yang sama dengan menerimanya; kunci sendiri berarti satu
  centang lagi untuk pemisahan yang tidak pernah diminta siapa pun.
- **Kartu, bukan tabel** — isian yang diketik tidak muat di sel tabel `fixed`
  selebar 15%. Alat cari dan saringannya tetap sama, jadi kebiasaan panitia
  tidak berubah.
- **Isiannya baru digambar saat kartunya dibuka.** 250 pendaftaran × 7 kotak
  per regu adalah ribuan elemen form yang tidak berguna sampai satu disentuh.
- **Tombol Simpan per blok**, bukan satu untuk seluruh kartu: satu nama regu
  yang kembar tidak boleh menggagalkan penyimpanan lima regu lain yang sudah
  benar.
- **Riwayatnya tercatat sendiri** lewat trigger `record_history` (0042) — siapa
  mengubah, kapan, dari apa ke apa. Itu yang membuat layar ini aman diberikan.
- **Validasinya satu, bukan dua.** `ubah_identitas_regu` memakai aturan yang
  sama persis dengan `submit_pendaftaran`; dua pintu masuk dengan aturan
  berbeda berarti data yang lolos lewat yang satu ditolak yang lain.
- **Nomor WA dinormalkan** ke `08xxxxxxxxxx`, jadi `+62 812-…`, `62812…` dan
  `812…` mendarat sama.

## Tesnya menempati kursi

Migrasinya cuma bisa membuktikan pintunya **terkunci** — ia berjalan tanpa
kursi pengguna, jadi `boleh()` selalu false di sana. Jalur positifnya di
`tests/sql/88`, dijalankan sebagai akun **registrasi**:

```
88.1 LULUS: kontak dibetulkan, nomornya dinormalkan.
88.2 LULUS: identitas regu dibetulkan, kotak kosong dibuang.
88.3 LULUS: nama regu bisa diganti; yang kembar ditolak.
88.4 LULUS: validasi lama ikut berlaku lewat pintu baru.
88.5 LULUS: mencabut centang pendaftaran menutup keduanya.
```

## Dijalankan di layar sungguhan (bagian 17)

Dev server + database dev berisi 145 pendaftaran:

| Langkah | Hasil |
| --- | --- |
| kartu dibuka | isian tergambar: Contact Person, WA, Nama Regu, Ketua, 4 anggota |
| kontak → `+62 822-6263-9999` | tersimpan **082262639999** |
| nama ketua diganti | tersimpan |
| kotak anggota **di tengah** dikosongkan | dibuang, bukan disimpan string kosong |

Diperiksa langsung ke tabelnya, bukan dari layar.

**Satu jebakan harness ikut dibetulkan:** `dev_server` meneruskan daftar JSON ke
argumen `text[]` lewat `json.dumps`, jadi Postgres menolaknya dengan "malformed
array literal". PostgREST di produksi sudah memetakannya sendiri; yang perlu
diajari cuma tiruannya.

```
bash tests/run.sh            -> SEMUA TES LULUS
node --test tests/*.test.mjs -> 218 pass, 0 fail
```