### PR TITLE
feat: award Kostum, Yel Yel and Terfavorit per golongan

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -203,7 +203,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/finish` | Kedatangan | catat jam datang + anggota hadir |
 | `#/pos` | Input Nilai Pos | lembar penilaian satu pos, satu baris per regu |
 | `#/live-score` | Live Score | pemegang hak `live_score` — cincin kemajuan per pos + podium; saklar fase hanya untuk pemegang `pengaturan` |
-| `#/kejuaraan` | Kejuaraan | hasil juara dari skor, Peserta Terbanyak dari nomor dada Eksternal, dan tiga pilihan manual panitia |
+| `#/kejuaraan` | Kejuaraan | hasil juara dari skor, Yel Yel dari poin Pos 5 per golongan, Peserta Terbanyak dari nomor dada Eksternal, dan pilihan manual panitia: Kostum dan Terfavorit per golongan, Terjauh satu untuk seluruh acara |
 | `#/pengaturan-kloter` | Pengaturan Kloter | simulasi dan perbaikan jadwal keberangkatan; pemegang `pengaturan` |
 | `#/ganti-password` | Ganti Password | — |
 | `#/account` | Akun | buat/nonaktifkan akun dan atur matriks hak; pemegang `akun` |

--- a/live/style.css
+++ b/live/style.css
@@ -764,14 +764,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-kejuaraan > tbody > tr > th { display: block; width: auto; padding: 0; }
   .table-kejuaraan > tbody > tr > td { display: block; padding: 0; }
 
-  /* Penghargaan Khusus BERTUMPUK, dan itu bukan pengecualian yang malas:
-     labelnya sampai 159px ("Peserta Terfavorit") — separuh lebar HP — dan tiga
-     dari lima barisnya berisi kotak cari beserta tombol Hapus pilihan, yang
-     tidak muat di sisa 200px. Di sini tidak ada yang bisa tertukar juga:
-     tiap label berbeda kata, bukan Juara I sampai Harapan III. */
-  .kejuaraan-khusus .table-kejuaraan > tbody > tr { display: block; }
-  .kejuaraan-khusus .table-kejuaraan > tbody > tr > th { padding-bottom: .15rem; }
 }
+
+/* Kartu berisi PILIHAN panitia bertumpuk di SEMUA lebar: label di atas, kotak
+   cari selebar kartu di bawahnya.
+
+   Dulu ini cuma aturan HP, karena Penghargaan Khusus satu-satunya kartu
+   pilihan dan ia selebar dua kolom. Sejak Kostum dan Terfavorit ikut dibagi
+   empat golongan, ketiganya berdiri di setengah lebar, dan bersebelahan
+   TIDAK ADA lebar yang benar: label butuh 170px agar "PENGGALANG PA" dan
+   "PESERTA TERBANYAK" tidak patah dua baris, kotak carinya butuh 280px agar
+   perintahnya terbaca utuh, dan di layar 941px — saat dua kolom baru saja
+   menyala — seluruh tabelnya cuma 373px. Diukur di browser, bukan dikira:
+   45% membuat labelnya utuh dan placeholder-nya terpotong, 30% sebaliknya.
+   Bertumpuk, keduanya utuh di 320px sampai 1920px.
+
+   Yel Yel TIDAK ikut: ia dihitung dari poin Pos 5, barisnya cuma nama
+   pemenang, dan itu muat bersebelahan seperti kartu gelar golongan. */
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr {
+  display: block; padding: .5rem 0;
+}
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr:first-child { padding-top: 0; }
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr:last-child { padding-bottom: 0; }
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr > th {
+  display: block; width: auto; padding: 0 0 .15rem;
+}
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr > td { display: block; padding: 0; }
 
 /* Warna per TINGKAT, bukan per kartu.
 
@@ -794,9 +812,19 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kejuaraan-umum-penggalang { --aksen: #067647; background: #f3faf6; }
 .kejuaraan-penggalang-pa,
 .kejuaraan-penggalang-pi   { --aksen: #067647; }
+.kejuaraan-kostum,
+.kejuaraan-yel-yel,
+.kejuaraan-terfavorit,
 .kejuaraan-khusus          { --aksen: #6941c6; }
 .kejuaraan-bagian { display: grid; gap: 1rem; }
 .kejuaraan-bagian .card { margin-bottom: 0; }
+/* `.card { overflow-x: auto }` di bawah membuat overflow-y ikut `auto` — itu
+   aturan CSS, bukan salah ketik — dan daftar saran kotak cari digunting oleh
+   tepi kartunya sendiri. Yang terlihat: kartu Juara Kostum tumbuh penggulir
+   sendiri dan hanya tiga dari delapan calon terbaca. Tabel di sini cuma dua
+   kolom dan tidak pernah perlu menggeser, jadi kartunya tidak butuh gunting
+   itu sama sekali. */
+.kejuaraan-bagian .card { overflow: visible; }
 .kejuaraan-terkunci { display: flex; align-items: center; gap: .45rem; }
 .kejuaraan-nilai { flex: 1; min-width: 0; }
 @media (min-width: 900px) {
@@ -811,7 +839,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .kejuaraan-penegak-pi { grid-column: 1; grid-row: 4; }
   .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 3; }
   .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 4; }
-  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 5; }
+  /* Empat kartu penghargaan khusus, dua baris. Kostum dan Terfavorit — dua
+     kartu yang panitia ISI — berdiri di kolom yang sama supaya kotak carinya
+     berbaris lurus dari kartu ke kartu. */
+  .kejuaraan-kostum { grid-column: 1; grid-row: 5; }
+  .kejuaraan-yel-yel { grid-column: 2; grid-row: 5; }
+  .kejuaraan-terfavorit { grid-column: 1; grid-row: 6; }
+  .kejuaraan-khusus { grid-column: 2; grid-row: 6; }
 }
 .kejuaraan-cari { position: relative; }
 .kejuaraan-isian { display: flex; align-items: center; gap: .45rem; }

