### PR TITLE
chore: add a checker that reports look-alike school rows

### DIFF
--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -649,6 +649,15 @@ SMPT RIYADLUL ULUM WADDAWAH   ->  SMP Terpadu Riyadlul Ulum Waddawah
 nama yang benar-benar ada di produksi. Enam baris, disebut satu per satu, tidak
 ada normalisasi yang perlu dipercaya.
 
+**Sebelum cetak blangko, jalankan `supabase/checks/sekolah_kembar.sql`.**
+Ia melapor pasangan baris `sekolah` yang bedanya cuma tanda baca, huruf `h`,
+huruf status Dapodik, sisipan satu kata, atau kata terakhir yang sama — hal-hal
+yang `kunci_sekolah()` sengaja lewatkan. Ia TIDAK melebur apa pun; yang
+memutuskan tetap manusia, lewat NPSN. Diuji atas 217 nama produksi: lima dari
+enam baris kembar yang pernah ada tertangkap, tanpa satu pun lapor palsu. Yang
+keenam, `MAN Darussalam` lawan `MAN 1 Ciamis`, tidak punya satu huruf pun yang
+sama dan hanya bisa dibuktikan NPSN — yang tidak disimpan tabel `sekolah`.
+
 **Kalau mengulanginya tahun depan:** cocokkan ke daftar kurasi memakai `kunci()`
 Python, cetak pasangannya, baca, baru rakit migrasinya. Jangan serahkan
 pencocokan itu ke SQL.

