### PR TITLE
fix: exclude Intern from most participants

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0140`
+sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0141`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0140`.
+`0119`-`0141`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-140 migrasi, `0001` sampai `0140`, dijalankan berurutan tanpa lubang penomoran.
+141 migrasi, `0001` sampai `0141`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -198,7 +198,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/finish` | Kedatangan | catat jam datang + anggota hadir |
 | `#/pos` | Input Nilai Pos | lembar penilaian satu pos, satu baris per regu |
 | `#/live-score` | Live Score | pemegang hak `live_score` — cincin kemajuan per pos + podium; saklar fase hanya untuk pemegang `pengaturan` |
-| `#/kejuaraan` | Kejuaraan | hasil juara dari skor, Peserta Terbanyak dari nomor dada, dan tiga pilihan manual panitia |
+| `#/kejuaraan` | Kejuaraan | hasil juara dari skor, Peserta Terbanyak dari nomor dada Eksternal, dan tiga pilihan manual panitia |
 | `#/pengaturan-kloter` | Pengaturan Kloter | simulasi dan perbaikan jadwal keberangkatan; pemegang `pengaturan` |
 | `#/ganti-password` | Ganti Password | — |
 | `#/account` | Akun | buat/nonaktifkan akun dan atur matriks hak; pemegang `akun` |

--- a/supabase/migrations/0141_peserta_terbanyak_eksternal.sql
+++ b/supabase/migrations/0141_peserta_terbanyak_eksternal.sql
@@ -1,0 +1,54 @@
+-- Peserta Terbanyak adalah penghargaan sekolah peserta lomba Eksternal.
+-- Regu intern_pa dan intern_pi tetap mendapat nomor dada untuk alur lapangan,
+-- tetapi tidak ikut dalam hitungan penghargaan ini.
+
+drop view v_kejuaraan;
+
+create or replace function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric
+)
+language sql stable security definer
+set search_path = public
+as $$
+  select * from hasil_kejuaraan_dasar() d
+  where d.kode not in ('yel_yel', 'peserta_terbanyak')
+  union all
+  select 62, 'yel_yel', 'Juara Yel Yel', 'skor',
+         y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+         y.golongan, y.poin_pos
+  from (values (true)) satu(ada)
+  left join lateral (
+    select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+           k.golongan, pp.poin_pos
+    from v_klasemen k
+    join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+    order by pp.poin_pos desc, k.total desc, k.nomor_dada
+    limit 1
+  ) y on true
+  where boleh('live_score')
+  union all
+  select 70, 'peserta_terbanyak', 'Peserta Terbanyak', 'nomor_dada',
+         null::uuid, null::integer, null::text, p.nama_sekolah,
+         null::text, p.jumlah::numeric
+  from (values (true)) satu(ada)
+  left join lateral (
+    select s.name nama_sekolah, count(*) jumlah
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    join sekolah s on s.id = d.sekolah_id
+    where r.nomor_dada is not null and not r.is_cancelled
+      and d.status = 'lunas' and r.golongan not like 'intern_%'
+    group by s.name
+    order by jumlah desc, s.name
+    limit 1
+  ) p on true
+  where boleh('live_score')
+  order by urutan
+$$;
+
+create view v_kejuaraan as select * from hasil_kejuaraan();
+grant select on v_kejuaraan to authenticated;
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -677,5 +677,7 @@ run supabase/migrations/0139_kejuaraan.sql
 run tests/sql/90_kejuaraan.sql
 run supabase/migrations/0140_yel_yel_dari_pos_5.sql
 run tests/sql/91_yel_yel_dari_pos_5.sql
+run supabase/migrations/0141_peserta_terbanyak_eksternal.sql
+run tests/sql/92_peserta_terbanyak_eksternal.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/92_peserta_terbanyak_eksternal.sql
+++ b/tests/sql/92_peserta_terbanyak_eksternal.sql
@@ -1,0 +1,44 @@
+do $blok$
+declare
+  v_sekolah_eksternal uuid := gen_random_uuid();
+  v_sekolah_intern uuid := gen_random_uuid();
+  v_daftar_eksternal uuid := gen_random_uuid();
+  v_daftar_intern uuid := gen_random_uuid();
+  v_pemenang text;
+begin
+  insert into sekolah (id, name, address) values
+    (v_sekolah_eksternal, 'SEKOLAH EKSTERNAL UJI 92', 'Alamat uji'),
+    (v_sekolah_intern, 'SEKOLAH INTERN UJI 92', 'Alamat uji');
+  insert into pendaftaran
+    (id, sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+     jumlah_regu, kontak_wa, status, kunci_kirim)
+  values
+    (v_daftar_eksternal, v_sekolah_eksternal, 'UJI92-E', false, 0,
+     1, '081111111111', 'lunas', gen_random_uuid()),
+    (v_daftar_intern, v_sekolah_intern, 'UJI92-I', false, 0,
+     2, '082222222222', 'lunas', gen_random_uuid());
+  insert into regu
+    (pendaftaran_id, nama_regu, nama_ketua, golongan,
+     nomor_dada, kloter_nomor, urutan_kloter)
+  values
+    (v_daftar_eksternal, 'EKSTERNAL UJI', 'KETUA EKSTERNAL',
+     'penegak_pa', 499, 75, 1),
+    (v_daftar_intern, 'INTERN PA UJI', 'KETUA INTERN PA',
+     'intern_pa', 1200, 75, 2),
+    (v_daftar_intern, 'INTERN PI UJI', 'KETUA INTERN PI',
+     'intern_pi', 1201, 75, 3);
+
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  select nama_sekolah into v_pemenang from hasil_kejuaraan()
+  where kode = 'peserta_terbanyak';
+  reset role;
+
+  assert v_pemenang = 'SEKOLAH EKSTERNAL UJI 92',
+    format('92 GAGAL: dua regu Intern ikut dihitung; pemenang = %s', v_pemenang);
+
+  delete from regu where pendaftaran_id in (v_daftar_eksternal, v_daftar_intern);
+  delete from pendaftaran where id in (v_daftar_eksternal, v_daftar_intern);
+  delete from sekolah where id in (v_sekolah_eksternal, v_sekolah_intern);
+end;
+$blok$;


### PR DESCRIPTION
## What
- exclude Intern PA and Intern PI from Peserta Terbanyak
- count only numbered External regu per school
- add a regression fixture covering an Intern-majority school

## Why
Peserta Terbanyak is an External participant award; Intern regu use nomor dada operationally but do not belong in this category.