### PR TITLE
fix: give the dev database the penalty rules production uses

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -788,6 +788,22 @@ yang hanya dibaca developer berbahasa Inggris. Nama berkasnya selalu Inggris
 
 ## 6. Menjalankan secara lokal
 
+> **`supabase/seed.sql` sengaja menyimpan konfigurasi penalti seperti saat
+> edisi 37 dibuat** — blok 10 menit, 10 poin per blok, −100 tanpa jam datang —
+> bukan yang berlaku sekarang. `tests/run.sh` menjalankannya SEBELUM `0089`
+> dan `0143`, persis seperti produksi, dan di sanalah kedua migrasi itu
+> benar-benar diuji mengubah barisnya. Menyegarkan seed akan membuat keduanya
+> lulus tanpa mengubah apa pun.
+>
+> `tests/dev_database.sh` urutannya terbalik — seluruh migrasi berjalan
+> sebelum seed membuat edisi aktif — jadi ia mengembalikan baris itu ke
+> **bawaan kolomnya** sesudah seed, lewat `set kolom = default`. Defaultnya
+> sendiri dipasang `0089` dan `0143`, bagian migrasi yang memang berhasil
+> berjalan tanpa memerlukan satu baris pun, sehingga tidak ada angka penalti
+> yang ditulis dua kali di repo ini. Menjalankan ulang `0143` BUKAN jalan
+> keluarnya: ia juga membuat ulang `v_klasemen` dan `simpan_kejuaraan_manual`,
+> yang sudah diganti `0144`, `0145`, `0152`, dan `0153`.
+
 Tanpa akun Supabase sama sekali. `tests/dev_server.py` menirukan PostgREST +
 GoTrue di atas Postgres lokal, termasuk RLS: tiap request dijalankan dalam
 transaksi dengan `SET LOCAL app.uid` dan `SET LOCAL ROLE`, sehingga policy yang
@@ -868,17 +884,6 @@ Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
   empat hal lain, dan kait `segarkanDiTempat` justru masih hidup — sekarang
   yang mendaftarkannya layar Input Nilai Pos, bukan layar itu. Bagian 7 nomor
   10 juga masih menyebutnya sebagai contoh.
