### PR TITLE
feat: tombol hapus foto, dan penggeser yang memakai komponen aplikasi

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4366,7 +4366,14 @@ button.pill-number:hover { filter: brightness(.95); }
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kartu); color: inherit; text-align: left;
 }
-.lomba-kotak:hover, .lomba-kotak:focus-visible { border-color: var(--utama); }
+.lomba-kotak:hover { border-color: var(--utama); }
+/* Garis fokus dipasang sendiri: aturan global hanya mengenai .button, input,
+   .option, dan .icon-button, dan kotak ini bukan salah satunya. Tanpa ini
+   yang berpindah dengan Tab tidak punya satu pun petunjuk di mana ia berada. */
+.lomba-kotak:focus-visible,
+.sw-bulat:focus-visible {
+  outline: 2px solid var(--utama); outline-offset: 2px;
+}
 .lomba-jenis { display: flex; flex: 0 0 auto; color: var(--tinta-lembut); }
 .lomba-nama { font-weight: 700; line-height: 1.2; }
 
@@ -4408,28 +4415,26 @@ button.pill-number:hover { filter: brightness(.95); }
   scrollbar-width: none;
 }
 .foto-geser::-webkit-scrollbar { display: none; }
-/* Panah dan penghitung. Sasaran sentuh 44px, dan penghitungnya di antara
-   keduanya supaya ketiganya terbaca sebagai satu alat. */
+/* Panah dan penghitung. Keduanya memakai komponen yang SUDAH ADA — `.button
+   .button-secondary .button-small` dan `.badge` — bukan bentuk baru: tombol
+   yang tidak terlihat seperti tombol lain di aplikasi ini harus dicoba dulu
+   sebelum dipercaya, dan itu ongkos yang dibayar tiap petugas baru. Ikut pula
+   gaya sentuh, hover, dan garis fokusnya tanpa satu baris tambahan. */
 .foto-navigasi {
-  grid-area: 4 / 1 / 5 / 3; margin-top: .4rem;
-  display: flex; align-items: center; justify-content: center; gap: 1rem;
+  grid-area: 4 / 1 / 5 / 3; margin-top: .5rem;
+  display: flex; align-items: center; justify-content: center; gap: .8rem;
 }
-.foto-panah {
-  display: flex; align-items: center; justify-content: center;
-  width: 44px; height: 44px; padding: 0; line-height: 1;
-  border: 1px solid var(--garis); border-radius: 50%;
-  background: var(--kartu); color: var(--tinta); font-size: 1.5rem;
-}
-.foto-hitung {
-  min-width: 3.5rem; text-align: center;
-  font-weight: 700; font-variant-numeric: tabular-nums;
-}
+.foto-panah { min-width: 3.2rem; font-size: 1.4rem; line-height: 1; padding: .2rem .6rem; }
+.foto-hitung { min-width: 3.6rem; justify-content: center; font-variant-numeric: tabular-nums; }
+/* `position: relative` karena silangnya duduk DI ATAS fotonya. Anchor dan
+   tombol jadi bersaudara di dalamnya, bukan bersarang: <button> di dalam <a>
+   bukan HTML yang sah, dan tiap browser memperbaikinya dengan caranya sendiri. */
 .foto-lembar {
-  flex: 0 0 100%; scroll-snap-align: start;
-  display: flex; align-items: center; justify-content: center;
+  position: relative; flex: 0 0 100%; scroll-snap-align: start;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kertas); overflow: hidden;
 }
