### PR TITLE
fix: kotak ketik kembali, rentang per golongan, foto selebar kartu

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=10">
+  <link rel="stylesheet" href="style.css?v=11">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1287,46 +1287,6 @@ export function stopwatchTeks(ms) {
  *  ditemukan belakangan waktu angkanya sudah masuk. */
 export const detikDariMs = (ms) => Math.round(Math.max(0, Number(ms) || 0) / 1000);
 
-/** Angka terbanyak yang masih pantas digambar sebagai deretan tombol.
- *
- *  Empat puluh satu tombol (0-40) muat dalam enam baris di layar HP, dan
- *  seluruh lomba edisi ini berada di bawahnya — yang terlebar Kreativitas
- *  Yel-Yel, 0-35. Yang di atasnya cuma Menaksir, yang rentangnya 0-99999999
- *  karena ia menulis SELISIH dalam sentimeter; menggambarnya sebagai tombol
- *  bukan pilihan yang lebih buruk, melainkan pilihan yang mustahil.
- *
- *  Angkanya dipatok di sini, bukan diturunkan dari daftar lomba: tahun depan
- *  panitia mengubah rentangnya lewat layar Akun, dan aturan yang menyebut nama
- *  lomba akan menggambar dinding tombol untuk lomba yang tidak disangka. */
-export const MAKS_TOMBOL_ANGKA = 41;
-
-/** Bisakah komponen ini digambar sebagai deretan tombol angka?
- *
- *  Bentuk lain sudah punya cara pengisian yang tidak menuntut mengetik atau
- *  tidak bisa diganti: centang sudah satu ketukan, waktu diisi stopwatch,
- *  meter dan benar/salah punya bentuknya sendiri. Yang tersisa — dan yang
- *  benar-benar diketik angka demi angka di lapangan — adalah kotak angka
- *  polos milik hampir semua kriteria juri dan seluruh lomba soal. */
-export function bisaTombolAngka(k) {
-  if (k.form === "biner" || k.form === "benar_kurang_salah") return false;
-  if (k.satuan === "detik" || k.satuan === "meter") return false;
-
-  /* KOSONG DIPERIKSA SEBELUM Number(), dan itu bukan kerapian.
-     `Number(null)` dan `Number("")` sama-sama 0 — bilangan bulat yang sah —
-     jadi komponen yang batas atasnya belum diisi akan lolos sebagai rentang
-     0 sampai 0 dan digambar sebagai SATU tombol berbunyi "0". Petugas lalu
-     menekannya, karena itu satu-satunya yang ada, dan yang tersimpan nol
-     untuk kriteria yang sebenarnya bernilai sampai 30. Tidak ada galat di
-     mana pun: nol adalah nilai yang sah. */
-  const bulat = (v) =>
-    v !== null && v !== undefined && v !== "" && Number.isInteger(Number(v));
-  if (!bulat(k.rentang_mentah_min) || !bulat(k.rentang_mentah_maks)) return false;
-
-  const min = Number(k.rentang_mentah_min), maks = Number(k.rentang_mentah_maks);
-  return maks >= min && maks - min + 1 <= MAKS_TOMBOL_ANGKA;
-}
-
-
 /** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
  *  berapa yang sudah ada isinya, dan jumlah nilainya.
  *

--- a/live/style.css
+++ b/live/style.css
@@ -4390,20 +4390,52 @@ button.pill-number:hover { filter: brightness(.95); }
 .foto-judul { grid-area: 1 / 1; font-weight: 700; }
 .foto-status { grid-area: 2 / 1; font-size: .82rem; color: var(--tinta-lembut); }
 .foto-aksi { grid-area: 1 / 2 / 3 / 3; display: flex; gap: .4rem; }
+/* Selebar kartunya dan digeser ke samping. `scroll-snap` supaya gesernya
+   berhenti tepat di satu foto; `overscroll-behavior-x: contain` supaya geseran
+   yang kelewat ujung tidak ikut menggeser halaman di belakangnya. */
+.foto-geser {
+  grid-area: 3 / 1 / 4 / 3; margin-top: .5rem;
+  display: flex; gap: .5rem;
+  overflow-x: auto; overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+}
+.foto-lembar {
+  flex: 0 0 100%; scroll-snap-align: center;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kertas); overflow: hidden;
+}
+/* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
+   dipotong `cover` justru sering sisi yang memuat angkanya. */
+.foto-lembar img {
+  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+}
+.foto-lembar-kosong {
+  min-height: 8rem; font-size: .85rem; color: var(--tinta-lembut);
+}
 
 /* ---------- kotak isian kriteria ---------- */
 
 .isian-lomba { display: flex; flex-direction: column; gap: .5rem; margin-top: .7rem; }