--- a/supabase/checks/sekolah_kembar.sql
+++ b/supabase/checks/sekolah_kembar.sql
@@ -1,0 +1,142 @@
+-- ============================================================================
+-- hrcd-rekap : sekolah_kembar.sql — TIDAK mengubah apa pun.
+--
+-- Berkas ini menjawab satu pertanyaan yang tidak bisa dijawab indeks unique:
+-- "adakah dua baris `sekolah` yang sebenarnya satu sekolah?"
+--
+-- KENAPA INDEKS UNIQUE TIDAK CUKUP, DAN JANGAN DIUBAH
+--
+-- Pagar kembar di database `unique (kunci_sekolah(name))`, dan `kunci_sekolah()`
+-- sengaja JINAK (CLAUDE.md 12.10): ia hanya menyamakan yang PASTI sama —
+-- besar-kecil huruf, tanda baca, dan bentuk "Negeri". Ia bekerja tanpa ada yang
+-- memeriksa hasilnya, jadi ia tidak boleh agresif: melebur dua sekolah yang
+-- berbeda adalah kerusakan yang jauh lebih sulit ditemukan daripada baris
+-- kembar.
+--
+-- Harganya: enam baris kembar lolos bertahun-tahun, dan yang menemukannya
+-- audit manual pada 30 Agustus 2026 — bukan alat apa pun.
+--
+--   SMK Ma'arif NU Ciamis          lawan  SMK MAARIF NU CIAMIS
+--   SMA 1 Sindangkasih             lawan  SMAN 1 SINDANGKASIH
+--   SMA IT MD Fathahillah          lawan  SMA IT MD FATAHILLAH
+--   SMP IT MD Fathahillah          lawan  SMP IT MUHAMADANU FATAHILAH
+--   MA Al-Azhar Citangkolo K.B.    lawan  MA Al-Azhar Kota Banjar
+--   MAN Darussalam                 lawan  MAN 1 Ciamis
+--
+-- Berkas ini MELAPOR, tidak melebur. Yang memutuskan tetap manusia, dan
+-- karena itu ia boleh agresif — lapor palsu cuma memakan satu menit membaca,
+-- sedangkan peleburan yang salah memakan satu sekolah.
+--
+-- YANG TIDAK BISA DITEMUKANNYA, DAN INI PENTING
+--
+-- Pasangan terakhir di atas, `MAN Darussalam` lawan `MAN 1 Ciamis`, TIDAK
+-- akan muncul di laporan mana pun di bawah. Tidak ada satu huruf pun yang
+-- menghubungkan keduanya; yang membuktikannya NPSN 20276451 yang sama, dan
+-- tabel `sekolah` tidak menyimpan NPSN. Selama itu belum berubah, pemeriksaan
+-- ini menutup lima dari enam — dan pembacanya harus tahu yang keenam ada.
+--
+-- Cara pakai: Actions -> "Apply migration to Supabase" -> Run workflow, isi
+--   supabase/checks/sekolah_kembar.sql
+-- ============================================================================
+
+\pset border 2
+
+-- `rapat`  : tanda baca dan spasi DIBUANG, bukan diganti spasi. Inilah bedanya
+--            dengan kunci_sekolah(), dan inilah yang membuat "Ma'arif" bertemu
+--            "MAARIF" — di kunci database keduanya jadi "ma arif" lawan
+--            "maarif" dan tidak pernah bertemu.
+-- `serupa` : `rapat` ditambah dua penyeragaman ejaan yang paling sering
+--            beredar di nama madrasah — huruf `h` yang kadang ditulis kadang
+--            tidak (Fathahillah ~ Fatahillah), dan huruf ganda (Fadliliyah ~
+--            Fadlilliyah). Kasar, dan memang boleh kasar: ini laporan.
+-- `jenjang`: huruf status Dapodik (SMAS, MTsS) dan huruf N negeri dibuang,
+--            supaya "SMA 1" bertemu "SMAN 1".
+with s as (
+  select id, name, address,
+         regexp_replace(lower(name), '[^a-z0-9]', '', 'g') as rapat,
+         regexp_replace(
+           regexp_replace(regexp_replace(lower(name), '[^a-z0-9]', '', 'g'), 'h', '', 'g'),
+           '(.)\1+', '\1', 'g') as serupa,
+         regexp_replace(lower(name), '^(sd|smp|sma|smk|mi|mts|ma)[ns]?\y', '\1', '') as jenjang,
+         lower(split_part(name, ' ', 1)) as kata1,
+         lower(regexp_replace(name, '^.* ', '')) as kata_akhir,
+         regexp_replace(
+           regexp_replace(regexp_replace(lower(regexp_replace(name, '^.* ', '')),
+                                         '[^a-z0-9]', '', 'g'), 'h', '', 'g'),
+           '(.)\1+', '\1', 'g') as akhir_serupa,
+         string_to_array(lower(regexp_replace(name, '[^A-Za-z0-9 ]', '', 'g')), ' ') as kata
+    from sekolah
+),
+-- Kata terakhir yang dipakai BANYAK sekolah adalah nama tempat, bukan nama
+-- diri: "Ciamis" menutup 40-an nama, "Kawali" belasan. Daftarnya diturunkan
+-- dari datanya sendiri, bukan diketik — supaya kecamatan yang baru muncul
+-- tahun depan ikut terhitung tanpa ada yang perlu ingat menambahkannya.
+kata_umum as (
+  select lower(regexp_replace(name, '^.* ', '')) as kata
+    from sekolah group by 1 having count(*) > 2
+),
+pasangan as (
+  -- A. Sama persis begitu tanda baca dan spasi dibuang.
+  select a.name as sekolah_a, b.name as sekolah_b,
+         'tanda baca / spasi saja bedanya' as sebab,
+         a.address as alamat_a, b.address as alamat_b
+    from s a join s b on a.id < b.id and a.rapat = b.rapat
+
+  union all
+  -- B. Sama begitu huruf h dan huruf ganda diseragamkan.
+  select a.name, b.name, 'ejaan h / huruf ganda saja bedanya', a.address, b.address
+    from s a join s b on a.id < b.id and a.serupa = b.serupa and a.rapat <> b.rapat
+
+  union all
+  -- C. Sama begitu huruf status Dapodik dan huruf N negeri dibuang.
+  select a.name, b.name, 'huruf N / status negeri-swasta saja bedanya', a.address, b.address
+    from s a join s b on a.id < b.id
+                     and regexp_replace(a.jenjang, '[^a-z0-9]', '', 'g')
+                       = regexp_replace(b.jenjang, '[^a-z0-9]', '', 'g')
+                     and a.rapat <> b.rapat
+
+  union all
+  -- D. SELURUH kata satu nama ada di nama satunya, dan yang satunya lebih
+  --    panjang — satu nama memuat sisipan yang satunya tidak. Yang menangkap
+  --    "MA Al-Azhar Kota Banjar" lawan "MA Al-Azhar Citangkolo Kota Banjar",
+  --    dan tidak menangkap "SMPN 1 Kawali" lawan "SMPN 2 Kawali", karena
+  --    angkanya membuat himpunan katanya tidak termuat.
+  select a.name, b.name, 'satu nama memuat sisipan yang satunya tidak', a.address, b.address
+    from s a join s b on a.id < b.id
+                     and ((a.kata <@ b.kata
+                           and array_length(a.kata, 1) < array_length(b.kata, 1))
+                       or (b.kata <@ a.kata
+                           and array_length(b.kata, 1) < array_length(a.kata, 1)))
+
+  union all
+  -- E. Kata terakhirnya nama diri yang sama dan jarang dipakai, kata
+  --    pertamanya sama. Yang menangkap "SMP IT MD Fathahillah" lawan
+  --    "SMP IT MUHAMADANU FATAHILAH", karena di situ cuma kata terakhirnya
+  --    yang bertemu.
+  --
+  --    Pasangan yang bedanya HANYA angka dibuang: "SMPN 1 Kawali" dan
+  --    "SMPN 2 Kawali" dua sekolah, dan tanpa syarat ini seluruh keluarga
+  --    SMPN bernomor saling melapor.
+  select a.name, b.name, 'kata terakhirnya nama diri yang sama', a.address, b.address
+    from s a join s b on a.id < b.id
+                     and a.akhir_serupa = b.akhir_serupa
+                     and length(a.kata_akhir) >= 6
+                     and a.kata_akhir not in (select kata from kata_umum)
+                     and b.kata_akhir not in (select kata from kata_umum)
+                     and a.kata1 = b.kata1
+                     and a.serupa <> b.serupa
+                     and regexp_replace(lower(a.name), '[0-9]', '', 'g')
+                      <> regexp_replace(lower(b.name), '[0-9]', '', 'g')
+)
+select sebab, sekolah_a, sekolah_b,
+       left(coalesce(nullif(alamat_a, ''), '(kosong)'), 46) as alamat_a,
+       left(coalesce(nullif(alamat_b, ''), '(kosong)'), 46) as alamat_b
+  from pasangan
+ order by sebab, sekolah_a;
+
+\echo ''
+\echo 'KOSONG = tidak ada yang perlu diperiksa.'
+\echo 'ADA ISI = baca sendiri, jangan lebur otomatis. Yang membuktikan dua nama'
+\echo '          satu sekolah adalah NPSN, dan NPSN tidak ada di tabel ini —'
+\echo '          cari di referensi.data.kemendikdasmen.go.id, lalu tulis'
+\echo '          migrasi peleburan seperti 0154 kalau memang sama.'