--- a/supabase/migrations/0152_kejuaraan_empat_golongan.sql
+++ b/supabase/migrations/0152_kejuaraan_empat_golongan.sql
@@ -1,0 +1,306 @@
+-- ============================================================================
+-- hrcd-rekap : 0152_kejuaraan_empat_golongan.sql
+-- Kostum, Yel Yel, dan Terfavorit diberikan per golongan, bukan satu untuk
+-- seluruh peserta.
+--
+-- Sebelum ini ketiganya hanya punya SATU pemenang. Penegak PA dan Penggalang
+-- PI bersaing di meja yang sama padahal setiap gelar lain di acara ini sudah
+-- dipisah empat golongan, dan Yel Yel bahkan dinilai di Pos 5 yang berjalan
+-- per golongan sejak awal. Sekarang ketiganya ikut pembagian yang sama:
+--
+--   kostum_<golongan>      manual, dipilih pemegang hak `pengaturan`
+--   yel_yel_<golongan>     otomatis, poin Pos 5 tertinggi di golongan itu
+--   terfavorit_<golongan>  manual
+--
+-- Peserta Terjauh tetap satu untuk seluruh acara: yang diukur jarak sekolah,
+-- dan jarak tidak mengenal golongan. Peserta Terbanyak juga tetap satu.
+--
+-- Pilihan manual yang sudah tersimpan TIDAK dibuang: ia dipindahkan ke kode
+-- golongan regu yang terlanjur dipilih, sehingga panitia yang sudah memutuskan
+-- satu Juara Kostum tidak kehilangan keputusannya.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kode penghargaan manual
+-- ---------------------------------------------------------------------------
+
+alter table kejuaraan_manual drop constraint kejuaraan_manual_kode_check;
+
+update kejuaraan_manual m
+set kode = m.kode || '_' || r.golongan
+from regu r
+where r.id = m.regu_id
+  and m.kode in ('kostum', 'terfavorit')
+  and r.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi');
+
+-- Sisanya hanya bisa berupa baris yang regunya tidak lagi sah — 0142 sudah
+-- membuang yang Intern dan 0143 yang belum tiba.
+delete from kejuaraan_manual where kode in ('kostum', 'yel_yel', 'terfavorit');
+
+alter table kejuaraan_manual add constraint kejuaraan_manual_kode_check
+  check (kode in (
+    'kostum_penegak_pa', 'kostum_penegak_pi',
+    'kostum_penggalang_pa', 'kostum_penggalang_pi',
+    'terfavorit_penegak_pa', 'terfavorit_penegak_pi',
+    'terfavorit_penggalang_pa', 'terfavorit_penggalang_pi',
+    'terjauh'));
+
+-- ---------------------------------------------------------------------------
+-- 2. Penyimpan pilihan manual
+-- ---------------------------------------------------------------------------
+
+create or replace function simpan_kejuaraan_manual(p_kode text, p_regu uuid)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_golongan text;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'akun ini tidak berhak mengubah Kejuaraan';
+  end if;
+  if p_kode not in (
+    'kostum_penegak_pa', 'kostum_penegak_pi',
+    'kostum_penggalang_pa', 'kostum_penggalang_pi',
+    'terfavorit_penegak_pa', 'terfavorit_penegak_pi',
+    'terfavorit_penggalang_pa', 'terfavorit_penggalang_pi',
+    'terjauh') then
+    raise exception 'penghargaan manual tidak dikenal';
+  end if;
+
+  if p_regu is null then
+    delete from kejuaraan_manual
+    where edisi = edisi_aktif() and kode = p_kode;
+    return;
+  end if;
+
+  select r.golongan into v_golongan
+  from regu r
+  join closing_regu c on c.regu_id = r.id
+  where r.id = p_regu and r.nomor_dada is not null and not r.is_cancelled
+    and r.golongan not like 'intern_%';
+
+  if v_golongan is null then
+    raise exception 'regu tidak ditemukan, belum tiba, belum mendapat nomor dada, atau termasuk Intern';
+  end if;
+
+  -- Gelar per golongan hanya boleh jatuh ke regu golongan itu. Layar boleh
+  -- saja sudah menyaring daftar pilihannya, tetapi tanpa pagar ini RPC-nya
+  -- tetap menerima regu Penggalang sebagai Juara Kostum Penegak PA.
+  if p_kode <> 'terjauh'
+     and right(p_kode, length(v_golongan) + 1) <> '_' || v_golongan then
+    raise exception 'regu ini golongan %, bukan golongan penghargaan itu', v_golongan;
+  end if;
+
+  insert into kejuaraan_manual (edisi, kode, regu_id, diubah_oleh)
+  values (edisi_aktif(), p_kode, p_regu, auth.uid())
+  on conflict (edisi, kode) do update
+    set regu_id = excluded.regu_id,
+        diubah_oleh = excluded.diubah_oleh,
+        diubah_pada = now();
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Daftar hasil
+--
+-- Yang masih diambil dari hasil_kejuaraan_dasar() tinggal 24 gelar golongan.
+-- Juara Umum, ketiga penghargaan per golongan, Terjauh, dan Terbanyak disusun
+-- di sini — versi 0139 sudah tidak menyisakan satu pun baris lain yang dipakai
+-- apa adanya.
+--
+-- Urutan tampil: 1-3 Juara Umum, 11-56 gelar golongan, 61-64 Kostum,
+-- 65-68 Yel Yel, 69-72 Terfavorit, 73 Terjauh, 74 Terbanyak.
+--
+-- `where boleh('live_score')` sekarang membungkus SELURUH hasil. Sebelumnya
+-- tiap arm membawa pagarnya sendiri dan arm Juara Umum tidak kebagian, jadi
+-- panitia tanpa hak `live_score` tetap bisa membaca nama sekolah Juara Umum.
+-- ---------------------------------------------------------------------------
+
+drop view v_kejuaraan;
+drop function hasil_kejuaraan();
+
+create function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric, poin_juara numeric, jumlah_skor numeric
+)
+language sql stable security definer
+set search_path = public
+as $$
+with
+golongan_juara(kode, nama, nomor) as (values
+  ('penegak_pa', 'Penegak PA', 1), ('penegak_pi', 'Penegak PI', 2),
+  ('penggalang_pa', 'Penggalang PA', 3), ('penggalang_pi', 'Penggalang PI', 4)
+),
+peringkat_eksternal as (
+  select k.*,
+         row_number() over (
+           partition by k.golongan
+           order by k.total desc,
+                    abs(coalesce(k.selisih_menit, 100000)) asc,
+                    k.nomor_dada asc) as nomor_juara
+  from v_klasemen k
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+),
+calon_umum as (
+  select nama_sekolah,
+         count(*) filter (where nomor_juara <= 6) as jumlah_juara,
+         sum(7 - nomor_juara) filter (where nomor_juara <= 6) as bobot_juara,
+         sum(total) filter (where nomor_juara <= 6) as jumlah_skor,
+         case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end as tingkat
+  from peringkat_eksternal
+  group by nama_sekolah,
+           case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end
+),
+calon_semua as (
+  select nama_sekolah, sum(jumlah_juara) jumlah_juara,
+         sum(bobot_juara) bobot_juara, sum(jumlah_skor) jumlah_skor
+  from calon_umum group by nama_sekolah
+),
+kandidat_umum as (
+  select 'semua'::text tingkat, * from calon_semua
+  union all
+  select tingkat, nama_sekolah, jumlah_juara, bobot_juara, jumlah_skor
+  from calon_umum
+),
+juara_umum as (
+  select d.urutan, d.kode, d.nama nama_penghargaan,
+         'skor'::text sumber, null::uuid regu_id, null::integer nomor_dada,
+         null::text nama_regu, x.nama_sekolah, null::text golongan,
+         null::numeric total, x.bobot_juara poin_juara, x.jumlah_skor
+  from (values
+    (1, 'juara_umum', 'Juara Umum ' || (select name from edisi where is_active), 'semua'),
+    (2, 'juara_umum_penegak', 'Juara Umum Penegak', 'penegak'),
+    (3, 'juara_umum_penggalang', 'Juara Umum Penggalang', 'penggalang')
+  ) d(urutan, kode, nama, tingkat)
+  left join lateral (
+    select nama_sekolah, bobot_juara, jumlah_skor
+    from kandidat_umum k where k.tingkat = d.tingkat
+    order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah
+    limit 1
+  ) x on true
+),
+manual as (
+  select a.urutan_dasar + g.nomor as urutan,
+         a.kode || '_' || g.kode as kode,
+         a.nama || ' ' || g.nama as nama_penghargaan,
+         'manual'::text as sumber,
+         r.id as regu_id, r.nomor_dada, r.nama_regu, s.name as nama_sekolah,
+         r.golongan, null::numeric total,
+         null::numeric poin_juara, null::numeric jumlah_skor
+  from (values ('kostum', 'Juara Kostum', 60),
+               ('terfavorit', 'Peserta Terfavorit', 68))
+       a(kode, nama, urutan_dasar)
+  cross join golongan_juara g
+  left join kejuaraan_manual m
+    on m.edisi = edisi_aktif() and m.kode = a.kode || '_' || g.kode
+  left join regu r on r.id = m.regu_id
+  left join pendaftaran d on d.id = r.pendaftaran_id
+  left join sekolah s on s.id = d.sekolah_id
+  union all
+  select 73, 'terjauh', 'Peserta Terjauh', 'manual',
+         r.id, r.nomor_dada, r.nama_regu, s.name, r.golongan,
+         null::numeric, null::numeric, null::numeric
+  from (values (true)) satu(ada)
+  left join kejuaraan_manual m
+    on m.edisi = edisi_aktif() and m.kode = 'terjauh'
+  left join regu r on r.id = m.regu_id
+  left join pendaftaran d on d.id = r.pendaftaran_id
+  left join sekolah s on s.id = d.sekolah_id
+),
+yel_yel as (
+  select 64 + g.nomor as urutan,
+         'yel_yel_' || g.kode as kode,
+         'Juara Yel Yel ' || g.nama as nama_penghargaan,
+         'skor'::text as sumber,
+         y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+         y.golongan, y.poin_pos as total,
+         null::numeric poin_juara, null::numeric jumlah_skor
+  from golongan_juara g
+  left join lateral (
+    select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+           k.golongan, pp.poin_pos
+    from v_klasemen k
+    join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+    where k.golongan = g.kode
+    order by pp.poin_pos desc, k.total desc, k.nomor_dada
+    limit 1
+  ) y on true
+),
+terbanyak as (
+  select 74, 'peserta_terbanyak', 'Peserta Terbanyak', 'nomor_dada'::text,
+         null::uuid, null::integer, null::text, p.nama_sekolah,
+         null::text, p.jumlah::numeric, null::numeric, null::numeric
+  from (values (true)) satu(ada)
+  left join lateral (
+    select s.name nama_sekolah, count(*) jumlah
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    join sekolah s on s.id = d.sekolah_id
+    where r.nomor_dada is not null and not r.is_cancelled
+      and d.status = 'lunas' and r.golongan not like 'intern_%'
+    group by s.name
+    order by jumlah desc, s.name
+    limit 1
+  ) p on true
+)
+select * from (
+  select d.urutan, d.kode, d.nama_penghargaan, d.sumber, d.regu_id,
+         d.nomor_dada, d.nama_regu, d.nama_sekolah, d.golongan, d.total,
+         null::numeric, null::numeric
+  from hasil_kejuaraan_dasar() d
+  where d.kode ~ '^(penegak|penggalang)_(pa|pi)_[1-6]$'
+  union all select * from juara_umum
+  union all select * from manual
+  union all select * from yel_yel
+  union all select * from terbanyak
+) semua
+where boleh('live_score')
+order by urutan
+$$;
+
+revoke all on function hasil_kejuaraan() from public;
+grant execute on function hasil_kejuaraan() to authenticated;
+
+create view v_kejuaraan as select * from hasil_kejuaraan();
+grant select on v_kejuaraan to authenticated;
+
+comment on column v_kejuaraan.poin_juara is
+  'Total poin posisi enam besar: 6, 5, 4, 3, 2, 1. Hanya diisi untuk Juara Umum.';
+comment on column v_kejuaraan.jumlah_skor is
+  'Jumlah skor regu sekolah yang berada di peringkat 1-6 dalam cakupan Juara Umum; pemecah poin sama.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Pagar penutup
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+  v_sisa integer;
+begin
+  -- Yang dijaga 0148, 0149 dan 0151 ikut ditulis ulang di sini. Kalau salah
+  -- satunya luput, Juara Umum kembali ke aturan lama tanpa satu pun galat.
+  assert v_def like
+    '%order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah%',
+    '0152: urutan Juara Umum tidak lagi memakai poin gelar dengan NULLS LAST';
+  assert v_def like '%sum(total) filter (where nomor_juara <= 6) as jumlah_skor%',
+    '0152: jumlah skor Juara Umum tidak lagi dibatasi ke enam besar';
+
+  -- Ketiganya harus dibangun dari golongan_juara, bukan ditulis satu baris.
+  assert v_def like '%''yel_yel_'' || g.kode%',
+    '0152: Yel Yel tidak dibangun per golongan';
+  assert v_def like '%a.kode || ''_'' || g.kode%',
+    '0152: Kostum dan Terfavorit tidak dibangun per golongan';
+
+  select count(*) into v_sisa from kejuaraan_manual
+  where kode in ('kostum', 'yel_yel', 'terfavorit');
+  assert v_sisa = 0,
+    format('0152: %s pilihan manual masih memakai kode lama', v_sisa);
+end;
+$$;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -89,12 +89,15 @@ LEWATI_DULU="0076_bidai_dan_lomba_soal 0118_jeda_kloter_maksimal
              0129_impor_pendaftaran_xxxvii 0130_bukti_transfer_link_drive
              0131_impor_pendaftaran_xxxvii_susulan
              0132_impor_pendaftaran_xxxvii_lanjutan