+.foto-tautan { display: flex; align-items: center; justify-content: center; width: 100%; }
 /* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
    dipotong `cover` justru sering sisi yang memuat angkanya. */
 .foto-lembar img {

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 12, sidik: "004a6b77f568" },
+  "style.css": { versi: 13, sidik: "7d6a66595e01" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=10">
+  <link rel="stylesheet" href="style.css?v=11">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7529,11 +7529,11 @@ async function gambarLombaNilai(l) {
              panah mati di kiri-kanannya adalah dua tombol yang tidak pernah
              melakukan apa pun. -->
         <div class="foto-navigasi" id="v2-foto-nav" hidden>
-          <button type="button" class="foto-panah" data-foto-geser="-1"
-                  aria-label="Foto sebelumnya">&lsaquo;</button>
-          <span class="foto-hitung" id="v2-foto-hitung"></span>
-          <button type="button" class="foto-panah" data-foto-geser="1"
-                  aria-label="Foto berikutnya">&rsaquo;</button>
+          <button type="button" class="button button-secondary button-small foto-panah"
+                  data-foto-geser="-1" aria-label="Foto sebelumnya">&lsaquo;</button>
+          <span class="badge foto-hitung" id="v2-foto-hitung"></span>
+          <button type="button" class="button button-secondary button-small foto-panah"
+                  data-foto-geser="1" aria-label="Foto berikutnya">&rsaquo;</button>
         </div>
       </div>
       <button class="button button-primary" id="v2-simpan" type="button" disabled
@@ -7689,11 +7689,21 @@ async function gambarLombaNilai(l) {
       const url = peta[f.path];
       const kapan = f.diunggah_pada ? tanggalJam(f.diunggah_pada) : "";
       const judul = `Foto ${i + 1} dari ${milik.length}${kapan ? ` · ${kapan}` : ""}`;
-      return url
-        ? `<a class="foto-lembar" href="${esc(url)}" target="_blank" rel="noopener"
-              title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"
-              loading="lazy"></a>`
-        : `<span class="foto-lembar foto-lembar-kosong">tautan gagal</span>`;
+      /* Silang hanya untuk baris yang PUNYA id. Baris hasil unggahan yang
+         daftarnya gagal dibaca ulang tidak punya id, dan tombol hapus yang
+         tidak tahu apa yang dihapusnya lebih baik tidak ada. */
+      const silang = f.id ? `
+        <button type="button" class="ubin-silang" data-hapus-foto="${esc(f.id)}"
+                title="Hapus foto ${i + 1}"
+                aria-label="Hapus foto ${i + 1}">${ikon("x")}</button>` : "";
+      return `<div class="foto-lembar">
+        ${url
+          ? `<a class="foto-tautan" href="${esc(url)}" target="_blank" rel="noopener"
+                title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"
+                loading="lazy"></a>`
+          : `<span class="foto-tautan foto-lembar-kosong">tautan gagal</span>`}
+        ${silang}
+      </div>`;
     }).join("")));
 
     petakFoto.scrollLeft = 0;
