### PR TITLE
fix: finish the Ciamis addresses and merge two twins the import missed

### DIFF
--- a/supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
+++ b/supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
@@ -1,0 +1,257 @@
+-- ============================================================================
+-- hrcd-rekap : 0160_kode_pos_dan_nama_tersisa.sql
+-- Kode pos untuk 297 alamat direktori, dan empat nama yang tidak berjenjang.
+--
+-- KENAPA ADA
+--
+-- 0157 memasukkan 309 sekolah se-Kabupaten Ciamis dari Data Referensi, dan
+-- kolom alamat Dapodik memuat kode pos hanya pada delapan di antaranya. Bentuk
+-- alamat yang dipakai repositori ini (runbook bagian 8) menyertakan kode pos:
+--
+--   jalan, desa, Kec. X, Kabupaten Y, Jawa Barat NNNNN, Indonesia
+--
+-- Jadi 297 baris berbentuk benar tetapi tidak lengkap, dan itu kelihatan di
+-- kotak cari pendaftaran — dua sekolah bersebelahan, yang satu berkode pos,
+-- yang satu tidak.
+--
+-- DARI MANA ANGKANYA, DAN KENAPA BOLEH DIPERCAYA
+--
+-- Dari daftar kode pos per desa se-Kabupaten Ciamis. Yang membuatnya layak
+-- dipakai bukan situsnya, melainkan bahwa ia DIUJI DULU terhadap isi produksi
+-- sendiri: 130 baris kurasi di Kabupaten Ciamis sudah punya kode pos, dan
+-- rujukan itu setuju dengan SELURUH 130 — nol berbeda, nol desa yang tidak
+-- dikenalnya. Termasuk dua angka yang dulu sempat diperdebatkan: Panyingkiran
+-- 46211 (bukan 46251) dan Cigayam 46384 (bukan 46383, dibetulkan 0159).
+--
+-- DUA CARA MENCOCOKKAN, DAN KENAPA HARUS DUA
+--
+-- Dua puluh enam kecamatan Kabupaten Ciamis memakai SATU kode pos untuk
+-- seluruh desanya, jadi nama kecamatannya sudah cukup. Kecamatan Ciamis
+-- TIDAK: dua belas desanya terbagi ke enam kode pos (46211 sampai 46219),
+-- karena ia kecamatan kotanya. Mencocokkan Kec. Ciamis lewat kecamatan akan
+-- memberi angka yang salah kepada sebelas dari dua belas desanya, jadi ia
+-- dicocokkan lewat NAMA DESA dan punya tabelnya sendiri di bawah.
+--
+-- EMPAT NAMA YANG TIDAK BERJENJANG
+--
+-- Data Referensi menulis nama satuan tanpa bentuk pendidikannya, dan untuk
+-- tiga baris bentuk itu tidak ikut tersalin waktu 0157 dibuat. Bentuknya
+-- diambil dari halaman NPSN masing-masing:
+--
+--   Al-Hikmah              -> MA Al-Hikmah            (NPSN 69976341, bentuk MA)
+--   Intesif An-Najmu       -> MA Intensif An-Najmu    (NPSN 69976342, bentuk MA)
+--   Pdf Ulya Pp Darussalam -> PDF Ulya PP Darussalam  (NPSN 69937222, bentuk PDF Ulya)
+--
+-- "Intensif" ditulis dengan huruf N yang di daftar resmi hilang. Data
+-- Referensi mengejanya "INTESIF", dan direktori lain menyalin ejaan itu dari
+-- sana — jadi keduanya satu sumber, bukan dua. Yang menentukan di sini kotak
+-- cari: pembina mengetik "intensif", dan "Intesif" tidak akan ketemu. Tidak
+-- ada satu pendaftaran pun yang menunjuk baris ini, jadi ini murni soal bisa
+-- ditemukan atau tidak.
+--
+-- PDF Ulya setara SMA, jadi ia memang boleh ikut golongan Penegak. Pendidikan
+-- Diniyah Formal jenjang Ulya adalah satuan formal di bawah Kemenag; namanya
+-- ditulis huruf besar seperti singkatan lain.
+--
+-- SMP AL FADLILIYAH DARUSSALAM: ALAMATNYA DIISI, TIDAK DILEBUR
+--
+-- Baris ini satu-satunya di seluruh tabel yang alamatnya bukan alamat:
+-- "Jl KH Ahmad Fadhil", tanpa desa, tanpa kecamatan, tanpa kabupaten — tanda
+-- khas alamat yang DIKETIK di form pendaftaran. Ia diberi alamat kampus
+-- pesantrennya dan ejaannya disamakan dengan baris MTs-nya.
+--
+-- Yang TIDAK dilakukan di sini: meleburnya. Data Referensi tidak memuat SMP
+-- dengan nama itu — kompleks Pesantren Darussalam terdaftar sebagai MI, MTs
+-- Al-Fadliliyah Darussalam (NPSN 20211978), SMA Plus Darussalam, dan PDF Ulya.
+-- Jadi ada dua kemungkinan yang sama masuk akalnya: SMP yang memang ada tetapi
+-- belum terdaftar, atau salah ketik untuk MTs-nya. Keduanya setingkat
+-- Penggalang, jadi tidak ada di data yang bisa memutuskan. Meleburnya
+-- memindahkan pendaftaran, dan itu keputusan pemilik acara, bukan keputusan
+-- yang boleh diambil diam-diam oleh sebuah migrasi (CLAUDE.md 12.3). Blok
+-- terakhir mencetak `raise notice` supaya pertanyaannya tidak hilang.
+--
+-- REKAP NILAI TIDAK DISENTUH. Hanya `sekolah.name` dan `sekolah.address` yang
+-- diubah; tidak ada baris dilebur, ditambah, atau dihapus, jadi tidak ada
+-- `pendaftaran.sekolah_id` yang berpindah. Blok penutup membandingkan
+-- jumlahnya.
+--
+-- BISA DIJALANKAN DUA KALI: penggantian nama menyaring nama lamanya, dan
+-- pengisian kode pos hanya mengenai alamat yang berakhir "Jawa Barat,".
+-- ============================================================================
+
+drop table if exists potret_0160;
+create temporary table potret_0160 as
+select (select count(*) from regu)         as regu,
+       (select count(*) from nilai_mentah) as nilai_mentah,
+       (select count(*) from closing_regu) as closing_regu,
+       (select count(*) from pendaftaran)  as pendaftaran,
+       (select count(*) from sekolah)      as sekolah;
+
+-- ---------------------------------------------------------------------------
+-- 1. Empat nama.
+-- ---------------------------------------------------------------------------
+drop table if exists nama_0160;
+create temporary table nama_0160 (lama text, baru text, npsn text);
+insert into nama_0160 (lama, baru, npsn) values
+  ('Al-Hikmah',                    'MA Al-Hikmah',                 '69976341'),
+  ('Intesif An-Najmu',             'MA Intensif An-Najmu',         '69976342'),
+  ('Pdf Ulya Pp Darussalam',       'PDF Ulya PP Darussalam',       '69937222'),
+  ('SMP AL Fadliliyah Darussalam', 'SMP Al-Fadliliyah Darussalam', null);
+
+do $$
+declare r record; v_n int; v_total int := 0;
+begin
+  for r in select * from nama_0160 order by lama loop
+    if not exists (select 1 from sekolah where name = r.lama) then
+      raise notice '0160: (dilewati) "%" memang tidak ada.', r.lama;
+      continue;
+    end if;
+    -- Nama barunya tidak boleh sudah dipakai baris LAIN: itu peleburan, dan
+    -- peleburan bukan pekerjaan migrasi ini.
+    if exists (select 1 from sekolah
+                where kunci_sekolah(name) = kunci_sekolah(r.baru)
+                  and name <> r.lama) then
+      raise exception '0160: "%" sudah ada sebagai baris lain — itu peleburan, bukan penggantian nama', r.baru;
+    end if;
+    update sekolah set name = r.baru where name = r.lama;
+    get diagnostics v_n = row_count;
+    v_total := v_total + v_n;
+    raise notice '0160: "%" -> "%" (NPSN %).', r.lama, r.baru, coalesce(r.npsn, 'tidak terdaftar');
+  end loop;
+  raise notice '0160: % nama dibakukan.', v_total;
+end $$;
+
+-- Alamat kampus pesantrennya. Desa Dewasari, Kec. Cijeungjing, sama dengan
+-- baris MTs-nya, dan 46271 kode pos seluruh sebelas desa Cijeungjing.
+update sekolah
+   set address = 'Jl. K.H. Ahmad Fadlil I, Dewasari, Kec. Cijeungjing, Kabupaten Ciamis, Jawa Barat 46271, Indonesia'
+ where name = 'SMP Al-Fadliliyah Darussalam'
+   and address not like '%Kec. Cijeungjing%';
+
+-- ---------------------------------------------------------------------------
+-- 2. Kode pos: dua puluh enam kecamatan yang seragam.
+-- ---------------------------------------------------------------------------
+drop table if exists kodepos_kec_0160;
+create temporary table kodepos_kec_0160 (kecamatan text, kodepos text);
+insert into kodepos_kec_0160 (kecamatan, kodepos) values
+  ('Banjaranyar', '46384'),
+  ('Banjarsari', '46383'),
+  ('Baregbeg', '46274'),
+  ('Cidolog', '46352'),
+  ('Cihaurbeuti', '46262'),
+  ('Cijeungjing', '46271'),
+  ('Cikoneng', '46261'),
+  ('Cimaragas', '46381'),
+  ('Cipaku', '46252'),
+  ('Cisaga', '46386'),
+  ('Jatinagara', '46273'),
+  ('Kawali', '46253'),
+  ('Lakbok', '46385'),
+  ('Lumbung', '46258'),
+  ('Pamarican', '46382'),
+  ('Panjalu', '46264'),
+  ('Panawangan', '46255'),
+  ('Panumbangan', '46263'),
+  ('Purwadadi', '46385'),
+  ('Rajadesa', '46254'),
+  ('Rancah', '46387'),
+  ('Sadananya', '46256'),
+  ('Sindangkasih', '46268'),
+  ('Sukadana', '46272'),
+  ('Sukamantri', '46264'),
+  ('Tambaksari', '46388');
+
+-- ---------------------------------------------------------------------------
+-- 3. Kode pos: dua belas desa Kecamatan Ciamis, yang TIDAK seragam.
+-- ---------------------------------------------------------------------------
+drop table if exists kodepos_ciamis_0160;
+create temporary table kodepos_ciamis_0160 (desa text, kodepos text);
+insert into kodepos_ciamis_0160 (desa, kodepos) values
+  ('Benteng', '46217'),
+  ('Ciamis', '46211'),
+  ('Cigembor', '46212'),
+  ('Cisadap', '46215'),
+  ('Imbanagara', '46219'),
+  ('Imbanagara Raya', '46219'),
+  ('Kertasari', '46213'),
+  ('Linggasari', '46216'),
+  ('Maleber', '46214'),
+  ('Panyingkiran', '46211'),
+  ('Pawindan', '46218'),
+  ('Sindangrasa', '46215');
+
+do $$
+declare v_kec int; v_kota int;
+begin
+  update sekolah s
+     set address = replace(s.address, 'Jawa Barat, Indonesia',
+                           'Jawa Barat ' || k.kodepos || ', Indonesia')
+    from kodepos_kec_0160 k
+   where s.address like '%Kec. ' || k.kecamatan || ',%'
+     and s.address like '%Kabupaten Ciamis%'
+     and s.address like '%Jawa Barat, Indonesia';
+  get diagnostics v_kec = row_count;
+
+  update sekolah s
+     set address = replace(s.address, 'Jawa Barat, Indonesia',
+                           'Jawa Barat ' || k.kodepos || ', Indonesia')
+    from kodepos_ciamis_0160 k
+   where s.address like '%, ' || k.desa || ', Kec. Ciamis,%'
+     and s.address like '%Kabupaten Ciamis%'
+     and s.address like '%Jawa Barat, Indonesia';
+  get diagnostics v_kota = row_count;
+
+  raise notice '0160: % kode pos lewat kecamatan, % lewat desa Kec. Ciamis.', v_kec, v_kota;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Pemeriksaan penutup.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  s potret_0160%rowtype;
+  n_regu int; n_nilai int; n_closing int; n_daftar int; n_sekolah int;
+  v_sisa int; v_kembar int;
+begin
+  select * into s from potret_0160;
+  select count(*) into n_regu    from regu;
+  select count(*) into n_nilai   from nilai_mentah;
+  select count(*) into n_closing from closing_regu;
+  select count(*) into n_daftar  from pendaftaran;
+  select count(*) into n_sekolah from sekolah;
+
+  assert (n_regu, n_nilai, n_closing, n_daftar, n_sekolah)
+         = (s.regu, s.nilai_mentah, s.closing_regu, s.pendaftaran, s.sekolah),
+    format('0160: DATA BERGESER — regu %s->%s, nilai %s->%s, closing %s->%s, pendaftaran %s->%s, sekolah %s->%s',
+           s.regu, n_regu, s.nilai_mentah, n_nilai, s.closing_regu, n_closing,
+           s.pendaftaran, n_daftar, s.sekolah, n_sekolah);
+
+  -- Tidak ada lagi alamat Kabupaten Ciamis tanpa kode pos.
+  select count(*) into v_sisa from sekolah
+   where address like '%Kabupaten Ciamis%' and address !~ '\m\d{5}\M';
+  assert v_sisa = 0,
+    format('0160: masih ada %s alamat Kabupaten Ciamis tanpa kode pos', v_sisa);
+
+  -- Penggantian nama tidak melahirkan kembar.
+  select count(*) into v_kembar from (
+    select kunci_sekolah(name) from sekolah group by 1 having count(*) > 1) x;
+  assert v_kembar = 0, format('0160: %s kunci sekolah kembar', v_kembar);
+
+  raise notice '0160: % sekolah, rekap nilai utuh — % regu, % nilai, % closing.',
+               n_sekolah, n_regu, n_nilai, n_closing;
+end $$;
+
+-- Pertanyaan yang sengaja TIDAK diputuskan migrasi ini. Dicetak tiap kali
+-- dijalankan supaya tidak hilang di antara catatan lain.
+do $$
+begin
+  if exists (select 1 from sekolah where name = 'SMP Al-Fadliliyah Darussalam')
+     and exists (select 1 from sekolah where name = 'MTs Al-Fadliliyah Darussalam') then
+    raise notice '0160: PERIKSA — "SMP Al-Fadliliyah Darussalam" tidak ada di Data Referensi, dan "MTs Al-Fadliliyah Darussalam" (NPSN 20211978) beralamat sama. Keduanya setingkat Penggalang. Kalau pemilik acara memastikan keduanya satu sekolah, peleburannya perlu migrasi tersendiri.';
+  end if;
+end $$;
+
+drop table if exists potret_0160;
+drop table if exists nama_0160;
+drop table if exists kodepos_kec_0160;
+drop table if exists kodepos_ciamis_0160;