-             0133_kelas_organisasi_regu 0134_kelas_organisasi_tanpa_simbol"
+             0133_kelas_organisasi_regu 0134_kelas_organisasi_tanpa_simbol
+             0137_riwayat_pendaftaran 0138_riwayat_pelaku_kosong
+             0146_cache_live_score 0147_waktu_nol_pos_2"
 ULANG="0032_konfigurasi_xxxvii 0033_nama_pos_xxxvii 0034_nama_pos_final
        0035_tangga_menaksir 0036_kriteria_bidai 0037_petunjuk_kolom
        0038_petunjuk_menaksir 0039_judul_isian 0054_kolom_lomba
        0076_bidai_dan_lomba_soal 0091_intern_golongan
-       0093_configure_fifo_capacity 0118_jeda_kloter_maksimal"
+       0093_configure_fifo_capacity 0105_expand_kloter_capacity
+       0118_jeda_kloter_maksimal"
 
 # Yang dilewati WAJIB dijalankan lagi di suatu tempat. Kalau tidak, ia tidak
 # dijalankan sama sekali — kerusakan yang sama dengan berhenti di 0011, dan
@@ -164,7 +167,15 @@ run supabase/migrations/0024_komponen_pos.sql
 #     database ini" dan penjaganya diam.
 #   * 0091 harus SESUDAH 0076 agar lima komponen Soal Tulis yang disalin untuk
 #     Intern sudah ada. 0093 menyiapkan 60 kloter setelah edisi aktif lahir;
