### PR TITLE
fix: merge SMP Al-Fadliliyah into the MTs, as the event owner confirmed

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,10 +6,10 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0161`: angka
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0162`: angka
 tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database, dan
 bagian 3 diperiksa terhadap layar. Isi bagian 2 sampai 9 selebihnya belum
-dibaca ulang baris demi baris terhadap `0119`-`0161`.
+dibaca ulang baris demi baris terhadap `0119`-`0162`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -74,7 +74,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-161 migrasi, `0001` sampai `0161`, dijalankan berurutan tanpa lubang penomoran.
+162 migrasi, `0001` sampai `0162`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -859,18 +859,33 @@ lewat dua baris yang akan bertabrakan kalau seseorang mencobanya.
 
 ### 13.6 Keadaan sekarang (29 Agustus 2026)
 
-**515 baris `sekolah` di produksi, seluruhnya beralamat lengkap dengan kode
+**514 baris `sekolah` di produksi, seluruhnya beralamat lengkap dengan kode
 pos.** Nol alamat kosong, nol yang bentuknya cacat, nol kunci kembar, nol nama
-tanpa jenjang. Dari 515 itu, 210 terkurasi (bagian 11) dan sisanya dari
+tanpa jenjang. Dari 514 itu, 210 terkurasi (bagian 11) dan sisanya dari
 direktori.
 
-Satu pertanyaan sengaja dibiarkan terbuka: `SMP Al-Fadliliyah Darussalam` tidak
-ada di Data Referensi, dan `MTs Al-Fadliliyah Darussalam` (NPSN 20211978)
-beralamat sama. Keduanya setingkat Penggalang, jadi tidak ada di data yang bisa
-memutuskan apakah itu SMP yang belum terdaftar atau salah ketik. `0160`
-mencetak pertanyaannya lewat `raise notice` tiap kali dijalankan.
+### 13.7 Kalau datanya habis, yang tersisa orang yang tahu
 
-### 13.7 Migrasi dan tesnya
+`SMP Al-Fadliliyah Darussalam` tidak ada di Data Referensi, dan
+`MTs Al-Fadliliyah Darussalam` (NPSN 20211978) beralamat sama dan setingkat
+sama. Bisa jadi SMP yang memang ada tetapi belum terdaftar, bisa jadi salah
+ketik untuk MTs-nya — dan **tidak ada di data yang bisa memutuskan**, karena
+yang biasanya memutuskan adalah NPSN dan di sini NPSN-nya justru tidak ada.
+
+`0160` mengisi alamatnya tetapi sengaja tidak meleburnya, dan mencetak
+pertanyaannya lewat `raise notice` tiap kali dijalankan. Pemilik acara menjawab
+**30 Agustus 2026: yang dimaksud MTs-nya**, dan `0162` meleburkannya.
+
+Pola ini yang layak ditiru, bukan jawabannya. Peleburan memindahkan
+`pendaftaran.sekolah_id`; tebakan yang salah memindahkan regu sungguhan ke
+sekolah yang salah — tidak melempar galat, tidak terlihat di layar mana pun,
+dan baru ketahuan waktu piagam dicetak dengan nama yang keliru. Jadi migrasinya
+mengerjakan bagian yang pasti (alamatnya), menahan bagian yang tidak pasti, dan
+**membawa pertanyaannya keluar** ke tempat yang pasti terbaca. Yang tidak boleh
+adalah menebak diam-diam, atau membiarkan pertanyaannya hilang di antara
+catatan lain.
+
+### 13.8 Migrasi dan tesnya
 
 | Berkas | Isi |
 | --- | --- |
@@ -879,10 +894,11 @@ mencetak pertanyaannya lewat `raise notice` tiap kali dijalankan.
 | `0159_lebur_kembar_direktori.sql` | 4 kembar bawaan impor + kode pos Banjaranyar |
 | `0160_kode_pos_dan_nama_tersisa.sql` | 297 kode pos + 4 nama tanpa jenjang |
 | `0161_lebur_kembar_ejaan.sql` | 2 kembar ejaan + nama Satu Atap |
