### PR TITLE
feat: publish the championship scores to peserta, and bracket "(6 besar)"

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -19,8 +19,10 @@
 # mengembalikan nol baris dan v_progres_publik tidak memuat satu pun angka
 # nilai. Fase 'top10' hanya menerbitkan maksimal sepuluh regu eligible per
 # golongan beserta totalnya; fase 'penuh' menerbitkan papan lengkap; fase
-# 'juara' menutup papan sepenuhnya dan menerbitkan daftar juara — tanpa satu
-# angka skor pun, karena kolomnya memang tidak ada di v_kejuaraan_publik.
+# 'juara' menutup papan sepenuhnya dan menerbitkan daftar juara beserta
+# angkanya. Yang menahan angka itu sebelum diumumkan bukan ketiadaan
+# kolomnya melainkan pagar fase: v_kejuaraan_publik mengembalikan nol baris
+# di luar fase 'juara' (0163, kolom skornya kembali di 0164).
 #
 # CRON 15 MENIT AKTIF HANYA 29 AGUSTUS 2026, 08:00-23:59 WIB. Cron memakai
 # UTC dan tidak punya kolom tahun, jadi jadwal memilih 01:00-16:45 UTC lalu
@@ -161,23 +163,28 @@ jobs:
           # Pagar kebocoran, dijaga di sini SEKALIGUS di view (0005/0026).
           if d['fase'] not in ('penuh', 'top10') and d['klasemen']:
               sys.exit('BOCOR: klasemen ikut tertulis pada fase yang tertutup')
-          # Daftar juara hanya pada fase 'juara' (0163), dan tidak pernah
-          # membawa satu angka skor pun. Kunci yang dilarang disebut satu per
-          # satu DAN apa pun yang bertipe angka ikut ditolak: penghargaan
-          # berikutnya bisa membawa kolom baru bernama lain, dan pagar yang
-          # cuma menyebut nama tidak akan melihatnya (CLAUDE.md 13.3).
-          # `nomor_dada` dikecualikan — ia identitas regu, sama terbukanya
-          # dengan namanya sendiri, dan sudah tercetak di punggung mereka.
+          # Daftar juara hanya pada fase 'juara' (0163). ITULAH pagarnya, dan
+          # sejak 0164 ia satu-satunya: angkanya sekarang memang ikut terbit,
+          # jadi tidak ada lapisan kedua di belakangnya. Sebelum juaranya
+          # diumumkan, view-nya mengembalikan nol baris dan tidak ada yang
+          # bisa dibaca siapa pun.
           if d['fase'] != 'juara' and d['kejuaraan']:
               sys.exit('BOCOR: kejuaraan tertulis padahal fase belum juara')
+          # Kolomnya DIDAFTAR, bukan dilarang satu per satu. Pagar lama
+          # menolak apa pun yang bertipe angka; itu tidak bisa dipertahankan
+          # sesudah 0164 dan menggantinya dengan daftar-larangan akan buta
+          # terhadap kolom baru bernama lain. Yang dipakai kebalikannya: kolom
+          # yang TIDAK dikenal menghentikan penerbitan. `hasil_kejuaraan()`
+          # duduk di atas `pendaftaran`, satu tabel dengan nomor WA pembina —
+          # satu `select *` yang kelewat lebar di masa depan berhenti di sini,
+          # bukan di HP peserta (CLAUDE.md 13.3).
+          KOLOM_JUARA = {'urutan', 'kode', 'nama_penghargaan', 'nomor_dada',
+                         'nama_regu', 'nama_sekolah', 'golongan',
+                         'total', 'poin_juara', 'jumlah_skor'}
           for baris in d['kejuaraan']:
-              for kunci, isi in baris.items():
-                  if kunci in ('nomor_dada', 'urutan'):
-                      continue
-                  if isinstance(isi, bool) or isi is None:
-                      continue
-                  if isinstance(isi, (int, float)):
-                      sys.exit(f'BOCOR: angka {kunci} ikut ke daftar juara')
+              asing = set(baris) - KOLOM_JUARA
+              if asing:
+                  sys.exit(f'BOCOR: kolom tak dikenal di daftar juara: {sorted(asing)}')
           # Fase juara menutup papan, dan itu bagian dari janjinya: yang
           # dilihat peserta di sana HANYA kejuaraan. Kedua view memang sudah
           # menutup sendiri; kalau suatu hari tidak lagi, berhenti di sini.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -619,20 +619,39 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    `v_progres_publik` hanya pada `progres` dan `penuh`. Jadi berkas yang
    terbit pada fase ini memuat daftar juara dan TIDAK memuat papan — pasal 4
    dipenuhi tanpa satu pagar tambahan pun.
