### PR TITLE
fix: show unarrived teams outside rankings

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -767,8 +767,9 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 
 ### Pengurangan lain di luar penalti waktu
 
-7. **Belum tercatat tiba** di meja Kedatangan: **tidak mendapat peringkat dan
-   tidak dapat menjadi juara**, tetapi tidak dikenai pengurangan skor.
+7. **Belum tercatat tiba** di meja Kedatangan: tetap ditampilkan di Live Score
+   tanpa peringkat, **tidak dapat masuk enam besar**, dan tidak dikenai
+   pengurangan skor.
 8. **Melewatkan sebuah pos**: nilai pos tersebut menjadi **0**. Tidak ada
    pengurangan tambahan di luar itu.
 9. **Anggota regu tidak lengkap.** Kelengkapan diperiksa di akhir lomba, dan

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0143`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0144`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0143`.
+`0119`-`0144`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-143 migrasi, `0001` sampai `0143`, dijalankan berurutan tanpa lubang penomoran.
+144 migrasi, `0001` sampai `0144`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -102,8 +102,9 @@ Konsekuensinya: memperbaiki satu nilai yang salah ketik langsung memperbaiki
 klasemen, tanpa proses hitung ulang apa pun.
 
 Regu yang belum punya jam datang tetap membawa skor posnya tanpa pengurangan
-`-100`, tetapi tidak masuk `v_klasemen` dan tidak dapat menjadi juara. Setelah
-jam datang dicatat, penalti waktu dapat dihitung dan regu baru masuk peringkat.
+`-100` dan tetap ditampilkan di kedua Live Score, tetapi peringkatnya kosong
+dan ia tidak dapat masuk enam besar. Setelah jam datang dicatat, penalti waktu
+dapat dihitung dan regu baru masuk peringkat.
 
 Apa yang dinilai di tiap pos juga konfigurasi: satu baris `wahana` per kolom
 penilaian, dengan **enam bentuk konversi** — `kecil_baik`, `besar_baik`,

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -253,7 +253,8 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
       konfigurasi sekarang `1 menit → 1 poin`, jadi tidak ada toleransi menit.
    5. `v_total_skor` — Σ pos − penalti waktu − `(5 − anggota_hadir) ×
       penalti_per_anggota_hilang`. Tanpa baris closing, penalti waktu dan
-      penalti checkout sama-sama 0; regunya tetap tidak masuk peringkat.
+      penalti checkout sama-sama 0; regunya tetap terlihat di Live Score tanpa
+      peringkat dan tidak dapat masuk enam besar.
    6. `v_klasemen` — `rank() OVER (PARTITION BY golongan ORDER BY total DESC,
       |selisih_menit| ASC)` — empat klasemen, tie-break ketepatan waktu sudah
       tertanam. Regu `batal` dan yang tidak pernah berangkat tidak ikut

--- a/supabase/migrations/0144_tampilkan_regu_belum_tiba.sql
+++ b/supabase/migrations/0144_tampilkan_regu_belum_tiba.sql
@@ -1,0 +1,69 @@
+-- Kelayakan juara dan isi papan adalah dua hal berbeda. v_klasemen tetap
+-- hanya memuat regu yang sudah tiba supaya seluruh mesin Kejuaraan aman,
+-- sementara dua pintu Live Score menambahkan kembali regu yang benar-benar
+-- sudah berangkat dengan peringkat NULL.
+
+create or replace function klasemen_live_score()
+returns table (
+  peringkat        bigint,
+  nomor_dada       integer,
+  nama_regu        text,
+  nama_sekolah     text,
+  golongan         text,
+  total_pos        numeric,
+  penalti_waktu    numeric,
+  penalti_checkout numeric,
+  penalti_anggota  numeric,
+  total            numeric,
+  poin_per_pos     jsonb,
+  selisih_menit    integer
+)
+language sql stable security definer
+set search_path = public
+as $$
+  select
+    kl.peringkat, t.nomor_dada, t.nama_regu, t.nama_sekolah, t.golongan,
+    t.total_pos, t.penalti_waktu, t.penalti_checkout, t.penalti_anggota, t.total,
+    (select jsonb_object_agg(pp.pos::text, pp.poin_pos)
+     from v_poin_pos pp where pp.regu_id = t.regu_id)        as poin_per_pos,
+    t.selisih_menit
+  from v_total_skor t
+  join regu r on r.id = t.regu_id
+  join kloter k on k.nomor = r.kloter_nomor
+  join keberangkatan_regu kb on kb.regu_id = t.regu_id
+  left join v_klasemen kl on kl.regu_id = t.regu_id
+  where k.jam_berangkat is not null
+    and boleh('live_score')
+$$;
+
+comment on function klasemen_live_score() is
+  'Alas Live Score panitia. Semua regu yang sudah berangkat ditampilkan; peringkat hanya terisi setelah jam datang dicatat.';
+
+create or replace view v_klasemen_publik as
+select
+  kl.peringkat, t.nomor_dada, t.nama_regu, t.nama_sekolah, t.golongan,
+  t.total_pos, t.penalti_waktu, t.penalti_checkout, t.penalti_anggota, t.total,
+  (select jsonb_object_agg(pp.pos::text, pp.poin_pos)
+   from v_poin_pos pp where pp.regu_id = t.regu_id)          as poin_per_pos,
+  t.selisih_menit
+from v_total_skor t
+join regu r on r.id = t.regu_id
+join kloter k on k.nomor = r.kloter_nomor
+join keberangkatan_regu kb on kb.regu_id = t.regu_id
+left join v_klasemen kl on kl.regu_id = t.regu_id
+where k.jam_berangkat is not null
+  and (select fase_live from status_acara) = 'penuh';
+
+comment on view v_klasemen_publik is
+  'Papan penuh peserta. Semua regu yang sudah berangkat ditampilkan; peringkat NULL menandai regu yang belum tercatat tiba dan tidak berhak masuk enam besar.';
+
+do $$
+begin
+  assert pg_get_functiondef('klasemen_live_score()'::regprocedure)
+           like '%left join v_klasemen%',
+    '0144: Live Score panitia masih membuang regu tanpa peringkat';
+  assert pg_get_viewdef('v_klasemen_publik'::regclass, true)
+           like '%LEFT JOIN v_klasemen%',
+    '0144: Live Score peserta masih membuang regu tanpa peringkat';
+end;
+$$;

--- a/tests/live_score_unarrived.test.mjs
+++ b/tests/live_score_unarrived.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const panitia = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const peserta = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+
+test("regu tanpa peringkat tetap menjadi baris, bukan podium", () => {
+  assert.match(panitia, /baris\.filter\(k => k\.peringkat && k\.peringkat <= 3\)/);
+  assert.match(peserta, /baris\.filter\(b => b\.peringkat && b\.peringkat <= 3\)/);
+});
+
+test("peringkat kosong digambar kosong, bukan tulisan null", () => {
+  assert.match(panitia, /String\(k\.peringkat \?\? ""\)/);
+  assert.match(peserta, /String\(b\.peringkat \?\? ""\)/);
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -684,5 +684,7 @@ run tests/sql/93_kejuaraan_tanpa_intern.sql
 run tests/sql/94_simulasi_pemenang_kejuaraan.sql
 run supabase/migrations/0143_juara_harus_tiba.sql
 run tests/sql/95_juara_harus_tiba.sql
+run supabase/migrations/0144_tampilkan_regu_belum_tiba.sql
+run tests/sql/96_tampilkan_regu_belum_tiba.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/96_tampilkan_regu_belum_tiba.sql
+++ b/tests/sql/96_tampilkan_regu_belum_tiba.sql
@@ -1,0 +1,61 @@
+-- Belum tiba berarti terlihat tanpa peringkat, bukan menghilang dan bukan
+-- merebut salah satu dari enam gelar golongan.
+
+do $blok$
+declare
+  v_sekolah uuid := gen_random_uuid();
+  v_daftar uuid := gen_random_uuid();
+  v_regu uuid := gen_random_uuid();
+  v_jam_lama timestamptz;
+  v_fase_lama text;
+  v_peringkat bigint;
+begin
+  insert into sekolah (id, name, address)
+  values (v_sekolah, 'SEKOLAH UJI PAPAN BELUM TIBA', 'Alamat uji');
+  insert into pendaftaran
+    (id, sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+     jumlah_regu, kontak_wa, status, kunci_kirim)
+  values
+    (v_daftar, v_sekolah, 'UJI96', false, 0, 1,
+     '086666666666', 'lunas', gen_random_uuid());
+  insert into regu
+    (id, pendaftaran_id, nama_regu, nama_ketua, golongan,
+     nomor_dada, kloter_nomor, urutan_kloter)
+  values
+    (v_regu, v_daftar, 'UJI PAPAN TIBA 96', 'KETUA UJI',
+     'penegak_pa', 499, 75, 1);
+
+  select jam_berangkat into v_jam_lama from kloter where nomor = 75;
+  select fase_live into v_fase_lama from status_acara;
+  update kloter set jam_berangkat = timestamptz '2026-08-29 09:00+07'
+  where nomor = 75;
+  update status_acara set fase_live = 'penuh';
+  insert into keberangkatan_regu (regu_id, recorded_by)
+  values (v_regu, '00000000-0000-0000-0000-00000000000a');
+
+  assert not exists (select 1 from v_klasemen where regu_id = v_regu),
+    '96.1 GAGAL: regu belum tiba masuk mesin peringkat';
+
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  select peringkat into v_peringkat from klasemen_live_score()
+  where nomor_dada = 499;
+  assert found and v_peringkat is null,
+    '96.2 GAGAL: regu belum tiba tidak tampil tanpa peringkat di papan panitia';
+
+  reset role;
+  select peringkat into v_peringkat from v_klasemen_publik
+  where nomor_dada = 499;
+  assert found and v_peringkat is null,
+    '96.3 GAGAL: regu belum tiba tidak tampil tanpa peringkat di papan peserta';
+
+  delete from keberangkatan_regu where regu_id = v_regu;
+  delete from regu where id = v_regu;
+  update kloter set jam_berangkat = v_jam_lama where nomor = 75;
+  update status_acara set fase_live = v_fase_lama;
+  delete from pendaftaran where id = v_daftar;
+  delete from sekolah where id = v_sekolah;
+end;
+$blok$;
+
+select '96_tampilkan_regu_belum_tiba OK' hasil;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5631,7 +5631,7 @@ async function layarLiveScore() {
 
   const kartuGolongan = (g) => {
         const baris = klasemen.filter(k => k.golongan === g);
-        const juara = baris.filter(k => k.peringkat <= 3);
+        const juara = baris.filter(k => k.peringkat && k.peringkat <= 3);
         const sekolahAda = [...new Set(baris.map(k => k.nama_sekolah).filter(Boolean))]
           .sort((a, b) => a.localeCompare(b, "id"));
         if (!baris.length) return `
@@ -5768,7 +5768,7 @@ async function layarLiveScore() {
                   const poin = k.poin_per_pos || {};
                   return `
                   <tr data-sekolah="${esc(k.nama_sekolah || "")}">
-                    <td class="rekap-rank">${MEDALI[k.peringkat] || ""}<span class="rank-angka">${esc(String(k.peringkat))}</span></td>
+                    <td class="rekap-rank">${MEDALI[k.peringkat] || ""}<span class="rank-angka">${esc(String(k.peringkat ?? ""))}</span></td>
                     <td class="angka">${esc(dada3(k.nomor_dada))}</td>
                     <td>${esc(k.nama_regu)}</td>
                     <td class="rekap-batas sub-kolom">${esc(k.nama_sekolah)}</td>


### PR DESCRIPTION
## What

- Keep departed teams without an arrival time visible on both live score boards
- Render their rank as blank and keep them out of podium and championship calculations
- Add SQL and UI regression coverage

## Why

Teams that have not reached SMAN 1 Ciamis still need to remain visible, but they must not occupy any of the six championship places.