-#     0105 menambah headroom-nya menjadi 75.
+#     0105 menambah headroom-nya menjadi 75, dan ia HARUS ikut diulang di
+#     sini: di glob ia berjalan sebelum edisi aktif lahir, jadi
+#     `select kloter_maks from edisi where is_active` tidak menemukan apa
+#     pun dan nol kloter dibuat — tanpa sepatah galat. Akibatnya dev
+#     berhenti di 60 kloter sementara produksi punya 75, dan layar yang
+#     dicoba di laptop memakai papan kloter yang tidak ada di lapangan.
+#     Urutannya sesudah 0093 dan sebelum 0118, sama dengan nomornya di
+#     tests/run.sh: 0093 membuat 60, 0105 menaikkannya jadi 75, lalu
+#     assert 0118 memeriksa sebaran jamnya atas jumlah yang benar.
 for m in $ULANG; do
   run "supabase/migrations/$m.sql"
 done
@@ -222,5 +233,35 @@ run supabase/migrations/0132_impor_pendaftaran_xxxvii_lanjutan.sql
 # yang sama dengan keempat migrasi impor di atasnya.
 run supabase/migrations/0133_kelas_organisasi_regu.sql
 run supabase/migrations/0134_kelas_organisasi_tanpa_simbol.sql
+# 0137 dan 0138 sebab yang SAMA PERSIS dengan 0133/0134 di atas: pagar
+# penutupnya mengirim satu pendaftaran lewat submit_pendaftaran lalu
+# menghapusnya lagi. Tanpa edisi aktif, `'HRCD' || edisi_aktif() || '-' || ...`
+# jadi NULL dan kode_pembayaran menabrak not-null constraint — skripnya
+# berhenti persis di situ, dan sejak 0137 mendarat TIDAK ADA cara membuka satu
+# layar pun di laptop (CLAUDE.md 17.6).
+#
+# Keduanya cuma meninggalkan `create or replace view v_riwayat_pendaftaran`
+# beserta grant dan comment-nya. Yang membacanya sesudah 0137 sampai ujung
+# daftar cuma 0138, dan 0138 ikut ditunda ke sini — urutannya tetap 0137 lalu
+# 0138, sama dengan nomornya.
+run supabase/migrations/0137_riwayat_pendaftaran.sql
+run supabase/migrations/0138_riwayat_pelaku_kosong.sql
+
+# 0146 dan 0147 ditunda ke ujung karena keduanya diakhiri
+# `select segarkan_cache_live_score()`, dan fungsi itu memilih satu akun
+# aktif pemegang hak live_score untuk menempati kursinya. Di glob belum ada
+# satu akun pun, jadi ia melempar 'Tidak ada akun aktif dengan hak
+# live_score' dan skripnya BERHENTI di situ — 0148 sampai 0152 tidak pernah
+# jalan, dan layar Kejuaraan di laptop memakai aturan lama tanpa ada yang
+# memberi tahu (CLAUDE.md 17.6).
+#
+# 0147 punya alasan kedua untuk ada di sini: ia memasang tingkat nol pada
+# komponen waktu Pos 2 `where edisi = edisi_aktif()`. Di glob edisi aktif
+# belum lahir, jadi nol baris tersentuh dan ia cuma memberi notice
+# 'dilewati' — kalimat yang terbaca seperti keterangan, bukan kegagalan.
+# Urutannya 0146 lalu 0147, sama dengan nomornya: 0147 memanggil fungsi yang
+# baru dibuat 0146.
+run supabase/migrations/0146_cache_live_score.sql
+run supabase/migrations/0147_waktu_nol_pos_2.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -700,5 +700,7 @@ run supabase/migrations/0150_tampilkan_poin_juara_umum.sql
 run tests/sql/102_tampilkan_poin_juara_umum.sql
 run supabase/migrations/0151_skor_juara_umum_enam_besar.sql
 run tests/sql/103_skor_juara_umum_enam_besar.sql