+| `0162_lebur_smp_al_fadliliyah.sql` | SMP dilebur ke MTs-nya, atas jawaban pemilik acara |
 | `supabase/checks/sekolah_kembar.sql` | pemeriksa enam aturan, hanya membaca |
-| `tests/sql/109`–`113` | tesnya, satu per migrasi |
+| `tests/sql/109`–`114` | tesnya, satu per migrasi |
 
-Kelima migrasi memotret `regu`, `nilai_mentah`, `closing_regu`, dan
+Keenam migrasi memotret `regu`, `nilai_mentah`, `closing_regu`, dan
 `pendaftaran` di awal lalu membandingkannya di akhir. Itu bukan kehati-hatian
 berlebihan: peleburan memindahkan `pendaftaran.sekolah_id`, dan seluruh
 pekerjaan ini dikerjakan **selama acara berjalan** (CLAUDE.md bagian 17).

--- a/supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
+++ b/supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- hrcd-rekap : 0162_lebur_smp_al_fadliliyah.sql
+-- `SMP Al-Fadliliyah Darussalam` dilebur ke `MTs Al-Fadliliyah Darussalam`.
+--
+-- PERTANYAAN YANG 0160 BIARKAN TERBUKA, SEKARANG DIJAWAB
+--
+-- 0160 menemukan satu baris yang alamatnya bukan alamat — "Jl KH Ahmad Fadhil",
+-- tanpa desa, tanpa kecamatan, tanpa kabupaten, tanda khas alamat yang DIKETIK
+-- di form pendaftaran. Ia mengisi alamatnya tetapi sengaja TIDAK meleburnya,
+-- karena tidak ada di data yang bisa memutuskan: Data Referensi tidak memuat
+-- SMP dengan nama itu, dan `MTs Al-Fadliliyah Darussalam` (NPSN 20211978)
+-- beralamat sama dan setingkat sama (Penggalang). Bisa jadi SMP yang memang ada
+-- tetapi belum terdaftar, bisa jadi salah ketik untuk MTs-nya.
+--
+-- **Pemilik acara menjawab 30 Agustus 2026: yang dimaksud MTs-nya.** Jadi
+-- keduanya satu sekolah, dan yang bertahan baris MTs — ia yang punya NPSN,
+-- alamat kurasi, dan nama yang benar-benar dipakai orang.
+--
+-- KENAPA JAWABANNYA HARUS DATANG DARI ORANG, BUKAN DARI MIGRASI
+--
+-- Ini bukan formalitas. Peleburan memindahkan `pendaftaran.sekolah_id`, dan
+-- kalau tebakannya salah, regu sungguhan berpindah ke sekolah yang salah —
+-- kesalahan yang tidak melempar galat, tidak terlihat di layar mana pun, dan
+-- baru ketahuan waktu piagam dicetak dengan nama sekolah yang keliru. Yang
+-- membedakan dua nama mirip adalah NPSN, dan di sini NPSN-nya justru tidak ada
+-- karena satuan itu memang tidak terdaftar. Data habis di titik itu; yang
+-- tersisa cuma orang yang tahu (CLAUDE.md 12.3).
+--
+-- REKAP NILAI TIDAK DISENTUH. Pendaftaran dialihkan lebih dulu, baru barisnya
+-- dihapus; `regu` menempel pada `pendaftaran`, bukan pada `sekolah`, jadi tidak
+-- satu regu pun berpindah maupun hilang. Berbeda dengan 0159 dan 0161 yang
+-- meleburkan baris impor yang belum pernah dipilih siapa pun, baris ini LAHIR
+-- dari sebuah pendaftaran — jadi jumlah yang dialihkan di sini kemungkinan
+-- besar bukan nol, dan `raise notice` menyebutkannya. Blok penutup
+-- membandingkan seluruh jumlah barisnya.
+--
+-- BISA DIJALANKAN DUA KALI: seluruhnya menyaring `where name = <nama lama>`.
+-- ============================================================================
+
+drop table if exists potret_0162;
+create temporary table potret_0162 as
+select (select count(*) from regu)         as regu,
+       (select count(*) from nilai_mentah) as nilai_mentah,
+       (select count(*) from closing_regu) as closing_regu,
+       (select count(*) from pendaftaran)  as pendaftaran;
+
+do $$
+declare
+  v_buang  constant text := 'SMP Al-Fadliliyah Darussalam';
+  v_simpan constant text := 'MTs Al-Fadliliyah Darussalam';
+  v_id_buang uuid; v_id_simpan uuid; v_p int; v_k int;
+begin
+  select id into v_id_buang  from sekolah where name = v_buang;
+  select id into v_id_simpan from sekolah where name = v_simpan;
+
+  if v_id_buang is null then
+    raise notice '0162: (dilewati) "%" memang tidak ada.', v_buang;
+    return;
+  end if;
+  if v_id_simpan is null then
+    raise exception '0162: "%" ada tetapi "%" tidak — peleburan dibatalkan',
+                    v_buang, v_simpan;
+  end if;
+
+  update pendaftaran set sekolah_id = v_id_simpan where sekolah_id = v_id_buang;
+  get diagnostics v_p = row_count;
+
+  update kejuaraan_manual set sekolah_id = v_id_simpan where sekolah_id = v_id_buang;
+  get diagnostics v_k = row_count;
+
+  delete from sekolah where id = v_id_buang;
+
+  raise notice '0162: "%" -> "%" (NPSN 20211978, % pendaftaran, % penghargaan dialihkan)',
+               v_buang, v_simpan, v_p, v_k;
+end $$;
+
+do $$
+declare
+  s potret_0162%rowtype;
+  n_regu int; n_nilai int; n_closing int; n_daftar int;
+  v_sekolah int; v_kembar int;
+begin
+  select * into s from potret_0162;
+  select count(*) into n_regu    from regu;
+  select count(*) into n_nilai   from nilai_mentah;
+  select count(*) into n_closing from closing_regu;
+  select count(*) into n_daftar  from pendaftaran;
+  select count(*) into v_sekolah from sekolah;
+
+  assert (n_regu, n_nilai, n_closing, n_daftar)
+         = (s.regu, s.nilai_mentah, s.closing_regu, s.pendaftaran),
+    format('0162: DATA NILAI BERGESER — regu %s->%s, nilai %s->%s, closing %s->%s, pendaftaran %s->%s',
+           s.regu, n_regu, s.nilai_mentah, n_nilai, s.closing_regu, n_closing,
+           s.pendaftaran, n_daftar);
+
+  assert not exists (select 1 from pendaftaran where sekolah_id is null),
+    '0162: ada pendaftaran yang kehilangan sekolahnya';
+  assert not exists (
+    select 1 from pendaftaran d
+     where not exists (select 1 from sekolah t where t.id = d.sekolah_id)),
+    '0162: ada pendaftaran menunjuk sekolah yang sudah dihapus';
+
+  select count(*) into v_kembar from (
+    select kunci_sekolah(name) from sekolah group by 1 having count(*) > 1) x;
+  assert v_kembar = 0, format('0162: %s kunci sekolah kembar', v_kembar);
+
+  raise notice '0162: % baris sekolah, rekap nilai utuh — % regu, % nilai, % closing.',
+               v_sekolah, n_regu, n_nilai, n_closing;
+end $$;
+
+drop table if exists potret_0162;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -343,5 +343,6 @@ run supabase/migrations/0158_rapikan_alamat_direktori.sql
 run supabase/migrations/0159_lebur_kembar_direktori.sql
 run supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
 run supabase/migrations/0161_lebur_kembar_ejaan.sql
