### PR TITLE
fix: preserve championship scroll position

### DIFF
--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -26,6 +26,11 @@ test("pilihan manual tidak menawarkan regu Intern dan terkunci setelah dipilih",
   assert.match(app, /terkunci\.hidden = true;\s*isian\.hidden = false;/);
 });
 
+test("menyimpan juara mengunci baris tanpa memuat ulang layar", () => {
+  assert.match(app, /simpanKejuaraanManual[\s\S]*kejuaraan-nilai[\s\S]*isian\.hidden = true;[\s\S]*terkunci\.hidden = false;/);
+  assert.doesNotMatch(app, /simpanKejuaraanManual\(pilih\.dataset\.kode, dipilih\.regu_id\);\s*await layarKejuaraan\(\)/);
+});
+
 test("layout desktop menempatkan juara umum di tengah dan golongan berdampingan", () => {
   assert.match(css, /@media \(min-width: 900px\)[\s\S]*\.kejuaraan-umum[\s\S]*justify-self: center/);
   assert.match(css, /\.kejuaraan-umum-penegak \{ grid-column: 1; grid-row: 2; \}/);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6184,7 +6184,11 @@ async function layarKejuaraan() {
       pilih.disabled = true;
       try {
         await simpanKejuaraanManual(pilih.dataset.kode, dipilih.regu_id);
-        await layarKejuaraan();
+        terkunci.querySelector(".kejuaraan-nilai").innerHTML = nilai(dipilih);
+        pilih.value = labelRegu(dipilih);
+        saran.hidden = true;
+        isian.hidden = true;
+        terkunci.hidden = false;
         notif("Kejuaraan tersimpan.");
       } catch (e) { notif(e.message, true); }
       finally { pilih.disabled = false; }


### PR DESCRIPTION
## What
- update a saved manual champion in place
- keep the current Kejuaraan scroll position
- add focused regression coverage

## Why
Selecting a champion should not reload the screen and move the officer away from the current row.