--- a/supabase/migrations/0161_lebur_kembar_ejaan.sql
+++ b/supabase/migrations/0161_lebur_kembar_ejaan.sql
@@ -1,0 +1,139 @@
+-- ============================================================================
+-- hrcd-rekap : 0161_lebur_kembar_ejaan.sql
+-- Dua kembar lagi bawaan impor 0157, dan satu nama Satu Atap yang menyendiri.
+--
+-- KELAS KESALAHAN YANG SAMA DENGAN 0159, DAN INI KETIGA KALINYA
+--
+-- 0157 menyaring impornya dengan dua kunci penyamaan nama, dan dua baris ini
+-- lolos dari keduanya karena EJAANNYA berbeda, bukan namanya:
+--
+--   MA Daarul Huda                 = MA Darul Huda        (NPSN 70059223)
+--   SMK Galuh Rahayu Sindangkasih  = SMK Galuh Rahayu     (NPSN 20254622)
+--
+-- Yang membuktikannya bukan kemiripan nama melainkan NPSN, dan NPSN-nya ada
+-- di `tools/data/sekolah_alamat.json` — kedua baris kurasi itu mencatat
+-- `nama_resmi` yang PERSIS SAMA dengan nama yang diimpor 0157: "MA DAARUL
+-- HUDA" dan "SMKS Galuh Rahayu Sindangkasih". Jadi buktinya sudah ada di
+-- repositori ini sejak awal; yang tidak ada adalah pemeriksaan yang membacanya.
+--
+-- `sekolah` tidak menyimpan NPSN, jadi penyaringan impor tidak akan pernah
+-- bisa lengkap — persis alasan yang ditulis 0159. Yang menahan kembar
+-- berikutnya cuma `supabase/checks/sekolah_kembar.sql`, dan kali ini ia
+-- BEKERJA: aturan B (ejaan h / huruf ganda) menangkap Daarul Huda, dan aturan
+-- "satu nama memuat sisipan yang satunya tidak" menangkap Galuh Rahayu.
+-- Jalankan pemeriksa itu sesudah setiap impor, bukan sesudah ada yang
+-- mengeluh.
+--
+-- YANG BERTAHAN NAMA KURASINYA, SEPERTI 0159
+--
+-- Nama resmi keduanya lebih panjang, dan runbook bagian 5 menahan nama yang
+-- DIUCAPKAN orang. Tidak ada yang menyebut "SMKS Galuh Rahayu Sindangkasih"
+-- di lapangan, dan sekolah itu sudah pernah mendaftar dengan nama pendeknya.
+-- Nama resminya tetap tercatat di `sekolah_alamat.json`.
+--
+-- SMPN 1 ATAP 1 BANJARSARI -> SMPN SATU ATAP 1 BANJARSARI
+--
+-- Bukan kembar, cuma sendirian. Data Referensi meringkas "Satu Atap" jadi
+-- "1 Atap" pada baris ini saja (NPSN 20252095) sementara empat saudaranya
+-- ditulis penuh: Jatinagara, Panumbangan, Sukamantri, Cipaku. Akibatnya
+-- pembina yang mengetik "satu atap" menemukan empat dari lima. Nama sekolahnya
+-- tetap Banjarsari walau letaknya di Kec. Banjaranyar — kecamatannya mekar
+-- tahun 2015 dan sekolahnya tidak ikut berganti nama, sama seperti SMAN 2
+-- Banjarsari di 0159.
+--
+-- REKAP NILAI TIDAK DISENTUH. Kedua baris yang dibuang lahir dari impor 0157
+-- dan belum pernah dipilih siapa pun, tetapi pengalihan pendaftaran tetap
+-- dijalankan sebelum penghapusan — persis seperti 0154 dan 0159 — supaya
+-- benar walau anggapan itu meleset. Blok penutup membandingkan jumlah barisnya.
+--
+-- BISA DIJALANKAN DUA KALI.
+-- ============================================================================
+
+drop table if exists potret_0161;
+create temporary table potret_0161 as
+select (select count(*) from regu)         as regu,
+       (select count(*) from nilai_mentah) as nilai_mentah,
+       (select count(*) from closing_regu) as closing_regu,
+       (select count(*) from pendaftaran)  as pendaftaran;
+
+drop table if exists lebur_0161;
+create temporary table lebur_0161 (buang text, simpan text, npsn text);
+insert into lebur_0161 (buang, simpan, npsn) values
+  ('MA Daarul Huda',                'MA Darul Huda',    '70059223'),
+  ('SMK Galuh Rahayu Sindangkasih', 'SMK Galuh Rahayu', '20254622');
+
+do $$
+declare r record; v_p int; v_k int; v_total int := 0;
+begin
+  for r in select * from lebur_0161 order by buang loop
+    if not exists (select 1 from sekolah where name = r.buang) then
+      raise notice '0161: (dilewati) "%" memang tidak ada.', r.buang;
+      continue;
+    end if;
+    if not exists (select 1 from sekolah where name = r.simpan) then
+      raise exception '0161: "%" ada tetapi "%" tidak — pasangan peleburan salah',
+                      r.buang, r.simpan;
+    end if;
+
+    update pendaftaran d
+       set sekolah_id = (select id from sekolah where name = r.simpan)
+     where d.sekolah_id = (select id from sekolah where name = r.buang);
+    get diagnostics v_p = row_count;
+
+    update kejuaraan_manual m
+       set sekolah_id = (select id from sekolah where name = r.simpan)
+     where m.sekolah_id = (select id from sekolah where name = r.buang);
+    get diagnostics v_k = row_count;
+
+    delete from sekolah where name = r.buang;
+    v_total := v_total + 1;
+    raise notice '0161: "%" -> "%" (NPSN %, % pendaftaran, % penghargaan dialihkan)',
+                 r.buang, r.simpan, r.npsn, v_p, v_k;
+  end loop;
+  raise notice '0161: % baris kembar dilebur.', v_total;
+end $$;
+
+do $$
+declare v_n int;
+begin
+  if exists (select 1 from sekolah where name = 'SMPN Satu Atap 1 Banjarsari') then
+    raise notice '0161: (dilewati) "SMPN Satu Atap 1 Banjarsari" sudah bernama begitu.';
+  else
+    update sekolah set name = 'SMPN Satu Atap 1 Banjarsari'
+     where name = 'SMPN 1 Atap 1 Banjarsari';
+    get diagnostics v_n = row_count;
+    raise notice '0161: % nama Satu Atap dibakukan (NPSN 20252095).', v_n;
+  end if;
+end $$;
+
+do $$
+declare
+  s potret_0161%rowtype;
+  n_regu int; n_nilai int; n_closing int; n_daftar int;
+  v_sekolah int; v_kembar int;
+begin
+  select * into s from potret_0161;
+  select count(*) into n_regu    from regu;
+  select count(*) into n_nilai   from nilai_mentah;
+  select count(*) into n_closing from closing_regu;
+  select count(*) into n_daftar  from pendaftaran;
+  select count(*) into v_sekolah from sekolah;
+
+  assert (n_regu, n_nilai, n_closing, n_daftar)
+         = (s.regu, s.nilai_mentah, s.closing_regu, s.pendaftaran),
+    format('0161: DATA NILAI BERGESER — regu %s->%s, nilai %s->%s, closing %s->%s, pendaftaran %s->%s',
+           s.regu, n_regu, s.nilai_mentah, n_nilai, s.closing_regu, n_closing,
+           s.pendaftaran, n_daftar);
+  assert not exists (select 1 from pendaftaran where sekolah_id is null),
+    '0161: ada pendaftaran yang kehilangan sekolahnya';
+
+  select count(*) into v_kembar from (
+    select kunci_sekolah(name) from sekolah group by 1 having count(*) > 1) x;
+  assert v_kembar = 0, format('0161: %s kunci sekolah kembar', v_kembar);
+
+  raise notice '0161: % baris sekolah, rekap nilai utuh — % regu, % nilai, % closing.',
+               v_sekolah, n_regu, n_nilai, n_closing;
+end $$;
+
+drop table if exists potret_0161;
+drop table if exists lebur_0161;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -341,5 +341,7 @@ run supabase/migrations/0156_smk_lps_satu_dan_dua.sql
 run supabase/migrations/0157_direktori_sekolah_ciamis.sql
 run supabase/migrations/0158_rapikan_alamat_direktori.sql
 run supabase/migrations/0159_lebur_kembar_direktori.sql
