### PR TITLE
feat: nilai diisi dengan menekan angka, bukan diketik

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=8">
+  <link rel="stylesheet" href="style.css?v=9">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1280,6 +1280,46 @@ export function stopwatchTeks(ms) {
  *  ditemukan belakangan waktu angkanya sudah masuk. */
 export const detikDariMs = (ms) => Math.round(Math.max(0, Number(ms) || 0) / 1000);
 
+/** Angka terbanyak yang masih pantas digambar sebagai deretan tombol.
+ *
+ *  Empat puluh satu tombol (0-40) muat dalam enam baris di layar HP, dan
+ *  seluruh lomba edisi ini berada di bawahnya — yang terlebar Kreativitas
+ *  Yel-Yel, 0-35. Yang di atasnya cuma Menaksir, yang rentangnya 0-99999999
+ *  karena ia menulis SELISIH dalam sentimeter; menggambarnya sebagai tombol
+ *  bukan pilihan yang lebih buruk, melainkan pilihan yang mustahil.
+ *
+ *  Angkanya dipatok di sini, bukan diturunkan dari daftar lomba: tahun depan
+ *  panitia mengubah rentangnya lewat layar Akun, dan aturan yang menyebut nama
+ *  lomba akan menggambar dinding tombol untuk lomba yang tidak disangka. */
+export const MAKS_TOMBOL_ANGKA = 41;
+
+/** Bisakah komponen ini digambar sebagai deretan tombol angka?
+ *
+ *  Bentuk lain sudah punya cara pengisian yang tidak menuntut mengetik atau
+ *  tidak bisa diganti: centang sudah satu ketukan, waktu diisi stopwatch,
+ *  meter dan benar/salah punya bentuknya sendiri. Yang tersisa — dan yang
+ *  benar-benar diketik angka demi angka di lapangan — adalah kotak angka
+ *  polos milik hampir semua kriteria juri dan seluruh lomba soal. */
+export function bisaTombolAngka(k) {
+  if (k.form === "biner" || k.form === "benar_kurang_salah") return false;
+  if (k.satuan === "detik" || k.satuan === "meter") return false;
+
+  /* KOSONG DIPERIKSA SEBELUM Number(), dan itu bukan kerapian.
+     `Number(null)` dan `Number("")` sama-sama 0 — bilangan bulat yang sah —
+     jadi komponen yang batas atasnya belum diisi akan lolos sebagai rentang
+     0 sampai 0 dan digambar sebagai SATU tombol berbunyi "0". Petugas lalu
+     menekannya, karena itu satu-satunya yang ada, dan yang tersimpan nol
+     untuk kriteria yang sebenarnya bernilai sampai 30. Tidak ada galat di
+     mana pun: nol adalah nilai yang sah. */
+  const bulat = (v) =>
+    v !== null && v !== undefined && v !== "" && Number.isInteger(Number(v));
+  if (!bulat(k.rentang_mentah_min) || !bulat(k.rentang_mentah_maks)) return false;
+
+  const min = Number(k.rentang_mentah_min), maks = Number(k.rentang_mentah_maks);
+  return maks >= min && maks - min + 1 <= MAKS_TOMBOL_ANGKA;
+}
+
+
 /** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
  *  berapa yang sudah ada isinya, dan jumlah nilainya.
  *

--- a/live/style.css
+++ b/live/style.css
@@ -4399,6 +4399,25 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 1.15rem; font-weight: 700; text-align: center;
 }
 .isian-baris .checkbox { flex: 0 0 auto; }
+/* Baris berisi deretan tombol menumpuk ke bawah, bukan berdampingan: tiga
+   puluh enam tombol tidak muat di kolom kanan selebar kotak isian. */
+.isian-pilihan { flex-direction: column; align-items: stretch; }
+.isian-pilihan .isian-nama { flex: 0 0 auto; }
+/* Satu tombol per angka. `wrap`, bukan jumlah kolom yang dipatok: rentangnya
+   0-5 di Semaphore dan 0-35 di Kreativitas, dan keduanya memakai petak yang
+   sama. 48px adalah sasaran jempol yang tidak menuntut dilihat sebelum
+   ditekan — dan itulah seluruh gunanya menggantikan papan angka HP. */
+.pilih-angka { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .45rem; }
+.angka-kotak {
+  flex: 0 0 auto; min-width: 48px; min-height: 48px; padding: 0 .45rem;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kartu); color: var(--tinta);
+  font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.angka-kotak[aria-pressed="true"] {
+  background: var(--utama); border-color: var(--utama); color: #fff;
+}
+.angka-kotak:disabled { opacity: .45; cursor: not-allowed; }
 .isian-baris .pos-pasangan { flex: 0 0 auto; display: flex; align-items: center; gap: .3rem; }
 .isian-baris .pos-pasangan .small-input { width: 4rem; }
 
@@ -4444,12 +4463,7 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .sw-jalan.sw-berhenti { background: var(--bahaya); }
 .sw-jalan .sw-ikon { width: 34px; height: 34px; }
-.sw-ulang {
-  width: 52px; height: 52px;
-  background: var(--kartu); border-color: var(--garis); color: var(--tinta);
-}
 .sw-ulang:disabled { opacity: .45; cursor: not-allowed; }
-.sw-ulang .sw-ikon { width: 22px; height: 22px; }
 .sw-catatan {
   display: block; margin-top: .7rem; text-align: center;
   font-size: .85rem; font-weight: 700; color: var(--bahaya);

--- a/tests/input_pos_v2.test.mjs
+++ b/tests/input_pos_v2.test.mjs
@@ -7,7 +7,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { jenisLomba, katalogLomba, stopwatchTeks, detikDariMs }
+import { jenisLomba, katalogLomba, stopwatchTeks, detikDariMs, bisaTombolAngka }
   from "../web/js/util.js";
 
 /** Baris `wahana` seperti yang dikirim komponenSemua(). */
@@ -157,4 +157,47 @@ test("detik yang disimpan dibulatkan, bukan dipotong", () => {
   assert.equal(detikDariMs(30500), 31);
   assert.equal(detikDariMs(0), 0);
   assert.equal(detikDariMs(-100), 0);
+});
+
+/* -------------------------------------------------------------------------
+   bisaTombolAngka — kriteria mana yang diisi dengan menekan, bukan mengetik.
+   ---------------------------------------------------------------------- */
+
+// Seluruh rentang yang benar-benar dipakai edisi XXXVII, dari yang tersempit
+// sampai yang terlebar. Kalau salah satunya jatuh ke kotak ketik, satu lomba
+// kembali menuntut papan angka HP di tengah lapangan tanpa ada yang tahu.
+test("seluruh rentang lomba edisi ini digambar sebagai tombol", () => {
+  for (const [nama, maks] of [
+    ["Semaphore", 5], ["Tebak Simpul Penegak", 10], ["Kim Lihat", 10],
+    ["Keagamaan", 10], ["Logika", 20], ["Posisi Bidai", 15],
+    ["Kecepatan dan Kerja Sama", 20], ["Diagnosis", 25],
+    ["Gerakan Dasar", 30], ["Kreativitas", 35],
+  ]) {
+    assert.equal(bisaTombolAngka(w({ rentang_mentah_maks: maks })), true, nama);
+  }
+});
+
+// Menaksir menulis SELISIH dalam sentimeter, jadi rentangnya 0-99999999.
+// Tanpa pagar ini layar mencoba menggambar seratus juta tombol.
+test("Menaksir tetap kotak ketik", () => {
+  assert.equal(
+    bisaTombolAngka(w({ kode: "menaksir", rentang_mentah_maks: 99999999 })), false);
+});
+
+test("bentuk yang sudah punya cara pengisiannya sendiri tidak diganti", () => {
+  assert.equal(bisaTombolAngka(w({ form: "biner" })), false);
+  assert.equal(bisaTombolAngka(w({ form: "benar_kurang_salah" })), false);
+  assert.equal(bisaTombolAngka(w({ satuan: "detik", rentang_mentah_maks: 3600 })), false);
+  assert.equal(bisaTombolAngka(w({ satuan: "meter" })), false);
+});
+
+// Rentang yang tidak masuk akal tidak boleh menghasilkan larik kosong atau
+// putaran yang tidak pernah berhenti di selPilihanAngka().
+test("rentang rusak jatuh ke kotak ketik, bukan ke tombol", () => {
+  assert.equal(bisaTombolAngka(
+    w({ rentang_mentah_min: 5, rentang_mentah_maks: 2 })), false);
+  assert.equal(bisaTombolAngka(
+    w({ rentang_mentah_min: 0, rentang_mentah_maks: null })), false);
+  assert.equal(bisaTombolAngka(
+    w({ rentang_mentah_min: 0.5, rentang_mentah_maks: 5 })), false);
 });

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 8, sidik: "54049e231169" },
+  "style.css": { versi: 9, sidik: "6105e53c0a28" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=6">
+  <link rel="stylesheet" href="style.css?v=7">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -41,7 +41,8 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          jamPadaHari, bacaAnggotaHadir, kotakBerikutnyaDalamKolom,
          GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
          varianUntuk, kelompokLomba, ringkasLomba,
-         katalogLomba, stopwatchTeks, detikDariMs } from "./util.js";
+         katalogLomba, stopwatchTeks, detikDariMs,
+         bisaTombolAngka } from "./util.js";
 import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
 import { deretCocok, deretIntern, nomorStok, pesanDeret }
   from "./nomor-dada-series.mjs";
