### PR TITLE
feat: arrange championship desktop layout

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -732,6 +732,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .table-kejuaraan .select-small { width: 100%; }
 .kejuaraan-bagian { display: grid; gap: 1rem; }
 .kejuaraan-bagian .card { margin-bottom: 0; }
+@media (min-width: 900px) {
+  .kejuaraan-bagian { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .kejuaraan-umum {
+    grid-column: 1 / -1; grid-row: 1;
+    width: calc(50% - .5rem); justify-self: center;
+  }
+  .kejuaraan-penegak-pa { grid-column: 1; grid-row: 2; }
+  .kejuaraan-penegak-pi { grid-column: 1; grid-row: 3; }
+  .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 2; }
+  .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 3; }
+  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 4; }
+}
 .kejuaraan-cari { position: relative; }
 .kejuaraan-cari .small-input { width: 100%; }
 .kejuaraan-cari .suggestions {

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
 
 test("Kejuaraan dibagi menjadi section yang dibaca panitia", () => {
   for (const judul of ["Juara Umum", "Penegak PA", "Penegak PI",
@@ -14,4 +15,11 @@ test("pilihan manual mencari nomor dada, regu, dan sekolah", () => {
   assert.match(app, /placeholder="Nomor dada \/ nama regu \/ asal sekolah…"/);
   assert.match(app, /r\.nomor_dada.*dada3\(r\.nomor_dada\).*r\.nama_regu.*r\.nama_sekolah/s);
   assert.match(app, /slice\(0, 8\)/);
+});
+
+test("layout desktop menempatkan juara umum di tengah dan golongan berdampingan", () => {
+  assert.match(css, /@media \(min-width: 900px\)[\s\S]*\.kejuaraan-umum[\s\S]*justify-self: center/);
+  assert.match(css, /\.kejuaraan-penegak-pa \{ grid-column: 1; grid-row: 2; \}/);
+  assert.match(css, /\.kejuaraan-penggalang-pa \{ grid-column: 2; grid-row: 2; \}/);
+  assert.match(css, /\.kejuaraan-khusus \{ grid-column: 1 \/ -1; grid-row: 4; \}/);
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6089,23 +6089,24 @@ async function layarKejuaraan() {
 
   const bagian = [
     ["Juara Umum", x => x.kode.startsWith("juara_umum"),
-      x => x.nama_penghargaan.replace(/^Juara Umum /, "")],
+      x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum"],
     ["Penegak PA", x => x.kode.startsWith("penegak_pa_"),
-      x => x.nama_penghargaan.replace(/^Penegak PA /, "")],
+      x => x.nama_penghargaan.replace(/^Penegak PA /, ""), "kejuaraan-penegak-pa"],
     ["Penegak PI", x => x.kode.startsWith("penegak_pi_"),
-      x => x.nama_penghargaan.replace(/^Penegak PI /, "")],
+      x => x.nama_penghargaan.replace(/^Penegak PI /, ""), "kejuaraan-penegak-pi"],
     ["Penggalang PA", x => x.kode.startsWith("penggalang_pa_"),
-      x => x.nama_penghargaan.replace(/^Penggalang PA /, "")],
+      x => x.nama_penghargaan.replace(/^Penggalang PA /, ""), "kejuaraan-penggalang-pa"],
     ["Penggalang PI", x => x.kode.startsWith("penggalang_pi_"),
-      x => x.nama_penghargaan.replace(/^Penggalang PI /, "")],
+      x => x.nama_penghargaan.replace(/^Penggalang PI /, ""), "kejuaraan-penggalang-pi"],
     ["Penghargaan Khusus", x => !x.kode.startsWith("juara_umum")
-      && !/^(penegak|penggalang)_(pa|pi)_/.test(x.kode), x => x.nama_penghargaan],
+      && !/^(penegak|penggalang)_(pa|pi)_/.test(x.kode), x => x.nama_penghargaan,
+      "kejuaraan-khusus"],
   ];
 
   LAYAR.replaceChildren(h(`
     <div class="kejuaraan-bagian">
-      ${bagian.map(([judul, masuk, label]) => `
-        <section class="card"><h2>${esc(judul)}</h2>
+      ${bagian.map(([judul, masuk, label, kelas]) => `
+        <section class="card ${kelas}"><h2>${esc(judul)}</h2>
           <table class="table data-table table-kejuaraan"><tbody>
             ${hasil.filter(masuk).map(x => baris(x, label(x))).join("")}
           </tbody></table>

--- a/web/style.css
+++ b/web/style.css
@@ -732,6 +732,18 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .table-kejuaraan .select-small { width: 100%; }
 .kejuaraan-bagian { display: grid; gap: 1rem; }
 .kejuaraan-bagian .card { margin-bottom: 0; }
+@media (min-width: 900px) {
+  .kejuaraan-bagian { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .kejuaraan-umum {
+    grid-column: 1 / -1; grid-row: 1;
+    width: calc(50% - .5rem); justify-self: center;
+  }
+  .kejuaraan-penegak-pa { grid-column: 1; grid-row: 2; }
+  .kejuaraan-penegak-pi { grid-column: 1; grid-row: 3; }
+  .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 2; }
+  .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 3; }
+  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 4; }
+}
 .kejuaraan-cari { position: relative; }
 .kejuaraan-cari .small-input { width: 100%; }
 .kejuaraan-cari .suggestions {


### PR DESCRIPTION
## What
- center the Juara Umum card on desktop
- place Penegak and Penggalang sections side by side
- keep the existing single-column mobile layout
- add a layout regression test

## Why
The championship hierarchy is easier to scan on wide screens without changing the compact mobile flow.