### PR TITLE
feat: group championship titles by level

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -738,11 +738,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     grid-column: 1 / -1; grid-row: 1;
     width: calc(50% - .5rem); justify-self: center;
   }
-  .kejuaraan-penegak-pa { grid-column: 1; grid-row: 2; }
-  .kejuaraan-penegak-pi { grid-column: 1; grid-row: 3; }
-  .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 2; }
-  .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 3; }
-  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 4; }
+  .kejuaraan-umum-penegak { grid-column: 1; grid-row: 2; }
+  .kejuaraan-umum-penggalang { grid-column: 2; grid-row: 2; }
+  .kejuaraan-penegak-pa { grid-column: 1; grid-row: 3; }
+  .kejuaraan-penegak-pi { grid-column: 1; grid-row: 4; }
+  .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 3; }
+  .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 4; }
+  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 5; }
 }
 .kejuaraan-cari { position: relative; }
 .kejuaraan-isian { display: flex; align-items: center; gap: .45rem; }

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -6,9 +6,10 @@ const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8")
 const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
 
 test("Kejuaraan dibagi menjadi section yang dibaca panitia", () => {
-  for (const judul of ["Juara Umum", "Penegak PA", "Penegak PI",
-    "Penggalang PA", "Penggalang PI", "Penghargaan Khusus"])
+  for (const judul of ["Juara Umum", "Juara Umum Penegak", "Penegak PA", "Penegak PI",
+    "Juara Umum Penggalang", "Penggalang PA", "Penggalang PI", "Penghargaan Khusus"])
     assert.ok(app.includes(`["${judul}"`));
+  assert.match(app, /\["Juara Umum", x => x\.kode === "juara_umum"/);
 });
 
 test("pilihan manual mencari nomor dada, regu, dan sekolah", () => {
@@ -25,7 +26,9 @@ test("pilihan manual tidak menawarkan regu Intern dan dapat dihapus", () => {
 
 test("layout desktop menempatkan juara umum di tengah dan golongan berdampingan", () => {
   assert.match(css, /@media \(min-width: 900px\)[\s\S]*\.kejuaraan-umum[\s\S]*justify-self: center/);
-  assert.match(css, /\.kejuaraan-penegak-pa \{ grid-column: 1; grid-row: 2; \}/);
-  assert.match(css, /\.kejuaraan-penggalang-pa \{ grid-column: 2; grid-row: 2; \}/);
-  assert.match(css, /\.kejuaraan-khusus \{ grid-column: 1 \/ -1; grid-row: 4; \}/);
+  assert.match(css, /\.kejuaraan-umum-penegak \{ grid-column: 1; grid-row: 2; \}/);
+  assert.match(css, /\.kejuaraan-umum-penggalang \{ grid-column: 2; grid-row: 2; \}/);
+  assert.match(css, /\.kejuaraan-penegak-pa \{ grid-column: 1; grid-row: 3; \}/);
+  assert.match(css, /\.kejuaraan-penggalang-pa \{ grid-column: 2; grid-row: 3; \}/);
+  assert.match(css, /\.kejuaraan-khusus \{ grid-column: 1 \/ -1; grid-row: 5; \}/);
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6097,12 +6097,16 @@ async function layarKejuaraan() {
       </div></td></tr>` : `<tr><th>${esc(label)}</th><td>${nilai(x)}</td></tr>`;
 
   const bagian = [
-    ["Juara Umum", x => x.kode.startsWith("juara_umum"),
+    ["Juara Umum", x => x.kode === "juara_umum",
       x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum"],
+    ["Juara Umum Penegak", x => x.kode === "juara_umum_penegak",
+      () => "PENEGAK", "kejuaraan-umum-penegak"],
     ["Penegak PA", x => x.kode.startsWith("penegak_pa_"),
       x => x.nama_penghargaan.replace(/^Penegak PA /, ""), "kejuaraan-penegak-pa"],
     ["Penegak PI", x => x.kode.startsWith("penegak_pi_"),
       x => x.nama_penghargaan.replace(/^Penegak PI /, ""), "kejuaraan-penegak-pi"],
+    ["Juara Umum Penggalang", x => x.kode === "juara_umum_penggalang",
+      () => "PENGGALANG", "kejuaraan-umum-penggalang"],
     ["Penggalang PA", x => x.kode.startsWith("penggalang_pa_"),
       x => x.nama_penghargaan.replace(/^Penggalang PA /, ""), "kejuaraan-penggalang-pa"],
     ["Penggalang PI", x => x.kode.startsWith("penggalang_pi_"),

--- a/web/style.css
+++ b/web/style.css
@@ -738,11 +738,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
     grid-column: 1 / -1; grid-row: 1;
     width: calc(50% - .5rem); justify-self: center;
   }
-  .kejuaraan-penegak-pa { grid-column: 1; grid-row: 2; }
-  .kejuaraan-penegak-pi { grid-column: 1; grid-row: 3; }
-  .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 2; }
-  .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 3; }
-  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 4; }
+  .kejuaraan-umum-penegak { grid-column: 1; grid-row: 2; }
+  .kejuaraan-umum-penggalang { grid-column: 2; grid-row: 2; }
+  .kejuaraan-penegak-pa { grid-column: 1; grid-row: 3; }
+  .kejuaraan-penegak-pi { grid-column: 1; grid-row: 4; }
+  .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 3; }
+  .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 4; }
+  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 5; }
 }
 .kejuaraan-cari { position: relative; }
 .kejuaraan-isian { display: flex; align-items: center; gap: .45rem; }


### PR DESCRIPTION
## What
- keep only the HRCD overall champion in the centered top section
- place the Penegak overall champion above Penegak PA and PI
- place the Penggalang overall champion above Penggalang PA and PI
- preserve the grouped single-column order on mobile

## Why
The championship hierarchy should show each level champion with the awards it summarizes.