### PR TITLE
feat: show championship points and score

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0149`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0150`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0149`.
+`0119`-`0150`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-149 migrasi, `0001` sampai `0149`, dijalankan berurutan tanpa lubang penomoran.
+150 migrasi, `0001` sampai `0150`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0150_tampilkan_poin_juara_umum.sql
+++ b/supabase/migrations/0150_tampilkan_poin_juara_umum.sql
@@ -1,0 +1,118 @@
+-- Halaman Kejuaraan perlu menunjukkan dasar penentuan Juara Umum. Poin juara
+-- tetap menjadi urutan utama; jumlah seluruh skor menjadi pemecah nilai sama.
+
+drop view v_kejuaraan;
+drop function hasil_kejuaraan();
+
+create function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric, poin_juara numeric, jumlah_skor numeric
+)
+language sql stable security definer
+set search_path = public
+as $$
+with
+peringkat_eksternal as (
+  select k.*,
+         row_number() over (
+           partition by k.golongan
+           order by k.total desc,
+                    abs(coalesce(k.selisih_menit, 100000)) asc,
+                    k.nomor_dada asc) as nomor_juara
+  from v_klasemen k
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+),
+calon_umum as (
+  select nama_sekolah,
+         count(*) filter (where nomor_juara <= 6) as jumlah_juara,
+         sum(7 - nomor_juara) filter (where nomor_juara <= 6) as bobot_juara,
+         sum(total) as jumlah_skor,
+         case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end as tingkat
+  from peringkat_eksternal
+  group by nama_sekolah,
+           case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end
+),
+calon_semua as (
+  select nama_sekolah, sum(jumlah_juara) jumlah_juara,
+         sum(bobot_juara) bobot_juara, sum(jumlah_skor) jumlah_skor
+  from calon_umum group by nama_sekolah
+),
+kandidat_umum as (
+  select 'semua'::text tingkat, * from calon_semua
+  union all
+  select tingkat, nama_sekolah, jumlah_juara, bobot_juara, jumlah_skor
+  from calon_umum
+),
+juara_umum as (
+  select d.urutan, d.kode, d.nama nama_penghargaan,
+         'skor'::text sumber, null::uuid regu_id, null::integer nomor_dada,
+         null::text nama_regu, x.nama_sekolah, null::text golongan,
+         null::numeric total, x.bobot_juara poin_juara, x.jumlah_skor
+  from (values
+    (1, 'juara_umum', 'Juara Umum ' || (select name from edisi where is_active), 'semua'),
+    (2, 'juara_umum_penegak', 'Juara Umum Penegak', 'penegak'),
+    (3, 'juara_umum_penggalang', 'Juara Umum Penggalang', 'penggalang')
+  ) d(urutan, kode, nama, tingkat)
+  left join lateral (
+    select nama_sekolah, bobot_juara, jumlah_skor
+    from kandidat_umum k where k.tingkat = d.tingkat
+    order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah
+    limit 1
+  ) x on true
+)
+select d.*, null::numeric poin_juara, null::numeric jumlah_skor
+from hasil_kejuaraan_dasar() d
+where d.kode not in
+  ('juara_umum', 'juara_umum_penegak', 'juara_umum_penggalang',
+   'yel_yel', 'peserta_terbanyak')
+union all
+select * from juara_umum
+union all
+select 62, 'yel_yel', 'Juara Yel Yel', 'skor',
+       y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+       y.golongan, y.poin_pos, null::numeric, null::numeric
+from (values (true)) satu(ada)
+left join lateral (
+  select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+         k.golongan, pp.poin_pos
+  from v_klasemen k
+  join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+  order by pp.poin_pos desc, k.total desc, k.nomor_dada
+  limit 1
+) y on true
+where boleh('live_score')
+union all
+select 70, 'peserta_terbanyak', 'Peserta Terbanyak', 'nomor_dada',
+       null::uuid, null::integer, null::text, p.nama_sekolah,
+       null::text, p.jumlah::numeric, null::numeric, null::numeric
+from (values (true)) satu(ada)
+left join lateral (
+  select s.name nama_sekolah, count(*) jumlah
+  from regu r
+  join pendaftaran d on d.id = r.pendaftaran_id
+  join sekolah s on s.id = d.sekolah_id
+  where r.nomor_dada is not null and not r.is_cancelled
+    and d.status = 'lunas' and r.golongan not like 'intern_%'
+  group by s.name
+  order by jumlah desc, s.name
+  limit 1
+) p on true
+where boleh('live_score')
+order by urutan
+$$;
+
+revoke all on function hasil_kejuaraan() from public;
+grant execute on function hasil_kejuaraan() to authenticated;
+
+create view v_kejuaraan as select * from hasil_kejuaraan();
+grant select on v_kejuaraan to authenticated;
+
+comment on column v_kejuaraan.poin_juara is
+  'Total poin posisi enam besar: 6, 5, 4, 3, 2, 1. Hanya diisi untuk Juara Umum.';
+comment on column v_kejuaraan.jumlah_skor is
+  'Jumlah seluruh skor regu sekolah dalam cakupan Juara Umum; pemecah poin sama.';

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -35,6 +35,13 @@ test("pilihan manual memakai snapshot tanpa menghitung rekap lagi", () => {
   assert.doesNotMatch(layar, /rekapPenuh\(/);
 });
 
+test("Juara Umum menampilkan poin juara dan total skor", () => {
+  assert.match(layar, /x\.poin_juara/);
+  assert.match(layar, /x\.jumlah_skor/);
+  assert.match(layar, /poin juara ·/);
+  assert.match(layar, /total skor/);
+});
+
 test("menyimpan juara mengunci baris tanpa memuat ulang layar", () => {
   assert.match(app, /simpanKejuaraanManual[\s\S]*kejuaraan-nilai[\s\S]*isian\.hidden = true;[\s\S]*terkunci\.hidden = false;/);
   assert.doesNotMatch(app, /simpanKejuaraanManual\(pilih\.dataset\.kode, dipilih\.regu_id\);\s*await layarKejuaraan\(\)/);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -696,5 +696,7 @@ run supabase/migrations/0148_juara_umum_berdasarkan_poin.sql
 run tests/sql/100_juara_umum_poin.sql
 run supabase/migrations/0149_juara_umum_tanpa_poin_di_bawah.sql
 run tests/sql/101_juara_umum_null.sql
+run supabase/migrations/0150_tampilkan_poin_juara_umum.sql
+run tests/sql/102_tampilkan_poin_juara_umum.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/102_tampilkan_poin_juara_umum.sql
+++ b/tests/sql/102_tampilkan_poin_juara_umum.sql
@@ -1,0 +1,25 @@
+\echo '--- 102. Kejuaraan menampilkan poin dan skor Juara Umum'
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+begin
+  assert v_def like
+    '%order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah%',
+    '102.1 GAGAL: total skor bukan pemecah poin Juara Umum yang sama';
+
+  assert exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'v_kejuaraan'
+      and column_name = 'poin_juara'
+  ), '102.2 GAGAL: poin juara tidak tersedia di Kejuaraan';
+
+  assert exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'v_kejuaraan'
+      and column_name = 'jumlah_skor'
+  ), '102.3 GAGAL: jumlah skor tidak tersedia di Kejuaraan';
+end;
+$$;
+
+\echo '102 tampilkan poin juara umum: LULUS'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6115,8 +6115,10 @@ async function layarKejuaraan() {
   const nilai = (x) => {
     if (x.nama_regu) return `<strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
       <span class="description">${esc(x.nama_sekolah || "")}</span>`;
-    if (x.nama_sekolah) return `<strong>${esc(x.nama_sekolah)}</strong>${x.kode === "peserta_terbanyak"
-      ? `<span class="description">${esc(angkaRapi(x.total))} regu bernomor dada</span>` : ""}`;
+    if (x.nama_sekolah) return `<strong>${esc(x.nama_sekolah)}</strong>${x.kode.startsWith("juara_umum")
+      ? `<span class="description">${esc(angkaRapi(x.poin_juara))} poin juara · ${esc(angkaRapi(x.jumlah_skor))} total skor</span>`
+      : x.kode === "peserta_terbanyak"
+        ? `<span class="description">${esc(angkaRapi(x.total))} regu bernomor dada</span>` : ""}`;
     return `<span class="description">Belum ditentukan</span>`;
   };
   const baris = (x, label = x.nama_penghargaan) => manual.has(x.kode) && bisaUbah ? `


### PR DESCRIPTION
## What
- expose title points and total school score for Juara Umum
- show both values on the Kejuaraan screen
- keep total score as the tie-breaker when title points are equal

## Why
Panitia need to verify why a school wins Juara Umum directly from the Kejuaraan screen.