-/* Nama kriteria di kiri, kotaknya di kanan — bentuk blangko kertasnya, supaya
-   juri yang menyalin dari kertas ke layar tidak perlu mencari padanannya. */
+/* DITUMPUK DAN DI TENGAH, bukan nama di kiri dan kotak di kanan.
+
+   Sejajar dengan judul lombanya yang juga di tengah, dan itu yang membuat
+   ketiganya terbaca sebagai satu kolom yang menurun: lomba apa, yang dihitung
+   apa, angkanya berapa. Nama di tengah dengan kotak menempel tepi kanan
+   membaca seperti dua hal yang tidak berhubungan.
+
+   Bentuk kiri-kanan sebelumnya meniru blangko kertas. Yang dipinjam dari
+   kertas tetap ada — urutan dan katanya — tetapi lebar kertas bukan lebar
+   layar HP, dan di sana kolom kiri selebar tiga perempat layar untuk dua kata
+   cuma menjauhkan mata dari angkanya. */
 .isian-baris {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .8rem; min-height: 48px; padding: .35rem .5rem;
+  display: flex; flex-direction: column; align-items: center;
+  gap: .35rem; padding: .55rem .5rem;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
 }
 .isian-nama {
-  display: flex; flex-direction: column;
-  flex: 1 1 auto; min-width: 0; font-weight: 700; line-height: 1.2;
+  display: flex; flex-direction: column; align-items: center;
+  max-width: 100%; font-weight: 700; line-height: 1.2; text-align: center;
 }
 .isian-petunjuk { font-size: .8rem; font-weight: 400; color: var(--tinta-lembut); }
 /* 48px, bukan tinggi bawaan .small-input: kotak ini diketik sambil berdiri,
@@ -4414,25 +4446,6 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 1.15rem; font-weight: 700; text-align: center;
 }
 .isian-baris .checkbox { flex: 0 0 auto; }
-/* Baris berisi deretan tombol menumpuk ke bawah, bukan berdampingan: tiga
-   puluh enam tombol tidak muat di kolom kanan selebar kotak isian. */
-.isian-pilihan { flex-direction: column; align-items: stretch; }
-.isian-pilihan .isian-nama { flex: 0 0 auto; }
-/* Satu tombol per angka. `wrap`, bukan jumlah kolom yang dipatok: rentangnya
-   0-5 di Semaphore dan 0-35 di Kreativitas, dan keduanya memakai petak yang
-   sama. 48px adalah sasaran jempol yang tidak menuntut dilihat sebelum
-   ditekan — dan itulah seluruh gunanya menggantikan papan angka HP. */
-.pilih-angka { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .45rem; }
-.angka-kotak {
-  flex: 0 0 auto; min-width: 48px; min-height: 48px; padding: 0 .45rem;
-  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
-  background: var(--kartu); color: var(--tinta);
-  font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums;
-}
-.angka-kotak[aria-pressed="true"] {
-  background: var(--utama); border-color: var(--utama); color: #fff;
-}
-.angka-kotak:disabled { opacity: .45; cursor: not-allowed; }
 .isian-baris .pos-pasangan { flex: 0 0 auto; display: flex; align-items: center; gap: .3rem; }
 .isian-baris .pos-pasangan .small-input { width: 4rem; }
 

--- a/tests/input_pos_v2.test.mjs
+++ b/tests/input_pos_v2.test.mjs
@@ -7,7 +7,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { jenisLomba, katalogLomba, stopwatchTeks, detikDariMs, bisaTombolAngka }
+import { jenisLomba, katalogLomba, stopwatchTeks, detikDariMs }
   from "../web/js/util.js";
 
 /** Baris `wahana` seperti yang dikirim komponenSemua(). */
