### PR TITLE
fix: rincian Data Peserta berbentuk form pendaftaran, dan Contact Person rata kiri

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -1870,23 +1870,23 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      WAJIB berjumlah 100: di bawah `fixed`, kolom yang tidak dipatok mendapat
      NOL, bukan sisanya (pasal 15.3).
 
-       induk    15 + 13 + 26 +  6 + 21 + 19           = 100
-       rincian  14 + 10 + 11 + 15 + 12 + 12 + 13 + 13 = 100
+       induk    15 + 13 + 26 + 6 + 21 + 19 = 100
 
-     Kolom rincian TIDAK dipatok dari max-content-nya: nama selengkapnya
-     menuntut 2.064px, dan tabel selebar itu tidak bisa dibaca di layar mana
-     pun. Isinya kotak isian, dan teks di dalam kotak isian menggulir sendiri
-     — yang perlu cukup lebar untuk MENYUNTING, bukan untuk memuat nama
-     terpanjang sekaligus. Keduanya juga sengaja tidak dipasangkan kolom per
-     kolom seperti tabel Pembayaran (pasal 15.2): di sana kolom terakhir harus
-     bertemu supaya angka rupiah jatuh di bawah tombolnya, di sini rinciannya
-     bicara hal lain sama sekali.
+     RINCIANNYA BUKAN TABEL, jadi tidak punya patokan kolom sama sekali. Versi
+     pertama membuatnya delapan kolom — Regu, Kategori, Kelas, Ketua, Anggota
+     1-4 — dan itu tidak bisa dipakai untuk apa yang layar itu ada: MENGETIK.
+     Delapan kolom dalam satu baris berarti tiap kotak sekitar 110px, dan
+     "MUHAMMAD FACHRY SEPTIAN RAMDANI" tidak muat seperempatnya. Memuat nama
+     terpanjang seluruhnya menuntut tabel selebar 2.064px, yang tidak muat di
+     layar mana pun.
+
+     Sekarang rinciannya berbentuk FORM PENDAFTARAN — bentuk yang sudah dikenal
+     karena itu yang diisi pembina waktu mendaftar. Yang dibaca sekilas tetap
+     tabel; yang diketik jadi form.
 
      Di bawah 900px ia sudah jadi kartu dan seluruh angka di sini tidak
      berlaku. */
-  .table-peserta, .detail-table-peserta { table-layout: fixed; }
-  .table-peserta { min-width: 980px; }
-  .detail-table-peserta { width: 100%; }
+  .table-peserta { table-layout: fixed; min-width: 980px; }
 
   .table-peserta > thead > tr > th:nth-child(1) { width: 15%; }
   .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }
@@ -1895,19 +1895,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-peserta > thead > tr > th:nth-child(5) { width: 21%; }
   .table-peserta > thead > tr > th:nth-child(6) { width: 19%; }
 
-  .detail-table-peserta > thead > tr > th:nth-child(1) { width: 14%; }
-  .detail-table-peserta > thead > tr > th:nth-child(2) { width: 10%; }
-  .detail-table-peserta > thead > tr > th:nth-child(3) { width: 11%; }
-  .detail-table-peserta > thead > tr > th:nth-child(4) { width: 15%; }
-  .detail-table-peserta > thead > tr > th:nth-child(5) { width: 12%; }
-  .detail-table-peserta > thead > tr > th:nth-child(6) { width: 12%; }
-  .detail-table-peserta > thead > tr > th:nth-child(7) { width: 13%; }
-  .detail-table-peserta > thead > tr > th:nth-child(8) { width: 13%; }
 
   /* Kotak isian mengisi selnya. Tanpa ini `.small-input` memakai lebar bawaan
      input dan meluap keluar kolom yang sudah dipatok. */
