### PR TITLE
fix: merge four duplicates the directory import brought back

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,10 +6,10 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0158`: angka
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0159`: angka
 tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database, dan
 bagian 3 diperiksa terhadap layar. Isi bagian 2 sampai 9 selebihnya belum
-dibaca ulang baris demi baris terhadap `0119`-`0158`.
+dibaca ulang baris demi baris terhadap `0119`-`0159`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -74,7 +74,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-158 migrasi, `0001` sampai `0158`, dijalankan berurutan tanpa lubang penomoran.
+159 migrasi, `0001` sampai `0159`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/supabase/checks/sekolah_kembar.sql
+++ b/supabase/checks/sekolah_kembar.sql
@@ -29,11 +29,20 @@
 --
 -- YANG TIDAK BISA DITEMUKANNYA, DAN INI PENTING
 --
--- Pasangan terakhir di atas, `MAN Darussalam` lawan `MAN 1 Ciamis`, TIDAK
--- akan muncul di laporan mana pun di bawah. Tidak ada satu huruf pun yang
--- menghubungkan keduanya; yang membuktikannya NPSN 20276451 yang sama, dan
--- tabel `sekolah` tidak menyimpan NPSN. Selama itu belum berubah, pemeriksaan
--- ini menutup lima dari enam — dan pembacanya harus tahu yang keenam ada.
+-- Pasangan terakhir di atas, `MAN Darussalam` lawan `MAN 1 Ciamis`, dulu
+-- TIDAK bisa ditemukan pemeriksaan ini: tidak ada satu huruf pun yang
+-- menghubungkan keduanya, dan yang membuktikannya NPSN 20276451 yang sama —
+-- sesuatu yang tidak disimpan tabel `sekolah`.
+--
+-- Aturan F menutupnya, dan lahirnya dari kejadian nyata. Impor 0157
+-- menghidupkan kembali `MAN 1 Ciamis` yang baru saja dilebur 0154, dan tidak
+-- satu pun aturan A-E bersuara. Yang menemukannya pertanyaan yang tidak
+-- membandingkan nama sama sekali: adakah dua baris beralamat JALAN dan DESA
+-- yang sama persis, dengan jenjang yang sama? Empat pasangan muncul dari
+-- situ, dan keempatnya terbukti satu NPSN.
+--
+-- Jadi keenamnya sekarang tertutup — tetapi lewat alamat, bukan lewat NPSN.
+-- Sekolah yang pindah alamat dan berganti nama sekaligus tetap lolos.
 --
 -- SESUDAH IMPOR DIREKTORI CIAMIS, LAPORAN INI TIDAK LAGI KOSONG
 --
@@ -84,7 +93,15 @@ with s as (
            regexp_replace(regexp_replace(lower(regexp_replace(name, '^.* ', '')),
                                          '[^a-z0-9]', '', 'g'), 'h', '', 'g'),
            '([a-z])\1+', '\1', 'g') as akhir_serupa,
-         string_to_array(lower(regexp_replace(name, '[^A-Za-z0-9 ]', '', 'g')), ' ') as kata
+         string_to_array(lower(regexp_replace(name, '[^A-Za-z0-9 ]', '', 'g')), ' ') as kata,
+         regexp_replace(lower(split_part(address, ', ', 1)), '[^a-z0-9]', '', 'g') as jalan,
+         lower(split_part(address, ', ', 2)) as desa_alamat,
+         -- TINGKAT sekolahnya saja: smp, mts, sma, smk, ma. Berbeda dari
+         -- kolom `jenjang` di atas, yang isinya nama LENGKAP dengan huruf N
+         -- dibuang. Aturan F sempat memakai `jenjang` dan karena itu menuntut
+         -- namanya hampir sama — yang justru meniadakan seluruh gunanya,
+         -- karena ia dibuat untuk pasangan yang namanya BERBEDA JAUH.
+         (regexp_match(lower(name), '^(smkn|smk|sman|sma|smpn|smp|mtsn|mts|man|ma|min|mi|sdn|sd)'))[1] as tingkat
     from sekolah
 ),
 -- Kata terakhir yang dipakai BANYAK sekolah adalah nama tempat, bukan nama
