### PR TITLE
fix: bump the peserta asset versions, and guard them with a test

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,8 +30,8 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=4">
-  <link rel="stylesheet" href="live.css?v=6">
+  <link rel="stylesheet" href="style.css?v=5">
+  <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>
   <header class="kepala">
@@ -78,6 +78,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=17"></script>
+  <script type="module" src="live.js?v=18"></script>
 </body>
 </html>

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -1,0 +1,74 @@
+// Berkas halaman peserta dialamati dengan `?v=<nomor>` di live/index.html, dan
+// nomornya dinaikkan tangan. Selama tujuh belas kali itu berjalan; pada kali
+// kedelapan belas tidak — `live.js` berubah dua kali (fase juara, lalu tata
+// letak kejuaraan) dan nomornya tetap 17.
+//
+// Yang menyelamatkannya kebetulan: `live/_headers` memberi SEMUA berkas
+// `Cache-Control: no-cache`, jadi browser tetap bertanya ulang sebelum memakai
+// salinannya, dan muat-ulang biasa selalu mendapat berkas terbaru. Tapi
+// nomornya ada justru untuk keadaan yang TIDAK bertanya: tab yang sudah
+// terbuka sejak pagi, halaman yang dipulihkan dari bfcache, perantara yang
+// memegang salinan sendiri. Di sana yang menentukan cuma alamatnya berubah
+// atau tidak.
+//
+// Tes ini menyimpan sidik jari isi tiap berkas di sebelah nomornya. Berkasnya
+// berubah tanpa nomornya naik = merah, dengan pesan yang menyebutkan persis
+// apa yang harus dilakukan.
+//
+// AKHIRAN BARIS DINORMALKAN sebelum di-hash: checkout di Windows memberi CRLF
+// dan di CI LF, dan sidik jari yang berbeda antar mesin adalah tes yang gagal
+// tanpa ada yang salah.
+//
+// `style.css` IKUT walaupun ia milik bersama dengan layar panitia, dan itu
+// disengaja: halaman peserta memuat berkas yang sama, jadi perubahan CSS yang
+// dikerjakan untuk panitia pun mengubah apa yang harus diambil peserta.
+// Konsekuensinya memang mengikat — menyunting style.css berarti menaikkan
+// nomor di live/index.html juga. Pemeriksaan yang cuma menjaga dua dari tiga
+// berkas akan menutup pertanyaannya sambil membiarkan lubangnya (CLAUDE.md
+// 13.3).
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const halaman = await readFile(new URL("../live/index.html", import.meta.url), "utf8");
+
+/** Nomor versi yang sedang tertulis di index.html, beserta sidik jari isi
+ *  berkas saat nomor itu dipasang. Ubah KEDUANYA bersama-sama. */
+const BERKAS = {
+  "live.js": { versi: 18, sidik: "5f58713bf57f" },
+  "live.css": { versi: 7, sidik: "3edc52a93ca9" },
+  "style.css": { versi: 5, sidik: "322a2ffb7783" },
+};
+
+const sidikIsi = (teks) =>
+  createHash("sha256").update(teks.replace(/\r\n/g, "\n")).digest("hex").slice(0, 12);
+
+for (const [nama, { versi, sidik }] of Object.entries(BERKAS)) {
+  test(`${nama} dialamati dengan nomor versinya`, () => {
+    // Lolos kalau nomornya cocok DAN tidak ada alamat tanpa `?v=` untuk
+    // berkas yang sama — alamat polos tidak pernah berganti sama sekali.
+    const pola = new RegExp(`${nama.replace(".", "\\.")}\\?v=(\\d+)`);
+    const cocok = halaman.match(pola);
+    assert.ok(cocok, `${nama} tidak dialamati dengan ?v= di live/index.html`);
+    assert.equal(Number(cocok[1]), versi,
+      `nomor ${nama} di index.html ${cocok[1]}, di tes ini ${versi}`);
+  });
+
+  test(`${nama} tidak berubah tanpa nomornya ikut naik`, async () => {
+    const isi = await readFile(new URL(`../live/${nama}`, import.meta.url), "utf8");
+    const sekarang = sidikIsi(isi);
+    assert.equal(sekarang, sidik, [
+      ``,
+      `live/${nama} berubah tetapi nomor versinya masih ${versi}.`,
+      ``,
+      `Naikkan DUA-DUANYA:`,
+      `  1. live/index.html  -> ${nama}?v=${versi + 1}`,
+      `  2. tes ini          -> { versi: ${versi + 1}, sidik: "${sekarang}" }`,
+      ``,
+      `Tanpa itu, HP yang tabnya sudah terbuka sejak pagi tetap menjalankan`,
+      `berkas lama sampai orangnya memuat ulang sendiri.`,
+      ``,
+    ].join("\n"));
+  });
+}


### PR DESCRIPTION
## What

`live/index.html` addresses its files as `?v=<number>`. The numbers were stale:

| file | was | now |
| --- | --- | --- |
| `live.js` | 17 | **18** |
| `live.css` | 6 | **7** |
| `style.css` | 4 | **5** |

A new test stores a fingerprint of each file beside its number, so changing the
file without bumping the number fails.

## Why

The counter had been bumped by hand seventeen times and it worked. On the
eighteenth it did not: `live.js` changed twice — #729 (the juara phase) and
#731 (the championship layout) — and the number stayed at 17. Mine to miss,
twice.

What kept it from hurting is luck, not design: `live/_headers` gives every file
`Cache-Control: no-cache`, so browsers revalidate before reusing a copy and an
ordinary reload always gets the current file. Verified against production —
`style.css?v=4` was already serving the `.kejuaraan-*` rules, and a fresh
browser renders the championship page correctly.

But the number exists for the cases that do **not** ask: a tab open since
morning, a page restored from bfcache, an intermediary holding its own copy.
There, the only thing that decides is whether the address changed. On an event
day where peserta leave the board open for hours, that is the common case, not
the rare one.

## Notes

- **`style.css` is included even though it is shared with the panitia screen.**
  The peserta page loads that same file, so CSS written for panitia also
  changes what peserta must fetch. This does bind: editing `web/style.css` now
  means bumping the number in `live/index.html` too. Guarding two of the three
  files would close the question while leaving the hole open (CLAUDE.md 13.3).
- Line endings are normalised before hashing — a checkout on Windows gives CRLF
  and CI gives LF, and a fingerprint that differs per machine is a test that
  fails with nothing wrong.
- The failure message names both edits to make, so whoever hits it does not
  have to work out the convention from scratch.

## Verification

Checked in both directions, because a guard that only ever passes is worse than
none:

- appending one line to `live.js` turns the test red, printing
  `live/live.js berubah tetapi nomor versinya masih 18` with the two edits to make
- restoring the file turns it green again

`node --test tests/*.test.mjs` -> 295 pass, 0 fail.