-- **`supabase/seed.sql` menyimpan konfigurasi penalti yang sudah diganti dua
-  migrasi, dan itu membuat database dev BERBEDA dari produksi.** Barisnya
-  `(37, 10, 10, 100, 20, 0)` — blok 10 menit, 10 poin per blok, −100 tanpa jam
-  datang — sedangkan `0089` menjadikannya 1 menit/1 poin dan `0143`
-  menjadikan potongan tanpa jam datang 0. Di produksi keduanya benar, karena
-  keduanya berjalan di atas database yang barisnya sudah ada. Di
-  `tests/dev_database.sh` seed berjalan SESUDAH seluruh migrasi, jadi ia
-  menimpa keduanya dan laptop memakai aturan penalti lama tanpa sepatah galat.
-  Assert penutup `0143` pun tidak menangkapnya: saat ia berjalan, barisnya
-  belum ada. Perbaikannya satu baris — tambahkan `0089_penalti_waktu_per_menit`
-  dan `0143_juara_harus_tiba` ke `ULANG` di `tests/dev_database.sh`.
 - **Empat tes di `tests/championship_ui.test.mjs` gagal di `main`**, dan yang
   tertinggal adalah TESNYA, bukan layarnya. Ia masih menuntut empat judul
   section per golongan ("Penegak PA", "Penggalang PI", …) yang dirapikan #703,

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -134,6 +134,70 @@ for m in "$ROOT"/supabase/migrations/*.sql; do
   run "supabase/migrations/$nama"
 done
 run supabase/seed.sql
+
+# KONFIGURASI PENALTI DIKEMBALIKAN KE BAWAAN KOLOM, dan tanpa ini database dev
+# memakai aturan penalti yang sudah dua kali diganti.
+#
+# seed.sql menulis konfig_penalti apa adanya seperti saat edisi 37 dibuat:
+# blok 10 menit, 10 poin per blok, -100 tanpa jam datang. Di produksi angka itu
+# benar sesaat, lalu 0089 menjadikannya 1 menit -> 1 poin dan 0143 menjadikan
+# potongan tanpa jam datang 0 — keduanya berjalan di atas database yang barisnya
+# sudah ada, jadi keduanya menemukan baris itu dan membetulkannya.
+#
+# Di sini urutannya terbalik. Seluruh migrasi berjalan di glob SEBELUM seed.sql
+# membuat edisi 37, jadi 0089 dan 0143 tidak menemukan satu baris pun untuk
+# diperbaiki — 0089 malah mengatakannya dengan tenang lewat notice "data
+# dilewati" — lalu seed.sql menulis angka lamanya, dan tidak ada lagi yang
+# lewat sesudahnya. Assert penutup 0143 pun tidak menangkapnya, karena saat ia
+# berjalan barisnya memang belum ada. Akibatnya layar yang dicoba di laptop
+# menghitung penalti dengan aturan yang tidak dipakai siapa pun, tanpa sepatah
+# galat (CLAUDE.md pasal 17.6).
+#
+# TIDAK bisa dibereskan dengan menaruh 0089 dan 0143 di ULANG. 0089 sendiri
+# aman, tapi 0143 juga membuat ulang view v_klasemen dan fungsi
+# simpan_kejuaraan_manual — dan keduanya sudah diganti migrasi yang lebih muda
+# (0144, 0145, 0152, 0153). Menjalankannya ulang di ujung daftar akan
+# MENGEMBALIKAN keempatnya ke versi lama; itu jebakan yang sama dengan yang
+# ditulis di CLAUDE.md pasal 7.8.
+#
+# Yang dipakai di bawah karena itu BUKAN angka. `set kolom = default` membaca
+# default kolomnya sendiri, dan default itulah yang dipasang 0089 dan 0143 —
+# bagian migrasi yang memang berhasil berjalan di glob, karena ia tidak
+# memerlukan satu baris pun. Jadi tidak ada satu angka penalti pun yang ditulis
+# dua kali di repo ini: migrasinya tetap satu-satunya tempat angka itu hidup.
+# Migrasi penalti berikutnya cukup memindahkan default kolomnya seperti 0089
+# dan 0143 — kebiasaan yang memang sudah ditulis di kepala 0089 — dan langkah
+# ini ikut benar dengan sendirinya.
+"$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q -c "
+  do \$blok\$
+  declare
+    n integer;
+    v konfig_penalti%rowtype;
+  begin
+    update konfig_penalti
+    set blok_menit                 = default,
+        penalti_per_blok           = default,
+        penalti_tanpa_checkout     = default,
+        penalti_per_anggota_hilang = default,
+        nilai_pos_terlewat         = default
+    where edisi = edisi_aktif();
+
+    -- Yang diperiksa cuma bahwa barisnya KENA. Nilainya sendiri tidak
+    -- diperiksa terhadap angka mana pun: sesudah 'set = default' ia sama
+    -- dengan default kolomnya menurut definisi, dan menuliskan angka yang
+    -- diharapkan di sini justru mengembalikan salinan kedua yang langkah ini
+    -- dibuat untuk menghilangkan. Nol baris berarti belum ada edisi aktif -
+    -- dan itu berarti seluruh skrip ini berjalan di urutan yang salah.
+    get diagnostics n = row_count;
+    assert n = 1,
+           format('dev_database.sh: %s baris konfig_penalti tersentuh, seharusnya 1', n);
+
+    select * into v from konfig_penalti where edisi = edisi_aktif();
+    raise notice 'konfig_penalti edisi %: blok % menit -> % poin, tanpa jam datang %, anggota hilang %.',
+                 v.edisi, v.blok_menit, v.penalti_per_blok,
+                 v.penalti_tanpa_checkout, v.penalti_per_anggota_hilang;
+  end;
+  \$blok\$;"
 # Konfigurasi pos butuh edisinya sudah ada — lihat catatan panjang yang sama
 # di tests/run.sh.
 run supabase/migrations/0024_komponen_pos.sql

--- a/tests/dev_penalty_config.test.mjs
+++ b/tests/dev_penalty_config.test.mjs
@@ -1,0 +1,59 @@
+// Database dev harus memakai aturan penalti yang SAMA dengan produksi.
+//
+// Urutan di tests/dev_database.sh terbalik dari produksi: seluruh migrasi
+// berjalan sebelum seed.sql membuat edisi aktif, jadi 0089 dan 0143 tidak
+// menemukan baris konfig_penalti untuk diperbaiki, lalu seed.sql menulis
+// angka lamanya. Yang membetulkannya satu langkah `set kolom = default`
+// sesudah seed. Tanpa itu layar yang dicoba di laptop menghitung penalti
+// dengan aturan yang tidak dipakai siapa pun, tanpa sepatah galat.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const akar = new URL("../", import.meta.url);
+const dev = await readFile(new URL("tests/dev_database.sh", akar), "utf8");
+const seed = await readFile(new URL("supabase/seed.sql", akar), "utf8");
+const runSh = await readFile(new URL("tests/run.sh", akar), "utf8");
+
+test("dev mengembalikan konfig_penalti ke bawaan kolom sesudah seed", () => {
+  const sesudahSeed = dev.slice(dev.indexOf("run supabase/seed.sql"))
+    .replace(/\s+/g, " ");
+  for (const kolom of ["blok_menit", "penalti_per_blok", "penalti_tanpa_checkout"])
+    assert.ok(sesudahSeed.includes(`${kolom} = default`),
+      `${kolom} tidak dikembalikan ke default sesudah seed.sql`);
+  assert.ok(sesudahSeed.includes("where edisi = edisi_aktif()"));
+});
+
+test("langkahnya tidak menuliskan satu angka penalti pun", () => {
+  // Angka yang ditulis di sini akan jadi salinan kedua yang diam-diam
+  // menyimpang begitu migrasi berikutnya mengubah aturannya. Yang dibaca
+  // `set = default` adalah default kolom yang dipasang 0089 dan 0143.
+  const awal = dev.indexOf("KONFIGURASI PENALTI DIKEMBALIKAN");
+  const langkah = dev.slice(awal, dev.indexOf("0024_komponen_pos", awal));
+  const sql = langkah.slice(langkah.indexOf("update konfig_penalti"),
+                            langkah.indexOf("get diagnostics"));
+  assert.doesNotMatch(sql, /=\s*[0-9]/,
+    "ada angka yang ditulis langsung di langkah ini");
+});
+
+test("0143 TIDAK boleh masuk daftar ULANG", () => {
+  // Ia membuat ulang v_klasemen dan simpan_kejuaraan_manual, dan keduanya
+  // sudah diganti 0144, 0145, 0152, dan 0153 (CLAUDE.md pasal 7.8).
+  const ulang = dev.slice(dev.indexOf("ULANG="), dev.indexOf('"', dev.indexOf("ULANG=") + 8));
+  assert.doesNotMatch(ulang, /0143/);
+});
+
+test("seed.sql tetap menyimpan konfigurasi awal edisi, bukan yang sekarang", () => {
+  // tests/run.sh menjalankan seed SEBELUM 0089 dan 0143 — persis seperti
+  // produksi — jadi di sanalah kedua migrasi itu benar-benar diuji mengubah
+  // barisnya. Menyegarkan seed akan membuat keduanya lulus tanpa mengubah
+  // apa pun, dan tidak ada lagi yang menguji jalur konversinya.
+  assert.match(seed, /insert into konfig_penalti/);
+  const urutSeed = runSh.indexOf("run supabase/seed.sql");
+  const urut0089 = runSh.indexOf("0089_penalti_waktu_per_menit");
+  const urut0143 = runSh.indexOf("0143_juara_harus_tiba");
+  assert.ok(urutSeed > 0 && urut0089 > urutSeed,
+    "run.sh harus menjalankan seed.sql sebelum 0089");
+  assert.ok(urut0143 > urutSeed,
+    "run.sh harus menjalankan seed.sql sebelum 0143");
+});


### PR DESCRIPTION
## What

`tests/dev_database.sh` mengembalikan baris `konfig_penalti` ke **bawaan kolomnya** sesudah `seed.sql`, plus satu tes sumber yang menjaganya. `supabase/seed.sql` sengaja tidak diubah.

## Why

Sejak `0089` penalti waktu **1 poin tiap 1 menit**, dan sejak `0143` tanpa jam datang **tidak lagi memotong 100**. Database dev memakai aturan sebelum keduanya — 10 menit per blok, 10 poin, potongan −100 — tanpa sepatah galat.

Sebabnya urutan. Di produksi `seed.sql` berjalan sekali di awal, lalu `0089` dan `0143` menemukan baris `konfig_penalti` yang sudah ada dan membetulkannya. Di `dev_database.sh` seluruh migrasi berjalan lebih dulu, **sebelum** `seed.sql` membuat edisi 37 — jadi keduanya tidak menemukan satu baris pun untuk diperbaiki (`0089` mengatakannya lewat notice `data dilewati`), lalu `seed.sql` menulis angka lamanya dan tidak ada lagi yang lewat sesudahnya. Assert penutup `0143` pun tidak menangkapnya: saat ia berjalan, barisnya belum ada.

Akibatnya persis yang CLAUDE.md pasal 17.6 sebut: alat untuk membuka layar sendiri yang rusak. Pasal 17.2 mewajibkan membuka layar sebelum merge, dan setiap layar yang menampilkan penalti — Kedatangan, Live Score, klasemen — memberi angka yang berbeda dari produksi.

## Kenapa bukan ditaruh di ULANG

`0089` sendiri aman diulang; ia hanya menyentuh `konfig_penalti`. **`0143` tidak.** Ia juga `create or replace` `v_klasemen` dan `simpan_kejuaraan_manual`, dan keduanya sudah diganti migrasi yang lebih muda:

| Objek | Dibuat ulang oleh |
| --- | --- |
| `v_klasemen` | `0144`, `0145` |
| `simpan_kejuaraan_manual` | `0152`, `0153` |

Menjalankan ulang `0143` di ujung daftar akan **mengembalikan keempatnya ke versi lama** — jebakan yang sama dengan CLAUDE.md pasal 7.8.

## Kenapa bukan menyegarkan seed.sql

`tests/run.sh` menjalankan `seed.sql` di baris 69, **sebelum** `0089` dan `0143` — persis urutan produksi — dan di sanalah kedua migrasi itu benar-benar diuji MENGUBAH barisnya. Menyegarkan seed akan membuat keduanya lulus tanpa mengubah apa pun, dan jalur konversinya berhenti diuji di mana pun.

## Bentuk perbaikannya

```sql
update konfig_penalti
set blok_menit = default, penalti_per_blok = default, penalti_tanpa_checkout = default, ...
where edisi = edisi_aktif();
```

Default kolomnya dipasang `0089` dan `0143` sendiri — bagian migrasi yang memang berhasil berjalan di glob, karena ia tidak memerlukan satu baris pun. Jadi **tidak ada satu angka penalti pun yang ditulis dua kali** di repo ini: migrasinya tetap satu-satunya tempat angka itu hidup, dan migrasi penalti berikutnya cukup memindahkan default kolomnya seperti `0089` sudah menyuruh di kepalanya.

## Notes

Dibuktikan dengan membangun ulang `hrcd_dev` dari nol, lalu menjalankan `tools/simulasi_end_to_end.py` atas 143 regu:

```
konfig_penalti edisi 37: blok 1 menit -> 1.00 poin, tanpa jam datang 0.00
```

| Pemeriksaan | Hasil |
| --- | --- |
| baris dengan `penalti_waktu <> abs(selisih_menit)` | **0** dari 143 |
| baris yang masih kena potongan tanpa jam datang | **0** dari 143 |

Layarnya juga dibuka (CLAUDE.md 17.2). Kedatangan, regu 001: berangkat 07:00, target 10:30, datang 10:55 → **"Sama dengan catatan — penalti −25"**. Dua puluh lima menit, dua puluh lima poin. Dengan konfigurasi dev yang lama ia akan menulis −20.

- `tests/dev_penalty_config.test.mjs` baru: langkahnya ada dan berada sesudah seed, tidak ada angka yang ditulis langsung di dalamnya, `0143` tidak boleh masuk `ULANG`, dan `run.sh` harus tetap menjalankan seed sebelum `0089`/`0143`. Dicek juga bahwa tes ini GAGAL terhadap versi skrip sebelum PR ini.
- Isi `-c` sengaja ASCII saja: client encoding psql di Windows bukan UTF-8, dan satu tanda pisah panjang saja menghentikan langkah ini dengan `invalid byte sequence for encoding UTF8`. Penjelasan panjangnya tinggal di komentar bash, yang tidak pernah dikirim ke psql.
- `node --test tests/*.test.mjs`: 261 tes, 257 lulus. Empat kegagalan yang tersisa semuanya di `championship_ui.test.mjs`, sudah ada di `main`, dan tidak berhubungan.
