### PR TITLE
feat: combine all scores in one printout

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -31,7 +31,7 @@
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
   <link rel="stylesheet" href="style.css?v=4">
-  <link rel="stylesheet" href="live.css?v=5">
+  <link rel="stylesheet" href="live.css?v=6">
 </head>
 <body>
   <header class="kepala">
@@ -56,8 +56,6 @@
   <dialog class="dialog-cetak" id="dialog-cetak" aria-labelledby="judul-cetak">
     <form method="dialog">
       <h2 id="judul-cetak">Print Skor</h2>
-      <label for="pilihan-cetak">Pilih daftar</label>
-      <select id="pilihan-cetak"></select>
       <label for="golongan-cetak">Golongan</label>
       <select id="golongan-cetak"></select>
       <div class="aksi-cetak">
@@ -80,6 +78,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=16"></script>
+  <script type="module" src="live.js?v=17"></script>
 </body>
 </html>

--- a/live/live.css
+++ b/live/live.css
@@ -282,15 +282,22 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
   .cetak-skor .kepala-cetak-skor h1 { font-size: 11pt; margin: 0; white-space: nowrap; }
   .cetak-skor .kepala-cetak-skor p { font-size: 7pt; margin: 0; text-align: right; }
   .cetak-skor .print-table { margin-top: 0; }
+  .cetak-skor .print-table { table-layout: fixed; width: 100%; }
   .cetak-skor thead { display: table-header-group; }
   .cetak-skor tr { break-inside: avoid; page-break-inside: avoid; }
   .cetak-skor .print-table th, .cetak-skor .print-table td {
     padding: .5pt 2pt; font-size: 7pt; line-height: 1;
   }
   .cetak-skor .print-table th { font-size: 7pt; border-bottom-width: 1pt; }
-  .cetak-skor .print-table td.dada { width: 12mm; font-size: 7pt; }
-  .cetak-skor .print-table td:nth-child(2) { width: 38mm; }
-  .cetak-skor .print-table td:nth-child(3) { width: 48mm; }
-  .cetak-skor .print-table td:last-child { width: 17mm; }
+  .cetak-skor .print-table th:nth-child(1),
+  .cetak-skor .print-table td.dada { width: 10mm; font-size: 7pt; }
+  .cetak-skor .print-table th:nth-child(2),
+  .cetak-skor .print-table td:nth-child(2) { width: 30mm; }
+  .cetak-skor .print-table th:nth-child(3),
+  .cetak-skor .print-table td:nth-child(3) { width: 38mm; }
+  .cetak-skor .print-table th:last-child,
+  .cetak-skor .print-table td:last-child { width: 15mm; }
+  .cetak-skor .kepala-pos { border-left-width: 1.5pt; }
+  .cetak-skor .kepala-lomba { white-space: normal; overflow-wrap: anywhere; }
 }
 

--- a/live/live.js
+++ b/live/live.js
@@ -369,51 +369,31 @@ const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
 /* ---------------------------------------------------------------------------
    CETAK SKOR — hanya fase penuh, dan tidak mengambil data lagi.
 
-   Pos memakai poin per lomba dari `progres.poin`, lalu Total Pos dari
-   `klasemen.poin_per_pos`. Keberangkatan adalah klasemen total yang dibawa
-   `total`; lembar itu dipasang di titik kumpul ketika seluruh hasil sudah
-   dibuka. Empat golongan dipisah agar regu tidak pernah dibandingkan dengan
-   golongan lain.
+   Seluruh lomba Pos 1-5 digabung dalam satu tabel, lalu Total Akhir dari
+   klasemen. Detail memakai `progres.poin`; identitas, total, dan urutan juara
+   memakai `klasemen`. Satu golongan tetap satu lembar agar regu tidak pernah
+   dibandingkan dengan golongan lain.
    ------------------------------------------------------------------------- */
