### PR TITLE
fix: serve live score from private snapshot

### DIFF
--- a/.github/workflows/refresh-live-score.yml
+++ b/.github/workflows/refresh-live-score.yml
@@ -1,0 +1,34 @@
+name: Refresh Live Score cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 08:00-23:59 WIB pada hari lomba. GitHub cron memakai UTC.
+    - cron: '*/5 1-16 29 8 *'
+
+concurrency:
+  group: refresh-live-score
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Periksa hari lomba
+        id: jadwal
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" != "schedule" ] || [[ "$(date -u '+%Y-%m-%dT%H:%M')" =~ ^2026-08-29T(0[1-9]|1[0-6]): ]]; then
+            echo "aktif=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "aktif=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Refresh snapshot
+        if: steps.jadwal.outputs.aktif == 'true'
+        env:
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          psql "$DB_URL" -v ON_ERROR_STOP=1 -c 'select segarkan_cache_live_score();'

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0145`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0146`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0145`.
+`0119`-`0146`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-145 migrasi, `0001` sampai `0145`, dijalankan berurutan tanpa lubang penomoran.
+146 migrasi, `0001` sampai `0146`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -785,6 +785,25 @@ export async function kelengkapanPos() {
   return baca(null, "v_kelengkapan_pos?select=*&order=pos.asc");
 }
 
+/** Snapshot privat untuk papan Live Score panitia.
+ *
+ *  Seluruh kalkulasi berat dijalankan scheduled job satu kali tiap lima menit,
+ *  bukan sekali per HP yang membuka layar. Status fase tetap dibaca langsung
+ *  karena saklar publish harus berubah seketika. */
+export async function cacheLiveScore() {
+  if (K.mode === "dev") {
+    const [kelengkapan, pos, komponen, rekap] = await Promise.all([
+      baca("/kelengkapan-pos"), baca("/pos"), baca("/komponen-semua"),
+      baca("/rekap-penuh"),
+    ]);
+    return { dibuat_pada: new Date().toISOString(), kelengkapan, pos, komponen, rekap };
+  }
+  const d = await baca(null,
+    "cache_live_score?select=dibuat_pada,data&tunggal=eq.true");
+  if (!d.length) throw new ErrorApi("Cache Live Score belum tersedia.");
+  return { dibuat_pada: d[0].dibuat_pada, ...d[0].data };
+}
+
 /** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
  *
  *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena

--- a/supabase/migrations/0146_cache_live_score.sql
+++ b/supabase/migrations/0146_cache_live_score.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- hrcd-rekap : 0146_cache_live_score.sql
+-- Snapshot privat Live Score agar satu kalkulasi dipakai seluruh panitia.
+--
+-- v_rekap_penuh menghitung seluruh rantai nilai. Menjalankannya saat setiap HP
+-- membuka papan membuat lonjakan yang tidak ada gunanya: Live Score boleh
+-- tertinggal beberapa menit. Snapshot terakhir tidak dihapus ketika refresh
+-- gagal, sehingga layar tetap berguna dan cap waktunya tetap jujur.
+-- ============================================================================
+
+create table cache_live_score (
+  tunggal       boolean primary key default true check (tunggal),
+  dibuat_pada   timestamptz not null,
+  data          jsonb not null
+);
+
+alter table cache_live_score enable row level security;
+
+create policy sel_cache_live_score on cache_live_score for select
+using (boleh('live_score'));
+
+grant select on cache_live_score to authenticated, service_role;
+revoke all on cache_live_score from anon;
+
+create or replace function segarkan_cache_live_score()
+returns timestamptz
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_dibuat timestamptz := clock_timestamp();
+  v_data jsonb;
+begin
+  -- View panitia tetap menjaga boleh('live_score'). Scheduled job bekerja
+  -- tanpa JWT, jadi pilih satu akun aktif yang memang memegang hak itu hanya
+  -- selama transaksi ini; RLS dan pagar view tetap menjalani jalur produksi.
+  select h.user_id into v_uid
+  from akun_hak h
+  join akun_panitia a on a.user_id = h.user_id
+  where h.fitur = 'live_score' and a.is_active
+  order by h.user_id
+  limit 1;
+
+  if v_uid is null then
+    raise exception 'Tidak ada akun aktif dengan hak live_score';
+  end if;
+
+  perform set_config('request.jwt.claim.sub', v_uid::text, true);
+  -- Harness PostgreSQL lokal memakai app.uid sebagai tiruan auth.uid().
+  perform set_config('app.uid', v_uid::text, true);
+
+  select jsonb_build_object(
+    'kelengkapan', (select coalesce(jsonb_agg(to_jsonb(x) order by x.pos), '[]')
+                    from v_kelengkapan_pos x),
+    'pos',         (select coalesce(jsonb_agg(to_jsonb(x) order by x.nomor), '[]')
+                    from v_pos x),
+    'komponen',    (select coalesce(jsonb_agg(to_jsonb(x)
+                                      order by x.pos, x.sort_order), '[]')
+                    from wahana x where x.edisi = edisi_aktif()),
+    'rekap',       (select coalesce(jsonb_agg(to_jsonb(x)
+                                      order by x.nomor_dada), '[]')
+                    from v_rekap_penuh x)
+  ) into v_data;
+
+  insert into cache_live_score (tunggal, dibuat_pada, data)
+  values (true, v_dibuat, v_data)
+  on conflict (tunggal) do update
+  set dibuat_pada = excluded.dibuat_pada,
+      data = excluded.data;
+
+  return v_dibuat;
+end;
+$$;
+
+revoke all on function segarkan_cache_live_score() from public, anon, authenticated;
+grant execute on function segarkan_cache_live_score() to service_role;
+
+select segarkan_cache_live_score();
+
+comment on table cache_live_score is
+  'Snapshot privat Live Score panitia. Satu baris, diganti utuh tiap refresh; pembaca wajib memegang hak live_score.';
+comment on function segarkan_cache_live_score() is
+  'Hitung ulang snapshot Live Score. Dipanggil scheduled job, bukan oleh HP panitia.';

--- a/tests/live_score_loading.test.mjs
+++ b/tests/live_score_loading.test.mjs
@@ -19,10 +19,11 @@ test("pembacaan Live Score yang putus dicoba satu kali lagi", () => {
 });
 
 
-test("status dan kelengkapan boleh gagal tanpa merobohkan papan", () => {
-  assert.match(layar, /muatDataLiveScore\(kelengkapanPos, \[\]\)/);
+test("Live Score membaca satu snapshot dan status ringan", () => {
+  assert.match(layar, /muatDataLiveScore\(cacheLiveScore\)/);
   assert.match(layar, /muatDataLiveScore\(statusAcara, null\)/);
-  assert.match(layar, /muatDataLiveScore\(rekapPenuh\)/);
+  assert.doesNotMatch(layar, /muatDataLiveScore\(rekapPenuh\)/);
+  assert.doesNotMatch(layar, /muatDataLiveScore\(kelengkapanPos/);
 });
 
 
@@ -31,4 +32,9 @@ test("klasemen memakai hasil rekap tanpa menghitung skor dua kali", () => {
   assert.match(layar, /const klasemen = rekap/);
   assert.match(layar, /\.filter\(r => r\.sudah_berangkat\)/);
   assert.match(layar, /poin_per_pos: r\.poin_pos/);
+});
+
+
+test("umur snapshot terlihat di layar", () => {
+  assert.match(layar, /Update \$\{esc\(tanggalJam\(snapshot\.dibuat_pada\)\)\}/);
 });

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -688,5 +688,7 @@ run supabase/migrations/0144_tampilkan_regu_belum_tiba.sql
 run tests/sql/96_tampilkan_regu_belum_tiba.sql
 run supabase/migrations/0145_top_10_live_score.sql
 run tests/sql/97_top_10_live_score.sql
+run supabase/migrations/0146_cache_live_score.sql
+run tests/sql/98_cache_live_score.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/98_cache_live_score.sql
+++ b/tests/sql/98_cache_live_score.sql
@@ -1,0 +1,39 @@
+\echo '--- 98. cache Live Score privat dan lengkap'
+
+do $$
+declare
+  v_n int;
+  v_data jsonb;
+begin
+  perform segarkan_cache_live_score();
+
+  select count(*) into v_n from cache_live_score;
+  select data into v_data from cache_live_score where tunggal;
+  assert v_n = 1, format('98.1 GAGAL: cache berisi %s baris, seharusnya satu', v_n);
+  assert v_data ?& array['kelengkapan', 'pos', 'komponen', 'rekap'],
+    '98.2 GAGAL: bentuk snapshot tidak lengkap';
+end;
+$$;
+
+do $$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_n int;
+begin
+  set local role authenticated;
+  perform set_config('app.uid', v_juri::text, true);
+  select count(*) into v_n from cache_live_score;
+  assert v_n = 1, '98.3 GAGAL: pemegang live_score tidak dapat membaca cache';
+
+  reset role;
+  delete from akun_hak where user_id = v_juri and fitur = 'live_score';
+  set local role authenticated;
+  select count(*) into v_n from cache_live_score;
+  reset role;
+  insert into akun_hak (user_id, fitur) values (v_juri, 'live_score')
+  on conflict do nothing;
+  assert v_n = 0, '98.4 GAGAL: cache terbaca tanpa hak live_score';
+end;
+$$;
+
+\echo '98 cache live score: LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -785,6 +785,25 @@ export async function kelengkapanPos() {
   return baca(null, "v_kelengkapan_pos?select=*&order=pos.asc");
 }
 
+/** Snapshot privat untuk papan Live Score panitia.
+ *
+ *  Seluruh kalkulasi berat dijalankan scheduled job satu kali tiap lima menit,
+ *  bukan sekali per HP yang membuka layar. Status fase tetap dibaca langsung
+ *  karena saklar publish harus berubah seketika. */
+export async function cacheLiveScore() {
+  if (K.mode === "dev") {
+    const [kelengkapan, pos, komponen, rekap] = await Promise.all([
+      baca("/kelengkapan-pos"), baca("/pos"), baca("/komponen-semua"),
+      baca("/rekap-penuh"),
+    ]);
+    return { dibuat_pada: new Date().toISOString(), kelengkapan, pos, komponen, rekap };
+  }
+  const d = await baca(null,
+    "cache_live_score?select=dibuat_pada,data&tunggal=eq.true");
+  if (!d.length) throw new ErrorApi("Cache Live Score belum tersedia.");
+  return { dibuat_pada: d[0].dibuat_pada, ...d[0].data };
+}
+
 /** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
  *
  *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -20,7 +20,8 @@ import {
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
   rentangNomorDada,
-  komponenSemua, rekapPenuh, kelengkapanPos, riwayatNilai, riwayatPendaftaran,
+  komponenSemua, rekapPenuh, kelengkapanPos, cacheLiveScore,
+  riwayatNilai, riwayatPendaftaran,
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto,
   hasilKejuaraan, simpanKejuaraanManual,
@@ -5466,9 +5467,9 @@ let pengendaliFilterSekolah = null;
 
 /** Satu request yang putus tidak boleh merobohkan seluruh papan.
  *
- *  Live Score menarik lima sumber sekaligus. Di koneksi lapangan, satu dari
- *  lima request kadang putus walau empat lainnya sudah sampai; Promise.all
- *  lalu membuang keempatnya dan mengganti seluruh layar dengan kartu galat.
+ *  Live Score menarik snapshot skor dan status acara. Di koneksi lapangan,
+ *  salah satunya kadang putus walau yang lain sudah sampai; Promise.all lalu
+ *  membuang hasil yang berhasil dan mengganti seluruh layar dengan kartu galat.
  *  Semua pembacaan ini idempotent, jadi yang gagal aman dicoba sekali lagi.
  *
  *  Status acara dan cincin kelengkapan hanya keterangan tambahan. Setelah
@@ -5490,20 +5491,22 @@ async function layarLiveScore() {
   LAYAR.replaceChildren(h(pemuat()));
   const layarIni = location.hash;
 
-  let pos, status, posSemua, komponen, rekap;
+  let snapshot, status;
   try {
-    [pos, status, posSemua, komponen, rekap] = await Promise.all([
-      muatDataLiveScore(kelengkapanPos, []),
+    [snapshot, status] = await Promise.all([
+      muatDataLiveScore(cacheLiveScore),
       muatDataLiveScore(statusAcara, null),
-      muatDataLiveScore(daftarPos),
-      muatDataLiveScore(() => komponenSemua(EDISI.nomor)),
-      muatDataLiveScore(rekapPenuh),
     ]);
   } catch (e) {
     LAYAR.replaceChildren(kartuGagalMuat(e.message, layarLiveScore));
     return;
   }
   if (location.hash !== layarIni) return;
+
+  const pos = snapshot.kelengkapan || [];
+  const posSemua = snapshot.pos || [];
+  const komponen = snapshot.komponen || [];
+  const rekap = snapshot.rekap || [];
 
   /* v_rekap_penuh sudah menghitung peringkat, total, penalti, dan poin per pos
      yang sama dengan klasemen_live_score(). Meminta keduanya membuat database
@@ -5553,6 +5556,7 @@ async function layarLiveScore() {
         <span class="js-persen">${esc(String(persenSemua))}%</span>
         <span class="kr-panah" aria-hidden="true">▾</span>
       </button>
+      <div class="description">Update ${esc(tanggalJam(snapshot.dibuat_pada))}</div>
       <ul class="kemajuan" id="kemajuan-rinci">
         ${pos.map(p => {
           const s = persenPos(p);
@@ -5870,8 +5874,8 @@ async function layarLiveScore() {
     ${papan}`));
 
   /* Diperbarui DI TEMPAT, bukan dengan menggambar ulang layar.
-     layarLiveScore() menarik lima permintaan sekaligus — rekap, kelengkapan,
-     pos, komponen, status — dan menggambar ulang seluruh papan.
+     layarLiveScore() menarik snapshot dan status, lalu menggambar ulang
+     seluruh papan.
      Untuk satu kolom yang berpindah itu mahal, dan yang paling terasa: papan
      berkedip dan tab golongan yang sedang dibuka kembali ke awal. Yang
      berubah di layar cuma tombol mana yang menyala. */


### PR DESCRIPTION
## What

- cache the private panitia Live Score payload in Supabase
- refresh the snapshot every five minutes during the event window
- make the screen read one protected snapshot plus the live phase
- show the snapshot timestamp and retain the last valid result

## Why

Opening Live Score still recalculated the full standings for every panitia device. A shared private snapshot changes that cost to one calculation every five minutes without exposing Intern or unpublished score data.