### PR TITLE
fix: require arrival before ranking winners

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -767,7 +767,8 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 
 ### Pengurangan lain di luar penalti waktu
 
-7. **Tidak melakukan checkout** di meja closing: **−100**.
+7. **Belum tercatat tiba** di meja Kedatangan: **tidak mendapat peringkat dan
+   tidak dapat menjadi juara**, tetapi tidak dikenai pengurangan skor.
 8. **Melewatkan sebuah pos**: nilai pos tersebut menjadi **0**. Tidak ada
    pengurangan tambahan di luar itu.
 9. **Anggota regu tidak lengkap.** Kelengkapan diperiksa di akhir lomba, dan
@@ -866,11 +867,7 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    tidak memindahkan kertas sama sekali. Kalau foto tidak diwajibkan, perlu
    disepakati siapa yang bertanggung jawab atas kotak sejak pos tutup sampai
    isinya masuk sistem.
-5. **Dua pembacaan pada bagian 10 yang belum dipastikan:**
-   - Pengurangan −100 karena tidak checkout — apakah menggantikan penalti waktu,
-     atau ditambahkan padanya? Tanpa checkout tidak ada jam datang, sehingga
-     penalti waktu tidak dapat dihitung. Dokumen ini menuliskannya sebagai
-     pengurangan tersendiri.
+5. **Satu pembacaan pada bagian 10 yang belum dipastikan:**
    - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
      yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
      Dokumen ini mengasumsikan per orang.

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 28 Agustus 2026 sampai migrasi `0142`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0143`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0142`.
+`0119`-`0143`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-142 migrasi, `0001` sampai `0142`, dijalankan berurutan tanpa lubang penomoran.
+143 migrasi, `0001` sampai `0143`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -100,6 +100,10 @@ bukan menghitung ulang data.
 
 Konsekuensinya: memperbaiki satu nilai yang salah ketik langsung memperbaiki
 klasemen, tanpa proses hitung ulang apa pun.
