### PR TITLE
fix: keep unentered live scores unchecked

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1181,7 +1181,10 @@ export function ringkasLomba(lomba, golongan, pos, peta) {
     if (!w) continue;
     berlaku++;
     const v = (peta || {})[`${pos}.${w.kode}`];
-    if (v === null || v === undefined) continue;
+    /* `komponen_terisi` membawa semua kunci sebagai boolean. `false` berarti
+       nilainya BELUM masuk, bukan nilai sah yang kebetulan falsy. Peta poin
+       memakai angka, jadi 0 tetap harus dihitung sebagai sudah terisi. */
+    if (v === null || v === undefined || v === false) continue;
     terisi++;
     jumlah += Number(v) || 0;
   }

--- a/tests/live_score_per_lomba.test.mjs
+++ b/tests/live_score_per_lomba.test.mjs
@@ -112,6 +112,20 @@ test("nol komponen terisi berbeda dari nol poin", () => {
 });
 
 
+test("boolean false pada komponen_terisi tetap terbaca kosong", () => {
+  const [pbb] = lombaPos(POS4);
+  const r = ringkasLomba(pbb, "penegak_pa", 4, {
+    "4.pbb_sikap": false,
+    "4.pbb_gerakan": false,
+    "4.pbb_kekompakan": true,
+    "4.pbb_kerapihan": false,
+  });
+  assert.equal(r.berlaku, 4);
+  assert.equal(r.terisi, 1,
+    "hanya boolean true yang menandakan penilaian sudah masuk");
+});
+
+
 test("kedua papan memakai ringkasLomba yang sama", () => {
   assert.match(app, /ringkasLomba\(l, k\.golongan, p\.nomor, poinKomponen\)/);
   assert.match(live, /ringkasLomba\(l, b\.golongan, x\.pos\.nomor,/);

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1181,7 +1181,10 @@ export function ringkasLomba(lomba, golongan, pos, peta) {
     if (!w) continue;
     berlaku++;
     const v = (peta || {})[`${pos}.${w.kode}`];
-    if (v === null || v === undefined) continue;
+    /* `komponen_terisi` membawa semua kunci sebagai boolean. `false` berarti
+       nilainya BELUM masuk, bukan nilai sah yang kebetulan falsy. Peta poin
+       memakai angka, jadi 0 tetap harus dihitung sebagai sudah terisi. */
+    if (v === null || v === undefined || v === false) continue;
     terisi++;
     jumlah += Number(v) || 0;
   }


### PR DESCRIPTION
## What

- treat boolean false in komponen_terisi as an unentered score
- preserve numeric zero as a valid entered score
- add regression coverage for mixed true and false component states

## Why

The public progress view rendered every component with a green checkmark because false values were counted as present. Unentered components must remain blank until their score is actually saved.