### PR TITLE
docs: MA Bahrul Anwar's desa is confirmed, raise it to tinggi

### DIFF
--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -1,6 +1,6 @@
 # Sekolah yang belum tuntas
 
-Duapuluh empat dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
+Duapuluh tiga dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
 dipakai apa adanya. Halaman ini daftar kerjanya: apa yang kurang, kenapa, dan
 apa yang harus ditanyakan.
 
@@ -37,7 +37,6 @@ yang kurang satu kalimat dari orang yang tahu.
 
 | Sekolah | Peserta | Kenapa belum tuntas | Yang ditanyakan ke pembina |
 | --- | ---: | --- | --- |
-| **MA Bahrul Anwar** | 6 | Data Referensi mengosongkan kolom **desa** untuk MA-nya (NPSN 70044831); yang terisi sekarang `Mekarsari`, diambil dari MTs Bahrul Anwar (NPSN 69955929) yang berdiri di Dusun Cicurug yang sama. | "MA-nya sedesa dengan MTs-nya di Mekarsari, atau desanya lain?" |
 | **MA Adzkia** | 2 | **Tidak punya NPSN.** Yang terdaftar di Data Referensi cuma MTs-nya (NPSN 69976289). Alamatnya dipinjam dari MTs itu, dan kebetulan cocok persis dengan yang diketik pembina sendiri. | "Berapa NPSN MA-nya, dan alamat suratnya sama dengan MTs yang sekompleks?" |
 | **SMA IT Nurul Huda** | 1 | **Tidak ada SMA bernama ini di Data Referensi.** Yang terdaftar SMP IT Nurul Huda (Pamarican dan Panjalu) dan MA Nurul Huda (Kawali). Petunjuk kwartir rantingnya "Pamarican", jadi alamatnya dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153). | "Sekolahnya SMA yang sekompleks dengan SMP IT Nurul Huda di Margajaya, Pamarican? Berapa NPSN-nya?" |
 | **MTsN 2 Ciamis** | 16 | Alamat yang ditulis peserta, `Jl. Raya Ciamis-Banjar KM 3 No. 141`, adalah **alamat MTs PUI Cijantung** di Kec. Cijeungjing. MTsN 2 Ciamis ada di Kec. Lumbung, jauh dari situ. Yang terisi sekarang alamat resmi MTsN 2. | "Regunya dari MTsN 2 Ciamis di Lumbung, atau dari MTs PUI Cijantung di Cijeungjing?" |

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -135,9 +135,9 @@
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
     "kode_pos": "46252",
-    "keyakinan": "sedang",
-    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70044831 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
-    "catatan": "Desa dikosongkan Dapodik untuk MA-nya; diambil dari MTs Bahrul Anwar (NPSN 69955929) di dusun yang sama."
+    "keyakinan": "tinggi",
+    "sumber": "Data Referensi Kemendikdasmen, https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/70044831 ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama ; desa dikonfirmasi pemilik acara",
+    "catatan": "Data Referensi mengosongkan kolom desa untuk MA-nya; desa Mekarsari dikonfirmasi pemilik acara 30 Agustus 2026 — MA dan MTs Bahrul Anwar satu desa, satu dusun."
   },
   {
     "nama": "MA Darul Huda",


### PR DESCRIPTION
## What

`MA Bahrul Anwar` naik dari `keyakinan: sedang` jadi `tinggi`, dan barisnya keluar dari `sekolah-belum-tuntas.md` bagian A.

## Why

Data Referensi **mengosongkan kolom desa** untuk MA-nya (NPSN 70044831). Yang terisi selama ini `Mekarsari`, diambil dari `MTs Bahrul Anwar` (NPSN 69955929) yang berdiri di Dusun Cicurug yang sama — masuk akal, tetapi **kesimpulan, bukan keterangan tentang MA-nya**. Itu yang membuatnya `sedang`.

Pemilik acara membenarkannya 30 Agustus 2026: MA dan MTs Bahrul Anwar **satu desa**. Sekarang ia keterangan, bukan lagi inferensi, jadi keyakinannya naik dan kolom catatan-nya mencatat dari mana kepastian itu datang.

## Notes

- **Tidak ada migrasi.** Alamat di produksi sudah benar sejak `0154` — `Dusun Cicurug, Mekarsari, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia`. Yang berubah cuma catatan seberapa jauh ia bisa dipercaya.
- `python tools/periksa_sekolah.py` — bersih: 212 baris alamat, **188 keyakinan tinggi** (dari 187).
- Sisa yang menunggu jawaban pembina tinggal dua: `MA Adzkia` (NPSN) dan `SMA IT Nurul Huda` (sekolahnya sendiri belum pasti).


