### PR TITLE
fix: exclude Intern from championship awards

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0141`
+sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0142`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0141`.
+`0119`-`0142`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-141 migrasi, `0001` sampai `0141`, dijalankan berurutan tanpa lubang penomoran.
+142 migrasi, `0001` sampai `0142`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/style.css
+++ b/live/style.css
@@ -745,6 +745,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 4; }
 }
 .kejuaraan-cari { position: relative; }
+.kejuaraan-isian { display: flex; align-items: center; gap: .45rem; }
+.kejuaraan-isian .kejuaraan-cari { flex: 1 1 auto; min-width: 0; }
+.kejuaraan-hapus { flex: 0 0 auto; }
 .kejuaraan-cari .small-input { width: 100%; }
 .kejuaraan-cari .suggestions {
   position: absolute; z-index: 10; left: 0; right: 0;

--- a/supabase/migrations/0142_kejuaraan_tanpa_intern.sql
+++ b/supabase/migrations/0142_kejuaraan_tanpa_intern.sql
@@ -1,0 +1,147 @@
+-- Gelar Kejuaraan hanya untuk peserta Eksternal. Pilihan manual dapat
+-- dikosongkan lewat RPC yang sama dengan memilih regu, menggunakan NULL.
+
+delete from kejuaraan_manual m
+using regu r
+where r.id = m.regu_id and r.golongan like 'intern_%';
+
+create or replace function simpan_kejuaraan_manual(p_kode text, p_regu uuid)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if not boleh('pengaturan') then
+    raise exception 'akun ini tidak berhak mengubah Kejuaraan';
+  end if;
+  if p_kode not in ('kostum', 'terfavorit', 'terjauh') then
+    raise exception 'penghargaan manual tidak dikenal';
+  end if;
+
+  if p_regu is null then
+    delete from kejuaraan_manual
+    where edisi = edisi_aktif() and kode = p_kode;
+    return;
+  end if;
+
+  if not exists (
+    select 1 from regu
+    where id = p_regu and nomor_dada is not null and not is_cancelled
+      and golongan not like 'intern_%'
+  ) then
+    raise exception 'regu tidak ditemukan, belum mendapat nomor dada, atau termasuk Intern';
+  end if;
+
+  insert into kejuaraan_manual (edisi, kode, regu_id, diubah_oleh)
+  values (edisi_aktif(), p_kode, p_regu, auth.uid())
+  on conflict (edisi, kode) do update
+    set regu_id = excluded.regu_id,
+        diubah_oleh = excluded.diubah_oleh,
+        diubah_pada = now();
+end;
+$$;
+
+drop view v_kejuaraan;
+
+create or replace function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric
+)
+language sql stable security definer
+set search_path = public
+as $$
+with
+peringkat_eksternal as (
+  select k.*,
+         row_number() over (
+           partition by k.golongan
+           order by k.total desc,
+                    abs(coalesce(k.selisih_menit, 100000)) asc,
+                    k.nomor_dada asc) as nomor_juara
+  from v_klasemen k
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+),
+calon_umum as (
+  select nama_sekolah,
+         count(*) filter (where nomor_juara <= 6) as jumlah_juara,
+         sum(7 - nomor_juara) filter (where nomor_juara <= 6) as bobot_juara,
+         sum(total) as jumlah_skor,
+         case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end as tingkat
+  from peringkat_eksternal
+  group by nama_sekolah,
+           case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end
+),
+calon_semua as (
+  select nama_sekolah, sum(jumlah_juara) jumlah_juara,
+         sum(bobot_juara) bobot_juara, sum(jumlah_skor) jumlah_skor
+  from calon_umum group by nama_sekolah
+),
+kandidat_umum as (
+  select 'semua'::text tingkat, * from calon_semua
+  union all
+  select tingkat, nama_sekolah, jumlah_juara, bobot_juara, jumlah_skor
+  from calon_umum
+),
+juara_umum as (
+  select d.urutan, d.kode, d.nama nama_penghargaan,
+         'skor'::text sumber, null::uuid regu_id, null::integer nomor_dada,
+         null::text nama_regu, x.nama_sekolah, null::text golongan,
+         null::numeric total
+  from (values
+    (1, 'juara_umum', 'Juara Umum ' || (select name from edisi where is_active), 'semua'),
+    (2, 'juara_umum_penegak', 'Juara Umum Penegak', 'penegak'),
+    (3, 'juara_umum_penggalang', 'Juara Umum Penggalang', 'penggalang')
+  ) d(urutan, kode, nama, tingkat)
+  left join lateral (
+    select nama_sekolah from kandidat_umum k where k.tingkat = d.tingkat
+    order by jumlah_juara desc, bobot_juara desc, jumlah_skor desc, nama_sekolah
+    limit 1
+  ) x on true
+)
+select * from hasil_kejuaraan_dasar() d
+where d.kode not in
+  ('juara_umum', 'juara_umum_penegak', 'juara_umum_penggalang',
+   'yel_yel', 'peserta_terbanyak')
+union all
+select * from juara_umum
+union all
+select 62, 'yel_yel', 'Juara Yel Yel', 'skor',
+       y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+       y.golongan, y.poin_pos
+from (values (true)) satu(ada)
+left join lateral (
+  select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+         k.golongan, pp.poin_pos
+  from v_klasemen k
+  join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+  order by pp.poin_pos desc, k.total desc, k.nomor_dada
+  limit 1
+) y on true
+where boleh('live_score')
+union all
+select 70, 'peserta_terbanyak', 'Peserta Terbanyak', 'nomor_dada',
+       null::uuid, null::integer, null::text, p.nama_sekolah,
+       null::text, p.jumlah::numeric
+from (values (true)) satu(ada)
+left join lateral (
+  select s.name nama_sekolah, count(*) jumlah
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  join sekolah s on s.id = d.sekolah_id
+  where r.nomor_dada is not null and not r.is_cancelled
+    and d.status = 'lunas' and r.golongan not like 'intern_%'
+  group by s.name
+  order by jumlah desc, s.name
+  limit 1
+) p on true
+where boleh('live_score')
+order by urutan
+$$;
+
+create view v_kejuaraan as select * from hasil_kejuaraan();
+grant select on v_kejuaraan to authenticated;

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -17,6 +17,12 @@ test("pilihan manual mencari nomor dada, regu, dan sekolah", () => {
   assert.match(app, /slice\(0, 8\)/);
 });
 
+test("pilihan manual tidak menawarkan regu Intern dan dapat dihapus", () => {
+  assert.match(app, /!String\(r\.golongan\)\.startsWith\("intern_"\)/);
+  assert.match(app, />Hapus pilihan<\/button>/);
+  assert.match(app, /simpanKejuaraanManual\(pilih\.dataset\.kode, null\)/);
+});
+
 test("layout desktop menempatkan juara umum di tengah dan golongan berdampingan", () => {
   assert.match(css, /@media \(min-width: 900px\)[\s\S]*\.kejuaraan-umum[\s\S]*justify-self: center/);
   assert.match(css, /\.kejuaraan-penegak-pa \{ grid-column: 1; grid-row: 2; \}/);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -679,5 +679,7 @@ run supabase/migrations/0140_yel_yel_dari_pos_5.sql
 run tests/sql/91_yel_yel_dari_pos_5.sql
 run supabase/migrations/0141_peserta_terbanyak_eksternal.sql
 run tests/sql/92_peserta_terbanyak_eksternal.sql
+run supabase/migrations/0142_kejuaraan_tanpa_intern.sql
+run tests/sql/93_kejuaraan_tanpa_intern.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/93_kejuaraan_tanpa_intern.sql
+++ b/tests/sql/93_kejuaraan_tanpa_intern.sql
@@ -1,0 +1,61 @@
+do $blok$
+declare
+  v_sekolah uuid := gen_random_uuid();
+  v_daftar uuid := gen_random_uuid();
+  v_eksternal uuid := gen_random_uuid();
+  v_intern uuid := gen_random_uuid();
+  v_jumlah integer;
+  v_definisi text;
+begin
+  insert into sekolah (id, name, address)
+  values (v_sekolah, 'SEKOLAH UJI 93', 'Alamat uji');
+  insert into pendaftaran
+    (id, sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+     jumlah_regu, kontak_wa, status, kunci_kirim)
+  values
+    (v_daftar, v_sekolah, 'UJI93', false, 0, 2,
+     '083333333333', 'lunas', gen_random_uuid());
+  insert into regu
+    (id, pendaftaran_id, nama_regu, nama_ketua, golongan,
+     nomor_dada, kloter_nomor, urutan_kloter)
+  values
+    (v_eksternal, v_daftar, 'EKSTERNAL UJI 93', 'KETUA EKSTERNAL',
+     'penegak_pa', 498, 75, 1),
+    (v_intern, v_daftar, 'INTERN UJI 93', 'KETUA INTERN',
+     'intern_pa', 1202, 75, 2);
+
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  begin
+    perform simpan_kejuaraan_manual('kostum', v_intern);
+    assert false, '93.1 GAGAL: regu Intern dapat dipilih';
+  exception when others then
+    assert sqlerrm like '%termasuk Intern',
+      format('93.1 GAGAL: penolakannya salah: %s', sqlerrm);
+  end;
+
+  perform simpan_kejuaraan_manual('kostum', v_eksternal);
+  reset role;
+  select count(*) into v_jumlah from kejuaraan_manual
+  where edisi = edisi_aktif() and kode = 'kostum' and regu_id = v_eksternal;
+  assert v_jumlah = 1, '93.2 GAGAL: regu Eksternal tidak tersimpan';
+
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  perform simpan_kejuaraan_manual('kostum', null);
+  reset role;
+  select count(*) into v_jumlah from kejuaraan_manual
+  where edisi = edisi_aktif() and kode = 'kostum';
+  assert v_jumlah = 0, '93.3 GAGAL: pilihan tidak terhapus';
+
+  select pg_get_functiondef('hasil_kejuaraan()'::regprocedure) into v_definisi;
+  assert (length(v_definisi) - length(replace(v_definisi,
+    'k.golongan in', ''))) / length('k.golongan in') = 2,
+    '93.4 GAGAL: hasil otomatis tidak dibatasi ke empat golongan Eksternal';
+
+  delete from regu where id in (v_eksternal, v_intern);
+  delete from pendaftaran where id = v_daftar;
+  delete from sekolah where id = v_sekolah;
+end;
+$blok$;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6059,13 +6059,18 @@ async function layarKejuaraan() {
   }
   LAYAR.replaceChildren(h(pemuat()));
   const layarIni = location.hash;
+  const bisaUbah = bolehLihat("pengaturan");
   let hasil, regu;
-  try { [hasil, regu] = await Promise.all([hasilKejuaraan(), rekapPenuh()]); }
+  try {
+    [hasil, regu] = await Promise.all([
+      hasilKejuaraan(), bisaUbah ? rekapPenuh() : Promise.resolve([]),
+    ]);
+  }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarKejuaraan)); return; }
   if (location.hash !== layarIni) return;
 
-  const bisaUbah = bolehLihat("pengaturan");
-  const opsi = [...new Map(regu.filter(r => r.nomor_dada != null)
+  const opsi = [...new Map(regu.filter(r => r.nomor_dada != null
+      && !String(r.golongan).startsWith("intern_"))
     .map(r => [r.regu_id, r])).values()]
     .sort((a, b) => Number(a.nomor_dada) - Number(b.nomor_dada));
   const manual = new Set(["kostum", "terfavorit", "terjauh"]);
@@ -6079,12 +6084,16 @@ async function layarKejuaraan() {
   };
   const baris = (x, label = x.nama_penghargaan) => manual.has(x.kode) && bisaUbah ? `
     <tr><th>${esc(label)}</th><td>
