### PR TITLE
feat: show who changed what on Pembayaran and Daftar Ulang

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0136`
+sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0137`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0136`.
+`0119`-`0137`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-136 migrasi, `0001` sampai `0136`, dijalankan berurutan tanpa lubang penomoran.
+137 migrasi, `0001` sampai `0137`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -757,6 +757,22 @@ export async function riwayatNilai(pos, nomorDada) {
     `&select=*&order=changed_at.desc`);
 }
 
+/** Riwayat satu pendaftaran: perubahan pada pendaftaran, regu, dan pembayaran
+ *  (view v_riwayat_pendaftaran, migrasi 0137).
+ *
+ *  Sejajar dengan riwayatNilai() di atas, dan sengaja dibaca PER KODE
+ *  PEMBAYARAN: itu yang dipegang ketiga layar yang memakainya — Pembayaran,
+ *  Daftar Ulang, dan Data Peserta. Memuatnya sekaligus untuk seluruh tabel
+ *  berarti ratusan baris yang hampir semuanya tidak dibuka siapa pun. */
+export async function riwayatPendaftaran(kode) {
+  if (K.mode === "dev") {
+    return baca(`/riwayat-pendaftaran?kode=${encodeURIComponent(kode)}`);
+  }
+  return baca(null,
+    `v_riwayat_pendaftaran?kode_pembayaran=eq.${encodeURIComponent(kode)}` +
+    "&select=*&order=changed_at.desc,id.desc");
+}
+
 /** Kelengkapan input per pos — satu baris per pos, bukan per regu.
  *
  *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5

--- a/live/style.css
+++ b/live/style.css
@@ -1936,7 +1936,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      memang terbaca oleh pengukurannya. */
   .table-bayar .action-row .button { white-space: nowrap; }
   .table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
-  .table-bayar > thead > tr > th:nth-child(2) { width: 24%; }
+  /* 23%, bukan 24%. Satu persen pindah ke kolom Metode di bawah — lihat
+     catatannya di sana. Nama sekolah tetap 195px di tabel tersempit (848px,
+     diukur di browser), yang memuat "MTs Al-Hasan Banjarsari" tanpa membungkus
+     dan membungkus yang lebih panjang seperti sebelumnya. */
+  .table-bayar > thead > tr > th:nth-child(2) { width: 23%; }
   .table-bayar > thead > tr > th:nth-child(3) { width:  6%; }
   .table-bayar > thead > tr > th:nth-child(4) { width: 12%; }
   /* Metode 20%, naik dari 15%, dan 5%-nya diambil dari kolom tombol di
@@ -1950,7 +1954,14 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      (aturan .teks-lebar di atas), jadi kolom tombol cuma butuh 152px dan
      20% memberinya 174px pada ambang yang sama. Sebelum labelnya
      dipendekkan, 5% ini TIDAK ada untuk diambil. */
-  .table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
+  /* 21%, bukan 20%. Lencana LUNAS sekarang berbunyi "✓ LUNAS" — ia tombol
+     riwayat — dan satu glif itu melebarkannya ±11px. DIUKUR, bukan dikira
+     (pasal 15.9): isi kolom Metode jadi 175px, sementara 20% di tabel
+     tersempit yang mungkin di rentang ini (848px) cuma 170px. Meleset lima
+     piksel, dan "Transfer ✓ LUNAS [nota]" meluap keluar selnya pada jendela
+     946–961px SAJA — pita selebar 16 piksel yang tidak akan pernah tertangkap
+     dengan membaca aturannya. 21% memberi 178px. */
+  .table-bayar > thead > tr > th:nth-child(5) { width: 21%; }
   .table-bayar > thead > tr > th:nth-child(6) { width: 20%; }
 
   /* Perataan kolom Metode dan kolom tombol TIDAK diatur di sini melainkan di
@@ -2220,6 +2231,35 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   color: var(--tinta-lembut); font-size: .78rem;
   white-space: nowrap; margin-left: auto;
 }
+
+/* Riwayat PENDAFTARAN memakai daftar, warna, dan kelas yang sama dengan
+   riwayat nilai pos — dua dialog yang menjawab pertanyaan yang sama tidak
+   boleh terasa seperti dua aplikasi. Satu hal yang berbeda: "oleh · kapan"
+   turun ke barisnya SENDIRI, selalu.
+
+   Sebabnya bukan selera, melainkan lebar yang diukur. Di riwayat pos ketiga
+   kolomnya muat sebaris karena nilainya ANGKA — "1250 → 1250" selebar 92px.
+   Di sini nilainya nama, status, dan daftar anggota: "menunggu_pembayaran →
+   lunas" saja sudah 242px. Diukur di kartu dialog yang isinya 423px, baris
+   terpendek pun menuntut 482px dan yang memuat tautan bukti 638px — jadi
+   SETIAP baris tergeser mendatar, dan yang hilang di ujung kanan adalah
+   jamnya, justru yang dicari orang yang membuka riwayat.
+
+   SELALU turun, bukan kadang-kadang. Membungkus hanya saat tidak muat adalah
+   bug yang sudah pernah diperbaiki di .riwayat li di atas: daftar jadi
+   bergerigi, sebagian baris dua baris dan sebagian satu, dan justru lebih
+   sulit disapu mata daripada dua baris yang rata. */
+.riwayat-pendaftaran li { flex-wrap: wrap; min-width: 0; }
+/* Nilainya boleh memakai sisa lebar dan MEMBUNGKUS di dalam kolomnya: daftar
+   anggota adalah empat nama sekaligus, dan menahannya nowrap mengembalikan
+   penggulir mendatar yang baru saja dibuang. */
+.riwayat-pendaftaran .r-nilai {
+  flex: 1 1 auto; min-width: 0; white-space: normal; overflow-wrap: anywhere;
+}
+/* Barisnya sendiri, dan rata KIRI di bawah nama kolomnya — bukan didorong ke
+   kanan oleh margin-left: auto, yang di baris kedua cuma membuat jam setiap
+   entri berhenti di tempat yang berbeda-beda. */
+.riwayat-pendaftaran .r-oleh { flex: 0 0 100%; margin-left: 0; }
 
 /* Galeri seluruh foto satu lomba. Gambarnya ditumpuk ke bawah, bukan dibuka
    satu per satu di tab baru: sembilan tab adalah sembilan kali menekan

--- a/supabase/migrations/0137_riwayat_pendaftaran.sql
+++ b/supabase/migrations/0137_riwayat_pendaftaran.sql
@@ -1,0 +1,164 @@
+-- ============================================================================
+-- hrcd-rekap : 0137_riwayat_pendaftaran.sql
+--
+-- Riwayat perubahan untuk PENDAFTARAN — sejajar dengan v_riwayat_nilai (0042)
+-- yang sudah ada untuk nilai pos.
+--
+-- ---------------------------------------------------------------------------
+-- DATANYA SUDAH ADA SEJAK 0002
+--
+-- Trigger `catat_riwayat()` menempel di `regu`, `pendaftaran`, `pembayaran`,
+-- dan `nilai_mentah` — keempatnya, bukan cuma nilai. Setiap INSERT, UPDATE,
+-- dan DELETE menulis satu baris `history` berisi SELURUH baris lama dan baru
+-- dalam JSON, beserta `changed_by` dan `changed_at`.
+--
+-- Jadi "siapa menandai lunas", "siapa memberi nomor dada", dan "siapa mengubah
+-- nama anggota" sudah tersimpan sejak hari pertama. Yang belum ada cuma cara
+-- MELIHATNYA: nilai pos punya v_riwayat_nilai dan centang hijau yang bisa
+-- diketuk, tiga layar lainnya tidak punya apa-apa.
+--
+-- Berkas ini menutup jarak itu, dan tidak menambah satu kolom pun.
+--
+-- ---------------------------------------------------------------------------
+-- YANG BERUBAH, BUKAN SELURUH BARISNYA
+--
+-- `old_value` dan `new_value` memuat seluruh kolom, dan sebagian besar tidak
+-- berubah. Menampilkan keduanya apa adanya berarti petugas membandingkan dua
+-- blok JSON dengan mata untuk menemukan satu kolom yang berbeda.
+--
+-- View ini menghitung SELISIHNYA di database: `perubahan` hanya memuat kolom
+-- yang benar-benar berbeda, dengan nilai lama dan barunya berdampingan.
+--
+-- Kolom yang tidak menjelaskan apa pun dibuang lebih dulu — `id`, kunci asing,
+-- dan cap waktu internal. Yang tersisa persis yang ditanyakan orang saat
+-- menatap centang hijau.
+--
+-- ---------------------------------------------------------------------------
+-- PAGARNYA MENYALIN YANG SUDAH ADA, BUKAN MEMBUAT YANG BARU
+--
+-- Siapa boleh melihat riwayat pendaftaran = siapa boleh melihat pendaftaran
+-- itu sendiri. Layar Pembayaran, Daftar Ulang, dan Data Peserta masing-masing
+-- sudah punya haknya (`pembayaran`, `daftar_ulang`, `pendaftaran`), dan
+-- `pengaturan` melihat semuanya.
+--
+-- Tidak ada fitur baru: satu centang lagi yang harus diingat panitia adalah
+-- satu layar yang lumpuh saat lupa dicentang (CLAUDE.md 13.1).
+-- ============================================================================
+
+create or replace view v_riwayat_pendaftaran as
+with kolom_dibuang as (
+  select array[
+    'id', 'pendaftaran_id', 'sekolah_id', 'kunci_kirim', 'created_at',
+    'dibuat_pada', 'verified_at', 'wahana_id', 'regu_id',
+    -- `verified_by` adalah uuid petugas, dan kolom `oleh` di bawah sudah
+    -- menerjemahkan uuid itu jadi nama yang bisa dibaca. Menampilkan keduanya
+    -- berarti satu baris riwayat berbunyi "Diverifikasi: — -> 0000...b1"
+    -- tepat di sebelah "meja1hrcd37" — angka yang tidak menjawab apa pun.
+    'verified_by'
+  ] as nama
+)
+select
+  h.id,
+  d.kode_pembayaran,
+  h.regu_id,
+  r.nama_regu,
+  r.nomor_dada,
+  h.table_name,
+  h.action,
+  -- Hanya kolom yang benar-benar berbeda. INSERT tidak punya nilai lama, jadi
+  -- seluruh kolomnya terhitung berubah — itu memang keadaannya, dan di layar
+  -- ia terbaca sebagai "baris ini lahir di sini".
+  (
+    select jsonb_object_agg(k.key, jsonb_build_object(
+             'lama', h.old_value -> k.key,
+             'baru', h.new_value -> k.key))
+    from jsonb_object_keys(coalesce(h.new_value, h.old_value)) as k(key),
+         kolom_dibuang b
+    where not (k.key = any (b.nama))
+      and (h.old_value -> k.key) is distinct from (h.new_value -> k.key)
+  ) as perubahan,
+  coalesce(a.username, '(tidak dikenal)') as oleh,
+  h.changed_at
+from history h
+left join regu r on r.id = h.regu_id
+-- Satu baris riwayat harus bisa ditemukan lewat KODE PEMBAYARAN, karena itu
+-- yang dipegang ketiga layar. Untuk `pendaftaran` kodenya ada di barisnya
+-- sendiri; untuk `regu` dan `pembayaran` ia diambil lewat pendaftaran_id.
+join pendaftaran d
+  on d.id = coalesce(
+       case when h.table_name = 'pendaftaran'
+            then coalesce((h.new_value ->> 'id')::uuid, (h.old_value ->> 'id')::uuid) end,
+       (h.new_value ->> 'pendaftaran_id')::uuid,
+       (h.old_value ->> 'pendaftaran_id')::uuid)
+left join akun_panitia a on a.user_id = h.changed_by
+where h.table_name in ('pendaftaran', 'regu', 'pembayaran')
+  and (boleh('pengaturan') or boleh('pembayaran')
+       or boleh('daftar_ulang') or boleh('pendaftaran'));
+
+comment on view v_riwayat_pendaftaran is
+  'Riwayat perubahan pendaftaran, regu, dan pembayaran — sejajar dengan '
+  'v_riwayat_nilai untuk nilai pos. `perubahan` hanya memuat kolom yang '
+  'benar-benar berbeda, jadi layar tidak perlu membandingkan dua blok JSON. '
+  'Pagarnya menyalin hak yang sudah ada, tanpa fitur baru.';
+
+grant select on v_riwayat_pendaftaran to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Pagar: view-nya terbaca, menyaring tabel yang benar, dan `perubahan` memang
+-- berisi kolom yang berubah SAJA. Diperiksa lewat baris yang dibuat di sini
+-- lalu dihapus lagi — migrasi ini berjalan di produksi saat acara berlangsung.
+-- ---------------------------------------------------------------------------
+do $blok$
+declare
+  v_kunci uuid := gen_random_uuid();
+  v_kode  text;
+  v_regu  uuid;
+  v_ubah  jsonb;
+  v_n     integer;
+begin
+  select (submit_pendaftaran(
+    'SMA Negeri 1 Ciamis', '', false, '081200000137',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'UJI RIWAYAT 0137', 'nama_ketua', 'Ketua Lama',
+      'golongan', 'intern_pa')),
+    0::smallint, v_kunci, null, 'tunai', null) ->> 'kode_pembayaran')
+  into v_kode;
+
+  select r.id into v_regu
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_kode;
+
+  update regu set nama_ketua = 'Ketua Baru' where id = v_regu;
+
+  -- View menyaring dengan boleh(), dan migrasi berjalan tanpa kursi pengguna —
+  -- jadi yang bisa dibuktikan di sini bentuk datanya, bukan haknya. Haknya
+  -- diuji tes 89 yang menempati kursi (CLAUDE.md 13.8).
+  select jsonb_object_agg(k.key, jsonb_build_object(
+           'lama', h.old_value -> k.key, 'baru', h.new_value -> k.key))
+    into v_ubah
+  from history h,
+       jsonb_object_keys(coalesce(h.new_value, h.old_value)) as k(key)
+  where h.table_name = 'regu' and h.regu_id = v_regu and h.action = 'UPDATE'
+    and not (k.key = any (array['id','pendaftaran_id','sekolah_id','kunci_kirim',
+                                'created_at','dibuat_pada','verified_at',
+                                'wahana_id','regu_id','verified_by']))
+    and (h.old_value -> k.key) is distinct from (h.new_value -> k.key)
+  group by h.id;
+
+  if v_ubah is null or not (v_ubah ? 'nama_ketua') then
+    raise exception '0137: perubahan nama ketua tidak tercatat — %', coalesce(v_ubah::text, '<NULL>');
+  end if;
+  select count(*) into v_n from jsonb_object_keys(v_ubah);
+  if v_n <> 1 then
+    raise exception '0137: perubahan memuat % kolom, seharusnya 1 — %', v_n, v_ubah;
+  end if;
+
+  delete from history where regu_id = v_regu;
+  delete from history where table_name = 'pendaftaran'
+    and coalesce(new_value ->> 'kunci_kirim', old_value ->> 'kunci_kirim') = v_kunci::text;
+  delete from regu where id = v_regu;
+  delete from pendaftaran where kunci_kirim = v_kunci;
+
+  raise notice '0137: riwayat pendaftaran terbaca, dan perubahan memuat kolom yang berubah saja.';
+end;
+$blok$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -219,6 +219,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "select * from v_riwayat_nilai where pos = %s "
                     "and nomor_dada = %s order by changed_at desc",
                     (p.get("pos") or 0, p.get("dada") or 0), uid=p.get("uid")))
+            elif u.path == "/riwayat-pendaftaran":
+                self._kirim(200, q(
+                    "select * from v_riwayat_pendaftaran "
+                    "where kode_pembayaran = %s order by changed_at desc, id desc",
+                    (p.get("kode") or "",), uid=p.get("uid")))
             elif u.path == "/rentang-nomor-dada":
                 self._kirim(200, q(
                     "select * from v_rentang_nomor_dada",

--- a/tests/payment_rows_render.test.mjs
+++ b/tests/payment_rows_render.test.mjs
@@ -55,6 +55,21 @@ function blokPembangunBaris() {
 }
 
 
+/** Ambil centangRiwayat() APA ADANYA dari app.js.
+ *
+ *  Sejak lencana LUNAS menjadi tombol riwayat, fungsi inilah yang menggambar
+ *  lencana itu — jadi menirunya di sini berarti menguji lencana yang tidak
+ *  pernah muncul di layar. Yang dijalankan harus yang sungguhan. */
+function sumberCentangRiwayat() {
+  const mulai = app.indexOf("const centangRiwayat = (kode");
+  assert.notEqual(mulai, -1,
+    "centangRiwayat() tidak ditemukan di app.js — kalau namanya berubah, " +
+    "sesuaikan potongan ini, JANGAN hapus tesnya");
+  const akhir = app.indexOf("`;", app.indexOf("aria-label=", mulai)) + 2;
+  return app.slice(mulai, akhir);
+}
+
+
 /* Tiruan seadanya. Yang ditiru cuma yang DIPANGGIL blok itu; kalau ia mulai
    memanggil yang lain, tes ini gagal dengan "x is not defined" — dan itu
    memang laporan yang benar, bukan gangguan. */