+run supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -720,5 +720,7 @@ run supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
 run tests/sql/112_kode_pos_dan_nama_tersisa.sql
 run supabase/migrations/0161_lebur_kembar_ejaan.sql
 run tests/sql/113_lebur_kembar_ejaan.sql
+run supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
+run tests/sql/114_lebur_smp_al_fadliliyah.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/114_lebur_smp_al_fadliliyah.sql
+++ b/tests/sql/114_lebur_smp_al_fadliliyah.sql
@@ -1,0 +1,74 @@
+\echo '--- 114. SMP Al-Fadliliyah dilebur ke MTs-nya, pendaftaran ikut pindah'
+
+-- Database uji tidak memuat baris `SMP Al-Fadliliyah Darussalam` — ia lahir
+-- dari sebuah pendaftaran di produksi. Jadi jalur yang berlaku di sini jalur
+-- "dilewati", dan itu justru yang paling penting diuji: migrasi peleburan yang
+-- pasangannya tidak ada harus DIAM, bukan gagal.
+
+do $$
+begin
+  assert not exists (select 1 from sekolah where name = 'SMP Al-Fadliliyah Darussalam'),
+    '114.1 GAGAL: SMP Al-Fadliliyah Darussalam masih ada sesudah 0162';
+  assert exists (select 1 from sekolah where name = 'MTs Al-Fadliliyah Darussalam'),
+    '114.2 GAGAL: MTs Al-Fadliliyah Darussalam hilang — yang dilebur seharusnya SMP-nya';
+end;
+$$;
+
+-- Peleburan yang sama dijalankan sungguhan di sini, atas sepasang baris
+-- karangan, supaya jalur yang di produksi cuma berjalan sekali tetap punya
+-- tes yang menempati kursinya. Yang diperiksa satu hal: pendaftaran IKUT
+-- PINDAH, bukan ikut terhapus.
+do $$
+declare
+  v_lama uuid; v_baru uuid; v_daftar uuid;
+  n_sebelum int; n_sesudah int; v_tujuan uuid;
+begin
+  insert into sekolah (name, address) values
+    ('SMP Uji Lebur 0162', 'Jl. Uji, Uji, Kec. Uji, Kabupaten Uji, Jawa Barat 40000, Indonesia')
+    returning id into v_lama;
+  insert into sekolah (name, address) values
+    ('MTs Uji Lebur 0162', 'Jl. Uji, Uji, Kec. Uji, Kabupaten Uji, Jawa Barat 40000, Indonesia')
+    returning id into v_baru;
+
+  select id into v_daftar from pendaftaran limit 1;
+  assert v_daftar is not null, '114.3 GAGAL: tidak ada pendaftaran untuk diuji';
+
+  select count(*) into n_sebelum from pendaftaran;
+  update pendaftaran set sekolah_id = v_lama where id = v_daftar;
+
+  -- Bentuk yang sama persis dengan 0162.
+  update pendaftaran set sekolah_id = v_baru where sekolah_id = v_lama;
+  delete from sekolah where id = v_lama;
+
+  select count(*) into n_sesudah from pendaftaran;
+  assert n_sesudah = n_sebelum,
+    format('114.4 GAGAL: pendaftaran hilang saat peleburan, %s -> %s', n_sebelum, n_sesudah);
+
+  select sekolah_id into v_tujuan from pendaftaran where id = v_daftar;
+  assert v_tujuan = v_baru,
+    '114.5 GAGAL: pendaftaran tidak berpindah ke sekolah yang bertahan';
+
+  assert not exists (select 1 from sekolah where id = v_lama),
+    '114.6 GAGAL: baris yang dilebur masih ada';
+
+  rollback;
+end;
+$$;
+
+do $$
+declare v_kembar int; v_regu int;
+begin
+  select count(*) into v_kembar from (
+    select kunci_sekolah(name) from sekolah group by 1 having count(*) > 1) x;
+  assert v_kembar = 0, format('114.7 GAGAL: %s kunci sekolah kembar', v_kembar);
+
+  assert not exists (select 1 from pendaftaran where sekolah_id is null),
+    '114.8 GAGAL: ada pendaftaran tanpa sekolah';
+
+  select count(*) into v_regu from regu;
+  assert v_regu > 0, '114.9 GAGAL: tabel regu kosong sesudah 0162';
+  raise notice '114: % regu tetap utuh.', v_regu;
+end;
+$$;
+
+\echo '114 lebur SMP Al-Fadliliyah: LULUS'