--- a/tests/school_duplicate_check.test.mjs
+++ b/tests/school_duplicate_check.test.mjs
@@ -1,0 +1,43 @@
+// `supabase/checks/sekolah_kembar.sql` melapor, tidak melebur — dan itu bukan
+// gaya penulisan. Indeks unique di database sengaja jinak (CLAUDE.md 12.10),
+// jadi pemeriksa ini boleh agresif justru karena hasilnya dibaca manusia.
+// Begitu ia mulai mengubah baris, sifat itu hilang dan lapor palsunya berubah
+// jadi peleburan yang salah.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sql = await readFile(
+  new URL("../supabase/checks/sekolah_kembar.sql", import.meta.url), "utf8");
+
+test("pemeriksa kembar tidak mengubah satu baris pun", () => {
+  const perintah = sql.replace(/^--.*$/gm, "").replace(/\echo.*$/gm, "");
+  for (const kata of ["insert into", "update ", "delete from", "drop ", "alter ",
+                      "create table", "create or replace"])
+    assert.doesNotMatch(perintah, new RegExp(kata, "i"),
+      `pemeriksa kembar memuat "${kata}" — ia harus hanya membaca`);
+});
+
+test("kelima aturan disebut, masing-masing dengan alasannya", () => {
+  for (const sebab of ["tanda baca / spasi saja bedanya",
+                       "ejaan h / huruf ganda saja bedanya",
+                       "huruf N / status negeri-swasta saja bedanya",
+                       "satu nama memuat sisipan yang satunya tidak",
+                       "kata terakhirnya nama diri yang sama"])
+    assert.ok(sql.includes(sebab), `aturan hilang: ${sebab}`);
+});
+
+test("aturan sisipan diperiksa dua arah", () => {
+  // Pasangannya dijoin `a.id < b.id`, dan id-nya uuid acak — memeriksa satu
+  // arah saja membuat separuh pasangan lolos tergantung urutan uuid.
+  assert.match(sql, /a\.kata <@ b\.kata/);
+  assert.match(sql, /b\.kata <@ a\.kata/);
+});
+
+test("yang TIDAK bisa ditemukannya ikut ditulis", () => {
+  // MAN Darussalam lawan MAN 1 Ciamis tidak punya satu huruf pun yang sama;
+  // yang membuktikannya NPSN, dan `sekolah` tidak menyimpan NPSN. Pemeriksa
+  // yang diam soal batasnya dibaca seolah menutup semuanya.
+  assert.match(sql, /MAN Darussalam/);
+  assert.match(sql, /tabel `sekolah` tidak menyimpan NPSN/);
+});


