### PR TITLE
feat: print live scores by station

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -31,13 +31,16 @@
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
   <link rel="stylesheet" href="style.css?v=4">
-  <link rel="stylesheet" href="live.css?v=2">
+  <link rel="stylesheet" href="live.css?v=3">
 </head>
 <body>
   <header class="kepala">
-    <div class="kepala-isi">
-      <h1 id="judul">Live Score</h1>
-      <p class="sinkron" id="sinkron">Memuat…</p>
+    <div class="kepala-isi kepala-baris">
+      <div>
+        <h1 id="judul">Live Score</h1>
+        <p class="sinkron" id="sinkron">Memuat…</p>
+      </div>
+      <button type="button" class="tombol-cetak" id="buka-cetak" hidden>Print</button>
     </div>
   </header>
 
@@ -49,6 +52,18 @@
     <p>Hiking Rally Ciradyka · Ambalan Ciung Wanara – Dyah Pitaloka,
        SMA Negeri 1 Ciamis</p>
   </footer>
+
+  <dialog class="dialog-cetak" id="dialog-cetak" aria-labelledby="judul-cetak">
+    <form method="dialog">
+      <h2 id="judul-cetak">Print Skor</h2>
+      <label for="pilihan-cetak">Pilih daftar</label>
+      <select id="pilihan-cetak"></select>
+      <div class="aksi-cetak">
+        <button type="submit" class="tombol-dialog" value="batal">Batal</button>
+        <button type="button" class="tombol-dialog utama" id="cetak-skor">Print</button>
+      </div>
+    </form>
+  </dialog>
 
   <!-- Versinya DINAIKKAN tiap kali live.js berubah. Cache-Control-nya
        memang `no-cache` (selalu divalidasi), tapi itu tidak menolong
@@ -63,6 +78,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=13"></script>
+  <script type="module" src="live.js?v=14"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -71,11 +71,37 @@ body {
   position: sticky; top: 0; z-index: 10;
 }
 .kepala-isi { max-width: 1200px; margin: 0 auto; }