@@ -147,6 +164,28 @@ pasangan as (
                      and a.serupa <> b.serupa
                      and regexp_replace(lower(a.name), '[0-9]', '', 'g')
                       <> regexp_replace(lower(b.name), '[0-9]', '', 'g')
+
+  union all
+  -- F. Jalan DAN desa sama persis, jenjangnya sama. Ini satu-satunya aturan
+  --    yang tidak membandingkan nama sama sekali, dan karena itu satu-satunya
+  --    yang bisa menemukan `MAN Darussalam` lawan `MAN 1 Ciamis` — dua nama
+  --    tanpa satu huruf pun yang sama, satu NPSN. Impor 0157 menghidupkan
+  --    kembali baris yang 0154 baru saja lebur, dan tidak ada aturan A-E yang
+  --    bersuara; aturan ini yang menemukannya.
+  --
+  --    Jenjang HARUS sama. Tanpa syarat itu ia melaporkan tigapuluh pasangan
+  --    MA+MTs dan SMA+SMP satu yayasan yang memang dua sekolah berbeda.
+  --    Jalan yang terlalu pendek diabaikan: "Pasawahan" saja bukan alamat.
+  select a.name, b.name, 'jalan dan desa sama persis, jenjang sama', a.address, b.address
+    from s a join s b on a.id < b.id
+                     and a.jalan = b.jalan and a.desa_alamat = b.desa_alamat
+                     and length(a.jalan) >= 8
+                     -- Alamat tanpa nama jalan dimulai dari desanya, jadi
+                     -- bagian kedua berbunyi "Kec. ...". Dua sekolah sedesa
+                     -- yang Dapodik tidak beri nama jalan akan selalu terlihat
+                     -- seliteral-literalnya sama; itu sedesa, bukan sealamat.
+                     and a.desa_alamat not like 'kec. %'
+                     and regexp_replace(a.tingkat, 'n$', '') = regexp_replace(b.tingkat, 'n$', '')
 )
 select sebab, sekolah_a, sekolah_b,
        left(coalesce(nullif(alamat_a, ''), '(kosong)'), 46) as alamat_a,

