### PR TITLE
chore: measure event-day traffic and size the crons from it

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -24,7 +24,7 @@
 # kolomnya melainkan pagar fase: v_kejuaraan_publik mengembalikan nol baris
 # di luar fase 'juara' (0163, kolom skornya kembali di 0164).
 #
-# CRON 15 MENIT AKTIF HANYA 29 AGUSTUS 2026, 08:00-23:59 WIB. Cron memakai
+# CRON 15 MENIT AKTIF HANYA 29 AGUSTUS 2026, 06:00-18:59 WIB. Cron memakai
 # UTC dan tidak punya kolom tahun, jadi jadwal memilih 01:00-16:45 UTC lalu
 # langkah pertama memeriksa tahun/tanggal lengkap. Di luar jendela itu workflow
 # berhenti sebelum membaca database atau deploy. Tombol Run workflow tetap bisa
@@ -69,9 +69,18 @@ on:
       - 'supabase/checks/live_json.sql'
       - '.github/workflows/publish-live.yml'
   schedule:
-    # 01:00-16:45 UTC = 08:00-23:45 WIB. Cron tidak mendukung tahun;
-    # langkah `jadwal` di bawah menolak semua tanggal selain 29-08-2026.
-    - cron: '*/15 1-16 29 8 *'
+    # 06:00-18:59 WIB pada hari lomba, tiap 15 menit. Cron memakai UTC dan
+    # 06:00 WIB jatuh pada 23:00 UTC hari sebelumnya, jadi dua baris. Cron
+    # tidak mendukung tahun; langkah `jadwal` di bawah menolak tanggal lain.
+    #
+    # Jendelanya disamakan dengan refresh-live-score.yml dan diambil dari
+    # pengukuran yang sama — penjelasan lengkapnya di sana. Ringkasnya:
+    # penulisan nilai berlangsung 06:00-19:00 WIB dengan puncak 12:00-13:00,
+    # sementara jendela lama jalan sampai tengah malam.
+    #
+    # 64 run jadi ~50.
+    - cron: '*/15 23 28 8 *'
+    - cron: '*/15 0-11 29 8 *'
 
 # Dua jalan yang bertumpuk akan saling menimpa live.json di Cloudflare, dan
 # yang menang belum tentu yang terbaru. Satu jalan saja pada satu waktu.
@@ -95,7 +104,11 @@ jobs:
           fi
 
           sekarang="$(date -u '+%Y-%m-%dT%H:%M')"
-          if [[ "$sekarang" =~ ^2026-08-29T(0[1-9]|1[0-6]): ]]; then
+          # Dua jendela, sama dengan dua baris cron di atas: 23:00 UTC
+          # 28 Agustus (= 06:00 WIB) dan 00:00-11:59 UTC 29 Agustus
+          # (= 07:00-18:59 WIB).
+          if [[ "$sekarang" =~ ^2026-08-28T23: ]] \
+             || [[ "$sekarang" =~ ^2026-08-29T(0[0-9]|1[01]): ]]; then
             echo "aktif=true" >> "$GITHUB_OUTPUT"
           else
             echo "aktif=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/refresh-live-score.yml
+++ b/.github/workflows/refresh-live-score.yml
@@ -3,8 +3,34 @@ name: Refresh Live Score cache
 on:
   workflow_dispatch:
   schedule:
-    # 08:00-23:59 WIB pada hari lomba. GitHub cron memakai UTC.
-    - cron: '*/5 1-16 29 8 *'
+    # 06:00-18:59 WIB pada hari lomba, tiap 10 menit. GitHub cron memakai
+    # UTC, dan 06:00 WIB jatuh pada 23:00 UTC HARI SEBELUMNYA — itu sebabnya
+    # ada dua baris, bukan satu.
+    #
+    # UKURANNYA DARI DATA, bukan perkiraan. Setelah edisi XXXVII,
+    # supabase/checks/lalu_lintas.sql menghitung penulisan per jam dari
+    # tabel `history`:
+    #
+    #   06:00  137      12:00  2016  <- puncak
+    #   07:00  169      13:00  1754
+    #   08:00  589      14:00   726
+    #   09:00 1057      15:00   196
+    #   10:00 1278      17:00    51
+    #   11:00 1557      19:00    38
+    #
+    # Jendela lama 08:00-23:59 salah di KEDUA ujungnya: ia melewatkan 306
+    # penulisan sebelum jam delapan, lalu terus jalan sampai tengah malam
+    # padahal penulisan terakhir jam tujuh malam. Snapshot terakhir edisi
+    # kemarin tercatat 23:55 — empat jam sesudah apa pun berubah.
+    #
+    # Lima menit juga terlalu rapat: papan ini milik PANITIA, ditonton
+    # belasan orang, dan tiap penyegaran menghitung ulang lalu menulis
+    # ulang payload 587 kB berisi 273 baris. Sejak #730 layarnya punya
+    # tombol refresh sendiri, jadi yang butuh angka detik itu menekannya.
+    #
+    # 83 run jadi ~40.
+    - cron: '*/10 23 28 8 *'
+    - cron: '*/10 0-11 29 8 *'
 
 concurrency:
   group: refresh-live-score
@@ -19,7 +45,14 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" != "schedule" ] || [[ "$(date -u '+%Y-%m-%dT%H:%M')" =~ ^2026-08-29T(0[1-9]|1[0-6]): ]]; then
+          # Cron tidak punya kolom tahun, jadi penjaga inilah yang menolak
+          # setiap jadwal di luar tanggal lomba. Dua jendela, sama dengan
+          # dua baris cron di atas: 23:00 UTC 28 Agustus (= 06:00 WIB) dan
+          # 00:00-11:59 UTC 29 Agustus (= 07:00-18:59 WIB).
+          SEKARANG="$(date -u '+%Y-%m-%dT%H:%M')"
+          if [ "$EVENT_NAME" != "schedule" ] \
+             || [[ "$SEKARANG" =~ ^2026-08-28T23: ]] \
+             || [[ "$SEKARANG" =~ ^2026-08-29T(0[0-9]|1[01]): ]]; then
             echo "aktif=true" >> "$GITHUB_OUTPUT"
           else
             echo "aktif=false" >> "$GITHUB_OUTPUT"