+run supabase/migrations/0152_kejuaraan_empat_golongan.sql
+run tests/sql/104_kejuaraan_empat_golongan.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/104_kejuaraan_empat_golongan.sql
+++ b/tests/sql/104_kejuaraan_empat_golongan.sql
@@ -1,0 +1,172 @@
+\echo '--- 104. Kostum, Yel Yel dan Terfavorit dibagi empat golongan'
+
+-- Lima regu uji: dua Penegak PA supaya Yel Yel benar-benar harus memilih di
+-- dalam golongan, dan satu di tiap golongan lain supaya keempat baris Yel Yel
+-- pasti terisi apa pun isi database sebelum tes ini.
+
+do $blok$
+declare
+  v_sekolah uuid := gen_random_uuid();
+  v_daftar uuid := gen_random_uuid();
+  v_pa_kalah uuid := gen_random_uuid();
+  v_pa_menang uuid := gen_random_uuid();
+  v_pi uuid := gen_random_uuid();
+  v_penggalang_pa uuid := gen_random_uuid();
+  v_penggalang_pi uuid := gen_random_uuid();
+  v_petugas uuid := '00000000-0000-0000-0000-00000000000a';
+  v_jam_lama timestamptz;
+  v_wahana uuid;
+  v_salah integer;
+  v_jumlah integer;
+  v_nomor integer;
+begin
+  select jam_berangkat into v_jam_lama from kloter where nomor = 75;
+  update kloter set jam_berangkat = timestamptz '2026-08-29 07:00+07'
+  where nomor = 75;
+
+  insert into sekolah (id, name, address)
+  values (v_sekolah, 'SEKOLAH UJI 104', 'Alamat uji');
+  insert into pendaftaran
+    (id, sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+     jumlah_regu, kontak_wa, status, kunci_kirim)
+  values
+    (v_daftar, v_sekolah, 'UJI104', false, 0, 5,
+     '086666666666', 'lunas', gen_random_uuid());
+  insert into regu
+    (id, pendaftaran_id, nama_regu, nama_ketua, golongan,
+     nomor_dada, kloter_nomor, urutan_kloter)
+  values
+    (v_pa_kalah, v_daftar, 'UJI KEJUARAAN PA 1', 'KETUA UJI',
+     'penegak_pa', 491, 75, 1),
+    (v_pa_menang, v_daftar, 'UJI KEJUARAAN PA 2', 'KETUA UJI',
+     'penegak_pa', 492, 75, 2),
+    (v_pi, v_daftar, 'UJI KEJUARAAN PI 3', 'KETUA UJI',
+     'penegak_pi', 493, 75, 3),
+    (v_penggalang_pa, v_daftar, 'UJI KEJUARAAN GALANG PA 4', 'KETUA UJI',
+     'penggalang_pa', 494, 75, 4),
+    (v_penggalang_pi, v_daftar, 'UJI KEJUARAAN GALANG PI 5', 'KETUA UJI',
+     'penggalang_pi', 495, 75, 5);
+
+  insert into keberangkatan_regu (regu_id, recorded_by)
+  select id, v_petugas from regu where pendaftaran_id = v_daftar;
+  insert into closing_regu (regu_id, jam_datang, anggota_hadir, recorded_by)
+  select id, timestamptz '2026-08-29 10:00+07', 5, v_petugas
+  from regu where pendaftaran_id = v_daftar;
+
+  -- Sandi Morse adalah komponen Pos 5 di database uji: benar_kurang_salah,
+  -- +10 per benar, dipotong di 100. Sepuluh benar = 100 poin, tiga = 30.
+  select id into strict v_wahana from wahana
+  where edisi = edisi_aktif() and kode = 'sandi_morse';
+  insert into nilai_mentah (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
+  values
+    (v_pa_kalah, v_wahana, 3, 0, 'manual', v_petugas),
+    (v_pa_menang, v_wahana, 10, 0, 'manual', v_petugas),
+    (v_pi, v_wahana, 10, 0, 'manual', v_petugas),
+    (v_penggalang_pa, v_wahana, 10, 0, 'manual', v_petugas),
+    (v_penggalang_pi, v_wahana, 10, 0, 'manual', v_petugas);
+
+  set local role authenticated;
+  perform set_config('app.uid', v_petugas::text, true);
+
+  -- 104.1 sampai 104.3 — bentuk daftarnya
+  create temp table hasil_104 as select * from hasil_kejuaraan();
+
+  select count(*) into v_jumlah from hasil_104 where kode like 'kostum\_%';
+  assert v_jumlah = 4, format('104.1 GAGAL: baris Kostum = %s', v_jumlah);
+  select count(*) into v_jumlah from hasil_104 where kode like 'yel\_yel\_%';
+  assert v_jumlah = 4, format('104.2 GAGAL: baris Yel Yel = %s', v_jumlah);
+  select count(*) into v_jumlah from hasil_104 where kode like 'terfavorit\_%';
+  assert v_jumlah = 4, format('104.3 GAGAL: baris Terfavorit = %s', v_jumlah);
+
+  -- 104.4 — Terjauh, Terbanyak dan 24 gelar golongan tidak ikut terbelah
+  select count(*) into v_jumlah from hasil_104
+  where kode in ('terjauh', 'peserta_terbanyak');
+  assert v_jumlah = 2, format('104.4 GAGAL: Terjauh + Terbanyak = %s', v_jumlah);
+  select count(*) into v_jumlah from hasil_104
+  where kode ~ '^(penegak|penggalang)_(pa|pi)_[1-6]$';
+  assert v_jumlah = 24, format('104.5 GAGAL: gelar golongan = %s', v_jumlah);
+
+  -- 104.6 — kode lama benar-benar hilang, bukan sekadar tidak dipakai layar
+  select count(*) into v_jumlah from hasil_104
+  where kode in ('kostum', 'yel_yel', 'terfavorit');
+  assert v_jumlah = 0, format('104.6 GAGAL: %s kode lama masih terbit', v_jumlah);
+
+  -- 104.7 — tiap pemenang Yel Yel benar-benar poin Pos 5 tertinggi DI
+  -- GOLONGANNYA. Diperiksa terhadap isi database, bukan terhadap nomor dada
+  -- yang ditulis di tes ini, supaya tetap benar walau tes lain menambah regu.
+  reset role;
+  select count(*) into v_salah from hasil_104 hk
+  where hk.kode like 'yel\_yel\_%'
+    and exists (
+      select 1 from v_klasemen k
+      join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+      where k.golongan = replace(hk.kode, 'yel_yel_', '')
+        and pp.poin_pos > coalesce(hk.total, -1));
+  assert v_salah = 0,
+    format('104.7 GAGAL: %s Juara Yel Yel bukan poin Pos 5 tertinggi di golongannya', v_salah);
+
+  select count(*) into v_salah from hasil_104
+  where kode like 'yel\_yel\_%' and nomor_dada is null;
+  assert v_salah = 0,
+    format('104.8 GAGAL: %s baris Yel Yel kosong padahal golongannya ada pesertanya', v_salah);
+
+  select nomor_dada into v_nomor from hasil_104 where kode = 'yel_yel_penegak_pa';
+  assert v_nomor <> 491,
+    '104.9 GAGAL: Yel Yel Penegak PA jatuh ke regu dengan poin Pos 5 lebih rendah';
+
+  -- 104.10 — golongan penghargaan dan golongan regu harus cocok
+  set local role authenticated;
+  perform set_config('app.uid', v_petugas::text, true);
+  begin
+    perform simpan_kejuaraan_manual('kostum_penegak_pa', v_penggalang_pi);
+    assert false, '104.10 GAGAL: regu Penggalang PI diterima sebagai Kostum Penegak PA';
+  exception when others then
+    assert sqlerrm like 'regu ini golongan %',
+      format('104.10 GAGAL: penolakannya salah: %s', sqlerrm);
+  end;
+
+  -- 104.11 — kode lama tidak bisa lagi disimpan
+  begin
+    perform simpan_kejuaraan_manual('kostum', v_pa_menang);
+    assert false, '104.11 GAGAL: kode Kostum lama masih diterima';
+  exception when others then
+    assert sqlerrm = 'penghargaan manual tidak dikenal',
+      format('104.11 GAGAL: penolakannya salah: %s', sqlerrm);
+  end;
+
+  -- 104.12 — jalur normal: simpan, terbit, lalu dikosongkan lagi
+  perform simpan_kejuaraan_manual('terfavorit_penggalang_pi', v_penggalang_pi);
+  select nomor_dada into v_nomor from hasil_kejuaraan()
+  where kode = 'terfavorit_penggalang_pi';
+  assert v_nomor = 495,
+    format('104.12 GAGAL: Terfavorit Penggalang PI = %s', v_nomor);
+
+  perform simpan_kejuaraan_manual('terfavorit_penggalang_pi', null);
+  reset role;
+  select count(*) into v_jumlah from kejuaraan_manual
+  where edisi = edisi_aktif() and kode = 'terfavorit_penggalang_pi';
+  assert v_jumlah = 0, '104.13 GAGAL: pilihan Terfavorit tidak terhapus';
+
+  -- 104.14 — akun tanpa live_score tidak melihat apa pun, Juara Umum termasuk
+  set local role authenticated;
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000ff', true);
+  select count(*) into v_jumlah from hasil_kejuaraan();
+  assert v_jumlah = 0,
+    format('104.14 GAGAL: akun tanpa live_score membaca %s baris', v_jumlah);
+
+  reset role;
+  drop table hasil_104;
+  delete from nilai_mentah where regu_id in
+    (select id from regu where pendaftaran_id = v_daftar);
+  delete from closing_regu where regu_id in
+    (select id from regu where pendaftaran_id = v_daftar);
+  delete from keberangkatan_regu where regu_id in
+    (select id from regu where pendaftaran_id = v_daftar);
+  delete from regu where pendaftaran_id = v_daftar;
+  delete from pendaftaran where id = v_daftar;
+  delete from sekolah where id = v_sekolah;
+  update kloter set jam_berangkat = v_jam_lama where nomor = 75;
+end;
+$blok$;
+
+\echo '104 kejuaraan empat golongan: LULUS'

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6110,7 +6110,13 @@ async function layarKejuaraan() {
       && !String(r.golongan).startsWith("intern_"))
     .map(r => [r.regu_id, r])).values()]
     .sort((a, b) => Number(a.nomor_dada) - Number(b.nomor_dada));