### PR DESCRIPTION
## What

`supabase/checks/sekolah_kembar.sql` — read-only, dijalankan lewat **Actions → Apply migration to Supabase**, melaporkan pasangan baris `sekolah` yang kemungkinan satu sekolah.

Lima aturan, masing-masing membawa alasannya sendiri ke kolom keluaran:

| Aturan | Menangkap |
| --- | --- |
| tanda baca **dibuang**, bukan diganti spasi | `SMK Ma'arif NU Ciamis` / `SMK MAARIF NU CIAMIS` |
| huruf `h` dan huruf ganda diseragamkan | `SMA IT MD Fathahillah` / `SMA IT MD FATAHILLAH` |
| huruf status Dapodik dan huruf N negeri dibuang | `SMA 1 Sindangkasih` / `SMAN 1 SINDANGKASIH` |
| seluruh kata satu nama termuat di nama satunya | `MA Al-Azhar Kota Banjar` / `MA Al-Azhar Citangkolo Kota Banjar` |
| kata terakhirnya nama diri yang sama | `SMP IT MD Fathahillah` / `SMP IT MUHAMADANU FATAHILAH` |

## Why

Enam baris kembar lolos indeks unique bertahun-tahun, dan yang menemukannya **audit manual kemarin** — bukan alat apa pun.

Melonggarkan `kunci_sekolah()` bukan jawabannya: ia bekerja tanpa ada yang memeriksa hasilnya, jadi ia hanya boleh menyamakan yang pasti sama (CLAUDE.md 12.10). Berkas ini mengambil sisi sebaliknya — **agresif, tapi melapor, tidak melebur.** Lapor palsu memakan satu menit membaca; peleburan yang salah memakan satu sekolah.

## Notes

**Diuji atas 217 nama produksi yang sebenarnya** (216 baris pra-`0154` + baris Al-Azhar kurasi):

| | |
| --- | ---: |
| baris kembar yang tertangkap | **5 dari 6** |
| lapor palsu | **0** |
| atas 211 baris produksi hari ini | **kosong** |

- **Yang keenam sengaja ditulis di kepala berkas sebagai batasnya.** `MAN Darussalam` lawan `MAN 1 Ciamis` tidak punya satu huruf pun yang menghubungkannya; yang membuktikannya NPSN 20276451, dan tabel `sekolah` tidak menyimpan NPSN. Pemeriksa yang diam soal batasnya dibaca seolah menutup semuanya.
- **Daftar kata tempat diturunkan dari datanya sendiri**, bukan diketik: kata terakhir yang dipakai lebih dari dua sekolah dianggap nama tempat. Kecamatan yang baru muncul tahun depan ikut terhitung tanpa ada yang perlu ingat menambahkannya. Tanpa ini seluruh keluarga `SMPN 1/2/3 <desa>` saling melapor — 14 lapor palsu di percobaan pertama.
- **Aturan sisipan diperiksa dua arah.** Pasangannya dijoin `a.id < b.id` dan id-nya uuid acak; memeriksa satu arah membuat separuh pasangan lolos tergantung urutan uuid. Ketahuan karena Al-Azhar tidak muncul di percobaan pertama.
- `tests/school_duplicate_check.test.mjs` menjaga sifatnya: **tidak ada `insert`/`update`/`delete`/`create`** di berkas itu, kelima aturan tetap disebut, sisipan tetap dua arah, dan batasnya tetap tertulis.
- Runbook bagian 12.2 menyebut alatnya, supaya yang mengulang tahun depan tidak mengulangi audit manualnya juga.
