### PR TITLE
fix: give 30 schools a postcode, and correct one that was wrong

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,10 +6,10 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0154`: angka
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0155`: angka
 tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database, dan
 bagian 3 diperiksa terhadap layar. Isi bagian 2 sampai 9 selebihnya belum
-dibaca ulang baris demi baris terhadap `0119`-`0154`.
+dibaca ulang baris demi baris terhadap `0119`-`0155`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -74,7 +74,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-154 migrasi, `0001` sampai `0154`, dijalankan berurutan tanpa lubang penomoran.
+155 migrasi, `0001` sampai `0155`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -1,6 +1,6 @@
 # Sekolah yang belum tuntas
 
-Duapuluh empat dari 210 baris di `tools/data/sekolah_alamat.json` belum bisa
+Duapuluh lima dari 210 baris di `tools/data/sekolah_alamat.json` belum bisa
 dipakai apa adanya. Halaman ini daftar kerjanya: apa yang kurang, kenapa, dan
 apa yang harus ditanyakan.
 
@@ -75,6 +75,7 @@ kode lama.
 
 | Sekolah | Peserta | Kenapa belum tuntas | Yang ditanyakan |
 | --- | ---: | --- | --- |
+| **MTsN 1 Ciamis** | 6 | Situs resmi sekolahnya menulis **46251**; desanya Panyingkiran, dan dua direktori berbeda sama-sama menulis **46211** — keduanya juga menyebut rentang Kec. Ciamis 46211-46219, yang tidak memuat 46251. Delapan belas sekolah kurasi lain di kecamatan itu semuanya cocok dengan direktori. Yang dipakai **46211**. | "Kode pos surat madrasahnya 46211 atau 46251? Situs sekolah dan direktori kode pos berbeda." |
 | **SMPN 1 Purwadadi** | 3 | Tiga sumber, tiga angka untuk Desa Karangpaningal: **46385** (cermin Dapodik dan kodeposina — ini yang dipakai), 46380 (nomor.net), 46286 (Pos Indonesia). | Tanyakan kode pos surat ke sekolahnya langsung. |
 | **SMP Islam Bahrul Ulum** | 1 | Desa Gunungsari, Kec. Sukaratu: **46415** (dipakai) lawan 46452 (Pos Indonesia). | Tanyakan kode pos surat ke sekolahnya langsung. |
 