@@ -7539,7 +7540,38 @@ async function gambarLombaNilai(l) {
     gambarIsian(r);
   }
 
-  /** Kotak isian kriteria lomba ini UNTUK GOLONGAN REGU INI.
+  /** Deretan tombol angka untuk satu kriteria.
+ *
+ *  KENAPA BUKAN KOTAK KETIK. Di pos, angka ini diketik sambil berdiri, sering
+ *  satu tangan, dengan papan angka HP yang menutupi separuh layar dan
+ *  mendorong sisanya ke atas. Satu ketukan menggantikan: menekan kotak,
+ *  menunggu papan ketik naik, mengetik, lalu menutupnya lagi.
+ *
+ *  Nilainya tetap tinggal di sebuah `<input>` tersembunyi ber-`data-kode`,
+ *  bukan di dataset tombolnya. Itu yang membuat bacaSel() — satu-satunya
+ *  pembaca isian di berkas ini, dan yang sama dipakai lembar pos lama —
+ *  tidak perlu tahu apa-apa tentang tombol: kotak kosong tetap berarti
+ *  "belum dinilai", dan aturan hapus-vs-abaikan di jalur simpan tetap
+ *  berlaku persis sama.
+ *
+ *  MENEKAN ANGKA YANG SEDANG TERPILIH MEMBATALKANNYA. Tanpa itu, angka yang
+ *  telanjur masuk ke regu yang salah tidak punya satu pun jalan untuk
+ *  dikosongkan lagi — dan mengosongkan adalah persis yang harus dilakukan,
+ *  karena menimpanya dengan 0 berarti mencatat nilai nol yang sah. */
+function selPilihanAngka(k, nilai) {
+  const n = nilai && nilai.nilai_1 !== null && nilai.nilai_1 !== undefined
+    ? Number(nilai.nilai_1) : null;
+  const min = Number(k.rentang_mentah_min), maks = Number(k.rentang_mentah_maks);
+  const angka = [];
+  for (let i = min; i <= maks; i += 1) angka.push(i);
+  return `<div class="pilih-angka" role="group" aria-label="${esc(k.name)}">
+    <input type="hidden" data-kode="${esc(k.kode)}" value="${n === null ? "" : esc(String(n))}">
+    ${angka.map(i => `<button type="button" class="angka-kotak" data-angka="${i}"
+        aria-pressed="${i === n ? "true" : "false"}">${i}</button>`).join("")}
+  </div>`;
+}
+
+/** Kotak isian kriteria lomba ini UNTUK GOLONGAN REGU INI.
    *
    *  varianUntuk() yang memilihnya, sama seperti layar lama — Tebak Simpul
    *  punya empat baris wahana dan regu ini cuma berhak atas satu. Lomba yang
@@ -7561,25 +7593,43 @@ async function gambarLombaNilai(l) {
 
     const nilai = r.nilai || {};
     wadah.hidden = false;
-    wadah.replaceChildren(h(dipakai.map(({ kol, k }) => `
-      <div class="isian-baris">
-        <label class="isian-nama" for="sel-${esc(k.kode)}">
-          ${esc(kol.nama)}<span class="isian-petunjuk">${esc(kol.petunjuk)}</span>
-        </label>
-        ${selKomponen(k, nilai[k.kode])}
-      </div>`).join("")));
+    wadah.replaceChildren(h(dipakai.map(({ kol, k }) => {
+      const tombol = bisaTombolAngka(k);
+      /* Nama kriteria jadi <label for> hanya kalau isiannya SATU kotak. Untuk
+         deretan tombol tidak ada satu sasaran yang benar — `for` yang menunjuk
+         tombol "0" akan memilih nol setiap kali namanya ditekan, dan nol
+         adalah nilai yang sah. Di sana namanya jadi teks biasa, dan yang
+         menyebutkan kelompoknya ke pembaca layar adalah aria-label di
+         .pilih-angka. */
+      return `
+      <div class="isian-baris${tombol ? " isian-pilihan" : ""}">
+        ${tombol
+          ? `<div class="isian-nama">${esc(kol.nama)}<span
+               class="isian-petunjuk">${esc(kol.petunjuk)}</span></div>
+             ${selPilihanAngka(k, nilai[k.kode])}`
+          : `<label class="isian-nama" for="sel-${esc(k.kode)}">
+               ${esc(kol.nama)}<span class="isian-petunjuk">${esc(kol.petunjuk)}</span>
+             </label>
+             ${selKomponen(k, nilai[k.kode])}`}
+      </div>`;
+    }).join("")));
 
     /* selKomponen menulis data-kode, bukan id — id-nya dipasang di sini
        supaya <label for> punya sasaran. Menekan nama kriterianya lalu
        mendarat di kotaknya adalah sasaran sentuh selebar barisnya, dan di HP
-       itulah yang membedakan kotak 32px dari baris 44px. */
+       itulah yang membedakan kotak 32px dari baris 44px. Kotak tersembunyi
+       milik deretan tombol dilewati: ia tidak bisa difokuskan, dan <label>
+       yang menunjuknya tidak melakukan apa pun. */
     dipakai.forEach(({ k }) => {
       const el = wadah.querySelector(`[data-kode="${CSS.escape(k.kode)}"]`);
-      if (el) el.id = `sel-${k.kode}`;
+      if (el && el.type !== "hidden") el.id = `sel-${k.kode}`;
     });
 
     const kunci = !!r.terkunci;