+run supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
+run supabase/migrations/0161_lebur_kembar_ejaan.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -716,5 +716,9 @@ run supabase/migrations/0158_rapikan_alamat_direktori.sql
 run tests/sql/110_rapikan_alamat_direktori.sql
 run supabase/migrations/0159_lebur_kembar_direktori.sql
 run tests/sql/111_lebur_kembar_direktori.sql
+run supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
+run tests/sql/112_kode_pos_dan_nama_tersisa.sql
+run supabase/migrations/0161_lebur_kembar_ejaan.sql
+run tests/sql/113_lebur_kembar_ejaan.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/112_kode_pos_dan_nama_tersisa.sql
+++ b/tests/sql/112_kode_pos_dan_nama_tersisa.sql
@@ -1,0 +1,89 @@
+\echo '--- 112. kode pos Kabupaten Ciamis, empat nama berjenjang, rekap nilai utuh'
+
+-- 0160 dijalankan tepat sebelum berkas ini. Database uji tidak memuat baris
+-- ketikan pembina yang jadi alasan migrasinya ada, jadi yang diperiksa di sini
+-- bukan jumlah barisnya melainkan bahwa jalur yang MEMANG berlaku berjalan
+-- benar, dan bahwa pagarnya masih terpasang.
+
+do $$
+declare v_alamat text;
+begin
+  -- 1. Ketiga nama tanpa jenjang mendapat bentuk pendidikannya. Ketiganya
+  --    lahir dari impor 0157, jadi ketiganya ADA di database uji.
+  assert exists (select 1 from sekolah where name = 'MA Al-Hikmah'),
+    '112.1 GAGAL: "Al-Hikmah" belum jadi "MA Al-Hikmah"';
+  assert exists (select 1 from sekolah where name = 'MA Intensif An-Najmu'),
+    '112.2 GAGAL: "Intesif An-Najmu" belum jadi "MA Intensif An-Najmu"';
+  assert exists (select 1 from sekolah where name = 'PDF Ulya PP Darussalam'),
+    '112.3 GAGAL: "Pdf Ulya Pp Darussalam" belum jadi "PDF Ulya PP Darussalam"';
+
+  assert not exists (select 1 from sekolah
+                      where name in ('Al-Hikmah', 'Intesif An-Najmu',
+                                     'Pdf Ulya Pp Darussalam')),
+    '112.4 GAGAL: nama lama tanpa jenjang masih ada';
+
+  -- 2. Kode posnya ikut terisi lewat kecamatannya.
+  select address into v_alamat from sekolah where name = 'MA Al-Hikmah';
+  assert v_alamat like '%Jawa Barat 46252, Indonesia',
+    format('112.5 GAGAL: MA Al-Hikmah (Kec. Cipaku) bukan 46252: %s', v_alamat);
+end;
+$$;
+
+do $$
+declare v_sisa int; v_salah int;
+begin
+  -- 3. Tidak ada satu pun alamat Kabupaten Ciamis yang tertinggal tanpa kode
+  --    pos. Ini yang menahan impor berikutnya menambah alamat setengah jadi.
+  select count(*) into v_sisa from sekolah
+   where address like '%Kabupaten Ciamis%' and address !~ '\m\d{5}\M';
+  assert v_sisa = 0,
+    format('112.6 GAGAL: %s alamat Kabupaten Ciamis tanpa kode pos', v_sisa);
+
+  -- 4. Kode pos Kabupaten Ciamis selalu 462xx, 463xx, atau 46352 — tidak
+  --    pernah angka provinsi lain. Menangkap salah tempel di tabel rujukan.
+  select count(*) into v_salah from sekolah
+   where address like '%Kabupaten Ciamis%'
+     and substring(address from '\m(\d{5})\M') !~ '^46(2[0-9][0-9]|3[0-9][0-9])$';
+  assert v_salah = 0,
+    format('112.7 GAGAL: %s kode pos di luar rentang Kabupaten Ciamis', v_salah);
+end;
+$$;
+
+do $$
+declare v_kp text;
+begin
+  -- 5. Kecamatan Ciamis dicocokkan lewat DESA, bukan lewat kecamatan. Kalau
+  --    seseorang menyederhanakannya jadi satu kode pos per kecamatan, dua
+  --    baris ini akan bertabrakan — keduanya Kec. Ciamis, kode posnya beda.
+  select substring(address from '\m(\d{5})\M') into v_kp
+    from sekolah where name = 'SMAN 3 Ciamis';   -- Maleber
+  assert v_kp = '46214',
+    format('112.8 GAGAL: SMAN 3 Ciamis (Maleber) bukan 46214: %s', v_kp);
+
+  select substring(address from '\m(\d{5})\M') into v_kp
+    from sekolah where name = 'MTsN 1 Ciamis';   -- Panyingkiran
+  assert v_kp = '46211',
+    format('112.9 GAGAL: MTsN 1 Ciamis (Panyingkiran) bukan 46211: %s', v_kp);
+end;
+$$;
+
+do $$
+declare v_kembar int; v_regu int; v_nilai int;
+begin
+  -- 6. Penggantian nama tidak melahirkan kembar, dan rekap nilai utuh.
+  select count(*) into v_kembar from (
+    select kunci_sekolah(name) from sekolah group by 1 having count(*) > 1) x;
+  assert v_kembar = 0, format('112.10 GAGAL: %s kunci sekolah kembar', v_kembar);
+
+  select count(*) into v_regu  from regu;
+  select count(*) into v_nilai from nilai_mentah;
+  assert v_regu > 0, '112.11 GAGAL: tabel regu kosong sesudah 0160';
+
+  assert not exists (select 1 from pendaftaran where sekolah_id is null),
+    '112.12 GAGAL: ada pendaftaran tanpa sekolah';
+
+  raise notice '112: % regu, % nilai tetap utuh.', v_regu, v_nilai;
+end;
+$$;
+
+\echo '112 kode pos dan nama tersisa: LULUS'

