### PR TITLE
feat: add Top 10 live score phase

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -17,9 +17,8 @@
 # YANG MENJAGA KEJUTAN ADA DI DATABASE, BUKAN DI SINI.
 # Selama status_acara.fase_live masih 'progres', v_klasemen_publik memang
 # mengembalikan nol baris dan v_progres_publik tidak memuat satu pun angka
-# nilai. Jadi live.json yang dihasilkan workflow ini memang TIDAK BERISI
-# nilai — bukan berisi nilai yang disembunyikan tampilan. Admin memindah fase
-# ke 'penuh' saat hasil diumumkan, dan jalan berikutnya klasemennya ikut.
+# nilai. Fase 'top10' hanya menerbitkan maksimal sepuluh regu eligible per
+# golongan beserta totalnya; fase 'penuh' menerbitkan papan lengkap.
 #
 # CRON 15 MENIT AKTIF HANYA 29 AGUSTUS 2026, 08:00-23:59 WIB. Cron memakai
 # UTC dan tidak punya kolom tahun, jadi jadwal memilih 01:00-16:45 UTC lalu
@@ -145,9 +144,29 @@ jobs:
           d['klasemen'] = [baris for baris in d['klasemen'] if eksternal(baris)]
           d['komponen'] = [baris for baris in d['komponen'] if eksternal(baris)]
 
+          # Top 10 bukan papan penuh yang kolomnya disembunyikan dengan CSS.
+          # Berkas publiknya sendiri hanya membawa identitas, peringkat, dan
+          # Total; poin per pos serta rincian penalti tidak ikut ke CDN.
+          if d['fase'] == 'top10':
+              kunci_top = ('peringkat', 'nomor_dada', 'nama_regu',
+                           'nama_sekolah', 'golongan', 'total')
+              d['klasemen'] = [
+                  {k: baris.get(k) for k in kunci_top}
+                  for baris in d['klasemen']
+              ]
+
           # Pagar kebocoran, dijaga di sini SEKALIGUS di view (0005/0026).
