### PR TITLE
docs: record the owner's confirmations for MA Adzkia and SMA IT Nurul Huda

### DIFF
--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -1,6 +1,6 @@
 # Sekolah yang belum tuntas
 
-Duapuluh tiga dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
+Duapuluh dua dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
 dipakai apa adanya. Halaman ini daftar kerjanya: apa yang kurang, kenapa, dan
 apa yang harus ditanyakan.
 
@@ -37,7 +37,6 @@ yang kurang satu kalimat dari orang yang tahu.
 
 | Sekolah | Peserta | Kenapa belum tuntas | Yang ditanyakan ke pembina |
 | --- | ---: | --- | --- |
-| **MA Adzkia** | 2 | **Tidak punya NPSN.** Yang terdaftar di Data Referensi cuma MTs-nya (NPSN 69976289). Alamatnya dipinjam dari MTs itu, dan kebetulan cocok persis dengan yang diketik pembina sendiri. | "Berapa NPSN MA-nya, dan alamat suratnya sama dengan MTs yang sekompleks?" |
 | **SMA IT Nurul Huda** | 1 | **Tidak ada SMA bernama ini di Data Referensi.** Yang terdaftar SMP IT Nurul Huda (Pamarican dan Panjalu) dan MA Nurul Huda (Kawali). Petunjuk kwartir rantingnya "Pamarican", jadi alamatnya dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153). | "Sekolahnya SMA yang sekompleks dengan SMP IT Nurul Huda di Margajaya, Pamarican? Berapa NPSN-nya?" |
 | **MTsN 2 Ciamis** | 16 | Alamat yang ditulis peserta, `Jl. Raya Ciamis-Banjar KM 3 No. 141`, adalah **alamat MTs PUI Cijantung** di Kec. Cijeungjing. MTsN 2 Ciamis ada di Kec. Lumbung, jauh dari situ. Yang terisi sekarang alamat resmi MTsN 2. | "Regunya dari MTsN 2 Ciamis di Lumbung, atau dari MTs PUI Cijantung di Cijeungjing?" |
 | **MTs Rancah** | 13 | Kec. Rancah punya **tujuh MTs**: MTsN 5, 14, 17 Ciamis, MTs Rancah, MTs Karangpari, MTs Al-Istiqomah Kiarapayung, MTs GUPPI Cileungsir. Dipilih MTs Rancah karena namanya persis dan ada di Desa Rancah. | "MTs-nya yang di Desa Rancah, atau salah satu MTs Negeri di Kec. Rancah? Kalau negeri, nomor berapa?" |

--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -1,6 +1,6 @@
 # Sekolah yang belum tuntas
 
-Duapuluh dua dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
+Duapuluh satu dari 212 baris di `tools/data/sekolah_alamat.json` belum bisa
 dipakai apa adanya. Halaman ini daftar kerjanya: apa yang kurang, kenapa, dan
 apa yang harus ditanyakan.
 
@@ -37,7 +37,6 @@ yang kurang satu kalimat dari orang yang tahu.
 
 | Sekolah | Peserta | Kenapa belum tuntas | Yang ditanyakan ke pembina |
 | --- | ---: | --- | --- |
-| **SMA IT Nurul Huda** | 1 | **Tidak ada SMA bernama ini di Data Referensi.** Yang terdaftar SMP IT Nurul Huda (Pamarican dan Panjalu) dan MA Nurul Huda (Kawali). Petunjuk kwartir rantingnya "Pamarican", jadi alamatnya dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153). | "Sekolahnya SMA yang sekompleks dengan SMP IT Nurul Huda di Margajaya, Pamarican? Berapa NPSN-nya?" |
 | **MTsN 2 Ciamis** | 16 | Alamat yang ditulis peserta, `Jl. Raya Ciamis-Banjar KM 3 No. 141`, adalah **alamat MTs PUI Cijantung** di Kec. Cijeungjing. MTsN 2 Ciamis ada di Kec. Lumbung, jauh dari situ. Yang terisi sekarang alamat resmi MTsN 2. | "Regunya dari MTsN 2 Ciamis di Lumbung, atau dari MTs PUI Cijantung di Cijeungjing?" |
 | **MTs Rancah** | 13 | Kec. Rancah punya **tujuh MTs**: MTsN 5, 14, 17 Ciamis, MTs Rancah, MTs Karangpari, MTs Al-Istiqomah Kiarapayung, MTs GUPPI Cileungsir. Dipilih MTs Rancah karena namanya persis dan ada di Desa Rancah. | "MTs-nya yang di Desa Rancah, atau salah satu MTs Negeri di Kec. Rancah? Kalau negeri, nomor berapa?" |
 | **MA Agrowisata Shaleha** | 11 | **Tidak punya NPSN.** MA ini di bawah Kemenag/EMIS, bukan Dapodik, jadi tidak ada di Data Referensi. Alamat dan kode posnya dipinjam dari SLB Agrowisata Shaleha (NPSN 20263112) yang satu kompleks yayasan. | "Berapa NPSN MA-nya, dan alamat suratnya sama dengan SLB yang sekompleks?" |

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -905,9 +905,9 @@
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
     "kode_pos": "46382",
