### PR TITLE
feat: detail printed scores by contest

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -31,7 +31,7 @@
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
   <link rel="stylesheet" href="style.css?v=4">
-  <link rel="stylesheet" href="live.css?v=3">
+  <link rel="stylesheet" href="live.css?v=4">
 </head>
 <body>
   <header class="kepala">
@@ -78,6 +78,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=14"></script>
+  <script type="module" src="live.js?v=15"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -266,11 +266,15 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 .tombol:hover { background: #004d43; }
 
 @media print {
+  @page { size: A4 landscape; margin: 10mm; }
   .kepala, #isi, .kaki, .dialog-cetak { display: none !important; }
   .cetak-skor { display: block !important; }
   .cetak-skor thead { display: table-header-group; }
   .cetak-skor tr { break-inside: avoid; page-break-inside: avoid; }
+  .cetak-skor .print-table th, .cetak-skor .print-table td {
+    padding: 3pt 4pt; font-size: 8pt;
+  }
   .cetak-skor .print-table td:nth-child(1) { width: 18mm; }
-  .cetak-skor .print-table td:nth-child(4) { width: 28mm; }
+  .cetak-skor .print-table td:last-child { width: 22mm; }
 }
 

--- a/live/live.js
+++ b/live/live.js
@@ -369,10 +369,11 @@ const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
 /* ---------------------------------------------------------------------------
    CETAK SKOR — hanya fase penuh, dan tidak mengambil data lagi.
 
-   Pos memakai poin akhir per pos dari `poin_per_pos`. Keberangkatan adalah
-   klasemen total yang dibawa `total`; lembar itu dipasang di titik kumpul
-   ketika seluruh hasil sudah dibuka. Empat golongan dipisah agar regu tidak
-   pernah dibandingkan dengan golongan lain.
+   Pos memakai poin per lomba dari `progres.poin`, lalu Total Pos dari
+   `klasemen.poin_per_pos`. Keberangkatan adalah klasemen total yang dibawa
+   `total`; lembar itu dipasang di titik kumpul ketika seluruh hasil sudah
+   dibuka. Empat golongan dipisah agar regu tidak pernah dibandingkan dengan
+   golongan lain.
    ------------------------------------------------------------------------- */
 const pilihanCetak = () => [
   ...((META && META.pos) || [])
@@ -413,10 +414,24 @@ function buatCetakanSkor(kode) {
   const pilihan = pilihanCetak().find(p => p.kode === kode);
   if (!pilihan || fase() !== "penuh" || !REKAP) return;
 
-  const semua = (REKAP.klasemen || []).filter(b => golonganPeserta(b.golongan));
+  // Rincian lomba tinggal di progres, sedangkan Total Pos dan peringkat tinggal
+  // di klasemen. Keduanya berasal dari snapshot statis yang sama dan disatukan
+  // dengan nomor dada, persis seperti papan Live di atas.
+  const perDada = new Map((REKAP.progres || []).map(b => [b.nomor_dada, b]));
+  const semua = (REKAP.klasemen || [])
+    .map(b => ({ ...perDada.get(b.nomor_dada), ...b }))
+    .filter(b => golonganPeserta(b.golongan));
+  const nomorPos = Number(kode);
+  const lomba = kode === "keberangkatan" ? [] : kelompokLomba(kolomPos(
+    ((META && META.komponen) || []).filter(w => Number(w.pos) === nomorPos),
+  ));
   const halaman = URUT_GOLONGAN_PESERTA.map(g => {
     const baris = semua.filter(b => b.golongan === g)
       .sort((a, b) => urutSkorCetak(a, b, kode));
+    const kepalaSkor = kode === "keberangkatan"
+      ? `<th class="text-right">Total Skor</th>`
+      : lomba.map(l => `<th class="text-right">${esc(l.nama)}</th>`).join("")
+        + `<th class="text-right">Total Pos</th>`;
     return `
       <section class="print-page">
         <h1>${esc(pilihan.judul)}</h1>
@@ -424,14 +439,20 @@ function buatCetakanSkor(kode) {
         <table class="print-table">
           <thead><tr>
             <th>No Dada</th><th>Nama Regu</th><th>Asal Sekolah</th>
-            <th class="text-right">Skor</th>
+            ${kepalaSkor}
           </tr></thead>
           <tbody>${baris.map(b => {
             const skor = skorCetak(b, kode);
+            const rincian = lomba.map(l => {
+              const r = ringkasLomba(l, b.golongan, nomorPos, b.poin || {});
+              const nilai = r.berlaku && r.terisi ? angkaRapi(r.jumlah) : "—";
+              return `<td class="text-right">${esc(nilai)}</td>`;
+            }).join("");
             return `<tr>
               <td class="dada">${esc(dada(b.nomor_dada))}</td>
               <td>${esc(b.nama_regu || "—")}</td>
               <td>${esc(b.nama_sekolah || "—")}</td>
+              ${rincian}
               <td class="text-right"><strong>${skor === null ? "—" : esc(angkaRapi(skor))}</strong></td>
             </tr>`;
           }).join("")}</tbody>

--- a/tests/live_score_print.test.mjs
+++ b/tests/live_score_print.test.mjs
@@ -20,14 +20,19 @@ test("pilihan cetak memuat Pos 1-5 dan Keberangkatan", () => {
 test("skor pos dan Keberangkatan memakai data statis yang sudah dimuat", () => {
   assert.match(js, /baris\.poin_per_pos && baris\.poin_per_pos\[kode\]/);
   assert.match(js, /\? baris\.total/);
+  assert.match(js, /new Map\(\(REKAP\.progres \|\| \[\]\)\.map/);
   assert.doesNotMatch(js.slice(js.indexOf("function buatCetakanSkor"),
     js.indexOf("function pasangCetakSkor")), /fetch\(/);
 });
 
-test("lembar diurutkan skor tertinggi dan memuat empat kolom yang diminta", () => {
+test("lembar diurutkan skor tertinggi dan dirinci per lomba", () => {
   assert.match(js, /if \(skorA !== skorB\) return skorB - skorA/);
-  for (const kepala of ["No Dada", "Nama Regu", "Asal Sekolah", "Skor"])
-    assert.ok(js.includes(`<th${kepala === "Skor" ? ' class="text-right"' : ""}>${kepala}</th>`));
+  for (const kepala of ["No Dada", "Nama Regu", "Asal Sekolah"])
+    assert.ok(js.includes(`<th>${kepala}</th>`));
+  assert.match(js, /kelompokLomba\(kolomPos\(/);
+  assert.match(js, /ringkasLomba\(l, b\.golongan, nomorPos, b\.poin \|\| \{\}\)/);
+  assert.match(js, /<th class="text-right">Total Pos<\/th>/);
+  assert.match(js, /<th class="text-right">Total Skor<\/th>/);
   assert.match(js, /URUT_GOLONGAN_PESERTA\.map\(g =>/);
 });
 


### PR DESCRIPTION
## What
- show one score column per lomba on each Pos printout
- keep Total Pos as the final column and ranking basis
- keep Keberangkatan as the overall total-score printout
- use landscape print layout for the additional columns

## Why
Panitia need to see how each lomba contributes to each regu score at a pos.