### PR TITLE
fix: derive Yel Yel winner from Pos 5

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0139`
+sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0140`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0139`.
+`0119`-`0140`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-139 migrasi, `0001` sampai `0139`, dijalankan berurutan tanpa lubang penomoran.
+140 migrasi, `0001` sampai `0140`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0140_yel_yel_dari_pos_5.sql
+++ b/supabase/migrations/0140_yel_yel_dari_pos_5.sql
@@ -1,0 +1,71 @@
+-- Juara Yel Yel bukan pilihan panitia: pemenangnya adalah regu dengan poin
+-- Pos 5 tertinggi. Poin keseluruhan lalu nomor dada memecah nilai yang sama.
+
+delete from kejuaraan_manual where kode = 'yel_yel';
+
+alter table kejuaraan_manual drop constraint kejuaraan_manual_kode_check;
+alter table kejuaraan_manual add constraint kejuaraan_manual_kode_check
+  check (kode in ('kostum', 'terfavorit', 'terjauh'));
+
+create or replace function simpan_kejuaraan_manual(p_kode text, p_regu uuid)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if not boleh('pengaturan') then
+    raise exception 'akun ini tidak berhak mengubah Kejuaraan';
+  end if;
+  if p_kode not in ('kostum', 'terfavorit', 'terjauh') then
+    raise exception 'penghargaan manual tidak dikenal';
+  end if;
+  if not exists (select 1 from regu where id = p_regu
+                 and nomor_dada is not null and not is_cancelled) then
+    raise exception 'regu tidak ditemukan atau belum mendapat nomor dada';
+  end if;
+
+  insert into kejuaraan_manual (edisi, kode, regu_id, diubah_oleh)
+  values (edisi_aktif(), p_kode, p_regu, auth.uid())
+  on conflict (edisi, kode) do update
+    set regu_id = excluded.regu_id,
+        diubah_oleh = excluded.diubah_oleh,
+        diubah_pada = now();
+end;
+$$;
+
+drop view v_kejuaraan;
+alter function hasil_kejuaraan() rename to hasil_kejuaraan_dasar;
+revoke all on function hasil_kejuaraan_dasar() from public, authenticated;
+
+create function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric
+)
+language sql stable security definer
+set search_path = public
+as $$
+  select * from hasil_kejuaraan_dasar() d where d.kode <> 'yel_yel'
+  union all
+  select 62, 'yel_yel', 'Juara Yel Yel', 'skor',
+         y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+         y.golongan, y.poin_pos
+  from (values (true)) satu(ada)
+  left join lateral (
+    select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+           k.golongan, pp.poin_pos
+    from v_klasemen k
+    join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+    order by pp.poin_pos desc, k.total desc, k.nomor_dada
+    limit 1
+  ) y on true
+  where boleh('live_score')
+  order by urutan
+$$;
+
+revoke all on function hasil_kejuaraan() from public;
+grant execute on function hasil_kejuaraan() to authenticated;
+create view v_kejuaraan as select * from hasil_kejuaraan();
+grant select on v_kejuaraan to authenticated;
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -675,5 +675,7 @@ run supabase/migrations/0138_riwayat_pelaku_kosong.sql
 run tests/sql/89_riwayat_pendaftaran.sql
 run supabase/migrations/0139_kejuaraan.sql
 run tests/sql/90_kejuaraan.sql
+run supabase/migrations/0140_yel_yel_dari_pos_5.sql
+run tests/sql/91_yel_yel_dari_pos_5.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/91_yel_yel_dari_pos_5.sql
+++ b/tests/sql/91_yel_yel_dari_pos_5.sql
@@ -1,0 +1,24 @@
+do $blok$
+declare v_sumber text; v_manual int;
+begin
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  select sumber into v_sumber from hasil_kejuaraan() where kode = 'yel_yel';
+  reset role;
+  select count(*) into v_manual from kejuaraan_manual where kode = 'yel_yel';
+
+  assert v_sumber = 'skor', format('91.1 GAGAL: sumber Yel Yel = %s', v_sumber);
+  assert v_manual = 0, '91.2 GAGAL: Yel Yel masih tersimpan sebagai pilihan manual';
+
+  set local role authenticated;
+  begin
+    perform simpan_kejuaraan_manual(
+      'yel_yel', (select id from regu where nomor_dada is not null limit 1));
+    assert false, '91.3 GAGAL: Yel Yel masih bisa dipilih manual';
+  exception when others then
+    assert sqlerrm = 'penghargaan manual tidak dikenal',
+      format('91.3 GAGAL: penolakannya salah: %s', sqlerrm);
+  end;
+end;
+$blok$;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6068,7 +6068,7 @@ async function layarKejuaraan() {
   const opsi = [...new Map(regu.filter(r => r.nomor_dada != null)
     .map(r => [r.regu_id, r])).values()]
     .sort((a, b) => Number(a.nomor_dada) - Number(b.nomor_dada));
-  const manual = new Set(["kostum", "yel_yel", "terfavorit", "terjauh"]);
+  const manual = new Set(["kostum", "terfavorit", "terjauh"]);
   const nilai = (x) => {
     if (x.nama_regu) return `<strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
       <span class="description">${esc(x.nama_sekolah || "")}</span>`;


### PR DESCRIPTION
## What
- derive Juara Yel Yel from the highest Pos 5 score
- remove Yel Yel from manual championship selections
- add migration and regression coverage

## Why
Yel Yel is a scored Pos 5 result, so its winner must follow the scoring system instead of a manual panitia choice.