### PR TITLE
fix: rank schools without title points last

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0148`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0149`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0148`.
+`0119`-`0149`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-148 migrasi, `0001` sampai `0148`, dijalankan berurutan tanpa lubang penomoran.
+149 migrasi, `0001` sampai `0149`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0149_juara_umum_tanpa_poin_di_bawah.sql
+++ b/supabase/migrations/0149_juara_umum_tanpa_poin_di_bawah.sql
@@ -1,0 +1,23 @@
+-- Sekolah tanpa satu pun gelar enam besar mempunyai bobot_juara NULL.
+-- Pada ORDER BY DESC PostgreSQL menaruh NULL di atas angka, sehingga sekolah
+-- tanpa poin dapat mengalahkan sekolah yang benar-benar mendapat 6-5-4-3-2-1.
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+  v_lama text := 'order by bobot_juara desc, jumlah_skor desc, nama_sekolah';
+  v_baru text := 'order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah';
+begin
+  assert position(v_lama in v_def) > 0,
+    '0149: urutan Juara Umum tanpa NULLS LAST tidak ditemukan';
+  execute replace(v_def, v_lama, v_baru);
+end;
+$$;
+
+do $$
+begin
+  assert pg_get_functiondef('hasil_kejuaraan()'::regprocedure)
+    like '%order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah%',
+    '0149: sekolah tanpa poin masih dapat berada di atas';
+end;
+$$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -694,5 +694,7 @@ run supabase/migrations/0147_waktu_nol_pos_2.sql
 run tests/sql/99_waktu_nol_pos_2.sql
 run supabase/migrations/0148_juara_umum_berdasarkan_poin.sql
 run tests/sql/100_juara_umum_poin.sql
+run supabase/migrations/0149_juara_umum_tanpa_poin_di_bawah.sql
+run tests/sql/101_juara_umum_null.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/101_juara_umum_null.sql
+++ b/tests/sql/101_juara_umum_null.sql
@@ -1,0 +1,21 @@
+\echo '--- 101. sekolah tanpa enam besar tidak menjadi Juara Umum'
+
+do $$
+declare v_juara text;
+begin
+  with calon(sekolah, poin, jumlah_skor) as (values
+    ('SEKOLAH ENAM BESAR', 6::numeric, 900::numeric),
+    ('SEKOLAH BANYAK REGU', null::numeric, 9000::numeric)
+  )
+  select sekolah into v_juara from calon
+  order by poin desc nulls last, jumlah_skor desc, sekolah limit 1;
+
+  assert v_juara = 'SEKOLAH ENAM BESAR',
+    format('101.1 GAGAL: sekolah tanpa poin menang: %s', v_juara);
+  assert pg_get_functiondef('hasil_kejuaraan()'::regprocedure)
+    like '%order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah%',
+    '101.2 GAGAL: hasil_kejuaraan belum memakai NULLS LAST';
+end;
+$$;
+
+\echo '101 juara umum null: LULUS'


### PR DESCRIPTION
## What

- place schools without any top-six title points below schools with points
- preserve the 6-5-4-3-2-1 title-point ranking
- add regression coverage for a zero-title school with a large raw score total

## Why

PostgreSQL sorts NULL values first for descending order. Schools without a top-six finish therefore appeared above schools that had earned title points.