@@ -7708,6 +7718,58 @@ async function gambarLombaNilai(l) {
     const ke = Math.max(0, Math.min(jml - 1,
       Math.round(petakFoto.scrollLeft / (petakFoto.clientWidth || 1))));
     if (ke !== fotoKe) { fotoKe = ke; perbaruiHitungFoto(); }
+  }, { signal: sinyal });
+
+  /** Membaca ulang daftar foto lomba ini dari server, lalu menggambarnya.
+   *
+   *  Dipakai sesudah mengunggah DAN sesudah menghapus. Sesudah mengunggah ia
+   *  punya alasan kedua: unggahFotoLembar tidak mengembalikan `id`, dan tanpa
+   *  id foto yang baru saja diambil tidak bisa dihapus lagi sampai layarnya
+   *  dibuka ulang. */
+  async function segarkanFotoLomba(dada) {
+    try {
+      const segar = await daftarFotoLembar(l.pos, dada);
+      fotoLomba = segar.filter(f => f.kode_lomba === l.kode);
+    } catch { return false; }
+    if (fotoKe >= fotoLomba.length) fotoKe = Math.max(0, fotoLomba.length - 1);
+    gambarStatusFoto();
+    await gambarPetakFoto();
+    return true;
+  }
+
+  /* ALASANNYA WAJIB, dan itu bukan formalitas: foto slip adalah bukti,
+     dipanggil justru ketika sebuah nilai dipertanyakan. Menghapusnya
+     menghapus kemampuan menjawab pertanyaan itu, dan tidak ada satu pun galat
+     yang muncul saat bukti hilang. RPC 0081 menolak alasan kosong; dialog ini
+     cuma menanyakannya sebelum perjalanan jaringan.
+
+     Kata-katanya SAMA PERSIS dengan dialog hapus foto di lembar pos lama —
+     dua layar yang menghapus benda yang sama tidak boleh menanyakannya dengan
+     dua kalimat berbeda. */
+  petakFoto.addEventListener("click", async (e) => {
+    const x = e.target.closest("[data-hapus-foto]");
+    if (!x || !regu) return;
+    e.preventDefault();
+    const petak = x.closest(".foto-lembar");
+    const ke = [...petakFoto.children].indexOf(petak) + 1;
+
+    const jawab = await dialog({
+      judul: `Hapus foto ${ke} ${l.nama}?`,
+      kartuHtml: "<p>Fotonya hilang dari daftar dan dari penyimpanan.</p>",
+      medan: [{ label: "Alasan menghapus", contoh: "misal: buram, difoto ulang" }],
+      labelAksi: "Hapus Foto",
+    });
+    if (jawab === null) return;
+
+    x.disabled = true;
+    try { await hapusFotoLembar(x.dataset.hapusFoto, jawab[0]); }
+    catch (err) {
+      x.disabled = false;
+      notif(`Foto tidak bisa dihapus: ${err.message}`, true);
+      return;
+    }
+    notif("Foto dihapus.");
+    await segarkanFotoLomba(Number(regu.nomor_dada));
   }, { signal: sinyal });
 
   navFoto.addEventListener("click", (e) => {
@@ -7781,13 +7843,17 @@ async function gambarLombaNilai(l) {
       try {
         statusFoto.textContent = `mengirim ${ukuranRapi(blob.size)}…`;
         const hasil = await unggahFotoLembar(l.pos, l.kode, l.nama, dada, blob);
-        // Disisipkan ke DEPAN: yang barusan difoto adalah yang paling ingin
-        // dilihat, dan menggesernya dari ujung kanan tiap kali adalah
-        // pekerjaan yang tidak menghasilkan apa pun.
-        fotoLomba = [{ path: hasil.path, diunggah_pada: new Date().toISOString() },
-                     ...(fotoLomba || [])];
-        gambarStatusFoto();
-        await gambarPetakFoto();
+        /* Dibaca ulang dari server, bukan sekadar disisipkan ke daftar di
+           layar: yang kembali dari unggahan cuma `path`, dan tombol hapus
+           butuh `id`. Kalau pembacaannya gagal — sinyal pos memang begitu —
+           barisnya tetap disisipkan supaya fotonya langsung terlihat; ia cuma
+           belum bisa dihapus sampai layarnya dibuka ulang. */
+        if (!(await segarkanFotoLomba(dada))) {
+          fotoLomba = [{ path: hasil.path, diunggah_pada: new Date().toISOString() },
+                       ...(fotoLomba || [])];
+          gambarStatusFoto();
+          await gambarPetakFoto();
+        }
       } catch (err) {
         statusFoto.textContent = `gagal — ${err.message}`;
         notif(`Foto ${dada3(dada)} gagal terkirim: ${err.message}`, true);

--- a/web/style.css
+++ b/web/style.css
@@ -4366,7 +4366,14 @@ button.pill-number:hover { filter: brightness(.95); }
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kartu); color: inherit; text-align: left;
 }
-.lomba-kotak:hover, .lomba-kotak:focus-visible { border-color: var(--utama); }
+.lomba-kotak:hover { border-color: var(--utama); }
+/* Garis fokus dipasang sendiri: aturan global hanya mengenai .button, input,
+   .option, dan .icon-button, dan kotak ini bukan salah satunya. Tanpa ini
+   yang berpindah dengan Tab tidak punya satu pun petunjuk di mana ia berada. */
+.lomba-kotak:focus-visible,
+.sw-bulat:focus-visible {
+  outline: 2px solid var(--utama); outline-offset: 2px;
+}
 .lomba-jenis { display: flex; flex: 0 0 auto; color: var(--tinta-lembut); }
 .lomba-nama { font-weight: 700; line-height: 1.2; }
 
@@ -4408,28 +4415,26 @@ button.pill-number:hover { filter: brightness(.95); }
   scrollbar-width: none;
 }
 .foto-geser::-webkit-scrollbar { display: none; }
-/* Panah dan penghitung. Sasaran sentuh 44px, dan penghitungnya di antara
-   keduanya supaya ketiganya terbaca sebagai satu alat. */
+/* Panah dan penghitung. Keduanya memakai komponen yang SUDAH ADA — `.button
+   .button-secondary .button-small` dan `.badge` — bukan bentuk baru: tombol
+   yang tidak terlihat seperti tombol lain di aplikasi ini harus dicoba dulu
+   sebelum dipercaya, dan itu ongkos yang dibayar tiap petugas baru. Ikut pula
+   gaya sentuh, hover, dan garis fokusnya tanpa satu baris tambahan. */
 .foto-navigasi {
-  grid-area: 4 / 1 / 5 / 3; margin-top: .4rem;
-  display: flex; align-items: center; justify-content: center; gap: 1rem;
+  grid-area: 4 / 1 / 5 / 3; margin-top: .5rem;
+  display: flex; align-items: center; justify-content: center; gap: .8rem;
 }
-.foto-panah {
-  display: flex; align-items: center; justify-content: center;
-  width: 44px; height: 44px; padding: 0; line-height: 1;
-  border: 1px solid var(--garis); border-radius: 50%;
-  background: var(--kartu); color: var(--tinta); font-size: 1.5rem;
-}
-.foto-hitung {
-  min-width: 3.5rem; text-align: center;
-  font-weight: 700; font-variant-numeric: tabular-nums;
-}
+.foto-panah { min-width: 3.2rem; font-size: 1.4rem; line-height: 1; padding: .2rem .6rem; }
+.foto-hitung { min-width: 3.6rem; justify-content: center; font-variant-numeric: tabular-nums; }
+/* `position: relative` karena silangnya duduk DI ATAS fotonya. Anchor dan
+   tombol jadi bersaudara di dalamnya, bukan bersarang: <button> di dalam <a>
+   bukan HTML yang sah, dan tiap browser memperbaikinya dengan caranya sendiri. */
 .foto-lembar {
-  flex: 0 0 100%; scroll-snap-align: start;
-  display: flex; align-items: center; justify-content: center;
+  position: relative; flex: 0 0 100%; scroll-snap-align: start;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kertas); overflow: hidden;
 }
