### PR TITLE
fix: "Waktu" dan "dikunci", dan penggeser foto yang menyatakan dirinya

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=11">
+  <link rel="stylesheet" href="style.css?v=12">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4393,14 +4393,39 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Selebar kartunya dan digeser ke samping. `scroll-snap` supaya gesernya
    berhenti tepat di satu foto; `overscroll-behavior-x: contain` supaya geseran
    yang kelewat ujung tidak ikut menggeser halaman di belakangnya. */
+/* `gap: 0`, dan itu bukan selera: tombol panah menggeser sejauh clientWidth
+   tepat satu foto, dan jarak antar foto membuat perhitungan itu meleset makin
+   jauh setiap kali digeser. Yang memisahkan keduanya garis tepi masing-masing.
+
+   Penggulir bawaannya disembunyikan — di HP ia memang tidak pernah terlihat,
+   dan di laptop batang tipis di bawah foto terbaca seperti bagian gambarnya.
+   Yang menyatakan ada foto lain adalah penghitung dan panah di bawahnya. */
 .foto-geser {
   grid-area: 3 / 1 / 4 / 3; margin-top: .5rem;
-  display: flex; gap: .5rem;
+  display: flex; gap: 0;
   overflow-x: auto; overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+.foto-geser::-webkit-scrollbar { display: none; }
+/* Panah dan penghitung. Sasaran sentuh 44px, dan penghitungnya di antara
+   keduanya supaya ketiganya terbaca sebagai satu alat. */
+.foto-navigasi {
+  grid-area: 4 / 1 / 5 / 3; margin-top: .4rem;
+  display: flex; align-items: center; justify-content: center; gap: 1rem;
+}
+.foto-panah {
+  display: flex; align-items: center; justify-content: center;
+  width: 44px; height: 44px; padding: 0; line-height: 1;
+  border: 1px solid var(--garis); border-radius: 50%;
+  background: var(--kartu); color: var(--tinta); font-size: 1.5rem;
+}
+.foto-hitung {
+  min-width: 3.5rem; text-align: center;
+  font-weight: 700; font-variant-numeric: tabular-nums;
 }
 .foto-lembar {
-  flex: 0 0 100%; scroll-snap-align: center;
+  flex: 0 0 100%; scroll-snap-align: start;
   display: flex; align-items: center; justify-content: center;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kertas); overflow: hidden;

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 11, sidik: "b0a929e03359" },
+  "style.css": { versi: 12, sidik: "004a6b77f568" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=9">
+  <link rel="stylesheet" href="style.css?v=10">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3583,7 +3583,11 @@ function siapkanCetakLembarPos(pos, kolomLayar, baris) {
  *  cadangannya sengaja tidak menjanjikan apa-apa. */
 function judulIsian(k) {
   if (k.judul_isian) return k.judul_isian;
-  if (k.satuan === "detik") return "Waktu tempuh";
+  // "Waktu", bukan "Waktu tempuh". Kotaknya sudah berdiri di layar lomba
+  // waktu, di bawah stopwatch, dengan keterangan "menit:detik" — tidak ada
+  // waktu lain yang mungkin dimaksud, jadi "tempuh" cuma satu kata lagi yang
+  // dilewati mata sebelum sampai ke angkanya (bagian 9.3).
+  if (k.satuan === "detik") return "Waktu";
   if (k.satuan === "meter") return "Hasil taksir";
   if (k.form === "biner") return "Kena / tidak";
   if (k.form === "benar_kurang_salah") return "Benar dan salah";
@@ -4294,7 +4298,7 @@ async function layarInputPos() {
     const sel = tr.querySelector(".pos-gembok");
     sel.replaceChildren(h(`<button type="button" class="gembok"
       data-gembok aria-pressed="${kunci}"
-      title="${kunci ? "Terkunci — buka gembok (admin)"
+      title="${kunci ? "Terkunci — buka kunci (admin)"
                      : "Kunci nilai"}">${
       ikon(kunci ? "lock" : "lock-open")}</button>`));
     sel.querySelector("[data-gembok]").addEventListener("click", () => ubahGembok(tr));
@@ -4329,7 +4333,7 @@ async function layarInputPos() {
     catch (err) { notif(`Gagal membuka: ${err.message}`, true); return; }
     tr.dataset.terkunci = "";
     gambarGembok(tr);
-    notif(`Gembok ${tiga} dibuka.`);
+    notif(`Kunci ${tiga} dibuka.`);
   }
 
   /** Riwayat perubahan nilai satu regu di pos ini.
@@ -4894,7 +4898,7 @@ async function layarInputPos() {
     // itu harus menjelaskan jalan keluarnya; putaran otomatis tetap diam agar
     // tidak menyemburkan notifikasi setiap 15 detik.
     if (tr.dataset.terkunci === "1") {
-      const pesan = "Nilai sudah digembok. Buka gembok sebelum mengirim ulang.";
+      const pesan = "Nilai sudah dikunci. Buka kunci sebelum mengirim ulang.";
       statusBaris(tr, "gagal", pesan);
       if (beriTahu) notif(pesanBaris(dada, pesan), true);
       return;
@@ -7340,7 +7344,7 @@ const kartuReguNilai = (r) => `
     ${html`<div class="nama">${dada3(r.nomor_dada)} · ${r.nama_regu}</div>
     <div class="detail">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</div>`}
     ${r.terkunci ? `<div style="margin-top:.4rem">
-      <span class="badge badge-gray">${ikon("lock")} tergembok</span></div>` : ""}
+      <span class="badge badge-gray">${ikon("lock")} dikunci</span></div>` : ""}
   </div>`;
 
 /* ---------------------------------------------------------------------------
@@ -7515,6 +7519,22 @@ async function gambarLombaNilai(l) {
           </label>
         </span>
         <div class="foto-geser" id="v2-foto-petak" hidden></div>
+        <!-- TOMBOL, bukan cuma geser. Petak yang bisa digeser tidak
+             mengumumkan dirinya: yang terlihat cuma satu foto, dan foto kedua
+             baru ada kalau seseorang kebetulan menyapu layarnya. Penghitung
+             "1 / 2" yang menyatakan ada berapa, dan panahnya yang menyatakan
+             bisa dipindah — keduanya terbaca tanpa mencoba apa pun.
+
+             Hanya muncul kalau memang lebih dari satu foto. Satu foto dengan
+             panah mati di kiri-kanannya adalah dua tombol yang tidak pernah
+             melakukan apa pun. -->
+        <div class="foto-navigasi" id="v2-foto-nav" hidden>
+          <button type="button" class="foto-panah" data-foto-geser="-1"
+                  aria-label="Foto sebelumnya">&lsaquo;</button>
+          <span class="foto-hitung" id="v2-foto-hitung"></span>
+          <button type="button" class="foto-panah" data-foto-geser="1"
+                  aria-label="Foto berikutnya">&rsaquo;</button>
+        </div>
       </div>
       <button class="button button-primary" id="v2-simpan" type="button" disabled
               style="margin-top:.7rem;min-height:60px;font-size:1.2rem">
@@ -7531,6 +7551,8 @@ async function gambarLombaNilai(l) {
   const barisFoto = document.getElementById("v2-foto");
   const statusFoto = document.getElementById("v2-foto-status");
   const petakFoto = document.getElementById("v2-foto-petak");
+  const navFoto = document.getElementById("v2-foto-nav");
+  const hitungFoto = document.getElementById("v2-foto-hitung");
   let regu = null;      // baris v_lembar_pos regu yang sedang terbuka
   let jeda = null;
 
@@ -7571,6 +7593,7 @@ async function gambarLombaNilai(l) {
     fotoLomba = null;
     petakFoto.hidden = true;
     petakFoto.replaceChildren();
+    navFoto.hidden = true;
     tombol.disabled = true;
     segarkanStopwatch?.();
   };
@@ -7623,10 +7646,35 @@ async function gambarLombaNilai(l) {
    *
    *  Tautan bertanda tangan diambil sekali untuk seluruh foto regu ini
    *  (tautanFotoBanyak), bukan satu permintaan per gambar. */
+  /** Foto keberapa yang sedang terlihat, dipegang SENDIRI dan bukan dihitung
+   *  ulang dari posisi gulirnya setiap kali.
+   *
+   *  Versi pertama membacanya dari `scrollLeft` di dalam penangan `scroll`,
+   *  dan itu menaruh seluruh penghitungnya di atas satu peristiwa yang tidak
+   *  dijamin datang: `scroll` dikirim pada frame berikutnya, jadi tab yang
+   *  sedang tidak menggambar tidak mengirimkannya sama sekali — terukur nol
+   *  kali walau `scrollLeft` benar-benar berpindah. Penghitung yang bertahan
+   *  di "1 / 3" sementara fotonya sudah berganti lebih buruk daripada tidak
+   *  ada penghitung.
+   *
+   *  Jadi tombolnya yang memindahkan angkanya, langsung. `scroll` tetap
+   *  didengar, tapi tugasnya cuma satu: menyamakan angka ini kalau yang
+   *  menggeser jari, bukan tombol. */
+  let fotoKe = 0;
+
+  const perbaruiHitungFoto = () => {
+    const jml = petakFoto.children.length;
+    hitungFoto.textContent = jml ? `${fotoKe + 1} / ${jml}` : "";
+    // Panah yang mati di ujung menyatakan "tidak ada lagi" tanpa satu kata.
+    navFoto.querySelector('[data-foto-geser="-1"]').disabled = fotoKe <= 0;
+    navFoto.querySelector('[data-foto-geser="1"]').disabled = fotoKe >= jml - 1;
+  };
+
   async function gambarPetakFoto() {
     if (!fotoLomba || !fotoLomba.length) {
       petakFoto.hidden = true;
       petakFoto.replaceChildren();
+      navFoto.hidden = true;
       return;
     }
     const milik = fotoLomba;
@@ -7647,7 +7695,29 @@ async function gambarLombaNilai(l) {
               loading="lazy"></a>`
         : `<span class="foto-lembar foto-lembar-kosong">tautan gagal</span>`;
     }).join("")));
+
+    petakFoto.scrollLeft = 0;
+    fotoKe = 0;
+    navFoto.hidden = milik.length < 2;
+    perbaruiHitungFoto();
   }
+
+  petakFoto.addEventListener("scroll", () => {
+    const jml = petakFoto.children.length;
+    if (!jml) return;
+    const ke = Math.max(0, Math.min(jml - 1,
+      Math.round(petakFoto.scrollLeft / (petakFoto.clientWidth || 1))));
+    if (ke !== fotoKe) { fotoKe = ke; perbaruiHitungFoto(); }
+  }, { signal: sinyal });
+
+  navFoto.addEventListener("click", (e) => {
+    const b = e.target.closest("[data-foto-geser]");
+    if (!b || b.disabled) return;
+    const jml = petakFoto.children.length;
+    fotoKe = Math.max(0, Math.min(jml - 1, fotoKe + Number(b.dataset.fotoGeser)));
+    petakFoto.scrollTo({ left: fotoKe * petakFoto.clientWidth, behavior: "smooth" });
+    perbaruiHitungFoto();
+  }, { signal: sinyal });
 
   async function cariDanGambar(dada) {
     let r, foto;
@@ -7784,7 +7854,7 @@ async function gambarLombaNilai(l) {
     const kunci = !!r.terkunci;
     wadah.querySelectorAll("input").forEach(el => { el.disabled = kunci; });
     tombol.disabled = kunci;
-    tombol.textContent = kunci ? "TERGEMBOK" : "SIMPAN NILAI";
+    tombol.textContent = kunci ? "DIKUNCI" : "SIMPAN NILAI";
 
     /* Kotak waktu dirapikan dan ditandai merah saat DITINGGALKAN, aturan yang
        sama persis dengan lembar pos lama. "1:75" terbaca wajar oleh mata tapi
@@ -8300,7 +8370,7 @@ async function gambarLombaSoal(l) {
     const r = reguCache.get(dada);
     sasaran.className = `ubin-regu${r ? "" : " ubin-regu-salah"}`;
     sasaran.textContent = r
-      ? `${r.nama_regu}${r.terkunci ? " · tergembok" : ""}`
+      ? `${r.nama_regu}${r.terkunci ? " · dikunci" : ""}`
       : `${dada3(dada)} tidak dikenal`;
   }
 
@@ -8442,7 +8512,7 @@ async function gambarLombaSoal(l) {
     }
     if (r.terkunci) {
       tombol.disabled = false;
-      notif(`Nilai ${dada3(dada)} sudah digembok. Buka gembok dulu.`, true);
+      notif(`Nilai ${dada3(dada)} sudah dikunci. Buka kuncinya dulu.`, true);
       return;
     }
 

--- a/web/style.css
+++ b/web/style.css
@@ -4393,14 +4393,39 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Selebar kartunya dan digeser ke samping. `scroll-snap` supaya gesernya
    berhenti tepat di satu foto; `overscroll-behavior-x: contain` supaya geseran
    yang kelewat ujung tidak ikut menggeser halaman di belakangnya. */
+/* `gap: 0`, dan itu bukan selera: tombol panah menggeser sejauh clientWidth
+   tepat satu foto, dan jarak antar foto membuat perhitungan itu meleset makin
+   jauh setiap kali digeser. Yang memisahkan keduanya garis tepi masing-masing.
+
+   Penggulir bawaannya disembunyikan — di HP ia memang tidak pernah terlihat,
+   dan di laptop batang tipis di bawah foto terbaca seperti bagian gambarnya.
+   Yang menyatakan ada foto lain adalah penghitung dan panah di bawahnya. */
 .foto-geser {
   grid-area: 3 / 1 / 4 / 3; margin-top: .5rem;
-  display: flex; gap: .5rem;
+  display: flex; gap: 0;
   overflow-x: auto; overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+.foto-geser::-webkit-scrollbar { display: none; }
+/* Panah dan penghitung. Sasaran sentuh 44px, dan penghitungnya di antara
+   keduanya supaya ketiganya terbaca sebagai satu alat. */
+.foto-navigasi {
+  grid-area: 4 / 1 / 5 / 3; margin-top: .4rem;
+  display: flex; align-items: center; justify-content: center; gap: 1rem;
+}
+.foto-panah {
+  display: flex; align-items: center; justify-content: center;
+  width: 44px; height: 44px; padding: 0; line-height: 1;
+  border: 1px solid var(--garis); border-radius: 50%;
+  background: var(--kartu); color: var(--tinta); font-size: 1.5rem;
+}
+.foto-hitung {
+  min-width: 3.5rem; text-align: center;
+  font-weight: 700; font-variant-numeric: tabular-nums;
 }
 .foto-lembar {
-  flex: 0 0 100%; scroll-snap-align: center;
+  flex: 0 0 100%; scroll-snap-align: start;
   display: flex; align-items: center; justify-content: center;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kertas); overflow: hidden;


### PR DESCRIPTION
## What

- `"Waktu tempuh"` → **`"Waktu"`**.
- `"tergembok"` → **`"dikunci"`** di v2, dan layar Input Nilai Pos lama ikut
  disamakan.
- Penggeser foto mendapat **penghitung `1 / 3`** dan **dua panah** yang mati di
  ujung; jarak antar foto dibuang supaya satu geseran tepat satu foto.

## Why

**"Waktu".** Kotaknya sudah berdiri di layar lomba waktu, di bawah stopwatch,
dengan keterangan "menit:detik" — tidak ada waktu lain yang mungkin dimaksud.
Satu tempat (`judulIsian`), dan ia melayani layar DAN blangko kertas, jadi
keduanya tetap berbunyi sama.

**"dikunci".** Layar lama sudah setengah memakai kata itu — notifnya berbunyi
`Nilai 001 dikunci.` — sementara sisanya berbunyi "gembok", jadi dua layar
menyebut satu keadaan dengan dua kata. "Kunci" juga kata yang dipakai RPC-nya
sendiri: `kunci_nilai_pos`, `buka_kunci_nilai_pos`.

**Penggeser foto.** Petak yang bisa digeser tidak mengumumkan apa pun: yang
terlihat cuma satu foto, dan foto kedua baru ada kalau seseorang kebetulan
menyapu layarnya. Foto kedua yang tadi mengintip di tepi kanan juga terbaca
sebagai dua foto sempit, bukan sebagai "ada lagi di sebelah".

## Notes

**Nomor fotonya dipegang sendiri, bukan dihitung dari `scrollLeft` di dalam
penangan `scroll`.** Peristiwa itu dikirim pada frame berikutnya, jadi tab yang
sedang tidak menggambar tidak mengirimkannya sama sekali — terukur **nol kali**
walau `scrollLeft` benar-benar berpindah dari 0 ke 1349. Penghitung yang
bertahan di "1 / 3" sementara fotonya sudah berganti lebih buruk daripada tidak
ada penghitung. `scroll` tetap didengar; tugasnya cuma menyamakan angkanya
kalau yang menggeser jari.

`fotoKe` dan `perbaruiHitungFoto` dinaikkan ke atas `gambarPetakFoto` yang
memakainya — pelajaran yang sama dengan `const nota` di Meja Pembayaran
(pasal 17.3).

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `node --test tests/*.test.mjs` — 310 lulus, 0 gagal; `periksa_impor.py`
  bersih; `diff` web/ vs live/ sama
- Lari Balok dengan 001 yang nilainya sengaja dikunci lewat `kunci_nilai_pos`:
  label `Waktu · menit:detik`, badge `dikunci`, tombol `DIKUNCI`, kotaknya
  `disabled`.
- Semaphore dengan tiga foto: tiap petak selebar wadahnya (674 = 674), panah
  ditekan berturut-turut menghasilkan `1 / 3` → `2 / 3` → `3 / 3` dengan panah
  maju mati di ujung, lalu mundur kembali ke `2 / 3`.

**Yang TIDAK bisa diuji di sini:** gerakan `scroll-behavior: smooth` tidak
berjalan di konteks otomasi yang tidak menggambar — `scrollLeft` tetap 0
sesudah panah ditekan, sementara `scrollBy` dengan `behavior: "auto"` terbukti
memindahkannya 0 → 674. Indeks dan rupa tombolnya sudah diuji terpisah di atas.
