### PR TITLE
feat: add a manual refresh to the Live Score board

### DIFF
--- a/tests/live_score_refresh.test.mjs
+++ b/tests/live_score_refresh.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const app = fs.readFileSync(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+test("Live Score menyediakan refresh manual", () => {
+  assert.match(app, /id="refresh-live-score"/);
+  assert.match(app, /aria-label="Refresh Live Score"/);
+  assert.match(app,
+    /getElementById\("refresh-live-score"\)[\s\S]*?addEventListener\("click",[\s\S]*?layarLiveScore\(\)/);
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5564,7 +5564,12 @@ async function layarLiveScore() {
         <span class="js-persen">${esc(String(persenSemua))}%</span>
         <span class="kr-panah" aria-hidden="true">▾</span>
       </button>
-      <div class="description">Update ${esc(tanggalJam(snapshot.dibuat_pada))}</div>
+      <div class="description toolbar-kanan">
+        <span>Update ${esc(tanggalJam(snapshot.dibuat_pada))}</span>
+        <button type="button" class="icon-button icon-button-inline"
+                id="refresh-live-score" aria-label="Refresh Live Score"
+                title="Refresh Live Score">${ikonRefresh}</button>
+      </div>
       <ul class="kemajuan" id="kemajuan-rinci">
         ${pos.map(p => {
           const s = persenPos(p);
@@ -5929,6 +5934,13 @@ async function layarLiveScore() {
       tombolKemajuan.classList.toggle("terbuka", buka);
     });
   }
+
+  /* Refresh diminta petugas, bukan berjalan sendiri. Menggambar ulang lewat
+     fungsi layar yang sama memastikan snapshot skor, status acara, dan cap
+     update berasal dari satu pemuatan baru. */
+  document.getElementById("refresh-live-score")?.addEventListener("click", () => {
+    layarLiveScore();
+  });
 
   /* Kepala tabel Live Score ada DUA baris, dan keduanya menempel di atas.
      Aturan umum `.data-table thead th` memaku semuanya di `top: 0`, jadi baris


### PR DESCRIPTION
## What

A refresh button on the Live Score board, next to the update stamp. Pressing it
redraws the screen through `layarLiveScore()` itself.

## Why

The board is read for minutes at a time while scores keep arriving. Until now
the only ways to see newer numbers were to leave the screen and come back, or
reload the page — and a reload costs the whole session load on a field
connection while losing the golongan tab that was open.

It sits beside the update stamp because that is where the question it answers
is already on screen: "how old is this?" and "make it newer" belong together,
so the button needs no label of its own (CLAUDE.md 9.1).

Redrawing through `layarLiveScore()` rather than refetching one piece keeps the
score snapshot, the event status, and the stamp from one single load. Three
separate refreshes can disagree with each other, and a board whose stamp says
one thing while its numbers say another is worse than a stale one.

## Notes

Nothing refreshes on its own. A board that moves under the hand of someone
reading a row is its own problem, and the panitia reading it are usually
checking one regu.

## Verification

Opened on the rendered screen with 32 regu and a full set of scores loaded, not
only checked by the test (CLAUDE.md 17.2). Deleting one component score from
the database and then pressing the button:

- update stamp moved 20:14 -> 20:15
- that component's cell went from `100` to empty
- the podium re-ranked (LASKAR TANI 852 -> 752, CAKRA DYNATA took first)
- the open golongan tab stayed on Penegak PA
- the button stayed wired after the redraw

`node --test tests/*.test.mjs` -> 287 pass, 0 fail.