### PR TITLE
fix: icon-only photo buttons, always on the lomba's own line

### DIFF
--- a/live/style.css
+++ b/live/style.css
@@ -2493,7 +2493,28 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    Kedua, di HP barisnya membungkus. Sebagai dua anak lepas, Kamera bisa
    tinggal di baris pertama sementara Galeri turun sendirian ke baris kedua —
    dua tombol yang sepasang tapi tidak terlihat sepasang. */
-.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap; }
+/* `margin-left: auto` supaya pasangan tombolnya berakhir di tepi kanan yang
+   SAMA di setiap baris, termasuk saat ia membungkus turun. Baris yang sudah
+   punya foto memuat "1 foto · 781 B" beserta tombol Lihat, dan di lebar HP
+   itu mendorong pasangannya ke baris kedua — tanpa aturan ini ia mendarat di
+   kiri sementara empat baris lain menaruhnya di kanan, dan kolomnya patah
+   tepat di baris yang berbeda dari yang lain.
+
+   Ia tidak bertabrakan dengan `:nth-last-child(2)` di atas: dua margin auto di
+   SATU baris membagi ruang kosongnya, dan yang lebih dulu — milik Lihat —
+   mengambil semuanya. Terukur di 600px dan 900px, jarak Lihat ke pasangannya
+   tetap 10px. */
+.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap;
+          margin-left: auto; }
+/* Tombol Kamera dan Galeri di dialog ini BERISI IKON SAJA — alasannya di
+   bukaFotoLembar(). Tanpa kata di dalamnya lebar .button-mini menyusut jadi
+   sekitar 32px, dan itu di bawah petak sentuh yang nyaman untuk jari; petugas
+   pos memakainya sambil berdiri, sering dengan tangan yang satunya memegang
+   lembar jawaban. 44px adalah ukuran yang dipakai dua-duanya di sini, jadi
+   meleset sedikit tetap mengenai tombol yang dimaksud — dan meleset ke tombol
+   SEBELAHNYA membuka kamera saat yang diminta galeri. */
+.f-aksi .button-mini { min-width: 44px; min-height: 40px; padding: .2rem; }
+.f-aksi .ikon { width: 1.3em; height: 1.3em; }
 /* Kamera dan Galeri di layar Foto Jawaban BERBAGI satu baris, tidak menumpuk.
    `.button` lebarnya 100%, jadi dua tombol di dalam .action-row masing-masing
    meminta selebar barisnya dan yang kedua terlempar ke baris berikutnya — dua

--- a/live/style.css
+++ b/live/style.css
@@ -2460,60 +2460,71 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua
    aplikasi berbeda. */
 .foto-lomba { list-style: none; margin: 0; padding: 0; }