@@ -157,47 +157,4 @@ test("detik yang disimpan dibulatkan, bukan dipotong", () => {
   assert.equal(detikDariMs(30500), 31);
   assert.equal(detikDariMs(0), 0);
   assert.equal(detikDariMs(-100), 0);
-});
-
-/* -------------------------------------------------------------------------
-   bisaTombolAngka — kriteria mana yang diisi dengan menekan, bukan mengetik.
-   ---------------------------------------------------------------------- */
-
-// Seluruh rentang yang benar-benar dipakai edisi XXXVII, dari yang tersempit
-// sampai yang terlebar. Kalau salah satunya jatuh ke kotak ketik, satu lomba
-// kembali menuntut papan angka HP di tengah lapangan tanpa ada yang tahu.
-test("seluruh rentang lomba edisi ini digambar sebagai tombol", () => {
-  for (const [nama, maks] of [
-    ["Semaphore", 5], ["Tebak Simpul Penegak", 10], ["Kim Lihat", 10],
-    ["Keagamaan", 10], ["Logika", 20], ["Posisi Bidai", 15],
-    ["Kecepatan dan Kerja Sama", 20], ["Diagnosis", 25],
-    ["Gerakan Dasar", 30], ["Kreativitas", 35],
-  ]) {
-    assert.equal(bisaTombolAngka(w({ rentang_mentah_maks: maks })), true, nama);
-  }
-});
-
-// Menaksir menulis SELISIH dalam sentimeter, jadi rentangnya 0-99999999.
-// Tanpa pagar ini layar mencoba menggambar seratus juta tombol.
-test("Menaksir tetap kotak ketik", () => {
-  assert.equal(
-    bisaTombolAngka(w({ kode: "menaksir", rentang_mentah_maks: 99999999 })), false);
-});
-
-test("bentuk yang sudah punya cara pengisiannya sendiri tidak diganti", () => {
-  assert.equal(bisaTombolAngka(w({ form: "biner" })), false);
-  assert.equal(bisaTombolAngka(w({ form: "benar_kurang_salah" })), false);
-  assert.equal(bisaTombolAngka(w({ satuan: "detik", rentang_mentah_maks: 3600 })), false);
-  assert.equal(bisaTombolAngka(w({ satuan: "meter" })), false);
-});
-
-// Rentang yang tidak masuk akal tidak boleh menghasilkan larik kosong atau
-// putaran yang tidak pernah berhenti di selPilihanAngka().
-test("rentang rusak jatuh ke kotak ketik, bukan ke tombol", () => {
-  assert.equal(bisaTombolAngka(
-    w({ rentang_mentah_min: 5, rentang_mentah_maks: 2 })), false);
-  assert.equal(bisaTombolAngka(
-    w({ rentang_mentah_min: 0, rentang_mentah_maks: null })), false);
-  assert.equal(bisaTombolAngka(
-    w({ rentang_mentah_min: 0.5, rentang_mentah_maks: 5 })), false);
 });

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 10, sidik: "26d2dc310c9a" },
+  "style.css": { versi: 11, sidik: "b0a929e03359" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=8">
+  <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -42,7 +42,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
          varianUntuk, kelompokLomba, ringkasLomba,
          katalogLomba, stopwatchTeks, detikDariMs,
-         bisaTombolAngka } from "./util.js";
+         petunjukKolom } from "./util.js";
 import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
 import { deretCocok, deretIntern, nomorStok, pesanDeret }
   from "./nomor-dada-series.mjs";