-          if d['fase'] != 'penuh' and d['klasemen']:
-              sys.exit('BOCOR: klasemen ikut tertulis padahal fase belum penuh')
+          if d['fase'] not in ('penuh', 'top10') and d['klasemen']:
+              sys.exit('BOCOR: klasemen ikut tertulis pada fase yang tertutup')
+          if d['fase'] == 'top10':
+              per_golongan = {}
+              for baris in d['klasemen']:
+                  if baris.get('peringkat') is None:
+                      sys.exit('BOCOR: regu tanpa peringkat ikut Top 10')
+                  golongan = baris.get('golongan')
+                  per_golongan[golongan] = per_golongan.get(golongan, 0) + 1
+              if any(jumlah > 10 for jumlah in per_golongan.values()):
+                  sys.exit('BOCOR: Top 10 memuat lebih dari sepuluh regu per golongan')
           # Sebelum lomba dimulai peserta tidak boleh melihat rekap apa pun,
           # dan v_progres_publik memang mengembalikan nol baris di fase 'pra'.
           # Kalau suatu hari ia tidak lagi begitu, berhenti di sini.

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0144`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0145`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0144`.
+`0119`-`0145`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-144 migrasi, `0001` sampai `0144`, dijalankan berurutan tanpa lubang penomoran.
+145 migrasi, `0001` sampai `0145`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -491,6 +491,11 @@ Tiga aturan membentuk seluruh halaman ini:
    `penuh` membuka klasemen empat golongan — tampil tanpa perlu mencari apa
    pun, karena itulah pengumumannya — dan menambahkan kloter, kontrak, jam
    berangkat, dan jam datang ke tabel sekolah.
+4. **Top 10 adalah papan ringkas per golongan.** Hanya sepuluh regu yang sudah
+   eligible untuk diperingkat yang terbit, dan tabelnya hanya membawa nomor
+   dada, regu, organisasi, peringkat, serta Total. Regu yang belum tercatat
+   tiba tidak ikut; poin per pos dan rincian penalti tidak ditulis ke berkas
+   publiknya.
 
 ### Yang menjaga kejutan adalah database, bukan tampilan
 
@@ -498,9 +503,9 @@ Selama `status_acara.fase_live` masih `progres`, `v_klasemen_publik`
 mengembalikan **nol baris** dan `v_progres_publik` tidak punya satu pun kolom
 berisi angka nilai. Jadi `live.json` yang terbit memang **tidak memuat**
 nilai — bukan memuatnya lalu disembunyikan CSS, yang bisa dibuka siapa pun
-dengan membuka alamat berkasnya langsung. Admin memindah fase ke `penuh` saat
-hasil diumumkan, dan jalan berikutnya klasemen empat golongan beserta juaranya
-ikut terbit.
+dengan membuka alamat berkasnya langsung. Admin dapat memindah fase ke
+`top10` untuk menerbitkan papan ringkas atau ke `penuh` untuk menerbitkan
+klasemen empat golongan beserta rinciannya.
 
 `tests/sql/09_rekap_publik.sql` menjaga janji itu dari dua arah: klasemen
 harus nol baris di fase progres, dan `v_progres_publik` diperiksa **lewat
@@ -529,8 +534,9 @@ yang menghasilkan seluruh isi — lalu memecah hasilnya jadi **dua berkas**
 sebelum men-deploy folder `live/`. Seluruh data peserta dan nilai hanya dibaca
 dari berkas statis itu. Satu-satunya permintaan langsung dari HP peserta ke
 Supabase adalah `v_fase_live` tiap 15 detik, supaya admin dapat memperketat
-`penuh` menjadi `progres` atau `pra` tanpa menunggu penerbitan baru; hasilnya
-tidak pernah boleh membuka lebih banyak daripada isi berkas yang sudah terbit.
+`penuh` menjadi `top10`, `progres`, atau `pra` tanpa menunggu penerbitan baru;
+hasilnya tidak pernah boleh membuka lebih banyak daripada isi berkas yang
+sudah terbit.
 
 | Sumber | Besar | Isinya | Kapan diambil |
 | --- | --- | --- | --- |
@@ -573,7 +579,9 @@ tanpa menambah kalimat yang harus dibaca berulang kali; umur dalam kurung sudah
 menunjukkan bahwa datanya tertinggal.
 
 Sebelum di-deploy, workflow memeriksa berkasnya sendiri: JSON harus terurai,
-kunci wajib harus ada, dan **klasemen harus kosong selama fase belum `penuh`**.
+kunci wajib harus ada, klasemen harus kosong di fase `pra` dan `progres`, serta
+fase `top10` tidak boleh membawa regu tanpa peringkat atau lebih dari sepuluh
+regu per golongan.
 JSON yang rusak akan membuat halaman rekap kosong tanpa pesan apa pun, dan
 tidak ada yang menyadarinya sampai ada peserta yang bertanya.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -867,7 +867,7 @@ export const hapusNilaiPos = (nomorDada, kode, pos) =>
 /** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin
  *  (0049, dinamai ulang 0050).
  *
- *  Bukan `v_klasemen_publik`: view itu dipagari `fase_live = 'penuh'` dan
+ *  Bukan `v_klasemen_publik`: view itu dipagari fase publik dan
  *  pagar itu yang menahan hasil lomba supaya tidak bocor sebelum diumumkan.
  *  Yang ini dipagari peran, dan hanya admin yang mendapat baris. */
 export async function klasemenLiveScore() {

--- a/live/live.js
+++ b/live/live.js
@@ -117,7 +117,10 @@ let mengambil = false;  // penjaga supaya tidak dua permintaan sekaligus
  *  digambar", dan siapa pun yang membuka rekap.json langsung melihatnya.
  *
  *  Jadi: mematikan seketika, menyalakan tetap lewat penerbitan. */
-const URUT_FASE = { pra: 0, progres: 1, penuh: 2 };
+// Top 10 membuka lebih sedikit data daripada Live penuh. Karena fase database
+// hanya boleh memperketat berkas yang sudah terbit, urutannya berada di antara
+// Progress dan Live meskipun tombolnya ditaruh setelah Live di layar panitia.
+const URUT_FASE = { pra: 0, progres: 1, top10: 2, penuh: 3 };
 // Fase database hanya memperketat isi berkas. Ia harus sempat menjawab sebelum
 // gambar pertama, tetapi tidak boleh menahan papan CDN lebih dari beberapa
 // detik ketika origin Supabase sedang sulit dijangkau.
@@ -387,7 +390,7 @@ const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
    ------------------------------------------------------------------------- */
 let golAktif = URUT_GOLONGAN_PESERTA[0];
 
-function barisPapan(penuh) {
+function barisPapan(klasemenTerbuka, top10 = false) {
   /* Penyaring ini tetap ada walau workflow penerbitan juga membuang Intern.
      Dengan begitu berkas lama yang masih tersimpan di cache tidak sempat
      menampilkan Intern setelah kode halaman yang baru sudah ter-deploy. */
@@ -398,8 +401,18 @@ function barisPapan(penuh) {
   const perDada = new Map(progres.map(p => [p.nomor_dada, p]));
   // Klasemen yang memimpin urutannya kalau ada — ia sudah berperingkat. Di
   // fase `progres` klasemen memang kosong, jadi urutannya jatuh ke nomor dada.
-  if (penuh && klasemen.length) {
-    return klasemen.map(k => ({ ...perDada.get(k.nomor_dada), ...k }));
+  if (klasemenTerbuka && klasemen.length) {
+    const jumlahGolongan = new Map();
+    const berperingkat = top10
+      ? klasemen.filter(k => {
+          if (k.peringkat === null || k.peringkat === undefined) return false;
+          const jumlah = jumlahGolongan.get(k.golongan) || 0;
+          if (jumlah >= 10) return false;
+          jumlahGolongan.set(k.golongan, jumlah + 1);
+          return true;
+        })
+      : klasemen;
+    return berperingkat.map(k => ({ ...perDada.get(k.nomor_dada), ...k }));
   }
   return [...progres].sort((a, b) => (a.nomor_dada ?? 1e9) - (b.nomor_dada ?? 1e9));
 }
@@ -416,7 +429,8 @@ function gambarTab(semua) {
 function gambarPapan() {
   if (!REKAP) return `<div class="kartu tengah"><p class="keterangan">Memuat…</p></div>`;
   const penuh = fase() === "penuh";
-  const semua = barisPapan(penuh);
+  const top10 = fase() === "top10";
+  const semua = barisPapan(penuh || top10, top10);
   const pos = (META && META.pos) || [];
   const komponen = (META && META.komponen) || [];
 
@@ -449,6 +463,27 @@ function gambarPapan() {
     const isi = !baris.length
       ? `<p class="keterangan tengah">Belum ada regu golongan ini yang bisa
            diperingkat.</p>`
+      : top10 ? `
+        <div class="gulir">
+          <table class="tabel ada-rank tabel-top-10">
+            <thead><tr>
+              <th class="rank-th">#</th>
+              <th class="dada-th">No<br>Dada</th>
+              <th class="regu-th">Regu</th>
+              <th>Organisasi</th>
+              <th>Total</th>
+            </tr></thead>
+            <tbody>${baris.map(b => `
+              <tr class="${b.peringkat && b.peringkat <= 3 ? "atas" : ""}">
+                <td class="rank-sel">${MEDALI[b.peringkat] || ""}${
+                  esc(String(b.peringkat))}</td>
+                <td class="dada">${esc(dada(b.nomor_dada))}</td>
+                <td class="regu">${esc(b.nama_regu)}</td>
+                <td class="sekolah-sel">${esc(b.nama_sekolah || "—")}</td>
+                <td class="total">${esc(angkaRapi(b.total))}</td>
+              </tr>`).join("")}</tbody>
+          </table>
+        </div>`
       : `
         ${!juara.length ? "" : `<div class="podium">${juara.map(k => `
           <div class="juara j${esc(String(k.peringkat))}">
@@ -580,7 +615,7 @@ function gambarPapan() {
 
     return `<div class="panel-gol kartu" data-gol="${esc(g)}"${
       g === golAktif ? "" : " hidden"}>
-        <h2 class="tengah">Klasemen sementara</h2>
+        <h2 class="tengah">${top10 ? "Top 10 sementara" : "Klasemen sementara"}</h2>
         ${isi}
       </div>`;
   }).join("");
