### PR TITLE
feat: fit the Live Score podium into two rows of three

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -3713,15 +3713,31 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .c-alarm { color: var(--bahaya); }
 
-/* Podium: SATU juara satu baris, bertumpuk ke bawah.
+/* Podium: DUA BARIS BERTIGA di layar lebar — Juara 1-3 di atas, Harapan 1-3
+   tepat di bawahnya — dan satu kolom bertumpuk di layar sempit.
 
-   Tiga kartu berdampingan membungkus jadi 2 + 1 di layar HP, dan baris kedua
-   yang cuma berisi satu kartu terbaca seperti tampilan yang rusak, bukan
-   seperti podium. Bertumpuk, ketiganya selalu sejajar, urutannya tidak pernah
-   ambigu, dan nama regu punya selebar layar untuk dirinya sendiri — nama
-   juara adalah satu-satunya hal di baris itu yang benar-benar dicari orang. */
+   Enam kartu bertumpuk memakan hampir seluruh tinggi layar, dan tabel yang
+   menjawab "regu saya di peringkat berapa" terdorong sepenuhnya ke bawah
+   lipatan. Dua baris bertiga memuat keenamnya dalam tinggi dua kartu, dan
+   bentuknya sendiri sudah mengatakan mana Juara dan mana Harapan tanpa satu
+   kata tambahan.
+
+   `grid`, BUKAN flex-wrap. Tiga kartu yang dibungkus flex akan patah jadi
+   2 + 1 begitu isinya melebar, dan baris berisi satu kartu terbaca seperti
+   tampilan yang rusak, bukan seperti podium. Grid tiga kolom tidak pernah
+   bisa melakukan itu: yang keempat SELALU memulai baris baru.
+
+   Ambangnya 901px, sama dengan ambang yang dipakai tabel di seluruh berkas
+   ini (bagian 15 CLAUDE.md). Di bawahnya podium kembali bertumpuk satu kolom
+   — di lebar HP, kartu selebar sepertiga layar tidak menyisakan tempat untuk
+   nama regu, dan nama itulah satu-satunya hal di kartu ini yang benar-benar
+   dicari orang. */
 .podium {
-  display: flex; flex-direction: column; gap: .5rem; margin: .6rem 0 1rem;
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  column-gap: .5rem; row-gap: .75rem; margin: .6rem 0 1rem;
+}
+@media (max-width: 900px) {
+  .podium { grid-template-columns: 1fr; row-gap: .5rem; }
 }
 .juara {
   display: flex; align-items: center; gap: .75rem;
@@ -3765,9 +3781,13 @@ button.pill-number:hover { filter: brightness(.95); }
 .juara.harapan { padding: .45rem .75rem; }
 .juara.harapan .medali { font-size: 1.5rem; }
 .juara.harapan .total { font-size: 1.15rem; }
-/* Satu jarak di tempat Juara berakhir: enam kartu berjarak sama terbaca
-   seperti satu daftar berisi enam juara. */
-.juara:not(.harapan) + .juara.harapan { margin-top: .45rem; }
+/* Satu jarak di tempat Juara berakhir, dan HANYA di rentang bertumpuk. Di
+   dua baris bertiga, `row-gap` sudah memisahkan keduanya; menambahkan margin
+   di sana cuma menurunkan kartu Harapan 1 sendirian sementara Harapan 2 dan 3
+   di sebelahnya tetap di tempatnya. */
+@media (max-width: 900px) {
+  .juara:not(.harapan) + .juara.harapan { margin-top: .3rem; }
+}
 
 /* RANTAI `th.pos-kol`, BUKAN `.pos-kol` SAJA — dan itu bukan kerapian.
    `.pos-kol` sendirian berkekhususan (0,1,0), kalah dari `.table th` (0,1,1)

--- a/tests/live_score_six_places.test.mjs
+++ b/tests/live_score_six_places.test.mjs
@@ -19,7 +19,11 @@ test("podium memuat enam tempat, bukan tiga", () => {
 test("keenamnya bermedali, dan Harapan memakai lambang yang sama", () => {
   const daftar = panitia.match(/const MEDALI = \{[^}]*\}/s)[0];
   for (const n of [1, 2, 3, 4, 5, 6]) assert.ok(daftar.includes(`${n}: "`));
-  assert.equal((daftar.match(/🏅/g) || []).length, 3);
+  // Pita, bukan medali bundar keempat: emas/perak/perunggu sudah habis di
+  // Juara 1-3. Satu lambang untuk ketiga Harapan — lambang berbeda per
+  // Harapan mengarang tingkatan yang tidak ada di penghargaannya.
+  assert.equal((daftar.match(/🎖️/g) || []).length, 3);
+  assert.doesNotMatch(daftar, /🏅/);
 });
 
 test("tempat 4-6 bernama Harapan 1-3", () => {
@@ -48,4 +52,27 @@ test("ketiga Harapan dibedakan satu kelas, bukan tiga selektor", () => {
   assert.match(panitia, /\$\{i >= 3 \? " harapan" : ""\}/);
   assert.match(gaya, /\.juara\.harapan \{/);
   assert.doesNotMatch(gaya, /\.juara\.j4/);
+});
+
+test("podium dua baris bertiga di layar lebar, bertumpuk di layar sempit", () => {
+  // Enam kartu bertumpuk mendorong tabel peringkat keluar layar sepenuhnya.
+  const blok = gaya.slice(gaya.indexOf(".podium {"), gaya.indexOf(".juara {"));
+  assert.match(blok, /display: grid; grid-template-columns: repeat\(3, 1fr\)/);
+  assert.match(blok, /@media \(max-width: 900px\) \{\s*\.podium \{ grid-template-columns: 1fr/);
+});
+
+test("grid, bukan flex-wrap: kartu keempat selalu memulai baris baru", () => {
+  // Tiga kartu yang dibungkus flex patah jadi 2 + 1 begitu isinya melebar,
+  // dan baris berisi satu kartu terbaca seperti tampilan yang rusak.
+  const blok = gaya.slice(gaya.indexOf(".podium {"), gaya.indexOf(".juara {"));
+  assert.doesNotMatch(blok, /flex-wrap|flex-direction/);
+});
+
+test("jarak antara Juara dan Harapan hanya dipasang di rentang bertumpuk", () => {
+  // Di dua baris bertiga, margin itu menurunkan kartu Harapan 1 sendirian
+  // sementara Harapan 2 dan 3 di sebelahnya tetap di tempatnya; `row-gap`
+  // yang memisahkan keduanya di sana.
+  const pisah = gaya.indexOf(".juara:not(.harapan) + .juara.harapan");
+  assert.ok(pisah > 0);
+  assert.match(gaya.slice(pisah - 200, pisah), /@media \(max-width: 900px\) \{\s*$/);
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5586,11 +5586,14 @@ async function layarLiveScore() {
      (migrasi 0139) — jadi papan yang berhenti di tiga membuat panitia menghitung
      sendiri siapa Harapan 1 dari baris tabel di bawahnya.
 
-     Ketiga Harapan memakai medali yang sama: emas, perak, dan perunggu sudah
-     habis di Juara 1-3, dan memberi Harapan 1 lambang yang berbeda dari
-     Harapan 2 mengarang tingkatan yang tidak ada di penghargaannya. */
+     Ketiga Harapan memakai PITA, satu lambang yang sama untuk ketiganya.
+     Bentuknya sengaja tidak bundar: emas, perak, dan perunggu sudah habis di
+     Juara 1-3, jadi medali bundar keempat cuma menambah satu benda yang mirip
+     tiga benda di atasnya. Memberi Harapan 1 lambang yang berbeda dari
+     Harapan 2 juga tidak dilakukan — itu mengarang tingkatan yang tidak ada
+     di penghargaannya. */
   const MEDALI = { 1: "🥇", 2: "🥈", 3: "🥉",
-                   4: "🏅", 5: "🏅", 6: "🏅" };
+                   4: "🎖️", 5: "🎖️", 6: "🎖️" };
   const gelar = (n) => n <= 3 ? `Juara ${n}` : `Harapan ${n - 3}`;
   /* Podium diurutkan SENDIRI, dengan pemecah seri yang sama persis dengan
      hasil_kejuaraan() (migrasi 0139): total, lalu yang paling dekat dengan

--- a/web/style.css
+++ b/web/style.css
@@ -3713,15 +3713,31 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .c-alarm { color: var(--bahaya); }
 
-/* Podium: SATU juara satu baris, bertumpuk ke bawah.
+/* Podium: DUA BARIS BERTIGA di layar lebar — Juara 1-3 di atas, Harapan 1-3
+   tepat di bawahnya — dan satu kolom bertumpuk di layar sempit.
 
-   Tiga kartu berdampingan membungkus jadi 2 + 1 di layar HP, dan baris kedua
-   yang cuma berisi satu kartu terbaca seperti tampilan yang rusak, bukan
-   seperti podium. Bertumpuk, ketiganya selalu sejajar, urutannya tidak pernah
-   ambigu, dan nama regu punya selebar layar untuk dirinya sendiri — nama
-   juara adalah satu-satunya hal di baris itu yang benar-benar dicari orang. */
+   Enam kartu bertumpuk memakan hampir seluruh tinggi layar, dan tabel yang
+   menjawab "regu saya di peringkat berapa" terdorong sepenuhnya ke bawah
+   lipatan. Dua baris bertiga memuat keenamnya dalam tinggi dua kartu, dan
+   bentuknya sendiri sudah mengatakan mana Juara dan mana Harapan tanpa satu
+   kata tambahan.
+
+   `grid`, BUKAN flex-wrap. Tiga kartu yang dibungkus flex akan patah jadi
+   2 + 1 begitu isinya melebar, dan baris berisi satu kartu terbaca seperti
+   tampilan yang rusak, bukan seperti podium. Grid tiga kolom tidak pernah
+   bisa melakukan itu: yang keempat SELALU memulai baris baru.
+
+   Ambangnya 901px, sama dengan ambang yang dipakai tabel di seluruh berkas
+   ini (bagian 15 CLAUDE.md). Di bawahnya podium kembali bertumpuk satu kolom
+   — di lebar HP, kartu selebar sepertiga layar tidak menyisakan tempat untuk
+   nama regu, dan nama itulah satu-satunya hal di kartu ini yang benar-benar
+   dicari orang. */
 .podium {
-  display: flex; flex-direction: column; gap: .5rem; margin: .6rem 0 1rem;
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  column-gap: .5rem; row-gap: .75rem; margin: .6rem 0 1rem;
+}
+@media (max-width: 900px) {
+  .podium { grid-template-columns: 1fr; row-gap: .5rem; }
 }
 .juara {
   display: flex; align-items: center; gap: .75rem;
@@ -3765,9 +3781,13 @@ button.pill-number:hover { filter: brightness(.95); }
 .juara.harapan { padding: .45rem .75rem; }
 .juara.harapan .medali { font-size: 1.5rem; }
 .juara.harapan .total { font-size: 1.15rem; }
-/* Satu jarak di tempat Juara berakhir: enam kartu berjarak sama terbaca
-   seperti satu daftar berisi enam juara. */
-.juara:not(.harapan) + .juara.harapan { margin-top: .45rem; }
+/* Satu jarak di tempat Juara berakhir, dan HANYA di rentang bertumpuk. Di
+   dua baris bertiga, `row-gap` sudah memisahkan keduanya; menambahkan margin
+   di sana cuma menurunkan kartu Harapan 1 sendirian sementara Harapan 2 dan 3
+   di sebelahnya tetap di tempatnya. */
+@media (max-width: 900px) {
+  .juara:not(.harapan) + .juara.harapan { margin-top: .3rem; }
+}
 
 /* RANTAI `th.pos-kol`, BUKAN `.pos-kol` SAJA — dan itu bukan kerapian.
    `.pos-kol` sendirian berkekhususan (0,1,0), kalah dari `.table th` (0,1,1)


### PR DESCRIPTION
## What

Podium Klasemen sementara sekarang **dua baris bertiga** di layar lebar — Juara 1, 2, 3 di atas; Harapan 1, 2, 3 tepat di bawahnya — bukan enam kartu bertumpuk.

- Grid tiga kolom, bukan flex-wrap.
- Di bawah 901px podium kembali bertumpuk satu kolom, dengan satu jarak di tempat Juara berakhir.
- Lambang Harapan 1-3 diganti dari medali bundar 🏅 jadi pita 🎖️.

## Why

Enam kartu bertumpuk memakan hampir seluruh tinggi layar, dan tabel yang menjawab "regu saya di peringkat berapa" terdorong sepenuhnya ke bawah lipatan. Dua baris memuat keenamnya dalam tinggi dua kartu, dan bentuknya sendiri sudah mengatakan mana Juara dan mana Harapan tanpa satu kata tambahan.

Flex-wrap ditolak karena tiga kartu yang dibungkus flex patah jadi 2 + 1 begitu isinya melebar, dan baris berisi satu kartu terbaca seperti tampilan yang rusak. Grid tiga kolom tidak pernah bisa melakukan itu — yang keempat selalu memulai baris baru.

Ambang 901px mengikuti ambang yang sudah dipakai tabel di seluruh berkas (CLAUDE.md 15). Di bawahnya kartu selebar sepertiga layar tinggal ~95px, dan nama regu adalah satu-satunya hal di kartu ini yang benar-benar dicari orang.

Pita untuk Harapan: emas, perak, dan perunggu sudah habis di Juara 1-3, jadi medali bundar keempat cuma menambah satu benda yang mirip tiga benda di atasnya. Ketiganya tetap memakai lambang yang sama — lambang berbeda per Harapan mengarang tingkatan yang tidak ada di penghargaannya.

## Notes

Diukur di browser, bukan dibaca (CLAUDE.md 15.9): iframe disapu 390 -> 1600px atas layar sungguhan berisi 143 regu.

| Lebar | Kolom | Tinggi podium |
| --- | --- | --- |
| 1400px | 3 | 157px (dari 477px) |
| 941px | 3 | 175px |
| 901px | 3 | 175px |
| 900px | 1 | 477px |
| 390px | 1 | 477px |

Diuji juga dengan isi TERPANJANG di data sungguhan — regu `WIJAYA KUSUMA NAWASENA` dan sekolah `SMP BP Plus Ma'arif NU Ciamis` dipasang di keenam kartu sekaligus: di 901px pun tidak ada kartu yang meluap (`scrollWidth > clientWidth`) dan tidak ada kotak isi yang menembus angka totalnya.

`node --test tests/*.test.mjs`: 257 tes, 252 lulus. Lima kegagalan yang tersisa sudah ada di `main` sebelum perubahan ini dan tidak menyentuh Live Score.