@@ -7514,6 +7514,7 @@ async function gambarLombaNilai(l) {
                    aria-label="Foto jawaban dari galeri">${ikon("image")}
           </label>
         </span>
+        <div class="foto-geser" id="v2-foto-petak" hidden></div>
       </div>
       <button class="button button-primary" id="v2-simpan" type="button" disabled
               style="margin-top:.7rem;min-height:60px;font-size:1.2rem">
@@ -7529,6 +7530,7 @@ async function gambarLombaNilai(l) {
   const tombol = document.getElementById("v2-simpan");
   const barisFoto = document.getElementById("v2-foto");
   const statusFoto = document.getElementById("v2-foto-status");
+  const petakFoto = document.getElementById("v2-foto-petak");
   let regu = null;      // baris v_lembar_pos regu yang sedang terbuka
   let jeda = null;
 
@@ -7566,6 +7568,9 @@ async function gambarLombaNilai(l) {
     wadah.hidden = true;
     barisFoto.hidden = true;
     statusFoto.textContent = "";
+    fotoLomba = null;
+    petakFoto.hidden = true;
+    petakFoto.replaceChildren();
     tombol.disabled = true;
     segarkanStopwatch?.();
   };
@@ -7593,15 +7598,56 @@ async function gambarLombaNilai(l) {
     if (pertama) { pertama.focus(); if (pertama.select) pertama.select(); }
   }, { signal: sinyal });
 
-  /** Berapa foto lomba ini yang sudah tertaut ke regu yang sedang terbuka.
-   *  null = permintaannya gagal, jadi jumlahnya tidak diketahui. */
-  let jumlahFoto = null;
+  /** Foto lomba ini yang sudah tertaut ke regu yang sedang terbuka.
+   *  null = permintaannya gagal, jadi keadaannya tidak diketahui — berbeda
+   *  dari larik kosong, yang berarti benar-benar belum ada. */
+  let fotoLomba = null;
 
   const gambarStatusFoto = () => {
-    statusFoto.textContent = jumlahFoto === null
-      ? "jumlah foto tidak terbaca"
-      : (jumlahFoto ? `${jumlahFoto} foto` : "belum ada");
+    statusFoto.textContent = fotoLomba === null
+      ? "foto tidak terbaca"
+      : (fotoLomba.length ? `${fotoLomba.length} foto` : "belum ada");
   };
+
+  /** Petak foto: SELEBAR KARTUNYA, satu foto satu layar penuh.
+   *
+   *  Yang dilihat di sini tulisan tangan di slip penilaian, dan petak kecil
+   *  tidak menjawab pertanyaan yang membuat orang membukanya — "angka di
+   *  kertas ini benar-benar 3 atau 8?". Jadi lebarnya penuh dan tingginya
+   *  dibiarkan sampai 60% layar.
+   *
+   *  Lebih dari satu foto DIGESER ke samping, bukan ditumpuk ke bawah:
+   *  ditumpuk, foto kedua mendorong tombol SIMPAN NILAI keluar layar, dan
+   *  tombol itu yang paling sering ditekan di kartu ini. `scroll-snap`
+   *  membuat gesernya berhenti tepat di satu foto, bukan di antara dua.
+   *
+   *  Tautan bertanda tangan diambil sekali untuk seluruh foto regu ini
+   *  (tautanFotoBanyak), bukan satu permintaan per gambar. */
+  async function gambarPetakFoto() {
+    if (!fotoLomba || !fotoLomba.length) {
+      petakFoto.hidden = true;
+      petakFoto.replaceChildren();
+      return;
+    }
+    const milik = fotoLomba;
+    let peta = {};
+    try { peta = await tautanFotoBanyak(milik.map(f => f.path)); }
+    catch { peta = {}; }
+    // Regunya bisa sudah berganti selagi tanda tangannya di jalan.
+    if (fotoLomba !== milik) return;
+
+    petakFoto.hidden = false;
+    petakFoto.replaceChildren(h(milik.map((f, i) => {
+      const url = peta[f.path];
+      const kapan = f.diunggah_pada ? tanggalJam(f.diunggah_pada) : "";
+      const judul = `Foto ${i + 1} dari ${milik.length}${kapan ? ` · ${kapan}` : ""}`;
+      return url
+        ? `<a class="foto-lembar" href="${esc(url)}" target="_blank" rel="noopener"
+              title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"
+              loading="lazy"></a>`
+        : `<span class="foto-lembar foto-lembar-kosong">tautan gagal</span>`;
+    }).join("")));
+  }
 
   async function cariDanGambar(dada) {
     let r, foto;
@@ -7636,9 +7682,9 @@ async function gambarLombaNilai(l) {
        fotonya justru bukti untuk angka final itu, dan menolak bukti sesudah
        putusan adalah urutan yang terbalik. */
     barisFoto.hidden = false;
-    jumlahFoto = foto === null
-      ? null : foto.filter(f => f.kode_lomba === l.kode).length;
+    fotoLomba = foto === null ? null : foto.filter(f => f.kode_lomba === l.kode);
     gambarStatusFoto();
+    gambarPetakFoto();
   }
 
   /* Diunggah SEKARANG, bukan ditahan sampai tombol Simpan.
@@ -7664,9 +7710,14 @@ async function gambarLombaNilai(l) {
       } catch (err) { statusFoto.textContent = err.message; continue; }
       try {
         statusFoto.textContent = `mengirim ${ukuranRapi(blob.size)}…`;
-        await unggahFotoLembar(l.pos, l.kode, l.nama, dada, blob);
-        jumlahFoto = (jumlahFoto || 0) + 1;
+        const hasil = await unggahFotoLembar(l.pos, l.kode, l.nama, dada, blob);
+        // Disisipkan ke DEPAN: yang barusan difoto adalah yang paling ingin
+        // dilihat, dan menggesernya dari ujung kanan tiap kali adalah
+        // pekerjaan yang tidak menghasilkan apa pun.
+        fotoLomba = [{ path: hasil.path, diunggah_pada: new Date().toISOString() },
+                     ...(fotoLomba || [])];
         gambarStatusFoto();
+        await gambarPetakFoto();
       } catch (err) {
         statusFoto.textContent = `gagal — ${err.message}`;
         notif(`Foto ${dada3(dada)} gagal terkirim: ${err.message}`, true);
@@ -7674,36 +7725,21 @@ async function gambarLombaNilai(l) {
     }
   }, { signal: sinyal });
 
-  /** Deretan tombol angka untuk satu kriteria.
- *
- *  KENAPA BUKAN KOTAK KETIK. Di pos, angka ini diketik sambil berdiri, sering
- *  satu tangan, dengan papan angka HP yang menutupi separuh layar dan
- *  mendorong sisanya ke atas. Satu ketukan menggantikan: menekan kotak,
- *  menunggu papan ketik naik, mengetik, lalu menutupnya lagi.
- *
- *  Nilainya tetap tinggal di sebuah `<input>` tersembunyi ber-`data-kode`,
- *  bukan di dataset tombolnya. Itu yang membuat bacaSel() — satu-satunya
- *  pembaca isian di berkas ini, dan yang sama dipakai lembar pos lama —
- *  tidak perlu tahu apa-apa tentang tombol: kotak kosong tetap berarti
- *  "belum dinilai", dan aturan hapus-vs-abaikan di jalur simpan tetap
- *  berlaku persis sama.
- *
- *  MENEKAN ANGKA YANG SEDANG TERPILIH MEMBATALKANNYA. Tanpa itu, angka yang
- *  telanjur masuk ke regu yang salah tidak punya satu pun jalan untuk
- *  dikosongkan lagi — dan mengosongkan adalah persis yang harus dilakukan,
- *  karena menimpanya dengan 0 berarti mencatat nilai nol yang sah. */
-function selPilihanAngka(k, nilai) {
-  const n = nilai && nilai.nilai_1 !== null && nilai.nilai_1 !== undefined
-    ? Number(nilai.nilai_1) : null;
-  const min = Number(k.rentang_mentah_min), maks = Number(k.rentang_mentah_maks);
-  const angka = [];
-  for (let i = min; i <= maks; i += 1) angka.push(i);
-  return `<div class="pilih-angka" role="group" aria-label="${esc(k.name)}">
-    <input type="hidden" data-kode="${esc(k.kode)}" value="${n === null ? "" : esc(String(n))}">
-    ${angka.map(i => `<button type="button" class="angka-kotak" data-angka="${i}"
-        aria-pressed="${i === n ? "true" : "false"}">${i}</button>`).join("")}
-  </div>`;
-}
+  /* DULU DI SINI ADA DERETAN TOMBOL ANGKA, satu tombol per nilai, dan ia
+     dibuang setelah dicoba di lapangan.
+
+     Alasan membuatnya masuk akal di atas kertas: papan angka HP menutupi
+     separuh layar, jadi satu ketukan menggantikan empat. Yang tidak terlihat
+     sebelum dipakai adalah harganya — Kreativitas Yel-Yel 0-35 jadi tiga baris
+     berisi tiga puluh enam petak yang harus DICARI dengan mata satu per satu,
+     dan empat kriteria di satu layar menjadikannya dinding. Mengetik "27"
+     ternyata lebih cepat daripada menemukan 27 di antara 36 petak yang
+     seragam, dan lebih sulit salah.
+
+     Jadi kalau ide ini muncul lagi: ia sudah dicoba, dan yang mematikannya
+     bukan jumlah ketukan melainkan waktu mencari. Kalau tetap ingin dicoba
+     ulang, batasi pada rentang yang benar-benar kecil (0-5) dan ukur di
+     lapangan, bukan di layar laptop. */
 
 /** Kotak isian kriteria lomba ini UNTUK GOLONGAN REGU INI.
    *
@@ -7727,44 +7763,26 @@ function selPilihanAngka(k, nilai) {
 
     const nilai = r.nilai || {};
     wadah.hidden = false;
-    wadah.replaceChildren(h(dipakai.map(({ kol, k }) => {
-      const tombol = bisaTombolAngka(k);
-      /* Nama kriteria jadi <label for> hanya kalau isiannya SATU kotak. Untuk
-         deretan tombol tidak ada satu sasaran yang benar — `for` yang menunjuk
-         tombol "0" akan memilih nol setiap kali namanya ditekan, dan nol
-         adalah nilai yang sah. Di sana namanya jadi teks biasa, dan yang
-         menyebutkan kelompoknya ke pembaca layar adalah aria-label di
-         .pilih-angka. */
-      return `
-      <div class="isian-baris${tombol ? " isian-pilihan" : ""}">
-        ${tombol
-          ? `<div class="isian-nama">${esc(labelIsian(kol, k))}<span
-               class="isian-petunjuk">${esc(kol.petunjuk)}</span></div>
-             ${selPilihanAngka(k, nilai[k.kode])}`
-          : `<label class="isian-nama" for="sel-${esc(k.kode)}">
-               ${esc(labelIsian(kol, k))}<span
-                 class="isian-petunjuk">${esc(kol.petunjuk)}</span>
-             </label>
-             ${selKomponen(k, nilai[k.kode])}`}
-      </div>`;
-    }).join("")));
+    wadah.replaceChildren(h(dipakai.map(({ kol, k }) => `
+      <div class="isian-baris">
+        <label class="isian-nama" for="sel-${esc(k.kode)}">
+          ${esc(labelIsian(kol, k))}<span
+            class="isian-petunjuk">${esc(petunjukKolom(k))}</span>
+        </label>
+        ${selKomponen(k, nilai[k.kode])}
+      </div>`).join("")));
 
     /* selKomponen menulis data-kode, bukan id — id-nya dipasang di sini
        supaya <label for> punya sasaran. Menekan nama kriterianya lalu
        mendarat di kotaknya adalah sasaran sentuh selebar barisnya, dan di HP
-       itulah yang membedakan kotak 32px dari baris 44px. Kotak tersembunyi
-       milik deretan tombol dilewati: ia tidak bisa difokuskan, dan <label>
-       yang menunjuknya tidak melakukan apa pun. */
+       itulah yang membedakan kotak 32px dari baris 44px. */
     dipakai.forEach(({ k }) => {
       const el = wadah.querySelector(`[data-kode="${CSS.escape(k.kode)}"]`);
-      if (el && el.type !== "hidden") el.id = `sel-${k.kode}`;
+      if (el) el.id = `sel-${k.kode}`;
     });
 
     const kunci = !!r.terkunci;
