### PR TITLE
feat: show six medals on the Live Score podium

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3752,6 +3752,23 @@ button.pill-number:hover { filter: brightness(.95); }
   font-variant-numeric: tabular-nums;
 }
 
+/* Harapan 1-3 berdiri di podium yang sama, satu tingkat lebih tenang.
+
+   Enam kartu berukuran sama membuat Juara 1 tidak lagi menonjol, padahal
+   itulah baris yang dicari orang lebih dulu. Yang dikecilkan cuma medali dan
+   angkanya — nama regu tetap sebesar juara, karena nama itulah yang dibacakan
+   saat penghargaan diserahkan.
+
+   Satu kelas `harapan`, bukan rantai `.j4, .j5, .j6`. Ketiganya diperlakukan
+   sama persis, dan aturan yang menyebut nomor kartunya satu per satu adalah
+   aturan yang lupa diperlebar pada hari podiumnya berubah panjang. */
+.juara.harapan { padding: .45rem .75rem; }
+.juara.harapan .medali { font-size: 1.5rem; }
+.juara.harapan .total { font-size: 1.15rem; }
+/* Satu jarak di tempat Juara berakhir: enam kartu berjarak sama terbaca
+   seperti satu daftar berisi enam juara. */
+.juara:not(.harapan) + .juara.harapan { margin-top: .45rem; }
+
 /* RANTAI `th.pos-kol`, BUKAN `.pos-kol` SAJA — dan itu bukan kerapian.
    `.pos-kol` sendirian berkekhususan (0,1,0), kalah dari `.table th` (0,1,1)
    yang menyetel `text-align: left` untuk semua kepala tabel. Aturan tengah di

--- a/tests/live_score_loading.test.mjs
+++ b/tests/live_score_loading.test.mjs
@@ -41,7 +41,14 @@ test("umur snapshot terlihat di layar", () => {
 
 
 test("snapshot diurutkan menurut peringkat dan score, bukan nomor dada", () => {
-  assert.match(layar, /Number\(a\.peringkat\) - Number\(b\.peringkat\)/);
-  assert.match(layar, /Number\(b\.total\) - Number\(a\.total\)/);
-  assert.doesNotMatch(layar, /Number\(a\.nomor_dada\)|Number\(b\.nomor_dada\)/);
+  // Yang diperiksa cuma pengurutan SNAPSHOT — baris tabel. Podium di bawahnya
+  // punya pengurutannya sendiri dan memang berakhir di nomor dada, karena
+  // penghargaan harus jatuh ke satu regu bahkan saat skornya seri; membaca
+  // seluruh layarLiveScore() di sini membuat pemecah seri itu terbaca seperti
+  // pelanggaran aturan ini.
+  const urut = layar.slice(layar.indexOf("const klasemen = rekap"),
+                           layar.indexOf("let fase ="));
+  assert.match(urut, /Number\(a\.peringkat\) - Number\(b\.peringkat\)/);
+  assert.match(urut, /Number\(b\.total\) - Number\(a\.total\)/);
+  assert.doesNotMatch(urut, /Number\(a\.nomor_dada\)|Number\(b\.nomor_dada\)/);
 });

--- a/tests/live_score_six_places.test.mjs
+++ b/tests/live_score_six_places.test.mjs
@@ -1,0 +1,51 @@
+// Papan Live Score panitia menyebut enam nama, sama dengan lembar penghargaan:
+// Juara 1-3 lalu Harapan 1-3. Yang dijaga di sini bukan tampilannya, melainkan
+// bahwa keenamnya adalah regu yang SAMA dengan yang dipilih hasil_kejuaraan()
+// — papan yang menyebut nama berbeda dari lembar yang dibacakan lebih buruk
+// daripada papan yang berhenti di tiga.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const panitia = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const kejuaraan = await readFile(
+  new URL("../supabase/migrations/0139_kejuaraan.sql", import.meta.url), "utf8");
+const gaya = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+test("podium memuat enam tempat, bukan tiga", () => {
+  assert.match(panitia, /\.sort\(urutJuara\)\.slice\(0, 6\)/);
+});
+
+test("keenamnya bermedali, dan Harapan memakai lambang yang sama", () => {
+  const daftar = panitia.match(/const MEDALI = \{[^}]*\}/s)[0];
+  for (const n of [1, 2, 3, 4, 5, 6]) assert.ok(daftar.includes(`${n}: "`));
+  assert.equal((daftar.match(/🏅/g) || []).length, 3);
+});
+
+test("tempat 4-6 bernama Harapan 1-3", () => {
+  assert.match(panitia,
+    /gelar = \(n\) => n <= 3 \? `Juara \$\{n\}` : `Harapan \$\{n - 3\}`/);
+});
+
+test("pemecah serinya sama persis dengan hasil_kejuaraan()", () => {
+  // SQL: total desc, abs(coalesce(selisih_menit, 100000)) asc, nomor_dada asc.
+  assert.match(kejuaraan,
+    /order by k\.total desc,\s*abs\(coalesce\(k\.selisih_menit, 100000\)\) asc,\s*k\.nomor_dada asc/);
+  assert.match(panitia, /Math\.abs\(k\.selisih_menit \?\? 100000\)/);
+  assert.match(panitia,
+    /Number\(b\.total\) - Number\(a\.total\)\s*\|\| dekatKontrak\(a\) - dekatKontrak\(b\)\s*\|\| Number\(a\.nomor_dada\) - Number\(b\.nomor_dada\)/);
+});
+
+test("peringkat rank() tidak lagi menamai podium", () => {
+  // rank() memberi angka yang sama pada skor yang sama lalu melompat, jadi
+  // podium yang bersandar padanya menulis "Harapan 1" dua kali dan tidak
+  // pernah menulis "Harapan 2".
+  assert.doesNotMatch(panitia, /gelar\(k\.peringkat\)/);
+  assert.doesNotMatch(panitia, /MEDALI\[k\.peringkat\] \|\| ""<\/div>/);
+});
+
+test("ketiga Harapan dibedakan satu kelas, bukan tiga selektor", () => {
+  assert.match(panitia, /\$\{i >= 3 \? " harapan" : ""\}/);
+  assert.match(gaya, /\.juara\.harapan \{/);
+  assert.doesNotMatch(gaya, /\.juara\.j4/);
+});

--- a/tests/live_score_unarrived.test.mjs
+++ b/tests/live_score_unarrived.test.mjs
@@ -6,7 +6,7 @@ const panitia = await readFile(new URL("../web/js/app.js", import.meta.url), "ut
 const peserta = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
 
 test("regu tanpa peringkat tetap menjadi baris, bukan podium", () => {
-  assert.match(panitia, /baris\.filter\(k => k\.peringkat && k\.peringkat <= 3\)/);
+  assert.match(panitia, /baris\.filter\(k => k\.peringkat\)\.sort\(urutJuara\)\.slice\(0, 6\)/);
   assert.match(peserta, /baris\.filter\(b => b\.peringkat && b\.peringkat <= 3\)/);
 });
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5581,7 +5581,33 @@ async function layarLiveScore() {
       </ul>
     </div>`;
 
-  const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉" };
+  /* Enam besar, bukan tiga. Yang diumumkan di lapangan adalah Juara 1-3 lalu
+     Harapan 1-3 — sama dengan daftar penghargaan yang dipilih layar Kejuaraan
+     (migrasi 0139) — jadi papan yang berhenti di tiga membuat panitia menghitung
+     sendiri siapa Harapan 1 dari baris tabel di bawahnya.
+
+     Ketiga Harapan memakai medali yang sama: emas, perak, dan perunggu sudah
+     habis di Juara 1-3, dan memberi Harapan 1 lambang yang berbeda dari
+     Harapan 2 mengarang tingkatan yang tidak ada di penghargaannya. */
+  const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉",
+                   4: "🏅", 5: "🏅", 6: "🏅" };
+  const gelar = (n) => n <= 3 ? `Juara ${n}` : `Harapan ${n - 3}`;
+  /* Podium diurutkan SENDIRI, dengan pemecah seri yang sama persis dengan
+     hasil_kejuaraan() (migrasi 0139): total, lalu yang paling dekat dengan
+     kontrak waktunya, lalu nomor dada terkecil.
+
+     Kolom # di tabel memakai `peringkat` dari rank(), dan itu memang benar di
+     sana — dua regu berskor sama berbagi angka yang sama. Di podium ia salah:
+     penghargaannya cuma satu per gelar, jadi rank() menuliskan "Harapan 1"
+     dua kali lalu melompat ke "Harapan 3", sementara layar Kejuaraan
+     menyerahkan Harapan 1 dan Harapan 2 kepada dua regu itu. Papan yang
+     dibacakan panitia harus menyebut enam nama yang sama dengan lembar
+     penghargaan. */
+  const dekatKontrak = (k) => Math.abs(k.selisih_menit ?? 100000);
+  const urutJuara = (a, b) =>
+    Number(b.total) - Number(a.total)
+    || dekatKontrak(a) - dekatKontrak(b)
+    || Number(a.nomor_dada) - Number(b.nomor_dada);
 
   /* Kolom rincian dibangun dengan kolomPos() yang SAMA dengan layar Input Pos
      dan Rekapitulasi. Satu kolom per LOMBA, bukan per baris wahana — tanpa itu
@@ -5636,7 +5662,7 @@ async function layarLiveScore() {
 
   const kartuGolongan = (g) => {
         const baris = klasemen.filter(k => k.golongan === g);
-        const juara = baris.filter(k => k.peringkat && k.peringkat <= 3);
+        const juara = baris.filter(k => k.peringkat).sort(urutJuara).slice(0, 6);
         const sekolahAda = [...new Set(baris.map(k => k.nama_sekolah).filter(Boolean))]
           .sort((a, b) => a.localeCompare(b, "id"));
         if (!baris.length) return `
@@ -5667,11 +5693,11 @@ async function layarLiveScore() {
             <div class="sisi kanan">${saklar}</div>
           </div>
           <div class="podium">
-            ${juara.map(k => `
-              <div class="juara j${esc(String(k.peringkat))}">
-                <div class="medali" aria-hidden="true">${MEDALI[k.peringkat] || ""}</div>
+            ${juara.map((k, i) => `
+              <div class="juara j${i + 1}${i >= 3 ? " harapan" : ""}">
+                <div class="medali" aria-hidden="true">${MEDALI[i + 1] || ""}</div>
                 <div class="j-teks">
-                  <div class="peringkat">Juara ${esc(String(k.peringkat))}
+                  <div class="peringkat">${esc(gelar(i + 1))}
                     <span class="dada-juara">${esc(dada3(k.nomor_dada))}</span></div>
                   <div class="nama">${esc(k.nama_regu)}</div>
                   <div class="sekolah">${esc(k.nama_sekolah)}</div>

--- a/web/style.css
+++ b/web/style.css
@@ -3752,6 +3752,23 @@ button.pill-number:hover { filter: brightness(.95); }
   font-variant-numeric: tabular-nums;
 }
 
+/* Harapan 1-3 berdiri di podium yang sama, satu tingkat lebih tenang.
+
+   Enam kartu berukuran sama membuat Juara 1 tidak lagi menonjol, padahal
+   itulah baris yang dicari orang lebih dulu. Yang dikecilkan cuma medali dan
+   angkanya — nama regu tetap sebesar juara, karena nama itulah yang dibacakan
+   saat penghargaan diserahkan.
+
+   Satu kelas `harapan`, bukan rantai `.j4, .j5, .j6`. Ketiganya diperlakukan
+   sama persis, dan aturan yang menyebut nomor kartunya satu per satu adalah
+   aturan yang lupa diperlebar pada hari podiumnya berubah panjang. */
+.juara.harapan { padding: .45rem .75rem; }
+.juara.harapan .medali { font-size: 1.5rem; }
+.juara.harapan .total { font-size: 1.15rem; }
+/* Satu jarak di tempat Juara berakhir: enam kartu berjarak sama terbaca
+   seperti satu daftar berisi enam juara. */
+.juara:not(.harapan) + .juara.harapan { margin-top: .45rem; }
+
 /* RANTAI `th.pos-kol`, BUKAN `.pos-kol` SAJA — dan itu bukan kerapian.
    `.pos-kol` sendirian berkekhususan (0,1,0), kalah dari `.table th` (0,1,1)
    yang menyetel `text-align: left` untuk semua kepala tabel. Aturan tengah di


### PR DESCRIPTION
## What

Papan Klasemen sementara di Live Score panitia sekarang menampilkan **enam** kartu bermedali per golongan — Juara 1, 2, 3 lalu Harapan 1, 2, 3 — bukan tiga.

- Juara 1-3 tetap emas/perak/perunggu; ketiga Harapan memakai medali yang sama (lambang berbeda per Harapan akan mengarang tingkatan yang tidak ada di penghargaannya).
- Kartu Harapan sedikit lebih ringkas (medali dan angka totalnya lebih kecil), dengan satu jarak di tempat Juara berakhir. Nama regu tetap sebesar juara — itu yang dibacakan saat penghargaan diserahkan.
- Podium diurutkan sendiri dengan pemecah seri yang sama persis dengan `hasil_kejuaraan()` (migrasi 0139): total, lalu yang paling dekat dengan kontrak waktunya, lalu nomor dada.

## Why

Yang diumumkan di lapangan enam gelar, sedangkan papan berhenti di tiga — panitia yang membacakan penghargaan harus menghitung sendiri siapa Harapan 1 dari baris tabel di bawah podium.

Podium sebelumnya bersandar pada `peringkat` dari `rank()`. Rank memberi angka yang sama pada skor yang sama lalu melompat, jadi seri di tempat keempat menghasilkan dua "Harapan 1" dan tidak ada "Harapan 2" — sementara layar Kejuaraan menyerahkan Harapan 1 dan Harapan 2 kepada dua regu itu. Papan yang dibacakan panitia harus menyebut enam nama yang sama dengan lembar penghargaannya.

## Notes

Diperiksa dengan membuka layarnya, bukan hanya tesnya (CLAUDE.md 17.2): `tests/dev_database.sh` + `tools/simulasi_end_to_end.py` atas 143 regu, lalu `#/live-score` di 127.0.0.1:8788.

- Keempat golongan menggambar tepat 6 kartu, dan keenam nomor dada per golongan **sama persis** dengan `v_kejuaraan` — termasuk dua seri yang sebelumnya membuat podium menulis gelar ganda.
- Tabel di bawahnya tetap utuh: 40 / 41 / 28 / 34 baris, sesuai hitungan tab golongan.
- Diukur di lebar 390px lewat iframe: tidak ada kartu yang meluap.
- `node --test tests/*.test.mjs`: 254 tes, 249 lulus. Lima kegagalan yang tersisa sudah ada di `main` sebelum perubahan ini (diperiksa dengan `git stash`) dan tidak menyentuh Live Score.
- `web/style.css` disalin ke `live/` (aturan `.juara.harapan` belum terpakai di situs peserta — podiumnya masih tiga).
