### PR TITLE
feat: register SMK LPS 1 and LPS 2, and give the registrant its number

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,10 +6,10 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0155`: angka
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0156`: angka
 tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database, dan
 bagian 3 diperiksa terhadap layar. Isi bagian 2 sampai 9 selebihnya belum
-dibaca ulang baris demi baris terhadap `0119`-`0155`.
+dibaca ulang baris demi baris terhadap `0119`-`0156`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -74,7 +74,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-155 migrasi, `0001` sampai `0155`, dijalankan berurutan tanpa lubang penomoran.
+156 migrasi, `0001` sampai `0156`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -1,6 +1,6 @@
 # Sekolah yang belum tuntas
 
-Duapuluh lima dari 210 baris di `tools/data/sekolah_alamat.json` belum bisa
+Duapuluh empat dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
 dipakai apa adanya. Halaman ini daftar kerjanya: apa yang kurang, kenapa, dan
 apa yang harus ditanyakan.
 
@@ -137,11 +137,18 @@ Anwar` (desanya dikosongkan Dapodik), `MA Adzkia` dan `SMA IT Nurul Huda`
 (tidak punya NPSN). Ketiganya sudah punya alamat yang bisa dipakai berkirim
 surat; yang kurang cuma satu kalimat dari pembina.
 
+**`SMK Lps Ciamis` sudah terjawab, 30 Agustus 2026.** Di Jl. R.E. Martadinata
+No. 23 memang ada dua sekolah — SMK LPS 1 (NPSN 20211529) dan SMK LPS 2
+(NPSN 20251831), satu alamat dan satu desa. Tidak ada data yang bisa memilih;
+pemilik acara yang menjawab: yang mendaftar **LPS 1**. Migrasi `0156`
+melengkapi angkanya dan sekalian mendaftarkan LPS 2, supaya angka itu punya
+lawan — nama pembeda yang berdiri sendiri tidak membedakan apa pun
+(CLAUDE.md 12.8).
+
 ### Yang masih tersisa dari XXXVII
 
 | Sekolah | Regu | Kenapa belum tuntas | Yang ditanyakan ke pembina |
 | --- | ---: | --- | --- |
-| **SMK Lps Ciamis** | 1 | Di Jl. R.E. Martadinata No. 23 ada **SMK LPS 1** DAN **SMK LPS 2**. Alamatnya sama, jadi surat tetap sampai; yang salah namanya, dan nama itulah yang dicetak di blangko. | "SMK LPS 1 atau SMK LPS 2?" |
 | **SMP AL Fadliliyah Darussalam** | 0 | Tidak ada SMP di kompleks Darussalam menurut Data Referensi — yang ada MTs Al-Fadliliyah Darussalam, dan alamat yang diketik pembina memang alamat MTs itu. Nol regu, jadi tidak mendesak. | "Regunya dari MTs Al-Fadliliyah Darussalam, atau memang ada SMP-nya?" |
 | **SMAN 1 Majalengka** | 0 | Alamatnya sudah berbentuk baku dan tidak ada yang salah; ia cuma belum punya baris di daftar kurasi. Nol regu. | — tidak perlu ditanyakan |
 

--- a/supabase/migrations/0156_smk_lps_satu_dan_dua.sql
+++ b/supabase/migrations/0156_smk_lps_satu_dan_dua.sql
@@ -1,0 +1,118 @@
+-- ============================================================================
+-- hrcd-rekap : 0156_smk_lps_satu_dan_dua.sql
+-- `SMK Lps Ciamis` dilengkapi angkanya, dan saudaranya ikut didaftarkan.
+--
+-- KENAPA ADA
+--
+-- Di Jl. R.E. Martadinata No. 23 berdiri DUA sekolah: SMK LPS 1 Ciamis
+-- (NPSN 20211529) dan SMK LPS 2 Ciamis (NPSN 20251831). Keduanya satu alamat,
+-- satu desa, dan yang membedakannya cuma angka di namanya. Pendaftaran XXXVII
+-- masuk dengan nama `SMK Lps Ciamis` — tanpa angka — jadi tidak ada satu pun
+-- data yang bisa memutuskan yang mana.
+--
+-- 0154 sengaja tidak menebaknya dan mencatatnya lewat `raise notice`. Pemilik
+-- acara menjawab: yang mendaftar **LPS 1**.
+--
+-- KENAPA LPS 2 IKUT DIMASUKKAN PADAHAL BELUM ADA YANG MENDAFTAR
+--
+-- Karena namanya yang membedakan keduanya, dan nama itu baru berarti kalau
+-- lawannya juga ada (CLAUDE.md 12.8). `SMK LPS 1 Ciamis` yang berdiri sendiri
+-- di kotak pilihan pendaftaran terbaca seperti satu-satunya LPS, dan pembina
+-- LPS 2 tahun depan akan memilihnya — persis kesalahan yang angka itu dibuat
+-- untuk mencegah. Nol regu bukan alasan menundanya; justru inilah saat yang
+-- murah untuk memasangnya.
+--
+-- ALAMAT KEDUANYA SAMA, DAN ITU MEMANG BENAR
+--
+-- Data Referensi menulis keduanya di Jl. RE Martadinata No. 23, desa Maleber,
+-- Kec. Ciamis. Kode pos Maleber 46214 — angka yang sama dipakai empat sekolah
+-- kurasi lain di desa itu (MA Darul Huda, SMA Informatika Ciamis, SMAN 3
+-- Ciamis, SMKN 2 Ciamis), jadi ia bukan tebakan dari kecamatan.
+--
+-- REKAP NILAI TIDAK DISENTUH. Satu baris diganti nama dan alamat, satu baris
+-- baru ditambahkan; tidak ada yang dilebur maupun dihapus, jadi tidak ada
+-- `pendaftaran.sekolah_id` yang berpindah. Blok penutup membuktikannya dengan
+-- membandingkan jumlah baris sebelum dan sesudah.
+--
+-- BISA DIJALANKAN DUA KALI: penggantian nama menyaring nama lamanya, dan
+-- penambahan memakai `where not exists`.
+-- ============================================================================
+
+drop table if exists potret_0156;
+create temporary table potret_0156 as
+select (select count(*) from regu)        as regu,
+       (select count(*) from nilai_mentah) as nilai_mentah,
+       (select count(*) from closing_regu) as closing_regu,
+       (select count(*) from pendaftaran)  as pendaftaran;
+
+do $$
+declare
+  v_alamat constant text :=
+    'Jl. R.E. Martadinata No. 23, Maleber, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46214, Indonesia';
+  v_n int;
+begin
+  -- 1. Yang sudah ada dilengkapi angkanya. Dicocokkan lewat kunci_sekolah()
+  --    supaya ejaan `Lps` / `LPS` / `lps` sama-sama tertangkap.
+  update sekolah
+     set name = 'SMK LPS 1 Ciamis', address = v_alamat
+   where kunci_sekolah(name) = kunci_sekolah('SMK Lps Ciamis')
+     and (name, address) is distinct from ('SMK LPS 1 Ciamis', v_alamat);
+  get diagnostics v_n = row_count;
+  if v_n > 0 then
+    raise notice '0156: "SMK Lps Ciamis" -> "SMK LPS 1 Ciamis" (NPSN 20211529).';
+  else
+    raise notice '0156: (dilewati) tidak ada baris "SMK Lps Ciamis" untuk dilengkapi.';
+  end if;
+
+  -- 2. Keduanya didaftarkan kalau belum ada. LPS 1 ikut di sini, bukan cuma
+  --    diandalkan dari penggantian nama di atas: database uji dan dev tidak
+  --    pernah memuat baris `SMK Lps Ciamis`, jadi tanpa langkah ini migrasinya
+  --    benar di produksi dan berhenti di tempat lain.
+  insert into sekolah (name, address)
+  select 'SMK LPS 1 Ciamis', v_alamat
+   where not exists (select 1 from sekolah
+                      where kunci_sekolah(name) = kunci_sekolah('SMK LPS 1 Ciamis'));
+  get diagnostics v_n = row_count;
+  if v_n > 0 then
+    raise notice '0156: baris "SMK LPS 1 Ciamis" ditambahkan (NPSN 20211529).';
+  end if;
+
+  insert into sekolah (name, address)
+  select 'SMK LPS 2 Ciamis', v_alamat
+   where not exists (select 1 from sekolah
+                      where kunci_sekolah(name) = kunci_sekolah('SMK LPS 2 Ciamis'));
+  get diagnostics v_n = row_count;
+  if v_n > 0 then
+    raise notice '0156: baris "SMK LPS 2 Ciamis" ditambahkan (NPSN 20251831).';
+  end if;
+
+  assert exists (select 1 from sekolah where name = 'SMK LPS 1 Ciamis'),
+    '0156: SMK LPS 1 Ciamis tidak ada sesudah migrasi ini';
+  assert exists (select 1 from sekolah where name = 'SMK LPS 2 Ciamis'),
+    '0156: SMK LPS 2 Ciamis tidak ada sesudah migrasi ini';
+  assert not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah('SMK Lps Ciamis')),
+    '0156: nama tanpa angka masih ada';
+end $$;
+
+do $$
+declare
+  s potret_0156%rowtype;
+  n_regu int; n_nilai int; n_closing int; n_daftar int;
+begin
+  select * into s from potret_0156;
+  select count(*) into n_regu    from regu;
+  select count(*) into n_nilai   from nilai_mentah;
+  select count(*) into n_closing from closing_regu;
+  select count(*) into n_daftar  from pendaftaran;
+
+  assert (n_regu, n_nilai, n_closing, n_daftar)
+         = (s.regu, s.nilai_mentah, s.closing_regu, s.pendaftaran),
+    format('0156: DATA NILAI BERGESER — regu %s->%s, nilai %s->%s, closing %s->%s, pendaftaran %s->%s',
+           s.regu, n_regu, s.nilai_mentah, n_nilai, s.closing_regu, n_closing,
+           s.pendaftaran, n_daftar);
+
+  raise notice '0156: rekap nilai utuh — % regu, % nilai, % closing, % pendaftaran.',
+               n_regu, n_nilai, n_closing, n_daftar;
+end $$;
+
+drop table if exists potret_0156;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -337,5 +337,6 @@ run supabase/migrations/0147_waktu_nol_pos_2.sql
 # pembakuannya menyaring `where name = <nama lama>`.
 run supabase/migrations/0154_sekolah_alamat_xxxvii.sql
 run supabase/migrations/0155_sekolah_kode_pos.sql
+run supabase/migrations/0156_smk_lps_satu_dan_dua.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -708,5 +708,7 @@ run supabase/migrations/0154_sekolah_alamat_xxxvii.sql
 run tests/sql/106_sekolah_alamat_xxxvii.sql
 run supabase/migrations/0155_sekolah_kode_pos.sql
 run tests/sql/107_sekolah_kode_pos.sql
+run supabase/migrations/0156_smk_lps_satu_dan_dua.sql
+run tests/sql/108_smk_lps_satu_dan_dua.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/108_smk_lps_satu_dan_dua.sql
+++ b/tests/sql/108_smk_lps_satu_dan_dua.sql
@@ -1,0 +1,26 @@
+\echo '--- 108. SMK LPS 1 dan LPS 2 berdampingan, alamatnya sama'
+
+do $$
+declare v1 text; v2 text;
+begin
+  -- Keduanya harus ADA. Nama pembeda yang berdiri sendiri tidak membedakan
+  -- apa pun: "SMK LPS 1 Ciamis" tanpa LPS 2 di sebelahnya terbaca seperti
+  -- satu-satunya LPS, dan pembina LPS 2 tahun depan akan memilihnya.
+  select address into v1 from sekolah where name = 'SMK LPS 1 Ciamis';
+  assert v1 is not null, '108.1 GAGAL: SMK LPS 1 Ciamis tidak ada';
+  select address into v2 from sekolah where name = 'SMK LPS 2 Ciamis';
+  assert v2 is not null, '108.2 GAGAL: SMK LPS 2 Ciamis tidak ada';
+
+  -- Alamatnya memang sama; keduanya berdiri di Jl. R.E. Martadinata No. 23.
+  assert v1 = v2, format('108.3 GAGAL: alamat keduanya berbeda: %s vs %s', v1, v2);
+  assert v1 like 'Jl. R.E. Martadinata No. 23, Maleber, Kec. Ciamis,%46214, Indonesia',
+    format('108.4 GAGAL: alamat LPS tidak baku: %s', v1);
+
+  -- Nama tanpa angka tidak boleh kembali: itu yang membuat pendaftaran XXXVII
+  -- tidak bisa diputuskan tanpa bertanya ke pemilik acara.
+  assert not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah('SMK Lps Ciamis')),
+    '108.5 GAGAL: nama SMK Lps Ciamis tanpa angka masih ada';
+end;
+$$;
+
+\echo '108 SMK LPS 1 dan 2: LULUS'

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -1722,6 +1722,34 @@
     "catatan": "Alamat lengkap di Dapodik: \"JL. RAYA TIMUR SAWALA KOTAK POS 20 KADIPATEN\" — ada Kotak Pos 20 yang saya pisahkan dari nama jalan. Sekolah negeri."
   },
   {
+    "nama": "SMK LPS 1 Ciamis",
+    "nama_resmi": "SMKS LPS 1 CIAMIS",
+    "npsn": "20211529",
+    "jalan": "Jl. R.E. Martadinata No. 23",
+    "desa": "Maleber",
+    "kecamatan": "Ciamis",
+    "kabupaten": "Kabupaten Ciamis",
+    "provinsi": "Jawa Barat",
+    "kode_pos": "46214",
+    "keyakinan": "tinggi",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20211529 ; kode pos desa Maleber sama dengan empat sekolah kurasi lain di desa itu",
+    "catatan": "Yang mendaftar HRCD XXXVII. Nama yang masuk lewat form tanpa angka; angkanya dari pemilik acara."
+  },
+  {
+    "nama": "SMK LPS 2 Ciamis",
+    "nama_resmi": "SMKS LPS 2 CIAMIS",
+    "npsn": "20251831",
+    "jalan": "Jl. R.E. Martadinata No. 23",
+    "desa": "Maleber",
+    "kecamatan": "Ciamis",
+    "kabupaten": "Kabupaten Ciamis",
+    "provinsi": "Jawa Barat",
+    "kode_pos": "46214",
+    "keyakinan": "tinggi",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20251831 ; kode pos desa Maleber sama dengan empat sekolah kurasi lain di desa itu",
+    "catatan": "Belum pernah mendaftar. Didaftarkan supaya angka pada nama LPS 1 punya lawan (CLAUDE.md 12.8)."
+  },
+  {
     "nama": "SMK Ma'arif NU Ciamis",
     "nama_resmi": "SMKS MAARIF NU CIAMIS",
     "npsn": "20254633",

--- a/tools/data/sekolah_nama.json
+++ b/tools/data/sekolah_nama.json
@@ -3135,6 +3135,18 @@
     ]
   },
   {
+    "kunci": "smk lps 1",
+    "nama": "SMK LPS 1 Ciamis",
+    "peserta": 1,
+    "edisi": [
+      "XXXVII"
+    ],
+    "ejaan": [
+      "SMK Lps Ciamis"
+    ],
+    "petunjuk_alamat": []
+  },
+  {
     "kunci": "smk nusantara 1 bekasi",
     "nama": "SMK Nusantara 1 Bekasi",
     "peserta": 1,
@@ -3337,5 +3349,17 @@
     "petunjuk_alamat": [
       "Cikupa, Dsn Mulyasari Rt.002 Rw.001 Banjarsari, Banjaranyar"
     ]
+  },
+  {
+    "kunci": "smk lps 2",
+    "nama": "SMK LPS 2 Ciamis",
+    "peserta": 0,
+    "edisi": [
+      "XXXVII"
+    ],
+    "ejaan": [
+      "SMK LPS 2 Ciamis"
+    ],
+    "petunjuk_alamat": []
   }
 ]


### PR DESCRIPTION
## What

- `SMK Lps Ciamis` → **`SMK LPS 1 Ciamis`** (NPSN 20211529), alamatnya dibakukan
- **`SMK LPS 2 Ciamis`** (NPSN 20251831) ditambahkan, alamatnya sama persis
- Keduanya masuk `sekolah_alamat.json` dan `sekolah_nama.json`

`Jl. R.E. Martadinata No. 23, Maleber, Kec. Ciamis, Kabupaten Ciamis, Jawa Barat 46214, Indonesia`

## Why

Keduanya berdiri di alamat yang sama, di desa yang sama, dan yang membedakannya **cuma angka di namanya**. Pendaftaran XXXVII masuk tanpa angka itu, jadi tidak ada data yang bisa memutuskan — `0154` sengaja tidak menebaknya dan mencatatnya lewat `raise notice`. Pemilik acara menjawab: yang mendaftar **LPS 1**.

**LPS 2 ikut dimasukkan meski nol regu**, dan itu bukan kelengkapan yang sia-sia. Nama pembeda baru berarti kalau lawannya juga ada (CLAUDE.md 12.8): `SMK LPS 1 Ciamis` yang berdiri sendiri di kotak pilihan pendaftaran terbaca seperti satu-satunya LPS, dan pembina LPS 2 tahun depan akan memilihnya — persis kesalahan yang angka itu dibuat untuk mencegah. Sekarang saat termurah untuk memasangnya.

Kode pos desa Maleber **46214** bukan tebakan dari kecamatan: empat sekolah kurasi lain di desa yang sama sudah memakainya (MA Darul Huda, SMA Informatika Ciamis, SMAN 3 Ciamis, SMKN 2 Ciamis).

## Notes

- **Rekap nilai tidak disentuh.** Satu baris diganti nama, satu ditambahkan; tidak ada yang dilebur maupun dihapus, jadi tidak ada `pendaftaran.sekolah_id` yang berpindah. Blok penutup membandingkan jumlah baris `regu`, `nilai_mentah`, `closing_regu` dan `pendaftaran` sebelum dan sesudah.
- **Gladi bersih atas 211 baris produksi**: rename berhasil, LPS 2 masuk, **211 → 212 baris**. Dijalankan kedua kali: nol baris tersentuh.
- **LPS 1 ikut di-`insert ... where not exists`, bukan cuma diandalkan dari penggantian nama.** Database uji dan dev tidak pernah memuat baris `SMK Lps Ciamis`, jadi tanpa itu migrasinya benar di produksi dan berhenti di tempat lain — ketahuan waktu `tests/run.sh` gagal di assert-nya sendiri.
- `tests/sql/108` baru: keduanya ada, alamatnya identik dan baku, dan nama tanpa angka tidak boleh kembali.
- `bash tests/run.sh` — SEMUA TES LULUS. `python tools/periksa_sekolah.py` — bersih: 211 sekolah, 212 baris alamat, **210 lengkap dengan kode pos**.
