### PR TITLE
fix: posisi gulir tidak hilang sesudah menyimpan nilai

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=14">
+  <link rel="stylesheet" href="style.css?v=15">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4432,12 +4432,27 @@ button.pill-number:hover { filter: brightness(.95); }
 /* `position: relative` karena silangnya duduk DI ATAS fotonya. Anchor dan
    tombol jadi bersaudara di dalamnya, bukan bersarang: <button> di dalam <a>
    bukan HTML yang sah, dan tiap browser memperbaikinya dengan caranya sendiri. */
+/* TINGGINYA DIPATOK, bukan mengikuti gambarnya.
+
+   Foto pertama yang terlihat menentukan tinggi petak ini, jadi menghapus foto
+   nomor satu menaikkan foto nomor dua ke tempatnya — dengan perbandingan sisi
+   yang berbeda, tinggi yang berbeda, dan seluruh isi di bawahnya bergeser
+   tepat setelah petugas menekan sesuatu. Tinggi tetap membuat menghapus dan
+   menambah foto tidak memindahkan apa pun.
+
+   `contain` di gambarnya yang mengurus sisanya: potret memenuhi kotak,
+   lanskap diberi pita kosong di atas-bawah. Yang tidak boleh terjadi adalah
+   memotong sisi gambar, karena sisi yang terpotong sering sisi yang memuat
+   angkanya. */
 .foto-lembar {
-  position: relative; flex: 0 0 100%; scroll-snap-align: start;
+  position: relative; flex: 0 0 100%; height: 60vh; scroll-snap-align: start;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kertas); overflow: hidden;
 }
-.foto-tautan { display: flex; align-items: center; justify-content: center; width: 100%; }
+.foto-tautan {
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; height: 100%;
+}
 /* SILANGNYA TIDAK BERUBAH WARNA SAAT DISENTUH, berbeda dengan .ubin-silang di
    layar Foto Jawaban.
 
@@ -4459,11 +4474,9 @@ button.pill-number:hover { filter: brightness(.95); }
 /* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
    dipotong `cover` justru sering sisi yang memuat angkanya. */
 .foto-lembar img {
-  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+  display: block; width: 100%; height: 100%; object-fit: contain;
 }
-.foto-lembar-kosong {
-  min-height: 8rem; font-size: .85rem; color: var(--tinta-lembut);
-}
+.foto-lembar-kosong { font-size: .85rem; color: var(--tinta-lembut); }
 
 /* ---------- kotak isian kriteria ---------- */
 

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 14, sidik: "88acb20b1160" },
+  "style.css": { versi: 15, sidik: "08e4162ba80c" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7609,6 +7609,23 @@ async function gambarLombaNilai(l) {
     jeda = setTimeout(() => cariDanGambar(dada), 160);
   }, { signal: sinyal });
 
