### PR TITLE
fix: load championship options from snapshot

### DIFF
--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -4,6 +4,8 @@ import test from "node:test";
 
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
 const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+const awal = app.indexOf("async function layarKejuaraan()");
+const layar = app.slice(awal, app.indexOf("/* ============================ AKUN", awal));
 
 test("Kejuaraan dibagi menjadi section yang dibaca panitia", () => {
   for (const judul of ["Juara Umum", "Juara Umum Penegak", "Penegak PA", "Penegak PI",
@@ -25,6 +27,12 @@ test("pilihan manual hanya menawarkan regu Eksternal yang sudah tiba", () => {
   assert.doesNotMatch(app, /Hapus pilihan/);
   assert.match(app, /kejuaraan-terkunci" \$\{x\.regu_id \? "" : "hidden"\}/);
   assert.match(app, /terkunci\.hidden = true;\s*isian\.hidden = false;/);
+});
+
+test("pilihan manual memakai snapshot tanpa menghitung rekap lagi", () => {
+  assert.match(layar, /bisaUbah \? cacheLiveScore\(\)/);
+  assert.match(layar, /snapshot \? snapshot\.rekap \|\| \[\] : \[\]/);
+  assert.doesNotMatch(layar, /rekapPenuh\(/);
 });
 
 test("menyimpan juara mengunci baris tanpa memuat ulang layar", () => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6085,15 +6085,19 @@ async function layarKejuaraan() {
   LAYAR.replaceChildren(h(pemuat()));
   const layarIni = location.hash;
   const bisaUbah = bolehLihat("pengaturan");
-  let hasil, regu;
+  let hasil, snapshot;
   try {
-    [hasil, regu] = await Promise.all([
-      hasilKejuaraan(), bisaUbah ? rekapPenuh() : Promise.resolve([]),
+    [hasil, snapshot] = await Promise.all([
+      hasilKejuaraan(), bisaUbah ? cacheLiveScore() : Promise.resolve(null),
     ]);
   }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarKejuaraan)); return; }
   if (location.hash !== layarIni) return;
 
+  /* Pilihan penghargaan manual hanya butuh identitas regu dan jam datang.
+     Semuanya sudah ada di snapshot Live Score; menjalankan v_rekap_penuh lagi
+     di sini membuat layar Kejuaraan mengulang seluruh kalkulasi skor. */
+  const regu = snapshot ? snapshot.rekap || [] : [];
   const opsi = [...new Map(regu.filter(r => r.nomor_dada != null && r.jam_datang != null
       && !String(r.golongan).startsWith("intern_"))
     .map(r => [r.regu_id, r])).values()]


### PR DESCRIPTION
## What

- load manual championship candidates from the existing private Live Score snapshot
- keep championship results live so manual winner changes remain immediate
- add regression coverage preventing the full recap query from returning

## Why

The Kejuaraan screen recalculated the complete recap only to populate three manual winner search fields. The five-minute snapshot already contains the required team identity and arrival data.