### PR DESCRIPTION
## What

`SMP Al-Fadliliyah Darussalam` dilebur ke `MTs Al-Fadliliyah Darussalam` (NPSN 20211978). Pendaftaran dialihkan lebih dulu, baru barisnya dihapus. **515 → 514 baris.**

## Why

`0160` menemukan satu baris yang alamatnya bukan alamat — `Jl KH Ahmad Fadhil`, tanpa desa, tanpa kecamatan, tanpa kabupaten: tanda khas alamat yang **diketik** di form pendaftaran. Ia mengisi alamatnya tetapi **sengaja tidak meleburnya**, karena tidak ada di data yang bisa memutuskan:

- Data Referensi tidak memuat SMP dengan nama itu — kompleks Pesantren Darussalam terdaftar sebagai MI, MTs, SMA Plus, dan PDF Ulya.
- `MTs Al-Fadliliyah Darussalam` beralamat sama dan setingkat sama (Penggalang).
- Yang biasanya membuktikan dua baris satu sekolah adalah NPSN, dan di sini NPSN-nya justru tidak ada karena satuan itu memang tidak terdaftar.

**Pemilik acara menjawab: yang dimaksud MTs-nya.** Yang bertahan baris MTs — ia yang punya NPSN, alamat kurasi, dan nama yang benar-benar dipakai orang.

