### PR TITLE
fix: score zero time as zero at pos 2

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0146`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0147`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0146`.
+`0119`-`0147`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-146 migrasi, `0001` sampai `0146`, dijalankan berurutan tanpa lubang penomoran.
+147 migrasi, `0001` sampai `0147`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0147_waktu_nol_pos_2.sql
+++ b/supabase/migrations/0147_waktu_nol_pos_2.sql
@@ -17,8 +17,21 @@ where edisi = edisi_aktif()
   and not tingkat @> '[{"sampai": 0, "poin": 0}]'::jsonb;
 
 do $$
-declare v_n int;
+declare v_total int; v_n int;
 begin
+  select count(*) into v_total
+  from wahana
+  where edisi = edisi_aktif() and pos = 2 and satuan = 'detik'
+    and form = 'bertingkat';
+
+  if v_total = 0 then
+    raise notice '0147: konfigurasi ini tidak punya komponen waktu Pos 2 — dilewati.';
+    return;
+  end if;
+
+  assert v_total = 3,
+    format('0147: ditemukan %s komponen waktu Pos 2, seharusnya 3', v_total);
+
   select count(*) into v_n
   from wahana
   where edisi = edisi_aktif() and pos = 2 and satuan = 'detik'

--- a/supabase/migrations/0147_waktu_nol_pos_2.sql
+++ b/supabase/migrations/0147_waktu_nol_pos_2.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- hrcd-rekap : 0147_waktu_nol_pos_2.sql
+-- Waktu 00:00 di Pos 2 berarti tidak menyelesaikan lomba, jadi nol poin.
+--
+-- Tangga lama membaca semua waktu sampai batas pertama sebagai nilai penuh;
+-- akibatnya 0 detik mendapat 100. Tingkat khusus tepat di nol memperbaikinya
+-- tanpa mengubah 1 detik sampai batas pertama, dan tanpa mengubah Menaksir
+-- yang memang sah bernilai mentah nol.
+-- ============================================================================
+
+update wahana
+set tingkat = jsonb_build_array(jsonb_build_object('sampai', 0, 'poin', 0)) || tingkat
+where edisi = edisi_aktif()
+  and pos = 2
+  and satuan = 'detik'
+  and form = 'bertingkat'
+  and not tingkat @> '[{"sampai": 0, "poin": 0}]'::jsonb;
+
+do $$
+declare v_n int;
+begin
+  select count(*) into v_n
+  from wahana
+  where edisi = edisi_aktif() and pos = 2 and satuan = 'detik'
+    and form = 'bertingkat'
+    and tingkat @> '[{"sampai": 0, "poin": 0}]'::jsonb;
+  assert v_n = 3,
+    format('0147: tingkat nol terpasang pada %s komponen Pos 2, seharusnya 3', v_n);
+end;
+$$;
+
+-- Snapshot harus langsung membawa hasil baru; scheduled refresh berikutnya
+-- tetap akan menjaganya setiap lima menit.
+select segarkan_cache_live_score();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -690,5 +690,7 @@ run supabase/migrations/0145_top_10_live_score.sql
 run tests/sql/97_top_10_live_score.sql
 run supabase/migrations/0146_cache_live_score.sql
 run tests/sql/98_cache_live_score.sql
+run supabase/migrations/0147_waktu_nol_pos_2.sql
+run tests/sql/99_waktu_nol_pos_2.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/99_waktu_nol_pos_2.sql
+++ b/tests/sql/99_waktu_nol_pos_2.sql
@@ -4,12 +4,14 @@ do $$
 declare
   v_w wahana%rowtype;
   v_poin numeric;
+  v_n int := 0;
 begin
   for v_w in
     select * from wahana
     where edisi = edisi_aktif() and pos = 2 and satuan = 'detik'
     order by kode
   loop
+    v_n := v_n + 1;
     v_poin := hitung_poin(v_w.form, 0, null, v_w.poin_maks,
       v_w.raw_terbaik, v_w.raw_terburuk, v_w.poin_benar, v_w.poin_salah,
       v_w.total_soal, v_w.tingkat);
@@ -23,7 +25,17 @@ begin
       format('99.2 GAGAL: %s pada 00:01 mendapat %s poin', v_w.kode, v_poin);
   end loop;
 
-  assert found, '99.3 GAGAL: komponen waktu Pos 2 tidak ditemukan';
+  -- Database test generik tidak selalu memuat konfigurasi lomba XXXVII.
+  -- Tangga representatif tetap membuktikan batas khusus 0 tidak mengubah
+  -- waktu positif pertama.
+  if v_n = 0 then
+    assert hitung_poin('bertingkat', 0, null, 100, null, null, null, null,
+      null, '[{"sampai":0,"poin":0},{"sampai":30,"poin":100}]') = 0,
+      '99.3 GAGAL: tangga 00:00 tidak menghasilkan nol';
+    assert hitung_poin('bertingkat', 1, null, 100, null, null, null, null,
+      null, '[{"sampai":0,"poin":0},{"sampai":30,"poin":100}]') = 100,
+      '99.4 GAGAL: tingkat nol mengubah waktu positif';
+  end if;
 end;
 $$;
 

--- a/tests/sql/99_waktu_nol_pos_2.sql
+++ b/tests/sql/99_waktu_nol_pos_2.sql
@@ -1,0 +1,30 @@
+\echo '--- 99. waktu 00:00 Pos 2 bernilai nol'
+
+do $$
+declare
+  v_w wahana%rowtype;
+  v_poin numeric;
+begin
+  for v_w in
+    select * from wahana
+    where edisi = edisi_aktif() and pos = 2 and satuan = 'detik'
+    order by kode
+  loop
+    v_poin := hitung_poin(v_w.form, 0, null, v_w.poin_maks,
+      v_w.raw_terbaik, v_w.raw_terburuk, v_w.poin_benar, v_w.poin_salah,
+      v_w.total_soal, v_w.tingkat);
+    assert v_poin = 0,
+      format('99.1 GAGAL: %s pada 00:00 mendapat %s poin', v_w.kode, v_poin);
+
+    v_poin := hitung_poin(v_w.form, 1, null, v_w.poin_maks,
+      v_w.raw_terbaik, v_w.raw_terburuk, v_w.poin_benar, v_w.poin_salah,
+      v_w.total_soal, v_w.tingkat);
+    assert v_poin = 100,
+      format('99.2 GAGAL: %s pada 00:01 mendapat %s poin', v_w.kode, v_poin);
+  end loop;
+
+  assert found, '99.3 GAGAL: komponen waktu Pos 2 tidak ditemukan';
+end;
+$$;
+
+\echo '99 waktu nol Pos 2: LULUS'


### PR DESCRIPTION
## What

- add a zero-point step for exactly 00:00 on all three timed Pos 2 events
- keep positive times on their existing scoring ladders
- refresh the private Live Score snapshot immediately after migration
- add SQL regression coverage

## Why

The ascending time ladders treated zero seconds as faster than the first threshold and awarded 100 points. At Pos 2, 00:00 means the event was not completed and must award zero.