--- a/tests/sql/113_lebur_kembar_ejaan.sql
+++ b/tests/sql/113_lebur_kembar_ejaan.sql
@@ -1,0 +1,55 @@
+\echo '--- 113. kembar ejaan dilebur, nama Satu Atap dibakukan, rekap nilai utuh'
+
+do $$
+begin
+  -- 1. Yang bertahan nama kurasinya, yang panjang hilang.
+  assert exists (select 1 from sekolah where name = 'MA Darul Huda'),
+    '113.1 GAGAL: MA Darul Huda hilang — yang dilebur seharusnya yang satunya';
+  assert not exists (select 1 from sekolah where name = 'MA Daarul Huda'),
+    '113.2 GAGAL: MA Daarul Huda (NPSN 70059223) masih ada';
+
+  assert exists (select 1 from sekolah where name = 'SMK Galuh Rahayu'),
+    '113.3 GAGAL: SMK Galuh Rahayu hilang';
+  assert not exists (select 1 from sekolah where name = 'SMK Galuh Rahayu Sindangkasih'),
+    '113.4 GAGAL: SMK Galuh Rahayu Sindangkasih (NPSN 20254622) masih ada';
+
+  -- 2. Kelima Satu Atap ditulis dengan cara yang sama, supaya pembina yang
+  --    mengetik "satu atap" menemukan kelimanya dan bukan empat.
+  assert exists (select 1 from sekolah where name = 'SMPN Satu Atap 1 Banjarsari'),
+    '113.5 GAGAL: SMPN 1 Atap 1 Banjarsari belum dibakukan';
+  assert not exists (select 1 from sekolah where name like '%1 Atap%'),
+    '113.6 GAGAL: masih ada nama yang meringkas "Satu Atap" jadi "1 Atap"';
+end;
+$$;
+
+do $$
+declare v_n int;
+begin
+  select count(*) into v_n from sekolah where name like 'SMPN Satu Atap%';
+  assert v_n = 5, format('113.7 GAGAL: %s baris SMPN Satu Atap, seharusnya 5', v_n);
+end;
+$$;
+
+do $$
+declare v_kembar int; v_regu int;
+begin
+  -- 3. Peleburan tidak meninggalkan pendaftaran yatim, dan tidak melahirkan
+  --    kembar baru.
+  select count(*) into v_kembar from (
+    select kunci_sekolah(name) from sekolah group by 1 having count(*) > 1) x;
+  assert v_kembar = 0, format('113.8 GAGAL: %s kunci sekolah kembar', v_kembar);
+
+  assert not exists (select 1 from pendaftaran where sekolah_id is null),
+    '113.9 GAGAL: ada pendaftaran tanpa sekolah';
+  assert not exists (
+    select 1 from pendaftaran d
+     where not exists (select 1 from sekolah s where s.id = d.sekolah_id)),
+    '113.10 GAGAL: ada pendaftaran menunjuk sekolah yang sudah dihapus';
+
+  select count(*) into v_regu from regu;
+  assert v_regu > 0, '113.11 GAGAL: tabel regu kosong sesudah 0161';
+  raise notice '113: % regu tetap utuh.', v_regu;
+end;
+$$;
+
+\echo '113 lebur kembar ejaan: LULUS'


