### PR TITLE
feat: penggeser foto di Cek Nilai menyatakan dirinya

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=18">
+  <link rel="stylesheet" href="style.css?v=19">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4661,6 +4661,10 @@ button.pill-number:hover { filter: brightness(.95); }
   scroll-snap-type: x mandatory; scrollbar-width: none;
 }
 .cek-foto::-webkit-scrollbar { display: none; }
+/* Navigasinya menempel ke petak di atasnya, bukan mengambang di tengah
+   antara dua lomba — ia milik foto tepat di atasnya, dan di daftar berisi
+   lima lomba kepemilikan itu harus terbaca tanpa dihitung. */
+.cek-lomba .foto-navigasi { margin-top: .4rem; }
 .cek-foto .fg-petak {
   flex: 0 0 100%; height: 46vh; scroll-snap-align: start;
   display: flex; align-items: center; justify-content: center;

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 18, sidik: "1fd2a5ed262c" },
+  "style.css": { versi: 19, sidik: "a7b86d101671" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=16">
+  <link rel="stylesheet" href="style.css?v=17">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9165,6 +9165,20 @@ async function layarCekNilai() {
                 <span class="cek-angka">${angka}</span>
               </div>
               <div class="cek-foto" data-foto="${esc(l.kode)}"></div>
+              <!-- Panah dan penghitung, disembunyikan sampai lombanya
+                   benar-benar punya lebih dari satu foto. Petak yang bisa
+                   digeser tidak mengumumkan dirinya: yang terlihat cuma satu
+                   foto, dan foto kedua baru ada kalau seseorang kebetulan
+                   menyapu layarnya. Bentuknya sama persis dengan penggeser di
+                   layar input — dua layar yang menggeser benda yang sama tidak
+                   boleh memakai dua alat berbeda. -->
+              <div class="foto-navigasi" data-nav-foto="${esc(l.kode)}" hidden>
+                <button type="button" class="button button-secondary button-small foto-panah"
+                        data-cek-geser="-1" aria-label="Foto sebelumnya">&lsaquo;</button>
+                <span class="badge foto-hitung" data-hitung-foto></span>
+                <button type="button" class="button button-secondary button-small foto-panah"
+                        data-cek-geser="1" aria-label="Foto berikutnya">&rsaquo;</button>
+              </div>
             </section>`;
         }).join("")}
       </div>`));