+.foto-tautan { display: flex; align-items: center; justify-content: center; width: 100%; }
 /* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
    dipotong `cover` justru sering sisi yang memuat angkanya. */
 .foto-lembar img {


### PR DESCRIPTION
## What

- **Tombol silang di tiap foto**, dengan dialog konfirmasi yang menuntut alasan.
- **Panah dan penghitung memakai komponen yang sudah ada** — `.button
  .button-secondary .button-small` dan `.badge` — bukan bentuk buatan sendiri.
- **Garis fokus** untuk dua tombol buatan sendiri yang tersisa: kotak pemilih
  lomba dan tombol bulat stopwatch.

## Why

**Hapus foto.** Foto slip adalah bukti, dipanggil justru ketika sebuah nilai
dipertanyakan; menghapusnya menghapus kemampuan menjawab pertanyaan itu, dan
tidak ada satu pun galat yang muncul saat bukti hilang. RPC 0081 sudah menolak
alasan kosong — dialog ini menanyakannya sebelum perjalanan jaringan. Kata-
katanya sama persis dengan dialog hapus foto di lembar pos lama: dua layar yang
menghapus benda yang sama tidak boleh menanyakannya dengan dua kalimat berbeda.

**Komponen.** Tombol yang tidak terlihat seperti tombol lain di aplikasi ini
harus dicoba dulu sebelum dipercaya, dan itu ongkos yang dibayar tiap petugas
baru. Dengan memakai kelas yang sudah ada, gaya sentuh, hover, dan garis
fokusnya ikut tanpa satu baris tambahan.

## Notes

**Silangnya hanya digambar untuk baris yang punya `id`.** `unggahFotoLembar`
mengembalikan `path` saja, jadi sesudah mengunggah daftarnya dibaca ulang dari
server; kalau pembacaan itu gagal — sinyal pos memang begitu — fotonya tetap
muncul, ia cuma belum bisa dihapus sampai layarnya dibuka ulang. Tombol hapus
yang tidak tahu apa yang dihapusnya lebih baik tidak ada.

Anchor dan tombol jadi **bersaudara** di dalam pembungkus, bukan bersarang:
`<button>` di dalam `<a>` bukan HTML yang sah.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `node --test tests/*.test.mjs` — 310 lulus, 0 gagal; `periksa_impor.py`
  bersih; `diff` web/ vs live/ sama
- Layar Semaphore dengan tiga foto milik 010: 3 petak, **3** tombol silang,
  panah berkelas `button button-secondary button-small foto-panah`, penghitung
  berkelas `badge foto-hitung`.
- Silang ditekan → dialog berjudul `Hapus foto 1 Semaphore?` dengan medan
  `Alasan menghapus` (contoh "misal: buram, difoto ulang") dan tombol
  `Hapus Foto`. Diisi lalu dikonfirmasi → dialog tutup, petak jadi 2, status
  `2 foto`, penghitung `1 / 2`.
- Diperiksa di database: `foto_lembar` untuk nomor dada 010 turun 3 → **2**,
  sementara foto milik 003 tidak tersentuh.
