### PR TITLE
feat: publish the championship list to peserta as a fifth live phase

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -18,7 +18,9 @@
 # Selama status_acara.fase_live masih 'progres', v_klasemen_publik memang
 # mengembalikan nol baris dan v_progres_publik tidak memuat satu pun angka
 # nilai. Fase 'top10' hanya menerbitkan maksimal sepuluh regu eligible per
-# golongan beserta totalnya; fase 'penuh' menerbitkan papan lengkap.
+# golongan beserta totalnya; fase 'penuh' menerbitkan papan lengkap; fase
+# 'juara' menutup papan sepenuhnya dan menerbitkan daftar juara — tanpa satu
+# angka skor pun, karena kolomnya memang tidak ada di v_kejuaraan_publik.
 #
 # CRON 15 MENIT AKTIF HANYA 29 AGUSTUS 2026, 08:00-23:59 WIB. Cron memakai
 # UTC dan tidak punya kolom tahun, jadi jadwal memilih 01:00-16:45 UTC lalu
@@ -130,7 +132,8 @@ jobs:
 
           d = json.load(open('/tmp/rekap-utuh.json'))
           for k in ('dibuat_pada', 'fase', 'edisi', 'ringkas', 'pos',
-                    'komponen', 'kelengkapan', 'progres', 'klasemen'):
+                    'komponen', 'kelengkapan', 'progres', 'klasemen',
+                    'kejuaraan'):
               if k not in d:
                   sys.exit(f'kunci {k} hilang dari keluaran live_json.sql')
 
@@ -158,6 +161,28 @@ jobs:
           # Pagar kebocoran, dijaga di sini SEKALIGUS di view (0005/0026).
           if d['fase'] not in ('penuh', 'top10') and d['klasemen']:
               sys.exit('BOCOR: klasemen ikut tertulis pada fase yang tertutup')
+          # Daftar juara hanya pada fase 'juara' (0163), dan tidak pernah
+          # membawa satu angka skor pun. Kunci yang dilarang disebut satu per
+          # satu DAN apa pun yang bertipe angka ikut ditolak: penghargaan
+          # berikutnya bisa membawa kolom baru bernama lain, dan pagar yang
+          # cuma menyebut nama tidak akan melihatnya (CLAUDE.md 13.3).
+          # `nomor_dada` dikecualikan — ia identitas regu, sama terbukanya
+          # dengan namanya sendiri, dan sudah tercetak di punggung mereka.
+          if d['fase'] != 'juara' and d['kejuaraan']:
+              sys.exit('BOCOR: kejuaraan tertulis padahal fase belum juara')
+          for baris in d['kejuaraan']:
+              for kunci, isi in baris.items():
+                  if kunci in ('nomor_dada', 'urutan'):
+                      continue
+                  if isinstance(isi, bool) or isi is None:
+                      continue
+                  if isinstance(isi, (int, float)):
+                      sys.exit(f'BOCOR: angka {kunci} ikut ke daftar juara')
+          # Fase juara menutup papan, dan itu bagian dari janjinya: yang
+          # dilihat peserta di sana HANYA kejuaraan. Kedua view memang sudah
+          # menutup sendiri; kalau suatu hari tidak lagi, berhenti di sini.
+          if d['fase'] == 'juara' and (d['klasemen'] or d['progres']):
+              sys.exit('BOCOR: papan ikut tertulis pada fase juara')
           if d['fase'] == 'top10':
               per_golongan = {}
               for baris in d['klasemen']:
@@ -192,7 +217,8 @@ jobs:
                       if baris.get(kunci):
                           sys.exit(f'BOCOR: {kunci} per komponen tertulis padahal fase belum penuh')
 
-          rekap = {'progres': d['progres'], 'klasemen': d['klasemen']}
+          rekap = {'progres': d['progres'], 'klasemen': d['klasemen'],
+                   'kejuaraan': d['kejuaraan']}
           sidik = hashlib.sha256(json.dumps(
               rekap, sort_keys=True, separators=(',', ':'),
               default=str).encode('utf-8')).hexdigest()[:12]
@@ -227,7 +253,8 @@ jobs:
 
           import os
           print(f"fase={d['fase']} versi={sidik} regu={len(d['progres'])} "
-                f"klasemen={len(d['klasemen'])} pos={len(d['pos'])} "
+                f"klasemen={len(d['klasemen'])} juara={len(d['kejuaraan'])} "
+                f"pos={len(d['pos'])} "
                 f"live.json={os.path.getsize('live/live.json')}B "
                 f"rekap.json={os.path.getsize('live/rekap.json')}B")
           PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -582,10 +582,20 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 
 ## 14. Fase live
 
-1. **Tiga fase, dan artinya di layar peserta:**
+1. **Lima fase, dan artinya di layar peserta:**
    - `pra` — peserta tidak melihat apa pun selain ajakan mendaftar
    - `progres` — peserta melihat CENTANG per komponen, bukan nilainya
    - `penuh` — peserta melihat yang sama dengan panitia
+   - `top10` — peserta melihat maksimal sepuluh regu berperingkat per
+     golongan beserta totalnya, tanpa poin per pos (migrasi 0145)
+   - `juara` — papan diganti DAFTAR JUARA, dan tidak ada yang lain
+     (migrasi 0163)
+
+   Pasal ini berbunyi "Tiga fase" sampai 30 Agustus 2026, sementara `top10`
+   sudah hidup sejak 0145. Yang membaca daftar ini lalu menambah fase
+   berikutnya tidak punya alasan menduga ada fase keempat yang tidak
+   disebut — dan setiap fase yang tidak disebut adalah satu pagar "BOCOR"
+   yang tidak ikut diperiksa. Kalau fase bertambah lagi, tambahkan DI SINI.
 2. **Saklarnya di layar Live Score panitia**, hanya untuk pemegang
    `pengaturan`, lewat RPC `atur_fase_live`.
 3. **Mematikan seketika, menyalakan tetap lewat penerbitan.** Halaman peserta
@@ -604,6 +614,32 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 6. **`UPDATE` tanpa `WHERE` ditolak Supabase.** Ekstensi `safeupdate` aktif di
    produksi tapi TIDAK ada di database uji, jadi tes lokal bisa hijau
    sementara RPC-nya gagal di layar. Tulis `WHERE` yang memang berarti.
+7. **Fase `juara` menutup papan dengan sendirinya, bukan dengan JavaScript.**
+   `v_klasemen_publik` hanya membuka pada `penuh` dan `top10`,
+   `v_progres_publik` hanya pada `progres` dan `penuh`. Jadi berkas yang
+   terbit pada fase ini memuat daftar juara dan TIDAK memuat papan — pasal 4
+   dipenuhi tanpa satu pagar tambahan pun.
+8. **Daftar juara terbit TANPA satu angka skor**, dan itu keputusan pemilik
+   acara. `v_kejuaraan_publik` tidak punya kolom `total`, `poin_juara`,
+   maupun `jumlah_skor` — bukan disembunyikan tampilan, memang tidak ada.
+   Nomor dada tetap ikut: ia identitas regu, sudah tercetak di punggung
+   mereka sejak pagi. Pagar di `publish-live.yml` menolak APA PUN yang
+   bertipe angka di daftar itu selain nomor dada dan urutan, jadi kolom baru
+   bernama lain ikut tertangkap (pasal 13.3).
+9. **Menurunkan saklar dari Juara ke Live TIDAK mengembalikan papan.**
+   Berkas fase juara memang tidak memuat satu baris klasemen pun, dan pasal
+   3 melarang layar menampilkan lebih dari isi berkasnya — jadi yang
+   tergambar papan kosong sampai rekap diterbitkan ulang. Itu bukan bug; itu
+   pasal 3 bekerja. Yang perlu diketahui panitia: urutan kerjanya nyalakan
+   fasenya dulu, terbitkan sesudahnya, dan itu berlaku ke DUA arah.
+10. **Pagar hak daftar juara ada di SATU tempat, `hasil_kejuaraan()`**
+    (migrasi 0163). Penyusunnya — `hasil_kejuaraan_dasar()` dan
+    `hasil_kejuaraan_semua()` — sengaja tanpa `boleh('live_score')` di
+    dalamnya, karena penerbit tersambung sebagai pemilik database dan
+    `auth.uid()` di sana NULL: pagar di dalam penyusun membuat berkas terbit
+    berisi NOL penghargaan tanpa satu pun galat. Yang menjaga keduanya
+    tinggal `revoke all ... from public, anon, authenticated`. Jangan
+    memberi mereka grant, dan jangan memindahkan pagarnya kembali ke dalam.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -580,10 +580,20 @@ Guidance for Claude Code when working in this repository.
 
 ## 14. Fase live
 
-1. **Tiga fase, dan artinya di layar peserta:**
+1. **Lima fase, dan artinya di layar peserta:**
    - `pra` — peserta tidak melihat apa pun selain ajakan mendaftar
    - `progres` — peserta melihat CENTANG per komponen, bukan nilainya
    - `penuh` — peserta melihat yang sama dengan panitia
+   - `top10` — peserta melihat maksimal sepuluh regu berperingkat per
+     golongan beserta totalnya, tanpa poin per pos (migrasi 0145)
+   - `juara` — papan diganti DAFTAR JUARA, dan tidak ada yang lain
+     (migrasi 0163)
+
+   Pasal ini berbunyi "Tiga fase" sampai 30 Agustus 2026, sementara `top10`
+   sudah hidup sejak 0145. Yang membaca daftar ini lalu menambah fase
+   berikutnya tidak punya alasan menduga ada fase keempat yang tidak
+   disebut — dan setiap fase yang tidak disebut adalah satu pagar "BOCOR"
+   yang tidak ikut diperiksa. Kalau fase bertambah lagi, tambahkan DI SINI.
 2. **Saklarnya di layar Live Score panitia**, hanya untuk pemegang
    `pengaturan`, lewat RPC `atur_fase_live`.
 3. **Mematikan seketika, menyalakan tetap lewat penerbitan.** Halaman peserta