-    wadah.querySelectorAll("input").forEach(el => { el.disabled = kunci; });
+    // Tombol angkanya ikut dimatikan, bukan cuma <input>-nya. Kotak yang masih
+    // bisa ditekan tapi selalu ditolak adalah jebakan, dan penolakannya baru
+    // muncul sesudah petugas mengira angkanya sudah masuk.
+    wadah.querySelectorAll("input, .angka-kotak").forEach(el => { el.disabled = kunci; });
     tombol.disabled = kunci;
     tombol.textContent = kunci ? "TERGEMBOK" : "SIMPAN NILAI";
 
@@ -7606,6 +7656,19 @@ async function gambarLombaNilai(l) {
     // harus ikut membaca isi kotak YANG BARU, bukan kotak regu sebelumnya.
     segarkanStopwatch?.();
   }
+
+  /* Ketukan angka. Menekan angka yang SEDANG terpilih membatalkannya —
+     lihat selPilihanAngka(). */
+  wadah.addEventListener("click", (e) => {
+    const b = e.target.closest(".angka-kotak");
+    if (!b || b.disabled) return;
+    const grup = b.closest(".pilih-angka");
+    const simpanan = grup.querySelector("input[data-kode]");
+    const batal = b.getAttribute("aria-pressed") === "true";
+    grup.querySelectorAll(".angka-kotak").forEach(x =>
+      x.setAttribute("aria-pressed", String(!batal && x === b)));
+    simpanan.value = batal ? "" : b.dataset.angka;
+  }, { signal: sinyal });
 
   // Enter di kotak isian = simpan. Di sini ia memang aksi terakhir barisnya:
   // sesudah angkanya diketik, petugas tidak punya urusan lain dengan regu itu.