-    // Tombol angkanya ikut dimatikan, bukan cuma <input>-nya. Kotak yang masih
-    // bisa ditekan tapi selalu ditolak adalah jebakan, dan penolakannya baru
-    // muncul sesudah petugas mengira angkanya sudah masuk.
-    wadah.querySelectorAll("input, .angka-kotak").forEach(el => { el.disabled = kunci; });
+    wadah.querySelectorAll("input").forEach(el => { el.disabled = kunci; });
     tombol.disabled = kunci;
     tombol.textContent = kunci ? "TERGEMBOK" : "SIMPAN NILAI";
 
@@ -7791,19 +7809,6 @@ function selPilihanAngka(k, nilai) {
     // harus ikut membaca isi kotak YANG BARU, bukan kotak regu sebelumnya.
     segarkanStopwatch?.();
   }
-
-  /* Ketukan angka. Menekan angka yang SEDANG terpilih membatalkannya —
-     lihat selPilihanAngka(). */
-  wadah.addEventListener("click", (e) => {
-    const b = e.target.closest(".angka-kotak");
-    if (!b || b.disabled) return;
-    const grup = b.closest(".pilih-angka");
-    const simpanan = grup.querySelector("input[data-kode]");
-    const batal = b.getAttribute("aria-pressed") === "true";
-    grup.querySelectorAll(".angka-kotak").forEach(x =>
-      x.setAttribute("aria-pressed", String(!batal && x === b)));
-    simpanan.value = batal ? "" : b.dataset.angka;
-  }, { signal: sinyal });
 
   // Enter di kotak isian = simpan. Di sini ia memang aksi terakhir barisnya:
   // sesudah angkanya diketik, petugas tidak punya urusan lain dengan regu itu.

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1287,46 +1287,6 @@ export function stopwatchTeks(ms) {
  *  ditemukan belakangan waktu angkanya sudah masuk. */
 export const detikDariMs = (ms) => Math.round(Math.max(0, Number(ms) || 0) / 1000);
 
-/** Angka terbanyak yang masih pantas digambar sebagai deretan tombol.
- *
- *  Empat puluh satu tombol (0-40) muat dalam enam baris di layar HP, dan
- *  seluruh lomba edisi ini berada di bawahnya — yang terlebar Kreativitas
- *  Yel-Yel, 0-35. Yang di atasnya cuma Menaksir, yang rentangnya 0-99999999
- *  karena ia menulis SELISIH dalam sentimeter; menggambarnya sebagai tombol
- *  bukan pilihan yang lebih buruk, melainkan pilihan yang mustahil.
- *
- *  Angkanya dipatok di sini, bukan diturunkan dari daftar lomba: tahun depan
- *  panitia mengubah rentangnya lewat layar Akun, dan aturan yang menyebut nama
- *  lomba akan menggambar dinding tombol untuk lomba yang tidak disangka. */
-export const MAKS_TOMBOL_ANGKA = 41;
-
-/** Bisakah komponen ini digambar sebagai deretan tombol angka?
- *
- *  Bentuk lain sudah punya cara pengisian yang tidak menuntut mengetik atau
- *  tidak bisa diganti: centang sudah satu ketukan, waktu diisi stopwatch,
- *  meter dan benar/salah punya bentuknya sendiri. Yang tersisa — dan yang
- *  benar-benar diketik angka demi angka di lapangan — adalah kotak angka
- *  polos milik hampir semua kriteria juri dan seluruh lomba soal. */
-export function bisaTombolAngka(k) {
-  if (k.form === "biner" || k.form === "benar_kurang_salah") return false;
-  if (k.satuan === "detik" || k.satuan === "meter") return false;
-
-  /* KOSONG DIPERIKSA SEBELUM Number(), dan itu bukan kerapian.
-     `Number(null)` dan `Number("")` sama-sama 0 — bilangan bulat yang sah —
-     jadi komponen yang batas atasnya belum diisi akan lolos sebagai rentang
-     0 sampai 0 dan digambar sebagai SATU tombol berbunyi "0". Petugas lalu
-     menekannya, karena itu satu-satunya yang ada, dan yang tersimpan nol
-     untuk kriteria yang sebenarnya bernilai sampai 30. Tidak ada galat di
-     mana pun: nol adalah nilai yang sah. */
-  const bulat = (v) =>
-    v !== null && v !== undefined && v !== "" && Number.isInteger(Number(v));
-  if (!bulat(k.rentang_mentah_min) || !bulat(k.rentang_mentah_maks)) return false;
-
-  const min = Number(k.rentang_mentah_min), maks = Number(k.rentang_mentah_maks);
-  return maks >= min && maks - min + 1 <= MAKS_TOMBOL_ANGKA;
-}
-
-
 /** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
  *  berapa yang sudah ada isinya, dan jumlah nilainya.
  *

--- a/web/style.css
+++ b/web/style.css
@@ -4390,20 +4390,52 @@ button.pill-number:hover { filter: brightness(.95); }
 .foto-judul { grid-area: 1 / 1; font-weight: 700; }
 .foto-status { grid-area: 2 / 1; font-size: .82rem; color: var(--tinta-lembut); }
 .foto-aksi { grid-area: 1 / 2 / 3 / 3; display: flex; gap: .4rem; }
+/* Selebar kartunya dan digeser ke samping. `scroll-snap` supaya gesernya
+   berhenti tepat di satu foto; `overscroll-behavior-x: contain` supaya geseran
+   yang kelewat ujung tidak ikut menggeser halaman di belakangnya. */
+.foto-geser {
+  grid-area: 3 / 1 / 4 / 3; margin-top: .5rem;
+  display: flex; gap: .5rem;
+  overflow-x: auto; overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+}
+.foto-lembar {
+  flex: 0 0 100%; scroll-snap-align: center;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kertas); overflow: hidden;
+}
+/* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
+   dipotong `cover` justru sering sisi yang memuat angkanya. */
+.foto-lembar img {
+  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+}
+.foto-lembar-kosong {
+  min-height: 8rem; font-size: .85rem; color: var(--tinta-lembut);
+}
 
 /* ---------- kotak isian kriteria ---------- */
 
 .isian-lomba { display: flex; flex-direction: column; gap: .5rem; margin-top: .7rem; }