--- a/supabase/checks/lalu_lintas.sql
+++ b/supabase/checks/lalu_lintas.sql
@@ -1,0 +1,112 @@
+-- ============================================================================
+-- hrcd-rekap : lalu_lintas.sql — berapa banyak yang ditulis ke database, kapan.
+--
+-- HANYA MEMBACA. Tidak ada INSERT, UPDATE, DELETE, maupun DDL di berkas ini;
+-- ia aman dijalankan kapan saja lewat apply-migration.yml, sama seperti
+-- status_migrasi.sql.
+--
+-- Dipakai untuk menjawab satu pertanyaan: seberapa berat sistem ini dipakai
+-- pada hari lomba, dan di jam berapa puncaknya. Yang diukur penulisan ke
+-- database — input nilai, kedatangan, keberangkatan, pendaftaran — bukan
+-- pembacaan. Pembacaan tidak meninggalkan jejak di sini; angkanya ada di
+-- dashboard Supabase dan Cloudflare.
+--
+-- HANYA ANGKA AGREGAT, TIDAK ADA DATA PRIBADI. Log Actions repo ini terbaca
+-- siapa pun sejak repo dibuka publik, jadi tidak satu pun nama regu, nama
+-- anggota, nomor WA, atau nama sekolah boleh keluar dari berkas ini. Kalau
+-- suatu saat ada yang menambahkan kolom identitas ke salah satu query di
+-- bawah, itu menerbitkannya ke publik — bukan sekadar menampilkannya.
+--
+-- Waktu ditampilkan WIB (Asia/Jakarta), bukan UTC: yang membaca laporan ini
+-- mengingat kejadiannya dalam jam lokal.
+-- ============================================================================
+
+\pset border 2
+\echo ''
+\echo '=== 0. Cakupan ==='
+select min(changed_at at time zone 'Asia/Jakarta') as paling_awal,
+       max(changed_at at time zone 'Asia/Jakarta') as paling_akhir,
+       count(*) as total_baris_history
+from history;
+
+\echo ''
+\echo '=== 1. Penulisan per hari (28-30 Agustus, WIB) ==='
+select (changed_at at time zone 'Asia/Jakarta')::date as tanggal,
+       count(*) as penulisan,
+       count(distinct changed_by) as akun_menulis,
+       count(distinct table_name) as tabel_tersentuh
+from history
+where (changed_at at time zone 'Asia/Jakarta')::date
+      between date '2026-08-28' and date '2026-08-30'
+group by 1 order by 1;
+
+\echo ''
+\echo '=== 2. Penulisan per tabel per hari ==='
+select (changed_at at time zone 'Asia/Jakarta')::date as tanggal,
+       table_name, action, count(*) as jumlah
+from history
+where (changed_at at time zone 'Asia/Jakarta')::date
+      between date '2026-08-28' and date '2026-08-30'
+group by 1, 2, 3
+having count(*) > 0
+order by 1, 4 desc;
+
+\echo ''
+\echo '=== 3. Hari lomba per JAM — di sinilah puncaknya terlihat ==='
+select to_char(changed_at at time zone 'Asia/Jakarta', 'YYYY-MM-DD HH24') || ':00' as jam,
+       count(*) as penulisan,
+       count(*) filter (where table_name = 'nilai_mentah') as input_nilai,
+       count(distinct changed_by) as akun_aktif
+from history
+where (changed_at at time zone 'Asia/Jakarta')::date
+      between date '2026-08-28' and date '2026-08-30'
+group by 1 order by 1;
+
+\echo ''
+\echo '=== 4. Menit tersibuk (10 teratas) — puncak beban tulis sesungguhnya ==='
+select to_char(changed_at at time zone 'Asia/Jakarta', 'YYYY-MM-DD HH24:MI') as menit,
+       count(*) as penulisan
+from history
+where (changed_at at time zone 'Asia/Jakarta')::date
+      between date '2026-08-28' and date '2026-08-30'
+group by 1 order by 2 desc, 1 limit 10;
+
+\echo ''
+\echo '=== 5. Sebaran per akun — TANPA nama akun, hanya bentuk sebarannya ==='
+select rank() over (order by count(*) desc) as peringkat_akun,
+       count(*) as penulisan,
+       count(*) filter (where table_name = 'nilai_mentah') as input_nilai,
+       min(changed_at at time zone 'Asia/Jakarta')::time(0) as mulai,
+       max(changed_at at time zone 'Asia/Jakarta')::time(0) as selesai
+from history
+where (changed_at at time zone 'Asia/Jakarta')::date
+      between date '2026-08-28' and date '2026-08-30'
+group by changed_by
+order by 2 desc limit 15;
+
+\echo ''
+\echo '=== 6. Isi yang dihasilkan hari itu ==='
+select
+  (select count(*) from nilai_mentah)                                as nilai_tersimpan,
+  (select count(*) from regu where nomor_dada is not null)           as regu_bernomor,
+  (select count(*) from keberangkatan_regu)                          as regu_berangkat,
+  (select count(*) from closing_regu)                                as regu_datang,
+  (select count(*) from foto_lembar)                                 as foto_lembar,
+  (select count(*) from pendaftaran)                                 as pendaftaran;
+
+\echo ''
+\echo ''
+\echo '=== 7. Berapa kali satu nilai disunting ulang — sinyal rework di layar ==='
+select h.action, count(*) as baris_history
+from history h where h.table_name = 'nilai_mentah'
+group by 1 order by 2 desc;
+
+\echo ''
+\echo '=== 8. Yang ditulis ulang cron tiap 5 menit ==='
+-- cache_live_score cuma SATU baris (pkey `tunggal`), jadi yang menarik bukan
+-- jumlahnya melainkan besarnya: segitu yang dihitung ulang dan ditulis ulang
+-- setiap kali cron jalan, 83 kali pada hari lomba.
+select pg_size_pretty(length(data::text)::bigint) as besar_payload,
+       jsonb_array_length(data -> 'rekap') as baris_rekap,
+       dibuat_pada at time zone 'Asia/Jakarta' as terakhir_disegarkan
+from cache_live_score;