### Yang layak ditiru pola-nya, bukan jawabannya

Peleburan memindahkan `pendaftaran.sekolah_id`. Tebakan yang salah memindahkan **regu sungguhan** ke sekolah yang salah — tidak melempar galat, tidak terlihat di layar mana pun, dan baru ketahuan waktu piagam dicetak dengan nama yang keliru. Jadi `0160` mengerjakan bagian yang pasti (alamatnya), menahan bagian yang tidak pasti, dan **membawa pertanyaannya keluar** lewat `raise notice` tiap kali dijalankan. Yang tidak boleh: menebak diam-diam, atau membiarkan pertanyaannya hilang di antara catatan lain. Runbook bagian 13.7 baru menuliskannya.

## Notes

- **Berbeda dengan `0159` dan `0161`.** Keduanya meleburkan baris impor yang belum pernah dipilih siapa pun (`0 pendaftaran dialihkan`). Baris ini **lahir dari sebuah pendaftaran**, jadi jumlah yang dialihkan kemungkinan besar bukan nol — `raise notice` menyebutkannya, dan itu yang perlu dibaca di log waktu diterapkan.
- **Digladi dengan bentuk yang sama seperti produksi**: baris SMP ada, FK utuh, satu pendaftaran menunjuknya. Hasilnya pendaftaran pindah ke MTs, regu yang menempel ikut, **nol pendaftaran yatim**, dan jalan kedua tidak mengubah apa-apa.
- **Gladi pertama sempat gagal, dan itu bukan bug migrasinya**: database gladi sebelumnya saya isi dengan menempelkan baris `sekolah` produksi setelah melepas FK-nya, jadi pendaftaran di sana menunjuk id yang memang sudah tidak ada. Pemeriksaan `ada pendaftaran menunjuk sekolah yang sudah dihapus` menangkapnya. Gladinya disusun ulang dengan FK utuh.
- **Tes 114 menempati kursinya.** Di database uji baris SMP itu tidak ada, jadi jalur yang berlaku adalah "dilewati" — dan itu ikut diuji: migrasi peleburan yang pasangannya tidak ada harus **diam, bukan gagal**. Peleburannya sendiri dijalankan sungguhan atas sepasang baris karangan lalu digulung balik, memeriksa pendaftaran **ikut pindah** dan bukan ikut terhapus.
- Rekap nilai tidak disentuh: `regu` menempel pada `pendaftaran`, bukan pada `sekolah`. Migrasinya memotret keempat tabel di awal dan membandingkannya di akhir.
- `node --test` **271 tes, 271 lulus**; `bash tests/run.sh` **SEMUA TES LULUS**.
- Sesudah merge, jalankan `0162` lewat `apply-migration.yml`.