-/* Nama kriteria di kiri, kotaknya di kanan — bentuk blangko kertasnya, supaya
-   juri yang menyalin dari kertas ke layar tidak perlu mencari padanannya. */
+/* DITUMPUK DAN DI TENGAH, bukan nama di kiri dan kotak di kanan.
+
+   Sejajar dengan judul lombanya yang juga di tengah, dan itu yang membuat
+   ketiganya terbaca sebagai satu kolom yang menurun: lomba apa, yang dihitung
+   apa, angkanya berapa. Nama di tengah dengan kotak menempel tepi kanan
+   membaca seperti dua hal yang tidak berhubungan.
+
+   Bentuk kiri-kanan sebelumnya meniru blangko kertas. Yang dipinjam dari
+   kertas tetap ada — urutan dan katanya — tetapi lebar kertas bukan lebar
+   layar HP, dan di sana kolom kiri selebar tiga perempat layar untuk dua kata
+   cuma menjauhkan mata dari angkanya. */
 .isian-baris {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .8rem; min-height: 48px; padding: .35rem .5rem;
+  display: flex; flex-direction: column; align-items: center;
+  gap: .35rem; padding: .55rem .5rem;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
 }
 .isian-nama {
-  display: flex; flex-direction: column;
-  flex: 1 1 auto; min-width: 0; font-weight: 700; line-height: 1.2;
+  display: flex; flex-direction: column; align-items: center;
+  max-width: 100%; font-weight: 700; line-height: 1.2; text-align: center;
 }
 .isian-petunjuk { font-size: .8rem; font-weight: 400; color: var(--tinta-lembut); }
 /* 48px, bukan tinggi bawaan .small-input: kotak ini diketik sambil berdiri,
@@ -4414,25 +4446,6 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 1.15rem; font-weight: 700; text-align: center;
 }
 .isian-baris .checkbox { flex: 0 0 auto; }
-/* Baris berisi deretan tombol menumpuk ke bawah, bukan berdampingan: tiga
-   puluh enam tombol tidak muat di kolom kanan selebar kotak isian. */
-.isian-pilihan { flex-direction: column; align-items: stretch; }
-.isian-pilihan .isian-nama { flex: 0 0 auto; }
-/* Satu tombol per angka. `wrap`, bukan jumlah kolom yang dipatok: rentangnya
-   0-5 di Semaphore dan 0-35 di Kreativitas, dan keduanya memakai petak yang
-   sama. 48px adalah sasaran jempol yang tidak menuntut dilihat sebelum
-   ditekan — dan itulah seluruh gunanya menggantikan papan angka HP. */
-.pilih-angka { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .45rem; }
-.angka-kotak {
-  flex: 0 0 auto; min-width: 48px; min-height: 48px; padding: 0 .45rem;
-  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
-  background: var(--kartu); color: var(--tinta);
-  font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums;
-}
-.angka-kotak[aria-pressed="true"] {
-  background: var(--utama); border-color: var(--utama); color: #fff;
-}
-.angka-kotak:disabled { opacity: .45; cursor: not-allowed; }
 .isian-baris .pos-pasangan { flex: 0 0 auto; display: flex; align-items: center; gap: .3rem; }
 .isian-baris .pos-pasangan .small-input { width: 4rem; }
 