-const pilihanCetak = () => [
-  ...((META && META.pos) || [])
-    .filter(p => Number(p.nomor) >= 1 && Number(p.nomor) <= 5)
-    .map(p => ({ kode: String(p.nomor),
-      label: `Pos ${p.nomor} · ${p.name}`, judul: `Skor Pos ${p.nomor} · ${p.name}` })),
-  { kode: "keberangkatan", label: "Keberangkatan",
-    judul: "Keberangkatan · Total Skor" },
-];
-
-const skorCetak = (baris, kode) => {
-  const mentah = kode === "keberangkatan"
-    ? baris.total
-    : baris.poin_per_pos && baris.poin_per_pos[kode];
+const skorTotalCetak = (baris) => {
+  const mentah = baris.total;
   if (mentah === null || mentah === undefined || mentah === "") return null;
   const angka = Number(mentah);
   return Number.isFinite(angka) ? angka : null;
 };
 
-function urutSkorCetak(a, b, kode) {
-  const skorA = skorCetak(a, kode);
-  const skorB = skorCetak(b, kode);
+function urutSkorCetak(a, b) {
+  if (a.peringkat !== b.peringkat)
+    return Number(a.peringkat ?? 1e9) - Number(b.peringkat ?? 1e9);
+  const skorA = skorTotalCetak(a);
+  const skorB = skorTotalCetak(b);
   if (skorA === null && skorB !== null) return 1;
   if (skorA !== null && skorB === null) return -1;
   if (skorA !== skorB) return skorB - skorA;
-
-  // Jika skor pos sama, total keseluruhan membuat urutannya tetap berguna.
-  // Untuk Keberangkatan, peringkat database sudah memuat tie-break ketepatan
-  // waktu; jangan membuat aturan peringkat kedua di browser.
-  if (kode === "keberangkatan" && a.peringkat !== b.peringkat)
-    return Number(a.peringkat ?? 1e9) - Number(b.peringkat ?? 1e9);
-  const total = Number(b.total ?? -1e9) - Number(a.total ?? -1e9);
-  if (total) return total;
   return Number(a.nomor_dada ?? 1e9) - Number(b.nomor_dada ?? 1e9);
 }
 
-function buatCetakanSkor(kode, golonganDipilih) {
-  const pilihan = pilihanCetak().find(p => p.kode === kode);
-  if (!pilihan || !golonganPeserta(golonganDipilih)
-      || fase() !== "penuh" || !REKAP) return;
+function buatCetakanSkor(golonganDipilih) {
+  if (!golonganPeserta(golonganDipilih) || fase() !== "penuh" || !REKAP) return;
 
   // Rincian lomba tinggal di progres, sedangkan Total Pos dan peringkat tinggal
   // di klasemen. Keduanya berasal dari snapshot statis yang sama dan disatukan
@@ -422,39 +402,44 @@ function buatCetakanSkor(kode, golonganDipilih) {
   const semua = (REKAP.klasemen || [])
     .map(b => ({ ...perDada.get(b.nomor_dada), ...b }))
     .filter(b => golonganPeserta(b.golongan));
-  const nomorPos = Number(kode);
-  const lomba = kode === "keberangkatan" ? [] : kelompokLomba(kolomPos(
-    ((META && META.komponen) || []).filter(w => Number(w.pos) === nomorPos),
-  ));
+  const perPos = ((META && META.pos) || [])
+    .filter(p => Number(p.nomor) >= 1 && Number(p.nomor) <= 5)
+    .map(p => ({ ...p, lomba: kelompokLomba(kolomPos(
+      ((META && META.komponen) || []).filter(w => Number(w.pos) === Number(p.nomor)),
+    )) }))
+    .filter(p => p.lomba.length);
   // Satu pilihan = satu golongan = satu lembar A4. Mencetak keempat golongan
   // sekaligus memaksa empat halaman padahal petugas biasanya hanya membawa
   // lembar golongan yang sedang diumumkan.
   const halaman = [golonganDipilih].map(g => {
     const baris = semua.filter(b => b.golongan === g)
-      .sort((a, b) => urutSkorCetak(a, b, kode));
-    const kepalaSkor = kode === "keberangkatan"
-      ? `<th class="text-right">Total Skor</th>`
-      : lomba.map(l => `<th class="text-right">${esc(l.nama)}</th>`).join("")
-        + `<th class="text-right">Total Pos</th>`;
+      .sort(urutSkorCetak);
     return `
       <section class="print-page">
         <div class="kepala-cetak-skor">
-          <h1>${esc(pilihan.judul)}</h1>
+          <h1>Rekap Seluruh Nilai</h1>
           <p><strong>${esc(GOLONGAN[g] || g)}</strong> · ${esc(META.edisi?.name || "")}
             · ${esc(tanggalJam(META.dibuat_pada))}</p>
         </div>
         <table class="print-table">
-          <thead><tr>
-            <th>No Dada</th><th>Nama Regu</th><th>Asal Sekolah</th>
-            ${kepalaSkor}
-          </tr></thead>
+          <thead>
+            <tr>
+              <th rowspan="2">No Dada</th><th rowspan="2">Nama Regu</th>
+              <th rowspan="2">Asal Sekolah</th>
+              ${perPos.map(p => `<th class="text-center kepala-pos" colspan="${
+                esc(String(p.lomba.length))}">Pos ${esc(String(p.nomor))}</th>`).join("")}
+              <th rowspan="2" class="text-right">Total Akhir</th>
+            </tr>
+            <tr>${perPos.map(p => p.lomba.map(l =>
+              `<th class="text-right kepala-lomba">${esc(l.nama)}</th>`).join("")).join("")}</tr>
+          </thead>
           <tbody>${baris.map(b => {
-            const skor = skorCetak(b, kode);
-            const rincian = lomba.map(l => {
-              const r = ringkasLomba(l, b.golongan, nomorPos, b.poin || {});
+            const skor = skorTotalCetak(b);
+            const rincian = perPos.map(p => p.lomba.map(l => {
+              const r = ringkasLomba(l, b.golongan, p.nomor, b.poin || {});
               const nilai = r.berlaku && r.terisi ? angkaRapi(r.jumlah) : "—";
               return `<td class="text-right">${esc(nilai)}</td>`;
-            }).join("");
+            }).join("")).join("");
             return `<tr>
               <td class="dada">${esc(dada(b.nomor_dada))}</td>
               <td>${esc(b.nama_regu || "—")}</td>
@@ -479,24 +464,20 @@ function buatCetakanSkor(kode, golonganDipilih) {
 function pasangCetakSkor() {
   const buka = document.getElementById("buka-cetak");
   const dialog = document.getElementById("dialog-cetak");
-  const daftar = document.getElementById("pilihan-cetak");
   const golongan = document.getElementById("golongan-cetak");
   const cetak = document.getElementById("cetak-skor");
-  if (!buka || !dialog || !daftar || !golongan || !cetak) return;
+  if (!buka || !dialog || !golongan || !cetak) return;
 
   buka.addEventListener("click", () => {
-    daftar.innerHTML = pilihanCetak().map(p =>
-      `<option value="${esc(p.kode)}">${esc(p.label)}</option>`).join("");
     golongan.innerHTML = URUT_GOLONGAN_PESERTA.map(g =>
       `<option value="${esc(g)}"${g === golAktif ? " selected" : ""}>${
         esc(GOLONGAN[g] || g)}</option>`).join("");
     dialog.showModal();
   });
   cetak.addEventListener("click", () => {
-    const kode = daftar.value;
     const golonganDipilih = golongan.value;
     dialog.close();
-    buatCetakanSkor(kode, golonganDipilih);
+    buatCetakanSkor(golonganDipilih);
   });
   window.addEventListener("afterprint", () =>
     document.getElementById("cetakan")?.remove());

--- a/tests/live_score_print.test.mjs
+++ b/tests/live_score_print.test.mjs
@@ -11,29 +11,28 @@ test("Print hanya tersedia pada fase Live penuh", () => {
   assert.match(js, /tombolCetak\.hidden = fase\(\) !== "penuh" \|\| !REKAP/);
 });
 
-test("pilihan cetak memuat Pos 1-5 dan Keberangkatan", () => {
+test("cetakan menggabungkan seluruh lomba Pos 1-5", () => {
   assert.match(js, /Number\(p\.nomor\) >= 1 && Number\(p\.nomor\) <= 5/);
-  assert.match(js, /kode: "keberangkatan", label: "Keberangkatan"/);
-  assert.match(html, /<select id="pilihan-cetak"><\/select>/);
+  assert.doesNotMatch(html, /id="pilihan-cetak"/);
   assert.match(html, /<select id="golongan-cetak"><\/select>/);
+  assert.match(js, /<h1>Rekap Seluruh Nilai<\/h1>/);
 });
 
-test("skor pos dan Keberangkatan memakai data statis yang sudah dimuat", () => {
-  assert.match(js, /baris\.poin_per_pos && baris\.poin_per_pos\[kode\]/);
-  assert.match(js, /\? baris\.total/);
+test("seluruh nilai memakai data statis yang sudah dimuat", () => {
+  assert.match(js, /const mentah = baris\.total/);
   assert.match(js, /new Map\(\(REKAP\.progres \|\| \[\]\)\.map/);
   assert.doesNotMatch(js.slice(js.indexOf("function buatCetakanSkor"),
     js.indexOf("function pasangCetakSkor")), /fetch\(/);
 });
 
 test("lembar diurutkan skor tertinggi dan dirinci per lomba", () => {
-  assert.match(js, /if \(skorA !== skorB\) return skorB - skorA/);
+  assert.match(js, /return Number\(a\.peringkat \?\? 1e9\) - Number\(b\.peringkat \?\? 1e9\)/);
   for (const kepala of ["No Dada", "Nama Regu", "Asal Sekolah"])
-    assert.ok(js.includes(`<th>${kepala}</th>`));
+    assert.ok(js.includes(`<th rowspan="2">${kepala}</th>`));
   assert.match(js, /kelompokLomba\(kolomPos\(/);
-  assert.match(js, /ringkasLomba\(l, b\.golongan, nomorPos, b\.poin \|\| \{\}\)/);
-  assert.match(js, /<th class="text-right">Total Pos<\/th>/);
-  assert.match(js, /<th class="text-right">Total Skor<\/th>/);
+  assert.match(js, /ringkasLomba\(l, b\.golongan, p\.nomor, b\.poin \|\| \{\}\)/);
+  assert.match(js, /<th rowspan="2" class="text-right">Total Akhir<\/th>/);
+  assert.match(js, /class="text-center kepala-pos" colspan=/);
   assert.match(js, /const halaman = \[golonganDipilih\]\.map\(g =>/);
 });
 
@@ -41,7 +40,7 @@ test("print dibuka langsung dari klik kedua dan hanya cetakan yang terlihat", ()
   const awal = js.indexOf('cetak.addEventListener("click"');
   const akhir = js.indexOf("window.addEventListener", awal);
   const handler = js.slice(awal, akhir);
-  assert.match(handler, /buatCetakanSkor\(kode, golonganDipilih\)/);
+  assert.match(handler, /buatCetakanSkor\(golonganDipilih\)/);
   assert.doesNotMatch(handler, /await|fetch\(/);
   assert.match(css, /@media print[\s\S]*\.kepala, #isi, \.kaki, \.dialog-cetak[\s\S]*display: none !important/);
   assert.match(css, /\.cetak-skor \{ display: block !important; \}/);
@@ -55,6 +54,6 @@ test("setiap golongan dipadatkan ke satu A4 tanpa mengecilkan teks di bawah 7pt"
   assert.match(js, /class="kepala-cetak-skor"/);
   assert.doesNotMatch(js.slice(js.indexOf("function buatCetakanSkor"),
     js.indexOf("function pasangCetakSkor")), /class="print-note"/);
-  assert.match(js, /buatCetakanSkor\(kode, golonganDipilih\)/);
+  assert.match(js, /buatCetakanSkor\(golonganDipilih\)/);
   assert.match(js, /g === golAktif \? " selected" : ""/);
 });


### PR DESCRIPTION
## What
- replace per-pos print selection with one combined score table
- group every lomba column under Pos 1-5 headers
- include Total Akhir and sort by the official ranking
- keep one selected golongan on one compact A4 landscape page

## Why
Panitia need one paper containing the complete score breakdown instead of separate sheets for every pos.