@@ -602,6 +612,32 @@ Guidance for Claude Code when working in this repository.
 6. **`UPDATE` tanpa `WHERE` ditolak Supabase.** Ekstensi `safeupdate` aktif di
    produksi tapi TIDAK ada di database uji, jadi tes lokal bisa hijau
    sementara RPC-nya gagal di layar. Tulis `WHERE` yang memang berarti.
+7. **Fase `juara` menutup papan dengan sendirinya, bukan dengan JavaScript.**
+   `v_klasemen_publik` hanya membuka pada `penuh` dan `top10`,
+   `v_progres_publik` hanya pada `progres` dan `penuh`. Jadi berkas yang
+   terbit pada fase ini memuat daftar juara dan TIDAK memuat papan — pasal 4
+   dipenuhi tanpa satu pagar tambahan pun.
+8. **Daftar juara terbit TANPA satu angka skor**, dan itu keputusan pemilik
+   acara. `v_kejuaraan_publik` tidak punya kolom `total`, `poin_juara`,
+   maupun `jumlah_skor` — bukan disembunyikan tampilan, memang tidak ada.
+   Nomor dada tetap ikut: ia identitas regu, sudah tercetak di punggung
+   mereka sejak pagi. Pagar di `publish-live.yml` menolak APA PUN yang
+   bertipe angka di daftar itu selain nomor dada dan urutan, jadi kolom baru
+   bernama lain ikut tertangkap (pasal 13.3).
+9. **Menurunkan saklar dari Juara ke Live TIDAK mengembalikan papan.**
+   Berkas fase juara memang tidak memuat satu baris klasemen pun, dan pasal
+   3 melarang layar menampilkan lebih dari isi berkasnya — jadi yang
+   tergambar papan kosong sampai rekap diterbitkan ulang. Itu bukan bug; itu
+   pasal 3 bekerja. Yang perlu diketahui panitia: urutan kerjanya nyalakan
+   fasenya dulu, terbitkan sesudahnya, dan itu berlaku ke DUA arah.
+10. **Pagar hak daftar juara ada di SATU tempat, `hasil_kejuaraan()`**
+    (migrasi 0163). Penyusunnya — `hasil_kejuaraan_dasar()` dan
+    `hasil_kejuaraan_semua()` — sengaja tanpa `boleh('live_score')` di
+    dalamnya, karena penerbit tersambung sebagai pemilik database dan
+    `auth.uid()` di sana NULL: pagar di dalam penyusun membuat berkas terbit
+    berisi NOL penghargaan tanpa satu pun galat. Yang menjaga keduanya
+    tinggal `revoke all ... from public, anon, authenticated`. Jangan
+    memberi mereka grant, dan jangan memindahkan pagarnya kembali ke dalam.
 
 ---
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,10 +6,13 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0162`: angka
-tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database, dan
-bagian 3 diperiksa terhadap layar. Isi bagian 2 sampai 9 selebihnya belum
-dibaca ulang baris demi baris terhadap `0119`-`0162`.
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0163`:
+angka tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database
+sampai `0162`, dan bagian 3 diperiksa terhadap layar. `0163` — fase live
+kelima `juara` beserta `v_kejuaraan_publik` dan `hasil_kejuaraan_semua()` —
+mendarat sesudah penghitungan itu, jadi angka view dan fungsi di bagian 2
+kurang satu masing-masing. Isi bagian 2 sampai 9 selebihnya belum dibaca
+ulang baris demi baris terhadap `0119`-`0163`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -74,7 +77,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-162 migrasi, `0001` sampai `0162`, dijalankan berurutan tanpa lubang penomoran.
+163 migrasi, `0001` sampai `0163`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/live.css
+++ b/live/live.css
@@ -266,6 +266,43 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 }
 .tombol:hover { background: #004d43; }
 
+/* ---------- kejuaraan (fase juara) ---------- */
+/* DI BAWAH seluruh aturan `.tabel`, dan itu bukan soal kerapian berkas.
+   `.tabel-juara th` dan `.tabel th` sama kekhususannya — satu kelas dan satu
+   elemen — jadi yang menang cuma ditentukan urutan baris (CLAUDE.md 15.6).
+   Ditaruh di atas, tiga aturan di bawah ini tidak berlaku sedetik pun dan
+   tidak ada yang memberi tahu. */
+
+/* Dua kolom: nama gelar di kiri selebar isinya, penerimanya mengisi sisa
+   baris. `width: 1%` dengan `nowrap` membuat "Juara I" sampai "Harapan III"
+   berbaris lurus dari baris ke baris, dan nama sekolah yang panjang
+   membungkus DI DALAM kolomnya sendiri alih-alih menggeser kolom kiri tiap
+   baris — pola yang sama dengan kartu HP di CLAUDE.md 15.7. */
+.tabel-juara { white-space: normal; }
+.tabel-juara th {
+  width: 1%; white-space: nowrap; vertical-align: top;
+  padding: .55rem .9rem .55rem 0;
+  /* Bukan kepala tabel yang perlu ikut tergulir: di sini `th` adalah LABEL
+     baris, dan `position: sticky` warisan `.tabel th` membuatnya menempel
+     di puncak layar satu per satu saat halaman digulir. */
+  position: static; background: none;
+  border-bottom: 1px solid var(--garis);
+}
+.tabel-juara td { padding: .55rem 0; }
+/* Nama sekolah turun ke barisnya sendiri di bawah nama regu, bukan mengalir
+   di sebelahnya: yang dicari mata di daftar ini nama regu, dan nama sekolah
+   yang berbaris di kanannya mendorong nama regu ke tempat berbeda tiap
+   baris. `.kartu .keterangan` memberinya margin bawah .7rem — itu jarak
+   antar-kartu, bukan antar-baris. */
+.tabel-juara .keterangan { display: block; margin: .1rem 0 0; }
+.tabel-juara tbody tr:last-child th,
+.tabel-juara tbody tr:last-child td { border-bottom: 0; }
+/* Juara Umum satu-satunya yang ditonjolkan, dan cuma dengan garis di tepi
+   kiri — bukan blok warna. Ia dibaca sekali lalu tidak dicari lagi; yang
+   dicari orang berkali-kali gelar golongannya sendiri. */
+.kartu-juara.juara-umum { border-left: 4px solid var(--utama); }
+.kartu-juara.juara-umum h2 { color: var(--utama); }
+
 @media print {
   /* Satu golongan harus selesai di satu A4. Margin 6mm masih aman untuk
      printer kantor (tepi 4-5mm tidak tercetak), sementara font 7pt adalah

--- a/live/live.js
+++ b/live/live.js
@@ -120,7 +120,18 @@ let mengambil = false;  // penjaga supaya tidak dua permintaan sekaligus
 // Top 10 membuka lebih sedikit data daripada Live penuh. Karena fase database
 // hanya boleh memperketat berkas yang sudah terbit, urutannya berada di antara
 // Progress dan Live meskipun tombolnya ditaruh setelah Live di layar panitia.
-const URUT_FASE = { pra: 0, progres: 1, top10: 2, penuh: 3 };
+//
+// `juara` paling terbuka, dan itu benar walaupun berkasnya justru memuat
+// PALING SEDIKIT: yang diukur urutan ini bukan besar berkasnya melainkan
+// seberapa jauh isinya boleh dibuka. Daftar juara adalah kabar yang tidak
+// bisa ditarik kembali, jadi tidak ada fase lain yang boleh menampilkannya.
+//
+// Akibat yang perlu diketahui panitia: menurunkan saklar dari Juara ke Live
+// TIDAK mengembalikan papan. Berkas fase juara memang tidak memuat satu baris
+// klasemen pun, jadi yang tergambar papan kosong sampai rekap diterbitkan
+// ulang — persis aturan CLAUDE.md 14.3: mematikan seketika, menyalakan tetap
+// lewat penerbitan.
+const URUT_FASE = { pra: 0, progres: 1, top10: 2, penuh: 3, juara: 4 };
 // Fase database hanya memperketat isi berkas. Ia harus sempat menjawab sebelum
 // gambar pertama, tetapi tidak boleh menahan papan CDN lebih dari beberapa
 // detik ketika origin Supabase sedang sulit dijangkau.
@@ -544,6 +555,81 @@ function gambarTab(semua) {
   }).join("")}</div>`;
 }
 
+/* ---------------------------------------------------------------------------
+   Fase 'juara' — daftar juara, dan TIDAK ADA YANG LAIN.
+
+   Papan klasemen tidak digambar di sini bukan karena disembunyikan: berkas
+   yang terbit pada fase ini memang tidak memuat satu baris klasemen pun
+   (v_klasemen_publik dan v_progres_publik dua-duanya menutup di luar fasenya,
+   migrasi 0163). Yang sudah selesai adalah juaranya; urutan sementara tidak
+   lagi menjawab pertanyaan siapa pun.
+
+   TIDAK ADA SATU ANGKA SKOR di layar ini, dan itu juga bukan keputusan
+   tampilan — kolomnya tidak ada di berkasnya. Nomor dada tetap ditulis: ia
+   identitas regu, sudah tercetak di punggung mereka sejak pagi, dan tanpa itu
+   dua regu bernama mirip tidak bisa dibedakan dari kursi penonton.
+   ------------------------------------------------------------------------- */
+/** Satu penerima gelar: regu, sekolah, atau belum ada. */
+const penerimaJuara = (j) => {
+  if (j.nama_regu) return `
+    <strong>${esc(dada(j.nomor_dada))} · ${esc(j.nama_regu)}</strong>
+    <span class="keterangan">${esc(j.nama_sekolah || "")}</span>`;
+  if (j.nama_sekolah) return `<strong>${esc(j.nama_sekolah)}</strong>`;
+  return `<span class="keterangan">Belum ditentukan</span>`;
+};
+
+function gambarKejuaraan() {
+  const daftar = (REKAP && REKAP.kejuaraan) || [];
+  if (!REKAP) return `<div class="kartu tengah"><p class="keterangan">Memuat…</p></div>`;
+  if (!daftar.length) return `
+    <div class="kartu tengah">
+      <p class="keterangan">Daftar juara belum terbit.</p></div>`;
+
+  /* Label bagian dan pemotong awalannya SAMA dengan layar panitia — di sana
+     `nama_penghargaan` berbunyi "Penegak PA Juara I" dan judul kartunya sudah
+     menyebut golongannya, jadi yang tersisa di baris cuma "Juara I".
+     Nama golongan diambil dari GOLONGAN_LABEL, tidak ditulis ulang di sini:
+     periksa_urutan_golongan.py yang menjaga daftar itu tetap satu. */
+  const gelarGolongan = (g) => ({
+    judul: GOLONGAN[g],
+    masuk: (j) => j.kode.startsWith(g + "_"),
+    label: (j) => j.nama_penghargaan.replace(GOLONGAN[g] + " ", ""),
+  });
+
+  const bagian = [
+    { judul: "Juara Umum", masuk: (j) => j.kode.startsWith("juara_umum"),
+      label: (j) => j.nama_penghargaan.replace(/^Juara Umum ?/, "") || "UMUM",
+      kelas: "juara-umum" },
+    ...URUT_GOLONGAN_PESERTA.map(gelarGolongan),
+    { judul: "Juara Kostum", masuk: (j) => j.kode.startsWith("kostum_"),
+      label: (j) => j.nama_penghargaan.replace(/^Juara Kostum /, "") },
+    { judul: "Juara Yel Yel", masuk: (j) => j.kode.startsWith("yel_yel_"),
+      label: (j) => j.nama_penghargaan.replace(/^Juara Yel Yel /, "") },
+    { judul: "Peserta Terfavorit", masuk: (j) => j.kode.startsWith("terfavorit_"),
+      label: (j) => j.nama_penghargaan.replace(/^Peserta Terfavorit /, "") },
+    { judul: "Penghargaan Khusus",
+      masuk: (j) => j.kode === "terjauh" || j.kode === "peserta_terbanyak",
+      label: (j) => j.nama_penghargaan },
+  ];
+
+  /* Kartu yang tidak kebagian satu baris pun DIBUANG, bukan digambar kosong.
+     Penghargaan pilihan panitia bisa saja tidak dipakai tahun ini, dan kartu
+     berjudul tanpa isi terbaca seperti hasil yang hilang. */
+  return bagian.map(b => {
+    const isi = daftar.filter(b.masuk);
+    if (!isi.length) return "";
+    return `
+    <div class="kartu kartu-juara ${b.kelas || ""}">
+      <h2>${esc(b.judul)}</h2>
+      <table class="tabel tabel-juara"><tbody>
+        ${isi.map(j => `
+          <tr><th>${esc(b.label(j))}</th>
+              <td>${penerimaJuara(j)}</td></tr>`).join("")}
+      </tbody></table>
+    </div>`;
+  }).join("");
+}
+
 function gambarPapan() {
   if (!REKAP) return `<div class="kartu tengah"><p class="keterangan">Memuat…</p></div>`;
   const penuh = fase() === "penuh";
@@ -861,21 +947,29 @@ function gambar() {
   const isi = document.getElementById("isi");
   if (!META) return;
 
+  /* Judulnya ikut berganti di fase juara. "Live Score" menjanjikan angka
+     yang berjalan; yang tergambar di bawahnya daftar yang sudah selesai. */
+  const namaLayar = fase() === "juara" ? "Kejuaraan" : "Live Score";
   document.getElementById("judul").textContent =
-    `Live Score${META.edisi ? ` — ${META.edisi.name}` : ""}`;
-  document.title = `Live Score — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
+    `${namaLayar}${META.edisi ? ` — ${META.edisi.name}` : ""}`;
+  document.title = `${namaLayar} — ${META.edisi ? META.edisi.name : "Hiking Rally Ciradyka"}`;
   const tombolCetak = document.getElementById("buka-cetak");
   if (tombolCetak) tombolCetak.hidden = fase() !== "penuh" || !REKAP;
 
-  // Top 10 sengaja hanya membawa papan ringkas. Pada fase lain susunannya
-  // sama dengan layar panitia: kemajuan di atas, lalu tab golongan, lalu
-  // papan klasemen.
+  // Top 10 sengaja hanya membawa papan ringkas, dan Juara tidak membawa papan
+  // sama sekali. Pada fase lain susunannya sama dengan layar panitia:
+  // kemajuan di atas, lalu tab golongan, lalu papan klasemen.
   isi.innerHTML = !mulai()
     ? gambarPra()
+    : fase() === "juara"
+    ? gambarKejuaraan()
     : (fase() === "top10" ? "" : gambarKelengkapan()) + gambarPapan();
 
-  if (mulai()) pasangPapan();
-  pasangKemajuan();
+  // pasangPapan() memasang pencarian sekolah dan tab golongan — dua hal yang
+  // tidak ada di layar juara. Memanggilnya di sana bukan sekadar mubazir:
+  // ia membaca elemen yang tidak digambar.
+  if (mulai() && fase() !== "juara") pasangPapan();
+  if (fase() !== "juara") pasangKemajuan();
   gambarSinkron();
   kunciTergambar = kunciGambar();
 }

--- a/supabase/checks/live_json.sql
+++ b/supabase/checks/live_json.sql
@@ -67,5 +67,14 @@ select jsonb_pretty(jsonb_build_object(
 
   'klasemen', (select coalesce(jsonb_agg(to_jsonb(k)
                         order by k.golongan, k.peringkat, k.nomor_dada), '[]'::jsonb)
-               from v_klasemen_publik k)
+               from v_klasemen_publik k),
+
+  -- Daftar juara (0163). Nol baris di luar fase 'juara' — pagarnya di dalam
+  -- view, sama seperti kedua saudaranya di atas, jadi tidak ada cara
+  -- menerbitkannya lebih awal dengan salah menyunting berkas ini. Tidak ada
+  -- satu pun kolom skor di sana; yang terbit cuma nama penghargaan dan siapa
+  -- yang menerimanya.
+  'kejuaraan', (select coalesce(jsonb_agg(to_jsonb(j) order by j.urutan),
+                       '[]'::jsonb)
+                from v_kejuaraan_publik j)
 ));

--- a/supabase/checks/status_migrasi.sql
+++ b/supabase/checks/status_migrasi.sql
@@ -26,7 +26,7 @@
 -- daripada masalahnya lebih berbahaya daripada tidak ada pemeriksaan, karena ia
 -- menutup pertanyaannya.
 --
--- Sekarang keduanya disebutkan: 111 migrasi punya jejak yang diperiksa
+-- Sekarang keduanya disebutkan: 112 migrasi punya jejak yang diperiksa
 -- (bagian 1), dan 51 tidak punya (bagian 2). Yang di bagian 2 bukan berarti
 -- belum diterapkan — berarti tidak ada yang tersisa untuk diperiksa.
 --
@@ -35,7 +35,7 @@
 -- Tidak ditulis tangan satu per satu, dan tidak ditebak. Database dibangun dari
 -- nol mengikuti urutan `tests/run.sh`, dan katalog beserta tabel konfigurasinya
 -- dipotret sesudah SETIAP migrasi. Sebuah potongan baru diterima jadi jejak
--- kalau ia lolos dua syarat, diuji terhadap seluruh 163 potret:
+-- kalau ia lolos dua syarat, diuji terhadap seluruh 164 potret:
 --
 --   1. TIDAK ada di SATU PUN potret sebelum migrasinya — jadi ia memang lahir
 --      dari migrasi itu, bukan dari yang lebih tua;
@@ -289,8 +289,14 @@ begin
    $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_klasemen' and position('FROM closing_regu c' in definition) > 0)$c$),
   ('0144', 'view v_klasemen_publik: t.golongan',
    $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_klasemen_publik' and position('t.golongan' in definition) > 0)$c$),
-  ('0145', 'constraint status_acara.status_acara_fase_live_check: CHECK ((fase_live = ANY (ARRAY[''pra''::text, ''progres''::tex',
-   $c$select exists (select 1 from pg_constraint where conrelid = 'status_acara'::regclass and conname = 'status_acara_fase_live_check' and position('CHECK ((fase_live = ANY (ARRAY[''pra''::text, ''progres''::text, ''penuh''::text, ''top10''::text])))' in pg_get_constraintdef(oid)) > 0)$c$),
+  -- Jejak 0145 dulu constraint fase-nya sendiri, dan 0163 menulis ulang
+  -- constraint itu untuk menyelipkan 'juara' — jejaknya lalu melapor BELUM
+  -- untuk migrasi yang jelas-jelas sudah jalan. Yang dipakai sekarang
+  -- `urutan_top` di v_klasemen_publik: sama-sama lahir dari 0145, dan 0163
+  -- tidak menyentuhnya. Pelajaran umumnya: jangan menjejaki objek yang
+  -- memang dibuat untuk ditulis ulang setiap ada keadaan baru.
+  ('0145', 'view v_klasemen_publik: urutan_top',
+   $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_klasemen_publik' and position('urutan_top' in definition) > 0)$c$),
   ('0146', 'constraint cache_live_score.cache_live_score_pkey: PRIMARY KEY (tunggal)',
    $c$select exists (select 1 from pg_constraint where conrelid = 'cache_live_score'::regclass and conname = 'cache_live_score_pkey' and position('PRIMARY KEY (tunggal)' in pg_get_constraintdef(oid)) > 0)$c$),
   ('0150', 'view v_kejuaraan: poin_juara',
@@ -314,7 +320,9 @@ begin
   ('0160', 'row sekolah: {"name": "MTs Ma''arif Darulhikam", "address": "Cieurih, Ke',
    $c$select exists (select 1 from sekolah t where position('{"name": "MTs Ma''arif Darulhikam", "address": "Cieurih, Kec. Cipaku, Kabupaten Ciamis, Jawa Barat 46252, Indonesia"}' in (to_jsonb(t) - 'id' - 'created_at' - 'updated_at' - 'dibuat_pada' - 'edisi' - 'sekolah_id')::text) > 0)$c$),
   ('0161', 'row sekolah: {"name": "SMPN Satu Atap 1 Banjarsari", "address": "Banjar',
-   $c$select exists (select 1 from sekolah t where position('{"name": "SMPN Satu Atap 1 Banjarsari", "address": "Banjaranyar, Kec. Banjaranyar, Kabupaten Ciamis, Jawa Barat 46384, Indonesia"}' in (to_jsonb(t) - 'id' - 'created_at' - 'updated_at' - 'dibuat_pada' - 'edisi' - 'sekolah_id')::text) > 0)$c$)
+   $c$select exists (select 1 from sekolah t where position('{"name": "SMPN Satu Atap 1 Banjarsari", "address": "Banjaranyar, Kec. Banjaranyar, Kabupaten Ciamis, Jawa Barat 46384, Indonesia"}' in (to_jsonb(t) - 'id' - 'created_at' - 'updated_at' - 'dibuat_pada' - 'edisi' - 'sekolah_id')::text) > 0)$c$),
+  ('0163', 'view v_kejuaraan_publik ada',
+   $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_kejuaraan_publik')$c$)
 ) as t(nomor, jejak, cek)
   loop
     begin

--- a/supabase/migrations/0163_fase_juara.sql
+++ b/supabase/migrations/0163_fase_juara.sql
@@ -1,0 +1,449 @@
+-- ============================================================================
+-- 0163 : fase live kelima - `juara`.
+--
+-- Sesudah Top 10 masih ada satu keadaan yang belum punya bentuk publik: acara
+-- sudah selesai, dan yang ditunggu peserta bukan lagi papan sementara
+-- melainkan siapa juaranya. Sampai sekarang daftar itu cuma ada di layar
+-- panitia; peserta menerimanya lewat pengeras suara.
+--
+-- APA YANG BERUBAH
+--
+--   1. `status_acara.fase_live` menerima nilai kelima, `juara`, dan
+--      `atur_fase_live` ikut menerimanya.
+--   2. Pagar `boleh('live_score')` DIPINDAH, bukan dilonggarkan: ia turun dari
+--      dalam kedua fungsi penyusun daftar ke satu tempat, `hasil_kejuaraan()`.
+--   3. View baru `v_kejuaraan_publik`, berpagar fase, boleh dibaca `anon`.
+--
+-- KENAPA PAGARNYA HARUS PINDAH
+--
+-- publish-live.yml tersambung sebagai pemilik database, bukan sebagai panitia
+-- yang login. `boleh('live_score')` membaca `auth.uid()`, yang di sana NULL,
+-- jadi seluruh daftar juara kosong untuk penerbit - dan berkas yang terbit ke
+-- peserta akan berisi nol penghargaan tanpa satu pun galat. Yang menjaga
+-- hasil_kejuaraan_dasar() dari panitia bukan `where` di dalamnya melainkan
+-- `revoke all ... from public, authenticated` sejak 0140: ia SECURITY DEFINER
+-- dan tidak seorang pun boleh memanggilnya langsung. Penjaga di ujung berkas
+-- ini memeriksa persis itu, supaya pemindahan tadi tidak diam-diam berubah
+-- jadi pelonggaran ketika suatu hari ada yang menambahkan grant.
+--
+-- TANPA SATU ANGKA SKOR, dan itu keputusan pemilik acara. Yang terbit cuma
+-- nama penghargaan, nomor dada, nama regu, dan nama sekolah. `total`,
+-- `poin_juara`, dan `jumlah_skor` tidak ikut sama sekali - bukan disembunyikan
+-- tampilan, memang TIDAK ADA di kolomnya (CLAUDE.md 14.4). Halaman peserta
+-- duduk di CDN dan bisa diminta siapa pun yang tahu alamatnya; satu-satunya
+-- jaminan bahwa angka belum bocor adalah angkanya memang tidak ditulis.
+--
+-- FASE `juara` MENUTUP PAPAN DENGAN SENDIRINYA, tanpa satu baris pun
+-- tambahan: v_klasemen_publik hanya membuka pada 'penuh' dan 'top10', dan
+-- v_progres_publik hanya pada 'progres' dan 'penuh'. Jadi berkas yang terbit
+-- pada fase ini memuat daftar juara dan tidak memuat papan - yang dilihat
+-- peserta memang hanya kejuaraan.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Fase kelima
+-- ---------------------------------------------------------------------------
+
+alter table status_acara
+  drop constraint status_acara_fase_live_check;
+
+alter table status_acara
+  add constraint status_acara_fase_live_check
+  check (fase_live in ('pra', 'progres', 'penuh', 'top10', 'juara'));
+
+create or replace function atur_fase_live(p_fase text)
+returns text
+language plpgsql security definer
+set search_path = public
+as $fn$
+declare v_lama text;
+begin
+  if not boleh('pengaturan') then
+    raise exception 'tidak berhak: pengaturan';
+  end if;
+  if p_fase not in ('pra', 'progres', 'penuh', 'top10', 'juara') then
+    raise exception
+      'fase tidak dikenal: % (pra / progres / penuh / top10 / juara)', p_fase;
+  end if;
+
+  select fase_live into v_lama from status_acara;
+  if v_lama = p_fase then
+    return v_lama;
+  end if;
+
+  update status_acara set fase_live = p_fase
+   where fase_live is distinct from p_fase;
+
+  raise notice 'fase_live: % -> %', v_lama, p_fase;
+  return p_fase;
+end;
+$fn$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Penyusun daftar, tanpa pagar hak di dalamnya
+--
+-- Isi kedua fungsi di bawah SAMA PERSIS dengan versi 0152/0153. Yang hilang
+-- cuma tiga baris `where boleh('live_score')`, dan ketiganya muncul kembali
+-- sebagai satu baris di hasil_kejuaraan() pada bagian 3.
+--
+-- Disalin utuh, bukan disunting di tempat, karena migrasi yang sudah
+-- diterapkan ke produksi tidak pernah diedit (final-architecture.md bagian 2).
+-- ---------------------------------------------------------------------------
+
+create or replace function hasil_kejuaraan_dasar()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric
+)
+language sql stable security definer
+set search_path = public
+as $fn$
+with
+peringkat as (
+  select k.*,
+         row_number() over (
+           partition by k.golongan
+           order by k.total desc,
+                    abs(coalesce(k.selisih_menit, 100000)) asc,
+                    k.nomor_dada asc) as nomor_juara
+  from v_klasemen k
+),
+nama_juara(nomor, nama) as (values
+  (1, 'Juara I'), (2, 'Juara II'), (3, 'Juara III'),
+  (4, 'Harapan I'), (5, 'Harapan II'), (6, 'Harapan III')
+),
+golongan_juara(kode, nama, urutan_dasar) as (values
+  ('penegak_pa', 'Penegak PA', 10), ('penegak_pi', 'Penegak PI', 20),
+  ('penggalang_pa', 'Penggalang PA', 40), ('penggalang_pi', 'Penggalang PI', 50)
+),
+baris_golongan as (
+  select g.urutan_dasar + n.nomor as urutan,
+         g.kode || '_' || n.nomor as kode,
+         g.nama || ' ' || n.nama as nama_penghargaan,
+         'skor'::text as sumber,
+         p.regu_id, p.nomor_dada, p.nama_regu, p.nama_sekolah, p.golongan, p.total
+  from golongan_juara g cross join nama_juara n
+  left join peringkat p on p.golongan = g.kode and p.nomor_juara = n.nomor
+),
+calon_umum as (
+  select nama_sekolah,
+         count(*) filter (where nomor_juara <= 6) as jumlah_juara,
+         sum(7 - nomor_juara) filter (where nomor_juara <= 6) as bobot_juara,
+         sum(total) as jumlah_skor,
+         case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end as tingkat
+  from peringkat
+  group by nama_sekolah,
+           case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end
+),
+calon_semua as (
+  select nama_sekolah, sum(jumlah_juara) jumlah_juara,
+         sum(bobot_juara) bobot_juara, sum(jumlah_skor) jumlah_skor
+  from calon_umum group by nama_sekolah
+),
+kandidat_umum as (
+  select 'semua'::text tingkat, * from calon_semua
+  union all
+  select tingkat, nama_sekolah, jumlah_juara, bobot_juara, jumlah_skor
+  from calon_umum
+),
+juara_umum as (
+  select d.urutan, d.kode, d.nama nama_penghargaan,
+         'skor'::text sumber, null::uuid regu_id, null::integer nomor_dada,
+         null::text nama_regu, x.nama_sekolah, null::text golongan,
+         null::numeric total
+  from (values
+    (1, 'juara_umum', 'Juara Umum ' || (select name from edisi where is_active), 'semua'),
+    (2, 'juara_umum_penegak', 'Juara Umum Penegak', 'penegak'),
+    (3, 'juara_umum_penggalang', 'Juara Umum Penggalang', 'penggalang')
+  ) d(urutan, kode, nama, tingkat)
+  left join lateral (
+    select nama_sekolah from kandidat_umum k where k.tingkat = d.tingkat
+    order by jumlah_juara desc, bobot_juara desc, jumlah_skor desc, nama_sekolah
+    limit 1
+  ) x on true
+),
+manual as (
+  select 60 + v.urutan urutan, v.kode, v.nama, 'manual'::text,
+         r.id, r.nomor_dada, r.nama_regu, s.name, r.golongan, null::numeric
+  from (values (1, 'kostum', 'Juara Kostum'),
+               (2, 'yel_yel', 'Juara Yel Yel'),
+               (3, 'terfavorit', 'Peserta Terfavorit'),
+               (4, 'terjauh', 'Peserta Terjauh')) v(urutan, kode, nama)
+  left join kejuaraan_manual m on m.edisi = edisi_aktif() and m.kode = v.kode
+  left join regu r on r.id = m.regu_id
+  left join pendaftaran d on d.id = r.pendaftaran_id
+  left join sekolah s on s.id = d.sekolah_id
+),
+terbanyak as (
+  select 70 urutan, 'peserta_terbanyak' kode, 'Peserta Terbanyak' nama_penghargaan,
+         'nomor_dada'::text sumber, null::uuid, null::integer, null::text,
+         x.nama_sekolah, null::text, x.jumlah::numeric
+  from (select s.name nama_sekolah, count(*) jumlah
+        from regu r join pendaftaran d on d.id = r.pendaftaran_id
+        join sekolah s on s.id = d.sekolah_id
+        where r.nomor_dada is not null and not r.is_cancelled and d.status = 'lunas'
+        group by s.name order by jumlah desc, s.name limit 1) x
+)
+select * from (
+  select * from juara_umum
+  union all select * from baris_golongan
+  union all select * from manual
+  union all select * from terbanyak
+) semua
+order by urutan
+$fn$;
+
+revoke all on function hasil_kejuaraan_dasar() from public, anon, authenticated;
+
+create function hasil_kejuaraan_semua()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric, poin_juara numeric, jumlah_skor numeric
+)
+language sql stable security definer
+set search_path = public
+as $fn$
+with
+golongan_juara(kode, nama, nomor) as (values
+  ('penegak_pa', 'Penegak PA', 1), ('penegak_pi', 'Penegak PI', 2),
+  ('penggalang_pa', 'Penggalang PA', 3), ('penggalang_pi', 'Penggalang PI', 4)
+),
+peringkat_eksternal as (
+  select k.*,
+         row_number() over (
+           partition by k.golongan
+           order by k.total desc,
+                    abs(coalesce(k.selisih_menit, 100000)) asc,
+                    k.nomor_dada asc) as nomor_juara
+  from v_klasemen k
+  where k.golongan in
+    ('penegak_pa', 'penegak_pi', 'penggalang_pa', 'penggalang_pi')
+),
+calon_umum as (
+  select nama_sekolah,
+         count(*) filter (where nomor_juara <= 6) as jumlah_juara,
+         sum(7 - nomor_juara) filter (where nomor_juara <= 6) as bobot_juara,
+         sum(total) filter (where nomor_juara <= 6) as jumlah_skor,
+         case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end as tingkat
+  from peringkat_eksternal
+  group by nama_sekolah,
+           case when golongan like 'penegak_%' then 'penegak' else 'penggalang' end
+),
+calon_semua as (
+  select nama_sekolah, sum(jumlah_juara) jumlah_juara,
+         sum(bobot_juara) bobot_juara, sum(jumlah_skor) jumlah_skor
+  from calon_umum group by nama_sekolah
+),
+kandidat_umum as (
+  select 'semua'::text tingkat, * from calon_semua
+  union all
+  select tingkat, nama_sekolah, jumlah_juara, bobot_juara, jumlah_skor
+  from calon_umum
+),
+juara_umum as (
+  select d.urutan, d.kode, d.nama nama_penghargaan,
+         'skor'::text sumber, null::uuid regu_id, null::integer nomor_dada,
+         null::text nama_regu, x.nama_sekolah, null::text golongan,
+         null::numeric total, x.bobot_juara poin_juara, x.jumlah_skor
+  from (values
+    (1, 'juara_umum', 'Juara Umum ' || (select name from edisi where is_active), 'semua'),
+    (2, 'juara_umum_penegak', 'Juara Umum Penegak', 'penegak'),
+    (3, 'juara_umum_penggalang', 'Juara Umum Penggalang', 'penggalang')
+  ) d(urutan, kode, nama, tingkat)
+  left join lateral (
+    select nama_sekolah, bobot_juara, jumlah_skor
+    from kandidat_umum k where k.tingkat = d.tingkat
+    order by bobot_juara desc nulls last, jumlah_skor desc, nama_sekolah
+    limit 1
+  ) x on true
+),
+manual as (
+  select a.urutan_dasar + g.nomor as urutan,
+         a.kode || '_' || g.kode as kode,
+         a.nama || ' ' || g.nama as nama_penghargaan,
+         'manual'::text as sumber,
+         r.id as regu_id, r.nomor_dada, r.nama_regu, s.name as nama_sekolah,
+         r.golongan, null::numeric total,
+         null::numeric poin_juara, null::numeric jumlah_skor
+  from (values ('kostum', 'Juara Kostum', 60),
+               ('terfavorit', 'Peserta Terfavorit', 68))
+       a(kode, nama, urutan_dasar)
+  cross join golongan_juara g
+  left join kejuaraan_manual m
+    on m.edisi = edisi_aktif() and m.kode = a.kode || '_' || g.kode
+  left join regu r on r.id = m.regu_id
+  left join pendaftaran d on d.id = r.pendaftaran_id
+  left join sekolah s on s.id = d.sekolah_id
+  union all
+  select 73, 'terjauh', 'Pangkalan Terjauh', 'manual_sekolah',
+         null::uuid, null::integer, null::text, s.name, null::text,
+         null::numeric, null::numeric, null::numeric
+  from (values (true)) satu(ada)
+  left join kejuaraan_manual m
+    on m.edisi = edisi_aktif() and m.kode = 'terjauh'
+  left join sekolah s on s.id = m.sekolah_id
+),
+yel_yel as (
+  select 64 + g.nomor as urutan,
+         'yel_yel_' || g.kode as kode,
+         'Juara Yel Yel ' || g.nama as nama_penghargaan,
+         'skor'::text as sumber,
+         y.regu_id, y.nomor_dada, y.nama_regu, y.nama_sekolah,
+         y.golongan, y.poin_pos as total,
+         null::numeric poin_juara, null::numeric jumlah_skor
+  from golongan_juara g
+  left join lateral (
+    select k.regu_id, k.nomor_dada, k.nama_regu, k.nama_sekolah,
+           k.golongan, pp.poin_pos
+    from v_klasemen k
+    join v_poin_pos pp on pp.regu_id = k.regu_id and pp.pos = 5
+    where k.golongan = g.kode
+    order by pp.poin_pos desc, k.total desc, k.nomor_dada
+    limit 1
+  ) y on true
+),
+terbanyak as (
+  select 74, 'peserta_terbanyak', 'Peserta Terbanyak', 'nomor_dada'::text,
+         null::uuid, null::integer, null::text, p.nama_sekolah,
+         null::text, p.jumlah::numeric, null::numeric, null::numeric
+  from (values (true)) satu(ada)
+  left join lateral (
+    select s.name nama_sekolah, count(*) jumlah
+    from regu r
+    join pendaftaran d on d.id = r.pendaftaran_id
+    join sekolah s on s.id = d.sekolah_id
+    where r.nomor_dada is not null and not r.is_cancelled
+      and d.status = 'lunas' and r.golongan not like 'intern_%'
+    group by s.name
+    order by jumlah desc, s.name
+    limit 1
+  ) p on true
+)
+select * from (
+  select d.urutan, d.kode, d.nama_penghargaan, d.sumber, d.regu_id,
+         d.nomor_dada, d.nama_regu, d.nama_sekolah, d.golongan, d.total,
+         null::numeric, null::numeric
+  from hasil_kejuaraan_dasar() d
+  where d.kode ~ '^(penegak|penggalang)_(pa|pi)_[1-6]$'
+  union all select * from juara_umum
+  union all select * from manual
+  union all select * from yel_yel
+  union all select * from terbanyak
+) semua
+order by urutan
+$fn$;
+
+revoke all on function hasil_kejuaraan_semua() from public, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. Kedua pembungkus: satu untuk panitia, satu untuk peserta
+--
+-- Pagar hak panitia tidak berubah sedikit pun - ia cuma pindah ke sini, dan
+-- di sini ia terbaca dalam satu baris alih-alih terkubur di ujung query 128
+-- baris.
+-- ---------------------------------------------------------------------------
+
+create or replace function hasil_kejuaraan()
+returns table (
+  urutan integer, kode text, nama_penghargaan text, sumber text,
+  regu_id uuid, nomor_dada integer, nama_regu text, nama_sekolah text,
+  golongan text, total numeric, poin_juara numeric, jumlah_skor numeric
+)
+language sql stable security definer
+set search_path = public
+as $fn$
+  select * from hasil_kejuaraan_semua()
+  where boleh('live_score')
+  order by urutan
+$fn$;
+
+revoke all on function hasil_kejuaraan() from public;
+grant execute on function hasil_kejuaraan() to authenticated;
+
+-- Kolom skor tidak ada di view publik, dan itulah yang menjadikannya aman
+-- terbit. Kolom `sumber` juga tidak ikut: ia menyebut CARA gelar itu
+-- ditentukan ('manual', 'skor', 'nomor_dada') - keterangan untuk panitia yang
+-- memilihnya, bukan untuk yang membaca hasilnya.
+
+create view v_kejuaraan_publik as
+select urutan, kode, nama_penghargaan, nomor_dada, nama_regu, nama_sekolah,
+       golongan
+from hasil_kejuaraan_semua()
+where (select fase_live from status_acara) = 'juara'
+order by urutan;
+
+grant select on v_kejuaraan_publik to anon, authenticated;
+
+comment on view v_kejuaraan_publik is
+  'Daftar juara untuk halaman peserta. Nol baris di luar fase juara, dan tidak pernah memuat satu angka skor pun.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Penjaga
+-- ---------------------------------------------------------------------------
+
+do $blok$
+declare v_lama text; v_kolom text[]; v_n integer;
+begin
+  assert pg_get_constraintdef(
+    (select oid from pg_constraint
+     where conrelid = 'status_acara'::regclass
+       and conname = 'status_acara_fase_live_check')) like '%juara%',
+    '0163: constraint fase belum menerima juara';
+  assert pg_get_functiondef('atur_fase_live(text)'::regprocedure) like '%juara%',
+    '0163: RPC fase belum menerima juara';
+
+  -- KEDUA fungsi tanpa pagar itu harus tetap tidak bisa dipanggil siapa pun
+  -- selain pemilik database. Inilah yang menggantikan `where` yang dibuang;
+  -- kalau suatu hari ada yang menambahkan grant, berhenti di sini.
+  assert not has_function_privilege(
+           'authenticated', 'hasil_kejuaraan_dasar()', 'execute'),
+    '0163: hasil_kejuaraan_dasar() bisa dipanggil authenticated';
+  assert not has_function_privilege(
+           'anon', 'hasil_kejuaraan_dasar()', 'execute'),
+    '0163: hasil_kejuaraan_dasar() bisa dipanggil anon';
+  assert not has_function_privilege(
+           'authenticated', 'hasil_kejuaraan_semua()', 'execute'),
+    '0163: hasil_kejuaraan_semua() bisa dipanggil authenticated';
+  assert not has_function_privilege(
+           'anon', 'hasil_kejuaraan_semua()', 'execute'),
+    '0163: hasil_kejuaraan_semua() bisa dipanggil anon';
+  assert has_function_privilege(
+           'authenticated', 'hasil_kejuaraan()', 'execute'),
+    '0163: panitia kehilangan hasil_kejuaraan()';
+  assert pg_get_functiondef('hasil_kejuaraan()'::regprocedure)
+           like '%boleh(''live_score'')%',
+    '0163: pagar live_score hilang dari hasil_kejuaraan()';
+
+  -- Kolom skor TIDAK BOLEH ada di view publik. Diperiksa dari katalog, bukan
+  -- dari teks view-nya: kolom baru bernama lain akan lolos pencocokan teks.
+  select array_agg(attname::text order by attnum) into v_kolom
+    from pg_attribute
+   where attrelid = 'v_kejuaraan_publik'::regclass and attnum > 0
+     and not attisdropped;
+  assert not (v_kolom && array['total', 'poin_juara', 'jumlah_skor']),
+    format('0163: kolom skor ikut ke view publik: %s', v_kolom);
+
+  -- Pagar fasenya diuji dengan MENGUBAH fasenya, bukan dengan membaca
+  -- definisinya (CLAUDE.md 13.8). `select true` lolos pemeriksaan teks.
+  select fase_live into v_lama from status_acara;
+
+  update status_acara set fase_live = 'penuh' where fase_live is not null;
+  assert not exists (select 1 from v_kejuaraan_publik),
+    '0163: kejuaraan terbaca padahal fase masih penuh';
+
+  update status_acara set fase_live = 'juara' where fase_live is not null;
+  select count(*) into v_n from v_kejuaraan_publik;
+  -- Papannya ikut ditutup fase ini, dan itu bagian dari janjinya: yang
+  -- dilihat peserta pada fase juara HANYA kejuaraan.
+  assert not exists (select 1 from v_klasemen_publik),
+    '0163: klasemen masih terbuka pada fase juara';
+  assert not exists (select 1 from v_progres_publik),
+    '0163: baris progres masih terbuka pada fase juara';
+
+  update status_acara set fase_live = v_lama where fase_live is not null;
+  raise notice '0163: fase juara siap - % baris penghargaan; fase dikembalikan ke %.',
+               v_n, v_lama;
+end;
+$blok$;

--- a/tests/juara_phase.test.mjs
+++ b/tests/juara_phase.test.mjs
@@ -1,0 +1,149 @@
+// Fase kelima, `juara`: papan peserta diganti daftar juara.
+//
+// Yang dijaga di sini bukan tampilannya melainkan rantainya — saklar panitia,
+// pagar penerbitan, dan halaman peserta. Satu mata rantai yang lupa menyebut
+// fase baru tidak menghasilkan galat apa pun; ia cuma membuat tombolnya tidak
+// mengubah apa-apa, atau lebih buruk, menerbitkan yang seharusnya tertutup.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const panitia = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const peserta = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
+const gaya = await readFile(new URL("../live/live.css", import.meta.url), "utf8");
+const terbit = await readFile(
+  new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
+const liveJson = await readFile(
+  new URL("../supabase/checks/live_json.sql", import.meta.url), "utf8");
+const migrasi = await readFile(
+  new URL("../supabase/migrations/0163_fase_juara.sql", import.meta.url), "utf8");
+
+/* ------------------------------- saklar panitia ------------------------- */
+
+test("saklar panitia punya tombol kelima, sesudah Top 10", () => {
+  const daftar = panitia.slice(panitia.indexOf("const FASE = ["),
+    panitia.indexOf("const saklar ="));
+  assert.match(daftar, /\["top10", "Top 10"\], \["juara", "Juara"\]/);
+  // Urutannya mengikat: saklar ini dibaca kiri ke kanan sebagai tahapan
+  // acara, dan Juara satu-satunya yang datang sesudah lomba selesai.
+  assert.ok(daftar.indexOf('"juara"') > daftar.indexOf('"top10"'));
+});
+
+test("menekannya memberi tahu bahwa penerbitan masih perlu", () => {
+  // Saklar hanya MEMPERKETAT (CLAUDE.md 14.3): daftar juaranya baru sampai ke
+  // HP peserta sesudah publish-live.yml menulis ulang berkasnya. Tanpa
+  // kalimat itu panitia menekan Juara, membaca "peserta melihat", dan peserta
+  // tidak melihat apa-apa.
+  assert.match(panitia, /ke === "juara"/);
+  assert.match(panitia, /Papan peserta diganti daftar juara[\s\S]{0,120}Publish/);
+});
+
+/* ------------------------------- pagar penerbitan ----------------------- */
+
+test("berkas terbit hanya memuat daftar juara pada fasenya", () => {
+  assert.match(terbit, /if d\['fase'\] != 'juara' and d\['kejuaraan'\]:/);
+  assert.match(terbit, /BOCOR: kejuaraan tertulis padahal fase belum juara/);
+});
+
+test("tidak satu pun angka boleh menumpang di daftar juara", () => {
+  // Pagar yang cuma menyebut nama kolom tidak melihat kolom baru bernama lain
+  // — bentuk kesalahan yang sama dengan CLAUDE.md 13.3. Nomor dada dan urutan
+  // dikecualikan: keduanya identitas dan susunan, bukan nilai.
+  assert.match(terbit, /if isinstance\(isi, \(int, float\)\):/);
+  assert.match(terbit, /BOCOR: angka \{kunci\} ikut ke daftar juara/);
+  assert.match(terbit, /if kunci in \('nomor_dada', 'urutan'\):/);
+});
+
+test("papan ikut ditutup pada fase juara", () => {
+  assert.match(terbit,
+    /if d\['fase'\] == 'juara' and \(d\['klasemen'\] or d\['progres'\]\):/);
+  assert.match(terbit, /BOCOR: papan ikut tertulis pada fase juara/);
+});
+
+test("daftar juara ikut ke rekap.json, bukan cuma ke live.json", () => {
+  // rekap.json yang dialamati `?v=<versi>`, jadi daftarnya ikut menentukan
+  // sidik jari — begitu juaranya berubah, HP mengambil berkas baru sekali.
+  assert.match(terbit, /rekap = \{'progres':[\s\S]{0,80}'kejuaraan': d\['kejuaraan'\]\}/);
+  assert.match(terbit, /'kejuaraan'\):/);   // ikut daftar kunci wajib
+});
+
+test("query penerbitnya benar-benar mengambil daftar juara", () => {
+  assert.match(liveJson, /'kejuaraan', \(select coalesce\(jsonb_agg/);
+  assert.match(liveJson, /from v_kejuaraan_publik j\)/);
+});
+
+/* ------------------------------- halaman peserta ------------------------ */
+
+test("fase juara paling terbuka, jadi saklar database tidak bisa membukanya", () => {
+  // URUT_FASE mengukur seberapa jauh isi boleh dibuka, bukan besar berkasnya.
+  assert.match(peserta,
+    /const URUT_FASE = \{ pra: 0, progres: 1, top10: 2, penuh: 3, juara: 4 \};/);
+});
+
+test("layar juara menggambar daftar juara dan tidak menggambar papan", () => {
+  const blok = peserta.slice(peserta.indexOf("function gambar() {"),
+    peserta.indexOf("async function muatRekap"));
+  assert.match(blok, /fase\(\) === "juara"\s*\?\s*gambarKejuaraan\(\)/);
+  // pasangPapan() membaca kotak pencarian dan tab golongan yang tidak
+  // digambar di layar ini.
+  assert.match(blok, /if \(mulai\(\) && fase\(\) !== "juara"\) pasangPapan\(\);/);
+  assert.match(blok, /if \(fase\(\) !== "juara"\) pasangKemajuan\(\);/);
+});
+
+test("judul halaman ikut berganti jadi Kejuaraan", () => {
+  assert.match(peserta, /const namaLayar = fase\(\) === "juara" \? "Kejuaraan" : "Live Score";/);
+});
+
+test("penggambarnya tidak menyentuh satu kolom skor pun", () => {
+  const blok = peserta.slice(peserta.indexOf("function gambarKejuaraan()"),
+    peserta.indexOf("function gambarPapan()"));
+  for (const kolom of ["total", "poin_juara", "jumlah_skor", "peringkat"]) {
+    assert.doesNotMatch(blok, new RegExp(`\\.${kolom}\\b`),
+      `gambarKejuaraan() membaca ${kolom}`);
+  }
+});
+
+test("label golongan diambil dari daftar bersama, tidak ditulis ulang", () => {
+  // periksa_urutan_golongan.py yang menjaga daftar itu tetap satu; nama
+  // golongan yang diketik ulang di sini lolos pemeriksaannya.
+  const blok = peserta.slice(peserta.indexOf("function gambarKejuaraan()"),
+    peserta.indexOf("function gambarPapan()"));
+  assert.match(blok, /GOLONGAN\[g\]/);
+  assert.doesNotMatch(blok, /"Penegak PA"/);
+});
+
+test("gaya kejuaraan berdiri SESUDAH aturan .tabel", () => {
+  // `.tabel-juara th` dan `.tabel th` sama kekhususannya, jadi yang menang
+  // ditentukan urutan baris (CLAUDE.md 15.6). Di atas, aturannya tidak
+  // berlaku sedetik pun dan tidak ada yang memberi tahu.
+  const juara = gaya.indexOf(".tabel-juara th {");
+  const tabel = gaya.indexOf(".tabel th {");
+  assert.ok(tabel !== -1 && juara !== -1, "kedua selektor harus ada");
+  assert.ok(juara > tabel,
+    ".tabel-juara th ditulis sebelum .tabel th — aturannya tidak akan berlaku");
+});
+
+/* ------------------------------- migrasinya ----------------------------- */
+
+test("migrasi memindahkan pagar hak, bukan melonggarkannya", () => {
+  // Pagar `boleh('live_score')` turun dari kedua fungsi penyusun ke satu
+  // pembungkus. Yang menjaga fungsi tanpa pagar itu dari panitia tinggal
+  // grant-nya, jadi penjaganya harus memeriksa grant itu.
+  assert.match(migrasi, /select \* from hasil_kejuaraan_semua\(\)\s*where boleh\('live_score'\)/);
+  assert.match(migrasi,
+    /revoke all on function hasil_kejuaraan_semua\(\) from public, anon, authenticated;/);
+  assert.match(migrasi,
+    /revoke all on function hasil_kejuaraan_dasar\(\) from public, anon, authenticated;/);
+  assert.match(migrasi, /has_function_privilege\(\s*'anon', 'hasil_kejuaraan_semua\(\)', 'execute'\)/);
+});
+
+test("view publiknya berpagar fase dan tanpa kolom skor", () => {
+  const view = migrasi.slice(migrasi.indexOf("create view v_kejuaraan_publik"),
+    migrasi.indexOf("grant select on v_kejuaraan_publik"));
+  assert.match(view, /where \(select fase_live from status_acara\) = 'juara'/);
+  for (const kolom of ["total", "poin_juara", "jumlah_skor"]) {
+    assert.doesNotMatch(view, new RegExp(`\\b${kolom}\\b`),
+      `kolom ${kolom} ikut ke view publik`);
+  }
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -583,9 +583,6 @@ run supabase/migrations/0126_nama_regu_kapital.sql
 run tests/sql/85_nama_regu_kapital.sql
 run tests/sql/83_pembayaran_pilihan_pembina.sql
 run tests/sql/77_nama_anggota_regu.sql
-# Parse dan jalankan query yang benar-benar menjadi live.json setelah seluruh
-# migrasi. Ini menangkap view/kolom yang berganti sebelum workflow publish.
-run supabase/checks/live_json.sql
 # Reset data operasional harus mempertahankan seluruh master Asal Sekolah.
 # Ditaruh paling akhir karena cleanup memang mengosongkan pendaftaran, regu,
 # nilai, dan data operasional lain yang dipakai tes sebelumnya.
@@ -722,5 +719,19 @@ run supabase/migrations/0161_lebur_kembar_ejaan.sql
 run tests/sql/113_lebur_kembar_ejaan.sql
 run supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
 run tests/sql/114_lebur_smp_al_fadliliyah.sql
+run supabase/migrations/0163_fase_juara.sql
+run tests/sql/115_fase_juara.sql
+
+# Parse dan jalankan query yang benar-benar menjadi live.json, SESUDAH
+# seluruh migrasi. Ini menangkap view atau kolom yang berganti sebelum
+# workflow publish menemukannya di produksi.
+#
+# Barisnya dulu duduk di antara 0126 dan 0127 dengan komentar yang sudah
+# berbunyi "setelah seluruh migrasi" — benar saat ditulis, lalu 37 migrasi
+# mendarat di bawahnya dan tidak ada yang memindahkannya. Yang menemukannya
+# 0163: view barunya lahir 37 baris SESUDAH query yang membacanya, jadi
+# run.sh berhenti pada 'relation v_kejuaraan_publik does not exist'. Kalau
+# ada migrasi baru, ia masuk di ATAS baris ini.
+run supabase/checks/live_json.sql
 
 echo "SEMUA TES LULUS"

--- a/tests/sql/115_fase_juara.sql
+++ b/tests/sql/115_fase_juara.sql
@@ -1,0 +1,123 @@
+-- Fase `juara` (0163). Yang diuji bukan bahwa view-nya ada, melainkan bahwa
+-- ia MENUTUP di luar fasenya dan MEMBUKA di dalamnya — dua arah, dijalankan
+-- dengan mengubah fasenya di antara dua panggilan yang sama persis
+-- (CLAUDE.md 13.8). Pemeriksaan satu arah lolos oleh `select true`.
+
+do $blok$
+declare
+  v_fase_lama text;
+  v_n integer;
+  v_juara integer;
+  v_ditolak boolean := false;
+begin
+  select fase_live into v_fase_lama from status_acara;
+
+  perform set_config(
+    'app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  -- 115.1 Fasenya sah, dan RPC-nya menerimanya.
+  assert atur_fase_live('juara') = 'juara',
+    '115.1 GAGAL: admin tidak bisa memilih fase juara';
+
+  -- 115.2 Daftar juaranya terbaca, dan isinya sama banyak dengan yang dilihat
+  --       panitia. Jumlah yang lebih sedikit berarti satu pagar hak tertinggal
+  --       di dalam salah satu fungsi penyusunnya — persis kegagalan yang
+  --       membuat penerbit menulis berkas berisi nol penghargaan tanpa satu
+  --       pun galat.
+  select count(*) into v_n from v_kejuaraan_publik;
+  select count(*) into v_juara from v_kejuaraan;
+  assert v_n > 0, '115.2 GAGAL: daftar juara kosong pada fase juara';
+  assert v_n = v_juara,
+    format('115.2 GAGAL: publik memuat %s penghargaan, panitia %s',
+           v_n, v_juara);
+
+  -- 115.3 Papannya tertutup. Inilah yang membuat "peserta hanya melihat
+  --       kejuaraan" bukan sekadar keputusan tampilan.
+  assert not exists (select 1 from v_klasemen_publik),
+    '115.3 GAGAL: klasemen masih terbuka pada fase juara';
+  assert not exists (select 1 from v_progres_publik),
+    '115.3 GAGAL: baris progres masih terbuka pada fase juara';
+
+  -- 115.4 Arah sebaliknya: fase lain, daftar juara harus NOL. Dijalankan untuk
+  --       keempat fase lainnya, bukan satu, karena yang dijaga di sini
+  --       kebocoran dan satu fase yang terlewat sudah cukup untuk membocorkan.
+  perform atur_fase_live('penuh');
+  select count(*) into v_n from v_kejuaraan_publik;
+  assert v_n = 0, '115.4 GAGAL: juara terbaca pada fase penuh';
+
+  perform atur_fase_live('top10');
+  select count(*) into v_n from v_kejuaraan_publik;
+  assert v_n = 0, '115.4 GAGAL: juara terbaca pada fase top10';
+
+  perform atur_fase_live('progres');
+  select count(*) into v_n from v_kejuaraan_publik;
+  assert v_n = 0, '115.4 GAGAL: juara terbaca pada fase progres';
+
+  perform atur_fase_live('pra');
+  select count(*) into v_n from v_kejuaraan_publik;
+  assert v_n = 0, '115.4 GAGAL: juara terbaca pada fase pra';
+
+  -- 115.5 Fase karangan tetap ditolak. Tanpa ini `atur_fase_live` yang
+  --       daftarnya dilonggarkan jadi "apa saja" akan lulus seluruh tes di
+  --       atas.
+  begin
+    perform atur_fase_live('juara_umum');
+  exception when others then
+    v_ditolak := true;
+  end;
+  assert v_ditolak, '115.5 GAGAL: fase karangan diterima';
+
+  perform atur_fase_live(v_fase_lama);
+end;
+$blok$;
+
+-- 115.6 Hak. Fungsi penyusun tanpa pagar tidak boleh bisa dipanggil siapa pun
+--       selain pemilik database; itulah yang menggantikan `where` yang dibuang
+--       dari dalamnya, dan tanpa pemeriksaan ini pemindahan pagar tadi bisa
+--       diam-diam berubah jadi pelonggaran.
+do $blok$
+begin
+  assert not has_function_privilege(
+           'authenticated', 'hasil_kejuaraan_semua()', 'execute'),
+    '115.6 GAGAL: hasil_kejuaraan_semua() terbuka untuk authenticated';
+  assert not has_function_privilege(
+           'anon', 'hasil_kejuaraan_semua()', 'execute'),
+    '115.6 GAGAL: hasil_kejuaraan_semua() terbuka untuk anon';
+  assert not has_function_privilege(
+           'authenticated', 'hasil_kejuaraan_dasar()', 'execute'),
+    '115.6 GAGAL: hasil_kejuaraan_dasar() terbuka untuk authenticated';
+  assert has_table_privilege('anon', 'v_kejuaraan_publik', 'select'),
+    '115.6 GAGAL: peserta tidak bisa membaca v_kejuaraan_publik';
+end;
+$blok$;
+
+-- 115.7 Pagar hak panitia TIDAK ikut longgar. Panggilan yang sama dijalankan
+--       dua kali dengan satu baris akun_hak diubah di antaranya; kalau
+--       jumlahnya tidak berubah, pagarnya tidak ada lagi.
+do $blok$
+declare
+  v_dengan integer;
+  v_tanpa integer;
+begin
+  perform set_config(
+    'app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  select count(*) into v_dengan from v_kejuaraan;
+
+  delete from akun_hak
+   where user_id = '00000000-0000-0000-0000-00000000000a'
+     and fitur = 'live_score';
+  select count(*) into v_tanpa from v_kejuaraan;
+
+  insert into akun_hak (user_id, fitur)
+  values ('00000000-0000-0000-0000-00000000000a', 'live_score')
+  on conflict do nothing;
+
+  assert v_dengan > 0,
+    '115.7 GAGAL: panitia berhak tidak melihat satu penghargaan pun';
+  assert v_tanpa = 0,
+    format('115.7 GAGAL: panitia tanpa live_score masih melihat %s penghargaan',
+           v_tanpa);
+end;
+$blok$;
+
+select '115_fase_juara OK' hasil;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5647,13 +5647,13 @@ async function layarLiveScore() {
      tahapan, bukan akibat. "Internal" langsung menjawab pertanyaan yang
      sebenarnya ditanyakan: apakah peserta sudah bisa melihat ini.
 
-     Kodenya TETAP pra/progres/penuh/top10. Nilai itu duduk di status_acara, dipakai
-     v_progres_publik, keempat pagar "BOCOR" di publish-live.yml, dan migrasi
+     Kodenya TETAP pra/progres/penuh/top10/juara. Nilai itu duduk di status_acara,
+     dipakai v_progres_publik, pagar-pagar "BOCOR" di publish-live.yml, dan migrasi
      0068/0070/0072 — menggantinya menuntut migrasi beserta seluruh policy,
      demi tiga kata di layar. */
   const FASE = [
     ["pra", "Internal"], ["progres", "Progress"], ["penuh", "Live"],
-    ["top10", "Top 10"],
+    ["top10", "Top 10"], ["juara", "Juara"],
   ];
   const saklar = !bisaPublish ? "" : `
     <div class="segmen-fase" role="group" aria-label="Fase Live Score">
@@ -5895,9 +5895,9 @@ async function layarLiveScore() {
      lain tidak melihat apa pun di tempat ini, bukan tombol mati: tombol mati
      di pojok tidak memberi tahu apa pun selain ada sesuatu yang tidak boleh
      disentuh. */
-  /* Judul di TENGAH, saklar empat keadaan di KANAN, satu baris.
+  /* Judul di TENGAH, saklar lima keadaan di KANAN, satu baris.
      Tombol besar sebelumnya memakan tinggi layar untuk sesuatu yang ditekan
-     beberapa kali sepanjang acara. Empat keadaan ditampilkan sekaligus, bukan satu
+     beberapa kali sepanjang acara. Kelima keadaan ditampilkan sekaligus, bukan satu
      tombol yang berganti tulisan: dengan begitu fase yang SEDANG berlaku
      terbaca tanpa harus tahu apa arti tulisan tombolnya.
 
@@ -5980,7 +5980,10 @@ async function layarLiveScore() {
            ini, admin menekan Live, membaca "peserta dapat melihat", dan
            peserta tetap melihat papan kosong tanpa satu pun tanda kenapa —
            cron penerbitan berkala masih dimatikan di luar minggu lomba. */
-        notif(ke === "top10"
+        notif(ke === "juara"
+          ? "Papan peserta diganti daftar juara — jalankan Publish rekap "
+            + "live supaya daftarnya ikut terbit."
+          : ke === "top10"
           ? "Peserta dapat melihat Top 10 per golongan — jalankan Publish "
             + "rekap live supaya angkanya ikut terbit."
           : ke === "penuh"


### PR DESCRIPTION
## What

The Live Score switch gains a fifth state — **Internal · Progress · Live ·
Top 10 · Juara**. Pressing Juara replaces the peserta board on
`hrcd37.ciradyka.workers.dev` with the championship list and nothing else:
Juara Umum, Juara I–Harapan III per golongan, Kostum, Yel Yel, Terfavorit,
Pangkalan Terjauh, Peserta Terbanyak.

- `0163` adds the phase to `status_acara` and `atur_fase_live`, and creates
  `v_kejuaraan_publik` — phase-gated, readable by `anon`.
- `publish-live.yml` writes the list into `rekap.json` and gains two new
  BOCOR guards.
- `live/live.js` draws it; the board is not drawn on this phase.
- Peserta cannot edit anything: the list is a static file, and choosing the
  manual awards stays behind `pengaturan` on the panitia screen.

## Why

The list existed only on the panitia screen. Peserta heard it from a
loudspeaker and had nowhere to check it afterwards.

**Without a single score, by the event owner's decision.** `v_kejuaraan_publik`
has no `total`, `poin_juara`, or `jumlah_skor` column at all — not hidden by
the page, absent from the file. `rekap.json` sits on a CDN and anyone who
knows the address can ask for it, so the only guarantee that a number has not
leaked is that it was never written (CLAUDE.md 14.4). The guard rejects **any**
numeric value in that list except nomor dada and urutan, so an award column
added later under a different name is caught too — the shape of mistake
CLAUDE.md 13.3 describes.

**The phase closes the board by itself**, with no extra rule:
`v_klasemen_publik` opens only on `penuh` and `top10`, `v_progres_publik` only
on `progres` and `penuh`.

**`0163` moves the `boleh('live_score')` gate rather than loosening it.**
`publish-live.yml` connects as the database owner, where `auth.uid()` is NULL —
a gate inside the list-building functions would make the published file contain
zero awards without a single error. The gate now sits in one place,
`hasil_kejuaraan()`. What keeps `hasil_kejuaraan_dasar()` and
`hasil_kejuaraan_semua()` away from panitia is the `revoke` that was already
there; the migration's own guard and test 115 both check that revoke, and 115
also confirms a panitia without `live_score` still sees nothing.

## Notes

- **Turning the switch back from Juara to Live does not restore the board.**
  The file published on this phase carries no klasemen rows, and the page may
  only tighten what was published (CLAUDE.md 14.3), so the board stays empty
  until the rekap is published again. That is section 14.3 working, not a bug —
  it is now written down as section 14.9.
- `0145`'s fingerprint in `status_migrasi.sql` had to change: it tracked the
  phase constraint, which `0163` rewrites, so it would have reported BELUM for
  a migration that plainly ran. It now tracks `urutan_top` in
  `v_klasemen_publik`, which `0163` does not touch.
- `supabase/checks/live_json.sql` moved to the end of `tests/run.sh`. Its own
  comment already said "after every migration"; it had sat between `0126` and
  `0127` while 37 migrations landed below it.
- CLAUDE.md 14.1 said "Tiga fase" while `top10` had been live since `0145`.
  It now lists all five, with a note to keep it that way.

## Verification

Local, on PostgreSQL 17.11 — production's major version:

    bash tests/run.sh          -> SEMUA TES LULUS   (incl. new test 115)
    node --test tests/*.test.mjs -> 287 pass, 0 fail
    tools/periksa_impor.py, periksa_urutan_golongan.py, periksa_sekolah.py -> OK

Both screens were opened with 32 regu and 832 scores loaded (CLAUDE.md 17.2),
not just tested: the panitia switch showing five states and reporting the phase
change, and the peserta page showing the championship list on `juara` and the
unchanged full board on `penuh`. Layout was measured at 360/480/768/1200 px —
no horizontal scroll, no overflowing cell, label column constant at 97 px.

The four BOCOR guards were run in both directions using the workflow's own
python block: `penuh` + list rejected, `juara` + a score column rejected,
`juara` + klasemen rejected, `juara` + progres rows rejected, nomor dada
allowed.