### PR TITLE
feat: Cek Nilai jadi hak admin, dan pemeriksa jawaban simpan diuji mesin

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1298,6 +1298,48 @@ export function stopwatchTeks(ms) {
  *  ditemukan belakangan waktu angkanya sudah masuk. */
 export const detikDariMs = (ms) => Math.round(Math.max(0, Number(ms) || 0) / 1000);
 
+/** Apakah jawaban `simpan_nilai_massal` boleh dibaca sebagai BERHASIL.
+ *
+ *  Dipisah ke sini karena ia satu-satunya hal yang berdiri antara "nilainya
+ *  masuk" dan "layar berkata nilainya masuk" — dan salah di sini tidak
+ *  menghasilkan galat apa pun, cuma angka yang hilang sambil semua orang
+ *  mengira sudah tersimpan. Yang begitu harus diuji mesin, bukan dicoba
+ *  tangan sekali lalu dipercaya selamanya.
+ *
+ *  DUA SYARAT, bukan satu. Versi pertama cuma mencari status `ditolak` —
+ *  pemeriksaan yang lebih sempit daripada masalahnya, bentuk yang sudah dua
+ *  kali menggigit repo ini (CLAUDE.md 13.3):
+ *
+ *    1. SETIAP baris harus berstatus `tersimpan`. Bukan "tidak ada yang
+ *       ditolak" — status ketiga yang lahir tahun depan ikut tertangkap.
+ *    2. JUMLAHNYA harus sama dengan yang dikirim. RPC mengembalikan satu
+ *       baris hasil per baris masuk; jawaban yang lebih pendek berarti ada
+ *       yang tidak diproses sama sekali.
+ *
+ *  `dariServer` memisahkan dua kegagalan yang penanganannya berlawanan.
+ *  Ditolak server berarti angkanya memang tidak boleh masuk — menunggu tidak
+ *  mengubah jawabannya, jadi ia TIDAK boleh masuk antrean kirim ulang.
+ *  Jawaban yang tidak lengkap adalah keanehan yang mungkin sementara, jadi ia
+ *  diperlakukan seperti gagal jaringan: diantre, karena arah yang aman adalah
+ *  mencoba lagi, bukan membuang angkanya. */
+export function periksaJawabSimpan(jumlahKirim, jawab) {
+  const daftar = Array.isArray(jawab) ? jawab : [];
+  /* findIndex, BUKAN find. Baris `null` di dalam jawaban memang cocok dengan
+     penyaringnya, tetapi find() mengembalikan nilai itu sendiri — dan `null`
+     bersifat falsy, jadi pagar `if (ditolak)` dilewati dan jawabannya terbaca
+     BERHASIL. Ditemukan tes di bawah, bukan di lapangan. */
+  const buruk = daftar.findIndex(x => !x || x.status !== "tersimpan");
+  if (buruk >= 0) {
+    const b = daftar[buruk];
+    return { ok: false, dariServer: true,
+             alasan: (b && b.alasan) || "nilai ditolak server" };
+  }
+  if (daftar.length !== jumlahKirim) {
+    return { ok: false, dariServer: false, alasan: "jawaban server tidak lengkap" };
+  }
+  return { ok: true };
+}
+
 /** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
  *  berapa yang sudah ada isinya, dan jumlah nilainya.
  *

--- a/tests/input_pos_v2.test.mjs
+++ b/tests/input_pos_v2.test.mjs
@@ -7,7 +7,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { jenisLomba, katalogLomba, stopwatchTeks, detikDariMs }
+import { jenisLomba, katalogLomba, stopwatchTeks, detikDariMs, periksaJawabSimpan }
   from "../web/js/util.js";
 
 /** Baris `wahana` seperti yang dikirim komponenSemua(). */
@@ -158,3 +158,78 @@ test("detik yang disimpan dibulatkan, bukan dipotong", () => {
   assert.equal(detikDariMs(0), 0);
   assert.equal(detikDariMs(-100), 0);
 });
+
+/* -------------------------------------------------------------------------
+   periksaJawabSimpan — satu-satunya hal yang berdiri antara "nilainya masuk"
+   dan "layar berkata nilainya masuk".
+
+   Salah di sini tidak menghasilkan galat apa pun: angkanya hilang sambil
+   semua orang mengira sudah tersimpan. Itu sebabnya ia diuji mesin dan bukan
+   dicoba tangan sekali lalu dipercaya selamanya.
+   ---------------------------------------------------------------------- */
+
+const ok = (n) => Array.from({ length: n }, () => ({ status: "tersimpan" }));
+
+test("semua tersimpan dan jumlahnya sama = berhasil", () => {
+  assert.deepEqual(periksaJawabSimpan(1, ok(1)), { ok: true });
+  assert.deepEqual(periksaJawabSimpan(5, ok(5)), { ok: true });
+});
+
+// Ditolak server tidak boleh diantre: menunggu tidak mengubah jawabannya, dan
+// satu baris rusak akan menyumbat antrean di belakangnya selamanya.
+test("satu baris ditolak = gagal, dan gagalnya DARI SERVER", () => {
+  const j = periksaJawabSimpan(2,
+    [{ status: "tersimpan" }, { status: "ditolak", alasan: "di luar rentang" }]);
+  assert.equal(j.ok, false);
+  assert.equal(j.dariServer, true);
+  assert.equal(j.alasan, "di luar rentang");
+});
+
+test("ditolak tanpa alasan tetap punya kalimat", () => {
+  const j = periksaJawabSimpan(1, [{ status: "ditolak" }]);
+  assert.equal(j.ok, false);
+  assert.equal(j.dariServer, true);
+  assert.match(j.alasan, /ditolak/);
+});
+
+// Yang menangkap status ketiga yang lahir tahun depan tanpa menyentuh kode.
+test("status yang tidak dikenal diperlakukan sebagai gagal", () => {
+  const j = periksaJawabSimpan(1, [{ status: "tertunda" }]);
+  assert.equal(j.ok, false);
+  assert.equal(j.dariServer, true);
+});
+
+// RPC mengembalikan satu baris hasil per baris masuk. Jawaban yang lebih
+// pendek berarti ada yang tidak diproses sama sekali.
+test("jawaban lebih pendek daripada yang dikirim = gagal", () => {
+  const j = periksaJawabSimpan(3, ok(2));
+  assert.equal(j.ok, false);
+  assert.match(j.alasan, /tidak lengkap/);
+});
+
+test("jawaban lebih panjang juga gagal", () => {
+  assert.equal(periksaJawabSimpan(1, ok(2)).ok, false);
+});
+
+// Jawaban tidak lengkap adalah keanehan yang mungkin sementara, jadi ia
+// diantre seperti gagal jaringan — arah yang aman adalah mencoba lagi, bukan
+// membuang angkanya.
+test("jawaban tidak lengkap BUKAN dari server, jadi boleh diantre", () => {
+  assert.equal(periksaJawabSimpan(3, ok(2)).dariServer, false);
+});
+
+test("jawaban kosong atau bukan larik = gagal, bukan berhasil", () => {
+  for (const buruk of [null, undefined, [], {}, "tersimpan", 0]) {
+    assert.equal(periksaJawabSimpan(1, buruk).ok, false, JSON.stringify(buruk));
+  }
+});
+
+// Larik berisi null pernah lolos `x.status !== "tersimpan"` sebagai lemparan
+// TypeError, bukan sebagai penolakan; yang dilempar di tengah putaran kirim
+// akan terbaca sebagai gagal jaringan dan diantre selamanya.
+test("baris null di dalam jawaban tidak melempar", () => {
+  const j = periksaJawabSimpan(2, [{ status: "tersimpan" }, null]);
+  assert.equal(j.ok, false);
+  assert.equal(j.dariServer, true);
+});
+

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -42,7 +42,7 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
          GOLONGAN_LABEL, URUT_GOLONGAN, biayaRegu, totalBiaya,
          varianUntuk, kelompokLomba, ringkasLomba,
          katalogLomba, stopwatchTeks, detikDariMs,
-         petunjukKolom } from "./util.js";
+         petunjukKolom, periksaJawabSimpan } from "./util.js";
 import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
 import { deretCocok, deretIntern, nomorStok, pesanDeret }
   from "./nomor-dada-series.mjs";