### PR DESCRIPTION
## What

- **Deretan tombol angka dibuang**, kembali ke kotak ketik. `bisaTombolAngka()`
  dan `MAKS_TOMBOL_ANGKA` ikut pergi dari `util.js` beserta tesnya.
- Nama kriteria, rentang, dan kotaknya **ditumpuk di tengah**.
- **Rentangnya mengikuti golongan regu**: Tebak Simpul berbunyi `0 – 5` untuk
  Penggalang dan `0 – 10` untuk Penegak, bukan `0 – 5 / 0 – 10`.
- **Foto jawaban selebar kartu**, satu foto satu layar penuh, digeser ke
  samping kalau lebih dari satu.

## Why

**Tombol angka.** Masuk akal di atas kertas — papan angka HP menutupi separuh
layar, jadi satu ketukan menggantikan empat. Yang tidak terlihat sebelum
dipakai adalah harganya: Kreativitas Yel-Yel 0–35 jadi tiga baris berisi 36
petak yang harus DICARI dengan mata satu per satu, dan empat kriteria di satu
layar menjadikannya dinding. Mengetik "27" lebih cepat daripada menemukan 27 di
antara 36 petak seragam. Alasannya ditulis di tempat kodenya tadi berdiri,
supaya yang berikutnya tahu ini sudah dicoba dan tahu apa yang mematikannya —
bukan jumlah ketukan, melainkan waktu mencari.