-  const manual = new Set(["kostum", "terfavorit", "terjauh"]);
+  /* Kostum dan Terfavorit dipilih PER GOLONGAN, jadi kotak carinya hanya boleh
+     menawarkan regu golongan itu. Golongannya dibaca dari ekor kode
+     (`kostum_penegak_pa`); Terjauh tidak berekor dan tetap memilih dari
+     seluruh peserta. RPC-nya menolak pasangan yang salah juga — ini yang
+     membuat panitia tidak perlu sampai ditolak. */
+  const golonganKode = (kode) =>
+    (kode.match(/(?:penegak|penggalang)_(?:pa|pi)$/) || [""])[0];
   const labelRegu = (r) => `${dada3(r.nomor_dada)} · ${r.nama_regu} · ${r.nama_sekolah}`;
   const nilai = (x) => {
     if (x.nama_regu) return `<strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
@@ -6121,7 +6127,7 @@ async function layarKejuaraan() {
         ? `<span class="description">${esc(angkaRapi(x.total))} regu bernomor dada</span>` : ""}`;
     return `<span class="description">Belum ditentukan</span>`;
   };
-  const baris = (x, label = x.nama_penghargaan) => manual.has(x.kode) && bisaUbah ? `
+  const baris = (x, label = x.nama_penghargaan) => x.sumber === "manual" && bisaUbah ? `
     <tr><th>${esc(label)}</th><td>
       <div class="kejuaraan-terkunci" ${x.regu_id ? "" : "hidden"}>
         <div class="kejuaraan-nilai">${nilai(x)}</div>
