### PR TITLE
docs: record two more commits pushed straight to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    something GitHub enforces. Follow it deliberately.
 3. Git identity is configured **repo-locally**, not globally:
    `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
-4. **Eight commits on `main` have no merge point**, and the root
+4. **Ten commits on `main` have no merge point**, and the root
    `Initial commit` besides. All are known — none is new damage:
 
    | Commit | Date | Why |
@@ -156,6 +156,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    | `5502a5a` | 15 Aug | pushed straight to `main` by mistake |
    | `f133c8d` `b532dd9` `23ec32b` `aa28b57` `769d760` | 17 Aug | five more direct pushes, same mistake repeated |
    | `bde75b8` | 28 Aug | committed and pushed while the working copy sat on `main` after a merge |
+   | `199b0d6` `a245426` | 30 Aug | the same thing again, twice in a row, minutes after merging #718 |
 
    Leave all nine as they are: undoing any of them means force-pushing the
    default branch, which is worse than untidy history. Verify the count with
@@ -163,8 +164,8 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    reached as a merge's *second* parent is normal and must not be counted.
 
    **This clause said "two" until 27 August 2026, when a branch audit found
-   seven; `bde75b8` made it eight the next day.** The five from 17 August were
-   never recorded. A stale count is not a cosmetic error: whoever runs the
+   seven; `bde75b8` made it eight the next day, and `199b0d6`/`a245426` made
+   it ten two days after that.** The five from 17 August were never recorded. A stale count is not a cosmetic error: whoever runs the
    check next reads five false alarms and cannot tell known history from fresh
    damage. If the number changes again, change it HERE — do not leave the
    discrepancy for the next reader.
@@ -176,6 +177,13 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    silent — `git push` succeeds, the change ships, and only a later audit
    notices. Section 1.1 is not a formality; the moment it protects is the one
    right after a merge.
+
+   **`199b0d6` and `a245426` are that same warning, ignored.** They landed on
+   30 August 2026 minutes after #718 was merged — the exact moment the
+   paragraph above names — and by someone who had read it. Two commits, not
+   one, because nothing complains until an audit runs. If a habit is wanted
+   instead of a rule: after every `gh pr merge`, the next command is
+   `git checkout -b`, before `git add` is ever typed.
 5. **`tests/run.sh` lists every migration by hand.** A new migration is NOT
    tested until it is added there, and CI stays green while ignoring it
    completely. Seven migrations and three test files once sat unrun for a day

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Guidance for Claude Code when working in this repository.
    something GitHub enforces. Follow it deliberately.
 3. Git identity is configured **repo-locally**, not globally:
    `Furqon Aji Yudhistira <furqonajiy@gmail.com>`.
-4. **Eight commits on `main` have no merge point**, and the root
+4. **Ten commits on `main` have no merge point**, and the root
    `Initial commit` besides. All are known — none is new damage:
 
    | Commit | Date | Why |
@@ -154,6 +154,7 @@ Guidance for Claude Code when working in this repository.
    | `5502a5a` | 15 Aug | pushed straight to `main` by mistake |
    | `f133c8d` `b532dd9` `23ec32b` `aa28b57` `769d760` | 17 Aug | five more direct pushes, same mistake repeated |
    | `bde75b8` | 28 Aug | committed and pushed while the working copy sat on `main` after a merge |
+   | `199b0d6` `a245426` | 30 Aug | the same thing again, twice in a row, minutes after merging #718 |
 
    Leave all nine as they are: undoing any of them means force-pushing the
    default branch, which is worse than untidy history. Verify the count with
@@ -161,8 +162,8 @@ Guidance for Claude Code when working in this repository.
    reached as a merge's *second* parent is normal and must not be counted.
 
    **This clause said "two" until 27 August 2026, when a branch audit found
-   seven; `bde75b8` made it eight the next day.** The five from 17 August were
-   never recorded. A stale count is not a cosmetic error: whoever runs the
+   seven; `bde75b8` made it eight the next day, and `199b0d6`/`a245426` made
+   it ten two days after that.** The five from 17 August were never recorded. A stale count is not a cosmetic error: whoever runs the
    check next reads five false alarms and cannot tell known history from fresh
    damage. If the number changes again, change it HERE — do not leave the
    discrepancy for the next reader.
@@ -174,6 +175,13 @@ Guidance for Claude Code when working in this repository.
    silent — `git push` succeeds, the change ships, and only a later audit
    notices. Section 1.1 is not a formality; the moment it protects is the one
    right after a merge.
+
+   **`199b0d6` and `a245426` are that same warning, ignored.** They landed on
+   30 August 2026 minutes after #718 was merged — the exact moment the
+   paragraph above names — and by someone who had read it. Two commits, not
+   one, because nothing complains until an audit runs. If a habit is wanted
+   instead of a rule: after every `gh pr merge`, the next command is
+   `git checkout -b`, before `git add` is ever typed.
 5. **`tests/run.sh` lists every migration by hand.** A new migration is NOT
    tested until it is added there, and CI stays green while ignoring it
    completely. Seven migrations and three test files once sat unrun for a day


### PR DESCRIPTION
## What

CLAUDE.md dan AGENTS.md pasal 7.4: **delapan jadi sepuluh** commit di `main` tanpa merge point, plus satu kalimat baru di paragraf peringatannya.

## Why

`199b0d6` dan `a245426` mendarat di `main` tanpa PR pada 30 Agustus 2026, **beberapa menit sesudah #718 di-merge** — persis momen yang pasal 7.4 sebut sebagai titik bahayanya:

> a PR had just been merged, `--delete-branch` returned the working copy to `main`, and the next piece of work was committed without a `git checkout -b` in front of it

Dua commit, bukan satu, karena tidak ada yang bersuara sampai audit dijalankan.

**Keduanya dibiarkan.** Membatalkannya menuntut force-push ke branch default, dan pasal itu sendiri sudah memutuskan bahwa itu lebih buruk daripada riwayat yang tidak rapi. Yang diubah cuma hitungannya — supaya audit berikutnya bisa membedakan riwayat yang sudah dikenal dari kerusakan baru. Pasal itu juga menulis kenapa hitungan basi berbahaya: pembacanya tidak bisa memisahkan lapor palsu dari temuan.

## Notes

- Isi kedua commit itu tidak apa-apa dan sudah terverifikasi: `199b0d6` menutup sengketa kode pos MTsN 1 Ciamis di 46211, `a245426` menghidupkan kembali empat tes `championship_ui`. Yang salah caranya mendarat, bukan isinya.
- Paragraf peringatannya ditambah satu kalimat yang lebih berguna daripada "hati-hati": **sesudah tiap `gh pr merge`, perintah berikutnya `git checkout -b`, sebelum `git add` sempat diketik.**
- `node --test tests/*.test.mjs` — **266 tes, 266 lulus, nol gagal.**
- CLAUDE.md dan AGENTS.md tetap identik (pasal 7.7).