--- a/supabase/migrations/0159_lebur_kembar_direktori.sql
+++ b/supabase/migrations/0159_lebur_kembar_direktori.sql
@@ -1,0 +1,155 @@
+-- ============================================================================
+-- hrcd-rekap : 0159_lebur_kembar_direktori.sql
+-- Empat baris kembar yang dibawa impor 0157, dan satu kode pos yang salah.
+--
+-- SATU DI ANTARANYA REGRESI YANG SAYA BUAT SENDIRI
+--
+-- `MAN 1 Ciamis` DILEBUR ke `MAN Darussalam` oleh 0154 — NPSN keduanya sama,
+-- 20276451. Lalu 0157 memasukkannya kembali, karena Data Referensi memang
+-- menamainya `MAN 1 Ciamis` dan `kunci_sekolah('MAN 1 Ciamis')` tidak sama
+-- dengan `kunci_sekolah('MAN Darussalam')`. Impor itu menghidupkan lagi baris
+-- yang baru saja dihapus, tanpa satu galat pun.
+--
+-- Pelajarannya bukan "hati-hati": penyaringan impor memakai NAMA, sedangkan
+-- yang membuktikan dua baris satu sekolah adalah NPSN — dan `sekolah` tidak
+-- menyimpan NPSN. Selama itu belum berubah, impor berikutnya akan mengulangi
+-- kesalahan yang sama, dan yang menahannya cuma pemeriksaan sesudahnya.
+--
+-- APA YANG MENEMUKANNYA
+--
+-- Bukan `sekolah_kembar.sql` — kelima aturannya membandingkan NAMA, dan
+-- `MAN Darussalam` lawan `MAN 1 Ciamis` tidak punya satu huruf pun yang sama.
+-- Yang menemukannya pertanyaan lain: "adakah dua baris beralamat jalan DAN
+-- desa yang sama persis?" Keempat pasangan di bawah muncul dari situ, dan
+-- keempatnya terbukti lewat NPSN. Aturan itu sekarang ditambahkan ke
+-- pemeriksa sebagai aturan keenam.
+--
+-- KEEMPAT PASANGAN, DAN YANG MANA YANG BERTAHAN
+--
+--   MAN 1 Ciamis                                  -> MAN Darussalam
+--     NPSN 20276451. Nama resminya memang MAN 1 Ciamis, tetapi runbook
+--     bagian 5 menahan nama yang diucapkan orang, dan tidak ada yang
+--     menyebutnya MAN 1 Ciamis.
+--
+--   SMAN 1 Banjaranyar                            -> SMAN 2 Banjarsari
+--     NPSN 20255008. Banjaranyar mekar dari Banjarsari tahun 2015 dan
+--     sekolahnya ikut berganti nama. Yang bertahan nama LAMA, karena itu yang
+--     ditulis empat peserta di edisi XXXIV dan XXXVI dan tidak ada satu pun
+--     yang menulis nama barunya — alasan yang sama dengan MAN Darussalam.
+--     Nama resminya dicatat di sekolah_alamat.json.
+--
+--   SMP Islam Terpadu Muhammad Danu Fathahillah   -> SMP IT MD Fathahillah
+--     NPSN 70003434. "MD" memang singkatan Muhammad Danu; yang dipakai
+--     bentuk pendek karena itu yang tertulis di formulir pendaftarannya.
+--
+--   MA Al Islah                                   -> MA Al-Ishlah
+--     NPSN 20276441. Ejaan kurasi yang bertahan; `Al-` bagian nama diri dan
+--     ditulis dengan tanda hubung (runbook bagian 4).
+--
+-- KODE POS SMAN 2 BANJARSARI: 46383 -> 46384
+--
+-- Desanya Cigayam, Kec. Banjaranyar, dan SELURUH sepuluh desa Kec.
+-- Banjaranyar memakai 46384. Angka 46383 milik Kec. Banjarsari, kecamatan
+-- asalnya sebelum mekar tahun 2015 — cermin Dapodik masih memakai kode lama
+-- dan itu yang tersalin ke kurasi. `SMPN 6 Banjarsari` (Desa Cikupa,
+-- kecamatan yang sama) sudah memakai 46384 sejak awal, dan ketidaksepakatan
+-- antara kedua baris itulah yang membuat kesalahannya terlihat.
+--
+-- REKAP NILAI TIDAK DISENTUH. Keempat baris yang dibuang tidak memegang satu
+-- pendaftaran pun — semuanya lahir dari impor 0157 dan belum pernah dipilih
+-- siapa pun — tetapi pengalihan tetap dijalankan sebelum penghapusan, persis
+-- seperti 0154, supaya benar walau anggapan itu meleset. Blok penutup
+-- membandingkan jumlah barisnya.
+--
+-- BISA DIJALANKAN DUA KALI.
+-- ============================================================================
+
+drop table if exists potret_0159;
+create temporary table potret_0159 as
+select (select count(*) from regu)         as regu,
+       (select count(*) from nilai_mentah) as nilai_mentah,
+       (select count(*) from closing_regu) as closing_regu,
+       (select count(*) from pendaftaran)  as pendaftaran;
+
+drop table if exists lebur_0159;
+create temporary table lebur_0159 (buang text, simpan text, npsn text);
+insert into lebur_0159 (buang, simpan, npsn) values
+  ('MAN 1 Ciamis', 'MAN Darussalam', '20276451'),
+  ('SMAN 1 Banjaranyar', 'SMAN 2 Banjarsari', '20255008'),
+  ('SMP Islam Terpadu Muhammad Danu Fathahillah', 'SMP IT MD Fathahillah', '70003434'),
+  ('MA Al Islah', 'MA Al-Ishlah', '20276441');
+
+do $$
+declare r record; v_p int; v_k int; v_total int := 0;
+begin
+  for r in select * from lebur_0159 order by buang loop
+    if not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah(r.buang)) then
+      raise notice '0159: (dilewati) "%" memang tidak ada.', r.buang;
+      continue;
+    end if;
+    if not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah(r.simpan)) then
+      raise exception '0159: "%" ada tetapi "%" tidak — pasangan peleburan salah',
+                      r.buang, r.simpan;
+    end if;
+
+    update pendaftaran d
+       set sekolah_id = (select id from sekolah where kunci_sekolah(name) = kunci_sekolah(r.simpan))
+     where d.sekolah_id = (select id from sekolah where kunci_sekolah(name) = kunci_sekolah(r.buang));
+    get diagnostics v_p = row_count;
+
+    update kejuaraan_manual m
+       set sekolah_id = (select id from sekolah where kunci_sekolah(name) = kunci_sekolah(r.simpan))
+     where m.sekolah_id = (select id from sekolah where kunci_sekolah(name) = kunci_sekolah(r.buang));
+    get diagnostics v_k = row_count;
+
+    delete from sekolah where kunci_sekolah(name) = kunci_sekolah(r.buang);
+    v_total := v_total + 1;
+    raise notice '0159: "%" -> "%" (NPSN %, % pendaftaran, % penghargaan dialihkan)',
+                 r.buang, r.simpan, r.npsn, v_p, v_k;
+  end loop;
+  raise notice '0159: % baris kembar dilebur.', v_total;
+end $$;
+
+do $$
+declare v_n int;
+begin
+  update sekolah
+     set address = replace(address, 'Jawa Barat 46383,', 'Jawa Barat 46384,')
+   where name = 'SMAN 2 Banjarsari'
+     and address like '%Kec. Banjaranyar%'
+     and address like '%46383%';
+  get diagnostics v_n = row_count;
+  raise notice '0159: % kode pos SMAN 2 Banjarsari dibetulkan jadi 46384.', v_n;
+
+  assert not exists (
+    select 1 from sekolah
+     where address like '%Kec. Banjaranyar%' and address like '%46383%'),
+    '0159: masih ada alamat Kec. Banjaranyar berkode pos 46383';
+end $$;
+
+do $$
+declare
+  s potret_0159%rowtype;
+  n_regu int; n_nilai int; n_closing int; n_daftar int; v_sekolah int;
+begin
+  select * into s from potret_0159;
+  select count(*) into n_regu    from regu;
+  select count(*) into n_nilai   from nilai_mentah;
+  select count(*) into n_closing from closing_regu;
+  select count(*) into n_daftar  from pendaftaran;
+  select count(*) into v_sekolah from sekolah;
+
+  assert (n_regu, n_nilai, n_closing, n_daftar)
+         = (s.regu, s.nilai_mentah, s.closing_regu, s.pendaftaran),
+    format('0159: DATA NILAI BERGESER — regu %s->%s, nilai %s->%s, closing %s->%s, pendaftaran %s->%s',
+           s.regu, n_regu, s.nilai_mentah, n_nilai, s.closing_regu, n_closing,
+           s.pendaftaran, n_daftar);
+  assert not exists (select 1 from pendaftaran where sekolah_id is null),
+    '0159: ada pendaftaran yang kehilangan sekolahnya';
+
+  raise notice '0159: % baris sekolah, rekap nilai utuh — % regu, % nilai, % closing.',
+               v_sekolah, n_regu, n_nilai, n_closing;
+end $$;
+
+drop table if exists potret_0159;
+drop table if exists lebur_0159;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -340,5 +340,6 @@ run supabase/migrations/0155_sekolah_kode_pos.sql
 run supabase/migrations/0156_smk_lps_satu_dan_dua.sql
 run supabase/migrations/0157_direktori_sekolah_ciamis.sql
 run supabase/migrations/0158_rapikan_alamat_direktori.sql