-8. **Daftar juara terbit TANPA satu angka skor**, dan itu keputusan pemilik
-   acara. `v_kejuaraan_publik` tidak punya kolom `total`, `poin_juara`,
-   maupun `jumlah_skor` — bukan disembunyikan tampilan, memang tidak ada.
-   Nomor dada tetap ikut: ia identitas regu, sudah tercetak di punggung
-   mereka sejak pagi. Pagar di `publish-live.yml` menolak APA PUN yang
-   bertipe angka di daftar itu selain nomor dada dan urutan, jadi kolom baru
-   bernama lain ikut tertangkap (pasal 13.3).
-9. **Menurunkan saklar dari Juara ke Live TIDAK mengembalikan papan.**
+8. **Daftar juara terbit BESERTA angkanya** — total skor tiap regu juara,
+   poin juara dan total skor enam besar untuk Juara Umum, jumlah regu
+   bernomor dada untuk Peserta Terbanyak. Sama persis dengan layar panitia
+   `#/kejuaraan`, dan memakai kelas yang sama (`.kejuaraan-skor`) supaya
+   angkanya jatuh di tempat yang sama di dua layar.
+
+   **Ini terbit tanpa angka sampai 30 Agustus 2026** (migrasi 0163), lalu
+   pemilik acara memutuskan sebaliknya (0164). Yang perlu dipahami dari
+   pergantian itu: yang menahan angka lomba sebelum diumumkan BUKAN
+   ketiadaan kolomnya, melainkan pagar fase. `v_kejuaraan_publik`
+   mengembalikan nol baris di luar fase `juara`, jadi sebelum pengumuman
+   tidak ada satu baris pun untuk dibaca siapa pun — dengan atau tanpa
+   kolom skor. Sesudah pengumuman, yang terbaca cuma angka yang memang baru
+   saja dibacakan di lapangan.
+
+   **Karena itu pagar fase sekarang SATU-SATUNYA lapisan**, dan ia yang
+   diuji paling keras: penjaga 0164 dan tes 116 dua-duanya MENGUBAH fasenya
+   lalu membaca ulang, bukan membaca definisi view-nya.
+9. **Pagar di `publish-live.yml` memakai DAFTAR IZIN kolom, bukan daftar
+   larangan.** Yang dulu menolak apa pun bertipe angka tidak bisa
+   dipertahankan sesudah 0164, dan menggantinya dengan daftar larangan akan
+   buta terhadap kolom baru bernama lain. Sekarang kolom yang TIDAK dikenal
+   yang menghentikan penerbitan — `hasil_kejuaraan()` duduk di atas
+   `pendaftaran`, satu tabel dengan nomor WA pembina, dan satu `select *`
+   yang kelewat lebar di masa depan berhenti di situ, bukan di HP peserta
+   (pasal 13.3).
+10. **Menurunkan saklar dari Juara ke Live TIDAK mengembalikan papan.**
    Berkas fase juara memang tidak memuat satu baris klasemen pun, dan pasal
    3 melarang layar menampilkan lebih dari isi berkasnya — jadi yang
    tergambar papan kosong sampai rekap diterbitkan ulang. Itu bukan bug; itu
    pasal 3 bekerja. Yang perlu diketahui panitia: urutan kerjanya nyalakan
    fasenya dulu, terbitkan sesudahnya, dan itu berlaku ke DUA arah.
-10. **Pagar hak daftar juara ada di SATU tempat, `hasil_kejuaraan()`**
+11. **Pagar hak daftar juara ada di SATU tempat, `hasil_kejuaraan()`**
     (migrasi 0163). Penyusunnya — `hasil_kejuaraan_dasar()` dan
     `hasil_kejuaraan_semua()` — sengaja tanpa `boleh('live_score')` di
     dalamnya, karena penerbit tersambung sebagai pemilik database dan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,20 +617,39 @@ Guidance for Claude Code when working in this repository.
    `v_progres_publik` hanya pada `progres` dan `penuh`. Jadi berkas yang
    terbit pada fase ini memuat daftar juara dan TIDAK memuat papan — pasal 4
    dipenuhi tanpa satu pagar tambahan pun.