### PR DESCRIPTION
## What

Audit terhadap **517 baris `sekolah` produksi** menemukan lima hal. Dua migrasi membereskan semuanya.

| | Sebelum | Sesudah |
| --- | --- | --- |
| Alamat Kab. Ciamis tanpa kode pos | **297** | 0 |
| Nama tanpa jenjang | 3 | 0 |
| Alamat yang bukan alamat | 1 | 0 |
| Baris kembar | 2 | 0 |
| Nama "Satu Atap" yang menyendiri | 1 | 0 |
| **Baris sekolah** | 517 | **515** |

### 0160 — kode pos dan empat nama

`0157` menyalin alamat Dapodik apa adanya, dan kolom itu memuat kode pos hanya pada **delapan dari 309** baris. Jadi 297 alamat berbentuk benar tetapi tidak lengkap, dan itu kelihatan di kotak cari: dua sekolah bersebelahan, yang satu berkode pos, yang satu tidak.

Empat nama juga dibakukan, bentuk pendidikannya diambil dari halaman NPSN masing-masing:

| Sebelum | Sesudah | NPSN |
| --- | --- | --- |
| `Al-Hikmah` | `MA Al-Hikmah` | 69976341 |
| `Intesif An-Najmu` | `MA Intensif An-Najmu` | 69976342 |
| `Pdf Ulya Pp Darussalam` | `PDF Ulya PP Darussalam` | 69937222 |
| `SMP AL Fadliliyah Darussalam` | `SMP Al-Fadliliyah Darussalam` | tidak terdaftar |

