### PR TITLE
fix: Diskualifikasi pindah ke sebelah kotak nomor dada

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=7">
+  <link rel="stylesheet" href="style.css?v=8">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4415,13 +4415,22 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 2.6rem; font-weight: 800; line-height: 1.1;
   font-variant-numeric: tabular-nums;
 }
-/* Play/stop dan reset berdampingan di SATU kelompok, di tengah, tepat di
-   bawah penunjuknya — bentuk yang sama dengan alat perekam mana pun, jadi
-   tangannya tahu ke mana tanpa layarnya dibaca. */
+/* Kotak nomor dada mengisi barisnya, Diskualifikasi hanya selebar tulisannya
+   di ujung kanan. Yang dijaga di sini JARAK: sejauh mungkin dari tombol
+   berhenti, karena jarak adalah satu-satunya pengaman yang bekerja saat orang
+   menekan tergesa. */
+.dada-baris { display: flex; align-items: stretch; gap: .6rem; }
+.dada-baris .besar { flex: 1 1 auto; min-width: 0; }
+.dada-baris .sw-dq { flex: 0 0 auto; white-space: nowrap; }
+
+/* Play/stop sendirian di tengah, tepat di bawah penunjuknya — bentuk yang
+   sama dengan alat perekam mana pun, jadi tangannya tahu ke mana tanpa
+   layarnya dibaca. Reset di barisnya sendiri di bawah. */
 .sw-kendali {
   display: flex; align-items: center; justify-content: center;
   gap: 1rem; margin-top: .6rem;
 }
