### PR TITLE
docs: note that a production-matching Postgres can sit beside the existing one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,11 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    all differ between environments without anything being wrong. Section 0 of
    the check prints `version()` for exactly this reason.
 
+   Matching costs nothing: `tests/run.sh`, `tests/dev_database.sh` and
+   `tests/status_migrasi_check.sh` all take `PSQL` and `PGPORT`, so a server on
+   production's major version can sit beside an existing one on another port
+   and neither has to be removed.
+
    **Re-running a skipped migration is not automatically safe.** Check first
    whether a younger migration already replaced any of its objects: running
    the old file now would roll those back. That is why `0119` deliberately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,11 @@ Guidance for Claude Code when working in this repository.
    all differ between environments without anything being wrong. Section 0 of
    the check prints `version()` for exactly this reason.
 
+   Matching costs nothing: `tests/run.sh`, `tests/dev_database.sh` and
+   `tests/status_migrasi_check.sh` all take `PSQL` and `PGPORT`, so a server on
+   production's major version can sit beside an existing one on another port
+   and neither has to be removed.
+
    **Re-running a skipped migration is not automatically safe.** Check first
    whether a younger migration already replaced any of its objects: running
    the old file now would roll those back. That is why `0119` deliberately


### PR DESCRIPTION
## What

Satu paragraf di CLAUDE.md / AGENTS.md bagian 7.8: server PostgreSQL seversi produksi bisa **berdampingan** dengan yang sudah terpasang, karena `tests/run.sh`, `tests/dev_database.sh`, dan `tests/status_migrasi_check.sh` ketiganya sudah menerima `PSQL` dan `PGPORT`.

## Why

Bagian itu sudah menyuruh menyamakan versi mayor, tapi tidak menyebut bahwa itu murah. Pembaca yang mengira harus **mengganti** PostgreSQL yang sudah terpasang punya alasan bagus untuk menunda — dan penundaan itu persis yang melahirkan 22 jejak migrasi yang salah kemarin, karena jejaknya dirakit di PostgreSQL 18 sementara produksi 17.6.

Sudah dijalankan sungguhan: PostgreSQL 17.11 berdiri di port 5433 di samping 18.6 di 5432, `tests/run.sh` **SEMUA TES LULUS** di keduanya, dan `tests/status_migrasi_check.sh` **LULUS 111 jejak** di keduanya — jadi jejaknya memang tahan lintas versi seperti yang dirancang.

## Notes

- Tidak ada kode yang berubah, dan tidak ada detail mesin siapa pun yang masuk repo.
- Kedua berkas tetap sama persis di luar kepalanya masing-masing — diperiksa dengan `diff`.