### PR TITLE
fix: Cek Nilai — navigasi < nomor dada >, angka menempel fotonya

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=17">
+  <link rel="stylesheet" href="style.css?v=18">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4600,29 +4600,69 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* ---------- cek nilai ---------- */
 
+/* Panah - nomor dada - panah. Nomor dadanya di TENGAH karena di situlah mata
+   mencarinya, dan panahnya cuma selebar jempol di kedua sisinya. */
 .cek-navigasi {
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: stretch; justify-content: center;
   gap: .6rem; margin-top: .4rem;
 }
-.cek-posisi { font-weight: 700; font-variant-numeric: tabular-nums; }
+/* `width: auto` WAJIB disebut: `.button` dasar memasang `width: 100%`, dan
+   `flex: 0 0 auto` tidak membatalkannya — basisnya jadi 100% lebar wadah, jadi
+   kedua panah memakan seluruh baris dan kotak nomor dadanya tersisa 28px.
+   Terukur di browser, bukan ditebak; `.button-small` menyebut hal yang sama
+   untuk alasan yang sama. */
+.cek-panah {
+  flex: 0 0 auto; width: auto; min-width: 3.4rem;
+  font-size: 1.5rem; line-height: 1; padding: .2rem .6rem;
+}
+.cek-dada {
+  flex: 1 1 auto; min-width: 0; max-width: 11rem; min-height: 46px;
+  text-align: center; font-size: 1.45rem; font-weight: 700;
+  letter-spacing: .05em; font-variant-numeric: tabular-nums;
+}
+.cek-posisi {
+  margin-top: .35rem; text-align: center;
+  font-size: .85rem; color: var(--tinta-lembut); font-variant-numeric: tabular-nums;
+}
+/* Kartu identitas regu diberi jarak ke blok lomba pertama. Tanpa ini nama
+   regunya menempel ke kotak lomba di bawahnya dan keduanya terbaca sebagai
+   satu blok — padahal yang satu identitas dan yang satu lagi nilai. */
+.cek-identitas { margin-bottom: .9rem; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */
 .cek-lomba { padding: .7rem 0; border-top: 1px solid var(--garis); }
 .cek-lomba:first-child { border-top: 0; padding-top: 0; }
-.cek-kepala {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: .8rem; flex-wrap: wrap;
-}
+/* Nama di atas, angkanya tepat di bawahnya, KEDUANYA RATA KIRI — lalu
+   fotonya. Sebelumnya angkanya didorong ke tepi kanan, jadi membandingkan
+   tulisan tangan di foto dengan angka yang diketik menuntut mata menyeberang
+   selebar layar dan turun; sekarang keduanya di satu kolom yang sama. */
+.cek-kepala { display: flex; flex-direction: column; align-items: flex-start; gap: .15rem; }
 .cek-nama { font-weight: 700; }
-.cek-angka { display: flex; gap: .9rem; flex-wrap: wrap; }
-.cek-butir { font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.cek-angka { display: flex; gap: .9rem; flex-wrap: wrap; align-items: baseline; }
+/* Angkanya sengaja besar: ia satu-satunya hal di kartu ini yang sedang
+   dibandingkan dengan sesuatu, dan pembandingnya tulisan tangan di foto
+   sebesar layar. */
+.cek-butir { font-size: 1.6rem; font-weight: 800; font-variant-numeric: tabular-nums; }
 .cek-butir-nama {
   display: block; font-size: .75rem; font-weight: 400; color: var(--tinta-lembut);
 }
 .cek-kosong { font-size: .85rem; font-weight: 400; color: var(--tinta-lembut); }
+/* Foto SELEBAR KARTU, bukan petak kecil berjajar. Yang dibaca di sini tulisan
+   tangan — "JUMLAH KATA YANG BENAR: 1" — dan petak 7rem tidak menjawab
+   pertanyaan yang membuat orang membuka layar ini. Lebih dari satu foto
+   digeser ke samping, sama seperti di layar input.
+
+   `contain`, bukan `cover`: sisi yang dipotong `cover` justru sering sisi
+   yang memuat angkanya. */
 .cek-foto {
-  display: grid; gap: .5rem; margin-top: .5rem;
-  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  display: flex; gap: 0; margin-top: .5rem;
+  overflow-x: auto; overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory; scrollbar-width: none;
 }
-.cek-foto img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.cek-foto::-webkit-scrollbar { display: none; }
+.cek-foto .fg-petak {
+  flex: 0 0 100%; height: 46vh; scroll-snap-align: start;
+  display: flex; align-items: center; justify-content: center;
+}
+.cek-foto img { display: block; width: 100%; height: 100%; object-fit: contain; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 17, sidik: "5f2bd1e11031" },
+  "style.css": { versi: 18, sidik: "1fd2a5ed262c" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=15">
+  <link rel="stylesheet" href="style.css?v=16">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9056,25 +9056,32 @@ async function layarCekNilai() {
               >${esc(judulPos(p))}</option>`).join("")}
           </select>
         </div>
-        <div class="field">
-          <label for="cek-lompat">Lompat ke nomor dada</label>
-          <input type="number" id="cek-lompat" class="small-input" inputmode="numeric"
-                 min="1" placeholder="misal: 042">
-        </div>
       </div>
+      <!-- PANAH, NOMOR DADA, PANAH — satu baris, dan kotak tengahnya sekaligus
+           jalan melompat. Sebelumnya ada dua alat untuk satu pekerjaan: kotak
+           "Lompat ke nomor dada" di atas, dan sepasang tombol "Sebelumnya /
+           Berikutnya" selebar setengah layar di bawahnya. Keduanya menjawab
+           "regu mana yang saya lihat sekarang", dan dua jawaban untuk satu
+           pertanyaan berarti petugas memilih dulu sebelum bergerak.
+
+           Panahnya sengaja tanpa kata. "Berikutnya ▶" selebar setengah layar
+           bukan sasaran sentuh yang lebih baik daripada panah 3rem — ia cuma
+           mendorong nomor dadanya keluar dari tengah, tempat mata mencarinya. -->
       <div class="cek-navigasi">
-        <button type="button" class="button button-secondary" id="cek-mundur"
-                >◀ Sebelumnya</button>
-        <span class="cek-posisi" id="cek-posisi"></span>
-        <button type="button" class="button button-secondary" id="cek-maju"
-                >Berikutnya ▶</button>
+        <button type="button" class="button button-secondary cek-panah"
+                id="cek-mundur" aria-label="Regu sebelumnya">&lsaquo;</button>
+        <input type="number" id="cek-dada" class="cek-dada" inputmode="numeric"
+               min="1" aria-label="Nomor dada yang sedang dilihat">
+        <button type="button" class="button button-secondary cek-panah"
+                id="cek-maju" aria-label="Regu berikutnya">&rsaquo;</button>
       </div>
+      <div class="cek-posisi" id="cek-posisi"></div>
     </div>
     <div id="cek-isi"></div>
   `));
 
   const elPos = document.getElementById("cek-pos");
-  const elLompat = document.getElementById("cek-lompat");
+  const elDada = document.getElementById("cek-dada");
   const elPosisi = document.getElementById("cek-posisi");
   const elIsi = document.getElementById("cek-isi");
   const elMundur = document.getElementById("cek-mundur");
@@ -9099,6 +9106,12 @@ async function layarCekNilai() {
       ? `${indeks + 1} / ${lembar.length}` : "0 / 0";
     elMundur.disabled = indeks <= 0;
     elMaju.disabled = indeks >= lembar.length - 1;
+    /* Kotaknya JANGAN ditimpa selagi diketik: petugas yang sedang mengetik
+       "04" untuk menuju 042 akan melihat ketikannya diganti nomor yang sedang
+       terbuka, di tengah ketikan. */
+    if (document.activeElement !== elDada) {
+      elDada.value = lembar.length ? String(lembar[indeks].nomor_dada) : "";
+    }
   }
 
   async function gambarRegu() {
@@ -9118,7 +9131,7 @@ async function layarCekNilai() {
        bertanda tangan butuh satu perjalanan jaringan per regu, dan layar yang
        kosong selama itu membuat petugas menekan "Berikutnya" dua kali. */
     elIsi.replaceChildren(h(`
-      ${kartuReguNilai(r)}
+      <div class="cek-identitas">${kartuReguNilai(r)}</div>
       <div class="card">
         ${daftar.map(l => {
           const dipakai = l.kolom
@@ -9139,6 +9152,12 @@ async function layarCekNilai() {
                   : html`<span class="cek-butir">${teks}</span>`;
               }).join("")
             : `<span class="cek-butir cek-kosong">belum dinilai</span>`;
+          /* Nama dan angkanya SATU BLOK di kiri, tepat di atas fotonya.
+             Sebelumnya angkanya didorong ke tepi kanan oleh
+             `justify-content: space-between`, jadi membandingkan tulisan
+             tangan di foto dengan angka yang diketik menuntut mata menyeberang
+             selebar layar dan turun — dua gerakan untuk satu perbandingan yang
+             dilakukan ratusan kali. */
           return `
             <section class="cek-lomba">
               <div class="cek-kepala">
@@ -9220,13 +9239,34 @@ async function layarCekNilai() {
     muatPos();
   }, { signal: sinyal });
 
-  elLompat.addEventListener("change", () => {
-    const cari = Number(elLompat.value);
-    if (!cari) return;
+  /** Melompat ke nomor yang diketik. Nomor yang tidak ada di pos ini
+   *  dikembalikan ke nomor yang sedang terbuka — kotak yang ditinggalkan
+   *  berisi nomor yang tidak sedang dilihat siapa pun berbohong tentang
+   *  layar di bawahnya. */
+  const lompat = () => {
+    const cari = Number(elDada.value);
     const i = lembar.findIndex(r => Number(r.nomor_dada) === cari);
-    if (i < 0) { notif(`Nomor ${dada3(cari)} tidak ada di pos ini.`, true); return; }
-    elLompat.value = "";
+    if (i < 0) {
+      notif(`Nomor ${dada3(cari)} tidak ada di pos ini.`, true);
+      elDada.value = lembar.length ? String(lembar[indeks].nomor_dada) : "";
+      return;
+    }
+    elDada.blur();
     ke(i);
+  };
+  elDada.addEventListener("change", lompat, { signal: sinyal });
+  elDada.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") { e.preventDefault(); lompat(); }
+  }, { signal: sinyal });
+  // Isi kotak dipilih saat diketuk, jadi nomor berikutnya tinggal diketik
+  // menimpa — aturan yang sama dengan kotak nomor dada di layar input.
+  elDada.addEventListener("focusin", () => {
+    if (!elDada.value) return;
+    setTimeout(() => {
+      if (document.activeElement === elDada) {
+        try { elDada.select(); } catch { /* abaikan */ }
+      }
+    }, 0);
   }, { signal: sinyal });
 
   await muatPos();

--- a/web/style.css
+++ b/web/style.css
@@ -4600,29 +4600,69 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* ---------- cek nilai ---------- */
 
+/* Panah - nomor dada - panah. Nomor dadanya di TENGAH karena di situlah mata
+   mencarinya, dan panahnya cuma selebar jempol di kedua sisinya. */
 .cek-navigasi {
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: stretch; justify-content: center;
   gap: .6rem; margin-top: .4rem;
 }
-.cek-posisi { font-weight: 700; font-variant-numeric: tabular-nums; }
+/* `width: auto` WAJIB disebut: `.button` dasar memasang `width: 100%`, dan
+   `flex: 0 0 auto` tidak membatalkannya — basisnya jadi 100% lebar wadah, jadi
+   kedua panah memakan seluruh baris dan kotak nomor dadanya tersisa 28px.
+   Terukur di browser, bukan ditebak; `.button-small` menyebut hal yang sama
+   untuk alasan yang sama. */
+.cek-panah {
+  flex: 0 0 auto; width: auto; min-width: 3.4rem;
+  font-size: 1.5rem; line-height: 1; padding: .2rem .6rem;
+}
+.cek-dada {
+  flex: 1 1 auto; min-width: 0; max-width: 11rem; min-height: 46px;
+  text-align: center; font-size: 1.45rem; font-weight: 700;
+  letter-spacing: .05em; font-variant-numeric: tabular-nums;
+}
+.cek-posisi {
+  margin-top: .35rem; text-align: center;
+  font-size: .85rem; color: var(--tinta-lembut); font-variant-numeric: tabular-nums;
+}
+/* Kartu identitas regu diberi jarak ke blok lomba pertama. Tanpa ini nama
+   regunya menempel ke kotak lomba di bawahnya dan keduanya terbaca sebagai
+   satu blok — padahal yang satu identitas dan yang satu lagi nilai. */
+.cek-identitas { margin-bottom: .9rem; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */
 .cek-lomba { padding: .7rem 0; border-top: 1px solid var(--garis); }
 .cek-lomba:first-child { border-top: 0; padding-top: 0; }
-.cek-kepala {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: .8rem; flex-wrap: wrap;
-}
+/* Nama di atas, angkanya tepat di bawahnya, KEDUANYA RATA KIRI — lalu
+   fotonya. Sebelumnya angkanya didorong ke tepi kanan, jadi membandingkan
+   tulisan tangan di foto dengan angka yang diketik menuntut mata menyeberang
+   selebar layar dan turun; sekarang keduanya di satu kolom yang sama. */
+.cek-kepala { display: flex; flex-direction: column; align-items: flex-start; gap: .15rem; }
 .cek-nama { font-weight: 700; }
-.cek-angka { display: flex; gap: .9rem; flex-wrap: wrap; }
-.cek-butir { font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.cek-angka { display: flex; gap: .9rem; flex-wrap: wrap; align-items: baseline; }
+/* Angkanya sengaja besar: ia satu-satunya hal di kartu ini yang sedang
+   dibandingkan dengan sesuatu, dan pembandingnya tulisan tangan di foto
+   sebesar layar. */
+.cek-butir { font-size: 1.6rem; font-weight: 800; font-variant-numeric: tabular-nums; }
 .cek-butir-nama {
   display: block; font-size: .75rem; font-weight: 400; color: var(--tinta-lembut);
 }
 .cek-kosong { font-size: .85rem; font-weight: 400; color: var(--tinta-lembut); }
+/* Foto SELEBAR KARTU, bukan petak kecil berjajar. Yang dibaca di sini tulisan
+   tangan — "JUMLAH KATA YANG BENAR: 1" — dan petak 7rem tidak menjawab
+   pertanyaan yang membuat orang membuka layar ini. Lebih dari satu foto
+   digeser ke samping, sama seperti di layar input.
+
+   `contain`, bukan `cover`: sisi yang dipotong `cover` justru sering sisi
+   yang memuat angkanya. */
 .cek-foto {
-  display: grid; gap: .5rem; margin-top: .5rem;
-  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  display: flex; gap: 0; margin-top: .5rem;
+  overflow-x: auto; overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory; scrollbar-width: none;
 }
-.cek-foto img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.cek-foto::-webkit-scrollbar { display: none; }
+.cek-foto .fg-petak {
+  flex: 0 0 100%; height: 46vh; scroll-snap-align: start;
+  display: flex; align-items: center; justify-content: center;
+}
+.cek-foto img { display: block; width: 100%; height: 100%; object-fit: contain; }


### PR DESCRIPTION
## What

- Navigasi jadi **`‹ [nomor dada] ›`** satu baris; kotak "Lompat ke nomor dada"
  yang terpisah dan tombol "Sebelumnya / Berikutnya" dibuang. Posisi `10 / 36`
  turun jadi keterangan kecil.
- **Angka dan foto di satu kolom**, rata kiri, angkanya diperbesar; fotonya
  selebar kartu dan digeser ke samping kalau lebih dari satu.
- Kartu identitas regu diberi **jarak** ke blok lomba pertama.

## Why

**Satu alat untuk satu pekerjaan.** Kotak lompat dan sepasang tombol
sebelumnya sama-sama menjawab "regu mana yang saya lihat sekarang", dan dua
jawaban untuk satu pertanyaan berarti petugas memilih dulu sebelum bergerak.
Panah tanpa kata juga bukan sasaran sentuh yang lebih buruk: "Berikutnya"
selebar setengah layar cuma mendorong nomor dadanya keluar dari tengah, tempat
mata mencarinya.

**Perbandingannya yang jadi mudah.** Angkanya sebelumnya didorong ke tepi kanan
oleh `justify-content: space-between`, jadi membandingkan tulisan tangan di
foto dengan angka yang diketik menuntut mata menyeberang selebar layar lalu
turun. Fotonya pun cuma petak 7rem — sebesar perangko untuk membaca "JUMLAH
KATA YANG BENAR: 1".

## Notes

Nomor yang tidak ada di pos itu **mengembalikan kotaknya** ke nomor yang sedang
terbuka: kotak yang ditinggalkan berisi nomor yang tidak sedang dilihat siapa
pun berbohong tentang layar di bawahnya.

**Satu jebakan yang kena, diukur di browser bukan ditebak.** `.cek-panah` sudah
`flex: 0 0 auto` tetapi tetap selebar **310px**, dan kotak nomor dadanya
tersisa **28px**. Sebabnya `.button` dasar memasang `width: 100%`, dan
`flex: 0 0 auto` tidak membatalkannya — basisnya jadi 100% lebar wadah.
`width: auto` harus disebut, persis seperti yang sudah dilakukan
`.button-small` untuk alasan yang sama.

**Diuji lokal** (pasal 16 dan 17.2) di iframe 390×780:

- Panah ditekan berturut-turut: kotak dan posisi bergerak `1 → 2 → 3 → 2`,
  dan kotaknya selalu menampilkan nomor dada yang sedang terbuka.
- Diketik `12` lalu Enter → melompat ke `12 / 36`.
- Diketik `999` → notif `Nomor 999 tidak ada di pos ini.` dan kotaknya kembali
  ke `12`.
- Sesudah perbaikan lebar: panah **54px**, kotak **176px**, petak foto **310px**
  (= lebar kartu). Sebelumnya 310 / 28.
- `node --test tests/*.test.mjs` 310 lulus 0 gagal; `periksa_impor.py` bersih;
  `diff` web/ vs live/ sama.