--- a/supabase/migrations/0155_sekolah_kode_pos.sql
+++ b/supabase/migrations/0155_sekolah_kode_pos.sql
@@ -1,0 +1,163 @@
+-- ============================================================================
+-- hrcd-rekap : 0155_sekolah_kode_pos.sql
+-- Kode pos untuk 30 sekolah, dan satu yang salah dibetulkan.
+--
+-- KENAPA ADA
+--
+-- Data Referensi Kemendikdasmen TIDAK memuat kode pos sama sekali, jadi 20
+-- alamat yang dipasang 0154 berakhir tanpa kode pos, bersama sebelas baris
+-- lama yang sudah begitu sejak kurasi. Suratnya tetap sampai — alamatnya
+-- memuat desa, kecamatan, dan kabupaten — tetapi kode pos memangkas satu
+-- tahap sortir dan mengurangi risiko.
+--
+-- DICARI PER DESA, BUKAN PER KECAMATAN
+--
+-- Runbook bagian 6 melarang menebak kode pos dari kecamatan, dan larangannya
+-- bukan teoretis: Kec. Pamarican punya TIGA kode (46361, 46365, 46382) dan
+-- Kec. Ciamis punya SEMBILAN (46211-46219). Menyalin kode kecamatan akan
+-- salah untuk lima desa di antaranya. Yang dipakai di sini pasangan
+-- (kecamatan, desa) dari kodepos.co.id.
+--
+-- YANG MEMBUATNYA BISA DIPERCAYA: 179 BARIS KURASI YANG SUDAH ADA
+--
+-- Delapan belas sekolah kurasi berdiri di Kec. Ciamis, masing-masing dengan
+-- desa dan kode pos yang sudah diverifikasi lebih dulu. Kesembilan belasnya
+-- cocok dengan direktori tanpa kecuali: Ciamis 46211, Kertasari 46213,
+-- Maleber 46214, Sindangrasa 46215, Linggasari 46216, Imbanagara 46219.
+-- Direktori yang cocok delapan belas kali bukan lagi tebakan.
+--
+-- SATU YANG SALAH, DAN CARA KETAHUANNYA
+--
+-- `MTsN 1 Ciamis` dipasang 0154 dengan kode pos **46251**, diambil dari situs
+-- resmi sekolahnya sendiri — sumber tingkat 3 menurut runbook bagian 6. Desanya
+-- Panyingkiran, dan dua direktori yang berbeda sama-sama menyebut Panyingkiran
+-- **46211**; keduanya juga sama-sama menyebut rentang Kec. Ciamis 46211-46219,
+-- yang tidak memuat 46251 sama sekali. Delapan belas tetangganya di kecamatan
+-- yang sama mendukung direktori. Jadi yang dipakai 46211, dan sengketanya
+-- dicatat di docs/sekolah-belum-tuntas.md bagian C — tempat yang memang sudah
+-- ada untuk kode pos yang diperdebatkan.
+--
+-- Ini juga jawaban kenapa sumber tingkat 1 tetap dicocokkan ke sumber lain:
+-- alamat jalannya benar dari situs sekolah, kode posnya tidak.
+--
+-- HANYA KOLOM `address` YANG BERUBAH. Tidak ada baris dilebur, tidak ada nama
+-- diganti, tidak ada baris dihapus. Blok penutup memeriksa jumlah baris nilai
+-- sebelum dan sesudah, sama seperti 0154.
+--
+-- BISA DIJALANKAN DUA KALI: `where address is distinct from` menyaring baris
+-- yang alamatnya sudah sama.
+-- ============================================================================
+
+drop table if exists potret_nilai_0155;
+create temporary table potret_nilai_0155 as
+select (select count(*) from regu)         as regu,
+       (select count(*) from nilai_mentah) as nilai_mentah,
+       (select count(*) from closing_regu) as closing_regu,
+       (select count(*) from sekolah)      as sekolah,
+       (select count(*) from pendaftaran)  as pendaftaran;
+
+drop table if exists pos_0155;
+create temporary table pos_0155 (nama text, alamat text);
+insert into pos_0155 (nama, alamat) values
+  ('MA Adzkia',
+   'Dusun Desa RT 01 RW 03, Kertaharja, Kec. Cijeungjing, Kabupaten Ciamis, Jawa Barat 46271, Indonesia'),   -- kode pos 46271
+  ('MA Al-Ma''sum Malausma',
+   'Jl. Desa Malausma - Bungursari, Malausma, Kec. Malausma, Kabupaten Majalengka, Jawa Barat 45464, Indonesia'),   -- kode pos 45464
+  ('MA Bahrul Anwar',
+   'Dusun Cicurug, Mekarsari, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia'),   -- kode pos 46252
+  ('MA IPHI Pamarican',
+   'Jl. Raya Pamarican No. 424, Pamarican, Kec. Pamarican, Kabupaten Ciamis, Jawa Barat 46382, Indonesia'),   -- kode pos 46382
+  ('MA Mujahidin',
+   'Jl. KH. Fachruddin No. 96 Dusun Urug RT 004 RW 002, Pusakasari, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia'),   -- kode pos 46252
+  ('MA Sirnarasa',
+   'Dusun Ciceuri RT 10 RW 05, Ciomas, Kec. Panjalu, Kabupaten Ciamis, Jawa Barat 46264, Indonesia'),   -- kode pos 46264
+  ('MAN 1 Kota Tasikmalaya',
+   'Jl. Awipari 1, Awipari, Kec. Cibeureum, Kota Tasikmalaya, Jawa Barat 46196, Indonesia'),   -- kode pos 46196
+  ('MAN 6 Ciamis',
+   'Jl. Rumah Sakit No. 20, Situmandala, Kec. Rancah, Kabupaten Ciamis, Jawa Barat 46387, Indonesia'),   -- kode pos 46387
+  ('MTs Adzkia',
+   'Dusun Desa RT 01 RW 03, Kertaharja, Kec. Cijeungjing, Kabupaten Ciamis, Jawa Barat 46271, Indonesia'),   -- kode pos 46271
+  ('MTs Al-Iqna Cisaga',
+   'Jl. Cimanggu No. 09 RT 01 RW 08, Cisaga, Kec. Cisaga, Kabupaten Ciamis, Jawa Barat 46386, Indonesia'),   -- kode pos 46386
+  ('MTs Al-Istiqomah Kiarapayung',
+   'Jl. Rancah-Ciilat No. 131, Kiarapayung, Kec. Rancah, Kabupaten Ciamis, Jawa Barat 46387, Indonesia'),   -- kode pos 46387
+  ('MTs Bahrul Anwar',
+   'Dusun Cicurug RT 05 RW 04, Mekarsari, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia'),   -- kode pos 46252
+  ('MTs Mujahidin',
+   'Jl. KH. Fachruddin No. 96 Dusun Urug, Jalatrang, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia'),   -- kode pos 46252
+  ('MTs Rancah',
+   'Jl. Cibeureum No. 50, Rancah, Kec. Rancah, Kabupaten Ciamis, Jawa Barat 46387, Indonesia'),   -- kode pos 46387
+  ('MTsN 1 Ciamis',
+   'Jl. Panyingkiran No. 70, Panyingkiran, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46211, Indonesia'),   -- kode pos 46211
+  ('MTsN 4 Ciamis',
+   'Jl. Raya Buniseuri No. 17, Muktisari, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia'),   -- kode pos 46252
+  ('MTsN 5 Ciamis',
+   'Dusun Mandalagiri RT 03 RW 03, Cisontrol, Kec. Rancah, Kabupaten Ciamis, Jawa Barat 46387, Indonesia'),   -- kode pos 46387
+  ('SMA IT MD Fathahillah',
+   'Jl. Pasanggrahan-Saguling RT 05 RW 08, Saguling, Kec. Baregbeg, Kabupaten Ciamis, Jawa Barat 46274, Indonesia'),   -- kode pos 46274
+  ('SMA IT Nurul Huda',
+   'Dusun Sukasari RT 026 RW 011, Margajaya, Kec. Pamarican, Kabupaten Ciamis, Jawa Barat 46382, Indonesia'),   -- kode pos 46382
+  ('SMA Terpadu Al-Mu''aawanah',
+   'Jl. KH. Ahmad Romli No. 26, Rajadesa, Kec. Rajadesa, Kabupaten Ciamis, Jawa Barat 46254, Indonesia'),   -- kode pos 46254
+  ('SMK As-Sulthoniah',
+   'Dusun Desa RT 014 RW 007, Jalatrang, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia'),   -- kode pos 46252
+  ('SMK Siliwangi AMS Banjarsari',
+   'Jl. Raya Timur No. 60, Cibadak, Kec. Banjarsari, Kabupaten Ciamis, Jawa Barat 46383, Indonesia'),   -- kode pos 46383
+  ('SMP IT MD Fathahillah',
+   'Jl. Pasanggrahan RT 05 RW 08, Saguling, Kec. Baregbeg, Kabupaten Ciamis, Jawa Barat 46274, Indonesia'),   -- kode pos 46274
+  ('SMP IT Nurul Huda Margajaya',
+   'Dusun Sukasari RT 026 RW 011, Margajaya, Kec. Pamarican, Kabupaten Ciamis, Jawa Barat 46382, Indonesia'),   -- kode pos 46382
+  ('SMP Terpadu Dampasan',
+   'Dusun Tuban RT 02 RW 06, Ratawangi, Kec. Banjarsari, Kabupaten Ciamis, Jawa Barat 46383, Indonesia'),   -- kode pos 46383
+  ('SMPN 1 Kawali',
+   'Jl. Veteran No. 37, Kawali, Kec. Kawali, Kabupaten Ciamis, Jawa Barat 46253, Indonesia'),   -- kode pos 46253
+  ('SMPN 2 Kawali',
+   'Jl. Sindangraja, Citeureup, Kec. Kawali, Kabupaten Ciamis, Jawa Barat 46253, Indonesia'),   -- kode pos 46253
+  ('SMPN 3 Baregbeg',
+   'Jl. Raya Desa Jelat, Dusun Mekarmulya RT 01 RW 06, Jelat, Kec. Baregbeg, Kabupaten Ciamis, Jawa Barat 46274, Indonesia'),   -- kode pos 46274
+  ('SMPN 3 Kawali',
+   'Jl. Kebon Kopi RT 05 RW 05 Dusun Karangmulya, Karangpawitan, Kec. Kawali, Kabupaten Ciamis, Jawa Barat 46253, Indonesia'),   -- kode pos 46253
+  ('SMPN 4 Ciamis',
+   'Jl. Tentara Pelajar No. 2, Ciamis, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46211, Indonesia');   -- kode pos 46211
+
+do $$
+declare r record; v_n int := 0;
+begin
+  for r in select * from pos_0155 order by nama loop
+    update sekolah
+       set address = r.alamat
+     where kunci_sekolah(name) = kunci_sekolah(r.nama)
+       and address is distinct from r.alamat;
+    if found then
+      v_n := v_n + 1;
+    end if;
+  end loop;
+  raise notice '0155: % alamat diberi kode pos.', v_n;
+end $$;
+
+do $$
+declare
+  s potret_nilai_0155%rowtype;
+  n_regu int; n_nilai int; n_closing int; n_sekolah int; n_daftar int; v_tanpa int;
+begin
+  select * into s from potret_nilai_0155;
+  select count(*) into n_regu    from regu;
+  select count(*) into n_nilai   from nilai_mentah;
+  select count(*) into n_closing from closing_regu;
+  select count(*) into n_sekolah from sekolah;
+  select count(*) into n_daftar  from pendaftaran;
+
+  assert (n_regu, n_nilai, n_closing, n_sekolah, n_daftar)
+         = (s.regu, s.nilai_mentah, s.closing_regu, s.sekolah, s.pendaftaran),
+    format('0155: JUMLAH BARIS BERGESER — regu %s->%s, nilai %s->%s, closing %s->%s, sekolah %s->%s, pendaftaran %s->%s',
+           s.regu, n_regu, s.nilai_mentah, n_nilai, s.closing_regu, n_closing,
+           s.sekolah, n_sekolah, s.pendaftaran, n_daftar);
+
+  select count(*) into v_tanpa from sekolah
+   where btrim(address) <> '' and address !~ '[0-9]{5}, Indonesia$';
+  raise notice '0155: % sekolah, % alamat masih tanpa kode pos.', n_sekolah, v_tanpa;
+  raise notice '0155: rekap nilai utuh — % regu, % nilai, % closing.', n_regu, n_nilai, n_closing;
+end $$;
+
+drop table if exists potret_nilai_0155;
+drop table if exists pos_0155;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -336,5 +336,6 @@ run supabase/migrations/0147_waktu_nol_pos_2.sql
 # bersih. Aman diulang: peleburannya melewati pasangan yang tidak ada, dan
 # pembakuannya menyaring `where name = <nama lama>`.
 run supabase/migrations/0154_sekolah_alamat_xxxvii.sql
