### PR TITLE
feat: publish live scores every 15 minutes

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -21,10 +21,11 @@
 # nilai — bukan berisi nilai yang disembunyikan tampilan. Admin memindah fase
 # ke 'penuh' saat hasil diumumkan, dan jalan berikutnya klasemennya ikut.
 #
-# CRON SENGAJA DIMATIKAN (baris `schedule` dikomentari). Nyalakan pada minggu
-# lomba, matikan lagi sesudahnya — repo ini privat, dan menit Actions
-# terpakai walau tidak ada yang berubah. Tombol Run workflow tetap bisa
-# ditekan kapan pun, termasuk dari HP.
+# CRON 15 MENIT AKTIF HANYA UNTUK HARI-H. Tanggal cron memakai UTC, jadi
+# 28-29 Agustus mencakup 29 Agustus WIB dari sebelum acara sampai pagi
+# sesudahnya. Batas tanggal menahan biaya di paling banyak 192 run per tahun;
+# jangan lebarkan menjadi setiap hari. Tombol Run workflow tetap bisa ditekan
+# kapan pun, termasuk dari HP.
 #
 # Butuh repository secret (dua-duanya sudah dipakai workflow lain):
 #   SUPABASE_DB_URL       connection string Postgres (Session pooler, 5432)
@@ -64,18 +65,10 @@ on:
       # terbit, walau tidak satu berkas pun di live/ ikut berubah.
       - 'supabase/checks/live_json.sql'
       - '.github/workflows/publish-live.yml'
-  # schedule:
-  #   - cron: '*/5 * * * *'   # nyalakan pada minggu lomba
-  #
-  # SEBELUM MENYALAKANNYA, HITUNG DULU. Tiap lima menit = 288 run sehari, dan
-  # GitHub membulatkan tiap job ke atas ke menit penuh — jadi 288 menit sehari
-  # walaupun run-nya cuma 30 detik. Jatah repo privat 2.000 menit sebulan habis
-  # dalam SEMINGGU, dan yang ikut mati bukan cuma penerbitan ini melainkan
-  # seluruh Actions: tes PR, apply-migration, ganti password panitia.
-  #
-  # Kalau memang dibutuhkan pada hari-H, `*/15` sudah memberi papan yang
-  # terbarui empat kali sejam dengan sepertiga biayanya, dan matikan lagi
-  # begitu acaranya usai.
+  schedule:
+    # Cron memakai UTC. Rentang ini mencakup 28 Agustus 07:00 WIB sampai
+    # 30 Agustus 06:45 WIB, termasuk seluruh hari lomba 29 Agustus.
+    - cron: '*/15 * 28-29 8 *'
 
 # Dua jalan yang bertumpuk akan saling menimpa live.json di Cloudflare, dan
 # yang menang belum tentu yang terbaru. Satu jalan saja pada satu waktu.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -687,7 +687,10 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
-   run from their phones.
+   run from their phones. The event-only exception in `publish-live.yml` runs
+   every 15 minutes on 28-29 August UTC, covering the 29 August event in WIB.
+   Its date-bound schedule costs at most 192 runs a year; do not widen it to an
+   everyday schedule.
 
 ## 17. Selama acara berjalan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -685,7 +685,10 @@ Guidance for Claude Code when working in this repository.
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
-   run from their phones.
+   run from their phones. The event-only exception in `publish-live.yml` runs
+   every 15 minutes on 28-29 August UTC, covering the 29 August event in WIB.
+   Its date-bound schedule costs at most 192 runs a year; do not widen it to an
+   everyday schedule.
 
 ## 17. Selama acara berjalan
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -662,7 +662,7 @@ Service key hidup sebagai `wrangler secret` di Worker, tidak pernah di SPA.
 | Yang di-deploy | Cara | Pemicu |
 | --- | --- | --- |
 | Layar panitia (`web/`) | Cloudflare Workers, tersambung Git | otomatis tiap push ke `main` |
-| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | **otomatis** tiap push ke `main` yang menyentuh `live/**` atau `live_json.sql` (#235); cron 5 menit masih dikomentari, nyalakan pada minggu lomba supaya rekapnya ikut segar tanpa ada yang push |
+| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | **otomatis** tiap push ke `main` yang menyentuh `live/**` atau `live_json.sql` (#235); pada hari-H juga terbit tiap 15 menit lewat cron bertanggal 28-29 Agustus UTC |
 | Gateway Worker | GitHub Actions `deploy-gateway.yml` | manual |
 | Migrasi database | GitHub Actions `apply-migration.yml` | manual, satu berkas per jalan |
 
@@ -836,12 +836,12 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
   lain), padahal di layar selalu tiga digit. Migrasi `0020` baru membetulkan
   `berangkatkan_kloter`; sisanya menunggu karena tiap perbaikan menuntut
   seluruh badan fungsinya disalin ulang.
-- **Cron rekap live masih dimatikan.** `publish-live.yml` punya jadwal 5
-  menit yang sengaja dikomentari; nyalakan pada minggu lomba dan matikan lagi
-  sesudahnya. Sampai dinyalakan, halaman rekap hanya terbit saat ada push yang
-  menyentuh `live/` atau saat tombol Run workflow ditekan — dan pada hari-H
-  keduanya tidak terjadi, karena tidak ada yang mengubah kode hari itu.
-  Angkanya bergerak dari database, bukan dari repo.
+- **Cron rekap live hanya hidup pada hari-H.** `publish-live.yml` berjalan
+  tiap 15 menit pada 28-29 Agustus UTC, rentang yang mencakup seluruh 29
+  Agustus WIB. Batas tanggal itu sengaja menahan biaya di paling banyak 192
+  run per tahun; jangan ubah menjadi jadwal setiap hari. Di luar rentang itu,
+  halaman rekap terbit saat ada push yang menyentuh `live/` atau saat tombol
+  Run workflow ditekan.
 - **Upload massal nilai belum ada.** `rancangan-b.md` bagian 6 menjelaskan
   jalur tempel-dari-Excel lengkap dengan layar preview. Yang sudah dibangun
   baru input tabelnya (`#/pos`) — yang sebenarnya sudah menutup sebagian besar

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -299,11 +299,13 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
    `live.json` tiap 60 detik dan menampilkan cap "Diperbarui 10:35". Ratusan
    HP penonton hanya menyentuh hosting statis — bandwidth gratis tak terbatas,
    **nol request ke Supabase**.
-2. Regenerasi: workflow GitHub Actions (`publish-live.yml`) — cron 5 menit
-   (dinyalakan hanya minggu lomba) + tombol manual. Tiga langkah yang bisa
+2. Regenerasi: workflow GitHub Actions (`publish-live.yml`) — cron 15 menit
+   bertanggal 28-29 Agustus UTC (mencakup hari-H dalam WIB) + tombol manual.
+   Tiga langkah yang bisa
    dibaca pelajar: baca view publik memakai **service role key dari GitHub
    Secrets** (bukan anon — anon tidak bisa baca apa pun) → tulis `live.json` →
-   deploy ke Pages. ±144 run di hari-H ≪ kuota gratis 2.000 menit/bulan.
+   deploy ke Pages. Maksimal 192 run per tahun ≪ kuota gratis 2.000
+   menit/bulan.
 3. **Bertahap sebagai data, bukan kode**: `status_acara.fase_live` menentukan
    isi view publik — `pra` (jumlah pendaftar per golongan), `progres` (per
    regu: sudah lewat pos mana, **tanpa angka**), `penuh` (klasemen 4 golongan

--- a/tests/live_publish_schedule.test.mjs
+++ b/tests/live_publish_schedule.test.mjs
@@ -1,0 +1,18 @@
+// Penerbitan berkala hanya hidup di sekitar hari-H. Jadwal tanpa batas tanggal
+// menghabiskan 2.880 menit Actions per bulan pada repo privat, padahal seluruh
+// kebutuhan edisi 37 selesai dalam dua tanggal UTC.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+const workflow = await readFile(
+  new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
+
+
+test("rekap terbit tiap 15 menit hanya pada tanggal UTC hari-H", () => {
+  assert.match(workflow, /schedule:\s*[\s\S]*?- cron: '\*\/15 \* 28-29 8 \*'/);
+  assert.doesNotMatch(workflow, /cron: '\*\/15 \* \* \* \*'/,
+    "cron tidak boleh berjalan tiap hari sepanjang tahun");
+});


### PR DESCRIPTION
## What

- publish the participant Live Score every 15 minutes around event day
- limit the schedule to 28-29 August UTC so it covers 29 August WIB without running all year
- document the active schedule and add regression coverage for its date boundary

## Why

Scores entered by panitia should reach participants automatically without manually dispatching the workflow after every batch.

## Notes

The schedule permits at most 192 runs per year instead of 2,880 runs per month from an unrestricted 15-minute cron.