-      <div class="kejuaraan-cari">
-        <input type="search" class="small-input kejuaraan-pilih" data-kode="${esc(x.kode)}"
-          autocomplete="off" aria-label="Pilih ${esc(x.nama_penghargaan)}"
-          placeholder="Nomor dada / nama regu / asal sekolah…"
-          value="${esc(x.regu_id ? labelRegu(x) : "")}">
-        <div class="suggestions kejuaraan-saran" hidden></div>
+      <div class="kejuaraan-isian">
+        <div class="kejuaraan-cari">
+          <input type="search" class="small-input kejuaraan-pilih" data-kode="${esc(x.kode)}"
+            autocomplete="off" aria-label="Pilih ${esc(x.nama_penghargaan)}"
+            placeholder="Nomor dada / nama regu / asal sekolah…"
+            value="${esc(x.regu_id ? labelRegu(x) : "")}">
+          <div class="suggestions kejuaraan-saran" hidden></div>
+        </div>
+        <button type="button" class="button button-secondary button-small kejuaraan-hapus"
+          ${x.regu_id ? "" : "hidden"}>Hapus pilihan</button>
       </div></td></tr>` : `<tr><th>${esc(label)}</th><td>${nilai(x)}</td></tr>`;
 
   const bagian = [
@@ -6115,6 +6124,7 @@ async function layarKejuaraan() {
 
   LAYAR.querySelectorAll(".kejuaraan-pilih").forEach(pilih => {
     const saran = pilih.nextElementSibling;
+    const hapus = pilih.closest(".kejuaraan-isian").querySelector(".kejuaraan-hapus");
     const cocok = (r, q) => `${r.nomor_dada} ${dada3(r.nomor_dada)} ${r.nama_regu} ${r.nama_sekolah}`
       .toLocaleLowerCase("id").includes(q.toLocaleLowerCase("id"));
     const gambarSaran = () => {
@@ -6136,14 +6146,25 @@ async function layarKejuaraan() {
       if (!tombol) return;
       const dipilih = opsi.find(r => r.regu_id === tombol.dataset.reguId);
       if (!dipilih) return;
-      pilih.disabled = true;
+      pilih.disabled = hapus.disabled = true;
       try {
         await simpanKejuaraanManual(pilih.dataset.kode, dipilih.regu_id);
         pilih.value = labelRegu(dipilih);
+        hapus.hidden = false;
         saran.hidden = true;
         notif("Kejuaraan tersimpan.");
       } catch (e) { notif(e.message, true); }
-      finally { pilih.disabled = false; }
+      finally { pilih.disabled = hapus.disabled = false; }
+    });
+    hapus.addEventListener("click", async () => {
+      pilih.disabled = hapus.disabled = true;
+      try {
+        await simpanKejuaraanManual(pilih.dataset.kode, null);
+        pilih.value = "";
+        hapus.hidden = true;
+        notif("Pilihan juara dihapus.");
+      } catch (e) { notif(e.message, true); }
+      finally { pilih.disabled = hapus.disabled = false; }
     });
   });
 }

--- a/web/style.css
+++ b/web/style.css
@@ -745,6 +745,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 4; }
 }
 .kejuaraan-cari { position: relative; }
+.kejuaraan-isian { display: flex; align-items: center; gap: .45rem; }
+.kejuaraan-isian .kejuaraan-cari { flex: 1 1 auto; min-width: 0; }
+.kejuaraan-hapus { flex: 0 0 auto; }
 .kejuaraan-cari .small-input { width: 100%; }
 .kejuaraan-cari .suggestions {
   position: absolute; z-index: 10; left: 0; right: 0;


### PR DESCRIPTION
## What
- exclude Intern regu from every automatic championship result
- reject Intern regu in manual award selections at the database boundary
- remove any existing Intern manual selections
- add a clear-selection action for manual awards
- avoid loading full participant data for read-only viewers

## Why
Championship awards are only available to External participants, and panitia need a direct way to undo an accidental manual selection.