### PR TITLE
fix: kotak pemilih lomba tanpa ikon

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=15">
+  <link rel="stylesheet" href="style.css?v=16">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4363,11 +4363,14 @@ button.pill-number:hover { filter: brightness(.95); }
   display: grid; gap: .6rem;
   grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
 }
+/* Isinya tinggal nama lombanya, jadi diletakkan di TENGAH kotak — nama
+   pendek yang rata kiri di petak selebar 11rem meninggalkan lahan kosong di
+   kanan yang terbaca seperti ada sesuatu yang hilang di sana. */
 .lomba-kotak {
-  display: flex; align-items: center; gap: .55rem;
+  display: flex; align-items: center; justify-content: center;
   min-height: 56px; padding: .6rem .8rem;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
-  background: var(--kartu); color: inherit; text-align: left;
+  background: var(--kartu); color: inherit; text-align: center;
 }
 .lomba-kotak:hover { border-color: var(--utama); }
 /* Garis fokus dipasang sendiri: aturan global hanya mengenai .button, input,
@@ -4377,7 +4380,6 @@ button.pill-number:hover { filter: brightness(.95); }
 .sw-bulat:focus-visible {
   outline: 2px solid var(--utama); outline-offset: 2px;
 }
-.lomba-jenis { display: flex; flex: 0 0 auto; color: var(--tinta-lembut); }
 .lomba-nama { font-weight: 700; line-height: 1.2; }
 
 /* ---------- kepala layar satu lomba ---------- */

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 15, sidik: "08e4162ba80c" },
+  "style.css": { versi: 16, sidik: "0e40fa7670d4" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=13">
+  <link rel="stylesheet" href="style.css?v=14">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7300,15 +7300,20 @@ async function muatKatalogPos() {
 const judulLomba = (l) =>
   `${l.bayangan ? l.namaPos : `Pos ${l.pos}`} — ${l.nama}`;
 
-/** Ikon jenis pengisian, dipakai di kotak pemilih.
- *
- *  IKON SAJA, tanpa katanya. Yang dijawabnya cuma sekali — "kotak ini membuka
- *  stopwatch atau kamera?" — dan sesudah kali pertama ia tinggal menambah teks
- *  di kotak yang isinya sudah bernama (bagian 9.1). Namanya tetap ada di
- *  `title` dan di label pembaca layar, jadi yang tidak bisa menebak ikonnya
- *  tidak buntu. */
-const IKON_JENIS = { waktu: "clock", soal: "camera", nilai: "square-pen" };
-const NAMA_JENIS = { waktu: "stopwatch", soal: "foto jawaban", nilai: "kotak nilai" };
+/* KOTAK PEMILIH TIDAK BERIKON, dan ketiadaannya disengaja.
+
+   Sempat ada lambang jenis pengisian di depan tiap nama — jam untuk lomba
+   waktu, kamera untuk lomba soal, pena untuk sisanya. Niatnya menjawab
+   "kotak ini membuka stopwatch atau kamera?" tanpa satu kata pun.
+
+   Yang tidak diperhitungkan: pertanyaan itu tidak pernah ditanya. Juri
+   membuka lomba yang ia pegang, dan ia sudah tahu lombanya diisi bagaimana
+   sebelum menyentuh layar — ia berdiri di sebelahnya sepagian. Jadi lambangnya
+   cuma satu benda lagi di kiri tiap nama yang harus dilewati mata, di petak
+   yang isinya memang cuma perlu dibaca namanya (bagian 9.1 dan 9.9).
+
+   Kalau ide ini muncul lagi: ia sudah dicoba dan dibuang atas permintaan
+   pemilik acara. */
 
 /** Pos yang boleh dibuka akun ini.
  *
@@ -7425,11 +7430,8 @@ function gambarPemilihLomba(katalog) {
       <h2>${esc(b.judul)}</h2>
       <div class="pilih-lomba">
         ${b.isi.map(l => `
-          <button type="button" class="lomba-kotak" data-kunci="${esc(l.kunci)}"
-                  title="${esc(l.nama)} — ${esc(NAMA_JENIS[l.jenis])}">
-            <span class="lomba-jenis" aria-hidden="true">${ikon(IKON_JENIS[l.jenis])}</span>
+          <button type="button" class="lomba-kotak" data-kunci="${esc(l.kunci)}">
             <span class="lomba-nama">${esc(l.nama)}</span>
-            <span class="visually-hidden">${esc(NAMA_JENIS[l.jenis])}</span>
           </button>`).join("")}
       </div>
     </div>`).join("")));

--- a/web/style.css
+++ b/web/style.css
@@ -4363,11 +4363,14 @@ button.pill-number:hover { filter: brightness(.95); }
   display: grid; gap: .6rem;
   grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
 }
+/* Isinya tinggal nama lombanya, jadi diletakkan di TENGAH kotak — nama
+   pendek yang rata kiri di petak selebar 11rem meninggalkan lahan kosong di
+   kanan yang terbaca seperti ada sesuatu yang hilang di sana. */
 .lomba-kotak {
-  display: flex; align-items: center; gap: .55rem;
+  display: flex; align-items: center; justify-content: center;
   min-height: 56px; padding: .6rem .8rem;
   border: 1px solid var(--garis); border-radius: var(--radius-kecil);
-  background: var(--kartu); color: inherit; text-align: left;
+  background: var(--kartu); color: inherit; text-align: center;
 }
 .lomba-kotak:hover { border-color: var(--utama); }
 /* Garis fokus dipasang sendiri: aturan global hanya mengenai .button, input,
@@ -4377,7 +4380,6 @@ button.pill-number:hover { filter: brightness(.95); }
 .sw-bulat:focus-visible {
   outline: 2px solid var(--utama); outline-offset: 2px;
 }
-.lomba-jenis { display: flex; flex: 0 0 auto; color: var(--tinta-lembut); }
 .lomba-nama { font-weight: 700; line-height: 1.2; }
 
 /* ---------- kepala layar satu lomba ---------- */


### PR DESCRIPTION
## What

Membuang lambang jenis pengisian dari kotak pemilih lomba. Nama lombanya
sekarang berdiri sendiri, di tengah kotak. `IKON_JENIS` dan `NAMA_JENIS` ikut
dibuang.

## Why

Lambangnya menjawab "kotak ini membuka stopwatch atau kamera?" tanpa satu kata
pun — pertanyaan yang ternyata tidak pernah ditanya. Juri membuka lomba yang ia
pegang, dan ia sudah tahu lombanya diisi bagaimana sebelum menyentuh layar; ia
berdiri di sebelahnya sepagian. Jadi lambangnya cuma satu benda lagi di kiri
tiap nama yang harus dilewati mata, di petak yang isinya memang cuma perlu
dibaca namanya.

Namanya dipindah ke tengah karena nama pendek yang rata kiri di petak selebar
11rem meninggalkan lahan kosong di kanan yang terbaca seperti ada sesuatu yang
hilang di sana — dan memang ada, sampai PR ini.

## Notes

Ketiga ikonnya (`clock`, `camera`, `square-pen`) **tetap terpakai** di ubin
Home dan di layar lain, diperiksa satu per satu, jadi tidak ada yang jadi kode
mati di `util.js`. Alasan pembuangannya ditulis di tempat petanya tadi berdiri,
supaya yang berikutnya tahu ini sudah dicoba.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- Layar pemilih dibuka: 15 lomba tergambar tanpa satu ikon pun
  (`.lomba-jenis` = 0), nama di tengah.
- Kotak "Bakiak" ditekan → judul `Pos 2 — Halang Rintang`, kartu `Bakiak`,
  panel stopwatch tergambar. Jalur pilihnya tidak tersentuh.
- `node --test tests/*.test.mjs` 310 lulus 0 gagal; `periksa_impor.py` bersih;
  `diff` web/ vs live/ sama; `grep` memastikan `IKON_JENIS`, `NAMA_JENIS`, dan
  `.lomba-jenis` tidak tersisa di `app.js` maupun `style.css`.