-    "keyakinan": "sedang",
-    "sumber": "Alamat dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153) satu yayasan; petunjuk kwartir ranting di form pendaftaran menyebut Pamarican / Ciamis ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
-    "catatan": "Belum ada di Data Referensi Kemendikdasmen dengan jenjang SMA. Perlu satu kali konfirmasi ke pembina."
+    "keyakinan": "tinggi",
+    "sumber": "Alamat dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153) satu yayasan; petunjuk kwartir ranting di form pendaftaran menyebut Pamarican / Ciamis ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama ; Margajaya Pamarican dikonfirmasi pemilik acara",
+    "catatan": "Belum terdaftar di Data Referensi Kemendikdasmen dengan jenjang SMA, jadi NPSN-nya belum diketahui — didaftar di TANPA_NPSN. Alamatnya dari SMP IT Nurul Huda Margajaya (NPSN 69993153): pemilik acara membenarkan 30 Agustus 2026 bahwa sekolahnya memang di Margajaya, Pamarican."
   },
   {
     "nama": "SMA Informatika Ciamis",

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -9,9 +9,9 @@
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
     "kode_pos": "46271",
-    "keyakinan": "sedang",
-    "sumber": "MTs Adzkia satu yayasan, Data Referensi Kemendikdasmen, (belum ada NPSN terdaftar) ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama",
-    "catatan": "Belum terdaftar di Data Referensi Kemendikdasmen. Alamat diambil dari MTs Adzkia (NPSN 69976289) di dusun yang sama, dan cocok dengan alamat yang diketik pembina sendiri."
+    "keyakinan": "tinggi",
+    "sumber": "MTs Adzkia satu yayasan, Data Referensi Kemendikdasmen, (belum ada NPSN terdaftar) ; kode pos desa dari kodepos.co.id, dicocokkan dengan 179 baris kurasi yang sudah terverifikasi di kecamatan yang sama ; satu tempat dengan MTs Adzkia, dikonfirmasi pemilik acara",
+    "catatan": "Belum terdaftar di Data Referensi Kemendikdasmen, jadi NPSN-nya belum diketahui — didaftar di TANPA_NPSN, sama seperti MTs Serba Bakti Suryalaya. Alamatnya dari MTs Adzkia (NPSN 69976289): pemilik acara membenarkan 30 Agustus 2026 bahwa keduanya satu tempat."
   },
   {
     "nama": "MA Agrowisata Shaleha",


### PR DESCRIPTION
## What

Dua sekolah naik dari `keyakinan: sedang` jadi `tinggi`, dan keduanya keluar dari `sekolah-belum-tuntas.md` bagian A:

| Sekolah | Kenapa tadinya `sedang` | Yang dibenarkan pemilik acara |
| --- | --- | --- |
| **MA Adzkia** | Belum terdaftar di Data Referensi; alamatnya dipinjam dari MTs Adzkia (NPSN 69976289) | Keduanya **satu tempat** |
| **SMA IT Nurul Huda** | Tidak ada SMA bernama itu di Data Referensi; alamatnya dipinjam dari SMP IT Nurul Huda Margajaya (NPSN 69993153) | Sekolahnya memang di **Margajaya, Pamarican, Ciamis** |

## Why

Keduanya `sedang` karena alasan yang sama: **alamatnya pinjaman dari sekolah saudara di kompleks yang sama**, bukan keterangan tentang sekolah itu sendiri. Masuk akal, dan hampir pasti benar — tetapi kesimpulan. Sekarang keduanya keterangan.

**NPSN keduanya tetap belum diketahui, dan itu tidak menahan keyakinan.** Presedennya ada di berkas yang sama: `MTs Serba Bakti Suryalaya` juga tanpa NPSN dan `tinggi` sejak kurasi. Yang menentukan keyakinan sebuah baris adalah **alamatnya**, bukan nomornya — dan yang menjaga NPSN tetap tercatat sebagai lubang adalah daftar `TANPA_NPSN` di `tools/periksa_sekolah.py`, tempat keduanya tetap terdaftar.

## Notes

- **Tidak ada migrasi.** Alamat keduanya di produksi sudah benar sejak `0154`; MA dan MTs Adzkia bahkan tersimpan dengan alamat yang sama persis. Yang berubah cuma catatan seberapa jauh alamat itu bisa dipercaya.
- `python tools/periksa_sekolah.py` — bersih: **190 keyakinan tinggi** (dari 188).
- **Daftar tunggu XXXVII habis.** Ketiga sekolah yang butuh jawaban pembina — MA Bahrul Anwar (#715), MA Adzkia, SMA IT Nurul Huda — semuanya sudah dijawab. Yang tersisa di `sekolah-belum-tuntas.md` cuma sekolah edisi lama dan dua yang alamatnya memang belum pernah ketemu (`SMPN 1 Kalijaya`, `SMK Nusantara 1 Bekasi`), keduanya tidak ikut tahun ini.
