### PR TITLE
fix: pita antrean ikut tampil di Cek Nilai

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9108,6 +9108,13 @@ async function layarCekNilai() {
   let indeks = 0;
 
   LAYAR.replaceChildren(h(`
+    <!-- Pita antrean ada DI SINI JUGA, dan itu bukan kerapian: sejak layar ini
+         boleh mengubah nilai, simpanan dari sini bisa gagal karena jaringan
+         dan masuk antrean seperti di layar input. Tanpa elemen ini
+         gambarPitaAntrean() tidak menemukan sasarannya dan langsung keluar —
+         admin cuma menerima satu notifikasi yang lalu hilang, lalu tidak ada
+         satu pun tanda bahwa masih ada angka yang belum sampai. -->
+    <div id="pita-antrean"></div>
     <div class="card">
       <div class="baris-pilih">
         <div class="field">
@@ -9140,6 +9147,9 @@ async function layarCekNilai() {
     </div>
     <div id="cek-isi"></div>
   `));
+
+  gambarPitaAntrean();
+  kirimAntrean();
 
   const elPos = document.getElementById("cek-pos");
   const elDada = document.getElementById("cek-dada");


### PR DESCRIPTION
## What

Menambahkan elemen pita antrean ke layar Cek Nilai, dan memanggil
`gambarPitaAntrean()` serta `kirimAntrean()` saat layarnya dibuka.

## Why

Sejak #755 layar ini boleh mengubah nilai, jadi simpanan dari sini bisa gagal
karena jaringan dan masuk antrean seperti di layar input. Penangannya memang
sudah memanggil `gambarPitaAntrean()` — tetapi layarnya **tidak punya**
`#pita-antrean`, jadi fungsinya menemukan null dan langsung keluar tanpa satu
pun galat.

Akibatnya: admin menerima satu notifikasi merah yang lalu hilang, dan sesudah
itu **tidak ada satu pun tanda** bahwa masih ada angka yang belum sampai — di
layar yang justru dipakai orang yang bertugas memastikan angkanya benar.
Kegagalan yang paling sulit dilaporkan orang: layarnya terlihat baik-baik saja,
dan yang hilang cuma peringatan yang seharusnya ada.

## Notes

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`:

- `fetch` untuk `simpan_nilai_massal` dipaksa gagal, lalu nilai Semaphore 010
  diubah dan disimpan **dari Cek Nilai** → notif merah `010 BELUM terkirim…`,
  `localStorage` berisi 1 entri, dan pitanya muncul:
  `1 nilai belum terkirim — jangan tutup halaman ini. | 010 | Kirim sekarang`.
- Tombol "Kirim sekarang" ditekan sesudah jaringan pulih → antrean **0**, pita
  kosong, notif `Nilai yang tertunda sudah terkirim.`
- `node --test tests/*.test.mjs` 310 lulus 0 gagal; `periksa_impor.py` bersih.

Tidak ada perubahan CSS, jadi nomor versi `style.css` tetap.