+  /* ISI KOTAK DIPILIH SAAT DIKETUK, jadi ketukan pertama MENGGANTI.
+     Sesudah menyimpan, nomor dadanya sengaja dibiarkan di kotaknya sebagai
+     keterangan siapa yang barusan disimpan — dan tanpa aturan ini, mengetik
+     nomor berikutnya akan MENYAMBUNG ke nomor lama: "010" lalu "7" jadi
+     "0107". Itu bukan nomor siapa pun, tapi "01" lalu "0" jadi "010" adalah
+     nomor yang SAH milik regu lain.
+
+     Lewat setTimeout dengan alasan yang sama dengan kotak nilai di lembar pos
+     lama: Safari iOS membatalkan select() yang dipanggil di dalam penanganan
+     focus itu sendiri. */
+  inp.addEventListener("focusin", () => {
+    if (!inp.value) return;
+    setTimeout(() => {
+      if (document.activeElement === inp) { try { inp.select(); } catch { /* abaikan */ } }
+    }, 0);
+  }, { signal: sinyal });
+
   inp.addEventListener("keydown", (e) => {
     if (e.key !== "Enter") return;
     e.preventDefault();
@@ -8040,10 +8057,31 @@ async function gambarLombaNilai(l) {
        dilempar sebagai galat di atas. */
     catatLomba(l, dada3(dada),
       `${nama}${ringkasan.length ? ` · ${ringkasan.join(" · ")}` : ""}`);
+
+    /* LAYARNYA TIDAK DIKOSONGKAN, dan itu yang menjaga posisi gulirnya.
+
+       Versi sebelumnya memanggil bersihkan() lalu inp.focus(): kartu regu,
+       kotak nilai, dan baris foto hilang sekaligus, halaman menyusut dari 929
+       ke 776 piksel — persis setinggi layar, jadi tidak bisa digulir sama
+       sekali — dan gulirannya jatuh ke 0. Petugas yang barusan menekan Simpan
+       di bagian bawah kartu terlempar ke atas setiap kali. Terukur, bukan
+       ditebak.
+
+       Yang tersisa sebagai bukti simpanan: pita notifikasi dan baris baru di
+       "Baru saja tersimpan". Keduanya sudah cukup, dan keduanya muncul tanpa
+       memindahkan apa pun.
+
+       Nomor dadanya juga dibiarkan. Menekan kotaknya memilih seluruh isinya
+       (lihat focusin di bawah), jadi mengetik nomor berikutnya tetap satu
+       gerakan — dan selama belum diketik, kartu regu di layar masih menyebut
+       siapa yang barusan disimpan. */
+    for (const b of baris) {
+      (regu.nilai ||= {})[b.kode] = { nilai_1: b.nilai_1, nilai_2: b.nilai_2 };
+    }
+    for (const kode of dihapus) delete (regu.nilai || {})[kode];
+
     tombol.dataset.jalan = "";
-    inp.value = "";
-    bersihkan();
-    inp.focus();
+    tombol.disabled = false;
     gambarRiwayatNilai();
     notif(`${dada3(dada)} tersimpan.`);
   }, { signal: sinyal });

--- a/web/style.css
+++ b/web/style.css
@@ -4432,12 +4432,27 @@ button.pill-number:hover { filter: brightness(.95); }
 /* `position: relative` karena silangnya duduk DI ATAS fotonya. Anchor dan
    tombol jadi bersaudara di dalamnya, bukan bersarang: <button> di dalam <a>
    bukan HTML yang sah, dan tiap browser memperbaikinya dengan caranya sendiri. */
+/* TINGGINYA DIPATOK, bukan mengikuti gambarnya.
+
+   Foto pertama yang terlihat menentukan tinggi petak ini, jadi menghapus foto
+   nomor satu menaikkan foto nomor dua ke tempatnya — dengan perbandingan sisi
+   yang berbeda, tinggi yang berbeda, dan seluruh isi di bawahnya bergeser
+   tepat setelah petugas menekan sesuatu. Tinggi tetap membuat menghapus dan
+   menambah foto tidak memindahkan apa pun.
+
+   `contain` di gambarnya yang mengurus sisanya: potret memenuhi kotak,
+   lanskap diberi pita kosong di atas-bawah. Yang tidak boleh terjadi adalah
+   memotong sisi gambar, karena sisi yang terpotong sering sisi yang memuat
+   angkanya. */
 .foto-lembar {
-  position: relative; flex: 0 0 100%; scroll-snap-align: start;
+  position: relative; flex: 0 0 100%; height: 60vh; scroll-snap-align: start;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
   background: var(--kertas); overflow: hidden;
 }
-.foto-tautan { display: flex; align-items: center; justify-content: center; width: 100%; }
+.foto-tautan {
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; height: 100%;
+}
 /* SILANGNYA TIDAK BERUBAH WARNA SAAT DISENTUH, berbeda dengan .ubin-silang di
    layar Foto Jawaban.
 
@@ -4459,11 +4474,9 @@ button.pill-number:hover { filter: brightness(.95); }
 /* `contain`, bukan `cover`: yang dibaca di sini tulisan tangan, dan sisi yang
    dipotong `cover` justru sering sisi yang memuat angkanya. */
 .foto-lembar img {
-  display: block; width: 100%; max-height: 60vh; object-fit: contain;
+  display: block; width: 100%; height: 100%; object-fit: contain;
 }
-.foto-lembar-kosong {
-  min-height: 8rem; font-size: .85rem; color: var(--tinta-lembut);
-}
+.foto-lembar-kosong { font-size: .85rem; color: var(--tinta-lembut); }
 
 /* ---------- kotak isian kriteria ---------- */
 


### PR DESCRIPTION
## What

- Sesudah SIMPAN NILAI layarnya **tidak dikosongkan**: kartu regu, nomor dada,
  dan angkanya tetap di tempatnya.
- Cermin nilai ikut diperbarui, jadi menekan Simpan dua kali berbunyi "Tidak
  ada angka yang berubah" alih-alih mengirim ulang.
- Menekan kotak nomor dada **memilih seluruh isinya**.
- Tinggi petak foto dipatok `60vh`.

## Why

Diukur di iframe seukuran HP (390×780), bukan ditebak — pasal 15.10:

| | scrollTop | tinggi halaman |
| --- | --- | --- |
| sebelum Simpan | 153 | 929 |
| sesudah Simpan (lama) | **0** | **776** |

`bersihkan()` membuang kartu regu, kotak nilai, dan baris foto sekaligus;
halamannya menyusut sampai persis setinggi layar — tidak bisa digulir sama
sekali — jadi gulirannya jatuh ke 0. Petugas yang menekan Simpan di bagian
bawah kartu terlempar ke atas setiap kali.

Kartu regu yang sekarang tetap di layar juga menjawab pertanyaan yang selama
ini dijawab dengan menghilang: siapa yang barusan disimpan.

**Nomor dada dibiarkan, dan itu menuntut seleksi otomatis.** Tanpa itu
mengetik nomor berikutnya MENYAMBUNG ke nomor lama: "010" lalu "7" jadi
"0107" — bukan nomor siapa pun — tetapi "01" lalu "0" jadi "010", yang
merupakan nomor **sah milik regu lain**.

**Tinggi petak foto.** Foto pertama yang terlihat menentukan tinggi petak, jadi
menghapus foto nomor satu menaikkan foto nomor dua ke tempatnya dengan
perbandingan sisi berbeda — dan seluruh isi di bawahnya bergeser tepat setelah
petugas menekan sesuatu.

## Notes

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`, di iframe
390×780 supaya halamannya benar-benar bisa digulir:

- Simpan: scrollTop **488 → 488**; kartu regu, nomor `10`, dan nilai `5`
  semuanya masih di layar; riwayat bertambah `010 ANYELIR · Jumlah benar 5`.
- Simpan kedua tanpa mengubah apa pun → `Tidak ada angka yang berubah.`
- Hapus foto: scrollTop **614 → 614**, tinggi halaman **1390 → 1390**.
- Seleksi nomor dada: `focusin` dikirim ke kotaknya → seleksi `[2,2]` jadi
  `[0,2]`, seluruh isinya terpilih.
- `node --test tests/*.test.mjs` 310 lulus 0 gagal; `periksa_impor.py` bersih;
  `diff` web/ vs live/ sama.

**Yang tidak bisa dipicu di konteks otomasi ini:** `focus()` terprogram tidak
mengirim `focusin` sama sekali (terukur nol kali walau `activeElement` benar
berpindah), sama seperti `scroll` pada percobaan sebelumnya. Karena itu
penangannya diuji dengan mengirim peristiwanya langsung.
