### PR TITLE
fix: stopwatch pakai lambang play/stop/reset, kartu regu tinggal identitas

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=6">
+  <link rel="stylesheet" href="style.css?v=7">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -899,6 +899,21 @@ const IKON = {
     '<path d="M21.801 10A10 10 0 1 1 17 3.335" /> <path d="m9 11 3 3L22 4" />',
   "x":
     '<path d="M18 6 6 18" /> <path d="m6 6 12 12" />',
+  /* Stopwatch di layar Input Nilai Pos v2. Ketiganya lambang yang sudah
+     dikenal dari alat perekam mana pun, jadi tombolnya tidak perlu dibaca —
+     dan itu inti gunanya di pos, tempat mata petugas ada di lapangan dan
+     bukan di layar.
+
+     Play dan stop sengaja BERISI, berbeda dengan ikon lain di berkas ini yang
+     semuanya bergaris. Segitiga bergaris pada ukuran tombol terbaca seperti
+     panah "berikutnya", dan bujur sangkar bergaris seperti kotak centang
+     kosong; keduanya lambang yang artinya justru ditentukan oleh isinya. */
+  "play":
+    '<path d="M7 4.2v15.6L19.4 12z" fill="currentColor" stroke-linejoin="round" />',
+  "square":
+    '<rect x="6.5" y="6.5" width="11" height="11" rx="1.5" fill="currentColor" />',
+  "rotate-ccw":
+    '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /> <path d="M3 3v5h5" />',
   "chart-column":
     '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
   "circle-check":

--- a/live/style.css
+++ b/live/style.css
@@ -4372,10 +4372,7 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* ---------- kepala layar satu lomba ---------- */
 
-.baris-lomba {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .8rem; flex-wrap: wrap;
-}
+.baris-lomba { padding-top: .7rem; padding-bottom: .7rem; }
 .lomba-pos { display: block; font-size: .85rem; color: var(--tinta-lembut); }
 .lomba-judul { margin: 0; }
 
@@ -4418,22 +4415,41 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 2.6rem; font-weight: 800; line-height: 1.1;
   font-variant-numeric: tabular-nums;
 }
-/* Mulai/Berhenti selebar kartunya dan setinggi 64px: satu tombol, satu
-   tempat, dan sasaran sentuh yang tidak menuntut dilihat sebelum ditekan. */
+/* Play/stop dan reset berdampingan di SATU kelompok, di tengah, tepat di
+   bawah penunjuknya — bentuk yang sama dengan alat perekam mana pun, jadi
+   tangannya tahu ke mana tanpa layarnya dibaca. */
+.sw-kendali {
+  display: flex; align-items: center; justify-content: center;
+  gap: 1rem; margin-top: .6rem;
+}
+.sw-bulat {
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%; border: 2px solid transparent; padding: 0;
+}
+/* Play/stop dua kali lebih besar daripada reset, dan itu perbedaan yang
+   dipakai: yang satu ditekan dua kali per regu sambil menatap lapangan, yang
+   satu lagi sesekali sambil menatap layar. */
 .sw-jalan {
-  width: 100%; min-height: 64px; margin-top: .5rem;
-  font-size: 1.3rem; font-weight: 800;
+  width: 76px; height: 76px;
+  background: var(--utama); color: #fff;
 }