@@ -471,6 +471,19 @@ async function layarHome() {
     // Yang tetap wajib di-escape: nilai dari database. Di sini cuma `pos`.
     LAYAR.replaceChildren(h(`
       <div class="function-menu">
+        <!-- v2 BERDIRI PALING ATAS di papan juri, dan itu bukan urutan
+             alfabet: layar inilah yang dibuat untuk orang yang membaca papan
+             ini. Yang lama tetap ada di bawahnya karena hanya dari sana
+             blangko bisa dicetak.
+
+             Papan ini SEPENUHNYA TERPISAH dari papan meja di bawah, dan itu
+             yang membuat ubin baru gampang terlupa: ditambahkan di satu
+             tempat, dan akun juri — satu-satunya yang memakai layar itu —
+             tidak melihatnya sama sekali. Persis yang terjadi sampai baris
+             ini ditulis. -->
+        <a href="#/pos2">
+          <div class="function-name">${ikonKotak("clock", "mawar")} Input Nilai Pos v2</div>
+        </a>
         <a href="#/pos">
           <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos${
             sesi().pos != null && sesi().pos !== "" ? ` ${esc(sesi().pos)}` : ""}</div>
@@ -582,7 +595,7 @@ async function layarHome() {
       <a href="#/pos2">
         <div class="function-name">${ikonKotak("clock", "mawar")} Input Nilai Pos v2</div>
       </a>` : ""}
-      ${bolehLihat("pos") ? `
+      ${bolehLihat("pengaturan") ? `
       <a href="#/cek-nilai">
         <div class="function-name">${ikonKotak("circle-check", "zamrud")} Cek Nilai</div>
       </a>` : ""}
@@ -7296,18 +7309,12 @@ async function kirimAntrean() {
     for (const p of antreanTertunda()) {
       try {
         if (p.baris && p.baris.length) {
-          const hasil = await simpanNilaiPos(p.baris, p.pos);
-          const daftar = hasil || [];
-          const ditolak = daftar.find(x => x.status !== "tersimpan");
-          /* JUMLAHNYA IKUT DIPERIKSA, bukan cuma statusnya. RPC mengembalikan
-             satu baris hasil per baris yang dikirim; jawaban yang lebih
-             pendek berarti ada yang tidak diproses, dan menganggapnya sukses
-             adalah cara nilai hilang sambil layar berkata "tersimpan". */
-          if (ditolak || daftar.length !== p.baris.length) {
-            const e = new ErrorApi(ditolak
-              ? (ditolak.alasan || "nilai ditolak server")
-              : "jawaban server tidak lengkap");
-            e.dariServer = !!ditolak;
+          // Aturannya di util.js, diuji mesin — lihat periksaJawabSimpan().
+          const periksa = periksaJawabSimpan(p.baris.length,
+            await simpanNilaiPos(p.baris, p.pos));
+          if (!periksa.ok) {
+            const e = new ErrorApi(periksa.alasan);
+            e.dariServer = periksa.dariServer;
             throw e;
           }
           // Nilainya sudah mendarat. Dikosongkan supaya percobaan berikutnya
@@ -7464,22 +7471,12 @@ async function kirimNilaiRegu({ pos, kolom, regu, wadah, labelUntuk }) {
 
   try {
     if (baris.length) {
-      const jawab = await simpanNilaiPos(baris, pos);
-      const daftar = jawab || [];
-      /* SEMUA HARUS `tersimpan`, DAN JUMLAHNYA HARUS SAMA.
-         Yang dicari dulu cuma status `ditolak` — pemeriksaan yang lebih sempit
-         daripada masalahnya, bentuk yang sudah dua kali menggigit repo ini
-         (bagian 13.3). RPC mengembalikan satu baris hasil per baris yang
-         dikirim; jawaban yang lebih pendek berarti ada yang tidak diproses,
-         dan menganggapnya sukses adalah cara nilai hilang sambil layar berkata
-         "tersimpan". Status ketiga yang lahir tahun depan ikut tertangkap
-         tanpa menyentuh baris ini. */
-      const ditolak = daftar.find(x => x.status !== "tersimpan");
-      if (ditolak || daftar.length !== baris.length) {
-        const e = new ErrorApi(ditolak
-          ? (ditolak.alasan || "nilai ditolak server")
-          : "jawaban server tidak lengkap");
-        e.dariServer = !!ditolak;
+      // Aturannya di util.js, diuji mesin — lihat periksaJawabSimpan().
+      const periksa = periksaJawabSimpan(baris.length,
+        await simpanNilaiPos(baris, pos));
+      if (!periksa.ok) {
+        const e = new ErrorApi(periksa.alasan);
+        e.dariServer = periksa.dariServer;
         throw e;
       }
     }
@@ -9080,9 +9077,26 @@ async function gambarLombaSoal(l) {
 
 async function layarCekNilai() {
   const s = sesi();
-  if (!bolehLihat("pos")) {
+  /* HAK `pengaturan`, BUKAN `pos`.
+
+     Layar Input Nilai Pos v2 dipakai juri dan tim input per lomba; layar ini
+     dipakai admin server. Selama pagarnya `pos`, setiap juri bisa membukanya —
+     dan sejak layar ini boleh mengubah nilai dan MENGUNCI, itu berarti setiap
+     juri bisa mengunci nilai regu mana pun di posnya, termasuk lomba yang
+     bukan pegangannya.
+
+     `pengaturan` dipilih karena hanya admin yang mendapatkannya dari
+     paket_peran() — diperiksa di database, bukan diduga: juri_pos dan
+     koordinator_pos sama-sama cuma menerima `live_score` dan `pos`.
+     Presedennya pasal 13.4, "yang dulu hanya admin dipetakan ke pengaturan,
+     bukan ke fitur ubin yang namanya mirip".
+
+     Ini bukan kunci mati: matriks centang di layar Akun tetap bisa memberikan
+     `pengaturan` ke akun tertentu yang memang perlu, tanpa menyentuh kode. */
+  if (!bolehLihat("pengaturan")) {
     pasangKepala("Cek Nilai");
-    LAYAR.replaceChildren(h(kartuGalat("Akun ini tidak berhak membuka Cek Nilai.")));
+    LAYAR.replaceChildren(h(kartuGalat(
+      "Cek Nilai dipakai admin server. Akun ini tidak berhak membukanya.")));
     return;
   }
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1298,6 +1298,48 @@ export function stopwatchTeks(ms) {
  *  ditemukan belakangan waktu angkanya sudah masuk. */
 export const detikDariMs = (ms) => Math.round(Math.max(0, Number(ms) || 0) / 1000);
 
+/** Apakah jawaban `simpan_nilai_massal` boleh dibaca sebagai BERHASIL.
+ *
+ *  Dipisah ke sini karena ia satu-satunya hal yang berdiri antara "nilainya
+ *  masuk" dan "layar berkata nilainya masuk" — dan salah di sini tidak
+ *  menghasilkan galat apa pun, cuma angka yang hilang sambil semua orang
+ *  mengira sudah tersimpan. Yang begitu harus diuji mesin, bukan dicoba
+ *  tangan sekali lalu dipercaya selamanya.
+ *
+ *  DUA SYARAT, bukan satu. Versi pertama cuma mencari status `ditolak` —
+ *  pemeriksaan yang lebih sempit daripada masalahnya, bentuk yang sudah dua
+ *  kali menggigit repo ini (CLAUDE.md 13.3):
+ *
+ *    1. SETIAP baris harus berstatus `tersimpan`. Bukan "tidak ada yang
+ *       ditolak" — status ketiga yang lahir tahun depan ikut tertangkap.
+ *    2. JUMLAHNYA harus sama dengan yang dikirim. RPC mengembalikan satu
+ *       baris hasil per baris masuk; jawaban yang lebih pendek berarti ada
+ *       yang tidak diproses sama sekali.
+ *
+ *  `dariServer` memisahkan dua kegagalan yang penanganannya berlawanan.
+ *  Ditolak server berarti angkanya memang tidak boleh masuk — menunggu tidak
+ *  mengubah jawabannya, jadi ia TIDAK boleh masuk antrean kirim ulang.
+ *  Jawaban yang tidak lengkap adalah keanehan yang mungkin sementara, jadi ia
+ *  diperlakukan seperti gagal jaringan: diantre, karena arah yang aman adalah
+ *  mencoba lagi, bukan membuang angkanya. */
+export function periksaJawabSimpan(jumlahKirim, jawab) {
+  const daftar = Array.isArray(jawab) ? jawab : [];
+  /* findIndex, BUKAN find. Baris `null` di dalam jawaban memang cocok dengan
+     penyaringnya, tetapi find() mengembalikan nilai itu sendiri — dan `null`
+     bersifat falsy, jadi pagar `if (ditolak)` dilewati dan jawabannya terbaca
+     BERHASIL. Ditemukan tes di bawah, bukan di lapangan. */
+  const buruk = daftar.findIndex(x => !x || x.status !== "tersimpan");
+  if (buruk >= 0) {
+    const b = daftar[buruk];
+    return { ok: false, dariServer: true,
+             alasan: (b && b.alasan) || "nilai ditolak server" };
+  }
+  if (daftar.length !== jumlahKirim) {
+    return { ok: false, dariServer: false, alasan: "jawaban server tidak lengkap" };
+  }
+  return { ok: true };
+}
+
 /** Ringkas satu LOMBA untuk satu regu: berapa komponennya yang berlaku,
  *  berapa yang sudah ada isinya, dan jumlah nilainya.
  *


### PR DESCRIPTION
## What

1. **Cek Nilai dipagari `pengaturan`**, bukan `pos` — di layarnya dan di ubin
   Home.
2. **Ubin Input Nilai Pos v2 ditambahkan ke papan Home milik juri**, yang
   selama ini terlewat.
3. **`periksaJawabSimpan()` pindah ke `util.js` dan diuji mesin**; kedua
   pemanggilnya (jalur simpan dan putaran antrean) kini memakai satu aturan.

## Why

**Hak akses.** Layar Input Nilai Pos v2 dipakai juri dan tim input per lomba;
Cek Nilai dipakai admin server. Selama pagarnya `pos`, setiap juri bisa
membukanya — dan sejak #755 layar itu boleh mengubah nilai dan **mengunci**,
jadi setiap juri bisa mengunci nilai regu mana pun di posnya, termasuk lomba
yang bukan pegangannya. `pengaturan` dipilih karena hanya admin yang
menerimanya dari `paket_peran()`; diperiksa di database, bukan diduga.
Presedennya pasal 13.4. Bukan kunci mati — matriks centang di layar Akun tetap
bisa memberikannya ke akun tertentu.

**Ubin juri.** Home punya **dua jalur yang sepenuhnya terpisah**: papan pendek
untuk akun yang cuma memegang pos, dan papan penuh untuk meja. Ubin v2 hanya
ditambahkan ke yang kedua, jadi juri — satu-satunya orang yang layar itu dibuat
untuknya — tidak punya jalan ke sana kecuali mengetik alamatnya sendiri.

**Pemeriksa jawaban.** Ia satu-satunya hal yang berdiri antara "nilainya masuk"
dan "layar berkata nilainya masuk", dan salah di sana tidak menghasilkan galat
apa pun.

## Notes

**Tesnya langsung menemukan bug di kode itu sendiri.** Baris `null` di dalam
jawaban memang cocok dengan penyaringnya, tetapi `find()` mengembalikan nilai
itu sendiri — dan `null` bersifat **falsy**, jadi pagar `if (ditolak)` dilewati
dan jawabannya terbaca **berhasil**. Diganti `findIndex`. Ditemukan tes, bukan
lapangan.

**Diuji lokal** (pasal 16 dan 17.2), PostgreSQL 17, `hrcd_dev`, dengan dua akun
sungguhan (`pos1hrcd37` juri_pos dan `admin.ciradyka`):

| | juri_pos | admin |
| --- | --- | --- |
| Ubin Input Nilai Pos v2 | ✓ paling atas | ✓ |
| Ubin Cek Nilai | ✗ | ✓ |
| Buka `#/cek-nilai` | ditolak: "Cek Nilai dipakai admin server…" | ✓ kelima pos |
| Pemilih lomba di v2 | hanya `Pos 1 — Kepramukaan` | kelima pos |

`node --test tests/*.test.mjs` — **319** lulus, 0 gagal (9 tes baru untuk
`periksaJawabSimpan`); `periksa_impor.py` bersih; `diff` util.js web/ vs live/
sama. Tidak ada perubahan CSS, jadi nomor versi `style.css` tetap.