-8. **Daftar juara terbit TANPA satu angka skor**, dan itu keputusan pemilik
-   acara. `v_kejuaraan_publik` tidak punya kolom `total`, `poin_juara`,
-   maupun `jumlah_skor` — bukan disembunyikan tampilan, memang tidak ada.
-   Nomor dada tetap ikut: ia identitas regu, sudah tercetak di punggung
-   mereka sejak pagi. Pagar di `publish-live.yml` menolak APA PUN yang
-   bertipe angka di daftar itu selain nomor dada dan urutan, jadi kolom baru
-   bernama lain ikut tertangkap (pasal 13.3).
-9. **Menurunkan saklar dari Juara ke Live TIDAK mengembalikan papan.**
+8. **Daftar juara terbit BESERTA angkanya** — total skor tiap regu juara,
+   poin juara dan total skor enam besar untuk Juara Umum, jumlah regu
+   bernomor dada untuk Peserta Terbanyak. Sama persis dengan layar panitia
+   `#/kejuaraan`, dan memakai kelas yang sama (`.kejuaraan-skor`) supaya
+   angkanya jatuh di tempat yang sama di dua layar.
+
+   **Ini terbit tanpa angka sampai 30 Agustus 2026** (migrasi 0163), lalu
+   pemilik acara memutuskan sebaliknya (0164). Yang perlu dipahami dari
+   pergantian itu: yang menahan angka lomba sebelum diumumkan BUKAN
+   ketiadaan kolomnya, melainkan pagar fase. `v_kejuaraan_publik`
+   mengembalikan nol baris di luar fase `juara`, jadi sebelum pengumuman
+   tidak ada satu baris pun untuk dibaca siapa pun — dengan atau tanpa
+   kolom skor. Sesudah pengumuman, yang terbaca cuma angka yang memang baru
+   saja dibacakan di lapangan.
+
+   **Karena itu pagar fase sekarang SATU-SATUNYA lapisan**, dan ia yang
+   diuji paling keras: penjaga 0164 dan tes 116 dua-duanya MENGUBAH fasenya
+   lalu membaca ulang, bukan membaca definisi view-nya.
+9. **Pagar di `publish-live.yml` memakai DAFTAR IZIN kolom, bukan daftar
+   larangan.** Yang dulu menolak apa pun bertipe angka tidak bisa
+   dipertahankan sesudah 0164, dan menggantinya dengan daftar larangan akan
+   buta terhadap kolom baru bernama lain. Sekarang kolom yang TIDAK dikenal
+   yang menghentikan penerbitan — `hasil_kejuaraan()` duduk di atas
+   `pendaftaran`, satu tabel dengan nomor WA pembina, dan satu `select *`
+   yang kelewat lebar di masa depan berhenti di situ, bukan di HP peserta
+   (pasal 13.3).
+10. **Menurunkan saklar dari Juara ke Live TIDAK mengembalikan papan.**
    Berkas fase juara memang tidak memuat satu baris klasemen pun, dan pasal
    3 melarang layar menampilkan lebih dari isi berkasnya — jadi yang
    tergambar papan kosong sampai rekap diterbitkan ulang. Itu bukan bug; itu
    pasal 3 bekerja. Yang perlu diketahui panitia: urutan kerjanya nyalakan
    fasenya dulu, terbitkan sesudahnya, dan itu berlaku ke DUA arah.
-10. **Pagar hak daftar juara ada di SATU tempat, `hasil_kejuaraan()`**
+11. **Pagar hak daftar juara ada di SATU tempat, `hasil_kejuaraan()`**
     (migrasi 0163). Penyusunnya — `hasil_kejuaraan_dasar()` dan
     `hasil_kejuaraan_semua()` — sengaja tanpa `boleh('live_score')` di
     dalamnya, karena penerbit tersambung sebagai pemilik database dan

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,13 +6,14 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0163`:
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0164`:
 angka tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database
 sampai `0162`, dan bagian 3 diperiksa terhadap layar. `0163` — fase live
 kelima `juara` beserta `v_kejuaraan_publik` dan `hasil_kejuaraan_semua()` —
 mendarat sesudah penghitungan itu, jadi angka view dan fungsi di bagian 2
-kurang satu masing-masing. Isi bagian 2 sampai 9 selebihnya belum dibaca
-ulang baris demi baris terhadap `0119`-`0163`.
+kurang satu masing-masing; `0164` menulis ulang view yang sama untuk
+membawa kolom skornya dan tidak mengubah jumlahnya. Isi bagian 2 sampai 9
+selebihnya belum dibaca ulang baris demi baris terhadap `0119`-`0164`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -77,7 +78,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-163 migrasi, `0001` sampai `0163`, dijalankan berurutan tanpa lubang penomoran.
+164 migrasi, `0001` sampai `0164`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/index.html
+++ b/live/index.html
@@ -78,6 +78,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=18"></script>
+  <script type="module" src="live.js?v=19"></script>
 </body>
 </html>