+/* DUA KOLOM TETAP, bukan satu baris yang membungkus.
+ *
+ * Kiri: nama lomba dengan keterangannya di bawahnya. Kanan: ketiga tombol,
+ * SELALU di baris yang sama dengan namanya.
+ *
+ * Bentuk sebelumnya satu baris flex ber-`wrap`, dan empat hal berebut lebar
+ * yang sama: nama lomba, keterangan, Lihat, dan pasangan Kamera/Galeri. Di
+ * lebar HP keempatnya tidak muat begitu sebuah baris punya foto — keterangan
+ * "belum ada" berubah jadi "1 foto · 781 B" dan tombol Lihat ikut muncul —
+ * jadi pasangan tombolnya terlempar ke baris kedua. Hanya baris yang sudah
+ * punya foto, jadi daftarnya bergerigi: sebagian tombol di kanan atas,
+ * sebagian di bawah, berpindah tempat justru saat petugas sedang memakainya.
+ *
+ * Menaikkan lebarnya tidak bisa menyelesaikan itu — yang berubah panjangnya
+ * adalah keterangan, dan panjangnya baru diketahui sesudah unggahannya
+ * selesai. Grid memberi keterangan itu barisnya sendiri, jadi sepanjang apa
+ * pun ia tidak pernah lagi mendorong tombol. */
 .foto-lomba li {
-  display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem;
+  display: grid;
+  /* minmax(0, 1fr): tanpa batas bawah nol, kolom kiri menolak menyusut di
+     bawah lebar kata terpanjangnya dan nama lomba yang panjang mendorong
+     kolom tombol keluar tabel. */
+  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-areas: "nama aksi"
+                       "info aksi";
+  align-items: center; column-gap: .6rem; row-gap: .1rem;
   padding: .55rem 0; border-bottom: 1px solid var(--garis);
 }
 .foto-lomba li:last-child { border-bottom: 0; }
 .f-nama {
-  font-weight: 600; flex: 1 1 6rem; min-width: 0;
+  grid-area: nama; align-self: end;
+  font-weight: 600; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* Keadaan unggahan menumpang di tempat jumlah foto: "belum ada" ->
    "mengecilkan…" -> "mengirim 71 KB…" -> "1 foto · 71 KB". Satu tempat, satu
    kalimat — petugas tidak perlu mencari di mana kabarnya muncul. */
 .f-jumlah {
+  grid-area: info; align-self: start;
   color: var(--tinta-lembut); font-size: .82rem;
-  flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere;
+  min-width: 0; overflow-wrap: anywhere;
 }
-/* Tombol didorong ke kanan supaya kolomnya lurus walau nama lombanya pendek. */
-.foto-lomba li > :nth-last-child(2) { margin-left: auto; }
 /* <label> yang membungkus <input type=file> tersembunyi. Tanpa ini ia
    ditampilkan sebagai teks biasa, bukan sebagai tombol. */
 .foto-lomba label.button { display: inline-flex; align-items: center; cursor: pointer; }
-/* Kamera dan Galeri dibungkus SATU kotak, bukan diletakkan berdampingan
-   sebagai dua anak <li>. Dua sebabnya:
+/* KETIGA tombol satu kelompok — Lihat ikut di dalamnya, bukan berdiri sendiri
+   sebagai anak <li>. Sebagai anak lepas ia menempati kolom grid-nya sendiri
+   dan tempatnya berpindah begitu ia disembunyikan; sebagai anggota kelompok
+   ini, baris tanpa foto cuma kehilangan satu tombol dan dua sisanya tetap
+   di tepi kanan yang sama. */
+.f-aksi {
+  grid-area: aksi;
+  display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap;
+}
+/* Kamera dan Galeri BERISI IKON SAJA — alasannya di bukaFotoLembar(). Tanpa
+   kata di dalamnya lebar .button-mini menyusut jadi sekitar 32px, dan itu di
+   bawah petak sentuh yang nyaman untuk jari; petugas pos memakainya sambil
+   berdiri, sering dengan tangan yang satunya memegang lembar jawaban. 44px
+   dipakai dua-duanya, jadi meleset sedikit tetap mengenai tombol yang
+   dimaksud — dan meleset ke tombol SEBELAHNYA membuka kamera saat yang
+   diminta galeri.
 
-   Pertama, `.foto-lomba li > :nth-last-child(2)` di atas mendorong tombol ke
-   kanan berdasarkan URUTAN. Menambah satu anak menggeser hitungannya, dan
-   yang terdorong jadi tombol Kamera — "Lihat" tertinggal menempel di nama
-   lombanya sendiri. Dengan pembungkus, jumlah anak <li> tetap empat dan
-   aturan itu tidak perlu disentuh.
-
-   Kedua, di HP barisnya membungkus. Sebagai dua anak lepas, Kamera bisa
-   tinggal di baris pertama sementara Galeri turun sendirian ke baris kedua —
-   dua tombol yang sepasang tapi tidak terlihat sepasang. */
-/* `margin-left: auto` supaya pasangan tombolnya berakhir di tepi kanan yang
-   SAMA di setiap baris, termasuk saat ia membungkus turun. Baris yang sudah
-   punya foto memuat "1 foto · 781 B" beserta tombol Lihat, dan di lebar HP
-   itu mendorong pasangannya ke baris kedua — tanpa aturan ini ia mendarat di
-   kiri sementara empat baris lain menaruhnya di kanan, dan kolomnya patah
-   tepat di baris yang berbeda dari yang lain.
-
-   Ia tidak bertabrakan dengan `:nth-last-child(2)` di atas: dua margin auto di
-   SATU baris membagi ruang kosongnya, dan yang lebih dulu — milik Lihat —
-   mengambil semuanya. Terukur di 600px dan 900px, jarak Lihat ke pasangannya
-   tetap 10px. */
-.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap;
-          margin-left: auto; }
-/* Tombol Kamera dan Galeri di dialog ini BERISI IKON SAJA — alasannya di
-   bukaFotoLembar(). Tanpa kata di dalamnya lebar .button-mini menyusut jadi
-   sekitar 32px, dan itu di bawah petak sentuh yang nyaman untuk jari; petugas
-   pos memakainya sambil berdiri, sering dengan tangan yang satunya memegang
-   lembar jawaban. 44px adalah ukuran yang dipakai dua-duanya di sini, jadi
-   meleset sedikit tetap mengenai tombol yang dimaksud — dan meleset ke tombol
-   SEBELAHNYA membuka kamera saat yang diminta galeri. */
-.f-aksi .button-mini { min-width: 44px; min-height: 40px; padding: .2rem; }
+   Hanya <label>, bukan seluruh .button-mini: "Lihat" di sebelahnya berisi
+   kata, dan padding .2rem akan menghimpitnya. */
+.f-aksi label.button { min-width: 44px; min-height: 40px; padding: .2rem; }
 .f-aksi .ikon { width: 1.3em; height: 1.3em; }
 /* Kamera dan Galeri di layar Foto Jawaban BERBAGI satu baris, tidak menumpuk.
    `.button` lebarnya 100%, jadi dua tombol di dalam .action-row masing-masing

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4502,7 +4502,20 @@ async function layarInputPos() {
        `multiple` sengaja tetap ditulis di tombol Kamera walau kamera hanya
        mengembalikan satu foto: pada peramban yang mengabaikan `capture` —
        hampir semua peramban laptop — tombol itu jatuh kembali jadi pemilih
-       berkas biasa, dan di sana memilih banyak sekaligus tetap berguna. */
+       berkas biasa, dan di sana memilih banyak sekaligus tetap berguna.
+
+       IKON SAJA DI SINI, berbeda dengan layar Foto Jawaban yang menuliskan
+       katanya. Bukan karena tempatnya sempit — melainkan karena pasangan ini
+       BERULANG sekali per lomba. Lima "Kamera" dan lima "Galeri" bertumpuk di
+       satu dialog cuma dibaca pada pasangan pertama; sisanya jadi keramaian
+       yang mendorong tombolnya turun ke baris kedua di HP. Di layar Foto
+       Jawaban pasangannya cuma satu dan barisnya lapang, jadi katanya gratis
+       dan tetap ditulis.
+
+       Namanya tidak hilang, cuma pindah: `title` untuk kursor di layar lebar,
+       `aria-label` di input untuk pembaca layar — dan aria-label-nya menyebut
+       nama lombanya, karena "Kamera" saja tidak memberi tahu kamera yang
+       mana dari lima yang ada. */
     const isi = `<ul class="foto-lomba">${lomba.map(([kode, nama]) => `
       <li data-kode="${esc(kode)}" data-nama="${esc(nama)}">
         <span class="f-nama">${esc(nama)}</span>
