### PR TITLE
perf: keep the school list on the phone instead of refetching it every visit

### DIFF
--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -99,6 +99,61 @@ const kosong = () => ({
 
 let jawab = kosong();
 let SEKOLAH = [];
+
+/* ---------------------------------------------------------------------------
+   DAFTAR SEKOLAH DISIMPAN DI HP, BUKAN DIMINTA ULANG TIAP BUKA HALAMAN.
+
+   Tabelnya 517 baris sejak migrasi 0157 memasukkan seluruh SMP/MTs/SMA/SMK/MA
+   se-Kabupaten Ciamis — 94 KB JSON. Sebelum ini setiap kali halaman ini dibuka
+   ia diminta ulang ke database, padahal pembina membuka form yang sama
+   berkali-kali: mengisi separuh, menutup, kembali lagi, mengoreksi satu regu.
+   Isinya nyaris tidak pernah berubah di antara kunjungan itu.
+
+   Bentuknya "pakai dulu, segarkan belakangan": kalau ada simpanan ia dipakai
+   SEKETIKA dan halaman terbuka tanpa satu permintaan pun; kalau simpanannya
+   sudah lewat enam jam, penyegaran jalan di latar belakang dan `SEKOLAH`
+   diganti begitu datang. Itu aman karena tidak ada yang menyalin `SEKOLAH` ke
+   indeks siapkan-dulu — `cariSekolah(SEKOLAH, ...)` membacanya saat diketik,
+   jadi hasil yang lebih baru langsung terpakai pada ketukan berikutnya.
+
+   Basi paling parah yang bisa terjadi: sekolah yang baru mendaftar hari ini
+   belum muncul di kotak cari pembina lain. Yang mengetiknya tetap menulis nama
+   yang sama, dan `kunci_sekolah()` di database tetap menyatukannya ke satu
+   baris — jadi yang hilang cuma kenyamanan, bukan kebenaran.
+
+   `infoEdisi()` SENGAJA tidak ikut disimpan. Ia 180 byte, dan ia yang memutus
+   pendaftaran masih dibuka atau tidak; menyimpannya berarti form yang sudah
+   ditutup masih menerima kiriman selama enam jam.
+   ------------------------------------------------------------------------ */
+const SIMPANAN_SEKOLAH = "hrcd_sekolah";
+const UMUR_SEKOLAH = 6 * 60 * 60 * 1000;
+
+/** Baca simpanan. Seluruh akses localStorage dibungkus try/catch: di mode
+ *  privat sebagian browser MELEMPAR, bukan mengembalikan null, dan form yang
+ *  gagal terbuka gara-gara cache adalah pertukaran yang salah arah. */
+function sekolahTersimpan() {
+  try {
+    const t = JSON.parse(localStorage.getItem(SIMPANAN_SEKOLAH) || "null");
+    if (!t || !Array.isArray(t.isi) || !t.isi.length) return null;
+    return { isi: t.isi, basi: Date.now() - (t.pada || 0) > UMUR_SEKOLAH };
+  } catch { return null; }
+}
+
+function simpanSekolah(isi) {
+  try {
+    localStorage.setItem(SIMPANAN_SEKOLAH, JSON.stringify({ pada: Date.now(), isi }));
+  } catch { /* kuota penuh atau mode privat — simpanan memang boleh gagal */ }
+}
+
+/** Segarkan di latar belakang. Gagalnya DIABAIKAN: yang sudah di layar tetap
+ *  bisa dipakai, dan memunculkan galat untuk penyegaran yang tidak diminta
+ *  siapa pun cuma membuat pembina mengira formnya rusak. */
+async function segarkanSekolah() {
+  try {
+    const baru = await daftarSekolah();
+    if (Array.isArray(baru) && baru.length) { SEKOLAH = baru; simpanSekolah(baru); }
+  } catch { /* diam */ }
+}
 let EDISI = null;
 let tokenTurnstile = null;
 let sudahDiperiksa = false;      // galat baru ditampilkan setelah Kirim ditekan
@@ -1288,7 +1343,15 @@ async function mulai() {
   // style.css yang sama, jadi tidak ada gaya kedua yang perlu dijaga.
   LAYAR.replaceChildren(h(pemuat()));
   try {
-    [SEKOLAH, EDISI] = await Promise.all([daftarSekolah(), infoEdisi()]);
+    const simpanan = sekolahTersimpan();
+    if (simpanan) {
+      SEKOLAH = simpanan.isi;
+      EDISI = await infoEdisi();
+      if (simpanan.basi) segarkanSekolah();
+    } else {
+      [SEKOLAH, EDISI] = await Promise.all([daftarSekolah(), infoEdisi()]);
+      simpanSekolah(SEKOLAH);
+    }
   } catch (e) {
     LAYAR.replaceChildren(kartuGagalMuat(e.message, mulai));
     return;

--- a/tests/registration_school_cache.test.mjs
+++ b/tests/registration_school_cache.test.mjs
@@ -1,0 +1,52 @@
+// Daftar sekolah disimpan di HP, bukan diminta ulang tiap halaman dibuka.
+// Tabelnya 517 baris sejak 0157 — 94 KB JSON — dan pembina membuka form yang
+// sama berkali-kali: mengisi separuh, menutup, kembali lagi.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const daftar = await readFile(new URL("../live/js/daftar.js", import.meta.url), "utf8");
+
+test("daftar sekolah dipakai dari simpanan sebelum diminta ulang", () => {
+  assert.match(daftar, /const simpanan = sekolahTersimpan\(\);/);
+  assert.match(daftar, /if \(simpanan\) \{\s*SEKOLAH = simpanan\.isi;/);
+  assert.match(daftar, /if \(simpanan\.basi\) segarkanSekolah\(\);/);
+  // Tanpa simpanan ia tetap meminta seperti biasa, lalu menyimpannya.
+  assert.match(daftar, /\[SEKOLAH, EDISI\] = await Promise\.all\(\[daftarSekolah\(\), infoEdisi\(\)\]\);\s*simpanSekolah\(SEKOLAH\);/);
+});
+
+test("infoEdisi TIDAK ikut disimpan", () => {
+  // Ia yang memutus pendaftaran masih dibuka atau tidak. Menyimpannya berarti
+  // form yang sudah ditutup masih menerima kiriman selama masa simpan.
+  const simpan = daftar.slice(daftar.indexOf("function simpanSekolah"),
+                              daftar.indexOf("async function segarkanSekolah"));
+  assert.doesNotMatch(simpan, /infoEdisi/);
+  assert.match(daftar, /EDISI = await infoEdisi\(\);/);
+});
+
+test("setiap sentuhan localStorage dibungkus try/catch", () => {
+  // Di mode privat sebagian browser MELEMPAR, bukan mengembalikan null, dan
+  // form yang gagal terbuka gara-gara cache adalah pertukaran yang salah arah.
+  for (const fn of ["sekolahTersimpan", "simpanSekolah"]) {
+    const i = daftar.indexOf(`function ${fn}`);
+    assert.ok(i > 0, `${fn} tidak ada`);
+    const badan = daftar.slice(i, daftar.indexOf("\n}", i));
+    assert.match(badan, /try \{/, `${fn} menyentuh localStorage tanpa try`);
+    assert.match(badan, /catch/, `${fn} tidak menangkap galat localStorage`);
+  }
+});
+
+test("penyegaran latar belakang gagal dengan diam", () => {
+  // Yang sudah di layar tetap bisa dipakai; memunculkan galat untuk
+  // penyegaran yang tidak diminta siapa pun cuma membuat pembina mengira
+  // formnya rusak.
+  const i = daftar.indexOf("async function segarkanSekolah");
+  const badan = daftar.slice(i, daftar.indexOf("\n}", i));
+  assert.match(badan, /catch \{ \/\* diam \*\/ \}/);
+  // Hasil kosong tidak boleh menimpa daftar yang sudah benar.
+  assert.match(badan, /if \(Array\.isArray\(baru\) && baru\.length\)/);
+});
+
+test("umur simpanan ditulis sebagai angka yang bisa dibaca", () => {
+  assert.match(daftar, /const UMUR_SEKOLAH = 6 \* 60 \* 60 \* 1000;/);
+});


### PR DESCRIPTION
## What

Halaman `/daftar` menyimpan daftar sekolah di HP pembina, bukan memintanya ulang ke database tiap kali dibuka.

| | Sebelum | Sesudah |
| --- | --- | --- |
| Buka pertama | `/sekolah` **94 KB** + `/edisi` | sama |
| **Buka kedua dan seterusnya** | `/sekolah` **94 KB** + `/edisi` | **`/edisi` saja, 180 byte** |
| Mengetik di kotak sekolah | dari memori | dari memori |

## Why

Tabel `sekolah` jadi **517 baris** sejak `0157` memasukkan seluruh SMP/MTs/SMA/SMK/MA se-Kabupaten Ciamis — 94 KB JSON, diminta ulang **setiap kali** halaman dibuka. Pembina membuka form yang sama berkali-kali: mengisi separuh, menutup, kembali lagi, mengoreksi satu regu. Isinya nyaris tidak pernah berubah di antara kunjungan itu, dan yang membayarnya kuota HP di lapangan.

## Bentuknya: pakai dulu, segarkan belakangan

Kalau ada simpanan ia dipakai **seketika** — halaman terbuka tanpa satu permintaan sekolah pun. Kalau simpanannya sudah lewat **enam jam**, penyegaran jalan di latar belakang dan `SEKOLAH` diganti begitu datang.

Itu aman karena **tidak ada yang menyalin `SEKOLAH` ke indeks siapkan-dulu**: `cariSekolah(SEKOLAH, ...)` membacanya saat diketik, jadi hasil yang lebih baru langsung terpakai pada ketukan berikutnya.

**`infoEdisi()` sengaja TIDAK ikut disimpan.** Ia 180 byte, dan ia yang memutus pendaftaran masih dibuka atau tidak — menyimpannya berarti form yang sudah ditutup masih menerima kiriman selama enam jam.

**Basi paling parah yang bisa terjadi:** sekolah yang baru mendaftar hari ini belum muncul di kotak cari pembina lain. Yang mengetiknya tetap menulis nama yang sama, dan `kunci_sekolah()` di database tetap menyatukannya ke satu baris — jadi yang hilang kenyamanan, bukan kebenaran.

## Notes

- **Diukur di browser, bukan disimpulkan.** Form dijalankan lokal terhadap database dev: buka pertama satu permintaan `/sekolah` lalu tersimpan (205 baris, 37 KB di localStorage); **buka kedua nol permintaan sekolah**, dan mengetik `smpn 1 kaw` tetap memunculkan `SMPN 1 Kawali` lengkap alamatnya. Sepanjang sesi kedua yang menyentuh database cuma `/edisi`.
- **Seluruh sentuhan `localStorage` dibungkus try/catch.** Di mode privat sebagian browser MELEMPAR, bukan mengembalikan null, dan form yang gagal terbuka gara-gara cache adalah pertukaran yang salah arah.
- **Penyegaran latar belakang gagal dengan diam**, dan hasil kosong tidak menimpa daftar yang sudah benar.
- Yang TIDAK diubah: pemeriksaan nama regu sudah hemat sejak awal — ditunda 450 ms dan diingat per nama, jadi mengetik tidak melahirkan satu permintaan per huruf.
- `tests/registration_school_cache.test.mjs` baru (5 tes) menjaga kelima sifat di atas. `node --test` — **271 tes, 271 lulus, nol gagal.**