-  .table-peserta .small-input,
-  .detail-table-peserta .small-input { width: 100%; min-width: 0; }
+  .table-peserta .small-input { width: 100%; min-width: 0; }
   /* Nama sekolah satu-satunya isi yang panjangnya tak terduga — ia yang
      mengalah dan membungkus, seperti di tabel Pembayaran. */
   .table-peserta > tbody > tr > td:nth-child(3) {

--- a/live/style.css
+++ b/live/style.css
@@ -2488,8 +2488,19 @@ input.small-input { text-align: center; }
 /* KECUALI yang isinya NAMA. `.small-input` ditengahkan karena isinya angka —
    nomor dada, jumlah benar — dan angka yang ditengahkan lebih mudah
    dibandingkan antar baris. Nama akun bukan angka: ditengahkan, ia terbaca
-   seperti judul, dan contoh isiannya makin terlihat seperti nilai sungguhan. */
-.form-akun input.small-input { text-align: left; }
+   seperti judul, dan contoh isiannya makin terlihat seperti nilai sungguhan.
+
+   Contact Person di layar Data Peserta masuk kelompok yang sama, dan itu
+   aturan ini dipakai lagi, bukan pengecualian baru: satu kolom berisi nama
+   orang yang panjangnya berbeda-beda, dan yang ditengahkan tepi kirinya
+   bergeser tiap baris — mata kehilangan garis tegaknya, persis alasan yang
+   sudah ditulis untuk kolom Metode di Meja Pembayaran.
+
+   Nomor WhatsApp di sebelahnya TETAP ditengahkan, dan itu bukan kelalaian:
+   ia angka, panjangnya hampir selalu sama, dan aturan di atas memang
+   membuatnya. */
+.form-akun input.small-input,
+.table-peserta input.small-input[data-kontak-nama] { text-align: left; }
 /* Isian yang ditolak sebelum dikirim — memerah di tempatnya supaya petugas
    tahu BARIS MANA yang salah, bukan cuma bahwa "ada yang salah". */
 .input-error { border-color: var(--bahaya); background: var(--bahaya-muda); }

--- a/live/style.css
+++ b/live/style.css
@@ -1849,8 +1849,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      tiap kolom atas 145 pendaftaran sungguhan di layar, dibandingkan dengan
      lebar JUDUL kolomnya, lalu ditambah padding sel 16px:
 
-       tanggal 139 · kode 123 · sekolah 242 · regu 50 · kontak 201 · WA 187
-       jumlah 942px
+       tanggal 147 · kode 123 · sekolah 242 · regu 50 · kontak 201 · WA 187
+       jumlah 950px
+
+     Tanggal 147, bukan 139: sejak formatnya jadi 28/08/2026 04:32 ia delapan
+     piksel lebih lebar daripada bentuk bernama bulan. Satu persen dipindahkan
+     dari Asal Sekolah, yang paling longgar — 25% masih 245px untuk kebutuhan
+     242px, dan nama sekolah memang kolom yang boleh membungkus.
 
      UNTUK SEL BERISI KOTAK ISIAN yang dipakai `scrollWidth` KOTAKNYA, bukan
      lebar teksnya. Pengukuran pertama memakai lebar teks lalu menambahkan
@@ -1870,7 +1875,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      WAJIB berjumlah 100: di bawah `fixed`, kolom yang tidak dipatok mendapat
      NOL, bukan sisanya (pasal 15.3).
 
-       induk    15 + 13 + 26 + 6 + 21 + 19 = 100
+       induk    16 + 13 + 25 + 6 + 21 + 19 = 100
 
      RINCIANNYA BUKAN TABEL, jadi tidak punya patokan kolom sama sekali. Versi
      pertama membuatnya delapan kolom — Regu, Kategori, Kelas, Ketua, Anggota
@@ -1888,9 +1893,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      berlaku. */
   .table-peserta { table-layout: fixed; min-width: 980px; }
 
-  .table-peserta > thead > tr > th:nth-child(1) { width: 15%; }
+  .table-peserta > thead > tr > th:nth-child(1) { width: 16%; }
   .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }
-  .table-peserta > thead > tr > th:nth-child(3) { width: 26%; }
+  .table-peserta > thead > tr > th:nth-child(3) { width: 25%; }
   .table-peserta > thead > tr > th:nth-child(4) { width:  6%; }
   .table-peserta > thead > tr > th:nth-child(5) { width: 21%; }
   .table-peserta > thead > tr > th:nth-child(6) { width: 19%; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -985,15 +985,9 @@ async function layarDataPeserta() {
         ${!aktif.length ? "" : `
         <tr class="detail-row" data-detail-untuk="${kode}" ${terbuka ? "" : "hidden"}>
           <td colspan="6" class="detail-cell-flush">
-            <table class="detail-table detail-table-peserta">
-              <thead>
-                <tr><th>Regu</th><th>Kategori</th><th>Kelas</th><th>Ketua</th>
-                    <th>Anggota 1</th><th>Anggota 2</th><th>Anggota 3</th><th>Anggota 4</th></tr>
-              </thead>
-              <tbody>
-                ${aktif.map(r => barisRegu(r)).join("")}
-              </tbody>
-            </table>
+            <div class="rincian-peserta">
+              ${aktif.map((r, i) => barisRegu(r, i)).join("")}
+            </div>
           </td>
         </tr>`}`;
     }).join("")));
@@ -1001,39 +995,65 @@ async function layarDataPeserta() {
     pasangBaris(() => gambar(cari, saring));
   };
 
-  /* Satu baris rincian = satu regu. Ketua DAN empat anggota, karena satu regu
-     lima orang: ketuanya salah satu dari kelima, bukan orang keenam. Kolom
-     "Anggota 5" karena itu tidak ada — constraint regu_anggota_maks_empat
-     menolaknya, dan yang menolak lebih dulu seharusnya layar ini.
+  /* Satu kartu per regu, BENTUKNYA SAMA DENGAN FORM PENDAFTARAN: lencana
+     golongan, Kelas/Organisasi selebar kartu, lalu Nama Regu dan Nama Ketua
+     berdampingan, lalu empat kotak anggota bertumpuk.
 
-     Kelas punya kolomnya sendiri, dan kotaknya cuma digambar untuk regu
-     Intern — regu Eksternal dibedakan oleh sekolahnya, dan kolom ini kosong
-     untuk mereka. Digambar "—", bukan kotak yang tidak bisa diisi: kotak
-     kosong yang menolak ketikan terbaca seperti kerusakan. */
-  const barisRegu = (r) => {
+     Versi pertama menaruh kedelapan kotak itu sebagai kolom tabel, dan itu
+     tidak bisa dipakai untuk apa yang layar ini ada: MENGETIK. Delapan kolom
+     dalam satu baris berarti tiap kotak sekitar 110px, dan "MUHAMMAD FACHRY
+     SEPTIAN RAMDANI" tidak muat seperempatnya — petugas mengganti satu nama
+     sambil melihat sepotong nama. Nama selengkapnya menuntut tabel selebar
+     2.064px, yang tidak muat di layar mana pun.
+
+     Barisnya tetap tabel, karena baris memang untuk DIPINDAI: tanggal, kode,
+     sekolah, kontak. Yang dibaca sekilas jadi tabel, yang diketik jadi form —
+     dan formnya sudah punya bentuk yang dikenal, yaitu bentuk yang diisi
+     pembina waktu mendaftar.
+
+     Ketua DAN empat anggota, karena satu regu lima orang: ketuanya salah satu
+     dari kelima, bukan orang keenam. Kotak "Anggota 5" karena itu tidak ada —
+     constraint regu_anggota_maks_empat menolaknya.
+
+     Kelas hanya untuk regu Intern; regu Eksternal dibedakan oleh sekolahnya
+     dan kotaknya tidak digambar sama sekali. */
+  const barisRegu = (r, i) => {
     const id = esc(r.id);
     const intern = String(r.golongan || "").startsWith("intern");
     const ang = [0, 1, 2, 3].map(k => (r.anggota || [])[k] || "");
     return `
-      <tr data-regu="${id}">
-        <td data-label="Regu">
-          <input type="text" class="small-input" data-f="nama_regu" data-id="${id}"
-                 maxlength="25" style="text-transform:uppercase"
-                 value="${esc(r.nama_regu || "")}"></td>
-        <td data-label="Kategori">
-          <span class="badge badge-green">${esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}</span></td>
-        <td data-label="Kelas">${!intern ? "—" : `
-          <input type="text" class="small-input" data-f="kelas_organisasi" data-id="${id}"
+      <div class="regu-card" data-regu="${id}">
+        <span class="badge badge-green">Regu ${i + 1} — ${
+          esc(GOLONGAN_LABEL[r.golongan] || r.golongan)}${
+          r.nomor_dada ? ` · ${esc(dada3(r.nomor_dada))}` : ""}</span>
+        ${!intern ? "" : `
+        <div class="field" style="margin:.45rem 0 .7rem">
+          <label for="dp-kelas-${id}">Kelas / Organisasi</label>
+          <input type="text" id="dp-kelas-${id}" data-f="kelas_organisasi" data-id="${id}"
                  maxlength="80" value="${esc(r.kelas_organisasi || "")}"
-                 placeholder="XI IPA 4">`}</td>
-        <td data-label="Ketua">
-          <input type="text" class="small-input" data-f="nama_ketua" data-id="${id}"
-                 value="${esc(r.nama_ketua || "")}"></td>
-        ${ang.map((a, k) => `
-        <td data-label="Anggota ${k + 1}">
-          <input type="text" class="small-input" data-f="anggota${k}" data-id="${id}"
-                 value="${esc(a)}"></td>`).join("")}
-      </tr>`;
+                 placeholder="misal: XI IPA 4 atau OSIS">
+        </div>`}
+        <div class="two-column">
+          <div class="field" style="margin:0">
+            <label for="dp-nama-${id}">Nama Regu</label>
+            <input type="text" id="dp-nama-${id}" data-f="nama_regu" data-id="${id}"
+                   maxlength="25" style="text-transform:uppercase"
+                   value="${esc(r.nama_regu || "")}">
+          </div>
+          <div class="field" style="margin:0">
+            <label for="dp-ketua-${id}">Nama Ketua</label>
+            <input type="text" id="dp-ketua-${id}" data-f="nama_ketua" data-id="${id}"
+                   value="${esc(r.nama_ketua || "")}">
+          </div>
+        </div>
+        <div class="field" style="margin-top:.5rem">
+          <label for="dp-ang-${id}-0">Nama Anggota (opsional)</label>
+          ${ang.map((a, k) => `
+            <input type="text" id="dp-ang-${id}-${k}" data-f="anggota${k}" data-id="${id}"
+                   style="margin-top:.35rem" value="${esc(a)}"
+                   placeholder="Nama Anggota ${k + 1}">`).join("")}
+        </div>
+      </div>`;
   };
 
   /* Disimpan saat kotaknya ditinggalkan (change), bukan tiap ketukan huruf:

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -877,19 +877,24 @@ const reguAktif = (b) => (b.regu || []).filter(r => !r.is_cancelled);
    salah ketik melainkan pendaftaran yang salah. Alasan lengkapnya di kepala
    migrasi 0135. */
 
-/** "17 Agu 26 16:55" — pendek karena ia satu kolom di antara enam, dan yang
- *  dicari orang di sana urutan kedatangan, bukan tanggal lengkapnya. WIB,
- *  sama seperti tanggalPanjang(): menjelang tengah malam tanggal alat dan
- *  tanggal WIB bisa menunjuk hari yang berbeda. */
+/** "28/08/2026 04:32" — angka semua, dan itu diminta pemilik acara. Bentuk
+ *  bernama bulan ("28 Agu 26") lebih pendek tapi panjangnya BERUBAH-UBAH: Mei
+ *  tiga huruf, Agustus disingkat tiga, September empat kalau tidak disingkat.
+ *  Di satu kolom yang dipindai dari atas ke bawah, angka dengan nol di depan
+ *  membuat tiap bagian jatuh di titik yang sama tiap baris.
+ *
+ *  WIB, sama seperti tanggalPanjang(): menjelang tengah malam tanggal alat dan
+ *  tanggal WIB bisa menunjuk hari yang berbeda, dan riwayat yang menyebut hari
+ *  kemarin untuk kejadian hari ini lebih buruk daripada tidak ada tanggal. */
 const FMT_DP = new Intl.DateTimeFormat("id-ID", {
-  timeZone: "Asia/Jakarta", day: "numeric", month: "short",
-  year: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false,
+  timeZone: "Asia/Jakarta", day: "2-digit", month: "2-digit",
+  year: "numeric", hour: "2-digit", minute: "2-digit", hour12: false,
 });
 const tanggalRingkas = (t) => {
   if (!t) return "—";
   const b = {};
   for (const x of FMT_DP.formatToParts(new Date(t))) b[x.type] = x.value;
-  return `${b.day} ${b.month.replace(".", "")} ${b.year} ${b.hour}:${b.minute}`;
+  return `${b.day}/${b.month}/${b.year} ${b.hour}:${b.minute}`;
 };
 
 async function layarDataPeserta() {

--- a/web/style.css
+++ b/web/style.css
@@ -1870,23 +1870,23 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      WAJIB berjumlah 100: di bawah `fixed`, kolom yang tidak dipatok mendapat
      NOL, bukan sisanya (pasal 15.3).
 
-       induk    15 + 13 + 26 +  6 + 21 + 19           = 100
-       rincian  14 + 10 + 11 + 15 + 12 + 12 + 13 + 13 = 100
+       induk    15 + 13 + 26 + 6 + 21 + 19 = 100
 
-     Kolom rincian TIDAK dipatok dari max-content-nya: nama selengkapnya
-     menuntut 2.064px, dan tabel selebar itu tidak bisa dibaca di layar mana
-     pun. Isinya kotak isian, dan teks di dalam kotak isian menggulir sendiri
-     — yang perlu cukup lebar untuk MENYUNTING, bukan untuk memuat nama
-     terpanjang sekaligus. Keduanya juga sengaja tidak dipasangkan kolom per
-     kolom seperti tabel Pembayaran (pasal 15.2): di sana kolom terakhir harus
-     bertemu supaya angka rupiah jatuh di bawah tombolnya, di sini rinciannya
-     bicara hal lain sama sekali.
+     RINCIANNYA BUKAN TABEL, jadi tidak punya patokan kolom sama sekali. Versi
+     pertama membuatnya delapan kolom — Regu, Kategori, Kelas, Ketua, Anggota
+     1-4 — dan itu tidak bisa dipakai untuk apa yang layar itu ada: MENGETIK.
+     Delapan kolom dalam satu baris berarti tiap kotak sekitar 110px, dan
+     "MUHAMMAD FACHRY SEPTIAN RAMDANI" tidak muat seperempatnya. Memuat nama
+     terpanjang seluruhnya menuntut tabel selebar 2.064px, yang tidak muat di
+     layar mana pun.
+
+     Sekarang rinciannya berbentuk FORM PENDAFTARAN — bentuk yang sudah dikenal
+     karena itu yang diisi pembina waktu mendaftar. Yang dibaca sekilas tetap
+     tabel; yang diketik jadi form.
 
      Di bawah 900px ia sudah jadi kartu dan seluruh angka di sini tidak
      berlaku. */
-  .table-peserta, .detail-table-peserta { table-layout: fixed; }
-  .table-peserta { min-width: 980px; }
-  .detail-table-peserta { width: 100%; }
+  .table-peserta { table-layout: fixed; min-width: 980px; }
 
   .table-peserta > thead > tr > th:nth-child(1) { width: 15%; }
   .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }
@@ -1895,19 +1895,10 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-peserta > thead > tr > th:nth-child(5) { width: 21%; }
   .table-peserta > thead > tr > th:nth-child(6) { width: 19%; }
 
-  .detail-table-peserta > thead > tr > th:nth-child(1) { width: 14%; }
-  .detail-table-peserta > thead > tr > th:nth-child(2) { width: 10%; }
-  .detail-table-peserta > thead > tr > th:nth-child(3) { width: 11%; }
-  .detail-table-peserta > thead > tr > th:nth-child(4) { width: 15%; }
-  .detail-table-peserta > thead > tr > th:nth-child(5) { width: 12%; }
-  .detail-table-peserta > thead > tr > th:nth-child(6) { width: 12%; }
-  .detail-table-peserta > thead > tr > th:nth-child(7) { width: 13%; }
-  .detail-table-peserta > thead > tr > th:nth-child(8) { width: 13%; }
 
   /* Kotak isian mengisi selnya. Tanpa ini `.small-input` memakai lebar bawaan
      input dan meluap keluar kolom yang sudah dipatok. */
-  .table-peserta .small-input,
-  .detail-table-peserta .small-input { width: 100%; min-width: 0; }
+  .table-peserta .small-input { width: 100%; min-width: 0; }
   /* Nama sekolah satu-satunya isi yang panjangnya tak terduga — ia yang
      mengalah dan membungkus, seperti di tabel Pembayaran. */
   .table-peserta > tbody > tr > td:nth-child(3) {

--- a/web/style.css
+++ b/web/style.css
@@ -2488,8 +2488,19 @@ input.small-input { text-align: center; }
 /* KECUALI yang isinya NAMA. `.small-input` ditengahkan karena isinya angka —
    nomor dada, jumlah benar — dan angka yang ditengahkan lebih mudah
    dibandingkan antar baris. Nama akun bukan angka: ditengahkan, ia terbaca
-   seperti judul, dan contoh isiannya makin terlihat seperti nilai sungguhan. */
-.form-akun input.small-input { text-align: left; }
+   seperti judul, dan contoh isiannya makin terlihat seperti nilai sungguhan.
+
+   Contact Person di layar Data Peserta masuk kelompok yang sama, dan itu
+   aturan ini dipakai lagi, bukan pengecualian baru: satu kolom berisi nama
+   orang yang panjangnya berbeda-beda, dan yang ditengahkan tepi kirinya
+   bergeser tiap baris — mata kehilangan garis tegaknya, persis alasan yang
+   sudah ditulis untuk kolom Metode di Meja Pembayaran.
+
+   Nomor WhatsApp di sebelahnya TETAP ditengahkan, dan itu bukan kelalaian:
+   ia angka, panjangnya hampir selalu sama, dan aturan di atas memang
+   membuatnya. */
+.form-akun input.small-input,
+.table-peserta input.small-input[data-kontak-nama] { text-align: left; }
 /* Isian yang ditolak sebelum dikirim — memerah di tempatnya supaya petugas
    tahu BARIS MANA yang salah, bukan cuma bahwa "ada yang salah". */
 .input-error { border-color: var(--bahaya); background: var(--bahaya-muda); }

--- a/web/style.css
+++ b/web/style.css
@@ -1849,8 +1849,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      tiap kolom atas 145 pendaftaran sungguhan di layar, dibandingkan dengan
      lebar JUDUL kolomnya, lalu ditambah padding sel 16px:
 
-       tanggal 139 · kode 123 · sekolah 242 · regu 50 · kontak 201 · WA 187
-       jumlah 942px
+       tanggal 147 · kode 123 · sekolah 242 · regu 50 · kontak 201 · WA 187
+       jumlah 950px
+
+     Tanggal 147, bukan 139: sejak formatnya jadi 28/08/2026 04:32 ia delapan
+     piksel lebih lebar daripada bentuk bernama bulan. Satu persen dipindahkan
+     dari Asal Sekolah, yang paling longgar — 25% masih 245px untuk kebutuhan
+     242px, dan nama sekolah memang kolom yang boleh membungkus.
 
      UNTUK SEL BERISI KOTAK ISIAN yang dipakai `scrollWidth` KOTAKNYA, bukan
      lebar teksnya. Pengukuran pertama memakai lebar teks lalu menambahkan
@@ -1870,7 +1875,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      WAJIB berjumlah 100: di bawah `fixed`, kolom yang tidak dipatok mendapat
      NOL, bukan sisanya (pasal 15.3).
 
-       induk    15 + 13 + 26 + 6 + 21 + 19 = 100
+       induk    16 + 13 + 25 + 6 + 21 + 19 = 100
 
      RINCIANNYA BUKAN TABEL, jadi tidak punya patokan kolom sama sekali. Versi
      pertama membuatnya delapan kolom — Regu, Kategori, Kelas, Ketua, Anggota
@@ -1888,9 +1893,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      berlaku. */
   .table-peserta { table-layout: fixed; min-width: 980px; }
 
-  .table-peserta > thead > tr > th:nth-child(1) { width: 15%; }
+  .table-peserta > thead > tr > th:nth-child(1) { width: 16%; }
   .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }
-  .table-peserta > thead > tr > th:nth-child(3) { width: 26%; }
+  .table-peserta > thead > tr > th:nth-child(3) { width: 25%; }
   .table-peserta > thead > tr > th:nth-child(4) { width:  6%; }
   .table-peserta > thead > tr > th:nth-child(5) { width: 21%; }
   .table-peserta > thead > tr > th:nth-child(6) { width: 19%; }


### PR DESCRIPTION
## What

1. **Rincian regu berbentuk form pendaftaran**, bukan delapan kolom tabel.
2. **Contact Person rata kiri.**

Barisnya tetap tabel; yang berubah cuma isi baris rinciannya.

## Why — delapan kolom tidak bisa dipakai untuk mengetik

Rinciannya dibuat delapan kolom — Regu, Kategori, Kelas, Ketua, Anggota 1–4 —
dan tiap kotak jadi sekitar **110px**. `MUHAMMAD FACHRY SEPTIAN RAMDANI` tidak
muat seperempatnya: petugas mengganti satu nama sambil melihat sepotong nama.

Memuat nama terpanjang seluruhnya menuntut tabel selebar **2.064px** — terukur
— yang tidak muat di layar mana pun. Jadi ini bukan soal menambah lebar;
**bentuknya** yang salah.

Sekarang rinciannya memakai bentuk yang sudah dikenal, karena itu yang diisi
pembina waktu mendaftar:

```
Regu 1 — Intern PA
Kelas / Organisasi   [ XI IPA 4                              ]
Nama Regu            [ GARUDA        ]  Nama Ketua [ Budi    ]
Nama Anggota (opsional)
  [ Anggota 1 ]  [ Anggota 2 ]  [ Anggota 3 ]  [ Anggota 4 ]
```

Yang dibaca sekilas tetap tabel — tanggal, kode, sekolah, kontak. Yang diketik
jadi form.

## Why — Contact Person rata kiri

`.small-input` ditengahkan karena isinya **angka**, dan aturan itu sudah punya
pengecualian tertulis untuk yang isinya **nama** (dipakai kolom nama akun).
Contact Person masuk kelompok yang sama: nama orang panjangnya berbeda-beda,
jadi yang ditengahkan tepi kirinya bergeser tiap baris — alasan yang sama
persis dengan kolom Metode di Meja Pembayaran.

**Nomor WhatsApp tetap ditengahkan**, dan itu bukan kelalaian: ia angka,
panjangnya hampir selalu sama.

## Diukur di layar sungguhan (bagian 17)

| | |
| --- | --- |
| kotak Nama Regu / Nama Ketua | 483px |
| keempat kotak anggota | 976px |
| kotak yang terpotong | **0** |
| tabel induk bergeser saat rincian dibuka | **tidak** |
| gulir mendatar | **tidak** |
| perataan Contact Person / WhatsApp | **left / center** |

Jalur Intern diperiksa terpisah: lencana "Regu 1 — Intern PA", dan kotak
Kelas / Organisasi ada dengan isinya.

Disimpan sungguhan sesudah dirombak — kelas diganti `XII IPS 3` dan satu
anggota diganti lewat kotaknya, diperiksa langsung ke tabelnya.

Patokan lebar kolom rincian ikut dibuang dari `style.css`: tidak ada lagi tabel
yang perlu dipatok di sana.

```
node --test tests/*.test.mjs -> 218 pass, 0 fail
diff web/style.css live/style.css -> identik
```