@@ -6132,31 +6138,43 @@ async function layarKejuaraan() {
       <div class="kejuaraan-isian" ${x.regu_id ? "hidden" : ""}>
         <div class="kejuaraan-cari">
           <input type="search" class="small-input kejuaraan-pilih" data-kode="${esc(x.kode)}"
+            data-golongan="${esc(golonganKode(x.kode))}"
             autocomplete="off" aria-label="Pilih ${esc(x.nama_penghargaan)}"
-            placeholder="Nomor dada / nama regu / asal sekolah…"
+            placeholder="Cari nomor dada / regu / sekolah…"
             value="${esc(x.regu_id ? labelRegu(x) : "")}">
           <div class="suggestions kejuaraan-saran" hidden></div>
         </div>
       </div></td></tr>` : `<tr><th>${esc(label)}</th><td>${nilai(x)}</td></tr>`;
+
+  /* Label golongan diambil dari GOLONGAN_LABEL, tidak ditulis ulang di sini:
+     satu-satunya tempatnya `util.js`, dan `periksa_urutan_golongan.py` yang
+     menjaganya tetap satu. */
+  const gelarGolongan = (kode, kelas) => [
+    GOLONGAN_LABEL[kode], x => x.kode.startsWith(kode + "_"),
+    x => x.nama_penghargaan.replace(GOLONGAN_LABEL[kode] + " ", ""), kelas];
 
   const bagian = [
     ["Juara Umum", x => x.kode === "juara_umum",
       x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum"],
     ["Juara Umum Penegak", x => x.kode === "juara_umum_penegak",
       () => "PENEGAK", "kejuaraan-umum-penegak"],
-    ["Penegak PA", x => x.kode.startsWith("penegak_pa_"),
-      x => x.nama_penghargaan.replace(/^Penegak PA /, ""), "kejuaraan-penegak-pa"],
-    ["Penegak PI", x => x.kode.startsWith("penegak_pi_"),
-      x => x.nama_penghargaan.replace(/^Penegak PI /, ""), "kejuaraan-penegak-pi"],
+    gelarGolongan("penegak_pa", "kejuaraan-penegak-pa"),
+    gelarGolongan("penegak_pi", "kejuaraan-penegak-pi"),
     ["Juara Umum Penggalang", x => x.kode === "juara_umum_penggalang",
       () => "PENGGALANG", "kejuaraan-umum-penggalang"],
-    ["Penggalang PA", x => x.kode.startsWith("penggalang_pa_"),
-      x => x.nama_penghargaan.replace(/^Penggalang PA /, ""), "kejuaraan-penggalang-pa"],
-    ["Penggalang PI", x => x.kode.startsWith("penggalang_pi_"),
-      x => x.nama_penghargaan.replace(/^Penggalang PI /, ""), "kejuaraan-penggalang-pi"],
-    ["Penghargaan Khusus", x => !x.kode.startsWith("juara_umum")
-      && !/^(penegak|penggalang)_(pa|pi)_/.test(x.kode), x => x.nama_penghargaan,
-      "kejuaraan-khusus"],
+    gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa"),
+    gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi"),
+    ["Juara Kostum", x => x.kode.startsWith("kostum_"),
+      x => x.nama_penghargaan.replace(/^Juara Kostum /, ""),
+      "kejuaraan-kostum kejuaraan-pilihan"],
+    ["Juara Yel Yel", x => x.kode.startsWith("yel_yel_"),
+      x => x.nama_penghargaan.replace(/^Juara Yel Yel /, ""), "kejuaraan-yel-yel"],
+    ["Peserta Terfavorit", x => x.kode.startsWith("terfavorit_"),
+      x => x.nama_penghargaan.replace(/^Peserta Terfavorit /, ""),
+      "kejuaraan-terfavorit kejuaraan-pilihan"],
+    ["Penghargaan Khusus",
+      x => x.kode === "terjauh" || x.kode === "peserta_terbanyak",
+      x => x.nama_penghargaan, "kejuaraan-khusus kejuaraan-pilihan"],
   ];
 
   LAYAR.replaceChildren(h(`
@@ -6176,9 +6194,11 @@ async function layarKejuaraan() {
     const ubah = terkunci.querySelector(".kejuaraan-ubah");
     const cocok = (r, q) => `${r.nomor_dada} ${dada3(r.nomor_dada)} ${r.nama_regu} ${r.nama_sekolah}`
       .toLocaleLowerCase("id").includes(q.toLocaleLowerCase("id"));
+    const golongan = pilih.dataset.golongan;
+    const calon = golongan ? opsi.filter(r => r.golongan === golongan) : opsi;
     const gambarSaran = () => {
       const q = pilih.value.trim();
-      const ditemukan = opsi.filter(r => cocok(r, q)).slice(0, 8);
+      const ditemukan = calon.filter(r => cocok(r, q)).slice(0, 8);
       saran.innerHTML = ditemukan.map(r => `
         <button type="button" data-regu-id="${esc(r.regu_id)}">
           <strong>${esc(dada3(r.nomor_dada))} · ${esc(r.nama_regu)}</strong>
@@ -6193,7 +6213,7 @@ async function layarKejuaraan() {
     saran.addEventListener("click", async e => {
       const tombol = e.target.closest("[data-regu-id]");
       if (!tombol) return;
-      const dipilih = opsi.find(r => r.regu_id === tombol.dataset.reguId);
+      const dipilih = calon.find(r => r.regu_id === tombol.dataset.reguId);
       if (!dipilih) return;
       pilih.disabled = true;
       try {

--- a/web/style.css
+++ b/web/style.css
@@ -764,14 +764,32 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-kejuaraan > tbody > tr > th { display: block; width: auto; padding: 0; }
   .table-kejuaraan > tbody > tr > td { display: block; padding: 0; }
 
-  /* Penghargaan Khusus BERTUMPUK, dan itu bukan pengecualian yang malas:
-     labelnya sampai 159px ("Peserta Terfavorit") — separuh lebar HP — dan tiga
-     dari lima barisnya berisi kotak cari beserta tombol Hapus pilihan, yang
-     tidak muat di sisa 200px. Di sini tidak ada yang bisa tertukar juga:
-     tiap label berbeda kata, bukan Juara I sampai Harapan III. */
-  .kejuaraan-khusus .table-kejuaraan > tbody > tr { display: block; }
-  .kejuaraan-khusus .table-kejuaraan > tbody > tr > th { padding-bottom: .15rem; }
 }
+
+/* Kartu berisi PILIHAN panitia bertumpuk di SEMUA lebar: label di atas, kotak
+   cari selebar kartu di bawahnya.
+
+   Dulu ini cuma aturan HP, karena Penghargaan Khusus satu-satunya kartu
+   pilihan dan ia selebar dua kolom. Sejak Kostum dan Terfavorit ikut dibagi
+   empat golongan, ketiganya berdiri di setengah lebar, dan bersebelahan
+   TIDAK ADA lebar yang benar: label butuh 170px agar "PENGGALANG PA" dan
+   "PESERTA TERBANYAK" tidak patah dua baris, kotak carinya butuh 280px agar
+   perintahnya terbaca utuh, dan di layar 941px — saat dua kolom baru saja
+   menyala — seluruh tabelnya cuma 373px. Diukur di browser, bukan dikira:
+   45% membuat labelnya utuh dan placeholder-nya terpotong, 30% sebaliknya.
+   Bertumpuk, keduanya utuh di 320px sampai 1920px.
+
+   Yel Yel TIDAK ikut: ia dihitung dari poin Pos 5, barisnya cuma nama
+   pemenang, dan itu muat bersebelahan seperti kartu gelar golongan. */
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr {
+  display: block; padding: .5rem 0;
+}
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr:first-child { padding-top: 0; }
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr:last-child { padding-bottom: 0; }
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr > th {
+  display: block; width: auto; padding: 0 0 .15rem;
+}
+.kejuaraan-pilihan .table-kejuaraan > tbody > tr > td { display: block; padding: 0; }
 
 /* Warna per TINGKAT, bukan per kartu.
 
@@ -794,9 +812,19 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kejuaraan-umum-penggalang { --aksen: #067647; background: #f3faf6; }
 .kejuaraan-penggalang-pa,
 .kejuaraan-penggalang-pi   { --aksen: #067647; }
+.kejuaraan-kostum,
+.kejuaraan-yel-yel,
+.kejuaraan-terfavorit,
 .kejuaraan-khusus          { --aksen: #6941c6; }
 .kejuaraan-bagian { display: grid; gap: 1rem; }
 .kejuaraan-bagian .card { margin-bottom: 0; }
+/* `.card { overflow-x: auto }` di bawah membuat overflow-y ikut `auto` — itu
+   aturan CSS, bukan salah ketik — dan daftar saran kotak cari digunting oleh
+   tepi kartunya sendiri. Yang terlihat: kartu Juara Kostum tumbuh penggulir
+   sendiri dan hanya tiga dari delapan calon terbaca. Tabel di sini cuma dua
+   kolom dan tidak pernah perlu menggeser, jadi kartunya tidak butuh gunting
+   itu sama sekali. */
+.kejuaraan-bagian .card { overflow: visible; }
 .kejuaraan-terkunci { display: flex; align-items: center; gap: .45rem; }
 .kejuaraan-nilai { flex: 1; min-width: 0; }
 @media (min-width: 900px) {
@@ -811,7 +839,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .kejuaraan-penegak-pi { grid-column: 1; grid-row: 4; }
   .kejuaraan-penggalang-pa { grid-column: 2; grid-row: 3; }
   .kejuaraan-penggalang-pi { grid-column: 2; grid-row: 4; }
-  .kejuaraan-khusus { grid-column: 1 / -1; grid-row: 5; }
+  /* Empat kartu penghargaan khusus, dua baris. Kostum dan Terfavorit — dua
+     kartu yang panitia ISI — berdiri di kolom yang sama supaya kotak carinya
+     berbaris lurus dari kartu ke kartu. */
+  .kejuaraan-kostum { grid-column: 1; grid-row: 5; }
+  .kejuaraan-yel-yel { grid-column: 2; grid-row: 5; }
+  .kejuaraan-terfavorit { grid-column: 1; grid-row: 6; }
+  .kejuaraan-khusus { grid-column: 2; grid-row: 6; }
 }
 .kejuaraan-cari { position: relative; }
 .kejuaraan-isian { display: flex; align-items: center; gap: .45rem; }


### PR DESCRIPTION
## What

Kostum, Yel Yel and Terfavorit are now awarded in the same four categories as
every other title: **Penegak PA, Penegak PI, Penggalang PA, Penggalang PI**.

* `kostum_<golongan>` and `terfavorit_<golongan>` — picked by a holder of
  `pengaturan`, four rows each.
* `yel_yel_<golongan>` — derived, still the highest Pos 5 points, now within
  each golongan.
* Peserta Terjauh and Peserta Terbanyak stay single.

Migration `0152_kejuaraan_empat_golongan.sql` moves picks that were already
saved to the code for the golongan of the regu that was chosen, so a decision
already made is not lost. `simpan_kejuaraan_manual` refuses a regu whose
golongan does not match the award, and the search box on the screen only offers
that golongan's regu to begin with.

The screen gains three cards: Juara Kostum, Juara Yel Yel, Peserta Terfavorit.
Penghargaan Khusus keeps Terjauh and Terbanyak.

Test `104_kejuaraan_empat_golongan.sql` covers the shape of the list, the old
codes being gone, each Yel Yel winner really holding the highest Pos 5 points
in its golongan (checked against the database, not against the numbers the test
writes), the golongan mismatch being refused, and an account without
`live_score` still reading nothing.

## Why

Every other title in the event is split four ways, and Pos 5 — where Yel Yel is
judged — runs per golongan already. One winner across all four categories put
Penegak PA and Penggalang PI at the same table.

## Notes

* **The migration must be applied before this merges.** The screen reads the
  new codes; the old ones disappear when `0152` runs. Apply, then merge
  immediately — the gap is the window where the manual awards read empty.
* `hasil_kejuaraan()` now wraps `where boleh('live_score')` around the whole
  result. The Juara Umum arm had no guard of its own since 0142, so a panitia
  without `live_score` could read the Juara Umum school names.
* Two layout fixes came out of measuring the screen in a browser, and both were
  already latent: `.card { overflow-x: auto }` makes `overflow-y` compute to
  `auto` as well, so the suggestion list was clipped by its own card; and the
  cards holding a picker now stack label over search box at every width,
  because side by side there is no width that works — the label needs 170px to
  keep "PENGGALANG PA" and "PESERTA TERBANYAK" on one line, the search box
  needs 280px for its placeholder, and at 941px the whole table is 373px.
  Measured 320px to 1920px: no horizontal scroll, no overflowing cell, no
  clipped card, no wrapped label.
* The section labels in `layarKejuaraan()` now come from `GOLONGAN_LABEL` in
  `util.js`. `tools/periksa_urutan_golongan.py` was already failing on `main`
  over those four literals; it passes now.
* `tests/dev_database.sh` is fixed in its own commit — it stopped at 0137 and
  again at 0146, so no screen could be opened on a laptop at all, which is what
  CLAUDE.md 17.2 requires before a merge.

Ran locally: `bash tests/run.sh` (all pass, including 104), `bash
tests/dev_database.sh`, `node --input-type=module --check` over every file in
`web/js/` and `live/js/`, the four `shared-files` diffs, `periksa_impor.py`,
`periksa_urutan_golongan.py`, `periksa_sekolah.py`. Screen opened at
`#/kejuaraan` against a dev database carrying 143 regu with scores: 11 cards,
picks saved and re-read.