### PR TITLE
fix: sort cached live score by ranking

### DIFF
--- a/tests/live_score_loading.test.mjs
+++ b/tests/live_score_loading.test.mjs
@@ -38,3 +38,10 @@ test("klasemen memakai hasil rekap tanpa menghitung skor dua kali", () => {
 test("umur snapshot terlihat di layar", () => {
   assert.match(layar, /Update \$\{esc\(tanggalJam\(snapshot\.dibuat_pada\)\)\}/);
 });
+
+
+test("snapshot diurutkan menurut peringkat dan score, bukan nomor dada", () => {
+  assert.match(layar, /Number\(a\.peringkat\) - Number\(b\.peringkat\)/);
+  assert.match(layar, /Number\(b\.total\) - Number\(a\.total\)/);
+  assert.doesNotMatch(layar, /Number\(a\.nomor_dada\)|Number\(b\.nomor_dada\)/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5515,7 +5515,15 @@ async function layarLiveScore() {
      poin dinormalkan di sini agar bentuk data untuk penggambar tidak berubah. */
   const klasemen = rekap
     .filter(r => r.sudah_berangkat)
-    .map(r => ({ ...r, poin_per_pos: r.poin_pos }));
+    .map(r => ({ ...r, poin_per_pos: r.poin_pos }))
+    .sort((a, b) => {
+      const aPunyaPeringkat = a.peringkat != null;
+      const bPunyaPeringkat = b.peringkat != null;
+      if (aPunyaPeringkat !== bPunyaPeringkat) return aPunyaPeringkat ? -1 : 1;
+      if (aPunyaPeringkat && a.peringkat !== b.peringkat)
+        return Number(a.peringkat) - Number(b.peringkat);
+      return Number(b.total) - Number(a.total);
+    });
 
   // `let`, bukan `const`: saklar di bawah memperbaruinya DI TEMPAT.
   let fase = (status && status.fase_live) || "pra";


### PR DESCRIPTION
## What

- sort cached Live Score rows by ranking and descending score
- keep teams without a recorded arrival below ranked teams
- preserve the cached data path without new database queries

## Why

The private snapshot is stored by chest number, and the screen inherited that order after switching to the cache.