### 0161 — dua kembar dan satu Satu Atap

`MA Daarul Huda` = `MA Darul Huda` (NPSN 70059223) dan `SMK Galuh Rahayu Sindangkasih` = `SMK Galuh Rahayu` (NPSN 20254622). Ditambah `SMPN 1 Atap 1 Banjarsari` → `SMPN Satu Atap 1 Banjarsari`.

## Why

**Kenapa angka kode posnya boleh dipercaya.** Bukan karena situsnya, tetapi karena ia **diuji dulu terhadap isi produksi sendiri**: 130 baris kurasi di Kabupaten Ciamis sudah punya kode pos, dan rujukan itu setuju dengan **seluruh 130** — nol berbeda, nol desa yang tidak dikenalnya. Termasuk dua angka yang dulu sempat salah: **Panyingkiran 46211** (bukan 46251) dan **Cigayam 46384** (bukan 46383, dibetulkan `0159`).

**Kenapa dua cara mencocokkan, bukan satu.** Dua puluh enam kecamatan Kabupaten Ciamis memakai satu kode pos untuk seluruh desanya. **Kecamatan Ciamis tidak** — dua belas desanya terbagi ke enam kode pos (46211–46219), karena ia kecamatan kotanya. Mencocokkannya lewat kecamatan akan memberi angka yang salah kepada sebelas dari dua belas desanya, jadi ia punya tabel desa sendiri.