@@ -712,12 +747,12 @@ function gambar() {
     `Live Score${META.edisi ? ` — ${META.edisi.name}` : ""}`;
   document.title = `Live Score — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
 
-  // Susunannya SAMA dengan layar panitia: kemajuan di atas, lalu tab
-  // golongan, lalu papan klasemen. Kotak cari sudah tidak ada — penyaring
-  // Organisasi di kepala kolom menggantikannya.
+  // Top 10 sengaja hanya membawa papan ringkas. Pada fase lain susunannya
+  // sama dengan layar panitia: kemajuan di atas, lalu tab golongan, lalu
+  // papan klasemen.
   isi.innerHTML = !mulai()
     ? gambarPra()
-    : gambarKelengkapan() + gambarPapan();
+    : (fase() === "top10" ? "" : gambarKelengkapan()) + gambarPapan();
 
   if (mulai()) pasangPapan();
   pasangKemajuan();

--- a/live/style.css
+++ b/live/style.css
@@ -854,9 +854,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 .printout { display: none; }
 
-/* Saklar tiga keadaan Live Score. Tiga tombol yang menempel jadi satu
-   batang: yang sedang berlaku memakai warna utama, dua lainnya diam. Bukan
-   satu tombol yang berganti tulisan — dengan tiga terlihat sekaligus, fase
+/* Saklar empat keadaan Live Score. Tombol-tombol yang menempel jadi satu
+   batang: yang sedang berlaku memakai warna utama, lainnya diam. Bukan
+   satu tombol yang berganti tulisan — dengan semua terlihat sekaligus, fase
    yang berlaku terbaca tanpa harus tahu arti tulisan tombolnya. */
 .segmen-fase { display: inline-flex; gap: 0; }
 /* Baris kepala kartu klasemen: judul di TENGAH, saklar di KANAN, dan judulnya

--- a/supabase/checks/atur_fase_live.sql
+++ b/supabase/checks/atur_fase_live.sql
@@ -3,7 +3,7 @@
 -- Pindahkan fase live. Ubah v_fase di bawah, lalu jalankan lewat
 -- apply-migration.yml.
 --
--- Tiga fase, dan yang membedakannya APA YANG DILIHAT PESERTA:
+-- Empat fase, dan yang membedakannya APA YANG DILIHAT PESERTA:
 --
 --   pra      peserta tidak melihat apa pun
 --   progres  peserta melihat kemajuan — siapa sudah sampai pos mana — TAPI
@@ -11,6 +11,7 @@
 --            klasemen selama fase belum penuh, dan penolakan itu berbunyi
 --            "BOCOR" dengan sengaja.
 --   penuh    klasemen dan juara terbit
+--   top10    maksimal sepuluh regu eligible per golongan, hanya Total
 --
 -- Layar panitia (v_klasemen_live_score) TIDAK terpengaruh fase — ia selalu
 -- berisi untuk yang memegang live_score. Fase hanya mengatur sisi peserta.
@@ -23,13 +24,15 @@
 -- ============================================================================
 do $$
 declare
-  v_fase text := 'progres';   -- <<< UBAH DI SINI: pra | progres | penuh
+  v_fase text := 'progres'; -- <<< pra | progres | penuh | top10
   v_lama text;
 begin
   select fase_live into v_lama from status_acara;
   update status_acara set fase_live = v_fase;
   raise notice 'fase live: % -> %', v_lama, v_fase;
-  if v_fase <> 'penuh' then
+  if v_fase not in ('penuh', 'top10') then
     raise notice 'klasemen TIDAK terbit ke peserta selama fase belum penuh.';
+  elsif v_fase = 'top10' then
+    raise notice 'hanya Top 10 per golongan dan Total yang terbit.';
   end if;
 end $$;

--- a/supabase/checks/live_json.sql
+++ b/supabase/checks/live_json.sql
@@ -66,6 +66,6 @@ select jsonb_pretty(jsonb_build_object(
               from v_progres_publik p),
 
   'klasemen', (select coalesce(jsonb_agg(to_jsonb(k)
-                        order by k.golongan, k.peringkat), '[]'::jsonb)
+                        order by k.golongan, k.peringkat, k.nomor_dada), '[]'::jsonb)
                from v_klasemen_publik k)
 ));

--- a/supabase/migrations/0145_top_10_live_score.sql
+++ b/supabase/migrations/0145_top_10_live_score.sql
@@ -1,0 +1,86 @@
+-- Top 10 adalah bentuk publik keempat Live Score. Ia hanya menerbitkan regu
+-- yang benar-benar sudah masuk mesin peringkat, maksimal sepuluh regu per
+-- golongan, dan tidak membawa regu yang baru berangkat tetapi belum tiba.
+
+alter table status_acara
+  drop constraint status_acara_fase_live_check;
+
+alter table status_acara
+  add constraint status_acara_fase_live_check
+  check (fase_live in ('pra', 'progres', 'penuh', 'top10'));
+
+create or replace function atur_fase_live(p_fase text)
+returns text
+language plpgsql security definer
+set search_path = public
+as $$
+declare v_lama text;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'tidak berhak: pengaturan';
+  end if;
+  if p_fase not in ('pra', 'progres', 'penuh', 'top10') then
+    raise exception
+      'fase tidak dikenal: % (pra / progres / penuh / top10)', p_fase;
+  end if;
+
+  select fase_live into v_lama from status_acara;
+  if v_lama = p_fase then
+    return v_lama;
+  end if;
+
+  update status_acara set fase_live = p_fase
+   where fase_live is distinct from p_fase;
+
+  raise notice 'fase_live: % -> %', v_lama, p_fase;
+  return p_fase;
+end;
+$$;
+
+create or replace view v_klasemen_publik as
+with papan as (
+  select
+    kl.peringkat, t.nomor_dada, t.nama_regu, t.nama_sekolah, t.golongan,
+    t.total_pos, t.penalti_waktu, t.penalti_checkout, t.penalti_anggota,
+    t.total,
+    (select jsonb_object_agg(pp.pos::text, pp.poin_pos)
+     from v_poin_pos pp where pp.regu_id = t.regu_id)        as poin_per_pos,
+    t.selisih_menit,
+    row_number() over (
+      partition by t.golongan
+      order by kl.peringkat nulls last, t.nomor_dada
+    )                                                       as urutan_top
+  from v_total_skor t
+  join regu r on r.id = t.regu_id
+  join kloter k on k.nomor = r.kloter_nomor
+  join keberangkatan_regu kb on kb.regu_id = t.regu_id
+  left join v_klasemen kl on kl.regu_id = t.regu_id
+  where k.jam_berangkat is not null
+)
+select
+  peringkat, nomor_dada, nama_regu, nama_sekolah, golongan,
+  total_pos, penalti_waktu, penalti_checkout, penalti_anggota, total,
+  poin_per_pos, selisih_menit
+from papan
+where (select fase_live from status_acara) = 'penuh'
+   or ((select fase_live from status_acara) = 'top10'
+       and peringkat is not null and urutan_top <= 10);
+
+comment on view v_klasemen_publik is
+  'Papan peserta. Fase penuh memuat semua regu yang sudah berangkat; fase top10 hanya memuat maksimal sepuluh regu berperingkat per golongan.';
+
+do $$
+begin
+  assert pg_get_constraintdef(
+    (select oid from pg_constraint
+     where conrelid = 'status_acara'::regclass
+       and conname = 'status_acara_fase_live_check')) like '%top10%',
+    '0145: constraint fase belum menerima top10';
+  assert pg_get_functiondef('atur_fase_live(text)'::regprocedure)
+           like '%top10%',
+    '0145: RPC fase belum menerima top10';
+  assert pg_get_viewdef('v_klasemen_publik'::regclass, true)
+           like '%urutan_top%10%',
+    '0145: papan publik belum membatasi Top 10';
+end;
+$$;

--- a/tests/live_score_top_10.test.mjs
+++ b/tests/live_score_top_10.test.mjs
@@ -1,0 +1,39 @@
+// Fase Top 10 adalah publikasi ringkas: maksimal sepuluh regu eligible per
+// golongan dan hanya tabel identitas + Total yang digambar.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const akar = new URL("../", import.meta.url);
+const app = await readFile(new URL("web/js/app.js", akar), "utf8");
+const live = await readFile(new URL("live/live.js", akar), "utf8");
+const workflow = await readFile(
+  new URL(".github/workflows/publish-live.yml", akar), "utf8");
+
+test("saklar panitia menyediakan fase Top 10", () => {
+  assert.match(app, /\["top10", "Top 10"\]/);
+  assert.match(app, /aturFaseLive\(ke\)/);
+});
+
+test("Top 10 dibatasi per golongan dan membuang regu tanpa peringkat", () => {
+  assert.match(live, /k\.peringkat === null \|\| k\.peringkat === undefined/);
+  assert.match(live, /if \(jumlah >= 10\) return false/);
+  assert.match(live, /jumlahGolongan\.set\(k\.golongan, jumlah \+ 1\)/);
+});
+
+test("papan Top 10 hanya menggambar identitas dan Total", () => {
+  const awal = live.indexOf(': top10 ? `');
+  const akhir = live.indexOf('\n      : `', awal);
+  const papan = live.slice(awal, akhir);
+  for (const kepala of ["#", "No<br>Dada", "Regu", "Organisasi", "Total"])
+    assert.ok(papan.includes(kepala), `kolom ${kepala} hilang dari Top 10`);
+  for (const kepala of ["Penalti", "Kontrak", "Pos 1", "Berangkat"])
+    assert.ok(!papan.includes(kepala), `kolom ${kepala} ikut ke Top 10`);
+});
+
+test("berkas Top 10 tidak menerbitkan rincian nilai tersembunyi", () => {
+  assert.match(workflow,
+    /kunci_top = \('peringkat', 'nomor_dada', 'nama_regu',[\s\S]*'golongan', 'total'\)/);
+  assert.match(workflow, /if d\['fase'\] == 'top10'/);
+});