+.sw-kendali-bawah { margin-top: .5rem; }
 .sw-bulat {
   display: flex; align-items: center; justify-content: center;
   border-radius: 50%; border: 2px solid transparent; padding: 0;
@@ -4441,15 +4450,10 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .sw-ulang:disabled { opacity: .45; cursor: not-allowed; }
 .sw-ulang .sw-ikon { width: 22px; height: 22px; }
-/* Diskualifikasi KECIL dan di baris bawah. Ia dipakai beberapa kali sepagi,
-   sementara play/stop dipakai dua kali per regu — tombol yang sama besar
-   dengan tetangganya menawarkan diri sesering tetangganya. Jempol yang
-   meleset ke sini menyimpan 0 poin untuk regu yang menyelesaikan lomba. */
-.sw-bawah {
-  display: flex; align-items: center; justify-content: center;
-  gap: .6rem; margin-top: .7rem; flex-wrap: wrap;
+.sw-catatan {
+  display: block; margin-top: .7rem; text-align: center;
+  font-size: .85rem; font-weight: 700; color: var(--bahaya);
 }
-.sw-catatan { font-size: .85rem; font-weight: 700; color: var(--bahaya); }
 
 /* ---------- ubin foto lomba soal ---------- */
 

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 7, sidik: "cabc31ce4453" },
+  "style.css": { versi: 8, sidik: "54049e231169" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=5">
+  <link rel="stylesheet" href="style.css?v=6">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7437,11 +7437,26 @@ async function gambarLombaNilai(l) {
 
   LAYAR.replaceChildren(h(`
     ${kepalaLomba(l)}
-    <div class="card" style="border-color:var(--utama)">
+    <div class="card" id="v2-kartu" style="border-color:var(--utama)">
       <div class="field" style="margin-bottom:0">
         <label for="v2-dada">Nomor dada</label>
-        <input type="text" id="v2-dada" class="besar" inputmode="numeric"
-               autocomplete="off" placeholder="001">
+        <!-- DISKUALIFIKASI DUDUK DI SINI, sejauh mungkin dari tombol berhenti.
+
+             Tempatnya tidak dipilih karena maknanya berdekatan dengan nomor
+             dada — melainkan karena JARAK adalah satu-satunya pengaman yang
+             bekerja saat orang menekan tergesa. Selama ia bertetangga dengan
+             play/stop, jempol yang meleset sekali menyimpan 0 poin untuk regu
+             yang menyelesaikan lomba, dan tidak ada satu pun galat yang
+             muncul saat itu terjadi.
+
+             Kotaknya sendiri tetap yang pertama dijangkau: ia mengisi sisa
+             lebar barisnya, tombolnya hanya selebar tulisannya. -->
+        <div class="dada-baris">
+          <input type="text" id="v2-dada" class="besar" inputmode="numeric"
+                 autocomplete="off" placeholder="001">
+          ${waktu ? `<button type="button" class="button button-danger button-small sw-dq"
+                  data-sw="dq">Diskualifikasi</button>` : ""}
+        </div>
       </div>
       <div id="v2-regu" style="margin-top:.7rem"></div>
       ${waktu ? panelStopwatchHtml() : ""}
@@ -7468,7 +7483,9 @@ async function gambarLombaNilai(l) {
   const kotakWaktu = () => wadah.querySelector(".input-waktu");
   // Penyegar catatan diskualifikasi. null untuk lomba non-waktu, yang memang
   // tidak punya panel stopwatch sama sekali.
-  const segarkanStopwatch = waktu ? pasangStopwatch(wadah, kotakWaktu, sinyal) : null;
+  const segarkanStopwatch = waktu
+    ? pasangStopwatch(document.getElementById("v2-kartu"), wadah, kotakWaktu, sinyal)
+    : null;
 
   inp.focus();
   gambarRiwayatNilai();
@@ -7720,29 +7737,30 @@ const panelStopwatchHtml = () => `
     <div class="sw-kendali">
       <button type="button" class="sw-bulat sw-jalan" data-sw="jalan"
               title="Mulai" aria-label="Mulai">${ikon("play", "ikon sw-ikon")}</button>
+    </div>
+    <div class="sw-kendali sw-kendali-bawah">
       <button type="button" class="sw-bulat sw-ulang" data-sw="ulang"
               title="Kembalikan penunjuk ke 00:00 — kotak Waktu tidak ikut dikosongkan"
               aria-label="Kembalikan penunjuk ke nol"
               disabled>${ikon("rotate-ccw", "ikon sw-ikon")}</button>
     </div>
-    <div class="sw-bawah">
-      <button type="button" class="button button-danger button-mini" data-sw="dq"
-              >Diskualifikasi</button>
-      <span class="sw-catatan" id="sw-catatan" hidden>Waktu 00:00 — tidak
-        menyelesaikan lomba, 0 poin.</span>
-    </div>
+    <span class="sw-catatan" id="sw-catatan" hidden>Waktu 00:00 — tidak
+      menyelesaikan lomba, 0 poin.</span>
   </div>`;
 
-/** Pasang stopwatch pada panel yang sudah tergambar.
+/** Pasang stopwatch pada kartu yang sudah tergambar.
+ *
+ *  `kartu`, bukan panel stopwatch-nya: Diskualifikasi sengaja duduk jauh dari
+ *  play/stop — di sebelah kotak nomor dada — jadi ketiga tombol yang diurus
+ *  fungsi ini tidak lagi berbagi satu induk selain kartunya.
  *
  *  `kotakWaktu` sebuah FUNGSI, bukan elemen — alasannya di pemanggilnya.
  *  Mengembalikan fungsi penyegar catatan diskualifikasi, karena kotaknya
  *  digambar ulang tiap regu dan panel ini tidak ikut tahu kapan. */
-function pasangStopwatch(wadah, kotakWaktu, sinyal) {
-  const panel = document.getElementById("v2-stopwatch");
+function pasangStopwatch(kartu, wadah, kotakWaktu, sinyal) {
   const angka = document.getElementById("sw-angka");
   const catatan = document.getElementById("sw-catatan");
-  const tombol = (nama) => panel.querySelector(`[data-sw="${nama}"]`);
+  const tombol = (nama) => kartu.querySelector(`[data-sw="${nama}"]`);
 
   /* Catatan hanya muncul saat kotaknya BENAR-BENAR berisi 00:00.
      Kalimat tetap yang selalu terpampang akan dibaca ratusan kali per shift
@@ -7797,7 +7815,7 @@ function pasangStopwatch(wadah, kotakWaktu, sinyal) {
     tombol("ulang").disabled = jalan || !tertahan;
   };
 
-  panel.addEventListener("click", (e) => {
+  kartu.addEventListener("click", (e) => {
     const b = e.target.closest("[data-sw]");
     if (!b) return;
 

--- a/web/style.css
+++ b/web/style.css
@@ -4415,13 +4415,22 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 2.6rem; font-weight: 800; line-height: 1.1;
   font-variant-numeric: tabular-nums;
 }
-/* Play/stop dan reset berdampingan di SATU kelompok, di tengah, tepat di
-   bawah penunjuknya — bentuk yang sama dengan alat perekam mana pun, jadi
-   tangannya tahu ke mana tanpa layarnya dibaca. */
+/* Kotak nomor dada mengisi barisnya, Diskualifikasi hanya selebar tulisannya
+   di ujung kanan. Yang dijaga di sini JARAK: sejauh mungkin dari tombol
+   berhenti, karena jarak adalah satu-satunya pengaman yang bekerja saat orang
+   menekan tergesa. */
+.dada-baris { display: flex; align-items: stretch; gap: .6rem; }
+.dada-baris .besar { flex: 1 1 auto; min-width: 0; }
+.dada-baris .sw-dq { flex: 0 0 auto; white-space: nowrap; }
+
+/* Play/stop sendirian di tengah, tepat di bawah penunjuknya — bentuk yang
+   sama dengan alat perekam mana pun, jadi tangannya tahu ke mana tanpa
+   layarnya dibaca. Reset di barisnya sendiri di bawah. */
 .sw-kendali {
   display: flex; align-items: center; justify-content: center;
   gap: 1rem; margin-top: .6rem;
 }
+.sw-kendali-bawah { margin-top: .5rem; }
 .sw-bulat {
   display: flex; align-items: center; justify-content: center;
   border-radius: 50%; border: 2px solid transparent; padding: 0;
@@ -4441,15 +4450,10 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .sw-ulang:disabled { opacity: .45; cursor: not-allowed; }
 .sw-ulang .sw-ikon { width: 22px; height: 22px; }
-/* Diskualifikasi KECIL dan di baris bawah. Ia dipakai beberapa kali sepagi,
-   sementara play/stop dipakai dua kali per regu — tombol yang sama besar
-   dengan tetangganya menawarkan diri sesering tetangganya. Jempol yang
-   meleset ke sini menyimpan 0 poin untuk regu yang menyelesaikan lomba. */
-.sw-bawah {
-  display: flex; align-items: center; justify-content: center;
-  gap: .6rem; margin-top: .7rem; flex-wrap: wrap;
+.sw-catatan {
+  display: block; margin-top: .7rem; text-align: center;
+  font-size: .85rem; font-weight: 700; color: var(--bahaya);
 }
-.sw-catatan { font-size: .85rem; font-weight: 700; color: var(--bahaya); }
 
 /* ---------- ubin foto lomba soal ---------- */
 


### PR DESCRIPTION
## What

- **Diskualifikasi** pindah dari panel stopwatch ke sebelah kanan kotak nomor
  dada. Kotaknya mengisi sisa lebar baris; tombolnya hanya selebar tulisannya.
- **Reset** turun ke barisnya sendiri di bawah play/stop, jadi tombol bulat
  besar itu berdiri sendirian di tengah.
- Ketukan didengar dari kartunya, bukan dari panel stopwatch — ketiga tombol
  yang diurus `pasangStopwatch()` tidak lagi berbagi satu induk selain kartu.

## Why

Selama Diskualifikasi bertetangga dengan play/stop, jempol yang meleset sekali
menyimpan 0 poin untuk regu yang menyelesaikan lomba — dan tidak ada satu pun
galat yang muncul saat itu terjadi. Mengecilkan tombolnya (#739) mengurangi
peluangnya, tidak menghilangkannya. Jarak yang menghilangkannya, dan sebelah
kotak nomor dada adalah titik terjauh dari tombol berhenti yang masih berada di
layar yang sama.

## Notes

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `node --test tests/*.test.mjs` — 310 lulus, 0 gagal
- `periksa_impor.py` bersih, `diff web/style.css live/style.css` sama
- `node --input-type=module --check < web/js/app.js`
- Layar Pos 2 — Bakiak dibuka: Diskualifikasi berdiri di kanan kotak nomor
  dada dan tidak ada lagi di dalam panel stopwatch; ditekan dari tempat barunya
  kotak Waktu jadi `00:00` dan catatan "tidak menyelesaikan lomba, 0 poin"
  muncul. Play sendirian di tengah, reset di baris bawahnya.