@@ -100,7 +115,8 @@ const BARIS = [
 function bangun(baris = BARIS) {
   const nama = Object.keys(TIRUAN);
   // eslint-disable-next-line no-new-func
-  const jalan = new Function("baris", ...nama, blokPembangunBaris());
+  const jalan = new Function("baris", ...nama,
+    [sumberCentangRiwayat(), blokPembangunBaris()].join(";"));
   return jalan(baris, ...nama.map((n) => TIRUAN[n]));
 }
 
@@ -112,7 +128,11 @@ test("blok pembangun baris berjalan sampai selesai untuk keempat bentuk", () => 
   const jumlah = (pola) => (keluaran.match(pola) || []).length;
 
   assert.equal(jumlah(/<tr class="invoice-row"/g), 4, "empat baris invoice");
-  assert.equal(jumlah(/badge-green">LUNAS/g), 2, "dua lencana LUNAS");
+  assert.equal(jumlah(/✓ LUNAS<\/button>/g), 2,
+    "dua lencana LUNAS, dan keduanya tombol riwayat");
+  assert.equal(jumlah(/data-riwayat-kode=/g), 2,
+    "centang riwayat HANYA di baris lunas — bukan di yang belum bayar " +
+    "atau yang batal, tempat ia akan berbohong tentang keadaannya");
   assert.equal(jumlah(/badge-red">BATAL/g), 1, "satu lencana BATAL");
   assert.equal(jumlah(/data-metode=/g), 1, "satu dropdown cara bayar");
 });
@@ -134,7 +154,11 @@ test("tombol nota duduk di kolom Metode, bukan di kolom tombol", () => {
   // keterangan tentang pembayaran — bukan aksi ketiga sejajar Kwitansi dan
   // Batalkan.
   const rapat = bangun().replace(/\s+/g, " ");
-  assert.match(rapat, /badge-green">LUNAS<\/span><button[^>]*data-bukti/,
+  // Lencana LUNAS sekarang <button> (ia tombol riwayat), bukan lagi <span>.
+  // Yang diuji tetap HUBUNGANNYA — nota tepat sesudah lencana lunas — bukan
+  // nama tagnya: tes yang memaku ejaan markup gagal atas perubahan yang benar
+  // dan diam atas yang salah.
+  assert.match(rapat, /✓ LUNAS<\/button><button[^>]*data-bukti/,
     "di baris lunas, nota harus tepat sesudah lencana LUNAS");
   assert.match(rapat, /<\/select><button[^>]*data-bukti/,
     "di baris belum lunas, nota harus tepat sesudah dropdown cara bayar");

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -663,4 +663,10 @@ run supabase/migrations/0132_impor_pendaftaran_xxxvii_lanjutan.sql
 # digagalkan: database uji dan produksi tidak memuat regu yang sama persis.
 run supabase/migrations/0136_tanggal_daftar_dari_form.sql
 
+# 0137 membuka riwayat pendaftaran, regu, dan pembayaran — datanya sudah
+# tercatat trigger sejak 0002, yang belum ada cuma cara melihatnya. Pagarnya
+# memakai boleh(), jadi jalur positifnya diuji tes 89 yang menempati kursi.
+run supabase/migrations/0137_riwayat_pendaftaran.sql
+run tests/sql/89_riwayat_pendaftaran.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/sql/89_riwayat_pendaftaran.sql
+++ b/tests/sql/89_riwayat_pendaftaran.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/89_riwayat_pendaftaran.sql
+--
+-- Riwayat pendaftaran (migrasi 0137) terbaca oleh yang berhak, dan tertutup
+-- untuk yang tidak.
+--
+-- Migrasinya sendiri hanya bisa membuktikan BENTUK datanya: ia berjalan tanpa
+-- kursi pengguna, jadi `boleh()` selalu false di sana. Yang menguji hak harus
+-- menempati kursi (CLAUDE.md 13.8), dan itu di sini.
+--
+--   89.1  petugas registrasi melihat riwayatnya
+--   89.2  isinya menyebut APA yang berubah, siapa, dan kapan
+--   89.3  ketiga tabel ikut — pendaftaran, regu, pembayaran
+--   89.4  mencabut seluruh centangnya menutup view-nya
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+begin;
+
+do $blok$
+declare
+  v_registrasi uuid := '00000000-0000-0000-0000-0000000000b1';
+  v_kunci uuid := gen_random_uuid();
+  v_kode  text;
+  v_regu  uuid;
+  v_n     integer;
+  v_teks  text;
+  v_tabel text;
+begin
+  perform set_config('app.uid', v_registrasi::text, true);
+
+  select (submit_pendaftaran(
+    'SMA Negeri 1 Ciamis', '', false, '081200000089',
+    jsonb_build_array(jsonb_build_object(
+      'nama_regu', 'UJI RIWAYAT DELAPAN', 'nama_ketua', 'Ketua Lama',
+      'golongan', 'intern_pa')),
+    0::smallint, v_kunci, 'Bu Lama', 'tunai', null) ->> 'kode_pembayaran')
+  into v_kode;
+
+  select r.id into v_regu
+  from regu r join pendaftaran d on d.id = r.pendaftaran_id
+  where d.kode_pembayaran = v_kode;
+
+  -- Tiga perbuatan yang benar-benar dilakukan panitia di tiga layar berbeda.
+  perform ubah_identitas_regu(v_regu, 'UJI RIWAYAT DELAPAN', 'Ketua Baru', null, null);
+  perform ubah_kontak_pendaftaran(v_kode, 'Bu Baru', '081299990089');
+  perform verifikasi_pembayaran(v_kode, tagihan_pendaftaran(
+    (select id from pendaftaran where kode_pembayaran = v_kode)), 'tunai');
+
+  -- 89.1  Terbaca oleh pemegang hak.
+  select count(*) into v_n from v_riwayat_pendaftaran
+  where kode_pembayaran = v_kode;
+  assert v_n > 0, '89.1 GAGAL: riwayatnya kosong untuk petugas registrasi';
+  raise notice '89.1 LULUS: petugas registrasi melihat % baris riwayat.', v_n;
+
+  -- 89.2  Menyebut APA yang berubah, siapa, dan kapan.
+  select (perubahan -> 'nama_ketua' ->> 'lama') || ' -> '
+      || (perubahan -> 'nama_ketua' ->> 'baru') || ' oleh ' || oleh
+    into v_teks
+  from v_riwayat_pendaftaran
+  where kode_pembayaran = v_kode and table_name = 'regu' and action = 'UPDATE'
+    and perubahan ? 'nama_ketua'
+  order by changed_at desc limit 1;
+
+  -- ->> mengembalikan TEKSNYA, tanpa tanda kutip JSON. Asersi pertama
+  -- menuntut tanda kutipnya ada dan gagal atas data yang sudah benar.
+  assert v_teks like 'Ketua Lama -> Ketua Baru oleh %',
+    format('89.2 GAGAL: berbunyi %s', coalesce(v_teks, '<NULL>'));
+  assert v_teks not like '%(tidak dikenal)%',
+    format('89.2 GAGAL: pelakunya tidak terbaca — %s', v_teks);
+  raise notice '89.2 LULUS: riwayat menyebut perubahan, pelaku, dan waktunya.';
+
+  -- 89.3  Ketiga tabel ikut. Yang paling penting `pembayaran`: itu jawaban
+  --       atas "siapa yang menandai lunas".
+  select string_agg(distinct table_name, ',' order by table_name) into v_tabel
+  from v_riwayat_pendaftaran where kode_pembayaran = v_kode;
+  assert v_tabel = 'pembayaran,pendaftaran,regu',
+    format('89.3 GAGAL: tabel yang tercatat %s', v_tabel);
+  raise notice '89.3 LULUS: pendaftaran, regu, dan pembayaran semuanya tercatat.';
+
+  -- 89.4  Centang dicabut seluruhnya — view-nya ikut tertutup. Panggilan yang
+  --       SAMA PERSIS dijalankan dua kali; yang berubah cuma baris akun_hak.
+  delete from akun_hak where user_id = v_registrasi
+    and fitur in ('pengaturan', 'pembayaran', 'daftar_ulang', 'pendaftaran');
+
+  select count(*) into v_n from v_riwayat_pendaftaran
+  where kode_pembayaran = v_kode;
+  assert v_n = 0,
+    format('89.4 GAGAL: masih terbaca % baris tanpa satu centang pun', v_n);
+  raise notice '89.4 LULUS: mencabut centangnya menutup riwayatnya.';
+end;
+$blok$;
+
+rollback;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -757,6 +757,22 @@ export async function riwayatNilai(pos, nomorDada) {
     `&select=*&order=changed_at.desc`);
 }
 
+/** Riwayat satu pendaftaran: perubahan pada pendaftaran, regu, dan pembayaran
+ *  (view v_riwayat_pendaftaran, migrasi 0137).
+ *
+ *  Sejajar dengan riwayatNilai() di atas, dan sengaja dibaca PER KODE
+ *  PEMBAYARAN: itu yang dipegang ketiga layar yang memakainya — Pembayaran,
+ *  Daftar Ulang, dan Data Peserta. Memuatnya sekaligus untuk seluruh tabel
+ *  berarti ratusan baris yang hampir semuanya tidak dibuka siapa pun. */
+export async function riwayatPendaftaran(kode) {
+  if (K.mode === "dev") {
+    return baca(`/riwayat-pendaftaran?kode=${encodeURIComponent(kode)}`);
+  }
+  return baca(null,
+    `v_riwayat_pendaftaran?kode_pembayaran=eq.${encodeURIComponent(kode)}` +
+    "&select=*&order=changed_at.desc,id.desc");
+}
+
 /** Kelengkapan input per pos — satu baris per pos, bukan per regu.
  *
  *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -20,7 +20,7 @@ import {
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
   rentangNomorDada,
-  komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai,
+  komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai, riwayatPendaftaran,
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto, klasemenLiveScore,
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
@@ -897,6 +897,136 @@ const tanggalRingkas = (t) => {
   return `${b.day}/${b.month}/${b.year} ${b.hour}:${b.minute}`;
 };
 
+/* ---------------------------------------------------------------------------
+   RIWAYAT SATU PENDAFTARAN — centang hijau yang bisa diketuk.
+
+   Bentuknya menyalin yang sudah ada di layar Input Nilai Pos: centang hijau
+   berarti "sudah masuk database", dan mengetuknya menjawab pertanyaan yang
+   memang muncul saat menatapnya — siapa yang menaruhnya, dan apa yang ia ganti.
+   Kelasnya pun sama (.riwayat, .r-lomba, .r-nilai, .r-oleh): dua dialog yang
+   menjawab pertanyaan yang sama tidak boleh terasa seperti dua aplikasi.
+
+   Hanya pada baris yang SUDAH SELESAI — Lunas di Pembayaran, dan bernomor dada
+   di Daftar Ulang. Itu bukan penghematan: pada baris yang belum lunas atau
+   belum bernomor, centang hijau berbohong tentang keadaannya.
+
+   Datanya sudah tercatat trigger `catat_riwayat()` sejak 0002 — pendaftaran,
+   regu, DAN pembayaran. Yang baru cuma cara melihatnya: view
+   v_riwayat_pendaftaran (migrasi 0137).
+   --------------------------------------------------------------------------- */
+
+/** Nama kolom database tidak terbaca oleh yang tidak menulisnya. Yang tidak
+ *  terdaftar di sini tetap tampil dengan nama aslinya — nama teknis yang jujur
+ *  lebih baik daripada baris yang hilang diam-diam. */
+const LABEL_RIWAYAT = {
+  nama_regu: "Nama regu", nama_ketua: "Ketua", anggota: "Anggota",
+  kelas_organisasi: "Kelas", golongan: "Golongan", nomor_dada: "Nomor dada",
+  kloter_nomor: "Kloter", urutan_kloter: "Urutan", kontrak_menit: "Kontrak",
+  is_cancelled: "Dibatalkan",
+  nama_kontak: "Contact person", kontak_wa: "WhatsApp",
+  status: "Status", jumlah_regu: "Jumlah regu", butuh_barak: "Barak",
+  jumlah_menginap: "Menginap", metode_bayar: "Cara bayar",
+  bukti_transfer: "Bukti transfer",
+  amount: "Nominal", method: "Metode", nomor_kwitansi: "Kwitansi",
+};
+
+const TABEL_RIWAYAT = {
+  pendaftaran: "Pendaftaran", regu: "Regu", pembayaran: "Pembayaran",
+};
+
+/** JSON apa adanya tidak dibaca orang: null jadi "—", daftar anggota jadi
+ *  kalimat, dan boolean jadi kata. */
+function nilaiRiwayat(v) {
+  if (v === null || v === undefined) return "—";
+  if (Array.isArray(v)) return v.length ? v.join(", ") : "—";
+  if (typeof v === "boolean") return v ? "ya" : "tidak";
+  const t = String(v);
+  if (t === "") return "—";
+  // Tautan bukti transfer ditulis "(tautan)", bukan alamatnya. Alamat Drive
+  // panjangnya 60 huruf dan tidak satu pun di antaranya menjawab pertanyaan
+  // yang sedang ditanyakan — sedangkan tombol yang MEMBUKA tautan itu ada di
+  // baris yang riwayatnya sedang dibaca.
+  return /^https?:\/\//.test(t) ? "(tautan)" : t;
+}
+
+/** Satu baris riwayat jadi satu atau beberapa <li>.
+ *
+ *  INSERT sengaja TIDAK dirinci kolom per kolom: saat baris lahir, SELURUH
+ *  kolomnya terhitung berubah, dan dua puluh baris "— → sesuatu" mengubur
+ *  perubahan sungguhan yang justru dicari. Satu baris "Regu dibuat" sudah
+ *  menyampaikan seluruh yang berguna. */
+function liRiwayat(b) {
+  const tabel = TABEL_RIWAYAT[b.table_name] || b.table_name;
+  const oleh = `${b.oleh} · ${tanggalJam(b.changed_at)}`;
+
+  if (b.action !== "UPDATE") {
+    return html`<li>
+      <span class="r-lomba">${tabel}</span>
+      <span class="r-nilai"><strong>${b.action === "DELETE" ? "dihapus" : "dibuat"}</strong></span>
+      <span class="r-oleh">${oleh}</span>
+    </li>`;
+  }
+
+  const ubah = b.perubahan || {};
+  return Object.keys(ubah).map(k => html`<li>
+    <span class="r-lomba">${LABEL_RIWAYAT[k] || k}</span>
+    <span class="r-nilai">${nilaiRiwayat(ubah[k].lama)} →
+      <strong>${nilaiRiwayat(ubah[k].baru)}</strong></span>
+    <span class="r-oleh">${oleh}</span>
+  </li>`).join("");
+}
+
+/** Centang hijau yang bisa diketuk.
+ *
+ *  `label` opsional, dan itu yang membuat satu fungsi melayani dua layar:
+ *
+ *  - Meja Pembayaran memakai centang BERLABEL, dan ia MENGGANTIKAN lencana
+ *    LUNAS yang sudah ada di sana — bukan berdiri di sebelahnya. Kolom tombol
+ *    di layar itu sudah penuh sampai piksel terakhir pada lebar tersempitnya
+ *    (diukur: isinya 197px di dalam sel 193px), jadi elemen ketujuh di baris
+ *    itu meluap keluar tabel. Menjadikan lencana statusnya SENDIRI sebagai
+ *    tombol tidak menambah satu elemen pun — dan itu persis idiom layar Input
+ *    Nilai Pos, tempat lencana hijaunya memang tombol riwayat.
+ *
+ *  - Meja Daftar Ulang memakai centang polos, karena di sana tidak ada lencana
+ *    status untuk dijadikan tombol: yang menyatakan "selesai" adalah deretan
+ *    nomor dadanya sendiri.
+ *
+ *  aria-label ditulis penuh: tombol yang isinya cuma "✓" tidak menyebutkan
+ *  apa-apa ke pembaca layar. */
+const centangRiwayat = (kode, label = "") => html`<button
+  class="badge badge-green badge-tombol" type="button"
+  data-riwayat-kode="${kode}" title="Riwayat perubahan"
+  aria-label="Riwayat perubahan ${kode}">✓${label ? " " + label : ""}</button>`;
+
+/** Pasang penangannya pada seluruh centang di dalam satu wadah. Dipanggil
+ *  sekali per penggambaran tabel, bukan per baris. */
+function pasangCentangRiwayat(wadah) {
+  wadah.querySelectorAll("[data-riwayat-kode]").forEach(btn =>
+    btn.addEventListener("click", () => bukaRiwayatPendaftaran(btn.dataset.riwayatKode)));
+}
+
+/** Dibaca saat DIKETUK, bukan ikut dimuat bersama tabelnya: satu layar memuat
+ *  ratusan baris dan hampir semuanya tidak pernah ditanya riwayatnya.
+ *
+ *  Yang ditampilkan sengaja apa adanya — dari apa jadi apa, siapa, kapan —
+ *  tanpa menyimpulkan mana yang "mencurigakan". Yang tahu apakah suatu
+ *  perubahan wajar adalah orang yang mengerjakannya, bukan layar. */
+async function bukaRiwayatPendaftaran(kode) {
+  let baris;
+  try { baris = await riwayatPendaftaran(kode); }
+  catch (err) { notif(`Riwayat tidak bisa dibaca: ${err.message}`, true); return; }
+
+  const isi = baris.map(liRiwayat).join("");
+  await dialog({
+    judul: `Riwayat ${kode}`,
+    kartuHtml: isi
+      ? `<ul class="riwayat riwayat-pendaftaran">${isi}</ul>`
+      : `<p class="description">Belum pernah diubah.</p>`,
+    labelAksi: "Tutup", bacaSaja: true,
+  });
+}
+
 async function layarDataPeserta() {
   if (!EDISI) { layarButuhEdisi("Data Peserta"); return; }
   pasangKepala("Data Peserta", true);
@@ -1276,7 +1406,7 @@ async function layarPembayaran() {
         // sebagai teks. Nilai dari luar tetap lewat esc() satu per satu.
         ? `<span class="metode-baris" style="flex-wrap:nowrap;gap:.25rem"
            ><span class="metode-kata">${esc(b.pembayaran ? b.pembayaran.method : "—")}</span
-           ><span class="badge badge-green">LUNAS</span>${nota}</span>`
+           >${centangRiwayat(b.kode_pembayaran, "LUNAS")}${nota}</span>`
         : b.status === "batal"
           ? `<span class="badge badge-red">BATAL</span>`
           // Yang terpilih lebih dulu adalah cara bayar yang DIPILIH PEMBINA saat
@@ -1389,6 +1519,11 @@ async function layarPembayaran() {
       satuan.textContent = " regu";
       return [document.createTextNode(`${terbuka ? "▾" : "▸"} ${jumlah}`), satuan];
     };
+
+    // Riwayat perubahan invoice ini. Dipasang sekali per penggambaran, bukan
+    // per baris — tabelnya digambar ulang tiap kali saringan atau pencarian
+    // berubah, dan penangan yang menempel di baris lama ikut hilang bersamanya.
+    pasangCentangRiwayat(tbody);
 
     // Bukti transfer yang diunggah pembina. Bucket-nya privat, jadi tautannya
     // ditandatangani saat diketuk — dan jendelanya dibuka SEBELUM await, karena
@@ -1697,7 +1832,10 @@ async function layarDaftarUlang() {
                    aria-expanded="${terbuka}">
              ${terbuka ? "▾" : "▸"} Isi ${menunggu.length} Nomor Dada
            </button>${nomorHtml ? `<div class="sub">${nomorHtml}</div>` : ""}`
-        : `<div class="pill-row">${nomorHtml}</div>`;
+        // Selesai = seluruh regunya sudah bernomor, dan tidak ada lagi tombol
+        // di baris ini. Centangnya berdiri di depan deretan nomor, tempat mata
+        // sudah berhenti untuk memastikan nomornya lengkap.
+        : `<div class="pill-row">${centangRiwayat(b.kode_pembayaran)}${nomorHtml}</div>`;
 
       // Template biasa (lihat catatan sama di layar Pembayaran).
       return `
@@ -1756,6 +1894,9 @@ async function layarDaftarUlang() {
           </td>
         </tr>`}`;
     }).join("")));
+
+    // Riwayat perubahan pendaftaran ini — lihat catatan sama di Meja Pembayaran.
+    pasangCentangRiwayat(tbody);
 
     // Nomor rusak/sobek di lapangan: nomor lama PENSIUN (tidak pernah terbit
     // ulang), supaya lembar nilai lama tidak menilai regu yang salah.

--- a/web/style.css
+++ b/web/style.css
@@ -1936,7 +1936,11 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      memang terbaca oleh pengukurannya. */
   .table-bayar .action-row .button { white-space: nowrap; }
   .table-bayar > thead > tr > th:nth-child(1) { width: 18%; }
-  .table-bayar > thead > tr > th:nth-child(2) { width: 24%; }
+  /* 23%, bukan 24%. Satu persen pindah ke kolom Metode di bawah — lihat
+     catatannya di sana. Nama sekolah tetap 195px di tabel tersempit (848px,
+     diukur di browser), yang memuat "MTs Al-Hasan Banjarsari" tanpa membungkus
+     dan membungkus yang lebih panjang seperti sebelumnya. */
+  .table-bayar > thead > tr > th:nth-child(2) { width: 23%; }
   .table-bayar > thead > tr > th:nth-child(3) { width:  6%; }
   .table-bayar > thead > tr > th:nth-child(4) { width: 12%; }
   /* Metode 20%, naik dari 15%, dan 5%-nya diambil dari kolom tombol di
@@ -1950,7 +1954,14 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      (aturan .teks-lebar di atas), jadi kolom tombol cuma butuh 152px dan
      20% memberinya 174px pada ambang yang sama. Sebelum labelnya
      dipendekkan, 5% ini TIDAK ada untuk diambil. */
-  .table-bayar > thead > tr > th:nth-child(5) { width: 20%; }
+  /* 21%, bukan 20%. Lencana LUNAS sekarang berbunyi "✓ LUNAS" — ia tombol
+     riwayat — dan satu glif itu melebarkannya ±11px. DIUKUR, bukan dikira
+     (pasal 15.9): isi kolom Metode jadi 175px, sementara 20% di tabel
+     tersempit yang mungkin di rentang ini (848px) cuma 170px. Meleset lima
+     piksel, dan "Transfer ✓ LUNAS [nota]" meluap keluar selnya pada jendela
+     946–961px SAJA — pita selebar 16 piksel yang tidak akan pernah tertangkap
+     dengan membaca aturannya. 21% memberi 178px. */
+  .table-bayar > thead > tr > th:nth-child(5) { width: 21%; }
   .table-bayar > thead > tr > th:nth-child(6) { width: 20%; }
 
   /* Perataan kolom Metode dan kolom tombol TIDAK diatur di sini melainkan di
@@ -2220,6 +2231,35 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   color: var(--tinta-lembut); font-size: .78rem;
   white-space: nowrap; margin-left: auto;
 }
+
+/* Riwayat PENDAFTARAN memakai daftar, warna, dan kelas yang sama dengan
+   riwayat nilai pos — dua dialog yang menjawab pertanyaan yang sama tidak
+   boleh terasa seperti dua aplikasi. Satu hal yang berbeda: "oleh · kapan"
+   turun ke barisnya SENDIRI, selalu.
+
+   Sebabnya bukan selera, melainkan lebar yang diukur. Di riwayat pos ketiga
+   kolomnya muat sebaris karena nilainya ANGKA — "1250 → 1250" selebar 92px.
+   Di sini nilainya nama, status, dan daftar anggota: "menunggu_pembayaran →
+   lunas" saja sudah 242px. Diukur di kartu dialog yang isinya 423px, baris
+   terpendek pun menuntut 482px dan yang memuat tautan bukti 638px — jadi
+   SETIAP baris tergeser mendatar, dan yang hilang di ujung kanan adalah
+   jamnya, justru yang dicari orang yang membuka riwayat.
+
+   SELALU turun, bukan kadang-kadang. Membungkus hanya saat tidak muat adalah
+   bug yang sudah pernah diperbaiki di .riwayat li di atas: daftar jadi
+   bergerigi, sebagian baris dua baris dan sebagian satu, dan justru lebih
+   sulit disapu mata daripada dua baris yang rata. */
+.riwayat-pendaftaran li { flex-wrap: wrap; min-width: 0; }
+/* Nilainya boleh memakai sisa lebar dan MEMBUNGKUS di dalam kolomnya: daftar
+   anggota adalah empat nama sekaligus, dan menahannya nowrap mengembalikan
+   penggulir mendatar yang baru saja dibuang. */
+.riwayat-pendaftaran .r-nilai {
+  flex: 1 1 auto; min-width: 0; white-space: normal; overflow-wrap: anywhere;
+}
+/* Barisnya sendiri, dan rata KIRI di bawah nama kolomnya — bukan didorong ke
+   kanan oleh margin-left: auto, yang di baris kedua cuma membuat jam setiap
+   entri berhenti di tempat yang berbeda-beda. */
+.riwayat-pendaftaran .r-oleh { flex: 0 0 100%; margin-left: 0; }
 
 /* Galeri seluruh foto satu lomba. Gambarnya ditumpuk ke bawah, bukan dibuka
    satu per satu di tab baru: sembilan tab adalah sembilan kali menekan


### PR DESCRIPTION
## What

A green check on rows that are finished — **Lunas** on Meja Pembayaran, **Selesai** on Meja Daftar Ulang — opens a dialog listing every change to that pendaftaran: what changed, from what to what, by whom, and when.

- **`0137_riwayat_pendaftaran.sql`** — view `v_riwayat_pendaftaran`. It computes the diff in the database, so each row carries only the columns that actually changed instead of two blocks of JSON to compare by eye. No new column, no new table, no new right: the guard reuses `pengaturan`, `pembayaran`, `daftar_ulang`, `pendaftaran`.
- **`tests/sql/89`** — four seated tests: the desk sees the history, it names the change and the actor, all three tables appear, and revoking every tick closes the view.
- **Screen** — the existing green badge *is* the button, the same idiom as Input Nilai Pos. Pembayaran's LUNAS badge now reads `✓ LUNAS`; Daftar Ulang gets a plain check in front of the nomor dada, since it has no status badge to reuse.

## Why

`catat_riwayat()` has recorded `pendaftaran`, `regu`, and `pembayaran` since `0002` — every INSERT, UPDATE, and DELETE, with the actor and the timestamp. Only nilai pos had a way to read it back. The data was already there; this is the reading half.

Rows that are not yet lunas or not yet numbered get no check. A green check on those would state something that has not happened.

## Notes

Measured in a browser across all three width ranges (CLAUDE.md §15.9), not read:

- The check could **not** go in the action column. At its narrowest the content needs 197px inside a 193px cell — that column was already full to the last pixel. Reusing the existing badge costs one glyph instead of a seventh element.
- That one glyph still needed 1% moved from Sekolah to Metode. Without it the row overflows on windows **946–961px wide and nowhere else** — a 16px band that reading the rules would never have found.
- The dialog puts "oleh · kapan" on its own line, unlike the pos one. Its values are names and statuses, not four-digit numbers: the shortest row measured 482px inside a 423px card, so every row scrolled sideways and what fell off the right edge was the time.

Local: `tests/run.sh` green through test 89, 218 JS tests green, `periksa_impor.py` clean. `payment_rows_render` now executes the real `centangRiwayat()` rather than a stub, and was proven to still fail when a check is drawn on a BATAL row.

Migration `0137` still needs to be applied with `apply-migration.yml` after merge.
