### PR TITLE
fix: fit score printout on one A4 page

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -31,7 +31,7 @@
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
   <link rel="stylesheet" href="style.css?v=4">
-  <link rel="stylesheet" href="live.css?v=4">
+  <link rel="stylesheet" href="live.css?v=5">
 </head>
 <body>
   <header class="kepala">
@@ -58,6 +58,8 @@
       <h2 id="judul-cetak">Print Skor</h2>
       <label for="pilihan-cetak">Pilih daftar</label>
       <select id="pilihan-cetak"></select>
+      <label for="golongan-cetak">Golongan</label>
+      <select id="golongan-cetak"></select>
       <div class="aksi-cetak">
         <button type="submit" class="tombol-dialog" value="batal">Batal</button>
         <button type="button" class="tombol-dialog utama" id="cetak-skor">Print</button>
@@ -78,6 +80,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=15"></script>
+  <script type="module" src="live.js?v=16"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -91,6 +91,7 @@ body {
 .dialog-cetak::backdrop { background: rgba(0,0,0,.45); }
 .dialog-cetak h2 { margin-bottom: .8rem; }
 .dialog-cetak label { display: block; margin-bottom: .3rem; font-weight: 700; }
+.dialog-cetak select + label { margin-top: .75rem; }
 .dialog-cetak select {
   width: 100%; min-height: 44px; padding: .5rem; border: 1px solid var(--garis);
   border-radius: 8px; background: #fff; font: inherit;
@@ -266,15 +267,30 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 .tombol:hover { background: #004d43; }
 
 @media print {
-  @page { size: A4 landscape; margin: 10mm; }
+  /* Satu golongan harus selesai di satu A4. Margin 6mm masih aman untuk
+     printer kantor (tepi 4-5mm tidak tercetak), sementara font 7pt adalah
+     batas bawah yang tetap bertahan saat hasilnya difotokopi. */
+  @page { size: A4 landscape; margin: 6mm; }
   .kepala, #isi, .kaki, .dialog-cetak { display: none !important; }
   .cetak-skor { display: block !important; }
+  .cetak-skor .print-page { break-after: page; page-break-after: always; }
+  .cetak-skor .print-page:last-child { break-after: auto; page-break-after: auto; }
+  .kepala-cetak-skor {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 4mm; margin-bottom: 2pt;
+  }
+  .cetak-skor .kepala-cetak-skor h1 { font-size: 11pt; margin: 0; white-space: nowrap; }
+  .cetak-skor .kepala-cetak-skor p { font-size: 7pt; margin: 0; text-align: right; }
+  .cetak-skor .print-table { margin-top: 0; }
   .cetak-skor thead { display: table-header-group; }
   .cetak-skor tr { break-inside: avoid; page-break-inside: avoid; }
   .cetak-skor .print-table th, .cetak-skor .print-table td {
-    padding: 3pt 4pt; font-size: 8pt;
+    padding: .5pt 2pt; font-size: 7pt; line-height: 1;
   }
-  .cetak-skor .print-table td:nth-child(1) { width: 18mm; }
-  .cetak-skor .print-table td:last-child { width: 22mm; }
+  .cetak-skor .print-table th { font-size: 7pt; border-bottom-width: 1pt; }
+  .cetak-skor .print-table td.dada { width: 12mm; font-size: 7pt; }
+  .cetak-skor .print-table td:nth-child(2) { width: 38mm; }
+  .cetak-skor .print-table td:nth-child(3) { width: 48mm; }
+  .cetak-skor .print-table td:last-child { width: 17mm; }
 }
 

--- a/live/live.js
+++ b/live/live.js
@@ -410,9 +410,10 @@ function urutSkorCetak(a, b, kode) {
   return Number(a.nomor_dada ?? 1e9) - Number(b.nomor_dada ?? 1e9);
 }
 
-function buatCetakanSkor(kode) {
+function buatCetakanSkor(kode, golonganDipilih) {
   const pilihan = pilihanCetak().find(p => p.kode === kode);
-  if (!pilihan || fase() !== "penuh" || !REKAP) return;
+  if (!pilihan || !golonganPeserta(golonganDipilih)
+      || fase() !== "penuh" || !REKAP) return;
 
   // Rincian lomba tinggal di progres, sedangkan Total Pos dan peringkat tinggal
   // di klasemen. Keduanya berasal dari snapshot statis yang sama dan disatukan
@@ -425,7 +426,10 @@ function buatCetakanSkor(kode) {
   const lomba = kode === "keberangkatan" ? [] : kelompokLomba(kolomPos(
     ((META && META.komponen) || []).filter(w => Number(w.pos) === nomorPos),
   ));
-  const halaman = URUT_GOLONGAN_PESERTA.map(g => {
+  // Satu pilihan = satu golongan = satu lembar A4. Mencetak keempat golongan
+  // sekaligus memaksa empat halaman padahal petugas biasanya hanya membawa
+  // lembar golongan yang sedang diumumkan.
+  const halaman = [golonganDipilih].map(g => {
     const baris = semua.filter(b => b.golongan === g)
       .sort((a, b) => urutSkorCetak(a, b, kode));
     const kepalaSkor = kode === "keberangkatan"
@@ -434,8 +438,11 @@ function buatCetakanSkor(kode) {
         + `<th class="text-right">Total Pos</th>`;
     return `
       <section class="print-page">
-        <h1>${esc(pilihan.judul)}</h1>
-        <p><strong>${esc(GOLONGAN[g] || g)}</strong> · ${esc(META.edisi?.name || "")}</p>
+        <div class="kepala-cetak-skor">
+          <h1>${esc(pilihan.judul)}</h1>
+          <p><strong>${esc(GOLONGAN[g] || g)}</strong> · ${esc(META.edisi?.name || "")}
+            · ${esc(tanggalJam(META.dibuat_pada))}</p>
+        </div>
         <table class="print-table">
           <thead><tr>
             <th>No Dada</th><th>Nama Regu</th><th>Asal Sekolah</th>
@@ -457,7 +464,6 @@ function buatCetakanSkor(kode) {
             </tr>`;
           }).join("")}</tbody>
         </table>
-        <p class="print-note">Data diperbarui ${esc(tanggalJam(META.dibuat_pada))}.</p>
       </section>`;
   }).join("");
 
@@ -474,18 +480,23 @@ function pasangCetakSkor() {
   const buka = document.getElementById("buka-cetak");
   const dialog = document.getElementById("dialog-cetak");
   const daftar = document.getElementById("pilihan-cetak");
+  const golongan = document.getElementById("golongan-cetak");
   const cetak = document.getElementById("cetak-skor");
-  if (!buka || !dialog || !daftar || !cetak) return;
+  if (!buka || !dialog || !daftar || !golongan || !cetak) return;
 
   buka.addEventListener("click", () => {
     daftar.innerHTML = pilihanCetak().map(p =>
       `<option value="${esc(p.kode)}">${esc(p.label)}</option>`).join("");
+    golongan.innerHTML = URUT_GOLONGAN_PESERTA.map(g =>
+      `<option value="${esc(g)}"${g === golAktif ? " selected" : ""}>${
+        esc(GOLONGAN[g] || g)}</option>`).join("");
     dialog.showModal();
   });
   cetak.addEventListener("click", () => {
     const kode = daftar.value;
+    const golonganDipilih = golongan.value;
     dialog.close();
-    buatCetakanSkor(kode);
+    buatCetakanSkor(kode, golonganDipilih);
   });
   window.addEventListener("afterprint", () =>
     document.getElementById("cetakan")?.remove());

--- a/tests/live_score_print.test.mjs
+++ b/tests/live_score_print.test.mjs
@@ -15,6 +15,7 @@ test("pilihan cetak memuat Pos 1-5 dan Keberangkatan", () => {
   assert.match(js, /Number\(p\.nomor\) >= 1 && Number\(p\.nomor\) <= 5/);
   assert.match(js, /kode: "keberangkatan", label: "Keberangkatan"/);
   assert.match(html, /<select id="pilihan-cetak"><\/select>/);
+  assert.match(html, /<select id="golongan-cetak"><\/select>/);
 });
 
 test("skor pos dan Keberangkatan memakai data statis yang sudah dimuat", () => {
@@ -33,15 +34,27 @@ test("lembar diurutkan skor tertinggi dan dirinci per lomba", () => {
   assert.match(js, /ringkasLomba\(l, b\.golongan, nomorPos, b\.poin \|\| \{\}\)/);
   assert.match(js, /<th class="text-right">Total Pos<\/th>/);
   assert.match(js, /<th class="text-right">Total Skor<\/th>/);
-  assert.match(js, /URUT_GOLONGAN_PESERTA\.map\(g =>/);
+  assert.match(js, /const halaman = \[golonganDipilih\]\.map\(g =>/);
 });
 
 test("print dibuka langsung dari klik kedua dan hanya cetakan yang terlihat", () => {
   const awal = js.indexOf('cetak.addEventListener("click"');
   const akhir = js.indexOf("window.addEventListener", awal);
   const handler = js.slice(awal, akhir);
-  assert.match(handler, /buatCetakanSkor\(kode\)/);
+  assert.match(handler, /buatCetakanSkor\(kode, golonganDipilih\)/);
   assert.doesNotMatch(handler, /await|fetch\(/);
   assert.match(css, /@media print[\s\S]*\.kepala, #isi, \.kaki, \.dialog-cetak[\s\S]*display: none !important/);
   assert.match(css, /\.cetak-skor \{ display: block !important; \}/);
+});
+
+test("setiap golongan dipadatkan ke satu A4 tanpa mengecilkan teks di bawah 7pt", () => {
+  assert.match(css, /@page \{ size: A4 landscape; margin: 6mm; \}/);
+  assert.match(css, /\.cetak-skor \.print-page \{ break-after: page; page-break-after: always; \}/);
+  assert.match(css, /padding: \.5pt 2pt; font-size: 7pt; line-height: 1/);
+  assert.doesNotMatch(css, /\.cetak-skor[\s\S]*font-size: [0-6](?:\.|pt)/);
+  assert.match(js, /class="kepala-cetak-skor"/);
+  assert.doesNotMatch(js.slice(js.indexOf("function buatCetakanSkor"),
+    js.indexOf("function pasangCetakSkor")), /class="print-note"/);
+  assert.match(js, /buatCetakanSkor\(kode, golonganDipilih\)/);
+  assert.match(js, /g === golAktif \? " selected" : ""/);
 });


### PR DESCRIPTION
## What
- add a golongan selector to the score-print dialog
- print exactly one selected golongan per job
- compact the detailed score table to one A4 landscape page
- keep text at the 7pt print-safe minimum

## Why
Panitia need readable score sheets while minimizing paper use.