--- a/tests/public_phase_downgrade.test.mjs
+++ b/tests/public_phase_downgrade.test.mjs
@@ -13,10 +13,12 @@ const barisPapan = live.slice(awalBaris, awalPapan);
 const gambarPapan = live.slice(awalPapan, akhirPapan);
 
 
-test("klasemen cache hanya menentukan urutan pada fase penuh", () => {
-  assert.match(barisPapan, /function barisPapan\(penuh\)/);
-  assert.match(barisPapan, /if \(penuh && klasemen\.length\)/);
-  assert.match(gambarPapan, /const penuh = fase\(\) === "penuh";\s+const semua = barisPapan\(penuh\);/);
+test("klasemen cache hanya terbuka pada fase Live atau Top 10", () => {
+  assert.match(barisPapan,
+    /function barisPapan\(klasemenTerbuka, top10 = false\)/);
+  assert.match(barisPapan, /if \(klasemenTerbuka && klasemen\.length\)/);
+  assert.match(gambarPapan,
+    /const top10 = fase\(\) === "top10";\s+const semua = barisPapan\(penuh \|\| top10, top10\);/);
 });
 
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -686,5 +686,7 @@ run supabase/migrations/0143_juara_harus_tiba.sql
 run tests/sql/95_juara_harus_tiba.sql
 run supabase/migrations/0144_tampilkan_regu_belum_tiba.sql
 run tests/sql/96_tampilkan_regu_belum_tiba.sql
+run supabase/migrations/0145_top_10_live_score.sql
+run tests/sql/97_top_10_live_score.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/97_top_10_live_score.sql
+++ b/tests/sql/97_top_10_live_score.sql
@@ -1,0 +1,42 @@
+-- Top 10 harus menjadi fase sah dan hanya menerbitkan maksimal sepuluh regu
+-- eligible per golongan. Peringkat NULL berarti regu belum tiba dan tidak
+-- boleh ikut walaupun total sementara sudah ada.
+
+do $blok$
+declare
+  v_fase_lama text;
+  v_golongan text;
+  v_aktual integer;
+  v_harapan integer;
+begin
+  select fase_live into v_fase_lama from status_acara;
+
+  perform set_config(
+    'app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  assert atur_fase_live('top10') = 'top10',
+    '97.1 GAGAL: admin tidak bisa memilih Top 10';
+
+  assert not exists (
+    select 1 from v_klasemen_publik where peringkat is null
+  ), '97.2 GAGAL: regu yang tidak eligible ikut Top 10';
+
+  assert not exists (
+    select 1 from v_klasemen_publik
+    group by golongan having count(*) > 10
+  ), '97.3 GAGAL: satu golongan memuat lebih dari sepuluh regu';
+
+  for v_golongan in select distinct golongan from v_klasemen loop
+    select count(*) into v_aktual
+    from v_klasemen_publik where golongan = v_golongan;
+    select least(count(*), 10) into v_harapan
+    from v_klasemen where golongan = v_golongan;
+    assert v_aktual = v_harapan,
+      format('97.4 GAGAL: %s memuat %s regu, seharusnya %s',
+             v_golongan, v_aktual, v_harapan);
+  end loop;
+
+  update status_acara set fase_live = v_fase_lama where id = true;
+end;
+$blok$;
+
+select '97_top_10_live_score OK' hasil;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -867,7 +867,7 @@ export const hapusNilaiPos = (nomorDada, kode, pos) =>
 /** Klasemen yang AKAN dilihat peserta, dibuka lebih awal untuk admin
  *  (0049, dinamai ulang 0050).
  *
- *  Bukan `v_klasemen_publik`: view itu dipagari `fase_live = 'penuh'` dan
+ *  Bukan `v_klasemen_publik`: view itu dipagari fase publik dan
  *  pagar itu yang menahan hasil lomba supaya tidak bocor sebelum diumumkan.
  *  Yang ini dipagari peran, dan hanya admin yang mendapat baris. */
 export async function klasemenLiveScore() {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5614,12 +5614,13 @@ async function layarLiveScore() {
      tahapan, bukan akibat. "Internal" langsung menjawab pertanyaan yang
      sebenarnya ditanyakan: apakah peserta sudah bisa melihat ini.
 
-     Kodenya TETAP pra/progres/penuh. Nilai itu duduk di status_acara, dipakai
+     Kodenya TETAP pra/progres/penuh/top10. Nilai itu duduk di status_acara, dipakai
      v_progres_publik, keempat pagar "BOCOR" di publish-live.yml, dan migrasi
      0068/0070/0072 — menggantinya menuntut migrasi beserta seluruh policy,
      demi tiga kata di layar. */
   const FASE = [
     ["pra", "Internal"], ["progres", "Progress"], ["penuh", "Live"],
+    ["top10", "Top 10"],
   ];
   const saklar = !bisaPublish ? "" : `
     <div class="segmen-fase" role="group" aria-label="Fase Live Score">
@@ -5861,9 +5862,9 @@ async function layarLiveScore() {
      lain tidak melihat apa pun di tempat ini, bukan tombol mati: tombol mati
      di pojok tidak memberi tahu apa pun selain ada sesuatu yang tidak boleh
      disentuh. */
-  /* Judul di TENGAH, saklar tiga keadaan di KANAN, satu baris.
+  /* Judul di TENGAH, saklar empat keadaan di KANAN, satu baris.
      Tombol besar sebelumnya memakan tinggi layar untuk sesuatu yang ditekan
-     dua kali sepanjang acara. Tiga keadaan ditampilkan sekaligus, bukan satu
+     beberapa kali sepanjang acara. Empat keadaan ditampilkan sekaligus, bukan satu
      tombol yang berganti tulisan: dengan begitu fase yang SEDANG berlaku
      terbaca tanpa harus tahu apa arti tulisan tombolnya.
 
@@ -5946,7 +5947,10 @@ async function layarLiveScore() {
            ini, admin menekan Live, membaca "peserta dapat melihat", dan
            peserta tetap melihat papan kosong tanpa satu pun tanda kenapa —
            cron penerbitan berkala masih dimatikan di luar minggu lomba. */
-        notif(ke === "penuh"
+        notif(ke === "top10"
+          ? "Peserta dapat melihat Top 10 per golongan — jalankan Publish "
+            + "rekap live supaya angkanya ikut terbit."
+          : ke === "penuh"
           ? "Live Score aktif. Peserta dapat melihat rekapitulasi penuh — "
             + "jalankan Publish rekap live supaya angkanya ikut terbit."
           : ke === "progres" ? "Peserta dapat melihat progress live score."

--- a/web/style.css
+++ b/web/style.css
@@ -854,9 +854,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
 .printout { display: none; }
 
-/* Saklar tiga keadaan Live Score. Tiga tombol yang menempel jadi satu
-   batang: yang sedang berlaku memakai warna utama, dua lainnya diam. Bukan
-   satu tombol yang berganti tulisan — dengan tiga terlihat sekaligus, fase
+/* Saklar empat keadaan Live Score. Tombol-tombol yang menempel jadi satu
+   batang: yang sedang berlaku memakai warna utama, lainnya diam. Bukan
+   satu tombol yang berganti tulisan — dengan semua terlihat sekaligus, fase
    yang berlaku terbaca tanpa harus tahu arti tulisan tombolnya. */
 .segmen-fase { display: inline-flex; gap: 0; }
 /* Baris kepala kartu klasemen: judul di TENGAH, saklar di KANAN, dan judulnya


### PR DESCRIPTION
## What

- add Top 10 as the fourth Live Score publication phase
- publish at most ten ranking-eligible teams per division with Total only
- strip per-post scores and penalty details from Top 10 public data
- add database, UI, publishing, and regression coverage

## Why

Provide a compact public leaderboard without exposing the full per-post score breakdown.