### PR TITLE
chore: buang lambang rotate-ccw yang tidak dipakai siapa pun

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -907,13 +907,20 @@ const IKON = {
      Play dan stop sengaja BERISI, berbeda dengan ikon lain di berkas ini yang
      semuanya bergaris. Segitiga bergaris pada ukuran tombol terbaca seperti
      panah "berikutnya", dan bujur sangkar bergaris seperti kotak centang
-     kosong; keduanya lambang yang artinya justru ditentukan oleh isinya. */
+     kosong; keduanya lambang yang artinya justru ditentukan oleh isinya.
+
+     TIDAK ADA LAMBANG RESET DI SINI, dan ketiadaannya disengaja. Panah
+     melingkar sempat ditambahkan untuk tombol itu lalu dibuang: ia dipakai
+     juga untuk "muat ulang", "putar ulang", dan "kembalikan", sementara yang
+     ini menghapus hitungan — dan tombolnya ditekan sambil menatap layar,
+     bukan sambil menatap lapangan seperti play dan stop, jadi satu kata
+     menyelesaikannya. Tombol Reset di layar Input Nilai Pos v2 bertuliskan
+     kata itu. Kalau lambangnya dibutuhkan lagi suatu hari, baca dulu alasan
+     ini; jangan menambahkannya kembali hanya karena tombolnya terlihat polos. */
   "play":
     '<path d="M7 4.2v15.6L19.4 12z" fill="currentColor" stroke-linejoin="round" />',
   "square":
     '<rect x="6.5" y="6.5" width="11" height="11" rx="1.5" fill="currentColor" />',
-  "rotate-ccw":
-    '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /> <path d="M3 3v5h5" />',
   "chart-column":
     '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
   "circle-check":

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -907,13 +907,20 @@ const IKON = {
      Play dan stop sengaja BERISI, berbeda dengan ikon lain di berkas ini yang
      semuanya bergaris. Segitiga bergaris pada ukuran tombol terbaca seperti
      panah "berikutnya", dan bujur sangkar bergaris seperti kotak centang
-     kosong; keduanya lambang yang artinya justru ditentukan oleh isinya. */
+     kosong; keduanya lambang yang artinya justru ditentukan oleh isinya.
+
+     TIDAK ADA LAMBANG RESET DI SINI, dan ketiadaannya disengaja. Panah
+     melingkar sempat ditambahkan untuk tombol itu lalu dibuang: ia dipakai
+     juga untuk "muat ulang", "putar ulang", dan "kembalikan", sementara yang
+     ini menghapus hitungan — dan tombolnya ditekan sambil menatap layar,
+     bukan sambil menatap lapangan seperti play dan stop, jadi satu kata
+     menyelesaikannya. Tombol Reset di layar Input Nilai Pos v2 bertuliskan
+     kata itu. Kalau lambangnya dibutuhkan lagi suatu hari, baca dulu alasan
+     ini; jangan menambahkannya kembali hanya karena tombolnya terlihat polos. */
   "play":
     '<path d="M7 4.2v15.6L19.4 12z" fill="currentColor" stroke-linejoin="round" />',
   "square":
     '<rect x="6.5" y="6.5" width="11" height="11" rx="1.5" fill="currentColor" />',
-  "rotate-ccw":
-    '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /> <path d="M3 3v5h5" />',
   "chart-column":
     '<path d="M3 3v16a2 2 0 0 0 2 2h16" /> <path d="M18 17V9" /> <path d="M13 17V5" /> <path d="M8 17v-3" />',
   "circle-check":


### PR DESCRIPTION
## What

Menghapus entri `rotate-ccw` dari `IKON` di `util.js`, dan menulis alasannya di
tempat lambang itu tadi berdiri.

## Why

Ia ditambahkan untuk tombol reset stopwatch (#739), lalu tombol itu diganti
jadi bertuliskan "Reset" (#741) dan lambangnya tertinggal — terdefinisi, dan
dipanggil nol tempat.

Bukan sekadar kerapian: namanya persis lambang yang baru saja diputuskan untuk
TIDAK dipakai, jadi orang berikutnya yang mencari ikon reset akan menemukannya
di sini, memungutnya kembali, dan tidak pernah tahu bahwa itu sudah dicoba.
Alasannya sekarang ikut tertulis — panah melingkar dipakai juga untuk "muat
ulang", "putar ulang", dan "kembalikan", sementara yang ini menghapus hitungan,
dan tombolnya ditekan sambil menatap layar bukan lapangan.

## Notes

Tidak ada perubahan perilaku: `ikon()` mengembalikan string kosong untuk nama
yang tidak dikenal, dan tidak ada pemanggil. `style.css` tidak tersentuh, jadi
nomor versinya tetap.

**Diuji lokal:** `node --test tests/*.test.mjs` 314 lulus 0 gagal;
`node --input-type=module --check < web/js/util.js`; `periksa_impor.py` bersih;
`diff web/js/util.js live/js/util.js` sama; `grep -c rotate-ccw` = 0 di
`web/js/util.js`, `live/js/util.js`, dan `web/js/app.js`.