+run supabase/migrations/0155_sekolah_kode_pos.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -706,5 +706,7 @@ run supabase/migrations/0153_terjauh_pilih_sekolah.sql
 run tests/sql/105_terjauh_pilih_sekolah.sql
 run supabase/migrations/0154_sekolah_alamat_xxxvii.sql
 run tests/sql/106_sekolah_alamat_xxxvii.sql
+run supabase/migrations/0155_sekolah_kode_pos.sql
+run tests/sql/107_sekolah_kode_pos.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/107_sekolah_kode_pos.sql
+++ b/tests/sql/107_sekolah_kode_pos.sql
@@ -1,0 +1,47 @@
+\echo '--- 107. kode pos per desa, bukan per kecamatan'
+
+do $$
+declare r record; v_n int := 0;
+begin
+  -- Kec. Ciamis punya sembilan kode pos dan Kec. Pamarican tiga, jadi kode pos
+  -- adalah sifat DESA. Yang diperiksa: tidak ada dua desa berbeda di kecamatan
+  -- yang sama dipaksa memakai kode yang sama hanya karena kecamatannya sama —
+  -- dan sebaliknya, satu desa tidak pernah punya dua kode.
+  for r in
+    select substring(address from '([^,]+), Kec\. ([^,]+),') as desa,
+           substring(address from ', Kec\. ([^,]+),') as kec,
+           count(distinct substring(address from '([0-9]{5}), Indonesia$')) as n
+      from sekolah
+     where address ~ '[0-9]{5}, Indonesia$'
+     group by 1, 2 having count(distinct substring(address from '([0-9]{5}), Indonesia$')) > 1
+  loop
+    v_n := v_n + 1;
+    raise warning '107: desa % Kec. % memakai % kode pos berbeda', r.desa, r.kec, r.n;
+  end loop;
+  assert v_n = 0, format('107.1 GAGAL: %s desa memakai lebih dari satu kode pos', v_n);
+end;
+$$;
+
+do $$
+declare v_n int;
+begin
+  -- Kode pos yang terpasang harus lima angka dan berada tepat sebelum
+  -- ", Indonesia" — bentuk yang ditetapkan runbook bagian 8.
+  select count(*) into v_n from sekolah
+   where btrim(address) <> '' and address ~ '[0-9]{5}'
+     and address !~ '[0-9]{5}, Indonesia$';
+  assert v_n = 0, format('107.2 GAGAL: %s alamat memuat angka lima digit di tempat yang salah', v_n);
+
+  -- MTsN 1 Ciamis: situs sekolahnya menulis 46251, dua direktori dan delapan
+  -- belas tetangganya di Kec. Ciamis menulis 46211. Yang dipakai 46211, dan
+  -- angka lama tidak boleh diam-diam kembali.
+  assert not exists (select 1 from sekolah where name = 'MTsN 1 Ciamis' and address like '%46251%'),
+    '107.3 GAGAL: MTsN 1 Ciamis kembali memakai 46251 — lihat sekolah-belum-tuntas.md bagian C';
+
+  select count(*) into v_n from sekolah
+   where btrim(address) <> '' and address !~ '[0-9]{5}, Indonesia$';
+  raise notice '107: % alamat masih tanpa kode pos.', v_n;
+end;
+$$;
+
+\echo '107 kode pos sekolah: LULUS'

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -8,9 +8,9 @@
     "kecamatan": "Cijeungjing",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46271",
     "keyakinan": "sedang",
