### PR TITLE
fix: silang foto tidak memerah, dan dialog hapus langsung ke alasannya

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=13">
+  <link rel="stylesheet" href="style.css?v=14">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -674,6 +674,17 @@ export function notif(pesan, galat = false) {
  *  adalah tiga tombol besar — tombol keempat bertuliskan "Tutup" berdiri
  *  sejajar ketiganya dan terbaca seperti pilihan keempat. Silang di pojok
  *  tidak pernah salah dibaca sebagai aksi. */
+/* JUDUL BOLEH KOSONG, dan h2-nya benar-benar tidak digambar. esc() atas nilai
+   kosong mengembalikan string kosong, jadi tanpa pagar itu yang tersisa sebuah
+   h2 kosong bermargin bawah — sejalur ruang putih yang tidak menjelaskan apa
+   pun. Yang memakainya: dialog yang seluruh isinya sudah bernama sendiri, mis.
+   satu medan berlabel "Alasan menghapus" di atas tombol "Hapus Foto", yang
+   tidak butuh judul mengulang keduanya (CLAUDE.md 9.2).
+
+   Catatan ini ditulis DI SINI dan bukan sebagai komentar HTML di dalam
+   template di bawah: satu backtick di dalam komentar itu MENUTUP template
+   literal-nya, dan seluruh util.js berhenti diparse. Versi pertama catatan ini
+   memuat esc(undefined) dalam kutip miring dan melakukan persis itu. */
 export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan",
                          bacaSaja = false, silangSaja = false, pasang = null }) {
   return new Promise(resolve => {
@@ -681,10 +692,10 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     document.body.appendChild(wadah);
     const el = document.body.lastElementChild;
     el.innerHTML = `
-      <div class="dialog">
+      <div class="dialog${judul ? "" : " dialog-tanpa-judul"}">
         <button class="dialog-silang" data-batal type="button"
           aria-label="Tutup">&times;</button>
-        <h2 style="padding-right:2.2rem">${esc(judul)}</h2>
+        ${judul ? `<h2 style="padding-right:2.2rem">${esc(judul)}</h2>` : ""}
         ${kartuHtml}
         ${medan.map((m, i) => `
           <div class="field">

--- a/live/style.css
+++ b/live/style.css
@@ -907,6 +907,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   box-shadow: 0 10px 40px rgba(0,0,0,.3);
 }
 .dialog h2 { margin-bottom: .8rem; }
+/* Tanpa <h2>, isi pertama dialog naik ke tepi atas dan bertemu silang tutup
+   yang duduk di pojok kanan. Padding ini yang memberinya jalan. */
+.dialog-tanpa-judul { padding-top: 2.6rem; }
 .notification { display: flex; align-items: center; gap: .7rem; }
 .notification-close {
   display: inline-flex; align-items: center; justify-content: center;
@@ -4435,6 +4438,24 @@ button.pill-number:hover { filter: brightness(.95); }
   background: var(--kertas); overflow: hidden;
 }
 .foto-tautan { display: flex; align-items: center; justify-content: center; width: 100%; }
+/* SILANGNYA TIDAK BERUBAH WARNA SAAT DISENTUH, berbeda dengan .ubin-silang di
+   layar Foto Jawaban.
+
+   Yang menjawab ketukannya adalah dialog konfirmasi yang muncul di atasnya,
+   dan tombol yang ikut memerah di belakang dialog terbaca seperti sudah
+   menghapus sesuatu — padahal belum, dan mungkin tidak jadi. Di HP warnanya
+   juga MENEMPEL: `:hover` bertahan sesudah jari diangkat, jadi merahnya
+   tinggal di sana sampai layar disentuh di tempat lain.
+
+   Garis fokus tetap ada, cuma bentuknya berganti jadi outline — yang
+   berpindah dengan Tab tetap butuh tahu di mana ia berada. */
+.foto-lembar .ubin-silang:hover,
+.foto-lembar .ubin-silang:focus-visible {
+  background: rgba(255, 255, 255, .92); color: var(--tinta);
+}
+.foto-lembar .ubin-silang:focus-visible {
+  outline: 2px solid var(--utama); outline-offset: 2px;
+}
 /* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
    dipotong `cover` justru sering sisi yang memuat angkanya. */
 .foto-lembar img {

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 13, sidik: "7d6a66595e01" },
+  "style.css": { versi: 14, sidik: "88acb20b1160" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=11">
+  <link rel="stylesheet" href="style.css?v=12">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7753,9 +7753,12 @@ async function gambarLombaNilai(l) {
     const petak = x.closest(".foto-lembar");
     const ke = [...petakFoto.children].indexOf(petak) + 1;
 
+    /* TANPA JUDUL DAN TANPA KALIMAT PENJELAS. Fotonya masih terlihat di atas
+       dialog ini, jadi "foto mana" sudah terjawab layar; dan medan berlabel
+       "Alasan menghapus" di atas tombol "Hapus Foto" sudah menyebutkan apa
+       yang akan terjadi. Judul yang mengulang keduanya cuma mendorong medan
+       isiannya turun — di HP, sampai ke bawah papan ketik (bagian 9.2). */
     const jawab = await dialog({
-      judul: `Hapus foto ${ke} ${l.nama}?`,
-      kartuHtml: "<p>Fotonya hilang dari daftar dan dari penyimpanan.</p>",
       medan: [{ label: "Alasan menghapus", contoh: "misal: buram, difoto ulang" }],
       labelAksi: "Hapus Foto",
     });

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -674,6 +674,17 @@ export function notif(pesan, galat = false) {
  *  adalah tiga tombol besar — tombol keempat bertuliskan "Tutup" berdiri
  *  sejajar ketiganya dan terbaca seperti pilihan keempat. Silang di pojok
  *  tidak pernah salah dibaca sebagai aksi. */
+/* JUDUL BOLEH KOSONG, dan h2-nya benar-benar tidak digambar. esc() atas nilai
+   kosong mengembalikan string kosong, jadi tanpa pagar itu yang tersisa sebuah
+   h2 kosong bermargin bawah — sejalur ruang putih yang tidak menjelaskan apa
+   pun. Yang memakainya: dialog yang seluruh isinya sudah bernama sendiri, mis.
+   satu medan berlabel "Alasan menghapus" di atas tombol "Hapus Foto", yang
+   tidak butuh judul mengulang keduanya (CLAUDE.md 9.2).
+
+   Catatan ini ditulis DI SINI dan bukan sebagai komentar HTML di dalam
+   template di bawah: satu backtick di dalam komentar itu MENUTUP template
+   literal-nya, dan seluruh util.js berhenti diparse. Versi pertama catatan ini
+   memuat esc(undefined) dalam kutip miring dan melakukan persis itu. */
 export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan",
                          bacaSaja = false, silangSaja = false, pasang = null }) {
   return new Promise(resolve => {
@@ -681,10 +692,10 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
     document.body.appendChild(wadah);
     const el = document.body.lastElementChild;
     el.innerHTML = `
-      <div class="dialog">
+      <div class="dialog${judul ? "" : " dialog-tanpa-judul"}">
         <button class="dialog-silang" data-batal type="button"
           aria-label="Tutup">&times;</button>
-        <h2 style="padding-right:2.2rem">${esc(judul)}</h2>
+        ${judul ? `<h2 style="padding-right:2.2rem">${esc(judul)}</h2>` : ""}
         ${kartuHtml}
         ${medan.map((m, i) => `
           <div class="field">

--- a/web/style.css
+++ b/web/style.css
@@ -907,6 +907,9 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   box-shadow: 0 10px 40px rgba(0,0,0,.3);
 }
 .dialog h2 { margin-bottom: .8rem; }
+/* Tanpa <h2>, isi pertama dialog naik ke tepi atas dan bertemu silang tutup
+   yang duduk di pojok kanan. Padding ini yang memberinya jalan. */
+.dialog-tanpa-judul { padding-top: 2.6rem; }
 .notification { display: flex; align-items: center; gap: .7rem; }
 .notification-close {
   display: inline-flex; align-items: center; justify-content: center;
@@ -4435,6 +4438,24 @@ button.pill-number:hover { filter: brightness(.95); }
   background: var(--kertas); overflow: hidden;
 }
 .foto-tautan { display: flex; align-items: center; justify-content: center; width: 100%; }
+/* SILANGNYA TIDAK BERUBAH WARNA SAAT DISENTUH, berbeda dengan .ubin-silang di
+   layar Foto Jawaban.
+
+   Yang menjawab ketukannya adalah dialog konfirmasi yang muncul di atasnya,
+   dan tombol yang ikut memerah di belakang dialog terbaca seperti sudah
+   menghapus sesuatu — padahal belum, dan mungkin tidak jadi. Di HP warnanya
+   juga MENEMPEL: `:hover` bertahan sesudah jari diangkat, jadi merahnya
+   tinggal di sana sampai layar disentuh di tempat lain.
+
+   Garis fokus tetap ada, cuma bentuknya berganti jadi outline — yang
+   berpindah dengan Tab tetap butuh tahu di mana ia berada. */
+.foto-lembar .ubin-silang:hover,
+.foto-lembar .ubin-silang:focus-visible {
+  background: rgba(255, 255, 255, .92); color: var(--tinta);
+}
+.foto-lembar .ubin-silang:focus-visible {
+  outline: 2px solid var(--utama); outline-offset: 2px;
+}
 /* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
    dipotong `cover` justru sering sisi yang memuat angkanya. */
 .foto-lembar img {


### PR DESCRIPTION
## What

- Silang di petak foto **tidak berubah warna** saat disentuh atau difokus.
- Dialog hapus foto **tanpa judul dan tanpa kalimat penjelas** — langsung medan
  "Alasan menghapus" lalu tombol "Hapus Foto".
- `dialog()` karena itu menerima judul kosong dan tidak menggambar `h2`-nya.

## Why

**Silang.** Yang menjawab ketukannya adalah dialog konfirmasi yang muncul di
atasnya; tombol yang ikut memerah di belakang dialog terbaca seperti sudah
menghapus sesuatu — padahal belum, dan mungkin tidak jadi. Di HP warnanya juga
**menempel**: `:hover` bertahan sesudah jari diangkat, jadi merahnya tinggal di
sana sampai layar disentuh di tempat lain.

Dibatasi ke `.foto-lembar` saja. Silang di layar Foto Jawaban membatalkan
unggahan **tanpa dialog**, jadi di sana perubahan warnanya memang satu-satunya
jawaban atas ketukan.

**Dialog.** Fotonya masih terlihat di atas dialog, jadi "foto mana" sudah
terjawab layar; dan medan berlabel "Alasan menghapus" di atas tombol "Hapus
Foto" sudah menyebutkan apa yang akan terjadi. Judul yang mengulang keduanya
cuma mendorong medan isiannya turun — di HP, sampai ke bawah papan ketik
(pasal 9.2).

## Notes

`esc()` atas nilai kosong mengembalikan string kosong, jadi tanpa pagar barunya
yang tersisa `h2` kosong bermargin bawah. **Ketujuh belas pemanggil lain
semuanya mengisi judul**, diperiksa satu per satu, jadi tidak ada yang berubah
bagi mereka. `.dialog-tanpa-judul` memberi ruang untuk silang tutup yang kini
tidak punya judul di sebelahnya.

**Satu jebakan yang kena dan sudah didokumentasikan di repo ini.** Penjelasan
pagar itu sempat ditulis sebagai komentar HTML DI DALAM template literal-nya
dan memuat `esc(undefined)` dalam kutip miring — satu backtick di sana menutup
template-nya, dan seluruh `util.js` berhenti diparse. Komentarnya sekarang di
luar template. Yang menemukannya `node --input-type=module --check`, bukan tes
mana pun.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `node --test tests/*.test.mjs` — 310 lulus, 0 gagal; `periksa_impor.py`
  bersih; `diff` web/ vs live/ sama untuk `util.js` dan `style.css`
- Dialog dibuka: kelasnya `dialog dialog-tanpa-judul`, **tidak ada `h2`**,
  isinya persis `× | Alasan menghapus | Hapus Foto`, padding atas 41.6px.
- Aturan CSS yang menang untuk silang diperiksa dari seluruh stylesheet:
  `.foto-lembar .ubin-silang:hover, …:focus-visible` berdiri sesudah aturan
  umumnya dan lebih khusus; latar saat difokus terukur
  `rgba(255, 255, 255, 0.92)`, bukan merah.
- Silang tutup dialog ditekan → fotonya tetap ada, status tetap `2 foto`.