-/* Ulang dan Diskualifikasi TIDAK berjajar dengan tombol jalan — mereka di
-   baris bawah, lebih kecil. Keduanya membatalkan sesuatu, dan jempol yang
-   meleset dari Berhenti ke Diskualifikasi menyimpan 0 poin untuk regu yang
-   menyelesaikan lomba. */
-.sw-tombol { display: flex; gap: .5rem; margin-top: .5rem; }
-.sw-tombol .button { flex: 1 1 0; min-width: 0; }
-.sw-catatan {
-  display: block; margin-top: .5rem;
-  font-size: .85rem; font-weight: 700; color: var(--bahaya);
+.sw-jalan.sw-berhenti { background: var(--bahaya); }
+.sw-jalan .sw-ikon { width: 34px; height: 34px; }
+.sw-ulang {
+  width: 52px; height: 52px;
+  background: var(--kartu); border-color: var(--garis); color: var(--tinta);
 }
+.sw-ulang:disabled { opacity: .45; cursor: not-allowed; }
+.sw-ulang .sw-ikon { width: 22px; height: 22px; }
+/* Diskualifikasi KECIL dan di baris bawah. Ia dipakai beberapa kali sepagi,
+   sementara play/stop dipakai dua kali per regu — tombol yang sama besar
+   dengan tetangganya menawarkan diri sesering tetangganya. Jempol yang
+   meleset ke sini menyimpan 0 poin untuk regu yang menyelesaikan lomba. */
+.sw-bawah {
+  display: flex; align-items: center; justify-content: center;
+  gap: .6rem; margin-top: .7rem; flex-wrap: wrap;
+}
+.sw-catatan { font-size: .85rem; font-weight: 700; color: var(--bahaya); }
 
 /* ---------- ubin foto lomba soal ---------- */
 

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 6, sidik: "e17ca1a61b2c" },
+  "style.css": { versi: 7, sidik: "cabc31ce4453" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=4">
+  <link rel="stylesheet" href="style.css?v=5">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7237,11 +7237,17 @@ async function layarFoto() {
    sejak 0044, 0074, dan 0081; yang baru cuma susunan layarnya.
    ========================================================================= */
 
-/** Lomba yang sedang dibuka. Dipegang DI LUAR fungsi layarnya supaya kembali
- *  ke sini — dari Home, dari tombol Back, sesudah menyimpan — mendarat di
- *  lomba yang tadi dikerjakan. Petugas yang memegang satu lomba sepagian
- *  tidak boleh memilihnya ulang ratusan kali. */
-const lombaDipilih = { kunci: null };
+/* PILIHAN LOMBA TIDAK DIINGAT ANTAR KUNJUNGAN, dan itu yang membuat tombol
+   "Ganti Lomba" tidak perlu ada.
+
+   Versi pertama mengingatnya, supaya petugas yang memegang satu lomba sepagian
+   tidak memilihnya ulang ratusan kali — lalu butuh satu tombol di kepala tiap
+   layar untuk membatalkan ingatan itu. Tombol itu duduk di sana sepanjang pagi
+   demi pekerjaan yang dilakukan sekali.
+
+   Sekarang membuka `#/pos2` selalu mendarat di pemilih. Yang hilang cuma satu
+   ketukan, dan hanya bagi orang yang MENINGGALKAN layarnya — sepanjang shift
+   petugas tidak pernah pergi dari sini. */
 
 /** Katalog pos + komponen, dipegang seumur sesi.
  *
@@ -7291,16 +7297,25 @@ const posUntukAkun = (s, semuaPos) => {
 
 /** Kartu identitas regu, bentuk yang sama dipakai ketiga layar di bawah.
  *
- *  `nilai_pos` ikut disebut, dan itu bukan hiasan: ia satu-satunya angka di
- *  layar ini yang datang dari v_poin_pos, jadi ia yang membuktikan bahwa yang
- *  barusan disimpan memang sampai ke mesin skor — bukan cuma ke kotaknya. */
+ *  IDENTITAS SAJA — nomor dada, nama regu, sekolah, golongan. Kartu ini ada
+ *  untuk menjawab SATU pertanyaan: "nomor yang barusan saya ketik ini benar
+ *  regu yang berdiri di depan saya?" Itu echo-confirm, dan setiap baris lain
+ *  di dalamnya harus dilewati mata sebelum sampai ke jawabannya.
+ *
+ *  Versi pertama ikut menulis "Nilai Kepramukaan: 70 · 5/5 terisi". Keduanya
+ *  fakta yang benar dan keduanya tidak dipakai di sini: nilai pos adalah
+ *  JUMLAH seluruh lomba pos itu, bukan angka yang sedang diketik, dan hitungan
+ *  terisi menjawab pertanyaan lembar pos — "mana yang belum dikerjakan" —
+ *  yang tidak pernah ditanya orang yang sedang memegang satu regu di depannya
+ *  (bagian 9.6).
+ *
+ *  Gembok tetap ada, dan itu bukan pengecualian: ia satu-satunya keadaan yang
+ *  membuat kotak di bawahnya menolak diisi, jadi ia harus terbaca SEBELUM
+ *  petugas mengetik (bagian 9.4). */
 const kartuReguNilai = (r) => `
   <div class="card card-identity" style="margin:0">
     ${html`<div class="nama">${dada3(r.nomor_dada)} · ${r.nama_regu}</div>
     <div class="detail">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</div>`}
-    <div class="detail">Nilai ${esc(r.nama_pos || "")}:
-      <strong>${esc(angkaRapi(r.nilai_pos))}</strong>
-      · ${esc(String(r.jumlah_terisi))}/${esc(String(r.jumlah_komponen))} terisi</div>
     ${r.terkunci ? `<div style="margin-top:.4rem">
       <span class="badge badge-gray">${ikon("lock")} tergembok</span></div>` : ""}
   </div>`;
@@ -7340,12 +7355,14 @@ async function layarInputPos2() {
     return;
   }
 
-  const pilih = katalog.find(l => l.kunci === lombaDipilih.kunci);
-  if (!pilih) { gambarPemilihLomba(katalog); return; }
+  gambarPemilihLomba(katalog);
+}
 
-  pasangKepala(judulLomba(pilih), pilih.jenis === "soal");
-  if (pilih.jenis === "soal") await gambarLombaSoal(pilih);
-  else await gambarLombaNilai(pilih);
+/** Buka satu lomba: kepala layarnya, lalu bentuk pengisiannya. */
+async function bukaLomba(l) {
+  pasangKepala(judulLomba(l), l.jenis === "soal");
+  if (l.jenis === "soal") await gambarLombaSoal(l);
+  else await gambarLombaNilai(l);
 }
 
 /** Kotak per lomba, DIKELOMPOKKAN PER POS.
@@ -7387,30 +7404,22 @@ function gambarPemilihLomba(katalog) {
   LAYAR.addEventListener("click", (e) => {
     const b = e.target.closest("[data-kunci]");
     if (!b) return;
-    lombaDipilih.kunci = b.dataset.kunci;
-    layarInputPos2();
+    const l = katalog.find(x => x.kunci === b.dataset.kunci);
+    if (l) bukaLomba(l);
   }, { signal: sinyalLayarBaru() });
 }
 
-/** Kepala layar tiap bentuk pengisian: nama lombanya, dan jalan kembali ke
- *  pemilih. Satu-satunya jalan kembali — memilih lomba tidak menambah entri
- *  riwayat browser, jadi tombol Back mendarat di layar SEBELUM layar ini. */
+/** Kepala layar tiap bentuk pengisian: nama lombanya, dan tidak lebih.
+ *
+ *  Judul bar di atas sudah menyebut hal yang sama, tapi ia hilang di HP saat
+ *  papan ketik naik dan halamannya tergulir; kartu ini ikut bergulir bersama
+ *  isinya. Yang dijawabnya satu pertanyaan yang mahal kalau salah — "angka
+ *  yang saya ketik ini masuk ke lomba mana?" */
 const kepalaLomba = (l) => `
   <div class="card baris-lomba">
-    <div>
-      <span class="lomba-pos">${esc(l.bayangan ? l.namaPos : `Pos ${l.pos}`)}</span>
-      <h2 class="lomba-judul">${esc(l.nama)}</h2>
-    </div>
-    <button type="button" class="button button-secondary button-small"
-            id="ganti-lomba">Ganti Lomba</button>
+    <span class="lomba-pos">${esc(l.bayangan ? l.namaPos : `Pos ${l.pos}`)}</span>
+    <h2 class="lomba-judul">${esc(l.nama)}</h2>
   </div>`;
-
-const pasangGantiLomba = (sinyal) => {
-  document.getElementById("ganti-lomba")?.addEventListener("click", () => {
-    lombaDipilih.kunci = null;
-    layarInputPos2();
-  }, { signal: sinyal });
-};
 
 /* ---------------------------------------------------------------------------
    BENTUK "nilai" DAN "waktu" — satu regu satu layar.
@@ -7444,8 +7453,6 @@ async function gambarLombaNilai(l) {
     </div>
     <div id="v2-riwayat"></div>
   `));
-
-  pasangGantiLomba(sinyal);
 
   const inp = document.getElementById("v2-dada");
   const kotakRegu = document.getElementById("v2-regu");
@@ -7710,17 +7717,20 @@ async function gambarLombaNilai(l) {
 const panelStopwatchHtml = () => `
   <div class="stopwatch" id="v2-stopwatch">
     <output class="sw-angka" id="sw-angka">00:00.0</output>
-    <button type="button" class="button button-primary sw-jalan"
-            data-sw="jalan">Mulai</button>
-    <div class="sw-tombol">
-      <button type="button" class="button button-secondary" data-sw="ulang"
+    <div class="sw-kendali">
+      <button type="button" class="sw-bulat sw-jalan" data-sw="jalan"
+              title="Mulai" aria-label="Mulai">${ikon("play", "ikon sw-ikon")}</button>
+      <button type="button" class="sw-bulat sw-ulang" data-sw="ulang"
               title="Kembalikan penunjuk ke 00:00 — kotak Waktu tidak ikut dikosongkan"
-              disabled>Ulang</button>
-      <button type="button" class="button button-danger" data-sw="dq"
-              >Diskualifikasi</button>
+              aria-label="Kembalikan penunjuk ke nol"
+              disabled>${ikon("rotate-ccw", "ikon sw-ikon")}</button>
     </div>
-    <span class="sw-catatan" id="sw-catatan" hidden>Waktu 00:00 — tidak
-      menyelesaikan lomba, 0 poin.</span>
+    <div class="sw-bawah">
+      <button type="button" class="button button-danger button-mini" data-sw="dq"
+              >Diskualifikasi</button>
+      <span class="sw-catatan" id="sw-catatan" hidden>Waktu 00:00 — tidak
+        menyelesaikan lomba, 0 poin.</span>
+    </div>
   </div>`;
 
 /** Pasang stopwatch pada panel yang sudah tergambar.
@@ -7768,15 +7778,22 @@ function pasangStopwatch(wadah, kotakWaktu, sinyal) {
   // dilepas di sini. Keduanya digantungkan ke sinyal yang sama.
   sinyal.addEventListener("abort", berhentiTik, { once: true });
 
-  /* Tombolnya BERGANTI WARNA, bukan cuma berganti kata. Yang dibaca sambil
-     menatap lapangan adalah warnanya, dan hijau yang berarti "sedang jalan"
-     akan ditekan orang yang mengira ia berarti "mulai". */
+  /* Satu tombol, dua lambang: play saat diam, stop saat jalan — di tempat
+     yang sama. Warnanya ikut berganti, dan itu bukan hiasan: yang terbaca
+     sambil menatap lapangan adalah warnanya, dan hijau yang berarti "sedang
+     jalan" akan ditekan orang yang mengira ia berarti "mulai".
+
+     Nama untuk pembaca layar ikut berganti bersama lambangnya. Tombol ikon
+     yang aria-label-nya tetap "Mulai" sepanjang lomba adalah tombol yang
+     berbohong kepada satu-satunya orang yang tidak bisa melihat lambangnya. */
   const perbaruiTombol = () => {
     const jalan = mulaiPada !== null;
     const b = tombol("jalan");
-    b.textContent = jalan ? "Berhenti" : (tertahan ? "Lanjut" : "Mulai");
-    b.classList.toggle("button-danger", jalan);
-    b.classList.toggle("button-primary", !jalan);
+    const nama = jalan ? "Berhenti" : (tertahan ? "Lanjutkan" : "Mulai");
+    b.innerHTML = ikon(jalan ? "square" : "play", "ikon sw-ikon");
+    b.title = nama;
+    b.setAttribute("aria-label", nama);
+    b.classList.toggle("sw-berhenti", jalan);
     tombol("ulang").disabled = jalan || !tertahan;
   };
 
@@ -7885,8 +7902,6 @@ async function gambarLombaSoal(l) {
       <div class="grid-foto" id="v2-grid"></div>
     </div>
   `));
-
-  pasangGantiLomba(sinyal);
 
   const elGrid  = document.getElementById("v2-grid");
   const elBelum = document.getElementById("v2-belum");

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -899,6 +899,21 @@ const IKON = {
     '<path d="M21.801 10A10 10 0 1 1 17 3.335" /> <path d="m9 11 3 3L22 4" />',
   "x":
     '<path d="M18 6 6 18" /> <path d="m6 6 12 12" />',
+  /* Stopwatch di layar Input Nilai Pos v2. Ketiganya lambang yang sudah
+     dikenal dari alat perekam mana pun, jadi tombolnya tidak perlu dibaca —
+     dan itu inti gunanya di pos, tempat mata petugas ada di lapangan dan
+     bukan di layar.
+
+     Play dan stop sengaja BERISI, berbeda dengan ikon lain di berkas ini yang
+     semuanya bergaris. Segitiga bergaris pada ukuran tombol terbaca seperti
+     panah "berikutnya", dan bujur sangkar bergaris seperti kotak centang
+     kosong; keduanya lambang yang artinya justru ditentukan oleh isinya. */
+  "play":
+    '<path d="M7 4.2v15.6L19.4 12z" fill="currentColor" stroke-linejoin="round" />',
+  "square":
+    '<rect x="6.5" y="6.5" width="11" height="11" rx="1.5" fill="currentColor" />',
+  "rotate-ccw":
+    '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /> <path d="M3 3v5h5" />',
   "chart-column":
     '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
   "circle-check":

--- a/web/style.css
+++ b/web/style.css
@@ -4372,10 +4372,7 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* ---------- kepala layar satu lomba ---------- */
 
-.baris-lomba {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .8rem; flex-wrap: wrap;
-}
+.baris-lomba { padding-top: .7rem; padding-bottom: .7rem; }
 .lomba-pos { display: block; font-size: .85rem; color: var(--tinta-lembut); }
 .lomba-judul { margin: 0; }
 
@@ -4418,22 +4415,41 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 2.6rem; font-weight: 800; line-height: 1.1;
   font-variant-numeric: tabular-nums;
 }
-/* Mulai/Berhenti selebar kartunya dan setinggi 64px: satu tombol, satu
-   tempat, dan sasaran sentuh yang tidak menuntut dilihat sebelum ditekan. */
+/* Play/stop dan reset berdampingan di SATU kelompok, di tengah, tepat di
+   bawah penunjuknya — bentuk yang sama dengan alat perekam mana pun, jadi
+   tangannya tahu ke mana tanpa layarnya dibaca. */
+.sw-kendali {
+  display: flex; align-items: center; justify-content: center;
+  gap: 1rem; margin-top: .6rem;
+}
+.sw-bulat {
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%; border: 2px solid transparent; padding: 0;
+}
+/* Play/stop dua kali lebih besar daripada reset, dan itu perbedaan yang
+   dipakai: yang satu ditekan dua kali per regu sambil menatap lapangan, yang
+   satu lagi sesekali sambil menatap layar. */
 .sw-jalan {
-  width: 100%; min-height: 64px; margin-top: .5rem;
-  font-size: 1.3rem; font-weight: 800;
+  width: 76px; height: 76px;
+  background: var(--utama); color: #fff;
 }
-/* Ulang dan Diskualifikasi TIDAK berjajar dengan tombol jalan — mereka di
-   baris bawah, lebih kecil. Keduanya membatalkan sesuatu, dan jempol yang
-   meleset dari Berhenti ke Diskualifikasi menyimpan 0 poin untuk regu yang
-   menyelesaikan lomba. */
-.sw-tombol { display: flex; gap: .5rem; margin-top: .5rem; }
-.sw-tombol .button { flex: 1 1 0; min-width: 0; }
-.sw-catatan {
-  display: block; margin-top: .5rem;
-  font-size: .85rem; font-weight: 700; color: var(--bahaya);
+.sw-jalan.sw-berhenti { background: var(--bahaya); }
+.sw-jalan .sw-ikon { width: 34px; height: 34px; }
+.sw-ulang {
+  width: 52px; height: 52px;
+  background: var(--kartu); border-color: var(--garis); color: var(--tinta);
 }
+.sw-ulang:disabled { opacity: .45; cursor: not-allowed; }
+.sw-ulang .sw-ikon { width: 22px; height: 22px; }
+/* Diskualifikasi KECIL dan di baris bawah. Ia dipakai beberapa kali sepagi,
+   sementara play/stop dipakai dua kali per regu — tombol yang sama besar
+   dengan tetangganya menawarkan diri sesering tetangganya. Jempol yang
+   meleset ke sini menyimpan 0 poin untuk regu yang menyelesaikan lomba. */
+.sw-bawah {
+  display: flex; align-items: center; justify-content: center;
+  gap: .6rem; margin-top: .7rem; flex-wrap: wrap;
+}
+.sw-catatan { font-size: .85rem; font-weight: 700; color: var(--bahaya); }
 
 /* ---------- ubin foto lomba soal ---------- */
 


### PR DESCRIPTION
## What

Tiga perubahan di layar Input Nilai Pos v2, semuanya mengurangi isi layar.

- **Tombol Ganti Lomba dibuang.** `#/pos2` sekarang selalu mendarat di pemilih
  lomba; pilihannya tidak lagi diingat antar kunjungan.
- **Stopwatch memakai lambang play, stop, dan reset dalam satu kelompok.** Satu
  tombol bulat memegang play dan stop di tempat yang sama — yang berganti
  lambang, warna, dan nama untuk pembaca layar. Reset berdampingan, lebih kecil.
- **Diskualifikasi mengecil** dan turun ke baris bawah.

Kartu regu tinggal nomor dada, nama regu, sekolah, dan golongan. Baris
`Nilai Kepramukaan: 70 · 5/5 terisi` dibuang. Gembok tetap.

Tiga ikon baru di `util.js`: `play`, `square`, `rotate-ccw`.

## Why

Tombol Ganti Lomba ada karena pilihan lomba diingat antar kunjungan, jadi butuh
sesuatu untuk membatalkan ingatan itu — satu tombol yang duduk di kepala layar
sepanjang pagi demi pekerjaan yang dilakukan sekali. Yang hilang sekarang cuma
satu ketukan, dan hanya bagi orang yang meninggalkan layarnya; sepanjang shift
petugas tidak pernah pergi dari sana.

Lambang play/stop/reset adalah bentuk alat perekam mana pun, jadi tangannya
tahu ke mana tanpa layarnya dibaca — dan itu inti gunanya di pos, tempat mata
petugas ada di lapangan.

Kartu regu menjawab satu pertanyaan: nomor yang barusan diketik ini benar regu
yang berdiri di depan saya? Nilai pos adalah JUMLAH seluruh lomba pos itu,
bukan angka yang sedang diketik, dan hitungan terisi menjawab pertanyaan lembar
pos — "mana yang belum dikerjakan" — yang tidak ditanya orang yang sedang
memegang satu regu di depannya.

## Notes

Play dan stop sengaja BERISI, berbeda dengan seluruh ikon lain di `util.js`
yang bergaris: segitiga bergaris pada ukuran tombol terbaca seperti panah
"berikutnya", dan bujur sangkar bergaris seperti kotak centang kosong.

Gembok tetap di kartu regu, dan itu bukan pengecualian dari aturan di atas — ia
satu-satunya keadaan yang membuat kotak di bawahnya menolak diisi, jadi ia
harus terbaca sebelum petugas mengetik.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev` berisi 36 regu
bernomor dada:

- `node --test tests/*.test.mjs` — 310 lulus, 0 gagal
- `periksa_impor.py`, `periksa_urutan_golongan.py` — bersih
- `node --input-type=module --check` atas `app.js`, `util.js`, `live/js/util.js`
- Layarnya dibuka: pemilih lomba tanpa tombol Ganti Lomba; ▶ hijau ditekan jadi
  ■ merah di titik yang sama, ditekan lagi kembali ▶ dengan aria-label
  "Lanjutkan" dan 00:06.4 masuk kotak sebagai `00:06`; reset menyala hanya
  sesudah jam berhenti dan tidak nol; kartu regu tinggal dua baris.
