### PR TITLE
refactor: draw the peserta championship page with the panitia card layout

### DIFF
--- a/live/live.css
+++ b/live/live.css
@@ -266,43 +266,6 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
 }
 .tombol:hover { background: #004d43; }
 
-/* ---------- kejuaraan (fase juara) ---------- */
-/* DI BAWAH seluruh aturan `.tabel`, dan itu bukan soal kerapian berkas.
-   `.tabel-juara th` dan `.tabel th` sama kekhususannya — satu kelas dan satu
-   elemen — jadi yang menang cuma ditentukan urutan baris (CLAUDE.md 15.6).
-   Ditaruh di atas, tiga aturan di bawah ini tidak berlaku sedetik pun dan
-   tidak ada yang memberi tahu. */
-
-/* Dua kolom: nama gelar di kiri selebar isinya, penerimanya mengisi sisa
-   baris. `width: 1%` dengan `nowrap` membuat "Juara I" sampai "Harapan III"
-   berbaris lurus dari baris ke baris, dan nama sekolah yang panjang
-   membungkus DI DALAM kolomnya sendiri alih-alih menggeser kolom kiri tiap
-   baris — pola yang sama dengan kartu HP di CLAUDE.md 15.7. */
-.tabel-juara { white-space: normal; }
-.tabel-juara th {
-  width: 1%; white-space: nowrap; vertical-align: top;
-  padding: .55rem .9rem .55rem 0;
-  /* Bukan kepala tabel yang perlu ikut tergulir: di sini `th` adalah LABEL
-     baris, dan `position: sticky` warisan `.tabel th` membuatnya menempel
-     di puncak layar satu per satu saat halaman digulir. */
-  position: static; background: none;
-  border-bottom: 1px solid var(--garis);
-}
-.tabel-juara td { padding: .55rem 0; }
-/* Nama sekolah turun ke barisnya sendiri di bawah nama regu, bukan mengalir
-   di sebelahnya: yang dicari mata di daftar ini nama regu, dan nama sekolah
-   yang berbaris di kanannya mendorong nama regu ke tempat berbeda tiap
-   baris. `.kartu .keterangan` memberinya margin bawah .7rem — itu jarak
-   antar-kartu, bukan antar-baris. */
-.tabel-juara .keterangan { display: block; margin: .1rem 0 0; }
-.tabel-juara tbody tr:last-child th,
-.tabel-juara tbody tr:last-child td { border-bottom: 0; }
-/* Juara Umum satu-satunya yang ditonjolkan, dan cuma dengan garis di tepi
-   kiri — bukan blok warna. Ia dibaca sekali lalu tidak dicari lagi; yang
-   dicari orang berkali-kali gelar golongannya sendiri. */
-.kartu-juara.juara-umum { border-left: 4px solid var(--utama); }
-.kartu-juara.juara-umum h2 { color: var(--utama); }
-
 @media print {
   /* Satu golongan harus selesai di satu A4. Margin 6mm masih aman untuk
      printer kantor (tepi 4-5mm tidak tercetak), sementara font 7pt adalah

--- a/live/live.js
+++ b/live/live.js
@@ -564,70 +564,95 @@ function gambarTab(semua) {
    migrasi 0163). Yang sudah selesai adalah juaranya; urutan sementara tidak
    lagi menjawab pertanyaan siapa pun.
 
+   SUSUNANNYA SAMA PERSIS DENGAN LAYAR PANITIA #/kejuaraan, sampai ke nama
+   kelasnya — `kejuaraan-bagian`, `kejuaraan-umum`, `kejuaraan-penegak-pa`,
+   dan seterusnya. Itu bukan kebetulan dan bukan tiruan: seluruh aturannya
+   hidup di `style.css`, dan halaman ini memuat berkas yang SAMA (lihat
+   index.html). Menata ulang sendiri di live.css akan melahirkan salinan
+   kedua atas tata letak yang sudah ada — dan salinan kedua itu yang
+   menyimpang diam-diam waktu penghargaannya bertambah.
+
+   Urutan kartunya pun mengikat, bukan selera: blok `@media (min-width:900px)`
+   di style.css memasang grid-column dan grid-row PER KELAS — Penegak di kolom
+   kiri, Penggalang di kanan, Juara Umum membentang di baris pertama. Kartu
+   yang kelasnya salah mendarat di kotak milik kartu lain.
+
    TIDAK ADA SATU ANGKA SKOR di layar ini, dan itu juga bukan keputusan
    tampilan — kolomnya tidak ada di berkasnya. Nomor dada tetap ditulis: ia
    identitas regu, sudah tercetak di punggung mereka sejak pagi, dan tanpa itu
    dua regu bernama mirip tidak bisa dibedakan dari kursi penonton.
    ------------------------------------------------------------------------- */
-/** Satu penerima gelar: regu, sekolah, atau belum ada. */
+/** Satu penerima gelar: regu, sekolah, atau belum ada.
+ *
+ *  Bentuknya sama dengan nilai() di layar panitia dikurangi angkanya. Yang
+ *  hilang cuma `.kejuaraan-skor` dan keterangan poin Juara Umum; pembungkus
+ *  `.kejuaraan-isi` dan `.kejuaraan-nama` tetap, karena itu yang membuat nama
+ *  regu dan nama sekolah bertumpuk rapi persis seperti di sana. */
 const penerimaJuara = (j) => {
-  if (j.nama_regu) return `
+  if (j.nama_regu) return `<div class="kejuaraan-isi"><div class="kejuaraan-nama">
     <strong>${esc(dada(j.nomor_dada))} · ${esc(j.nama_regu)}</strong>
-    <span class="keterangan">${esc(j.nama_sekolah || "")}</span>`;
+    <span class="description">${esc(j.nama_sekolah || "")}</span></div></div>`;
   if (j.nama_sekolah) return `<strong>${esc(j.nama_sekolah)}</strong>`;
-  return `<span class="keterangan">Belum ditentukan</span>`;
+  return `<span class="description">Belum ditentukan</span>`;
 };
 
 function gambarKejuaraan() {
-  const daftar = (REKAP && REKAP.kejuaraan) || [];
   if (!REKAP) return `<div class="kartu tengah"><p class="keterangan">Memuat…</p></div>`;
+  const daftar = REKAP.kejuaraan || [];
   if (!daftar.length) return `
     <div class="kartu tengah">
       <p class="keterangan">Daftar juara belum terbit.</p></div>`;
 
-  /* Label bagian dan pemotong awalannya SAMA dengan layar panitia — di sana
-     `nama_penghargaan` berbunyi "Penegak PA Juara I" dan judul kartunya sudah
-     menyebut golongannya, jadi yang tersisa di baris cuma "Juara I".
-     Nama golongan diambil dari GOLONGAN_LABEL, tidak ditulis ulang di sini:
+  /* Nama golongan diambil dari GOLONGAN_LABEL, tidak ditulis ulang di sini —
      periksa_urutan_golongan.py yang menjaga daftar itu tetap satu. */
-  const gelarGolongan = (g) => ({
-    judul: GOLONGAN[g],
-    masuk: (j) => j.kode.startsWith(g + "_"),
-    label: (j) => j.nama_penghargaan.replace(GOLONGAN[g] + " ", ""),
-  });
+  const gelarGolongan = (kode, kelas) => [
+    GOLONGAN[kode], (j) => j.kode.startsWith(kode + "_"),
+    (j) => j.nama_penghargaan.replace(GOLONGAN[kode] + " ", ""), kelas];
 
   const bagian = [
-    { judul: "Juara Umum", masuk: (j) => j.kode.startsWith("juara_umum"),
-      label: (j) => j.nama_penghargaan.replace(/^Juara Umum ?/, "") || "UMUM",
-      kelas: "juara-umum" },
-    ...URUT_GOLONGAN_PESERTA.map(gelarGolongan),
-    { judul: "Juara Kostum", masuk: (j) => j.kode.startsWith("kostum_"),
-      label: (j) => j.nama_penghargaan.replace(/^Juara Kostum /, "") },
-    { judul: "Juara Yel Yel", masuk: (j) => j.kode.startsWith("yel_yel_"),
-      label: (j) => j.nama_penghargaan.replace(/^Juara Yel Yel /, "") },
-    { judul: "Peserta Terfavorit", masuk: (j) => j.kode.startsWith("terfavorit_"),
-      label: (j) => j.nama_penghargaan.replace(/^Peserta Terfavorit /, "") },
-    { judul: "Penghargaan Khusus",
-      masuk: (j) => j.kode === "terjauh" || j.kode === "peserta_terbanyak",
-      label: (j) => j.nama_penghargaan },
+    ["Juara Umum", (j) => j.kode === "juara_umum",
+      (j) => j.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum"],
+    ["Juara Umum Penegak", (j) => j.kode === "juara_umum_penegak",
+      () => "PENEGAK", "kejuaraan-umum-penegak"],
+    gelarGolongan("penegak_pa", "kejuaraan-penegak-pa"),
+    gelarGolongan("penegak_pi", "kejuaraan-penegak-pi"),
+    ["Juara Umum Penggalang", (j) => j.kode === "juara_umum_penggalang",
+      () => "PENGGALANG", "kejuaraan-umum-penggalang"],
+    gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa"),
+    gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi"),
+    ["Juara Kostum", (j) => j.kode.startsWith("kostum_"),
+      (j) => j.nama_penghargaan.replace(/^Juara Kostum /, ""),
+      "kejuaraan-kostum"],
+    ["Juara Yel Yel", (j) => j.kode.startsWith("yel_yel_"),
+      (j) => j.nama_penghargaan.replace(/^Juara Yel Yel /, ""), "kejuaraan-yel-yel"],
+    ["Peserta Terfavorit", (j) => j.kode.startsWith("terfavorit_"),
+      (j) => j.nama_penghargaan.replace(/^Peserta Terfavorit /, ""),
+      "kejuaraan-terfavorit"],
+    ["Penghargaan Khusus",
+      (j) => j.kode === "terjauh" || j.kode === "peserta_terbanyak",
+      (j) => j.nama_penghargaan, "kejuaraan-khusus"],
   ];
 
-  /* Kartu yang tidak kebagian satu baris pun DIBUANG, bukan digambar kosong.
-     Penghargaan pilihan panitia bisa saja tidak dipakai tahun ini, dan kartu
-     berjudul tanpa isi terbaca seperti hasil yang hilang. */
-  return bagian.map(b => {
-    const isi = daftar.filter(b.masuk);
-    if (!isi.length) return "";
-    return `
-    <div class="kartu kartu-juara ${b.kelas || ""}">
-      <h2>${esc(b.judul)}</h2>
-      <table class="tabel tabel-juara"><tbody>
-        ${isi.map(j => `
-          <tr><th>${esc(b.label(j))}</th>
-              <td>${penerimaJuara(j)}</td></tr>`).join("")}
-      </tbody></table>
-    </div>`;
-  }).join("");
+  /* `kejuaraan-pilihan` TIDAK ikut, dan itu satu-satunya kelas panitia yang
+     sengaja ditinggalkan: ia menata kartu yang berisi KOTAK CARI, dan di sini
+     tidak ada yang bisa dipilih. Memakainya membuat baris terbaca seperti
+     isian yang menunggu diisi. */
+  return `<div class="kejuaraan-bagian">
+    ${bagian.map(([judul, masuk, label, kelas]) => {
+      const isi = daftar.filter(masuk);
+      /* Kartu tanpa satu baris pun DIBUANG, bukan digambar kosong. Kalau
+         penghargaan pilihan tahun ini tidak dipakai, kartu berjudul tanpa isi
+         terbaca seperti hasil yang hilang. */
+      if (!isi.length) return "";
+      return `
+      <section class="card ${kelas}"><h2>${esc(judul)}</h2>
+        <table class="table data-table table-kejuaraan"><tbody>
+          ${isi.map(j => `<tr><th>${esc(label(j))}</th>
+            <td>${penerimaJuara(j)}</td></tr>`).join("")}
+        </tbody></table>
+      </section>`;
+    }).join("")}
+  </div>`;
 }
 
 function gambarPapan() {

--- a/tests/juara_phase.test.mjs
+++ b/tests/juara_phase.test.mjs
@@ -12,6 +12,7 @@ import test from "node:test";
 const panitia = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
 const peserta = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
 const gaya = await readFile(new URL("../live/live.css", import.meta.url), "utf8");
+const gaya_panitia = await readFile(new URL("../live/style.css", import.meta.url), "utf8");
 const terbit = await readFile(
   new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
 const liveJson = await readFile(
@@ -109,19 +110,60 @@ test("label golongan diambil dari daftar bersama, tidak ditulis ulang", () => {
   // golongan yang diketik ulang di sini lolos pemeriksaannya.
   const blok = peserta.slice(peserta.indexOf("function gambarKejuaraan()"),
     peserta.indexOf("function gambarPapan()"));
-  assert.match(blok, /GOLONGAN\[g\]/);
+  assert.match(blok, /GOLONGAN\[kode\]/);
   assert.doesNotMatch(blok, /"Penegak PA"/);
 });
 
-test("gaya kejuaraan berdiri SESUDAH aturan .tabel", () => {
-  // `.tabel-juara th` dan `.tabel th` sama kekhususannya, jadi yang menang
-  // ditentukan urutan baris (CLAUDE.md 15.6). Di atas, aturannya tidak
-  // berlaku sedetik pun dan tidak ada yang memberi tahu.
-  const juara = gaya.indexOf(".tabel-juara th {");
-  const tabel = gaya.indexOf(".tabel th {");
-  assert.ok(tabel !== -1 && juara !== -1, "kedua selektor harus ada");
-  assert.ok(juara > tabel,
-    ".tabel-juara th ditulis sebelum .tabel th — aturannya tidak akan berlaku");
+test("susunannya kelas yang SAMA dengan layar panitia, bukan tiruan", () => {
+  // Seluruh aturannya hidup di style.css, dan halaman peserta memuat berkas
+  // yang sama. Menata ulang di live.css melahirkan salinan kedua atas tata
+  // letak yang sudah ada — dan salinan itu yang menyimpang diam-diam waktu
+  // penghargaannya bertambah.
+  const blok = peserta.slice(peserta.indexOf("function gambarKejuaraan()"),
+    peserta.indexOf("function gambarPapan()"));
+  for (const kelas of ["kejuaraan-bagian", "kejuaraan-umum",
+                       "kejuaraan-umum-penegak", "kejuaraan-penegak-pa",
+                       "kejuaraan-penegak-pi", "kejuaraan-umum-penggalang",
+                       "kejuaraan-penggalang-pa", "kejuaraan-penggalang-pi",
+                       "kejuaraan-kostum", "kejuaraan-yel-yel",
+                       "kejuaraan-terfavorit", "kejuaraan-khusus"]) {
+    assert.ok(blok.includes(kelas), `kelas ${kelas} hilang dari halaman peserta`);
+    // Pencocokan teks biasa, BUKAN RegExp yang dirakit dari template literal:
+    // di dalamnya `\b` adalah karakter backspace, bukan batas kata, jadi
+    // polanya tidak pernah cocok dan tesnya lulus tanpa memeriksa apa pun.
+    assert.ok(gaya_panitia.includes("." + kelas),
+      `kelas ${kelas} tidak punya aturan di style.css`);
+  }
+  assert.match(blok, /table table-kejuaraan/);
+  // live.css tidak boleh memuat tata letaknya sendiri lagi.
+  assert.doesNotMatch(gaya, /tabel-juara|kartu-juara/);
+});
+
+test("kotak cari panitia tidak ikut, jadi `kejuaraan-pilihan` ditinggalkan", () => {
+  // Kelas itu menata kartu yang berisi isian. Di halaman peserta tidak ada
+  // yang bisa dipilih, dan barisnya akan terbaca seperti isian yang menunggu.
+  // Dicari di daftar `bagian` saja, bukan di seluruh fungsi: komentar yang
+  // menjelaskan KENAPA kelas itu ditinggalkan tentu menyebut namanya.
+  const awal = peserta.indexOf("const bagian = [");
+  const bagian = peserta.slice(awal, peserta.indexOf("  ];", awal));
+  assert.doesNotMatch(bagian, /kejuaraan-pilihan/);
+});
+
+test("urutan kartunya mengikat grid style.css", () => {
+  // Blok @media (min-width:900px) memasang grid-column dan grid-row PER
+  // KELAS. Kartu yang urutannya tertukar mendarat di kotak milik kartu lain.
+  const blok = peserta.slice(peserta.indexOf("const bagian = ["),
+    peserta.indexOf("kejuaraan-pilihan` TIDAK ikut"));
+  const urut = ["kejuaraan-umum\"", "kejuaraan-umum-penegak",
+                "kejuaraan-penegak-pa", "kejuaraan-penegak-pi",
+                "kejuaraan-umum-penggalang", "kejuaraan-penggalang-pa",
+                "kejuaraan-penggalang-pi"];
+  let pos = -1;
+  for (const kelas of urut) {
+    const i = blok.indexOf(kelas);
+    assert.ok(i > pos, `${kelas} tidak pada urutannya`);
+    pos = i;
+  }
 });
 
 /* ------------------------------- migrasinya ----------------------------- */


### PR DESCRIPTION
## What

The championship page peserta see on fase `juara` now emits the same markup as
the panitia screen at `#/kejuaraan` — same cards, same order, same class names:
Juara Umum centred at the top, Penegak down the left column and Penggalang down
the right (each tinted by tingkat), the special awards in purple below.

The 38 lines of bespoke CSS added for it in `live.css` are gone.

## Why

#729 shipped the list with a layout of its own: one merged "Juara Umum" card,
then the four golongan. The panitia screen already had a settled arrangement
for exactly this list, so there were two layouts for one thing.

Reusing it is not imitation. Every `.kejuaraan-*` rule lives in `style.css`,
and `live/index.html` already loads that exact file — `web/style.css` and
`live/style.css` are the byte-identical pair `shared-files.yml` enforces.
Styling it a second time in `live.css` was a duplicate of a layout that already
existed, and the duplicate is the one that drifts silently when the award list
changes — which it has done seven times since `0139`.

## Notes

- **The card order is load-bearing.** `@media (min-width: 900px)` in
  `style.css` assigns `grid-column` and `grid-row` per class, so a card
  carrying the wrong class lands in another card's cell. A test now pins the
  order.
- **`kejuaraan-pilihan` is deliberately left off** — the one panitia class not
  reused. It arranges cards holding a search box, and nothing on this page can
  be chosen; with it, the rows read like inputs waiting to be filled.
- Still no score anywhere. That is unchanged and still enforced where it
  matters: the columns do not exist in `v_kejuaraan_publik`, and the
  `publish-live.yml` guard rejects any number in the list except nomor dada.
- One test in #729 was passing without checking anything: it built a RegExp
  from a template literal, where `\b` is a backspace character rather than a
  word boundary, so the pattern never matched. It now uses plain string
  matching, and the reason is written next to it.

## Verification

Opened the rendered page, not only the tests (CLAUDE.md 17.2) — screenshots
match the panitia screen card for card.

Measured in the browser at **360, 480, 899, 901 and 1200 px**:

| width | cards | columns | overlap | h-scroll | overflowing cells | numbers |
| --- | --- | --- | --- | --- | --- | --- |
| 360 | 11 | 1 | 0 | no | 0 | none |
| 480 | 11 | 1 | 0 | no | 0 | none |
| 899 | 11 | 1 | 0 | no | 0 | none |
| 901 | 11 | 3 | 0 | no | 0 | none |
| 1200 | 11 | 3 | 0 | no | 0 | none |

Three distinct x-positions above 900px is the panitia grid: left column, right
column, and the centred Juara Umum card.

`node --test tests/*.test.mjs` -> 289 pass, 0 fail. `periksa_impor.py` clean,
and the `web/`↔`live/` shared copies are still identical.