### PR TITLE
feat: pick a school for Pangkalan Terjauh, and tighten the board

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -904,6 +904,11 @@ export async function hasilKejuaraan() {
 export const simpanKejuaraanManual = (kode, reguId) =>
   rpc("simpan_kejuaraan_manual", { p_kode: kode, p_regu: reguId });
 
+/** Pangkalan Terjauh menunjuk SEKOLAH, bukan regu (migrasi 0153) — yang diukur
+ *  jarak pangkalannya, dan itu sama untuk seluruh regu yang dikirimnya. */
+export const simpanKejuaraanTerjauh = (sekolahId) =>
+  rpc("simpan_kejuaraan_terjauh", { p_sekolah: sekolahId });
+
 /* ============================ FOTO LEMBAR =============================== */
 
 /* Salinan slip penilaian di server (migrasi 0047). Kertas hilang; foto tidak.

--- a/live/style.css
+++ b/live/style.css
@@ -727,9 +727,42 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .function-menu .function-name .badge { margin-left: auto; }
 .function-menu .description { color: var(--tinta-lembut); margin-top: .3rem; }
 
-.table-kejuaraan th { width: 45%; }
+/* Kolom label MENYUSUT ke isinya, tidak dipatok 45%.
+
+   Dipatok, "JUARA I" berdiri di kolom selebar separuh kartu dan nama juaranya
+   mulai di tengah — jarak kosong yang terbaca seperti dua tabel berbeda, dan
+   itu keluhan yang datang dari lapangan. `width: 1%` di bawah `table-layout:
+   auto` adalah cara meminta "sesempit isinya"; nowrap menjaga "HARAPAN III"
+   tetap satu baris, dan karena ini TABEL sungguhan (bukan grid per baris),
+   satu lebar itu berlaku untuk seluruh barisnya — tepi kiri nama juara tidak
+   berpindah-pindah, syarat yang sama dengan kartu Meja Pembayaran (15.7).
+
+   Di dalam media query: di bawah 901px barisnya bertumpuk atau jadi grid, dan
+   nowrap di sana justru memaksa label panjang meluap keluar sel (15.8). */
+@media (min-width: 901px) {
+  .table-kejuaraan th { width: 1%; white-space: nowrap; }
+
+  /* Baris lebih rapat. Nilainya dua baris — nama regu dan asal sekolah — jadi
+     padding bawaan tabel data menambah tinggi yang tidak dipakai apa pun.
+     Di dalam media query karena di bawah 901px barisnya sudah punya aturan
+     paddingnya sendiri; menimpanya dari luar menggeser label terhadap
+     nilainya, dan yang menang cuma ditentukan urutan baris di berkas. */
+  .table-kejuaraan > tbody > tr > th,
+  .table-kejuaraan > tbody > tr > td { padding: .3rem .5rem; }
+  .table-kejuaraan > tbody > tr > th { padding-left: 0; }
+}
 .table-kejuaraan td strong, .table-kejuaraan td .description { display: block; }
 .table-kejuaraan .select-small { width: 100%; }
+.table-kejuaraan .description { line-height: 1.25; }
+
+/* Skor berdiri di kanan baris dengan angka selebar sama, supaya kolomnya bisa
+   dibaca lurus ke bawah untuk mengecek urutan juara. */
+.kejuaraan-isi { display: flex; align-items: baseline; gap: .5rem; }
+.kejuaraan-nama { flex: 1 1 auto; min-width: 0; }
+.kejuaraan-skor {
+  flex: 0 0 auto; font-weight: 700;
+  font-variant-numeric: tabular-nums; color: var(--tinta);
+}
 
 /* Satu juara = satu blok, dan garisnya di BARIS, bukan di sel.
    Sebelumnya tiap sel membawa border-bottom sendiri, jadi di HP — tempat th
@@ -816,8 +849,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kejuaraan-yel-yel,
 .kejuaraan-terfavorit,
 .kejuaraan-khusus          { --aksen: #6941c6; }
-.kejuaraan-bagian { display: grid; gap: 1rem; }
-.kejuaraan-bagian .card { margin-bottom: 0; }
+.kejuaraan-bagian { display: grid; gap: .75rem; }
+.kejuaraan-bagian .card { margin-bottom: 0; padding: .85rem 1rem; }
 /* `.card { overflow-x: auto }` di bawah membuat overflow-y ikut `auto` — itu
    aturan CSS, bukan salah ketik — dan daftar saran kotak cari digunting oleh
    tepi kartunya sendiri. Yang terlihat: kartu Juara Kostum tumbuh penggulir

--- a/supabase/migrations/0153_terjauh_pilih_sekolah.sql
+++ b/supabase/migrations/0153_terjauh_pilih_sekolah.sql
@@ -1,0 +1,334 @@
+-- ============================================================================
+-- hrcd-rekap : 0153_terjauh_pilih_sekolah.sql
+-- Pangkalan Terjauh diisi SEKOLAH, bukan regu.
+--
+-- Yang diukur penghargaan ini adalah jarak pangkalan ke lokasi acara, dan
+-- jarak itu milik sekolahnya — bukan milik salah satu regu yang dikirimnya.
+-- Sampai sekarang kolomnya menyimpan `regu_id`, jadi panitia harus memilih
+-- satu dari empat regu sekolah itu, dan tiga regu lain dari pangkalan yang
+-- sama seolah-olah tidak ikut menempuh jarak yang sama.
+--
+-- `kejuaraan_manual` sekarang memuat DUA bentuk pilihan dalam satu tabel:
+-- Kostum dan Terfavorit menunjuk regu, Terjauh menunjuk sekolah. Satu check
+-- constraint mengikat tiap kode ke kolom yang benar, sehingga tidak ada baris
+-- yang bisa menyimpan keduanya atau tidak menyimpan satu pun.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Kolom sekolah
+-- ---------------------------------------------------------------------------
+
+alter table kejuaraan_manual add column sekolah_id uuid references sekolah (id);
+alter table kejuaraan_manual alter column regu_id drop not null;
+
+-- Pilihan Terjauh yang sudah ada dipindahkan ke sekolah regunya. Panitia
+-- memilih regu itu karena pangkalannya, jadi pangkalannyalah yang disimpan.
+update kejuaraan_manual m
+set sekolah_id = d.sekolah_id, regu_id = null
+from regu r
+join pendaftaran d on d.id = r.pendaftaran_id
+where r.id = m.regu_id and m.kode = 'terjauh';
+
+-- Baris Terjauh yang regunya sudah tidak bisa ditelusuri tidak menyimpan
+-- keputusan apa pun yang bisa diselamatkan.
+delete from kejuaraan_manual where kode = 'terjauh' and sekolah_id is null;
+
+alter table kejuaraan_manual add constraint kejuaraan_manual_isi_check
+  check (case when kode = 'terjauh'
+              then sekolah_id is not null and regu_id is null
+              else regu_id is not null and sekolah_id is null end);
+
+comment on column kejuaraan_manual.sekolah_id is
+  'Terisi HANYA untuk kode terjauh; penghargaan lain menunjuk regu lewat regu_id.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Penyimpan pilihan
+--
+-- Dua RPC, bukan satu yang menerima dua macam id. Nama fungsinya menyebut apa
+-- yang disimpan, jadi pemanggil yang keliru gagal di nama fungsi — bukan di
+-- argumen ketiga yang diam-diam dibiarkan kosong.
+-- ---------------------------------------------------------------------------
+
+create or replace function simpan_kejuaraan_manual(p_kode text, p_regu uuid)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_golongan text;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'akun ini tidak berhak mengubah Kejuaraan';
+  end if;
+  if p_kode not in (
+    'kostum_penegak_pa', 'kostum_penegak_pi',
+    'kostum_penggalang_pa', 'kostum_penggalang_pi',
+    'terfavorit_penegak_pa', 'terfavorit_penegak_pi',
+    'terfavorit_penggalang_pa', 'terfavorit_penggalang_pi') then
+    raise exception 'penghargaan manual tidak dikenal';
+  end if;
+
+  if p_regu is null then
+    delete from kejuaraan_manual
+    where edisi = edisi_aktif() and kode = p_kode;
+    return;
+  end if;
+
+  select r.golongan into v_golongan
+  from regu r
+  join closing_regu c on c.regu_id = r.id
+  where r.id = p_regu and r.nomor_dada is not null and not r.is_cancelled
+    and r.golongan not like 'intern_%';
+
+  if v_golongan is null then
+    raise exception 'regu tidak ditemukan, belum tiba, belum mendapat nomor dada, atau termasuk Intern';
+  end if;
+
+  if right(p_kode, length(v_golongan) + 1) <> '_' || v_golongan then
+    raise exception 'regu ini golongan %, bukan golongan penghargaan itu', v_golongan;
+  end if;
+
+  insert into kejuaraan_manual (edisi, kode, regu_id, diubah_oleh)
+  values (edisi_aktif(), p_kode, p_regu, auth.uid())
+  on conflict (edisi, kode) do update
+    set regu_id = excluded.regu_id,
+        sekolah_id = null,
+        diubah_oleh = excluded.diubah_oleh,
+        diubah_pada = now();
+end;
+$$;
+
+create or replace function simpan_kejuaraan_terjauh(p_sekolah uuid)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+begin
+  if not boleh('pengaturan') then
+    raise exception 'akun ini tidak berhak mengubah Kejuaraan';
+  end if;
+
+  if p_sekolah is null then
+    delete from kejuaraan_manual
+    where edisi = edisi_aktif() and kode = 'terjauh';
+    return;
+  end if;
+
+  -- Pangkalan yang tidak mengirim satu regu pun tidak menempuh jarak apa pun.
+  -- Daftar sekolah dibaca dari master yang memuat SELURUH sekolah kurasi, jadi
+  -- tanpa pagar ini satu salah klik memberi gelar kepada sekolah yang tidak
+  -- hadir, dan tidak ada yang menyanggah.
+  if not exists (
+    select 1 from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    where d.sekolah_id = p_sekolah and r.nomor_dada is not null
+      and not r.is_cancelled and r.golongan not like 'intern_%'
+  ) then
+    raise exception 'sekolah ini tidak mengirim regu bernomor dada';
+  end if;
+
+  insert into kejuaraan_manual (edisi, kode, sekolah_id, diubah_oleh)
+  values (edisi_aktif(), 'terjauh', p_sekolah, auth.uid())
+  on conflict (edisi, kode) do update
+    set sekolah_id = excluded.sekolah_id,
+        regu_id = null,
+        diubah_oleh = excluded.diubah_oleh,
+        diubah_pada = now();
+end;
+$$;
+
+revoke all on function simpan_kejuaraan_terjauh(uuid) from public;
+grant execute on function simpan_kejuaraan_terjauh(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. Daftar hasil
+--
+-- Baris Terjauh berubah dua hal: `nama_sekolah` dibaca dari `sekolah` langsung
+-- dan bukan lewat regunya, dan `sumber`-nya jadi `manual_sekolah` supaya layar
+-- tahu kotak carinya berisi sekolah, bukan nomor dada.
+-- ---------------------------------------------------------------------------
+
+drop view v_kejuaraan;
+drop function hasil_kejuaraan();
+
+create function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric, poin_juara numeric, jumlah_skor numeric
+)
+language sql stable security definer
+set search_path = public
+as $$
+with
+golongan_juara(kode, nama, nomor) as (values
+  ('penegak_pa', 'Penegak PA', 1), ('penegak_pi', 'Penegak PI', 2),
+  ('penggalang_pa', 'Penggalang PA', 3), ('penggalang_pi', 'Penggalang PI', 4)
+),
+peringkat_eksternal as (
+  select k.*,
+         row_number() over (
+           partition by k.golongan
+           order by k.total desc,
+                    abs(coalesce(k.selisih_menit, 100000)) asc,
+                    k.nomor_dada asc) as nomor_juara
+  from v_klasemen k
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+),
+calon_umum as (
+  select nama_sekolah,
+         count(*) filter (where nomor_juara <= 6) as jumlah_juara,
+         sum(7 - nomor_juara) filter (where nomor_juara <= 6) as bobot_juara,
+         sum(total) filter (where nomor_juara <= 6) as jumlah_skor,
+         case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end as tingkat
+  from peringkat_eksternal
+  group by nama_sekolah,
+           case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end
+),
+calon_semua as (
+  select nama_sekolah, sum(jumlah_juara) jumlah_juara,
+         sum(bobot_juara) bobot_juara, sum(jumlah_skor) jumlah_skor
+  from calon_umum group by nama_sekolah
+),
+kandidat_umum as (
+  select 'semua'::text tingkat, * from calon_semua
+  union all
+  select tingkat, nama_sekolah, jumlah_juara, bobot_juara, jumlah_skor
+  from calon_umum
+),
+juara_umum as (
+  select d.urutan, d.kode, d.nama nama_penghargaan,
+         'skor'::text sumber, null::uuid regu_id, null::integer nomor_dada,
+         null::text nama_regu, x.nama_sekolah, null::text golongan,
+         null::numeric total, x.bobot_juara poin_juara, x.jumlah_skor
+  from (values
+    (1, 'juara_umum', 'Juara Umum ' || (select name from edisi where is_active), 'semua'),
+    (2, 'juara_umum_penegak', 'Juara Umum Penegak', 'penegak'),
+    (3, 'juara_umum_penggalang', 'Juara Umum Penggalang', 'penggalang')
+  ) d(urutan, kode, nama, tingkat)
+  left join lateral (
+    select nama_sekolah, bobot_juara, jumlah_skor
+    from kandidat_umum k where k.tingkat = d.tingkat
+    order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah
+    limit 1
+  ) x on true
+),
+manual as (
+  select a.urutan_dasar + g.nomor as urutan,
+         a.kode || '_' || g.kode as kode,
+         a.nama || ' ' || g.nama as nama_penghargaan,
+         'manual'::text as sumber,
+         r.id as regu_id, r.nomor_dada, r.nama_regu, s.name as nama_sekolah,
+         r.golongan, null::numeric total,
+         null::numeric poin_juara, null::numeric jumlah_skor
+  from (values ('kostum', 'Juara Kostum', 60),
+               ('terfavorit', 'Peserta Terfavorit', 68))
+       a(kode, nama, urutan_dasar)
+  cross join golongan_juara g
+  left join kejuaraan_manual m
+    on m.edisi = edisi_aktif() and m.kode = a.kode || '_' || g.kode
+  left join regu r on r.id = m.regu_id
+  left join pendaftaran d on d.id = r.pendaftaran_id
+  left join sekolah s on s.id = d.sekolah_id
+  union all
+  select 73, 'terjauh', 'Pangkalan Terjauh', 'manual_sekolah',
+         null::uuid, null::integer, null::text, s.name, null::text,
+         null::numeric, null::numeric, null::numeric
+  from (values (true)) satu(ada)
+  left join kejuaraan_manual m
+    on m.edisi = edisi_aktif() and m.kode = 'terjauh'
+  left join sekolah s on s.id = m.sekolah_id
+),
+yel_yel as (
+  select 64 + g.nomor as urutan,
+         'yel_yel_' || g.kode as kode,
+         'Juara Yel Yel ' || g.nama as nama_penghargaan,
+         'skor'::text as sumber,
+         y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+         y.golongan, y.poin_pos as total,
+         null::numeric poin_juara, null::numeric jumlah_skor
+  from golongan_juara g
+  left join lateral (
+    select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+           k.golongan, pp.poin_pos
+    from v_klasemen k
+    join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+    where k.golongan = g.kode
+    order by pp.poin_pos desc, k.total desc, k.nomor_dada
+    limit 1
+  ) y on true
+),
+terbanyak as (
+  select 74, 'peserta_terbanyak', 'Peserta Terbanyak', 'nomor_dada'::text,
+         null::uuid, null::integer, null::text, p.nama_sekolah,
+         null::text, p.jumlah::numeric, null::numeric, null::numeric
+  from (values (true)) satu(ada)
+  left join lateral (
+    select s.name nama_sekolah, count(*) jumlah
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    join sekolah s on s.id = d.sekolah_id
+    where r.nomor_dada is not null and not r.is_cancelled
+      and d.status = 'lunas' and r.golongan not like 'intern_%'
+    group by s.name
+    order by jumlah desc, s.name
+    limit 1
+  ) p on true
+)
+select * from (
+  select d.urutan, d.kode, d.nama_penghargaan, d.sumber, d.regu_id,
+         d.nomor_dada, d.nama_regu, d.nama_sekolah, d.golongan, d.total,
+         null::numeric, null::numeric
+  from hasil_kejuaraan_dasar() d
+  where d.kode ~ '^(penegak|penggalang)_(pa|pi)_[1-6]$'
+  union all select * from juara_umum
+  union all select * from manual
+  union all select * from yel_yel
+  union all select * from terbanyak
+) semua
+where boleh('live_score')
+order by urutan
+$$;
+
+revoke all on function hasil_kejuaraan() from public;
+grant execute on function hasil_kejuaraan() to authenticated;
+
+create view v_kejuaraan as select * from hasil_kejuaraan();
+grant select on v_kejuaraan to authenticated;
+
+comment on column v_kejuaraan.poin_juara is
+  'Total poin posisi enam besar: 6, 5, 4, 3, 2, 1. Hanya diisi untuk Juara Umum.';
+comment on column v_kejuaraan.jumlah_skor is
+  'Jumlah skor regu sekolah yang berada di peringkat 1-6 dalam cakupan Juara Umum; pemecah poin sama.';
+comment on column v_kejuaraan.sumber is
+  'skor = dihitung, nomor_dada = dihitung dari nomor dada, manual = panitia memilih regu, manual_sekolah = panitia memilih sekolah.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Pagar penutup
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  v_def text := pg_get_functiondef('hasil_kejuaraan()'::regprocedure);
+  v_salah integer;
+begin
+  assert v_def like
+    '%order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah%',
+    '0153: urutan Juara Umum tidak lagi memakai poin gelar dengan NULLS LAST';
+  assert v_def like '%sum(total) filter (where nomor_juara <= 6) as jumlah_skor%',
+    '0153: jumlah skor Juara Umum tidak lagi dibatasi ke enam besar';
+  assert v_def like '%''manual_sekolah''%',
+    '0153: baris Terjauh tidak menandai dirinya sebagai pilihan sekolah';
+
+  select count(*) into v_salah from kejuaraan_manual
+  where kode = 'terjauh' and (sekolah_id is null or regu_id is not null);
+  assert v_salah = 0,
+    format('0153: %s baris Terjauh masih menunjuk regu', v_salah);
+
+  select count(*) into v_salah from kejuaraan_manual
+  where kode <> 'terjauh' and (regu_id is null or sekolah_id is not null);
+  assert v_salah = 0,
+    format('0153: %s penghargaan regu menyimpan sekolah', v_salah);
+end;
+$$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -77,6 +77,7 @@ RPC = {
     "catat_foto_masuk":      ["p_pos", "p_kode_lomba", "p_nama_lomba", "p_path", "p_ukuran"],
     "tautkan_foto":          ["p_foto_id", "p_nomor_dada", "p_cara"],
     "simpan_kejuaraan_manual": ["p_kode", "p_regu"],
+    "simpan_kejuaraan_terjauh": ["p_sekolah"],
 }
 # RPC yang hasilnya tabel (bukan skalar/jsonb).
 RPC_TABEL = {"daftar_ulang_batch"}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -702,5 +702,7 @@ run supabase/migrations/0151_skor_juara_umum_enam_besar.sql
 run tests/sql/103_skor_juara_umum_enam_besar.sql
 run supabase/migrations/0152_kejuaraan_empat_golongan.sql
 run tests/sql/104_kejuaraan_empat_golongan.sql
+run supabase/migrations/0153_terjauh_pilih_sekolah.sql
+run tests/sql/105_terjauh_pilih_sekolah.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/105_terjauh_pilih_sekolah.sql
+++ b/tests/sql/105_terjauh_pilih_sekolah.sql
@@ -1,0 +1,108 @@
+\echo '--- 105. Pangkalan Terjauh diisi sekolah, bukan regu'
+
+do $blok$
+declare
+  v_sekolah uuid := gen_random_uuid();
+  v_sepi uuid := gen_random_uuid();
+  v_daftar uuid := gen_random_uuid();
+  v_regu uuid := gen_random_uuid();
+  v_petugas uuid := '00000000-0000-0000-0000-00000000000a';
+  v_jam_lama timestamptz;
+  v_nama text;
+  v_sumber text;
+  v_jumlah integer;
+begin
+  select jam_berangkat into v_jam_lama from kloter where nomor = 75;
+  update kloter set jam_berangkat = timestamptz '2026-08-29 07:00+07'
+  where nomor = 75;
+
+  insert into sekolah (id, name, address) values
+    (v_sekolah, 'SEKOLAH UJI 105', 'Alamat uji'),
+    (v_sepi, 'SEKOLAH UJI 105 TANPA REGU', 'Alamat uji');
+  insert into pendaftaran
+    (id, sekolah_id, kode_pembayaran, butuh_barak, jumlah_menginap,
+     jumlah_regu, kontak_wa, status, kunci_kirim)
+  values
+    (v_daftar, v_sekolah, 'UJI105', false, 0, 1,
+     '087777777777', 'lunas', gen_random_uuid());
+  insert into regu
+    (id, pendaftaran_id, nama_regu, nama_ketua, golongan,
+     nomor_dada, kloter_nomor, urutan_kloter)
+  values
+    (v_regu, v_daftar, 'UJI TERJAUH 1', 'KETUA UJI',
+     'penegak_pa', 496, 75, 1);
+  insert into keberangkatan_regu (regu_id, recorded_by) values (v_regu, v_petugas);
+  insert into closing_regu (regu_id, jam_datang, anggota_hadir, recorded_by)
+  values (v_regu, timestamptz '2026-08-29 10:00+07', 5, v_petugas);
+
+  set local role authenticated;
+  perform set_config('app.uid', v_petugas::text, true);
+
+  -- 105.1 — sekolah tersimpan dan terbit sebagai nama pangkalan
+  perform simpan_kejuaraan_terjauh(v_sekolah);
+  select nama_sekolah, sumber into v_nama, v_sumber
+  from hasil_kejuaraan() where kode = 'terjauh';
+  assert v_nama = 'SEKOLAH UJI 105',
+    format('105.1 GAGAL: Pangkalan Terjauh = %s', v_nama);
+  assert v_sumber = 'manual_sekolah',
+    format('105.2 GAGAL: sumber baris Terjauh = %s', v_sumber);
+
+  -- 105.3 — barisnya menyimpan sekolah, bukan regu
+  reset role;
+  select count(*) into v_jumlah from kejuaraan_manual
+  where edisi = edisi_aktif() and kode = 'terjauh'
+    and sekolah_id = v_sekolah and regu_id is null;
+  assert v_jumlah = 1, '105.3 GAGAL: baris Terjauh tidak menyimpan sekolah';
+
+  -- 105.4 — pangkalan tanpa regu bernomor dada ditolak
+  set local role authenticated;
+  perform set_config('app.uid', v_petugas::text, true);
+  begin
+    perform simpan_kejuaraan_terjauh(v_sepi);
+    assert false, '105.4 GAGAL: sekolah tanpa regu diterima';
+  exception when others then
+    assert sqlerrm = 'sekolah ini tidak mengirim regu bernomor dada',
+      format('105.4 GAGAL: penolakannya salah: %s', sqlerrm);
+  end;
+
+  -- 105.5 — terjauh tidak bisa lagi disimpan lewat jalur regu
+  begin
+    perform simpan_kejuaraan_manual('terjauh', v_regu);
+    assert false, '105.5 GAGAL: Terjauh masih bisa diisi regu';
+  exception when others then
+    assert sqlerrm = 'penghargaan manual tidak dikenal',
+      format('105.5 GAGAL: penolakannya salah: %s', sqlerrm);
+  end;
+
+  -- 105.6 — dikosongkan lagi
+  perform simpan_kejuaraan_terjauh(null);
+  reset role;
+  select count(*) into v_jumlah from kejuaraan_manual
+  where edisi = edisi_aktif() and kode = 'terjauh';
+  assert v_jumlah = 0, '105.6 GAGAL: pilihan Terjauh tidak terhapus';
+
+  -- 105.7 — constraint menolak baris yang mencampur dua bentuk
+  begin
+    insert into kejuaraan_manual (edisi, kode, regu_id, sekolah_id, diubah_oleh)
+    values (edisi_aktif(), 'terjauh', v_regu, v_sekolah, v_petugas);
+    assert false, '105.7 GAGAL: baris Terjauh boleh menyimpan regu sekaligus sekolah';
+  exception when check_violation then null;
+  end;
+
+  begin
+    insert into kejuaraan_manual (edisi, kode, sekolah_id, diubah_oleh)
+    values (edisi_aktif(), 'kostum_penegak_pa', v_sekolah, v_petugas);
+    assert false, '105.8 GAGAL: penghargaan regu boleh menyimpan sekolah';
+  exception when check_violation then null;
+  end;
+
+  delete from closing_regu where regu_id = v_regu;
+  delete from keberangkatan_regu where regu_id = v_regu;
+  delete from regu where id = v_regu;
+  delete from pendaftaran where id = v_daftar;
+  delete from sekolah where id in (v_sekolah, v_sepi);
+  update kloter set jam_berangkat = v_jam_lama where nomor = 75;
+end;
+$blok$;
+
+\echo '105 terjauh pilih sekolah: LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -904,6 +904,11 @@ export async function hasilKejuaraan() {
 export const simpanKejuaraanManual = (kode, reguId) =>
   rpc("simpan_kejuaraan_manual", { p_kode: kode, p_regu: reguId });
 
+/** Pangkalan Terjauh menunjuk SEKOLAH, bukan regu (migrasi 0153) — yang diukur
+ *  jarak pangkalannya, dan itu sama untuk seluruh regu yang dikirimnya. */
+export const simpanKejuaraanTerjauh = (sekolahId) =>
+  rpc("simpan_kejuaraan_terjauh", { p_sekolah: sekolahId });
+
 /* ============================ FOTO LEMBAR =============================== */
 
 /* Salinan slip penilaian di server (migrasi 0047). Kertas hilang; foto tidak.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -24,7 +24,7 @@ import {
   riwayatNilai, riwayatPendaftaran,
   kunciNilaiPos, bukaKunciNilaiPos,
   unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto,
-  hasilKejuaraan, simpanKejuaraanManual,
+  hasilKejuaraan, simpanKejuaraanManual, simpanKejuaraanTerjauh, daftarSekolah,
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
   statusAcara, bolehLihat, lengkapiHakSesi,
   aturFaseLive,
@@ -6093,10 +6093,11 @@ async function layarKejuaraan() {
   LAYAR.replaceChildren(h(pemuat()));
   const layarIni = location.hash;
   const bisaUbah = bolehLihat("pengaturan");
-  let hasil, snapshot;
+  let hasil, snapshot, semuaSekolah;
   try {
-    [hasil, snapshot] = await Promise.all([
+    [hasil, snapshot, semuaSekolah] = await Promise.all([
       hasilKejuaraan(), bisaUbah ? cacheLiveScore() : Promise.resolve(null),
+      bisaUbah ? daftarSekolah() : Promise.resolve([]),
     ]);
   }
   catch (e) { LAYAR.replaceChildren(kartuGagalMuat(e.message, layarKejuaraan)); return; }
@@ -6110,38 +6111,55 @@ async function layarKejuaraan() {
       && !String(r.golongan).startsWith("intern_"))
     .map(r => [r.regu_id, r])).values()]
     .sort((a, b) => Number(a.nomor_dada) - Number(b.nomor_dada));
+  /* Pangkalan Terjauh menunjuk SEKOLAH; daftarnya dipersempit ke sekolah yang
+     benar-benar mengirim regu. Master `sekolah` memuat seluruh sekolah kurasi
+     — 189 baris — dan menawarkan semuanya membuat satu salah klik memberi
+     gelar kepada pangkalan yang tidak hadir. */
+  const ikut = new Set(opsi.map(r => r.nama_sekolah));
+  const sekolah = (semuaSekolah || []).filter(s => ikut.has(s.name));
+
   /* Kostum dan Terfavorit dipilih PER GOLONGAN, jadi kotak carinya hanya boleh
      menawarkan regu golongan itu. Golongannya dibaca dari ekor kode
-     (`kostum_penegak_pa`); Terjauh tidak berekor dan tetap memilih dari
-     seluruh peserta. RPC-nya menolak pasangan yang salah juga — ini yang
+     (`kostum_penegak_pa`). RPC-nya menolak pasangan yang salah juga — ini yang
      membuat panitia tidak perlu sampai ditolak. */
   const golonganKode = (kode) =>
     (kode.match(/(?:penegak|penggalang)_(?:pa|pi)$/) || [""])[0];
   const labelRegu = (r) => `${dada3(r.nomor_dada)} · ${r.nama_regu} · ${r.nama_sekolah}`;
+  /* Skornya berdiri di kanan baris, bukan ikut mengalir di bawah nama sekolah:
+     panitia membaca kolom itu ke bawah untuk mengecek urutan juara, dan angka
+     yang letaknya berpindah-pindah menuntut mata mencarinya tiap baris. */
+  const skor = (x) => x.total == null ? ""
+    : `<span class="kejuaraan-skor">${esc(angkaRapi(x.total))}</span>`;
   const nilai = (x) => {
-    if (x.nama_regu) return `<strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
-      <span class="description">${esc(x.nama_sekolah || "")}</span>`;
+    if (x.nama_regu) return `<div class="kejuaraan-isi"><div class="kejuaraan-nama">
+      <strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
+      <span class="description">${esc(x.nama_sekolah || "")}</span></div>${skor(x)}</div>`;
     if (x.nama_sekolah) return `<strong>${esc(x.nama_sekolah)}</strong>${x.kode.startsWith("juara_umum")
       ? `<span class="description">${esc(angkaRapi(x.poin_juara))} poin juara · ${esc(angkaRapi(x.jumlah_skor))} total skor 6 besar</span>`
       : x.kode === "peserta_terbanyak"
         ? `<span class="description">${esc(angkaRapi(x.total))} regu bernomor dada</span>` : ""}`;
     return `<span class="description">Belum ditentukan</span>`;
   };
-  const baris = (x, label = x.nama_penghargaan) => x.sumber === "manual" && bisaUbah ? `
+  const bisaPilih = (x) =>
+    bisaUbah && (x.sumber === "manual" || x.sumber === "manual_sekolah");
+  const baris = (x, label = x.nama_penghargaan) => bisaPilih(x) ? `
     <tr><th>${esc(label)}</th><td>
-      <div class="kejuaraan-terkunci" ${x.regu_id ? "" : "hidden"}>
+      <div class="kejuaraan-terkunci" ${x.nama_sekolah ? "" : "hidden"}>
         <div class="kejuaraan-nilai">${nilai(x)}</div>
         <button type="button" class="button button-secondary button-small kejuaraan-ubah">
           Ubah Juara
         </button>
       </div>
-      <div class="kejuaraan-isian" ${x.regu_id ? "hidden" : ""}>
+      <div class="kejuaraan-isian" ${x.nama_sekolah ? "hidden" : ""}>
         <div class="kejuaraan-cari">
           <input type="search" class="small-input kejuaraan-pilih" data-kode="${esc(x.kode)}"
+            data-jenis="${x.sumber === "manual_sekolah" ? "sekolah" : "regu"}"
             data-golongan="${esc(golonganKode(x.kode))}"
             autocomplete="off" aria-label="Pilih ${esc(x.nama_penghargaan)}"
-            placeholder="Cari nomor dada / regu / sekolah…"
-            value="${esc(x.regu_id ? labelRegu(x) : "")}">
+            placeholder="${x.sumber === "manual_sekolah"
+              ? "Cari nama sekolah…" : "Cari nomor dada / regu / sekolah…"}"
+            value="${esc(x.sumber === "manual_sekolah"
+              ? (x.nama_sekolah || "") : (x.regu_id ? labelRegu(x) : ""))}">
           <div class="suggestions kejuaraan-saran" hidden></div>
         </div>
       </div></td></tr>` : `<tr><th>${esc(label)}</th><td>${nilai(x)}</td></tr>`;
@@ -6192,17 +6210,25 @@ async function layarKejuaraan() {
     const isian = pilih.closest(".kejuaraan-isian");
     const terkunci = pilih.closest("td").querySelector(".kejuaraan-terkunci");
     const ubah = terkunci.querySelector(".kejuaraan-ubah");
-    const cocok = (r, q) => `${r.nomor_dada} ${dada3(r.nomor_dada)} ${r.nama_regu} ${r.nama_sekolah}`
-      .toLocaleLowerCase("id").includes(q.toLocaleLowerCase("id"));
+    /* Satu kotak cari, dua macam isi: Kostum dan Terfavorit menunjuk regu,
+       Pangkalan Terjauh menunjuk sekolah. Yang membedakan cuma data-jenis;
+       sisanya — saran, blur, simpan, kunci lagi — sama persis. */
+    const sekolahan = pilih.dataset.jenis === "sekolah";
     const golongan = pilih.dataset.golongan;
-    const calon = golongan ? opsi.filter(r => r.golongan === golongan) : opsi;
+    const calon = sekolahan ? sekolah
+      : golongan ? opsi.filter(r => r.golongan === golongan) : opsi;
+    const kunci = (c) => sekolahan ? c.id : c.regu_id;
+    const teks = (c) => sekolahan ? `${c.name} ${c.address || ""}`
+      : `${c.nomor_dada} ${dada3(c.nomor_dada)} ${c.nama_regu} ${c.nama_sekolah}`;
+    const isiKotak = (c) => sekolahan ? c.name : labelRegu(c);
     const gambarSaran = () => {
-      const q = pilih.value.trim();
-      const ditemukan = calon.filter(r => cocok(r, q)).slice(0, 8);
-      saran.innerHTML = ditemukan.map(r => `
-        <button type="button" data-regu-id="${esc(r.regu_id)}">
-          <strong>${esc(dada3(r.nomor_dada))} · ${esc(r.nama_regu)}</strong>
-          <span class="alamat">${esc(r.nama_sekolah)}</span>
+      const q = pilih.value.trim().toLocaleLowerCase("id");
+      const ditemukan = calon
+        .filter(c => teks(c).toLocaleLowerCase("id").includes(q)).slice(0, 8);
+      saran.innerHTML = ditemukan.map(c => `
+        <button type="button" data-pilihan="${esc(kunci(c))}">
+          <strong>${esc(sekolahan ? c.name : `${dada3(c.nomor_dada)} · ${c.nama_regu}`)}</strong>
+          <span class="alamat">${esc(sekolahan ? (c.address || "") : c.nama_sekolah)}</span>
         </button>`).join("");
       saran.hidden = !ditemukan.length;
     };
