### PR TITLE
feat: offer Kamera and Galeri when attaching answer photos

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -880,6 +880,13 @@ const IKON = {
     '<circle cx="12" cy="12" r="9" /> <path d="M12 7v5l3 2" />',
   "camera":
     '<path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" /> <circle cx="12" cy="13" r="3" />',
+  // Pasangan "camera", dipakai di tombol Galeri. Dua tombol bersebelahan yang
+  // ikonnya sama-sama kamera membuat pilihannya harus dibaca kata demi kata,
+  // dan itu justru yang mau dihindari: petugas menuju yang bergambar kamera
+  // untuk memotret sekarang, dan yang bergambar foto untuk mengambil yang
+  // sudah ada.
+  "image":
+    '<rect width="18" height="18" x="3" y="3" rx="2" ry="2" /> <circle cx="9" cy="9" r="2" /> <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />',
   "lock":
     '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 10 0v4" />',
   "lock-open":

--- a/live/style.css
+++ b/live/style.css
@@ -2481,6 +2481,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* <label> yang membungkus <input type=file> tersembunyi. Tanpa ini ia
    ditampilkan sebagai teks biasa, bukan sebagai tombol. */
 .foto-lomba label.button { display: inline-flex; align-items: center; cursor: pointer; }
+/* Kamera dan Galeri dibungkus SATU kotak, bukan diletakkan berdampingan
+   sebagai dua anak <li>. Dua sebabnya:
+
+   Pertama, `.foto-lomba li > :nth-last-child(2)` di atas mendorong tombol ke
+   kanan berdasarkan URUTAN. Menambah satu anak menggeser hitungannya, dan
+   yang terdorong jadi tombol Kamera — "Lihat" tertinggal menempel di nama
+   lombanya sendiri. Dengan pembungkus, jumlah anak <li> tetap empat dan
+   aturan itu tidak perlu disentuh.
+
+   Kedua, di HP barisnya membungkus. Sebagai dua anak lepas, Kamera bisa
+   tinggal di baris pertama sementara Galeri turun sendirian ke baris kedua —
+   dua tombol yang sepasang tapi tidak terlihat sepasang. */
+.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap; }
+/* Kamera dan Galeri di layar Foto Jawaban BERBAGI satu baris, tidak menumpuk.
+   `.button` lebarnya 100%, jadi dua tombol di dalam .action-row masing-masing
+   meminta selebar barisnya dan yang kedua terlempar ke baris berikutnya — dua
+   pita hijau-putih setinggi 46px yang memakan seluruh kartu. `flex: 1` membuat
+   keduanya membagi lebar yang ada; 8rem adalah dasar yang masih memuat ikon
+   beserta katanya, jadi di HP sempit mereka baru menumpuk saat memang perlu. */
+#foto-aksi > label.button { flex: 1 1 8rem; width: auto; }
 
 .badge-tombol {
   border: 0; font: inherit; cursor: pointer;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4482,6 +4482,27 @@ async function layarInputPos() {
        memang harus dirender. Ditulis dengan html``, jalur SVG-nya tampil apa
        adanya sebagai teks hijau sepanjang tiga baris di dalam tombolnya.
        Yang datang dari luar tetap lewat esc() satu per satu. */
+
+    /* DUA TOMBOL, bukan satu. Yang membedakannya cuma `capture` di tombol
+       kiri, dan atribut itulah seluruh isi perbaikan ini.
+
+       `<input type="file" accept="image/*">` telanjang menyerahkan pilihannya
+       ke sistem: iOS memunculkan menu "Ambil Foto / Pustaka Foto / Pilih
+       Berkas", sedangkan sebagian HP Android langsung membuka galeri tanpa
+       menawarkan kamera sama sekali. Petugas pos yang mau memotret lembar di
+       depannya jadi harus keluar aplikasi, memotret lewat aplikasi kamera,
+       lalu kembali ke sini dan mencarinya di galeri.
+
+       `capture="environment"` membuka kamera belakang langsung — tapi ia juga
+       MENUTUP jalur galeri, jadi ia tidak bisa dipasang di satu-satunya
+       tombol: foto yang sudah terlanjur diambil di luar aplikasi tidak akan
+       bisa diunggah. Karena itu jalurnya dipisah jadi dua tombol yang namanya
+       menyebut tujuannya, dan pilihannya jadi sama di Android maupun iPhone.
+
+       `multiple` sengaja tetap ditulis di tombol Kamera walau kamera hanya
+       mengembalikan satu foto: pada peramban yang mengabaikan `capture` —
+       hampir semua peramban laptop — tombol itu jatuh kembali jadi pemilih
+       berkas biasa, dan di sana memilih banyak sekaligus tetap berguna. */
     const isi = `<ul class="foto-lomba">${lomba.map(([kode, nama]) => `
       <li data-kode="${esc(kode)}" data-nama="${esc(nama)}">
         <span class="f-nama">${esc(nama)}</span>
@@ -4489,9 +4510,16 @@ async function layarInputPos() {
           ? `${esc(String(hitung[kode]))} foto` : "belum ada"}</span>
         <button type="button" class="button button-mini" data-lihat
           ${hitung[kode] ? "" : "hidden"}>Lihat</button>
-        <label class="button button-mini button-primary">
-          <input type="file" accept="image/*" multiple hidden data-ambil>${ikon("camera")} Foto
-        </label>
+        <span class="f-aksi">
+          <label class="button button-mini button-primary">
+            <input type="file" accept="image/*" capture="environment" multiple
+                   hidden data-ambil>${ikon("camera")} Kamera
+          </label>
+          <label class="button button-mini button-secondary">
+            <input type="file" accept="image/*" multiple hidden data-ambil
+                   >${ikon("image")} Galeri
+          </label>
+        </span>
       </li>`).join("")}</ul>
 `;
 
@@ -6703,6 +6731,14 @@ async function layarFoto() {
   let nomorPos = terkunci ? Number(s.pos) : Number(posDinilai[0].nomor);
   let kodeLomba = null, namaLomba = null;
 
+  /* Kamera dan Galeri dipisah jadi dua tombol, alasannya lengkap di
+     bukaFotoLembar(): `capture` membuka kamera langsung tapi sekaligus
+     menutup jalur galeri, jadi satu tombol tidak bisa melayani keduanya.
+
+     Penjelasannya ditulis DI SINI dan bukan sebagai komentar HTML di dalam
+     template di bawah. Backtick di dalam komentar HTML itu MENUTUP template
+     literal-nya — berkasnya berhenti diparse dan seluruh app.js mati, tanpa
+     satu pun tanda selain layar putih. */
   LAYAR.replaceChildren(h(`
     <div class="card">
       <div class="baris-pilih">
@@ -6721,8 +6757,13 @@ async function layarFoto() {
       </div>
       <div class="action-row" id="foto-aksi" hidden>
         <label class="button button-primary">
-          <input type="file" accept="image/*" multiple hidden id="foto-ambil">
-          ${ikon("camera")} Pilih foto
+          <input type="file" accept="image/*" capture="environment" multiple
+                 hidden class="foto-ambil">
+          ${ikon("camera")} Kamera
+        </label>
+        <label class="button button-secondary">
+          <input type="file" accept="image/*" multiple hidden class="foto-ambil">
+          ${ikon("image")} Galeri
         </label>
         <span class="sub" id="foto-kuota"></span>
       </div>
@@ -6736,7 +6777,7 @@ async function layarFoto() {
   const elPos   = document.getElementById("foto-pos");
   const elLomba = document.getElementById("foto-lomba");
   const elAksi  = document.getElementById("foto-aksi");
-  const elAmbil = document.getElementById("foto-ambil");
+  const elAmbil = [...document.querySelectorAll(".foto-ambil")];
   const elGrid  = document.getElementById("foto-grid");
   const elBelum = document.getElementById("foto-belum");
   const elKuota = document.getElementById("foto-kuota");
@@ -7090,10 +7131,10 @@ async function layarFoto() {
     hitungUbin();
   }
 
-  elAmbil.addEventListener("change", async () => {
-    const berkas = [...(elAmbil.files || [])];
+  const terimaBerkas = async (inp) => {
+    const berkas = [...(inp.files || [])];
     // Dikosongkan supaya memilih berkas YANG SAMA lagi tetap memicu change.
-    elAmbil.value = "";
+    inp.value = "";
     if (!berkas.length || !kodeLomba) return;
 
     const kosong = elGrid.querySelector(".keterangan");
@@ -7123,7 +7164,11 @@ async function layarFoto() {
       if (k) elKuota.textContent =
         `${k.jumlah_foto} foto · ${ukuranRapi(k.total_bytes || 0)} terpakai`;
     } catch { /* Kuota cuma keterangan; gagal membacanya tidak menghalangi apa pun. */ }
-  });
+  };
+
+  // Kamera dan Galeri memakai penangan yang SAMA — yang berbeda cuma dari mana
+  // berkasnya datang, dan sesudah dipilih keduanya tidak bisa dibedakan lagi.
+  elAmbil.forEach(inp => inp.addEventListener("change", () => terimaBerkas(inp)));
 
   await isiLomba();
 }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -880,6 +880,13 @@ const IKON = {
     '<circle cx="12" cy="12" r="9" /> <path d="M12 7v5l3 2" />',
   "camera":
     '<path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" /> <circle cx="12" cy="13" r="3" />',
+  // Pasangan "camera", dipakai di tombol Galeri. Dua tombol bersebelahan yang
+  // ikonnya sama-sama kamera membuat pilihannya harus dibaca kata demi kata,
+  // dan itu justru yang mau dihindari: petugas menuju yang bergambar kamera
+  // untuk memotret sekarang, dan yang bergambar foto untuk mengambil yang
+  // sudah ada.
+  "image":
+    '<rect width="18" height="18" x="3" y="3" rx="2" ry="2" /> <circle cx="9" cy="9" r="2" /> <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />',
   "lock":
     '<rect width="18" height="11" x="3" y="11" rx="2" ry="2" /> <path d="M7 11V7a5 5 0 0 1 10 0v4" />',
   "lock-open":

--- a/web/style.css
+++ b/web/style.css
@@ -2481,6 +2481,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* <label> yang membungkus <input type=file> tersembunyi. Tanpa ini ia
    ditampilkan sebagai teks biasa, bukan sebagai tombol. */
 .foto-lomba label.button { display: inline-flex; align-items: center; cursor: pointer; }
+/* Kamera dan Galeri dibungkus SATU kotak, bukan diletakkan berdampingan
+   sebagai dua anak <li>. Dua sebabnya:
+
+   Pertama, `.foto-lomba li > :nth-last-child(2)` di atas mendorong tombol ke
+   kanan berdasarkan URUTAN. Menambah satu anak menggeser hitungannya, dan
+   yang terdorong jadi tombol Kamera — "Lihat" tertinggal menempel di nama
+   lombanya sendiri. Dengan pembungkus, jumlah anak <li> tetap empat dan
+   aturan itu tidak perlu disentuh.
+
+   Kedua, di HP barisnya membungkus. Sebagai dua anak lepas, Kamera bisa
+   tinggal di baris pertama sementara Galeri turun sendirian ke baris kedua —
+   dua tombol yang sepasang tapi tidak terlihat sepasang. */
+.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap; }
+/* Kamera dan Galeri di layar Foto Jawaban BERBAGI satu baris, tidak menumpuk.
+   `.button` lebarnya 100%, jadi dua tombol di dalam .action-row masing-masing
+   meminta selebar barisnya dan yang kedua terlempar ke baris berikutnya — dua
+   pita hijau-putih setinggi 46px yang memakan seluruh kartu. `flex: 1` membuat
+   keduanya membagi lebar yang ada; 8rem adalah dasar yang masih memuat ikon
+   beserta katanya, jadi di HP sempit mereka baru menumpuk saat memang perlu. */
+#foto-aksi > label.button { flex: 1 1 8rem; width: auto; }
 
 .badge-tombol {
   border: 0; font: inherit; cursor: pointer;


### PR DESCRIPTION
## What

Both places that attach an answer photo now offer **two** buttons instead of one:

- **Foto Jawaban dialog** on the pos scoring sheet — one pair per lomba
- **Foto Jawaban screen** — one pair above the tile grid

The camera button carries `capture="environment"`; the gallery button does not.
Both feed the same upload handler, so nothing downstream changes.

A matching `image` icon was added to `util.js` so the two buttons are told apart
before their labels are read.

## Why

A bare `<input type="file" accept="image/*">` leaves the choice to the system.
iOS shows an action sheet offering camera and library; many Android phones open
the gallery straight away and never offer the camera. A pos officer who wants to
photograph the sheet in front of them had to leave the app, shoot, come back,
and hunt for the file.

`capture` alone is not the fix — it opens the camera but *closes* the gallery
path, and photos already taken outside the app still have to be uploadable.
Hence two buttons rather than one attribute.

## Notes

- Verified against a local dev database with both screens rendered: each of the
  four inputs was fed a file and produced an uploaded tile / a `1 foto` count.
  No console errors.
- Layout measured from 280px up: the pair stays on one line together and there
  is no horizontal scroll at any width.
- Shared copies (`style.css`, `js/util.js`) re-synced from `web/` to `live/`.