### PR TITLE
docs: record what the migration status check now covers, and the PG version gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,8 +215,38 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    Before believing a merged migration is live, run
    `supabase/checks/status_migrasi.sql` through `apply-migration.yml`. It
    reports each migration's FINGERPRINT in the database — a constraint, a view
-   column, a fragment of a function body — and changes nothing. Names of files
-   cannot be checked, because nothing stores them.
+   column, a fragment of a function body, a row of configuration — and changes
+   nothing. Names of files cannot be checked, because nothing stores them.
+
+   **It covered ten migrations until 30 August 2026, while its own header
+   described it as a general check.** The other 152 were not examined at all
+   and it still reported green — the very shape of mistake section 13.3
+   describes. It now checks **111** and NAMES the **51** it cannot, so the
+   question stays open instead of being closed by silence.
+
+   **A migration with no fingerprint is not a problem.** It means nothing is
+   left to check: a younger migration rewrote its objects, or it only touched
+   operational data that "Bersihkan data" can wipe.
+
+   **`0102` reports BELUM in production, and that is the correct answer.** It
+   is one of the ten that never ran, and `0119` deliberately left its part out
+   because `0116` had already replaced `daftar_ulang_batch`. Do not "fix" it.
+
+   `tests/status_migrasi_check.sh` tests the checker itself, from BOTH
+   directions: after migration N its fingerprint must read ADA, and before
+   migration N it must read BELUM. The second direction is the one usually
+   missing — without it `select true` passes. Twenty fingerprints survived a
+   looser rule and were caught by that harness. It rebuilds the database 162
+   times, so it is deliberately not part of `tests/run.sh`.
+
+   **Production runs PostgreSQL 17.6; a laptop on 18.x will disagree with it
+   in ways that look like missing migrations.** PostgreSQL 18 records NOT NULL
+   constraints in `pg_constraint` and 17 does not, so 22 fingerprints built on
+   a PG18 laptop would have reported a false BELUM. Match the local server to
+   production's major version; where that is impossible, remember that
+   `pg_get_functiondef`, `pg_get_viewdef`, grant lists, and CRLF line endings
+   all differ between environments without anything being wrong. Section 0 of
+   the check prints `version()` for exactly this reason.
 
    **Re-running a skipped migration is not automatically safe.** Check first
    whether a younger migration already replaced any of its objects: running

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,8 +213,38 @@ Guidance for Claude Code when working in this repository.
    Before believing a merged migration is live, run
    `supabase/checks/status_migrasi.sql` through `apply-migration.yml`. It
    reports each migration's FINGERPRINT in the database — a constraint, a view
-   column, a fragment of a function body — and changes nothing. Names of files
-   cannot be checked, because nothing stores them.
+   column, a fragment of a function body, a row of configuration — and changes
+   nothing. Names of files cannot be checked, because nothing stores them.
+
+   **It covered ten migrations until 30 August 2026, while its own header
+   described it as a general check.** The other 152 were not examined at all
+   and it still reported green — the very shape of mistake section 13.3
+   describes. It now checks **111** and NAMES the **51** it cannot, so the
+   question stays open instead of being closed by silence.
+
+   **A migration with no fingerprint is not a problem.** It means nothing is
+   left to check: a younger migration rewrote its objects, or it only touched
+   operational data that "Bersihkan data" can wipe.
+
+   **`0102` reports BELUM in production, and that is the correct answer.** It
+   is one of the ten that never ran, and `0119` deliberately left its part out
+   because `0116` had already replaced `daftar_ulang_batch`. Do not "fix" it.
+
+   `tests/status_migrasi_check.sh` tests the checker itself, from BOTH
+   directions: after migration N its fingerprint must read ADA, and before
+   migration N it must read BELUM. The second direction is the one usually
+   missing — without it `select true` passes. Twenty fingerprints survived a
+   looser rule and were caught by that harness. It rebuilds the database 162
+   times, so it is deliberately not part of `tests/run.sh`.
+
+   **Production runs PostgreSQL 17.6; a laptop on 18.x will disagree with it
+   in ways that look like missing migrations.** PostgreSQL 18 records NOT NULL
+   constraints in `pg_constraint` and 17 does not, so 22 fingerprints built on
+   a PG18 laptop would have reported a false BELUM. Match the local server to
+   production's major version; where that is impossible, remember that
+   `pg_get_functiondef`, `pg_get_viewdef`, grant lists, and CRLF line endings
+   all differ between environments without anything being wrong. Section 0 of
+   the check prints `version()` for exactly this reason.
 
    **Re-running a skipped migration is not automatically safe.** Check first
    whether a younger migration already replaced any of its objects: running


### PR DESCRIPTION
## What

CLAUDE.md / AGENTS.md bagian 7.8 disesuaikan dengan keadaan `status_migrasi.sql` sesudah #724 dan #725: **111 migrasi diperiksa, 51 disebutkan tidak bisa** — sebelumnya sepuluh, sementara kalimatnya berbunyi "each migration's fingerprint".

## Why

Tiga hal yang tidak bisa disimpulkan dari kodenya, dan mahal kalau salah dibaca:

- **Migrasi tanpa jejak bukan masalah.** Artinya tidak ada yang tersisa untuk diperiksa — objeknya sudah ditulis ulang migrasi yang lebih muda, atau ia hanya menyentuh data operasional yang bisa dihapus "Bersihkan data". Tanpa kalimat ini, daftar 51 itu terbaca seperti 51 pekerjaan tertunda.

- **`0102` berbunyi BELUM di produksi dan itu jawaban yang benar.** Ia salah satu dari sepuluh yang tidak pernah dijalankan, dan `0119` sengaja tidak memasang bagiannya karena `0116` sudah menggantikan `daftar_ulang_batch`. Menjalankannya sekarang mengembalikan logika FIFO ke bentuk lama. Ini yang paling mungkin "diperbaiki" orang berikutnya kalau tidak ditulis.

- **Produksi PostgreSQL 17.6, laptop ini 18.6.** PostgreSQL 18 mencatat constraint `NOT NULL` di `pg_constraint` dan 17 tidak, jadi 22 jejak yang dirakit di laptop akan melapor **BELUM palsu** di produksi. Semuanya sudah dibuang, tapi aturannya yang perlu tercatat: samakan versi mayor server lokal dengan produksi.

## Notes

- Kedua berkas tetap sama persis di luar kepalanya masing-masing (bagian 7.7) — diperiksa dengan `diff`.
- `node --test` **271 tes, 271 lulus**.