--- a/live/live.js
+++ b/live/live.js
@@ -577,22 +577,32 @@ function gambarTab(semua) {
    kiri, Penggalang di kanan, Juara Umum membentang di baris pertama. Kartu
    yang kelasnya salah mendarat di kotak milik kartu lain.
 
-   TIDAK ADA SATU ANGKA SKOR di layar ini, dan itu juga bukan keputusan
-   tampilan — kolomnya tidak ada di berkasnya. Nomor dada tetap ditulis: ia
-   identitas regu, sudah tercetak di punggung mereka sejak pagi, dan tanpa itu
-   dua regu bernama mirip tidak bisa dibedakan dari kursi penonton.
+   ANGKANYA IKUT, sama dengan layar panitia (0164). Yang menahan angka itu
+   sebelum juaranya diumumkan bukan ketiadaan kolomnya melainkan pagar fase:
+   di luar fase ini berkasnya tidak memuat satu baris juara pun, jadi tidak
+   ada yang bisa dibaca dari CDN dengan cara apa pun.
    ------------------------------------------------------------------------- */
 /** Satu penerima gelar: regu, sekolah, atau belum ada.
  *
- *  Bentuknya sama dengan nilai() di layar panitia dikurangi angkanya. Yang
- *  hilang cuma `.kejuaraan-skor` dan keterangan poin Juara Umum; pembungkus
- *  `.kejuaraan-isi` dan `.kejuaraan-nama` tetap, karena itu yang membuat nama
- *  regu dan nama sekolah bertumpuk rapi persis seperti di sana. */
+ *  Bentuknya SAMA PERSIS dengan nilai() di layar panitia, termasuk
+ *  `.kejuaraan-isi`, `.kejuaraan-nama`, dan `.kejuaraan-skor` — itu yang
+ *  membuat nama regu, nama sekolah, dan angkanya jatuh di tempat yang sama
+ *  di dua layar. Yang tidak ikut cuma tombol Ubah Juara, karena di sini
+ *  tidak ada yang bisa dipilih. */
+const skorJuara = (j) => j.total == null ? ""
+  : `<span class="kejuaraan-skor">${esc(angkaRapi(j.total))}</span>`;
+
 const penerimaJuara = (j) => {
   if (j.nama_regu) return `<div class="kejuaraan-isi"><div class="kejuaraan-nama">
     <strong>${esc(dada(j.nomor_dada))} · ${esc(j.nama_regu)}</strong>
-    <span class="description">${esc(j.nama_sekolah || "")}</span></div></div>`;
-  if (j.nama_sekolah) return `<strong>${esc(j.nama_sekolah)}</strong>`;
+    <span class="description">${esc(j.nama_sekolah || "")}</span></div>${skorJuara(j)}</div>`;
+  if (j.nama_sekolah) return `<strong>${esc(j.nama_sekolah)}</strong>${
+    j.kode.startsWith("juara_umum")
+      ? `<span class="description">${esc(angkaRapi(j.poin_juara))} poin juara · ${
+          esc(angkaRapi(j.jumlah_skor))} total skor (6 besar)</span>`
+      : j.kode === "peserta_terbanyak"
+        ? `<span class="description">${esc(angkaRapi(j.total))} regu bernomor dada</span>`
+        : ""}`;
   return `<span class="description">Belum ditentukan</span>`;
 };
 

--- a/supabase/migrations/0164_kejuaraan_publik_dengan_skor.sql
+++ b/supabase/migrations/0164_kejuaraan_publik_dengan_skor.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- 0164 : daftar juara peserta ikut membawa angkanya.
+--
+-- 0163 menerbitkan daftar juara TANPA satu kolom skor pun, dan itu memang yang
+-- diminta saat itu. Pemilik acara memutuskan sebaliknya sehari kemudian:
+-- halaman peserta menampilkan angka yang sama dengan layar panitia
+-- #/kejuaraan — total skor tiap regu juara, poin juara dan total skor enam
+-- besar untuk Juara Umum, jumlah regu bernomor dada untuk Peserta Terbanyak.
+--
+-- KENAPA INI TIDAK MELONGGARKAN APA PUN
+--
+-- Yang menjaga angka lomba tetap tertutup BUKAN ketiadaan kolomnya, melainkan
+-- pagar fase: view ini mengembalikan NOL BARIS di luar fase 'juara', dan fase
+-- itu baru dinyalakan sesudah juaranya diumumkan. Sebelum diumumkan, tidak ada
+-- satu baris pun untuk dibaca siapa pun — dengan atau tanpa kolom skor.
+--
+-- Yang berubah karena itu cuma satu: sesudah pengumuman, angka yang memang
+-- sudah dibacakan di lapangan ikut terbaca di halaman peserta. Sampai
+-- pengumuman, keadaannya sama persis dengan sebelum migrasi ini.
+--
+-- Pagar di publish-live.yml IKUT DISEMPITKAN, bukan dibuang: yang dulu menolak
+-- APA PUN yang bertipe angka sekarang menolak KOLOM YANG TIDAK DIKENAL. Kolom
+-- baru yang muncul di view ini — nomor WA pembina, misalnya, yang duduk satu
+-- tabel dengan pendaftaran — tetap menghentikan penerbitan. Melepas pagarnya
+-- sama sekali akan menukar satu pemeriksaan sempit dengan tidak ada
+-- pemeriksaan (CLAUDE.md 13.3).
+--
+-- `sumber` tetap tidak ikut: ia menyebut CARA gelar ditentukan ('manual',
+-- 'skor', 'nomor_dada') — keterangan untuk panitia yang memilihnya, bukan
+-- untuk yang membaca hasilnya.
+-- ============================================================================
+
+drop view v_kejuaraan_publik;
+
+create view v_kejuaraan_publik as
+select urutan, kode, nama_penghargaan, nomor_dada, nama_regu, nama_sekolah,
+       golongan, total, poin_juara, jumlah_skor
+from hasil_kejuaraan_semua()
+where (select fase_live from status_acara) = 'juara'
+order by urutan;
+
+grant select on v_kejuaraan_publik to anon, authenticated;
+
+comment on view v_kejuaraan_publik is
+  'Daftar juara untuk halaman peserta, beserta angkanya. Nol baris di luar fase juara — pagar itu yang menjaga hasil sebelum diumumkan, bukan ketiadaan kolom skor.';
+
+-- ---------------------------------------------------------------------------
+-- Penjaga
+-- ---------------------------------------------------------------------------
+
+do $blok$
+declare v_lama text; v_kolom text[]; v_n integer; v_skor integer;
+begin
+  select array_agg(attname::text order by attnum) into v_kolom
+    from pg_attribute
+   where attrelid = 'v_kejuaraan_publik'::regclass and attnum > 0
+     and not attisdropped;
+  assert v_kolom @> array['total', 'poin_juara', 'jumlah_skor'],
+    format('0164: kolom skor belum ada di view publik: %s', v_kolom);
+  assert not (v_kolom && array['sumber', 'regu_id']),
+    format('0164: kolom yang tidak perlu ikut terbawa: %s', v_kolom);
+
+  -- Pagar fasenya diuji dengan MENGUBAH fasenya, bukan dengan membaca
+  -- definisinya (CLAUDE.md 13.8). Ini pemeriksaan yang paling penting di
+  -- berkas ini: sesudah kolom skornya kembali, hanya pagar inilah yang
+  -- menahan hasil lomba sebelum diumumkan.
+  select fase_live into v_lama from status_acara;
+
+  update status_acara set fase_live = 'penuh' where fase_live is not null;
+  assert not exists (select 1 from v_kejuaraan_publik),
+    '0164: daftar juara terbaca padahal fase masih penuh';
+
+  update status_acara set fase_live = 'juara' where fase_live is not null;
+  select count(*) into v_n from v_kejuaraan_publik;
+  select count(*) into v_skor from v_kejuaraan_publik where total is not null;
+
+  update status_acara set fase_live = v_lama where fase_live is not null;
+  raise notice '0164: % baris penghargaan, % di antaranya berangka; fase dikembalikan ke %.',
+               v_n, v_skor, v_lama;
+end;
+$blok$;

--- a/tests/championship_ui.test.mjs
+++ b/tests/championship_ui.test.mjs
@@ -68,7 +68,10 @@ test("Juara Umum menampilkan poin juara dan total skor", () => {
   assert.match(layar, /x\.poin_juara/);
   assert.match(layar, /x\.jumlah_skor/);
   assert.match(layar, /poin juara ·/);
-  assert.match(layar, /total skor 6 besar/);
+  // Tanda kurung, bukan tanpa. "2370 total skor 6 besar" terbaca seperti dua
+  // angka yang berhimpitan; "(6 besar)" memisahkan angkanya dari cakupannya.
+  // Kalimat yang sama dipakai halaman peserta — dijaga di juara_phase.test.mjs.
+  assert.match(layar, /total skor \(6 besar\)/);
 });
 
 test("menyimpan juara mengunci baris tanpa memuat ulang layar", () => {

--- a/tests/juara_phase.test.mjs
+++ b/tests/juara_phase.test.mjs
@@ -19,6 +19,8 @@ const liveJson = await readFile(
   new URL("../supabase/checks/live_json.sql", import.meta.url), "utf8");
 const migrasi = await readFile(
   new URL("../supabase/migrations/0163_fase_juara.sql", import.meta.url), "utf8");
+const skor = await readFile(new URL(
+  "../supabase/migrations/0164_kejuaraan_publik_dengan_skor.sql", import.meta.url), "utf8");
 
 /* ------------------------------- saklar panitia ------------------------- */
 
@@ -47,13 +49,25 @@ test("berkas terbit hanya memuat daftar juara pada fasenya", () => {
   assert.match(terbit, /BOCOR: kejuaraan tertulis padahal fase belum juara/);
 });
 
-test("tidak satu pun angka boleh menumpang di daftar juara", () => {
-  // Pagar yang cuma menyebut nama kolom tidak melihat kolom baru bernama lain
-  // — bentuk kesalahan yang sama dengan CLAUDE.md 13.3. Nomor dada dan urutan
-  // dikecualikan: keduanya identitas dan susunan, bukan nilai.
-  assert.match(terbit, /if isinstance\(isi, \(int, float\)\):/);
-  assert.match(terbit, /BOCOR: angka \{kunci\} ikut ke daftar juara/);
-  assert.match(terbit, /if kunci in \('nomor_dada', 'urutan'\):/);
+test("kolom yang tidak dikenal menghentikan penerbitan", () => {
+  // Sejak 0164 angkanya memang ikut terbit, jadi pagar lama — tolak apa pun
+  // yang bertipe angka — tidak bisa dipertahankan. Yang menggantikannya
+  // DAFTAR IZIN, bukan daftar larangan: daftar larangan buta terhadap kolom
+  // baru bernama lain, dan hasil_kejuaraan() duduk di atas `pendaftaran`,
+  // satu tabel dengan nomor WA pembina (CLAUDE.md 13.3).
+  assert.match(terbit, /KOLOM_JUARA = \{/);
+  assert.match(terbit, /asing = set\(baris\) - KOLOM_JUARA/);
+  assert.match(terbit, /BOCOR: kolom tak dikenal di daftar juara/);
+  // Kolom skor memang termasuk yang diizinkan sekarang.
+  const daftar = terbit.slice(terbit.indexOf("KOLOM_JUARA = {"),
+    terbit.indexOf("for baris in d['kejuaraan']"));
+  for (const kolom of ["total", "poin_juara", "jumlah_skor"]) {
+    assert.ok(daftar.includes(`'${kolom}'`), `${kolom} tidak ada di KOLOM_JUARA`);
+  }
+  // Yang TIDAK pernah boleh ikut tetap di luar daftar.
+  for (const kolom of ["sumber", "regu_id", "kontak_wa"]) {
+    assert.ok(!daftar.includes(`'${kolom}'`), `${kolom} tidak boleh diizinkan`);
+  }
 });
 
 test("papan ikut ditutup pada fase juara", () => {
@@ -96,13 +110,27 @@ test("judul halaman ikut berganti jadi Kejuaraan", () => {
   assert.match(peserta, /const namaLayar = fase\(\) === "juara" \? "Kejuaraan" : "Live Score";/);
 });
 
-test("penggambarnya tidak menyentuh satu kolom skor pun", () => {
-  const blok = peserta.slice(peserta.indexOf("function gambarKejuaraan()"),
-    peserta.indexOf("function gambarPapan()"));
-  for (const kolom of ["total", "poin_juara", "jumlah_skor", "peringkat"]) {
-    assert.doesNotMatch(blok, new RegExp(`\\.${kolom}\\b`),
-      `gambarKejuaraan() membaca ${kolom}`);
-  }
+test("angkanya digambar dengan bentuk yang sama dengan layar panitia", () => {
+  // Satu kelas yang sama, `.kejuaraan-skor`, supaya angkanya jatuh di tempat
+  // yang sama di dua layar — aturannya cuma ada sekali, di style.css.
+  const blok = peserta.slice(peserta.indexOf("const skorJuara"),
+    peserta.indexOf("function gambarKejuaraan()"));
+  assert.match(blok, /kejuaraan-skor/);
+  assert.match(blok, /j\.total == null/);
+  assert.match(blok, /poin juara/);
+  assert.match(blok, /regu bernomor dada/);
+  // `peringkat` tetap TIDAK dibaca: urutan gelar sudah dibawa
+  // `nama_penghargaan`, dan kolom itu memang tidak ikut terbit.
+  assert.doesNotMatch(blok, /\.peringkat\b/);
+});
+
+test("jumlah skor enam besar ditulis dengan tanda kurung, di DUA layar", () => {
+  // Kalimatnya satu dan sama. Dua bunyi untuk satu fakta adalah persis yang
+  // dilarang repo ini, jadi layar panitia ikut berubah bersamanya.
+  assert.match(peserta, /total skor \(6 besar\)/);
+  assert.match(panitia, /total skor \(6 besar\)/);
+  assert.doesNotMatch(peserta, /total skor 6 besar/);
+  assert.doesNotMatch(panitia, /total skor 6 besar/);
 });
 
 test("label golongan diambil dari daftar bersama, tidak ditulis ulang", () => {
@@ -180,12 +208,17 @@ test("migrasi memindahkan pagar hak, bukan melonggarkannya", () => {
   assert.match(migrasi, /has_function_privilege\(\s*'anon', 'hasil_kejuaraan_semua\(\)', 'execute'\)/);
 });
 
-test("view publiknya berpagar fase dan tanpa kolom skor", () => {
-  const view = migrasi.slice(migrasi.indexOf("create view v_kejuaraan_publik"),
-    migrasi.indexOf("grant select on v_kejuaraan_publik"));
+test("view publiknya berpagar fase, dan pagar itu satu-satunya", () => {
+  // 0164 mengembalikan kolom skornya, jadi tidak ada lagi lapisan kedua di
+  // belakang pagar fase. Karena itu penjaga migrasinya menguji pagar itu
+  // dengan MENGUBAH fasenya, bukan dengan membaca definisinya.
+  const view = skor.slice(skor.indexOf("create view v_kejuaraan_publik"),
+    skor.indexOf("grant select on v_kejuaraan_publik"));
   assert.match(view, /where \(select fase_live from status_acara\) = 'juara'/);
   for (const kolom of ["total", "poin_juara", "jumlah_skor"]) {
-    assert.doesNotMatch(view, new RegExp(`\\b${kolom}\\b`),
-      `kolom ${kolom} ikut ke view publik`);
+    assert.ok(view.includes(kolom), `kolom ${kolom} belum kembali ke view publik`);
   }
+  assert.ok(!view.includes("sumber"), "kolom sumber tidak boleh ikut");
+  assert.match(skor, /update status_acara set fase_live = 'penuh'/);
+  assert.match(skor, /0164: daftar juara terbaca padahal fase masih penuh/);
 });

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -36,7 +36,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 /** Nomor versi yang sedang tertulis di index.html, beserta sidik jari isi
  *  berkas saat nomor itu dipasang. Ubah KEDUANYA bersama-sama. */
 const BERKAS = {
-  "live.js": { versi: 18, sidik: "5f58713bf57f" },
+  "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
   "style.css": { versi: 5, sidik: "322a2ffb7783" },
 };

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -721,6 +721,8 @@ run supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
 run tests/sql/114_lebur_smp_al_fadliliyah.sql
 run supabase/migrations/0163_fase_juara.sql
 run tests/sql/115_fase_juara.sql
+run supabase/migrations/0164_kejuaraan_publik_dengan_skor.sql
+run tests/sql/116_kejuaraan_publik_skor.sql
 
 # Parse dan jalankan query yang benar-benar menjadi live.json, SESUDAH
 # seluruh migrasi. Ini menangkap view atau kolom yang berganti sebelum

--- a/tests/sql/116_kejuaraan_publik_skor.sql
+++ b/tests/sql/116_kejuaraan_publik_skor.sql
@@ -1,0 +1,88 @@
+-- Daftar juara peserta membawa angkanya (0164), dan pagar fasenya TETAP yang
+-- menahan hasil sebelum diumumkan. Arah kedua itu yang diuji paling keras di
+-- sini: sesudah kolom skornya kembali, tidak ada lagi lapisan lain.
+
+do $blok$
+declare
+  v_fase_lama text;
+  v_fase text;
+  v_n integer;
+  v_berangka integer;
+  v_panitia integer;
+begin
+  select fase_live into v_fase_lama from status_acara;
+  perform set_config(
+    'app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  -- 116.1 Pada fasenya, angkanya ikut.
+  --
+  -- Syaratnya digantung pada apa yang dilihat PANITIA, bukan pada angka yang
+  -- kebetulan ada di database ini. Berapa regu bernilai pada titik ini
+  -- ditentukan urutan tes di atasnya, dan tes yang menuntut data tertentu akan
+  -- merah karena tes lain berubah — bukan karena 0164 rusak.
+  perform atur_fase_live('juara');
+  select count(*) into v_n from v_kejuaraan_publik;
+  assert v_n > 0, '116.1 GAGAL: daftar juara kosong pada fase juara';
+
+  select count(*) into v_panitia from v_kejuaraan where total is not null;
+  select count(*) into v_berangka from v_kejuaraan_publik where total is not null;
+  if v_panitia > 0 then
+    assert v_berangka > 0,
+      format('116.1 GAGAL: panitia melihat %s baris berangka, peserta %s',
+             v_panitia, v_berangka);
+  else
+    raise notice '116.1: belum ada satu pun nilai di database ini, jadi yang diuji tinggal kesamaannya (116.2).';
+  end if;
+
+  -- 116.2 Angkanya SAMA dengan yang dilihat panitia. Kalau berbeda, salah satu
+  --       dari dua layar membacakan angka yang tidak ada di lembar penghargaan.
+  assert not exists (
+    select 1
+    from v_kejuaraan_publik p
+    join v_kejuaraan k on k.kode = p.kode
+    where p.total is distinct from k.total
+       or p.poin_juara is distinct from k.poin_juara
+       or p.jumlah_skor is distinct from k.jumlah_skor
+  ), '116.2 GAGAL: angka di halaman peserta berbeda dari layar panitia';
+
+  -- 116.3 DI LUAR fasenya, tidak ada satu baris pun — jadi tidak ada satu
+  --       angka pun. Inilah satu-satunya yang menahan hasil sebelum
+  --       diumumkan, dan karena itu diuji untuk KEEMPAT fase lainnya.
+  foreach v_fase in array array['pra', 'progres', 'penuh', 'top10'] loop
+    perform atur_fase_live(v_fase);
+    select count(*) into v_n from v_kejuaraan_publik;
+    assert v_n = 0,
+      format('116.3 GAGAL: %s baris juara terbaca pada fase %s', v_n, v_fase);
+  end loop;
+
+  perform atur_fase_live('juara');
+
+  -- 116.4 Papannya tetap tertutup pada fase juara: yang dilihat peserta di
+  --       sana HANYA kejuaraan, dan itu tidak berubah karena angkanya kembali.
+  assert not exists (select 1 from v_klasemen_publik),
+    '116.4 GAGAL: klasemen terbuka pada fase juara';
+  assert not exists (select 1 from v_progres_publik),
+    '116.4 GAGAL: baris progres terbuka pada fase juara';
+
+  perform atur_fase_live('penuh');
+end;
+$blok$;
+
+-- 116.5 Kolom yang TIDAK boleh ikut. Diperiksa dari katalog, bukan dari teks
+--       view-nya: `sumber` keterangan cara memilih, `regu_id` kunci internal
+--       yang tidak menjawab apa pun bagi pembacanya.
+do $blok$
+declare v_kolom text[];
+begin
+  select array_agg(attname::text order by attnum) into v_kolom
+    from pg_attribute
+   where attrelid = 'v_kejuaraan_publik'::regclass and attnum > 0
+     and not attisdropped;
+  assert not (v_kolom && array['sumber', 'regu_id']),
+    format('116.5 GAGAL: kolom yang tidak perlu ikut terbawa: %s', v_kolom);
+  assert has_table_privilege('anon', 'v_kejuaraan_publik', 'select'),
+    '116.5 GAGAL: peserta tidak bisa membaca v_kejuaraan_publik';
+end;
+$blok$;
+
+select '116_kejuaraan_publik_skor OK' hasil;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6179,7 +6179,7 @@ async function layarKejuaraan() {
       <strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>
       <span class="description">${esc(x.nama_sekolah || "")}</span></div>${skor(x)}</div>`;
     if (x.nama_sekolah) return `<strong>${esc(x.nama_sekolah)}</strong>${x.kode.startsWith("juara_umum")
-      ? `<span class="description">${esc(angkaRapi(x.poin_juara))} poin juara · ${esc(angkaRapi(x.jumlah_skor))} total skor 6 besar</span>`
+      ? `<span class="description">${esc(angkaRapi(x.poin_juara))} poin juara · ${esc(angkaRapi(x.jumlah_skor))} total skor (6 besar)</span>`
       : x.kode === "peserta_terbanyak"
         ? `<span class="description">${esc(angkaRapi(x.total))} regu bernomor dada</span>` : ""}`;
     return `<span class="description">Belum ditentukan</span>`;


### PR DESCRIPTION
## What

The peserta championship page now shows the same numbers as the panitia screen
— each champion regu's total, poin juara and total skor for Juara Umum, regu
count for Peserta Terbanyak — using the same `.kejuaraan-skor` class so the
number lands in the same place on both.

`2370 total skor 6 besar` becomes `2370 total skor (6 besar)`, on the panitia
screen too.

## Why

`0163` published the list with no score columns at all, as asked at the time;
the event owner decided otherwise. `0164` puts the columns back.

What the reversal makes clear is worth recording: **what keeps the scores
closed before the announcement is the phase gate, not the absence of the
columns.** `v_kejuaraan_publik` returns zero rows outside fase `juara`, so
before the announcement there is nothing to read either way. Afterwards the
only numbers on the page are the ones just read aloud in the field.

That gate is now the only layer, so it is tested hardest: the migration guard
and test 116 both change the phase and read again rather than inspecting the
view definition.

The wording is changed on both screens because it is one sentence; two
wordings for one fact is what this repo argues against.

## Notes

**The publish guard is narrowed, not dropped.** Rejecting anything numeric
cannot survive this change, and a deny-list would be blind to a new column
under another name. It is now an allow-list — an unknown column stops the
publish. `hasil_kejuaraan()` sits on `pendaftaran`, the same table as the
pembina's WA number, so one over-wide `select *` later stops here rather than
on a peserta's phone (CLAUDE.md 13.3).

## Verification

41 awards, 29 of them scored:

- both screens render the identical sentence and 28 scores
- measured at 360 / 480 / 901 / 1200 px — no horizontal scroll, no overflowing
  cell, no score overlapping a regu name
- guards run in both directions with the workflow's own python block: fase
  `penuh` + list → rejected, planted `kontak_wa` column → rejected, progres
  rows at fase juara → rejected, normal publish → 41 awards
- `bash tests/run.sh` → SEMUA TES LULUS (incl. new test 116)
- `node --test tests/*.test.mjs` → 296 pass, 0 fail