+
+Regu yang belum punya jam datang tetap membawa skor posnya tanpa pengurangan
+`-100`, tetapi tidak masuk `v_klasemen` dan tidak dapat menjadi juara. Setelah
+jam datang dicatat, penalti waktu dapat dihitung dan regu baru masuk peringkat.
 
 Apa yang dinilai di tiap pos juga konfigurasi: satu baris `wahana` per kolom
 penilaian, dengan **enam bentuk konversi** — `kecil_baik`, `besar_baik`,

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -87,7 +87,7 @@ penyelesaiannya dicatat di bagian 11.
 | `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
 | `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis`): bentuk konversi + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
 | `kontrak_opsi` | Pilihan kontrak waktu | `('3 jam',180), ('3,5 jam',210), ('4 jam',240)` |
-| `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=1, penalti_per_blok=1, penalti_tanpa_checkout=100, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
+| `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=1, penalti_per_blok=1, penalti_tanpa_checkout=0, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
 
 1. `wahana.kode` dibatasi `CHECK` huruf-kecil/angka/underscore — kode ini
    dipakai sebagai **header kolom lembar cetak sekaligus header import**,
@@ -251,9 +251,9 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
       `selisih_menit` bertanda, presisi menit;
       `penalti = floor(|selisih|/blok_menit) × penalti_per_blok` — simetris;
       konfigurasi sekarang `1 menit → 1 poin`, jadi tidak ada toleransi menit.
-   5. `v_total_skor` — Σ pos − penalti waktu − `penalti_tanpa_checkout` (bila
-      tidak ada baris closing; penalti waktu saat itu 0 karena tak
-      terhitung) − `(5 − anggota_hadir) × penalti_per_anggota_hilang`.
+   5. `v_total_skor` — Σ pos − penalti waktu − `(5 − anggota_hadir) ×
+      penalti_per_anggota_hilang`. Tanpa baris closing, penalti waktu dan
+      penalti checkout sama-sama 0; regunya tetap tidak masuk peringkat.
    6. `v_klasemen` — `rank() OVER (PARTITION BY golongan ORDER BY total DESC,
       |selisih_menit| ASC)` — empat klasemen, tie-break ketepatan waktu sudah
       tertanam. Regu `batal` dan yang tidak pernah berangkat tidak ikut

--- a/supabase/migrations/0143_juara_harus_tiba.sql
+++ b/supabase/migrations/0143_juara_harus_tiba.sql
@@ -1,0 +1,84 @@
+-- Tidak adanya catatan tiba bukan penalti skor. Regu itu tetap membawa nilai
+-- pos yang sudah dikumpulkan, tetapi belum sah masuk klasemen atau menerima
+-- gelar sampai meja Kedatangan mencatat jam datangnya.
+
+alter table konfig_penalti
+  alter column penalti_tanpa_checkout set default 0;
+
+update konfig_penalti
+set penalti_tanpa_checkout = 0
+where penalti_tanpa_checkout <> 0;
+
+create or replace view v_klasemen with (security_invoker = on) as
+select
+  rank() over (partition by t.golongan
+               order by t.total desc, abs(coalesce(t.selisih_menit, 100000)) asc)
+    as peringkat,
+  t.*
+from v_total_skor t
+where exists (select 1 from keberangkatan_regu kb where kb.regu_id = t.regu_id)
+  and exists (select 1 from regu r join kloter k on k.nomor = r.kloter_nomor
+              where r.id = t.regu_id and k.jam_berangkat is not null)
+  and exists (select 1 from closing_regu c where c.regu_id = t.regu_id);
+
+comment on view v_klasemen is
+  'Peringkat per golongan untuk regu yang benar-benar berangkat dan sudah tercatat tiba. Regu tanpa jam datang tetap ada di rekap, tetapi tidak berperingkat dan tidak dapat menjadi juara.';
+
+-- Pilihan penghargaan khusus yang dibuat sebelum aturan ini juga tidak boleh
+-- membuat regu tanpa jam datang tetap tampil sebagai juara.
+delete from kejuaraan_manual m
+where not exists (select 1 from closing_regu c where c.regu_id = m.regu_id);
+
+create or replace function simpan_kejuaraan_manual(p_kode text, p_regu uuid)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if not boleh('pengaturan') then
+    raise exception 'akun ini tidak berhak mengubah Kejuaraan';
+  end if;
+  if p_kode not in ('kostum', 'terfavorit', 'terjauh') then
+    raise exception 'penghargaan manual tidak dikenal';
+  end if;
+
+  if p_regu is null then
+    delete from kejuaraan_manual
+    where edisi = edisi_aktif() and kode = p_kode;
+    return;
+  end if;
+
+  if not exists (
+    select 1 from regu r
+    join closing_regu c on c.regu_id = r.id
+    where r.id = p_regu and r.nomor_dada is not null and not r.is_cancelled
+      and r.golongan not like 'intern_%'
+  ) then
+    raise exception 'regu tidak ditemukan, belum tiba, belum mendapat nomor dada, atau termasuk Intern';
+  end if;
+
+  insert into kejuaraan_manual (edisi, kode, regu_id, diubah_oleh)
+  values (edisi_aktif(), p_kode, p_regu, auth.uid())
+  on conflict (edisi, kode) do update
+    set regu_id = excluded.regu_id,
+        diubah_oleh = excluded.diubah_oleh,
+        diubah_pada = now();
+end;
+$$;
+
+do $$
+declare
+  v_default numeric;
+begin
+  select pg_get_expr(d.adbin, d.adrelid)::numeric into v_default
+  from pg_attrdef d
+  join pg_attribute a on a.attrelid = d.adrelid and a.attnum = d.adnum
+  where d.adrelid = 'konfig_penalti'::regclass
+    and a.attname = 'penalti_tanpa_checkout';
+
+  assert v_default = 0, '0143: default penalti tanpa jam datang bukan nol';
+  assert not exists (
+    select 1 from konfig_penalti where penalti_tanpa_checkout <> 0
+  ), '0143: masih ada konfigurasi penalti tanpa jam datang yang bukan nol';
+end;
+$$;

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -18,7 +18,8 @@ test("pilihan manual mencari nomor dada, regu, dan sekolah", () => {
   assert.match(app, /slice\(0, 8\)/);
 });
 
-test("pilihan manual tidak menawarkan regu Intern dan terkunci setelah dipilih", () => {
+test("pilihan manual hanya menawarkan regu Eksternal yang sudah tiba", () => {
+  assert.match(app, /r\.nomor_dada != null && r\.jam_datang != null/);
   assert.match(app, /!String\(r\.golongan\)\.startsWith\("intern_"\)/);
   assert.match(app, />\s*Ubah Juara\s*<\/button>/);
   assert.doesNotMatch(app, /Hapus pilihan/);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -682,5 +682,7 @@ run tests/sql/92_peserta_terbanyak_eksternal.sql
 run supabase/migrations/0142_kejuaraan_tanpa_intern.sql
 run tests/sql/93_kejuaraan_tanpa_intern.sql
 run tests/sql/94_simulasi_pemenang_kejuaraan.sql
+run supabase/migrations/0143_juara_harus_tiba.sql
+run tests/sql/95_juara_harus_tiba.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/95_juara_harus_tiba.sql
+++ b/tests/sql/95_juara_harus_tiba.sql
@@ -1,0 +1,64 @@
+-- Regu yang belum tercatat tiba tetap membawa skor sebenarnya tanpa penalti
+-- fiktif, tetapi tidak mempunyai peringkat dan tidak dapat dipilih sebagai
+-- penerima penghargaan manual.
+
+do $blok$
+declare
+  v_sekolah uuid := gen_random_uuid();
+  v_daftar uuid := gen_random_uuid();
+  v_regu uuid := gen_random_uuid();
+  v_jam_lama timestamptz;
+  v_skor record;
+begin
+  insert into sekolah (id, name, address)
+  values (v_sekolah, 'SEKOLAH UJI BELUM TIBA', 'Alamat uji');
+  insert into pendaftaran
+    (id, sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+     jumlah_regu, kontak_wa, status, kunci_kirim)
+  values
+    (v_daftar, v_sekolah, 'UJI95', false, 0, 1,
+     '085555555555', 'lunas', gen_random_uuid());
+  insert into regu
+    (id, pendaftaran_id, nama_regu, nama_ketua, golongan,
+     nomor_dada, kloter_nomor, urutan_kloter)
+  values
+    (v_regu, v_daftar, 'UJI BELUM TIBA 95', 'KETUA UJI',
+     'penegak_pa', 499, 75, 1);
+
+  select jam_berangkat into v_jam_lama from kloter where nomor = 75;
+  update kloter set jam_berangkat = timestamptz '2026-08-29 09:00+07'
+  where nomor = 75;
+  insert into keberangkatan_regu (regu_id, recorded_by)
+  values (v_regu, '00000000-0000-0000-0000-00000000000a');
+
+  assert not exists (select 1 from closing_regu where regu_id = v_regu),
+    '95.1 GAGAL: regu uji tanpa sengaja punya jam datang';
+
+  select * into strict v_skor from v_total_skor where regu_id = v_regu;
+  assert v_skor.penalti_checkout = 0,
+    format('95.2 GAGAL: penalti tanpa jam datang = %s', v_skor.penalti_checkout);
+  assert v_skor.total = v_skor.total_pos - v_skor.penalti_waktu - v_skor.penalti_anggota,
+    format('95.3 GAGAL: total %s masih dipotong penalti tanpa jam datang', v_skor.total);
+  assert not exists (select 1 from v_klasemen where regu_id = v_regu),
+    '95.4 GAGAL: regu tanpa jam datang masih mendapat peringkat';
+
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  begin
+    perform simpan_kejuaraan_manual('kostum', v_regu);
+    assert false, '95.5 GAGAL: regu tanpa jam datang dapat dipilih sebagai juara';
+  exception when others then
+    assert sqlerrm like '%belum tiba%',
+      format('95.5 GAGAL: alasan penolakan salah: %s', sqlerrm);
+  end;
+
+  reset role;
+  delete from keberangkatan_regu where regu_id = v_regu;
+  delete from regu where id = v_regu;
+  update kloter set jam_berangkat = v_jam_lama where nomor = 75;
+  delete from pendaftaran where id = v_daftar;
+  delete from sekolah where id = v_sekolah;
+end;
+$blok$;
+
+select '95_juara_harus_tiba OK' hasil;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6094,7 +6094,7 @@ async function layarKejuaraan() {
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarKejuaraan)); return; }
   if (location.hash !== layarIni) return;
 
-  const opsi = [...new Map(regu.filter(r => r.nomor_dada != null
+  const opsi = [...new Map(regu.filter(r => r.nomor_dada != null && r.jam_datang != null
       && !String(r.golongan).startsWith("intern_"))
     .map(r => [r.regu_id, r])).values()]
     .sort((a, b) => Number(a.nomor_dada) - Number(b.nomor_dada));


### PR DESCRIPTION
## What

- Set the missing-arrival penalty to zero
- Exclude teams without an arrival time from rankings and awards
- Filter manual award candidates to teams that have arrived
- Add SQL and UI regression coverage

## Why

A missing arrival record should make a team ineligible to win, not subtract a synthetic 100 points from its score.