-    "sumber": "MTs Adzkia satu yayasan, Data Referensi Kemendikdasmen, (belum ada NPSN terdaftar)",
+    "sumber": "MTs Adzkia satu yayasan, Data Referensi Kemendikdasmen, (belum ada NPSN terdaftar) ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Belum terdaftar di Data Referensi Kemendikdasmen. Alamat diambil dari MTs Adzkia (NPSN 69976289) di dusun yang sama, dan cocok dengan alamat yang diketik pembina sendiri."
   },
   {
@@ -92,9 +92,9 @@
     "kecamatan": "Malausma",
     "kabupaten": "Kabupaten Majalengka",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "45464",
     "keyakinan": "tinggi",
-    "sumber": "referensi.data.kemendikdasmen.go.id/pendidikan/dikmen/021624 (daftar dikmen Kec. Malausma)",
+    "sumber": "referensi.data.kemendikdasmen.go.id/pendidikan/dikmen/021624 (daftar dikmen Kec. Malausma) ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Sumber menulis \"Jln. Desa Malaumsa-Bungursari\" — \"Malaumsa\" salah ketik untuk Malausma. Satu-satunya MA di Kec. Malausma. Kode pos tidak tercantum di sumber mana pun yang saya buka."
   },
   {
@@ -134,9 +134,9 @@
     "kecamatan": "Cipaku",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46252",
     "keyakinan": "sedang",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70044831",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70044831 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Desa dikosongkan Dapodik untuk MA-nya; diambil dari MTs Bahrul Anwar (NPSN 69955929) di dusun yang sama."
   },
   {
@@ -176,9 +176,9 @@
     "kecamatan": "Pamarican",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46382",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20276455",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20276455 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -204,9 +204,9 @@
     "kecamatan": "Cipaku",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46252",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20280180 ; kabupatennya dipastikan kolom kwartir ranting di form pendaftaran (docs/sekolah-belum-tuntas.md bagian E: Cipaku / Ciamis), karena ada MA+MTs Mujahidin kedua di Kec. Sukaratu Kabupaten Tasikmalaya",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20280180 ; kabupatennya dipastikan kolom kwartir ranting di form pendaftaran (docs/sekolah-belum-tuntas.md bagian E: Cipaku / Ciamis), karena ada MA+MTs Mujahidin kedua di Kec. Sukaratu Kabupaten Tasikmalaya ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -260,9 +260,9 @@
     "kecamatan": "Panjalu",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46264",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20280196",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20280196 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -302,9 +302,9 @@
     "kecamatan": "Cibeureum",
     "kabupaten": "Kota Tasikmalaya",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46196",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20277188",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20277188 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Beda sekolah dengan MAN 1 Tasikmalaya (NPSN 20276807, Kec. Sukarame, Kab. Tasikmalaya). Kode pos tidak tercantum, tidak saya tebak."
   },
   {
@@ -428,9 +428,9 @@
     "kecamatan": "Rancah",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46387",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20280193",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20280193 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Ada di Kec. Rancah, bukan Kec. Ciamis — petunjuk peserta cuma menulis \"Ciamis\" (nama kabupaten). Kode pos kosong di data referensi maupun mirror Dapodik; situs man6ciamis.sch.id tidak bisa diakses saat pengecekan."
   },
   {
@@ -470,9 +470,9 @@
     "kecamatan": "Cijeungjing",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46271",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69976289",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69976289 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -526,9 +526,9 @@
     "kecamatan": "Cisaga",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46386",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278642 ; https://annibuku.com/sekolah/30997-mtss-al-iqna-cisaga ; https://data-sekolah.zekolah.id/sekolah/mtss-al-iqna-cisaga-39893",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278642 ; https://annibuku.com/sekolah/30997-mtss-al-iqna-cisaga ; https://data-sekolah.zekolah.id/sekolah/mtss-al-iqna-cisaga-39893 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Cocok persis dengan petunjuk Cisaga Ciamis. Alamat lengkap versi Dapodik menyebut \"Dusun Cisaga Kota, Desa Cisaga\". KODE POS TIDAK KETEMU — di Dapodik field kode pos memang kosong (tertulis \"-\"), jadi dikosongkan, tidak ditebak."
   },
   {
@@ -540,9 +540,9 @@
     "kecamatan": "Rancah",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46387",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278708",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278708 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Kiarapayung adalah desa di Kec. Rancah, bukan Rajadesa. Data Referensi menambahkan RT 01 RW 05. Kode pos tidak tercantum, tidak saya tebak."
   },
   {
@@ -596,9 +596,9 @@
     "kecamatan": "Cipaku",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46252",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69955929",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69955929 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -638,9 +638,9 @@
     "kecamatan": "Cipaku",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46252",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278636 ; kabupatennya dipastikan kolom kwartir ranting di form pendaftaran (docs/sekolah-belum-tuntas.md bagian E: Cipaku / Ciamis)",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278636 ; kabupatennya dipastikan kolom kwartir ranting di form pendaftaran (docs/sekolah-belum-tuntas.md bagian E: Cipaku / Ciamis) ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -666,9 +666,9 @@
     "kecamatan": "Rancah",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46387",
     "keyakinan": "sedang",
-    "sumber": "https://annibuku.com/sekolah/31096-mtss-rancah ; daftar alamat SMP/MTs Kecamatan Rancah di data.emka.web.id",
+    "sumber": "https://annibuku.com/sekolah/31096-mtss-rancah ; daftar alamat SMP/MTs Kecamatan Rancah di data.emka.web.id ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "AMBIGU. Di Kecamatan Rancah ada tujuh MTs: MTsN 5 Ciamis (Cisontrol), MTsN 14 Ciamis (Kawunglarang), MTsN 17 Ciamis (Jl. Gagak Ngampar), MTSS Rancah, MTSS Karangpari, MTSS Al-Istiqomah Kiarapayung, dan MTSS GUPPI Cileungsir. Saya memilih MTSS Rancah karena namanya persis \"MTs Rancah\" dan berada di Desa Rancah, tapi peserta bisa saja memaksudkan salah satu MTs Negeri di kecamatan yang sama. Perlu dikonfirmasi ke pembina. Kode pos tidak ketemu, dikosongkan."
   },
   {
@@ -722,10 +722,10 @@
     "kecamatan": "Ciamis",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": "46251",
-    "keyakinan": "tinggi",
-    "sumber": "Kode pos dari situs resmi www.mtsn1ciamis.sch.id ; Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278600",
-    "catatan": null
+    "kode_pos": "46211",
+    "keyakinan": "sedang",
+    "sumber": "Kode pos dari situs resmi www.mtsn1ciamis.sch.id ; Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278600 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
+    "catatan": "Situs resmi sekolah menulis kode pos 46251; desanya Panyingkiran, dan dua direktori menulis 46211 — sama dengan delapan belas sekolah kurasi lain di Kec. Ciamis. Yang dipakai 46211."
   },
   {
     "nama": "MTsN 2 Banjar",
@@ -764,9 +764,9 @@
     "kecamatan": "Cipaku",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46252",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278635",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278635 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -778,9 +778,9 @@
     "kecamatan": "Rancah",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46387",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278703",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20278703 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Alamat resmi tanpa nama jalan, hanya dusun dan RT/RW — itu yang diisikan. Madrasah di bawah Kemenag, kode pos tidak tercantum di Data Referensi dan tidak ketemu di sumber lain, dibiarkan kosong."
   },
   {
@@ -890,9 +890,9 @@
     "kecamatan": "Baregbeg",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46274",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70051695",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70051695 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -904,9 +904,9 @@
     "kecamatan": "Pamarican",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46382",
     "keyakinan": "sedang",
-    "sumber": "Alamat dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153) satu yayasan; petunjuk kwartir ranting di form pendaftaran menyebut Pamarican / Ciamis",
+    "sumber": "Alamat dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153) satu yayasan; petunjuk kwartir ranting di form pendaftaran menyebut Pamarican / Ciamis ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Belum ada di Data Referensi Kemendikdasmen dengan jenjang SMA. Perlu satu kali konfirmasi ke pembina."
   },
   {
@@ -1016,9 +1016,9 @@
     "kecamatan": "Rajadesa",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46254",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70006980",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70006980 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -1590,9 +1590,9 @@
     "kecamatan": "Cipaku",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46252",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69988146",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69988146 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -1814,9 +1814,9 @@
     "kecamatan": "Banjarsari",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46383",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20254624",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20254624 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Kec. Banjarsari Kab. Ciamis — bukan Kota Banjar, sesuai petunjuk. Kode pos tidak tercantum di data referensi dan situs sekolah (smksiliwangiams.sch.id) sudah tidak aktif."
   },
   {
@@ -2276,9 +2276,9 @@
     "kecamatan": "Baregbeg",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46274",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70003434",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70003434 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -2290,9 +2290,9 @@
     "kecamatan": "Pamarican",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46382",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69993153 ; https://smpitnudapamarican.sch.id/",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69993153 ; https://smpitnudapamarican.sch.id/ ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Petunjuk peserta cuma \"Kec. Pamarican Kab. Ciamis\" dan itu ternyata sudah cukup: daftar dikdas Kec. Pamarican memuat 8 satuan setingkat SMP, dan yang bernama Nurul Huda ada DUA — yang ini di Desa Margajaya, dan MTs Nurul Huda (NPSN 70059036) di Desa Sukahurip. Peserta menulis \"SMP IT\" dan \"Margajaya\", jadi dua sumbu sekaligus memisahkannya. Putaran pertama menyisir semua desa bernama Margajaya di lima kecamatan lain dan justru melewatkan Pamarican. Alamat resminya \"Dusun Sukasari RT 026 RW 011\" — dusun, bukan nama jalan, jadi kolom jalan diisi dusunnya; pakai keterangan itu kalau menyurati. KODE POS DIKOSONGKAN: tidak ada di halaman resmi maupun di situs sekolah. Direktori kode pos per desa menyebut Margajaya = 46382 dan Kec. Pamarican punya tiga kode berbeda, jadi 46382 bukan tebakan — tapi karena bukan dari sumber sekolahnya sendiri, angkanya ditulis di sini saja, tidak diisikan. JANGAN menyalin kode pos dari dua sekolah senama: SMP IT Nurul Huda di Kec. Panjalu (NPSN 69948101, 46264) dan yang di Kec. Rajagaluh, Majalengka (45472). Kalau nanti ada yang menulis \"Nurul Huda Pamarican\" saja, petunjuk itu tidak cukup untuk memilih antara keduanya."
   },
   {
@@ -2402,9 +2402,9 @@
     "kecamatan": "Banjarsari",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46383",
     "keyakinan": "tinggi",
-    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20252468",
+    "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20252468 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": "Alamat resmi di Dapodik tidak memakai nama jalan, hanya \"Dusun Tuban Rt.02 Rw.06\" — itu yang diisikan di field jalan. Satu situs mirror menyebut \"Jl. Pasir Garu\" di depannya, tapi tidak ada di sumber resmi jadi tidak dipakai. Kode pos tidak tercantum di Dapodik maupun mirror mana pun, dibiarkan kosong. Ada juga SMA Terpadu Dampasan (NPSN 259306) di yayasan yang sama, jangan tertukar."
   },
   {
@@ -2584,9 +2584,9 @@
     "kecamatan": "Kawali",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46253",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211633",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211633 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -2780,9 +2780,9 @@
     "kecamatan": "Kawali",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46253",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211652",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211652 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -2822,9 +2822,9 @@
     "kecamatan": "Baregbeg",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46274",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69969012",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/69969012 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -2850,9 +2850,9 @@
     "kecamatan": "Kawali",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46253",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211582",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211582 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {
@@ -2878,9 +2878,9 @@
     "kecamatan": "Ciamis",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": null,
+    "kode_pos": "46211",
     "keyakinan": "tinggi",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211613",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211613 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
     "catatan": null
   },
   {


### PR DESCRIPTION
## What

Migrasi `0155` memberi kode pos kepada **30 sekolah** dan membetulkan satu yang salah.

Data Referensi Kemendikdasmen — sumber tingkat 1 runbook — **tidak memuat kode pos sama sekali**, jadi kedua puluh alamat yang dipasang `0154` berakhir tanpanya, bersama sebelas baris lama yang sudah begitu sejak kurasi.

## Dicari per DESA, bukan per kecamatan

Larangan runbook bagian 6 bukan teoretis:

| Kecamatan | Jumlah kode pos |
| --- | ---: |
| Ciamis | **9** (46211-46219) |
| Pamarican | **3** (46361, 46365, 46382) |
| Baregbeg, Cipaku, Kawali, Cijeungjing, Panjalu, Rancah | 1 |

Menyalin kode kecamatan akan salah untuk lima desa di antaranya.

## Yang membuatnya bisa dipercaya bukan direktorinya

**179 baris kurasi yang sudah ada.** Delapan belas sekolah berdiri di Kec. Ciamis dengan desa dan kode pos yang sudah diverifikasi lebih dulu — Ciamis 46211, Kertasari 46213, Maleber 46214, Sindangrasa 46215, Linggasari 46216, Imbanagara 46219 — dan **kesembilan belasnya cocok dengan direktori tanpa kecuali.** Direktori yang cocok delapan belas kali bukan lagi tebakan.

## Justru itu yang membongkar satu kesalahan saya sendiri

`MTsN 1 Ciamis` diberi **46251** oleh `0154`, diambil dari situs resmi sekolahnya sendiri — sumber tingkat 3. Desanya **Panyingkiran**, dan dua direktori berbeda sama-sama menyebut **46211**; keduanya juga menyebut rentang Kec. Ciamis 46211-46219, yang **tidak memuat 46251 sama sekali**.

Yang dipakai 46211, keyakinannya turun jadi `sedang`, dan sengketanya dicatat di `sekolah-belum-tuntas.md` bagian C — bagian yang memang sudah ada untuk kode pos yang diperdebatkan, bersama SMPN 1 Purwadadi dan SMP Islam Bahrul Ulum. `tests/sql/107` menjaga angka lamanya tidak diam-diam kembali.

Ini juga jawaban kenapa sumber tingkat 1 tetap perlu dicocokkan: alamat jalannya benar dari situs sekolah, kode posnya tidak.

## Notes

- **Hanya kolom `address` yang berubah.** Tidak ada baris dilebur, diganti nama, atau dihapus. Blok penutup memeriksa jumlah baris `regu`, `nilai_mentah`, `closing_regu`, `sekolah` dan `pendaftaran` sebelum dan sesudah, sama seperti `0154`.
- **Gladi bersih atas 216 nama produksi**, `0154` lalu `0155`: **30 alamat diberi kode pos, 211 sekolah, tinggal 2 tanpa kode pos** — keduanya `SMK Lps Ciamis` dan `SMP AL Fadliliyah Darussalam`, yang memang belum punya baris kurasi. Dijalankan kedua kali: nol baris tersentuh.
- `tests/sql/107` baru: tidak ada desa yang memakai dua kode pos berbeda, kode pos selalu lima angka tepat sebelum `, Indonesia`, dan 46251 tidak boleh kembali.
- `bash tests/run.sh` — SEMUA TES LULUS. `node --test` — 261 tes, 257 lulus (empat sisanya di `championship_ui`, sudah ada di `main`).
- `python tools/periksa_sekolah.py` — bersih: **208 dari 210 baris lengkap dengan kode pos** (naik dari 179).