**Kenapa kedua kembar itu lolos `0157`.** Saringannya memakai dua kunci penyamaan nama, dan keduanya lolos karena **ejaannya** berbeda, bukan namanya. Yang membuktikan dua baris satu sekolah adalah NPSN, dan `sekolah` tidak menyimpan NPSN — persis alasan yang sudah ditulis `0159`. **Buktinya sebenarnya sudah ada di repositori ini sejak awal**: kedua baris kurasi mencatat `nama_resmi` yang persis sama dengan nama yang diimpor. Yang tidak ada adalah pemeriksaan yang membacanya. Kali ini `supabase/checks/sekolah_kembar.sql` yang menemukannya.

## Notes

- **Rekap nilai tidak disentuh.** Kedua migrasi memotret `regu`, `nilai_mentah`, `closing_regu`, dan `pendaftaran` di awal lalu membandingkannya di akhir; `0161` mengalihkan pendaftaran sebelum menghapus, seperti `0154` dan `0159`, walaupun kedua baris yang dibuang lahir dari impor dan belum pernah dipilih siapa pun.
- **Digladi terhadap 517 baris produksi yang sungguhan** di database sekali pakai, bukan terhadap data uji. Keduanya dijalankan **dua kali** untuk membuktikan idempoten — jalan kedua mengubah nol baris. Hasil akhir 515 baris, **nol temuan dari delapan pemeriksaan**, dan pemeriksa kembar enam aturan turun dari 16 laporan ke 14; keempat belas sisanya sekolah yang memang berbeda desa.
- **Satu pertanyaan sengaja tidak diputuskan.** `SMP Al-Fadliliyah Darussalam` tidak ada di Data Referensi, dan `MTs Al-Fadliliyah Darussalam` (NPSN 20211978) beralamat sama. Keduanya setingkat Penggalang, jadi tidak ada di data yang bisa memutuskan apakah itu SMP yang belum terdaftar atau salah ketik. Meleburnya memindahkan pendaftaran, dan itu keputusan pemilik acara — `0160` mencetak `raise notice` tiap kali dijalankan supaya pertanyaannya tidak hilang.
- **"Intensif" ditulis dengan huruf N yang di daftar resmi hilang.** Data Referensi mengejanya `INTESIF` dan direktori lain menyalin ejaan itu dari sana, jadi keduanya satu sumber, bukan dua. Yang menentukan di sini kotak cari: pembina mengetik "intensif". Tidak ada satu pendaftaran pun yang menunjuk baris ini.
- `tests/run.sh` dan `tests/dev_database.sh` dua-duanya sudah memuat kedua migrasi (CLAUDE.md 7.5). Tes SQL baru: `112` dan `113`. **Seluruh rangkaian dijalankan lokal — SEMUA TES LULUS.**
- Sesudah merge, kedua migrasi perlu **dijalankan lewat `apply-migration.yml`**, `0160` dulu lalu `0161`.
