### PR TITLE
fix: limit scheduled live publishing to event hours

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -21,11 +21,11 @@
 # nilai — bukan berisi nilai yang disembunyikan tampilan. Admin memindah fase
 # ke 'penuh' saat hasil diumumkan, dan jalan berikutnya klasemennya ikut.
 #
-# CRON 15 MENIT AKTIF HANYA UNTUK HARI-H. Tanggal cron memakai UTC, jadi
-# 28-29 Agustus mencakup 29 Agustus WIB dari sebelum acara sampai pagi
-# sesudahnya. Batas tanggal menahan biaya di paling banyak 192 run per tahun;
-# jangan lebarkan menjadi setiap hari. Tombol Run workflow tetap bisa ditekan
-# kapan pun, termasuk dari HP.
+# CRON 15 MENIT AKTIF HANYA 29 AGUSTUS 2026, 08:00-23:59 WIB. Cron memakai
+# UTC dan tidak punya kolom tahun, jadi jadwal memilih 01:00-16:45 UTC lalu
+# langkah pertama memeriksa tahun/tanggal lengkap. Di luar jendela itu workflow
+# berhenti sebelum membaca database atau deploy. Tombol Run workflow tetap bisa
+# ditekan kapan pun, termasuk dari HP.
 #
 # Butuh repository secret (dua-duanya sudah dipakai workflow lain):
 #   SUPABASE_DB_URL       connection string Postgres (Session pooler, 5432)
@@ -66,9 +66,9 @@ on:
       - 'supabase/checks/live_json.sql'
       - '.github/workflows/publish-live.yml'
   schedule:
-    # Cron memakai UTC. Rentang ini mencakup 28 Agustus 07:00 WIB sampai
-    # 30 Agustus 06:45 WIB, termasuk seluruh hari lomba 29 Agustus.
-    - cron: '*/15 * 28-29 8 *'
+    # 01:00-16:45 UTC = 08:00-23:45 WIB. Cron tidak mendukung tahun;
+    # langkah `jadwal` di bawah menolak semua tanggal selain 29-08-2026.
+    - cron: '*/15 1-16 29 8 *'
 
 # Dua jalan yang bertumpuk akan saling menimpa live.json di Cloudflare, dan
 # yang menang belum tentu yang terbaru. Satu jalan saja pada satu waktu.
@@ -80,9 +80,30 @@ jobs:
   terbitkan:
     runs-on: ubuntu-latest
     steps:
+      - name: Periksa jendela penerbitan otomatis
+        id: jadwal
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "aktif=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          sekarang="$(date -u '+%Y-%m-%dT%H:%M')"
+          if [[ "$sekarang" =~ ^2026-08-29T(0[1-9]|1[0-6]): ]]; then
+            echo "aktif=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "aktif=false" >> "$GITHUB_OUTPUT"
+            echo "Di luar 29 Agustus 2026 08:00-23:59 WIB; tidak menerbitkan."
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.jadwal.outputs.aktif == 'true'
 
       - name: Tulis live.json + rekap.json dari database
+        if: steps.jadwal.outputs.aktif == 'true'
         env:
           DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
@@ -193,16 +214,20 @@ jobs:
           PY
 
       - uses: actions/setup-node@v4
+        if: steps.jadwal.outputs.aktif == 'true'
         with:
           node-version: '20'
 
       - run: npm install -g wrangler
+        if: steps.jadwal.outputs.aktif == 'true'
 
       - name: Deploy halaman rekap
+        if: steps.jadwal.outputs.aktif == 'true'
         working-directory: live
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: wrangler deploy
 
       - name: Ringkasan
+        if: steps.jadwal.outputs.aktif == 'true'
         run: echo "REKAP TERBIT — $(date -u '+%Y-%m-%d %H:%M UTC')"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,9 +688,10 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
    run from their phones. The event-only exception in `publish-live.yml` runs
-   every 15 minutes on 28-29 August UTC, covering the 29 August event in WIB.
-   Its date-bound schedule costs at most 192 runs a year; do not widen it to an
-   everyday schedule.
+   every 15 minutes from 08:00 through 23:45 WIB on 29 August 2026. Cron has no
+   year field, so the first step rejects every scheduled run outside that exact
+   date before reading the database or deploying. Do not widen its window or
+   remove that year guard.
 
 ## 17. Selama acara berjalan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -686,9 +686,10 @@ Guidance for Claude Code when working in this repository.
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
    run from their phones. The event-only exception in `publish-live.yml` runs
-   every 15 minutes on 28-29 August UTC, covering the 29 August event in WIB.
-   Its date-bound schedule costs at most 192 runs a year; do not widen it to an
-   everyday schedule.
+   every 15 minutes from 08:00 through 23:45 WIB on 29 August 2026. Cron has no
+   year field, so the first step rejects every scheduled run outside that exact
+   date before reading the database or deploying. Do not widen its window or
+   remove that year guard.
 
 ## 17. Selama acara berjalan
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -662,7 +662,7 @@ Service key hidup sebagai `wrangler secret` di Worker, tidak pernah di SPA.
 | Yang di-deploy | Cara | Pemicu |
 | --- | --- | --- |
 | Layar panitia (`web/`) | Cloudflare Workers, tersambung Git | otomatis tiap push ke `main` |
-| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | **otomatis** tiap push ke `main` yang menyentuh `live/**` atau `live_json.sql` (#235); pada hari-H juga terbit tiap 15 menit lewat cron bertanggal 28-29 Agustus UTC |
+| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | **otomatis** tiap push ke `main` yang menyentuh `live/**` atau `live_json.sql` (#235); pada 29 Agustus 2026 pukul 08:00-23:59 WIB juga terbit tiap 15 menit |
 | Gateway Worker | GitHub Actions `deploy-gateway.yml` | manual |
 | Migrasi database | GitHub Actions `apply-migration.yml` | manual, satu berkas per jalan |
 
@@ -837,11 +837,11 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
   `berangkatkan_kloter`; sisanya menunggu karena tiap perbaikan menuntut
   seluruh badan fungsinya disalin ulang.
 - **Cron rekap live hanya hidup pada hari-H.** `publish-live.yml` berjalan
-  tiap 15 menit pada 28-29 Agustus UTC, rentang yang mencakup seluruh 29
-  Agustus WIB. Batas tanggal itu sengaja menahan biaya di paling banyak 192
-  run per tahun; jangan ubah menjadi jadwal setiap hari. Di luar rentang itu,
-  halaman rekap terbit saat ada push yang menyentuh `live/` atau saat tombol
-  Run workflow ditekan.
+  tiap 15 menit pada 29 Agustus 2026 pukul 08:00-23:45 WIB. GitHub cron tidak
+  punya kolom tahun, jadi langkah pertama memeriksa tanggal lengkap dan
+  berhenti sebelum membaca database atau deploy pada tahun lain. Di luar
+  jendela itu, halaman rekap hanya terbit saat ada push yang menyentuh `live/`
+  atau saat tombol Run workflow ditekan.
 - **Upload massal nilai belum ada.** `rancangan-b.md` bagian 6 menjelaskan
   jalur tempel-dari-Excel lengkap dengan layar preview. Yang sudah dibangun
   baru input tabelnya (`#/pos`) — yang sebenarnya sudah menutup sebagian besar

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -300,12 +300,13 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
    HP penonton hanya menyentuh hosting statis — bandwidth gratis tak terbatas,
    **nol request ke Supabase**.
 2. Regenerasi: workflow GitHub Actions (`publish-live.yml`) — cron 15 menit
-   bertanggal 28-29 Agustus UTC (mencakup hari-H dalam WIB) + tombol manual.
-   Tiga langkah yang bisa
+   pada 29 Agustus 2026 pukul 08:00-23:45 WIB + tombol manual. Tahun diperiksa
+   langkah pertama karena format cron hanya membawa tanggal dan bulan. Tiga
+   langkah yang bisa
    dibaca pelajar: baca view publik memakai **service role key dari GitHub
    Secrets** (bukan anon — anon tidak bisa baca apa pun) → tulis `live.json` →
-   deploy ke Pages. Maksimal 192 run per tahun ≪ kuota gratis 2.000
-   menit/bulan.
+   deploy ke Pages. Hanya 64 penerbitan terjadwal pada hari-H ≪ kuota gratis
+   2.000 menit/bulan.
 3. **Bertahap sebagai data, bukan kode**: `status_acara.fase_live` menentukan
    isi view publik — `pra` (jumlah pendaftar per golongan), `progres` (per
    regu: sudah lewat pos mana, **tanpa angka**), `penuh` (klasemen 4 golongan

--- a/tests/live_publish_schedule.test.mjs
+++ b/tests/live_publish_schedule.test.mjs
@@ -11,8 +11,26 @@ const workflow = await readFile(
   new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
 
 
-test("rekap terbit tiap 15 menit hanya pada tanggal UTC hari-H", () => {
-  assert.match(workflow, /schedule:\s*[\s\S]*?- cron: '\*\/15 \* 28-29 8 \*'/);
+test("rekap terbit tiap 15 menit hanya pada jam WIB hari-H", () => {
+  assert.match(workflow, /schedule:\s*[\s\S]*?- cron: '\*\/15 1-16 29 8 \*'/);
   assert.doesNotMatch(workflow, /cron: '\*\/15 \* \* \* \*'/,
     "cron tidak boleh berjalan tiap hari sepanjang tahun");
+  assert.match(workflow, /\^2026-08-29T\(0\[1-9\]\|1\[0-6\]\):/,
+    "tahun dan jendela UTC harus diperiksa sebelum penerbitan");
+  assert.match(workflow,
+    /uses: actions\/checkout@v4\s+if: steps\.jadwal\.outputs\.aktif == 'true'/,
+    "scheduled run di luar jendela tidak boleh membaca repository");
+  assert.match(workflow,
+    /name: Tulis live\.json \+ rekap\.json dari database\s+if: steps\.jadwal\.outputs\.aktif == 'true'/,
+    "scheduled run di luar jendela tidak boleh membaca database");
+});
+
+
+test("guard UTC tepat membuka 08:00-23:59 WIB pada 29 Agustus 2026", () => {
+  const aktif = /^2026-08-29T(0[1-9]|1[0-6]):/;
+  assert.equal(aktif.test("2026-08-29T00:59"), false);
+  assert.equal(aktif.test("2026-08-29T01:00"), true);
+  assert.equal(aktif.test("2026-08-29T16:59"), true);
+  assert.equal(aktif.test("2026-08-29T17:00"), false);
+  assert.equal(aktif.test("2027-08-29T01:00"), false);
 });


### PR DESCRIPTION
## What

- limit automatic publishing to 29 August 2026 from 08:00 through 23:59 WIB
- add a full UTC date and year guard before database access or deployment
- preserve manual and push-triggered publishing outside the automatic window
- update documentation and boundary tests

## Why

The 15-minute publisher should run only during the requested event hours and stop automatically afterward.