@@ -7739,10 +7802,16 @@ const panelStopwatchHtml = () => `
               title="Mulai" aria-label="Mulai">${ikon("play", "ikon sw-ikon")}</button>
     </div>
     <div class="sw-kendali sw-kendali-bawah">
-      <button type="button" class="sw-bulat sw-ulang" data-sw="ulang"
+      <!-- BERTULISAN, tidak berlambang, berbeda dengan play/stop di atasnya.
+           Play dan stop punya lambang yang sudah dikenal dari alat perekam
+           mana pun; reset tidak — panah melingkar dipakai juga untuk "muat
+           ulang", "putar ulang", dan "kembalikan", dan yang ini artinya
+           menghapus hitungan. Satu kata menyelesaikannya, dan tombol ini
+           ditekan sambil menatap layar, bukan sambil menatap lapangan. -->
+      <button type="button" class="button button-secondary button-small sw-ulang"
+              data-sw="ulang"
               title="Kembalikan penunjuk ke 00:00 — kotak Waktu tidak ikut dikosongkan"
-              aria-label="Kembalikan penunjuk ke nol"
-              disabled>${ikon("rotate-ccw", "ikon sw-ikon")}</button>
+              disabled>Reset</button>
     </div>
     <span class="sw-catatan" id="sw-catatan" hidden>Waktu 00:00 — tidak
       menyelesaikan lomba, 0 poin.</span>

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1280,6 +1280,46 @@ export function stopwatchTeks(ms) {
  *  ditemukan belakangan waktu angkanya sudah masuk. */
 export const detikDariMs = (ms) => Math.round(Math.max(0, Number(ms) || 0) / 1000);
 
+/** Angka terbanyak yang masih pantas digambar sebagai deretan tombol.
+ *
+ *  Empat puluh satu tombol (0-40) muat dalam enam baris di layar HP, dan
+ *  seluruh lomba edisi ini berada di bawahnya — yang terlebar Kreativitas
+ *  Yel-Yel, 0-35. Yang di atasnya cuma Menaksir, yang rentangnya 0-99999999
+ *  karena ia menulis SELISIH dalam sentimeter; menggambarnya sebagai tombol
+ *  bukan pilihan yang lebih buruk, melainkan pilihan yang mustahil.
+ *
+ *  Angkanya dipatok di sini, bukan diturunkan dari daftar lomba: tahun depan
+ *  panitia mengubah rentangnya lewat layar Akun, dan aturan yang menyebut nama
+ *  lomba akan menggambar dinding tombol untuk lomba yang tidak disangka. */
+export const MAKS_TOMBOL_ANGKA = 41;
+
+/** Bisakah komponen ini digambar sebagai deretan tombol angka?
+ *
+ *  Bentuk lain sudah punya cara pengisian yang tidak menuntut mengetik atau
+ *  tidak bisa diganti: centang sudah satu ketukan, waktu diisi stopwatch,
+ *  meter dan benar/salah punya bentuknya sendiri. Yang tersisa — dan yang
+ *  benar-benar diketik angka demi angka di lapangan — adalah kotak angka
+ *  polos milik hampir semua kriteria juri dan seluruh lomba soal. */
+export function bisaTombolAngka(k) {
+  if (k.form === "biner" || k.form === "benar_kurang_salah") return false;
+  if (k.satuan === "detik" || k.satuan === "meter") return false;
+
+  /* KOSONG DIPERIKSA SEBELUM Number(), dan itu bukan kerapian.
+     `Number(null)` dan `Number("")` sama-sama 0 — bilangan bulat yang sah —
+     jadi komponen yang batas atasnya belum diisi akan lolos sebagai rentang
+     0 sampai 0 dan digambar sebagai SATU tombol berbunyi "0". Petugas lalu
+     menekannya, karena itu satu-satunya yang ada, dan yang tersimpan nol
+     untuk kriteria yang sebenarnya bernilai sampai 30. Tidak ada galat di
+     mana pun: nol adalah nilai yang sah. */
+  const bulat = (v) =>
+    v !== null && v !== undefined && v !== "" && Number.isInteger(Number(v));
+  if (!bulat(k.rentang_mentah_min) || !bulat(k.rentang_mentah_maks)) return false;
+
+  const min = Number(k.rentang_mentah_min), maks = Number(k.rentang_mentah_maks);
+  return maks >= min && maks - min + 1 <= MAKS_TOMBOL_ANGKA;
+}
+
+
 /** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
  *  berapa yang sudah ada isinya, dan jumlah nilainya.
  *

--- a/web/style.css
+++ b/web/style.css
@@ -4399,6 +4399,25 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 1.15rem; font-weight: 700; text-align: center;
 }
 .isian-baris .checkbox { flex: 0 0 auto; }
+/* Baris berisi deretan tombol menumpuk ke bawah, bukan berdampingan: tiga
+   puluh enam tombol tidak muat di kolom kanan selebar kotak isian. */
+.isian-pilihan { flex-direction: column; align-items: stretch; }
+.isian-pilihan .isian-nama { flex: 0 0 auto; }
+/* Satu tombol per angka. `wrap`, bukan jumlah kolom yang dipatok: rentangnya
+   0-5 di Semaphore dan 0-35 di Kreativitas, dan keduanya memakai petak yang
+   sama. 48px adalah sasaran jempol yang tidak menuntut dilihat sebelum
+   ditekan — dan itulah seluruh gunanya menggantikan papan angka HP. */
+.pilih-angka { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .45rem; }
+.angka-kotak {
+  flex: 0 0 auto; min-width: 48px; min-height: 48px; padding: 0 .45rem;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kartu); color: var(--tinta);
+  font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.angka-kotak[aria-pressed="true"] {
+  background: var(--utama); border-color: var(--utama); color: #fff;
+}
+.angka-kotak:disabled { opacity: .45; cursor: not-allowed; }
 .isian-baris .pos-pasangan { flex: 0 0 auto; display: flex; align-items: center; gap: .3rem; }
 .isian-baris .pos-pasangan .small-input { width: 4rem; }
 
@@ -4444,12 +4463,7 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .sw-jalan.sw-berhenti { background: var(--bahaya); }
 .sw-jalan .sw-ikon { width: 34px; height: 34px; }
-.sw-ulang {
-  width: 52px; height: 52px;
-  background: var(--kartu); border-color: var(--garis); color: var(--tinta);
-}
 .sw-ulang:disabled { opacity: .45; cursor: not-allowed; }
-.sw-ulang .sw-ikon { width: 22px; height: 22px; }
 .sw-catatan {
   display: block; margin-top: .7rem; text-align: center;
   font-size: .85rem; font-weight: 700; color: var(--bahaya);


### PR DESCRIPTION
## What

- **Kriteria nilai jadi deretan tombol angka.** Semaphore menggambar 0–5,
  Logika 0–20, Kreativitas Yel-Yel 0–35. Menekan angka yang sedang terpilih
  membatalkannya.
- **Menaksir tetap kotak ketik** — rentangnya 0–99999999 karena ia menulis
  selisih dalam sentimeter.
- **Tombol reset stopwatch jadi bertuliskan "Reset"**, bukan lambang panah
  melingkar.

Batasnya 41 angka, dipatok di `MAKS_TOMBOL_ANGKA`. `bisaTombolAngka()` tinggal
di `util.js` supaya bisa diuji.

## Why

Di pos angka ini diketik sambil berdiri, sering satu tangan, dengan papan angka
HP yang menutupi separuh layar dan mendorong sisanya ke atas. Satu ketukan
sekarang menggantikan empat: menekan kotak, menunggu papan ketik naik,
mengetik, lalu menutupnya lagi.

Reset tidak ikut jadi lambang karena panah melingkar dipakai juga untuk "muat
ulang" dan "putar ulang", sementara yang ini menghapus hitungan — dan ia
ditekan sambil menatap layar, bukan sambil menatap lapangan seperti play/stop.

## Notes

**Nilainya tetap tinggal di `<input type="hidden" data-kode>`,** bukan di
dataset tombolnya. Itu yang membuat `bacaSel()` — satu-satunya pembaca isian di
`app.js`, dan yang sama dipakai lembar pos lama — tidak perlu tahu apa-apa
tentang tombol: kotak kosong tetap berarti "belum dinilai", dan aturan
hapus-vs-abaikan di jalur simpan tetap berlaku persis sama.

**Satu bug ditemukan tesnya sendiri.** `Number(null)` dan `Number("")`
sama-sama 0 — bilangan bulat yang sah — jadi komponen yang batas atasnya belum
diisi lolos sebagai rentang 0 sampai 0 dan digambar sebagai SATU tombol
berbunyi "0". Petugas menekannya karena itu satu-satunya yang ada, dan yang
tersimpan nol untuk kriteria yang sebenarnya bernilai sampai 30 — tanpa satu
pun galat, karena nol adalah nilai yang sah. Pemeriksaan kosong sekarang
dilakukan sebelum `Number()`.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `node --test tests/*.test.mjs` — 314 lulus, 0 gagal (4 baru; salah satunya
  menyebut kesepuluh rentang lomba edisi ini satu per satu)
- `periksa_impor.py`, `periksa_urutan_golongan.py` bersih; `diff` web/ vs live/ sama
- Layarnya dibuka: Semaphore menggambar 0–5, ditekan **4** lalu Simpan
  menghasilkan **80 poin** dari `v_poin_pos`; Yel-Yel menggambar empat petak
  (0–35, 0–25, 0–20, 0–20); Menaksir tetap satu kotak ketik berketerangan
  "(selisih meter)"; Reset tampil sebagai tulisan dan mati selagi jam nol.
