### PR TITLE
fix: rank overall champion by title points

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0147`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0148`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0147`.
+`0119`-`0148`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-147 migrasi, `0001` sampai `0147`, dijalankan berurutan tanpa lubang penomoran.
+148 migrasi, `0001` sampai `0148`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0148_juara_umum_berdasarkan_poin.sql
+++ b/supabase/migrations/0148_juara_umum_berdasarkan_poin.sql
@@ -1,0 +1,32 @@
+-- ============================================================================
+-- hrcd-rekap : 0148_juara_umum_berdasarkan_poin.sql
+-- Juara Umum ditentukan total poin gelar, bukan banyaknya gelar.
+--
+-- Juara I sampai Harapan III bernilai 6, 5, 4, 3, 2, 1. Versi lama sudah
+-- menghitung bobot itu, tetapi masih mengurutkan jumlah gelar lebih dahulu;
+-- enam Harapan dapat mengalahkan tiga Juara I. Jumlah skor lomba tetap menjadi
+-- tie-breaker ketika total poin gelarnya sama.
+-- ============================================================================
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+  v_lama text := 'order by jumlah_juara desc, bobot_juara desc, jumlah_skor desc, nama_sekolah';
+  v_baru text := 'order by bobot_juara desc, jumlah_skor desc, nama_sekolah';
+begin
+  assert position(v_lama in v_def) > 0,
+    '0148: urutan lama hasil_kejuaraan() tidak ditemukan';
+  v_def := replace(v_def, v_lama, v_baru);
+  execute v_def;
+end;
+$$;
+
+do $$
+declare v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+begin
+  assert v_def like '%order by bobot_juara desc, jumlah_skor desc, nama_sekolah%',
+    '0148: total poin gelar belum menjadi urutan utama';
+  assert v_def not like '%order by jumlah_juara desc, bobot_juara desc%',
+    '0148: jumlah gelar masih mengalahkan total poin';
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -692,5 +692,7 @@ run supabase/migrations/0146_cache_live_score.sql
 run tests/sql/98_cache_live_score.sql
 run supabase/migrations/0147_waktu_nol_pos_2.sql
 run tests/sql/99_waktu_nol_pos_2.sql
+run supabase/migrations/0148_juara_umum_berdasarkan_poin.sql
+run tests/sql/100_juara_umum_poin.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/100_juara_umum_poin.sql
+++ b/tests/sql/100_juara_umum_poin.sql
@@ -1,0 +1,27 @@
+\echo '--- 100. Juara Umum berdasarkan poin gelar'
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+  v_juara text;
+begin
+  assert v_def like '%order by bobot_juara desc, jumlah_skor desc, nama_sekolah%',
+    '100.1 GAGAL: hasil_kejuaraan tidak mengurutkan total poin lebih dahulu';
+  assert v_def not like '%order by jumlah_juara desc, bobot_juara desc%',
+    '100.2 GAGAL: banyaknya gelar masih mengalahkan total poin';
+
+  -- ALPHA: empat gelar = 6+5+6+3 = 20.
+  -- GAMMA: lima gelar = 4+3+5+4+2 = 18.
+  with gelar(sekolah, poin) as (values
+    ('ALPHA', 6), ('ALPHA', 5), ('ALPHA', 6), ('ALPHA', 3),
+    ('GAMMA', 4), ('GAMMA', 3), ('GAMMA', 5), ('GAMMA', 4), ('GAMMA', 2)
+  )
+  select sekolah into v_juara
+  from gelar group by sekolah order by sum(poin) desc limit 1;
+
+  assert v_juara = 'ALPHA',
+    format('100.3 GAGAL: empat gelar 20 poin kalah dari lima gelar 18 poin: %s', v_juara);
+end;
+$$;
+
+\echo '100 juara umum poin: LULUS'


### PR DESCRIPTION
## What

- rank Juara Umum by title points: 6, 5, 4, 3, 2, 1
- use total competition score only as the tie-breaker
- add regression coverage where four high placements beat five lower placements

## Why

The existing query calculated title points but incorrectly sorted by the number of titles first.