@@ -6211,15 +6237,17 @@ async function layarKejuaraan() {
     pilih.addEventListener("blur", () => setTimeout(() => { saran.hidden = true; }, 100));
     saran.addEventListener("mousedown", e => e.preventDefault());
     saran.addEventListener("click", async e => {
-      const tombol = e.target.closest("[data-regu-id]");
+      const tombol = e.target.closest("[data-pilihan]");
       if (!tombol) return;
-      const dipilih = calon.find(r => r.regu_id === tombol.dataset.reguId);
+      const dipilih = calon.find(c => kunci(c) === tombol.dataset.pilihan);
       if (!dipilih) return;
       pilih.disabled = true;
       try {
-        await simpanKejuaraanManual(pilih.dataset.kode, dipilih.regu_id);
-        terkunci.querySelector(".kejuaraan-nilai").innerHTML = nilai(dipilih);
-        pilih.value = labelRegu(dipilih);
+        if (sekolahan) await simpanKejuaraanTerjauh(dipilih.id);
+        else await simpanKejuaraanManual(pilih.dataset.kode, dipilih.regu_id);
+        terkunci.querySelector(".kejuaraan-nilai").innerHTML = nilai(
+          sekolahan ? { kode: "terjauh", nama_sekolah: dipilih.name } : dipilih);
+        pilih.value = isiKotak(dipilih);
         saran.hidden = true;
         isian.hidden = true;
         terkunci.hidden = false;

--- a/web/style.css
+++ b/web/style.css
@@ -727,9 +727,42 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .function-menu .function-name .badge { margin-left: auto; }
 .function-menu .description { color: var(--tinta-lembut); margin-top: .3rem; }
 
-.table-kejuaraan th { width: 45%; }
+/* Kolom label MENYUSUT ke isinya, tidak dipatok 45%.
+
+   Dipatok, "JUARA I" berdiri di kolom selebar separuh kartu dan nama juaranya
+   mulai di tengah — jarak kosong yang terbaca seperti dua tabel berbeda, dan
+   itu keluhan yang datang dari lapangan. `width: 1%` di bawah `table-layout:
+   auto` adalah cara meminta "sesempit isinya"; nowrap menjaga "HARAPAN III"
+   tetap satu baris, dan karena ini TABEL sungguhan (bukan grid per baris),
+   satu lebar itu berlaku untuk seluruh barisnya — tepi kiri nama juara tidak
+   berpindah-pindah, syarat yang sama dengan kartu Meja Pembayaran (15.7).
+
+   Di dalam media query: di bawah 901px barisnya bertumpuk atau jadi grid, dan
+   nowrap di sana justru memaksa label panjang meluap keluar sel (15.8). */
+@media (min-width: 901px) {
+  .table-kejuaraan th { width: 1%; white-space: nowrap; }
+
+  /* Baris lebih rapat. Nilainya dua baris — nama regu dan asal sekolah — jadi
+     padding bawaan tabel data menambah tinggi yang tidak dipakai apa pun.
+     Di dalam media query karena di bawah 901px barisnya sudah punya aturan
+     paddingnya sendiri; menimpanya dari luar menggeser label terhadap
+     nilainya, dan yang menang cuma ditentukan urutan baris di berkas. */
+  .table-kejuaraan > tbody > tr > th,
+  .table-kejuaraan > tbody > tr > td { padding: .3rem .5rem; }
+  .table-kejuaraan > tbody > tr > th { padding-left: 0; }
+}
 .table-kejuaraan td strong, .table-kejuaraan td .description { display: block; }
 .table-kejuaraan .select-small { width: 100%; }
+.table-kejuaraan .description { line-height: 1.25; }
+
+/* Skor berdiri di kanan baris dengan angka selebar sama, supaya kolomnya bisa
+   dibaca lurus ke bawah untuk mengecek urutan juara. */
+.kejuaraan-isi { display: flex; align-items: baseline; gap: .5rem; }
+.kejuaraan-nama { flex: 1 1 auto; min-width: 0; }
+.kejuaraan-skor {
+  flex: 0 0 auto; font-weight: 700;
+  font-variant-numeric: tabular-nums; color: var(--tinta);
+}
 
 /* Satu juara = satu blok, dan garisnya di BARIS, bukan di sel.
    Sebelumnya tiap sel membawa border-bottom sendiri, jadi di HP — tempat th
@@ -816,8 +849,8 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kejuaraan-yel-yel,
 .kejuaraan-terfavorit,
 .kejuaraan-khusus          { --aksen: #6941c6; }
-.kejuaraan-bagian { display: grid; gap: 1rem; }
-.kejuaraan-bagian .card { margin-bottom: 0; }
+.kejuaraan-bagian { display: grid; gap: .75rem; }
+.kejuaraan-bagian .card { margin-bottom: 0; padding: .85rem 1rem; }
 /* `.card { overflow-x: auto }` di bawah membuat overflow-y ikut `auto` — itu
    aturan CSS, bukan salah ketik — dan daftar saran kotak cari digunting oleh
    tepi kartunya sendiri. Yang terlihat: kartu Juara Kostum tumbuh penggulir


### PR DESCRIPTION
## What

Three changes to the Kejuaraan screen, all requested from the field.

**Pangkalan Terjauh names a school.** Migration `0153` adds a nullable
`sekolah_id` to `kejuaraan_manual`, makes `regu_id` nullable, and adds one check
constraint tying each kode to the right column — no row can hold both or
neither. A pick already saved moves to the school of the regu that was chosen.
`simpan_kejuaraan_terjauh` is a separate RPC; the row reports `sumber =
manual_sekolah` so the screen knows its search box holds schools. The RPC
refuses a school that sent no regu with a nomor dada.

**Every juara row carries its score** on the right in tabular figures — the 24
golongan titles and the four Yel Yel rows.

**The board is tighter.** The label column shrinks to its content instead of a
fixed 45%, and row padding, card padding and card gap all come down.

Test `105_terjauh_pilih_sekolah.sql` covers the school being stored and
published, the `manual_sekolah` marker, a school with no regu being refused,
`terjauh` no longer being reachable through the regu RPC, clearing the pick, and
both directions of the check constraint.

## Why

Distance belongs to the pangkalan, not to one of the four regu it sent — with a
`regu_id` the other three read as though they had not made the journey. The
score was the number panitia were reading off a separate screen to check the
order of winners. And "JUARA I" sitting in a column half the card wide, with the
winner's name starting in the middle, is the empty space that was reported.

## Notes

* The tightening lives inside `@media (min-width: 901px)`. Below that the rows
  already carry their own padding rule, and overriding it from outside shifts
  the label against its value with nothing but line order in the file deciding
  which wins. Measured 320px–1400px: label and value share a left edge below
  901px, the label column is 97px above it, and there is no horizontal scroll,
  overflowing cell, clipped card, or wrapped label anywhere.
* Found while measuring, **not fixed here**: the phone layout for these tables
  has never applied. `.table-kejuaraan > tbody > tr { display: grid }` is
  outranked by `.data-table:not(.table-tetap) > tbody > tr { display: block }`,
  so the rows have always stacked label-over-value despite the comment above the
  rule arguing at length for the grid. It reads fine stacked and changing it
  mid-event has no upside, but the comment describes a layout that does not
  exist.
* `simpan_kejuaraan_terjauh` is registered in `tests/dev_server.py` so the flow
  can be exercised on a laptop.

Ran locally: `bash tests/run.sh` (all pass, including 104 and 105), `bash
tests/dev_database.sh`, `node --input-type=module --check` over `web/js/` and
`live/js/`, the shared-file diffs, and the three `periksa_*` scripts. Screen
opened at `#/kejuaraan` against a dev database of 143 regu with scores: school
picked for Terjauh and re-read after reload, 28 score figures rendered.