@@ -9192,8 +9206,11 @@ async function layarCekNilai() {
 
     elIsi.querySelectorAll("[data-foto]").forEach(el => {
       const milik = foto.filter(f => f.kode_lomba === el.dataset.foto);
+      const nav = elIsi.querySelector(
+        `[data-nav-foto="${CSS.escape(el.dataset.foto)}"]`);
       if (!milik.length) {
         el.replaceChildren(h(`<span class="cek-kosong">belum difoto</span>`));
+        if (nav) nav.hidden = true;
         return;
       }
       el.replaceChildren(h(milik.map((f, i) => {
@@ -9205,7 +9222,51 @@ async function layarCekNilai() {
                 loading="lazy"></a>`
           : `<span class="fg-petak fg-kosong">tautan gagal</span>`;
       }).join("")));
+      if (nav) pasangGeserCek(el, nav);
     });
+  }
+
+  /** Panah dan penghitung untuk SATU petak foto.
+   *
+   *  Nomor fotonya dipegang di sini, bukan dihitung ulang dari `scrollLeft`
+   *  tiap kali dibutuhkan — pelajaran yang sama dengan penggeser di layar
+   *  input: peristiwa `scroll` dikirim pada frame berikutnya, jadi tab yang
+   *  sedang tidak menggambar tidak mengirimkannya sama sekali, dan penghitung
+   *  yang bertahan di "1 / 2" sementara fotonya sudah berganti lebih buruk
+   *  daripada tidak ada penghitung. `scroll` tetap didengar untuk menyamakan
+   *  angkanya kalau yang menggeser jari.
+   *
+   *  Pendengarnya dipasang pada elemen yang BARU dibuat setiap kali regunya
+   *  berganti; yang lama ikut terbuang bersama replaceChildren, dan sinyal
+   *  layar membersihkan sisanya saat layar ditinggalkan. */
+  function pasangGeserCek(petak, nav) {
+    const jml = petak.children.length;
+    nav.hidden = jml < 2;
+    if (jml < 2) return;
+
+    const hitung = nav.querySelector("[data-hitung-foto]");
+    let ke = 0;
+    const perbarui = () => {
+      hitung.textContent = `${ke + 1} / ${jml}`;
+      nav.querySelector('[data-cek-geser="-1"]').disabled = ke <= 0;
+      nav.querySelector('[data-cek-geser="1"]').disabled = ke >= jml - 1;
+    };
+
+    nav.addEventListener("click", (e) => {
+      const b = e.target.closest("[data-cek-geser]");
+      if (!b || b.disabled) return;
+      ke = Math.max(0, Math.min(jml - 1, ke + Number(b.dataset.cekGeser)));
+      petak.scrollTo({ left: ke * petak.clientWidth, behavior: "smooth" });
+      perbarui();
+    }, { signal: sinyal });
+
+    petak.addEventListener("scroll", () => {
+      const baru = Math.max(0, Math.min(jml - 1,
+        Math.round(petak.scrollLeft / (petak.clientWidth || 1))));
+      if (baru !== ke) { ke = baru; perbarui(); }
+    }, { signal: sinyal });
+
+    perbarui();
   }
 
   const ke = (i) => {

--- a/web/style.css
+++ b/web/style.css
@@ -4661,6 +4661,10 @@ button.pill-number:hover { filter: brightness(.95); }
   scroll-snap-type: x mandatory; scrollbar-width: none;
 }
 .cek-foto::-webkit-scrollbar { display: none; }
+/* Navigasinya menempel ke petak di atasnya, bukan mengambang di tengah
+   antara dua lomba — ia milik foto tepat di atasnya, dan di daftar berisi
+   lima lomba kepemilikan itu harus terbaca tanpa dihitung. */
+.cek-lomba .foto-navigasi { margin-top: .4rem; }
 .cek-foto .fg-petak {
   flex: 0 0 100%; height: 46vh; scroll-snap-align: start;
   display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## What

Tiap lomba di Cek Nilai yang punya **lebih dari satu foto** mendapat panah
`‹ ›` dan penghitung `1 / 5` sendiri, di bawah petak fotonya. Lomba berfoto
satu tidak diberi panah sama sekali.

## Why

#753 membuat petaknya bisa digeser tapi tidak memberi tanda apa pun bahwa ada
foto lain — persis keluhan yang dulu diperbaiki di layar input dan terulang di
sini. Petak yang bisa digeser tidak mengumumkan dirinya: yang terlihat cuma
satu foto, dan foto kedua baru ada kalau seseorang kebetulan menyapu layarnya.

Bentuknya sama persis dengan penggeser di layar input — dua layar yang
menggeser benda yang sama tidak boleh memakai dua alat berbeda. Lomba berfoto
satu dilewati karena dua tombol yang tidak pernah melakukan apa pun cuma
menambah benda untuk dilewati mata di daftar berisi lima lomba.

## Notes

**Tiap petak memegang nomornya sendiri.** Satu regu bisa punya lima lomba
berfoto, dan penghitung yang dibagi bersama akan melompat setiap kali petak
lain digeser.

Nomor fotonya dipegang di JS, bukan dihitung ulang dari `scrollLeft` — `scroll`
dikirim pada frame berikutnya, jadi tab yang sedang tidak menggambar tidak
mengirimkannya sama sekali, dan penghitung yang bertahan sementara fotonya
sudah berganti lebih buruk daripada tidak ada penghitung. `scroll` tetap
didengar untuk menyamakan angkanya kalau yang menggeser jari.

**Diuji lokal** (pasal 16 dan 17.2) di iframe 390×780, dengan 5 foto di
Semaphore dan 3 di Tebak Simpul untuk nomor dada 010:

| Lomba | Foto | Panah tampil | Penghitung |
| --- | --- | --- | --- |
| Semaphore | 5 | ya | `1 / 5` |
| Tebak Simpul | 3 | ya | `1 / 3` |
| Menaksir, Keagamaan, Kepramukaan | 0 | **tidak** | — |

Panah Semaphore ditekan lima kali: `1/5 → 2/5 → 3/5 → 4/5 → 5/5`, berhenti di
`5/5` dengan panah maju mati, lalu mundur ke `4/5`. Penghitung Tebak Simpul
tetap `1 / 3` selama itu. Lebar petak 310px = lebar kartunya.

`node --test tests/*.test.mjs` 310 lulus 0 gagal; `periksa_impor.py` bersih;
`diff` web/ vs live/ sama.