@@ -4511,13 +4524,14 @@ async function layarInputPos() {
         <button type="button" class="button button-mini" data-lihat
           ${hitung[kode] ? "" : "hidden"}>Lihat</button>
         <span class="f-aksi">
-          <label class="button button-mini button-primary">
+          <label class="button button-mini button-primary" title="Kamera">
             <input type="file" accept="image/*" capture="environment" multiple
-                   hidden data-ambil>${ikon("camera")} Kamera
+                   hidden data-ambil
+                   aria-label="Foto ${esc(nama)} pakai kamera">${ikon("camera")}
           </label>
-          <label class="button button-mini button-secondary">
+          <label class="button button-mini button-secondary" title="Galeri">
             <input type="file" accept="image/*" multiple hidden data-ambil
-                   >${ikon("image")} Galeri
+                   aria-label="Foto ${esc(nama)} dari galeri">${ikon("image")}
           </label>
         </span>
       </li>`).join("")}</ul>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4515,15 +4515,23 @@ async function layarInputPos() {
        Namanya tidak hilang, cuma pindah: `title` untuk kursor di layar lebar,
        `aria-label` di input untuk pembaca layar — dan aria-label-nya menyebut
        nama lombanya, karena "Kamera" saja tidak memberi tahu kamera yang
-       mana dari lima yang ada. */
+       mana dari lima yang ada.
+
+       TOMBOL "LIHAT" IKUT MASUK ke .f-aksi, tidak berdiri sebagai anak <li>
+       sendiri. Ketiganya adalah satu kelompok tombol di kanan baris, dan
+       barisnya sekarang grid dua kolom (lihat style.css) — satu area untuk
+       tombol, bukan tiga anak yang bisa terpisah sendiri-sendiri. Selama ia
+       di luar, baris yang sudah punya foto memuat nama + keterangan + Lihat
+       di baris pertama dan MENDORONG pasangan Kamera/Galeri turun ke baris
+       kedua. */
     const isi = `<ul class="foto-lomba">${lomba.map(([kode, nama]) => `
       <li data-kode="${esc(kode)}" data-nama="${esc(nama)}">
         <span class="f-nama">${esc(nama)}</span>
         <span class="f-jumlah" data-jumlah>${hitung[kode]
           ? `${esc(String(hitung[kode]))} foto` : "belum ada"}</span>
-        <button type="button" class="button button-mini" data-lihat
-          ${hitung[kode] ? "" : "hidden"}>Lihat</button>
         <span class="f-aksi">
+          <button type="button" class="button button-mini" data-lihat
+            ${hitung[kode] ? "" : "hidden"}>Lihat</button>
           <label class="button button-mini button-primary" title="Kamera">
             <input type="file" accept="image/*" capture="environment" multiple
                    hidden data-ambil

--- a/web/style.css
+++ b/web/style.css
@@ -2493,7 +2493,28 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    Kedua, di HP barisnya membungkus. Sebagai dua anak lepas, Kamera bisa
    tinggal di baris pertama sementara Galeri turun sendirian ke baris kedua —
    dua tombol yang sepasang tapi tidak terlihat sepasang. */
-.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap; }
+/* `margin-left: auto` supaya pasangan tombolnya berakhir di tepi kanan yang
+   SAMA di setiap baris, termasuk saat ia membungkus turun. Baris yang sudah
+   punya foto memuat "1 foto · 781 B" beserta tombol Lihat, dan di lebar HP
+   itu mendorong pasangannya ke baris kedua — tanpa aturan ini ia mendarat di
+   kiri sementara empat baris lain menaruhnya di kanan, dan kolomnya patah
+   tepat di baris yang berbeda dari yang lain.
+
+   Ia tidak bertabrakan dengan `:nth-last-child(2)` di atas: dua margin auto di
+   SATU baris membagi ruang kosongnya, dan yang lebih dulu — milik Lihat —
+   mengambil semuanya. Terukur di 600px dan 900px, jarak Lihat ke pasangannya
+   tetap 10px. */
+.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap;
+          margin-left: auto; }
+/* Tombol Kamera dan Galeri di dialog ini BERISI IKON SAJA — alasannya di
+   bukaFotoLembar(). Tanpa kata di dalamnya lebar .button-mini menyusut jadi
+   sekitar 32px, dan itu di bawah petak sentuh yang nyaman untuk jari; petugas
+   pos memakainya sambil berdiri, sering dengan tangan yang satunya memegang
+   lembar jawaban. 44px adalah ukuran yang dipakai dua-duanya di sini, jadi
+   meleset sedikit tetap mengenai tombol yang dimaksud — dan meleset ke tombol
+   SEBELAHNYA membuka kamera saat yang diminta galeri. */
+.f-aksi .button-mini { min-width: 44px; min-height: 40px; padding: .2rem; }
+.f-aksi .ikon { width: 1.3em; height: 1.3em; }
 /* Kamera dan Galeri di layar Foto Jawaban BERBAGI satu baris, tidak menumpuk.
    `.button` lebarnya 100%, jadi dua tombol di dalam .action-row masing-masing
    meminta selebar barisnya dan yang kedua terlempar ke baris berikutnya — dua

--- a/web/style.css
+++ b/web/style.css
@@ -2460,60 +2460,71 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
    dialog yang dibuka dari baris yang sama tidak boleh terasa seperti dua
    aplikasi berbeda. */
 .foto-lomba { list-style: none; margin: 0; padding: 0; }
+/* DUA KOLOM TETAP, bukan satu baris yang membungkus.
+ *
+ * Kiri: nama lomba dengan keterangannya di bawahnya. Kanan: ketiga tombol,
+ * SELALU di baris yang sama dengan namanya.
+ *
+ * Bentuk sebelumnya satu baris flex ber-`wrap`, dan empat hal berebut lebar
+ * yang sama: nama lomba, keterangan, Lihat, dan pasangan Kamera/Galeri. Di
+ * lebar HP keempatnya tidak muat begitu sebuah baris punya foto — keterangan
+ * "belum ada" berubah jadi "1 foto · 781 B" dan tombol Lihat ikut muncul —
+ * jadi pasangan tombolnya terlempar ke baris kedua. Hanya baris yang sudah
+ * punya foto, jadi daftarnya bergerigi: sebagian tombol di kanan atas,
+ * sebagian di bawah, berpindah tempat justru saat petugas sedang memakainya.
+ *
+ * Menaikkan lebarnya tidak bisa menyelesaikan itu — yang berubah panjangnya
+ * adalah keterangan, dan panjangnya baru diketahui sesudah unggahannya
+ * selesai. Grid memberi keterangan itu barisnya sendiri, jadi sepanjang apa
+ * pun ia tidak pernah lagi mendorong tombol. */
 .foto-lomba li {
-  display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem;
+  display: grid;
+  /* minmax(0, 1fr): tanpa batas bawah nol, kolom kiri menolak menyusut di
+     bawah lebar kata terpanjangnya dan nama lomba yang panjang mendorong
+     kolom tombol keluar tabel. */
+  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-areas: "nama aksi"
+                       "info aksi";
+  align-items: center; column-gap: .6rem; row-gap: .1rem;
   padding: .55rem 0; border-bottom: 1px solid var(--garis);
 }
 .foto-lomba li:last-child { border-bottom: 0; }
 .f-nama {
-  font-weight: 600; flex: 1 1 6rem; min-width: 0;
+  grid-area: nama; align-self: end;
+  font-weight: 600; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* Keadaan unggahan menumpang di tempat jumlah foto: "belum ada" ->
    "mengecilkan…" -> "mengirim 71 KB…" -> "1 foto · 71 KB". Satu tempat, satu
    kalimat — petugas tidak perlu mencari di mana kabarnya muncul. */
 .f-jumlah {
+  grid-area: info; align-self: start;
   color: var(--tinta-lembut); font-size: .82rem;
-  flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere;
+  min-width: 0; overflow-wrap: anywhere;
 }
-/* Tombol didorong ke kanan supaya kolomnya lurus walau nama lombanya pendek. */
-.foto-lomba li > :nth-last-child(2) { margin-left: auto; }
 /* <label> yang membungkus <input type=file> tersembunyi. Tanpa ini ia
    ditampilkan sebagai teks biasa, bukan sebagai tombol. */
 .foto-lomba label.button { display: inline-flex; align-items: center; cursor: pointer; }
-/* Kamera dan Galeri dibungkus SATU kotak, bukan diletakkan berdampingan
-   sebagai dua anak <li>. Dua sebabnya:
+/* KETIGA tombol satu kelompok — Lihat ikut di dalamnya, bukan berdiri sendiri
+   sebagai anak <li>. Sebagai anak lepas ia menempati kolom grid-nya sendiri
+   dan tempatnya berpindah begitu ia disembunyikan; sebagai anggota kelompok
+   ini, baris tanpa foto cuma kehilangan satu tombol dan dua sisanya tetap
+   di tepi kanan yang sama. */
+.f-aksi {
+  grid-area: aksi;
+  display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap;
+}
+/* Kamera dan Galeri BERISI IKON SAJA — alasannya di bukaFotoLembar(). Tanpa
+   kata di dalamnya lebar .button-mini menyusut jadi sekitar 32px, dan itu di
+   bawah petak sentuh yang nyaman untuk jari; petugas pos memakainya sambil
+   berdiri, sering dengan tangan yang satunya memegang lembar jawaban. 44px
+   dipakai dua-duanya, jadi meleset sedikit tetap mengenai tombol yang
+   dimaksud — dan meleset ke tombol SEBELAHNYA membuka kamera saat yang
+   diminta galeri.
 
-   Pertama, `.foto-lomba li > :nth-last-child(2)` di atas mendorong tombol ke
-   kanan berdasarkan URUTAN. Menambah satu anak menggeser hitungannya, dan
-   yang terdorong jadi tombol Kamera — "Lihat" tertinggal menempel di nama
-   lombanya sendiri. Dengan pembungkus, jumlah anak <li> tetap empat dan
-   aturan itu tidak perlu disentuh.
-
-   Kedua, di HP barisnya membungkus. Sebagai dua anak lepas, Kamera bisa
-   tinggal di baris pertama sementara Galeri turun sendirian ke baris kedua —
-   dua tombol yang sepasang tapi tidak terlihat sepasang. */
-/* `margin-left: auto` supaya pasangan tombolnya berakhir di tepi kanan yang
-   SAMA di setiap baris, termasuk saat ia membungkus turun. Baris yang sudah
-   punya foto memuat "1 foto · 781 B" beserta tombol Lihat, dan di lebar HP
-   itu mendorong pasangannya ke baris kedua — tanpa aturan ini ia mendarat di
-   kiri sementara empat baris lain menaruhnya di kanan, dan kolomnya patah
-   tepat di baris yang berbeda dari yang lain.
-
-   Ia tidak bertabrakan dengan `:nth-last-child(2)` di atas: dua margin auto di
-   SATU baris membagi ruang kosongnya, dan yang lebih dulu — milik Lihat —
-   mengambil semuanya. Terukur di 600px dan 900px, jarak Lihat ke pasangannya
-   tetap 10px. */
-.f-aksi { display: flex; gap: .4rem; align-items: center; flex-wrap: nowrap;
-          margin-left: auto; }
-/* Tombol Kamera dan Galeri di dialog ini BERISI IKON SAJA — alasannya di
-   bukaFotoLembar(). Tanpa kata di dalamnya lebar .button-mini menyusut jadi
-   sekitar 32px, dan itu di bawah petak sentuh yang nyaman untuk jari; petugas
-   pos memakainya sambil berdiri, sering dengan tangan yang satunya memegang
-   lembar jawaban. 44px adalah ukuran yang dipakai dua-duanya di sini, jadi
-   meleset sedikit tetap mengenai tombol yang dimaksud — dan meleset ke tombol
-   SEBELAHNYA membuka kamera saat yang diminta galeri. */
-.f-aksi .button-mini { min-width: 44px; min-height: 40px; padding: .2rem; }
+   Hanya <label>, bukan seluruh .button-mini: "Lihat" di sebelahnya berisi
+   kata, dan padding .2rem akan menghimpitnya. */
+.f-aksi label.button { min-width: 44px; min-height: 40px; padding: .2rem; }
 .f-aksi .ikon { width: 1.3em; height: 1.3em; }
 /* Kamera dan Galeri di layar Foto Jawaban BERBAGI satu baris, tidak menumpuk.
    `.button` lebarnya 100%, jadi dua tombol di dalam .action-row masing-masing


### PR DESCRIPTION
## What

Two changes to the **Foto Jawaban** dialog on the pos scoring sheet.

**1. The Kamera and Galeri buttons carry their icon and nothing else.** The name
moves to `title` and to an `aria-label` on the input, where it also names the
lomba (`"Foto Semaphore pakai kamera"`). Each gets a 44×40 tap target, since an
icon-only `.button-mini` would otherwise shrink to about 32px.

**2. The row is a two-column grid instead of one wrapping flex line.** The lomba
name sits above its status on the left; all three buttons sit on the right, on
the name's line. Lihat moves inside `.f-aksi`, so the group is one grid area
rather than three children that can separate.

The **Foto Jawaban screen** is unchanged and keeps its words.

## Why

The pair repeats once per lomba, so five "Kamera" and five "Galeri" stacked in
one dialog are read on the first row and are noise on the other four.

Dropping the words was not enough on its own. Four things were competing for the
same width — name, status, Lihat, and the pair — and on a phone they stopped
fitting the moment a row had a photo: "belum ada" became "1 foto · 781 B" and
Lihat appeared, so the pair dropped to a second line. Only on rows that had a
photo, which left the list ragged and moved the buttons exactly while an officer
was using them.

Widening cannot fix that. What changes length is the status, and its length is
only known once the upload finishes. Giving it its own line is what stops it
pushing anything.

## Notes

- Measured in an iframe at 320, 360, 390, 430, 600 and 900px, with the longest
  lomba name and the longest status (`mengirim 1,2 MB…`) and Lihat visible: the
  pair stays on one line beside the name at every width, no overflow, no
  horizontal scroll, and every row the same height.
- Both buttons fed a file end to end: uploaded, counter moved to `1 foto`, Lihat
  appeared. Lihat still reaches its handler after the move. No console errors.