--- a/tests/live_publish_schedule.test.mjs
+++ b/tests/live_publish_schedule.test.mjs
@@ -1,6 +1,12 @@
 // Penerbitan berkala hanya hidup di sekitar hari-H. Jadwal tanpa batas tanggal
 // menghabiskan 2.880 menit Actions per bulan pada repo privat, padahal seluruh
 // kebutuhan edisi 37 selesai dalam dua tanggal UTC.
+//
+// Jendelanya dipersempit sesudah edisi XXXVII, dan ukurannya dari data:
+// supabase/checks/lalu_lintas.sql menghitung penulisan per jam dari `history`,
+// dan hasilnya penulisan berlangsung 06:00-19:00 WIB dengan puncak 12:00-13:00.
+// Jendela lama 08:00-23:59 WIB salah di kedua ujungnya — melewatkan 306
+// penulisan sebelum jam delapan, lalu jalan terus sampai tengah malam.
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
@@ -9,13 +15,35 @@ import test from "node:test";
 
 const workflow = await readFile(
   new URL("../.github/workflows/publish-live.yml", import.meta.url), "utf8");
+const refresh = await readFile(
+  new URL("../.github/workflows/refresh-live-score.yml", import.meta.url), "utf8");
+
+/* 06:00 WIB jatuh pada 23:00 UTC HARI SEBELUMNYA, jadi jendelanya selalu dua
+   baris cron — dan penjaganya harus punya dua cabang yang sama. Satu baris
+   yang lupa berarti jam pertama hari lomba tidak pernah terbit. */
+const DUA_JENDELA = [
+  ["2026-08-28T22:59", false, "05:59 WIB, sebelum jendela"],
+  ["2026-08-28T23:00", true, "06:00 WIB, ujung awal"],
+  ["2026-08-28T23:59", true, "06:59 WIB"],
+  ["2026-08-29T00:00", true, "07:00 WIB"],
+  ["2026-08-29T11:59", true, "18:59 WIB, ujung akhir"],
+  ["2026-08-29T12:00", false, "19:00 WIB, sesudah jendela"],
+  ["2026-08-29T16:00", false, "23:00 WIB, jendela lama yang dibuang"],
+  ["2027-08-29T05:00", false, "tanggal sama tahun depan"],
+];
+
+const dalamJendela = (t) =>
+  /^2026-08-28T23:/.test(t) || /^2026-08-29T(0[0-9]|1[01]):/.test(t);
 
 
 test("rekap terbit tiap 15 menit hanya pada jam WIB hari-H", () => {
-  assert.match(workflow, /schedule:\s*[\s\S]*?- cron: '\*\/15 1-16 29 8 \*'/);
+  assert.match(workflow, /- cron: '\*\/15 23 28 8 \*'/);
+  assert.match(workflow, /- cron: '\*\/15 0-11 29 8 \*'/);
   assert.doesNotMatch(workflow, /cron: '\*\/15 \* \* \* \*'/,
     "cron tidak boleh berjalan tiap hari sepanjang tahun");
-  assert.match(workflow, /\^2026-08-29T\(0\[1-9\]\|1\[0-6\]\):/,
+  assert.match(workflow, /\^2026-08-28T23:/,
+    "jam pertama hari lomba jatuh pada tanggal UTC sebelumnya");
+  assert.match(workflow, /\^2026-08-29T\(0\[0-9\]\|1\[01\]\):/,
     "tahun dan jendela UTC harus diperiksa sebelum penerbitan");
   assert.match(workflow,
     /uses: actions\/checkout@v4\s+if: steps\.jadwal\.outputs\.aktif == 'true'/,
@@ -26,11 +54,22 @@ test("rekap terbit tiap 15 menit hanya pada jam WIB hari-H", () => {
 });
 
 
-test("guard UTC tepat membuka 08:00-23:59 WIB pada 29 Agustus 2026", () => {
-  const aktif = /^2026-08-29T(0[1-9]|1[0-6]):/;
-  assert.equal(aktif.test("2026-08-29T00:59"), false);
-  assert.equal(aktif.test("2026-08-29T01:00"), true);
-  assert.equal(aktif.test("2026-08-29T16:59"), true);
-  assert.equal(aktif.test("2026-08-29T17:00"), false);
-  assert.equal(aktif.test("2027-08-29T01:00"), false);
+test("guard UTC membuka tepat 06:00-18:59 WIB pada 29 Agustus 2026", () => {
+  for (const [waktu, harusAktif, kenapa] of DUA_JENDELA) {
+    assert.equal(dalamJendela(waktu), harusAktif, `${waktu} — ${kenapa}`);
+  }
+});
+
+
+test("papan panitia disegarkan lebih jarang, di jendela yang sama", () => {
+  // Sepuluh menit, bukan lima: papan ini milik panitia, ditonton belasan orang,
+  // dan tiap penyegaran menulis ulang payload 587 kB. Sejak #730 layarnya punya
+  // tombol refresh sendiri untuk yang butuh angka sedetik itu.
+  assert.match(refresh, /- cron: '\*\/10 23 28 8 \*'/);
+  assert.match(refresh, /- cron: '\*\/10 0-11 29 8 \*'/);
+  assert.doesNotMatch(refresh, /cron: '\*\/5 /,
+    "lima menit terlalu rapat untuk papan yang ditonton belasan orang");
+  // Penjaganya harus punya DUA cabang, sama dengan dua baris cron-nya.
+  assert.match(refresh, /\^2026-08-28T23:/);
+  assert.match(refresh, /\^2026-08-29T\(0\[0-9\]\|1\[01\]\):/);
 });


### PR DESCRIPTION
## What

- `supabase/checks/lalu_lintas.sql` — a read-only report over `history`: writes
  per day, per hour, per busiest minute, per account.
- Both event-day schedules now run **06:00–18:59 WIB** instead of 08:00–23:59,
  and the panitia cache refreshes every **10 minutes** instead of 5.

## Why

The schedules were sized by guess. Now they are sized by measurement — writes
per hour on race day, from `history`:

| Jam WIB | Penulisan | Input nilai |
|---|---|---|
| 06:00 | 137 | 10 |
| 07:00 | 169 | 20 |
| 08:00 | 589 | 163 |
| 10:00 | 1278 | 640 |
| **12:00** | **2016** | **1256** |
| 13:00 | 1754 | 1360 |
| 15:00 | 196 | 126 |
| 19:00 | 38 | 22 |

The old window was wrong at both ends: it missed 306 writes before eight in the
morning, then kept running until midnight — the last cached snapshot was stamped
**23:55**, four hours after anything changed.

Five minutes was also too tight for what it feeds. That board belongs to
panitia, a dozen people watch it, and every refresh recomputes and rewrites a
**587 kB** payload of 273 rows. Since #730 the screen has its own refresh
button, so whoever needs the number this second presses it.

Together: **147 scheduled runs on race day → roughly 90.**

## Notes

- **06:00 WIB falls on 23:00 UTC the previous day**, so each window is two cron
  lines and each guard has two branches. A missing branch silently drops the
  first hour of race day, so the test checks both boundaries from both sides —
  including the same date a year later, which must stay rejected because cron
  has no year field.
- The report is aggregates only. This repository is public now, so its Actions
  logs are readable by anyone; the header says that where the next person will
  read it, because a nama regu or nomor WA added to any query there would be
  published, not merely displayed.
- **`fix/instant-live-publish` is deleted**, along with its worktree. The
  measurements say the problem it solved does not exist: peak write load was
  **1.2 writes per second**, and peserta traffic is served entirely from the
  Cloudflare edge (every endpoint returned `cf-cache-status: HIT`). It would
  have moved the leak guards into a second place for no measured gain.

## Verification

- report run against production through `apply-migration.yml` — read-only, and
  the numbers in this PR are its output
- guard boundaries tested in both directions: 05:59 WIB rejected, 06:00 accepted,
  18:59 accepted, 19:00 rejected, 2027 rejected
- both workflow files parse as valid YAML with the expected cron entries
- `node --test tests/*.test.mjs` → 297 pass, 0 fail