### PR TITLE
fix: limit championship score to top six

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,9 +6,9 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0150`
+sampai migrasi `0136`. Penomorannya disegarkan 29 Agustus 2026 sampai migrasi `0151`
 — hanya angkanya; isi bagian 2 sampai 9 belum dibaca ulang terhadap
-`0119`-`0150`.
+`0119`-`0151`.
 
 ---
 
@@ -65,7 +65,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-150 migrasi, `0001` sampai `0150`, dijalankan berurutan tanpa lubang penomoran.
+151 migrasi, `0001` sampai `0151`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/migrations/0151_skor_juara_umum_enam_besar.sql
+++ b/supabase/migrations/0151_skor_juara_umum_enam_besar.sql
@@ -1,0 +1,26 @@
+-- Pemecah poin Juara Umum hanya memakai skor regu yang menghasilkan poin,
+-- yaitu peringkat 1 sampai 6. Skor regu di bawahnya tidak ikut dihitung.
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+  v_lama text := 'sum(total) as jumlah_skor';
+  v_baru text := 'sum(total) filter (where nomor_juara <= 6) as jumlah_skor';
+begin
+  assert position(v_lama in v_def) > 0,
+    '0151: perhitungan jumlah skor lama tidak ditemukan';
+
+  execute replace(v_def, v_lama, v_baru);
+end;
+$$;
+
+comment on column v_kejuaraan.jumlah_skor is
+  'Jumlah skor regu sekolah yang berada di peringkat 1-6 dalam cakupan Juara Umum; pemecah poin sama.';
+
+do $$
+begin
+  assert pg_get_functiondef('hasil_kejuaraan()'::regprocedure) like
+    '%sum(total) filter (where nomor_juara <= 6) as jumlah_skor%',
+    '0151: jumlah skor belum dibatasi ke enam besar';
+end;
+$$;

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -39,7 +39,7 @@ test("Juara Umum menampilkan poin juara dan total skor", () => {
   assert.match(layar, /x\.poin_juara/);
   assert.match(layar, /x\.jumlah_skor/);
   assert.match(layar, /poin juara ·/);
-  assert.match(layar, /total skor/);
+  assert.match(layar, /total skor 6 besar/);
 });
 
 test("menyimpan juara mengunci baris tanpa memuat ulang layar", () => {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -698,5 +698,7 @@ run supabase/migrations/0149_juara_umum_tanpa_poin_di_bawah.sql
 run tests/sql/101_juara_umum_null.sql
 run supabase/migrations/0150_tampilkan_poin_juara_umum.sql
 run tests/sql/102_tampilkan_poin_juara_umum.sql
+run supabase/migrations/0151_skor_juara_umum_enam_besar.sql
+run tests/sql/103_skor_juara_umum_enam_besar.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/103_skor_juara_umum_enam_besar.sql
+++ b/tests/sql/103_skor_juara_umum_enam_besar.sql
@@ -1,0 +1,29 @@
+\echo '--- 103. total skor Juara Umum hanya dari enam besar'
+
+do $$
+declare v_juara text;
+begin
+  -- Poin A dan B sama-sama 6. Skor peringkat 7 milik A tidak boleh membuat A
+  -- mengalahkan skor enam besar B yang lebih tinggi.
+  with hasil(sekolah, nomor_juara, skor) as (values
+    ('A', 1, 100::numeric),
+    ('A', 7, 9000::numeric),
+    ('B', 1, 200::numeric)
+  ), calon as (
+    select sekolah,
+           sum(7 - nomor_juara) filter (where nomor_juara <= 6) poin,
+           sum(skor) filter (where nomor_juara <= 6) jumlah_skor
+    from hasil group by sekolah
+  )
+  select sekolah into v_juara from calon
+  order by poin desc nulls last, jumlah_skor desc, sekolah limit 1;
+
+  assert v_juara = 'B',
+    format('103.1 GAGAL: skor di luar enam besar ikut dihitung: %s', v_juara);
+  assert pg_get_functiondef('hasil_kejuaraan()'::regprocedure) like
+    '%sum(total) filter (where nomor_juara <= 6) as jumlah_skor%',
+    '103.2 GAGAL: fungsi belum membatasi jumlah skor ke enam besar';
+end;
+$$;
+
+\echo '103 skor juara umum enam besar: LULUS'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6116,7 +6116,7 @@ async function layarKejuaraan() {
     if (x.nama_regu) return `<strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
       <span class="description">${esc(x.nama_sekolah || "")}</span>`;
     if (x.nama_sekolah) return `<strong>${esc(x.nama_sekolah)}</strong>${x.kode.startsWith("juara_umum")
-      ? `<span class="description">${esc(angkaRapi(x.poin_juara))} poin juara · ${esc(angkaRapi(x.jumlah_skor))} total skor</span>`
+      ? `<span class="description">${esc(angkaRapi(x.poin_juara))} poin juara · ${esc(angkaRapi(x.jumlah_skor))} total skor 6 besar</span>`
       : x.kode === "peserta_terbanyak"
         ? `<span class="description">${esc(angkaRapi(x.total))} regu bernomor dada</span>` : ""}`;
     return `<span class="description">Belum ditentukan</span>`;


### PR DESCRIPTION
## What
- calculate the Juara Umum score tie-breaker from positions 1-6 only
- label the displayed value as total skor 6 besar
- add regression coverage for scores below sixth place

## Why
Only placements that earn championship points should contribute to the score tie-breaker.