+.kepala-baris { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
 .kepala h1 { font-size: 1.15rem; font-weight: 800; }
 /* Cap sinkronisasi: kecil tapi selalu ada. Halaman yang menyegarkan dirinya
    sendiri harus bisa dibedakan dari halaman yang berhenti bekerja. */
 .sinkron { font-size: .8rem; opacity: .9; margin-top: .15rem; }
 .sinkron.basi { opacity: 1; font-weight: 700; color: #ffd9a0; }
+.tombol-cetak {
+  border: 1px solid #fff; border-radius: 8px; background: transparent;
+  color: #fff; padding: .45rem .85rem; font: inherit; font-weight: 700;
+  cursor: pointer;
+}
+.tombol-cetak:hover { background: rgba(255,255,255,.15); }
+
+.dialog-cetak {
+  width: min(90vw, 360px); border: 0; border-radius: 12px;
+  padding: 1.1rem; box-shadow: 0 16px 48px rgba(0,0,0,.25);
+}
+.dialog-cetak::backdrop { background: rgba(0,0,0,.45); }
+.dialog-cetak h2 { margin-bottom: .8rem; }
+.dialog-cetak label { display: block; margin-bottom: .3rem; font-weight: 700; }
+.dialog-cetak select {
+  width: 100%; min-height: 44px; padding: .5rem; border: 1px solid var(--garis);
+  border-radius: 8px; background: #fff; font: inherit;
+}
+.aksi-cetak { display: flex; justify-content: flex-end; gap: .5rem; margin-top: 1rem; }
+.tombol-dialog {
+  min-height: 42px; padding: .45rem .85rem; border: 1px solid var(--garis);
+  border-radius: 8px; background: #fff; color: var(--tinta); font: inherit;
+  font-weight: 700; cursor: pointer;
+}
+.tombol-dialog.utama { background: var(--utama); border-color: var(--utama); color: #fff; }
 
 main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 .memuat { text-align: center; color: var(--tinta-lembut); padding: 2rem 0; }
@@ -238,4 +264,13 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
   min-height: 48px; line-height: 34px;
 }
 .tombol:hover { background: #004d43; }
+
+@media print {
+  .kepala, #isi, .kaki, .dialog-cetak { display: none !important; }
+  .cetak-skor { display: block !important; }
+  .cetak-skor thead { display: table-header-group; }
+  .cetak-skor tr { break-inside: avoid; page-break-inside: avoid; }
+  .cetak-skor .print-table td:nth-child(1) { width: 18mm; }
+  .cetak-skor .print-table td:nth-child(4) { width: 28mm; }
+}
 

--- a/live/live.js
+++ b/live/live.js
@@ -367,6 +367,111 @@ const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
 
 
 /* ---------------------------------------------------------------------------
+   CETAK SKOR — hanya fase penuh, dan tidak mengambil data lagi.
+
+   Pos memakai poin akhir per pos dari `poin_per_pos`. Keberangkatan adalah
+   klasemen total yang dibawa `total`; lembar itu dipasang di titik kumpul
+   ketika seluruh hasil sudah dibuka. Empat golongan dipisah agar regu tidak
+   pernah dibandingkan dengan golongan lain.
+   ------------------------------------------------------------------------- */
+const pilihanCetak = () => [
+  ...((META && META.pos) || [])
+    .filter(p => Number(p.nomor) >= 1 && Number(p.nomor) <= 5)
+    .map(p => ({ kode: String(p.nomor),
+      label: `Pos ${p.nomor} · ${p.name}`, judul: `Skor Pos ${p.nomor} · ${p.name}` })),
+  { kode: "keberangkatan", label: "Keberangkatan",
+    judul: "Keberangkatan · Total Skor" },
+];
+
+const skorCetak = (baris, kode) => {
+  const mentah = kode === "keberangkatan"
+    ? baris.total
+    : baris.poin_per_pos && baris.poin_per_pos[kode];
+  if (mentah === null || mentah === undefined || mentah === "") return null;
+  const angka = Number(mentah);
+  return Number.isFinite(angka) ? angka : null;
+};
+
+function urutSkorCetak(a, b, kode) {
+  const skorA = skorCetak(a, kode);
+  const skorB = skorCetak(b, kode);
+  if (skorA === null && skorB !== null) return 1;
+  if (skorA !== null && skorB === null) return -1;
+  if (skorA !== skorB) return skorB - skorA;
+
+  // Jika skor pos sama, total keseluruhan membuat urutannya tetap berguna.
+  // Untuk Keberangkatan, peringkat database sudah memuat tie-break ketepatan
+  // waktu; jangan membuat aturan peringkat kedua di browser.
+  if (kode === "keberangkatan" && a.peringkat !== b.peringkat)
+    return Number(a.peringkat ?? 1e9) - Number(b.peringkat ?? 1e9);
+  const total = Number(b.total ?? -1e9) - Number(a.total ?? -1e9);
+  if (total) return total;
+  return Number(a.nomor_dada ?? 1e9) - Number(b.nomor_dada ?? 1e9);
+}
+
+function buatCetakanSkor(kode) {
+  const pilihan = pilihanCetak().find(p => p.kode === kode);
+  if (!pilihan || fase() !== "penuh" || !REKAP) return;
+
+  const semua = (REKAP.klasemen || []).filter(b => golonganPeserta(b.golongan));
+  const halaman = URUT_GOLONGAN_PESERTA.map(g => {
+    const baris = semua.filter(b => b.golongan === g)
+      .sort((a, b) => urutSkorCetak(a, b, kode));
+    return `
+      <section class="print-page">
+        <h1>${esc(pilihan.judul)}</h1>
+        <p><strong>${esc(GOLONGAN[g] || g)}</strong> · ${esc(META.edisi?.name || "")}</p>
+        <table class="print-table">
+          <thead><tr>
+            <th>No Dada</th><th>Nama Regu</th><th>Asal Sekolah</th>
+            <th class="text-right">Skor</th>
+          </tr></thead>
+          <tbody>${baris.map(b => {
+            const skor = skorCetak(b, kode);
+            return `<tr>
+              <td class="dada">${esc(dada(b.nomor_dada))}</td>
+              <td>${esc(b.nama_regu || "—")}</td>
+              <td>${esc(b.nama_sekolah || "—")}</td>
+              <td class="text-right"><strong>${skor === null ? "—" : esc(angkaRapi(skor))}</strong></td>
+            </tr>`;
+          }).join("")}</tbody>
+        </table>
+        <p class="print-note">Data diperbarui ${esc(tanggalJam(META.dibuat_pada))}.</p>
+      </section>`;
+  }).join("");
+
+  document.getElementById("cetakan")?.remove();
+  const cetakan = document.createElement("div");
+  cetakan.id = "cetakan";
+  cetakan.className = "printout cetak-skor";
+  cetakan.innerHTML = halaman;
+  document.body.appendChild(cetakan);
+  window.print();
+}
+
+function pasangCetakSkor() {
+  const buka = document.getElementById("buka-cetak");
+  const dialog = document.getElementById("dialog-cetak");
+  const daftar = document.getElementById("pilihan-cetak");
+  const cetak = document.getElementById("cetak-skor");
+  if (!buka || !dialog || !daftar || !cetak) return;
+
+  buka.addEventListener("click", () => {
+    daftar.innerHTML = pilihanCetak().map(p =>
+      `<option value="${esc(p.kode)}">${esc(p.label)}</option>`).join("");
+    dialog.showModal();
+  });
+  cetak.addEventListener("click", () => {
+    const kode = daftar.value;
+    dialog.close();
+    buatCetakanSkor(kode);
+  });
+  window.addEventListener("afterprint", () =>
+    document.getElementById("cetakan")?.remove());
+}
+
+
+/* ---------------------------------------------------------------------------
    PAPAN — bentuknya SAMA dengan layar Live Score panitia.
 
    Empat tab golongan Eksternal, judul "Klasemen sementara", podium tiga
@@ -746,6 +851,8 @@ function gambar() {
   document.getElementById("judul").textContent =
     `Live Score${META.edisi ? ` — ${META.edisi.name}` : ""}`;
   document.title = `Live Score — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
+  const tombolCetak = document.getElementById("buka-cetak");
+  if (tombolCetak) tombolCetak.hidden = fase() !== "penuh" || !REKAP;
 
   // Top 10 sengaja hanya membawa papan ringkas. Pada fase lain susunannya
   // sama dengan layar panitia: kemajuan di atas, lalu tab golongan, lalu
@@ -853,6 +960,7 @@ async function muat() {
 }
 
 muat();
+pasangCetakSkor();
 
 /* Polling hanya berjalan saat halamannya benar-benar dilihat. Ribuan HP yang
    tertinggal terbuka di saku adalah beban yang tidak menghasilkan apa pun —

--- a/tests/live_score_print.test.mjs
+++ b/tests/live_score_print.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const html = await readFile(new URL("../live/index.html", import.meta.url), "utf8");
+const js = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../live/live.css", import.meta.url), "utf8");
+
+test("Print hanya tersedia pada fase Live penuh", () => {
+  assert.match(html, /id="buka-cetak" hidden>Print<\/button>/);
+  assert.match(js, /tombolCetak\.hidden = fase\(\) !== "penuh" \|\| !REKAP/);
+});
+
+test("pilihan cetak memuat Pos 1-5 dan Keberangkatan", () => {
+  assert.match(js, /Number\(p\.nomor\) >= 1 && Number\(p\.nomor\) <= 5/);
+  assert.match(js, /kode: "keberangkatan", label: "Keberangkatan"/);
+  assert.match(html, /<select id="pilihan-cetak"><\/select>/);
+});
+
+test("skor pos dan Keberangkatan memakai data statis yang sudah dimuat", () => {
+  assert.match(js, /baris\.poin_per_pos && baris\.poin_per_pos\[kode\]/);
+  assert.match(js, /\? baris\.total/);
+  assert.doesNotMatch(js.slice(js.indexOf("function buatCetakanSkor"),
+    js.indexOf("function pasangCetakSkor")), /fetch\(/);
+});
+
+test("lembar diurutkan skor tertinggi dan memuat empat kolom yang diminta", () => {
+  assert.match(js, /if \(skorA !== skorB\) return skorB - skorA/);
+  for (const kepala of ["No Dada", "Nama Regu", "Asal Sekolah", "Skor"])
+    assert.ok(js.includes(`<th${kepala === "Skor" ? ' class="text-right"' : ""}>${kepala}</th>`));
+  assert.match(js, /URUT_GOLONGAN_PESERTA\.map\(g =>/);
+});
+
+test("print dibuka langsung dari klik kedua dan hanya cetakan yang terlihat", () => {
+  const awal = js.indexOf('cetak.addEventListener("click"');
+  const akhir = js.indexOf("window.addEventListener", awal);
+  const handler = js.slice(awal, akhir);
+  assert.match(handler, /buatCetakanSkor\(kode\)/);
+  assert.doesNotMatch(handler, /await|fetch\(/);
+  assert.match(css, /@media print[\s\S]*\.kepala, #isi, \.kaki, \.dialog-cetak[\s\S]*display: none !important/);
+  assert.match(css, /\.cetak-skor \{ display: block !important; \}/);
+});


### PR DESCRIPTION
## What
- add a Print action to the public Live Score during the full Live phase
- let users choose Pos 1-5 or Keberangkatan
- print nomor dada, regu, school, and score in descending order per golongan
- reuse the cached rekap snapshot without another database request

## Why
Panitia need printable score sheets for each pos and the overall board at Keberangkatan.