+run supabase/migrations/0159_lebur_kembar_direktori.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -714,5 +714,7 @@ run supabase/migrations/0157_direktori_sekolah_ciamis.sql
 run tests/sql/109_direktori_sekolah_ciamis.sql
 run supabase/migrations/0158_rapikan_alamat_direktori.sql
 run tests/sql/110_rapikan_alamat_direktori.sql
+run supabase/migrations/0159_lebur_kembar_direktori.sql
+run tests/sql/111_lebur_kembar_direktori.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/school_duplicate_check.test.mjs
+++ b/tests/school_duplicate_check.test.mjs
@@ -18,13 +18,24 @@ test("pemeriksa kembar tidak mengubah satu baris pun", () => {
       `pemeriksa kembar memuat "${kata}" — ia harus hanya membaca`);
 });
 
-test("kelima aturan disebut, masing-masing dengan alasannya", () => {
+test("keenam aturan disebut, masing-masing dengan alasannya", () => {
   for (const sebab of ["tanda baca / spasi saja bedanya",
                        "ejaan h / huruf ganda saja bedanya",
                        "huruf N / status negeri-swasta saja bedanya",
                        "satu nama memuat sisipan yang satunya tidak",
-                       "kata terakhirnya nama diri yang sama"])
+                       "kata terakhirnya nama diri yang sama",
+                       "jalan dan desa sama persis, jenjang sama"])
     assert.ok(sql.includes(sebab), `aturan hilang: ${sebab}`);
+});
+
+test("aturan alamat menuntut jenjang yang sama", () => {
+  // Tanpa syarat itu ia melaporkan tigapuluh pasangan MA+MTs dan SMA+SMP satu
+  // yayasan yang memang dua sekolah berbeda, dan laporan sepanjang itu
+  // berhenti dibaca.
+  const f = sql.slice(sql.indexOf("-- F. Jalan DAN desa"));
+  assert.match(f, /a\.jalan = b\.jalan and a\.desa_alamat = b\.desa_alamat/);
+  assert.match(f, /length\(a\.jalan\) >= 8/);
+  assert.match(f, /a\.jenjang.*=.*b\.jenjang/s);
 });
 
 test("aturan sisipan diperiksa dua arah", () => {
@@ -34,10 +45,12 @@ test("aturan sisipan diperiksa dua arah", () => {
   assert.match(sql, /b\.kata <@ a\.kata/);
 });
 
-test("yang TIDAK bisa ditemukannya ikut ditulis", () => {
-  // MAN Darussalam lawan MAN 1 Ciamis tidak punya satu huruf pun yang sama;
-  // yang membuktikannya NPSN, dan `sekolah` tidak menyimpan NPSN. Pemeriksa
-  // yang diam soal batasnya dibaca seolah menutup semuanya.
+test("batas pemeriksaan ini tetap tertulis", () => {
+  // Aturan F menutup kasus MAN Darussalam lawan MAN 1 Ciamis — tetapi lewat
+  // ALAMAT, bukan NPSN. Sekolah yang pindah alamat dan berganti nama sekaligus
+  // tetap lolos, dan pemeriksa yang diam soal batasnya dibaca seolah menutup
+  // semuanya.
   assert.match(sql, /MAN Darussalam/);
-  assert.match(sql, /tabel `sekolah` tidak menyimpan NPSN/);
+  assert.match(sql, /tetapi lewat alamat, bukan lewat NPSN/);
+  assert.match(sql, /berganti nama sekaligus tetap lolos/);
 });

--- a/tests/school_duplicate_check.test.mjs
+++ b/tests/school_duplicate_check.test.mjs
@@ -28,14 +28,20 @@ test("keenam aturan disebut, masing-masing dengan alasannya", () => {
     assert.ok(sql.includes(sebab), `aturan hilang: ${sebab}`);
 });
 
-test("aturan alamat menuntut jenjang yang sama", () => {
-  // Tanpa syarat itu ia melaporkan tigapuluh pasangan MA+MTs dan SMA+SMP satu
-  // yayasan yang memang dua sekolah berbeda, dan laporan sepanjang itu
-  // berhenti dibaca.
+test("aturan alamat memakai TINGKAT, bukan kolom jenjang", () => {
+  // Kolom `jenjang` isinya nama LENGKAP dengan huruf N dibuang, bukan tingkat
+  // sekolah. Aturan F sempat memakainya dan karena itu menuntut namanya hampir
+  // sama — yang meniadakan seluruh gunanya, karena ia dibuat justru untuk
+  // pasangan yang namanya berbeda jauh seperti MAN Darussalam lawan
+  // MAN 1 Ciamis.
   const f = sql.slice(sql.indexOf("-- F. Jalan DAN desa"));
   assert.match(f, /a\.jalan = b\.jalan and a\.desa_alamat = b\.desa_alamat/);
+  assert.match(f, /a\.tingkat.*b\.tingkat/s);
+  assert.doesNotMatch(f, /a\.jenjang/);
   assert.match(f, /length\(a\.jalan\) >= 8/);
-  assert.match(f, /a\.jenjang.*=.*b\.jenjang/s);
+  // Alamat tanpa nama jalan dimulai dari desanya; tanpa syarat ini dua sekolah
+  // sedesa terlihat sealamat.
+  assert.match(f, /desa_alamat not like 'kec\. %'/);
 });
 
 test("aturan sisipan diperiksa dua arah", () => {

--- a/tests/sql/111_lebur_kembar_direktori.sql
+++ b/tests/sql/111_lebur_kembar_direktori.sql
@@ -1,0 +1,40 @@
+\echo '--- 111. kembar bawaan impor dilebur, kode pos Banjaranyar dibetulkan'
+
+do $$
+begin
+  -- Keempat nama yang dibuang tidak boleh kembali. `MAN 1 Ciamis` yang paling
+  -- penting: ia sudah dilebur 0154, lalu dihidupkan lagi impor 0157 karena
+  -- penyaringan impor memakai NAMA sedangkan yang membuktikan dua baris satu
+  -- sekolah adalah NPSN.
+  assert not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah('MAN 1 Ciamis')),
+    '111.1 GAGAL: MAN 1 Ciamis hidup lagi — periksa impor direktori berikutnya';
+  assert not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah('SMAN 1 Banjaranyar')),
+    '111.2 GAGAL: SMAN 1 Banjaranyar masih ada di sebelah SMAN 2 Banjarsari';
+  assert not exists (select 1 from sekolah
+                      where kunci_sekolah(name) = kunci_sekolah('SMP Islam Terpadu Muhammad Danu Fathahillah')),
+    '111.3 GAGAL: nama panjang SMP IT MD Fathahillah masih ada';
+  assert not exists (select 1 from sekolah where kunci_sekolah(name) = kunci_sekolah('MA Al Islah')),
+    '111.4 GAGAL: MA Al Islah masih ada di sebelah MA Al-Ishlah';
+
+  -- Yang bertahan harus tetap ada.
+  assert exists (select 1 from sekolah where name = 'MAN Darussalam'), '111.5 GAGAL: MAN Darussalam hilang';
+  assert exists (select 1 from sekolah where name = 'SMP IT MD Fathahillah'), '111.6 GAGAL: SMP IT MD Fathahillah hilang';
+end;
+$$;
+
+do $$
+declare v_n int;
+begin
+  -- Seluruh sepuluh desa Kec. Banjaranyar memakai 46384. Angka 46383 milik
+  -- Kec. Banjarsari, kecamatan asalnya sebelum mekar tahun 2015.
+  select count(*) into v_n from sekolah
+   where address like '%Kec. Banjaranyar%' and address like '%46383%';
+  assert v_n = 0, format('111.7 GAGAL: %s alamat Kec. Banjaranyar masih berkode pos 46383', v_n);
+
+  select count(*) into v_n from sekolah
+   where address like '%Kec. Banjarsari%' and address like '%46384%';
+  assert v_n = 0, format('111.8 GAGAL: %s alamat Kec. Banjarsari memakai 46384', v_n);
+end;
+$$;
+
+\echo '111 lebur kembar direktori: LULUS'

--- a/tools/data/sekolah_alamat.json
+++ b/tools/data/sekolah_alamat.json
@@ -1457,17 +1457,17 @@
   },
   {
     "nama": "SMAN 2 Banjarsari",
-    "nama_resmi": null,
+    "nama_resmi": "SMAN 1 BANJARANYAR",
     "npsn": "20255008",
     "jalan": "Jl. Sukadana No. 239",
     "desa": "Cigayam",
     "kecamatan": "Banjaranyar",
     "kabupaten": "Kabupaten Ciamis",
     "provinsi": "Jawa Barat",
-    "kode_pos": "46383",
+    "kode_pos": "46384",
     "keyakinan": "tinggi",
     "sumber": "https://referensi.data.kemendikdasmen.go.id/pendidikan/npsn/20255008",
-    "catatan": "Namanya SMAN 2 Banjarsari tapi lokasinya sekarang di Kec. BANJARANYAR, Desa Cigayam — Banjaranyar dimekarkan dari Banjarsari, dan data referensi resmi sudah memakai kecamatan baru. Cermin Dapodik lama masih menulis Kec. Banjarsari. Kode pos 46383 dari cermin Dapodik, bukan dari halaman referensi."
+    "catatan": "Banjaranyar mekar dari Banjarsari tahun 2015 dan sekolahnya ikut berganti nama jadi SMAN 1 Banjaranyar. Nama lama dipertahankan karena itu yang ditulis empat peserta di edisi XXXIV dan XXXVI. Kode posnya sempat 46383 — kode Kec. Banjarsari — dan dibetulkan jadi 46384 pada migrasi 0159; seluruh sepuluh desa Kec. Banjaranyar memakai 46384."
   },
   {
     "nama": "SMAN 2 Ciamis",


### PR DESCRIPTION
## What

Empat baris kembar yang dibawa impor `0157` dilebur, satu kode pos dibetulkan, dan pemeriksa kembar dapat aturan keenam.

| Dibuang | Disimpan | NPSN |
| --- | --- | --- |
| `MAN 1 Ciamis` | `MAN Darussalam` | 20276451 |
| `SMAN 1 Banjaranyar` | `SMAN 2 Banjarsari` | 20255008 |
| `SMP Islam Terpadu Muhammad Danu Fathahillah` | `SMP IT MD Fathahillah` | 70003434 |
| `MA Al Islah` | `MA Al-Ishlah` | 20276441 |

Plus: `SMAN 2 Banjarsari` kode pos **46383 → 46384**.

## Satu di antaranya regresi yang saya buat sendiri

`MAN 1 Ciamis` **dilebur `0154`**, lalu **dihidupkan lagi `0157`** — karena Data Referensi memang menamainya begitu, dan `kunci_sekolah('MAN 1 Ciamis')` tidak sama dengan `kunci_sekolah('MAN Darussalam')`. Impor menghidupkan baris yang baru saja dihapus, **tanpa satu galat pun**.

Pelajarannya bukan "hati-hati": penyaringan impor memakai NAMA, sedangkan yang membuktikan dua baris satu sekolah adalah **NPSN** — dan `sekolah` tidak menyimpan NPSN. Selama itu belum berubah, impor berikutnya akan mengulangi kesalahan yang sama.

## Aturan keenam, dan kenapa aturan A–E tidak cukup

Kelima aturan lama membandingkan **nama**. `MAN Darussalam` lawan `MAN 1 Ciamis` tidak punya satu huruf pun yang sama, jadi tidak satu pun bersuara.

Yang menemukannya pertanyaan yang tidak membandingkan nama sama sekali: **adakah dua baris beralamat jalan DAN desa sama persis, dengan tingkat yang sama?** Diuji atas 521 baris produksi: **keempatnya tertangkap**, satu lapor palsu (`SMK LPS 1` dan `2` memang dua sekolah di satu alamat).

**Aturannya sempat salah dua kali, dan dua-duanya ketahuan karena dijalankan:**

1. Ia memakai kolom `jenjang` — yang isinya **nama lengkap dengan huruf N dibuang**, bukan tingkat sekolah. Jadi ia menuntut namanya hampir sama, meniadakan seluruh gunanya. Laporannya kosong, dan kosong itu terlihat seperti bersih.
2. Alamat tanpa nama jalan dimulai dari **desanya**, jadi dua sekolah sedesa terlihat sealamat — tiga lapor palsu.

## Kode pos SMAN 2 Banjarsari

Desanya Cigayam, Kec. Banjaranyar, dan **seluruh sepuluh desa** kecamatan itu memakai **46384**. Angka 46383 milik Kec. Banjarsari, kecamatan asalnya sebelum mekar tahun 2015 — cermin Dapodik masih memakai kode lama dan itu yang tersalin ke kurasi.

Yang membuat kesalahannya terlihat: `SMPN 6 Banjarsari` (Desa Cikupa, kecamatan yang sama) sudah memakai 46384 sejak awal. **Dua baris kita sendiri yang tidak sepakat.**

## Notes

- **Rekap nilai tidak disentuh.** Keempat baris yang dibuang tidak memegang satu pendaftaran pun, tetapi pengalihan tetap dijalankan sebelum penghapusan — supaya benar walau anggapan itu meleset.
- **Gladi bersih atas 521 baris produksi terkini**: 521 → **517**, kode pos betul, dijalankan kedua kali **0 baris**.
- `tests/sql/111` baru: keempat nama yang dibuang tidak boleh kembali — terutama `MAN 1 Ciamis`, yang sudah sekali hidup lagi — dan tidak boleh ada alamat Kec. Banjaranyar berkode 46383 atau Kec. Banjarsari berkode 46384.
- `bash tests/run.sh` — SEMUA TES LULUS. `node --test` — 266 tes, 262 lulus (empat sisanya di `championship_ui`, sudah ada di `main`).