**Rentang per golongan.** `kol.petunjuk` menggabungkan keterangan KEEMPAT baris
golongan Tebak Simpul — bentuk yang benar untuk kepala kolom lembar pos lama,
yang memang melayani keempatnya sekaligus. Di sini golongannya sudah diketahui
dan variannya sudah dipilih `varianUntuk()`, jadi keterangannya diambil dari
varian itu lewat `petunjukKolom(k)`.

Kotaknya sendiri sudah benar sejak awal — `min`/`max` memang datang dari varian
yang dipilih. Yang salah cuma kalimat di bawah namanya, dan justru itu yang
dibaca petugas sebelum mengetik.

**Foto.** Yang dilihat di sana tulisan tangan di slip; petak kecil tidak
menjawab pertanyaan yang membuat orang membukanya — "angka di kertas ini
benar-benar 3 atau 8?". Digeser dan bukan ditumpuk karena foto kedua akan
mendorong tombol SIMPAN NILAI keluar layar.

## Notes

`object-fit: contain`, bukan `cover`: sisi yang dipotong `cover` justru sering
sisi yang memuat angkanya.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `node --test tests/*.test.mjs` — 310 lulus, 0 gagal
- `periksa_impor.py`, `periksa_urutan_golongan.py` bersih; `diff` web/ vs live/ sama
- Layarnya dibuka dan diukur di browser: `#v2-isian` berisi **1** kotak ketik
  dan **0** tombol angka; `.isian-baris` `flex-direction: column`, `.isian-nama`
  `text-align: center`; petak foto berisi 3 anak, masing-masing selebar
  674px (= lebar kartunya), `overflow-x: auto`, dan `scrollWidth > clientWidth`
  jadi memang bisa digeser.
- Tebak Simpul diuji DUA golongan berturut-turut di layar yang sama:
  012 JALAK DEWATA (Penggalang PA) → `0 – 5`, `max="5.00"`;
  010 ANYELIR (Penegak PI) → `0 – 10`, `max="10.00"`.
