### PR TITLE
fix: Enter berpindah kotak, tombol simpan menempel, isyarat papan ketik

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=20">
+  <link rel="stylesheet" href="style.css?v=21">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4502,6 +4502,25 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .foto-lembar-kosong { font-size: .85rem; color: var(--tinta-lembut); }
 
+/* Tombol simpan MENEMPEL di dasar layar selama kartunya lebih tinggi daripada
+   layar. Terukur di iframe 390x780: dengan foto, tombolnya berakhir di 1133px
+   sementara layarnya 776px — 357px di bawah lipatan; dan dengan papan ketik
+   terbuka (~340px) bahkan regu tanpa foto pun (605 > 436) menuntut menggulir.
+   Foto Jawaban tetap berada di ATASNYA dalam urutan dokumen; yang berubah cuma
+   tombolnya tidak ikut terdorong turun.
+
+   `bottom` diberi jarak untuk menu bawah HP yang setinggi 56px + safe area,
+   supaya keduanya tidak bertumpuk. */
+.v2-simpan-lekat {
+  position: sticky; bottom: .6rem; z-index: 5;
+  margin-top: .7rem; min-height: 60px; font-size: 1.2rem;
+  box-shadow: 0 4px 14px rgba(16, 24, 40, .18);
+}
+@media (max-width: 560px) {
+  .v2-simpan-lekat { bottom: calc(56px + env(safe-area-inset-bottom) + .5rem); }
+}
+.cek-sudah { margin-top: .5rem; }
+
 /* ---------- kotak isian kriteria ---------- */
 
 .isian-lomba { display: flex; flex-direction: column; gap: .5rem; margin-top: .7rem; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 20, sidik: "fac644e54b62" },
+  "style.css": { versi: 21, sidik: "4e4c6630966d" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=18">
+  <link rel="stylesheet" href="style.css?v=19">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7789,7 +7789,7 @@ async function gambarLombaNilai(l) {
              lebar barisnya, tombolnya hanya selebar tulisannya. -->
         <div class="dada-baris">
           <input type="text" id="v2-dada" class="besar" inputmode="numeric"
-                 autocomplete="off" placeholder="001">
+                 autocomplete="off" enterkeyhint="next" placeholder="001">
           ${waktu ? `<button type="button" class="button button-danger button-small sw-dq"
                   data-sw="dq">Diskualifikasi</button>` : ""}
         </div>
@@ -7840,10 +7840,8 @@ async function gambarLombaNilai(l) {
                   data-foto-geser="1" aria-label="Foto berikutnya">&rsaquo;</button>
         </div>
       </div>
-      <button class="button button-primary" id="v2-simpan" type="button" disabled
-              style="margin-top:.7rem;min-height:60px;font-size:1.2rem">
-        SIMPAN NILAI
-      </button>
+      <button class="button button-primary v2-simpan-lekat" id="v2-simpan"
+              type="button" disabled>SIMPAN NILAI</button>
     </div>
     <div id="v2-riwayat"></div>
   `));
@@ -8149,6 +8147,24 @@ async function gambarLombaNilai(l) {
     }
     regu = r;
     kotakRegu.replaceChildren(h(kartuReguNilai(r)));
+
+    /* LENCANA "SUDAH DINILAI", dan ia menyebutkan angkanya.
+       Kotak yang sudah terisi memang sudah memperlihatkan angkanya, tetapi
+       juri yang mengetik cepat tidak membaca isi kotak — ia membaca kartu
+       regunya lalu langsung mengetik. Menimpa nilai orang lain harus jadi
+       tindakan sadar, dan satu lencana di tempat mata sudah berhenti lebih
+       murah daripada satu sengketa nilai. */
+    const sudah = l.kolom
+      .map(kol => varianUntuk(kol, r.golongan))
+      .filter(k => k && (r.nilai || {})[k.kode]);
+    if (sudah.length) {
+      const teks = sudah
+        .map(k => nilaiBagian(k, r.nilai[k.kode].nilai_1, r.nilai[k.kode].nilai_2).join(" / "))
+        .join(" · ");
+      kotakRegu.append(h(`<div class="cek-sudah">
+        <span class="badge badge-yellow">sudah dinilai · ${esc(teks)}</span></div>`));
+    }
+
     gambarIsian(r);
 
     /* Gembok TIDAK mematikan tombol foto. Mengunci berarti angkanya final;
@@ -8258,6 +8274,20 @@ async function gambarLombaNilai(l) {
       if (el) el.id = `sel-${k.kode}`;
     });
 
+    /* ISYARAT TOMBOL PAPAN KETIK. Rantai `10 → 3 →` sudah bekerja sejak
+       awal, tetapi tidak ada apa pun yang mengumumkannya: tombol pojok kanan
+       bawah papan angka Android berlabel panah generik, dan juri menggulir
+       lalu menekan SIMPAN NILAI ratusan kali per pagi tanpa tahu ada jalan
+       yang lebih pendek. `enterkeyhint` membuat tombol itu sendiri yang
+       mengatakannya — nol teks tambahan di layar.
+
+       Yang terakhir "done", sisanya "next", supaya labelnya cocok dengan apa
+       yang benar-benar terjadi saat ditekan (lihat penangan keydown). */
+    const kotakIsi = [...wadah.querySelectorAll("input")];
+    kotakIsi.forEach((el, i) => {
+      el.setAttribute("enterkeyhint", i === kotakIsi.length - 1 ? "done" : "next");
+    });
+
     const kunci = !!r.terkunci;
     wadah.querySelectorAll("input").forEach(el => { el.disabled = kunci; });
     tombol.disabled = kunci;
@@ -8289,9 +8319,27 @@ async function gambarLombaNilai(l) {
 
   // Enter di kotak isian = simpan. Di sini ia memang aksi terakhir barisnya:
   // sesudah angkanya diketik, petugas tidak punya urusan lain dengan regu itu.
+  /* ENTER BERPINDAH KE KOTAK BERIKUTNYA, dan hanya MENYIMPAN dari yang
+     terakhir.
+
+     Sebelumnya Enter di kotak mana pun langsung menyimpan. Untuk lomba
+     berkriteria satu itu benar — dan hampir semua lomba begitu, jadi
+     salahnya tidak pernah terlihat. Untuk Pembidaian yang punya LIMA
+     kriteria, menekan Enter sesudah kriteria pertama menyimpan satu angka
+     beserta empat kotak kosong, lalu mengosongkan layar untuk regu
+     berikutnya. Tidak ada galat, tidak ada yang merah: juri mengira ia
+     berpindah kolom, dan yang tersimpan cuma seperlima penilaiannya. */
   wadah.addEventListener("keydown", (e) => {
     if (e.key !== "Enter" || e.target.tagName !== "INPUT") return;
     e.preventDefault();
+    const kotak = [...wadah.querySelectorAll("input:not([disabled])")];
+    const i = kotak.indexOf(e.target);
+    if (i >= 0 && i < kotak.length - 1) {
+      const berikut = kotak[i + 1];
+      berikut.focus();
+      if (berikut.select) { try { berikut.select(); } catch { /* abaikan */ } }
+      return;
+    }
     if (!tombol.disabled) tombol.click();
   }, { signal: sinyal });
 

--- a/web/style.css
+++ b/web/style.css
@@ -4502,6 +4502,25 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .foto-lembar-kosong { font-size: .85rem; color: var(--tinta-lembut); }
 
+/* Tombol simpan MENEMPEL di dasar layar selama kartunya lebih tinggi daripada
+   layar. Terukur di iframe 390x780: dengan foto, tombolnya berakhir di 1133px
+   sementara layarnya 776px — 357px di bawah lipatan; dan dengan papan ketik
+   terbuka (~340px) bahkan regu tanpa foto pun (605 > 436) menuntut menggulir.
+   Foto Jawaban tetap berada di ATASNYA dalam urutan dokumen; yang berubah cuma
+   tombolnya tidak ikut terdorong turun.
+
+   `bottom` diberi jarak untuk menu bawah HP yang setinggi 56px + safe area,
+   supaya keduanya tidak bertumpuk. */
+.v2-simpan-lekat {
+  position: sticky; bottom: .6rem; z-index: 5;
+  margin-top: .7rem; min-height: 60px; font-size: 1.2rem;
+  box-shadow: 0 4px 14px rgba(16, 24, 40, .18);
+}
+@media (max-width: 560px) {
+  .v2-simpan-lekat { bottom: calc(56px + env(safe-area-inset-bottom) + .5rem); }
+}
+.cek-sudah { margin-top: .5rem; }
+
 /* ---------- kotak isian kriteria ---------- */
 
 .isian-lomba { display: flex; flex-direction: column; gap: .5rem; margin-top: .7rem; }


### PR DESCRIPTION
## What

1. **Enter berpindah ke kotak berikutnya**, dan hanya menyimpan dari yang
   terakhir.
2. **`enterkeyhint`** di setiap kotak: `next` … `next`, lalu `done`.
3. **Tombol simpan menempel** di dasar layar.
4. **Lencana "sudah dinilai"** beserta angkanya di kartu regu.

## Why

**Enter — ini bug, bukan pilihan.** Sebelumnya Enter di kotak mana pun langsung
menyimpan. Untuk lomba berkriteria satu itu benar, dan hampir semua lomba
begitu, jadi salahnya tidak pernah terlihat. Untuk **Pembidaian yang punya lima
kriteria**, menekan Enter sesudah kriteria pertama menyimpan satu angka beserta
empat kotak kosong lalu mengosongkan layar untuk regu berikutnya — tanpa galat,
tanpa apa pun yang merah. Juri mengira ia berpindah kolom, dan yang tersimpan
cuma seperlima penilaiannya.

**Isyarat papan ketik.** Rantai `10 → 3 →` sudah bekerja sejak awal tetapi tidak
ada apa pun yang mengumumkannya; juri menggulir lalu menekan SIMPAN NILAI
ratusan kali per pagi tanpa tahu ada jalan yang lebih pendek. Nol teks tambahan
di layar — tombol papan ketiknya sendiri yang mengatakannya.

**Tombol menempel.** Terukur di iframe 390×780: dengan foto, tombolnya berakhir
di **1133px** sementara layarnya **776px** — 357px di bawah lipatan; dengan
papan ketik terbuka (~340px) bahkan regu tanpa foto pun (605 > 436) menuntut
menggulir.

**Lencana.** Juri yang mengetik cepat tidak membaca isi kotak — ia membaca
kartu regunya lalu langsung mengetik. Menimpa nilai orang lain harus jadi
tindakan sadar.

## Notes

Foto Jawaban tetap berada **di atas** tombol simpan dalam urutan dokumen,
seperti yang diminta; yang berubah cuma tombolnya tidak ikut terdorong turun.
Jaraknya dari dasar memperhitungkan menu bawah HP setinggi 56px beserta safe
area.

**Diuji lokal** (pasal 16 dan 17.2) di iframe 390×780, memakai Pembidaian
(lima kriteria):

- Enter di kotak 1 → fokus pindah ke `bidai_posisi`; Enter lagi → `bidai_teknik`.
  Layar **tidak** tersimpan dan **tidak** dikosongkan.
- `enterkeyhint` terbaca `["next","next","next","next","done"]`, dan `next`
  pada kotak nomor dada.
- Enter di kotak **terakhir** → `007 tersimpan.`, riwayat memuat kelima
  kriterianya, layar bersih.
- Tombol simpan: `position: sticky`, dan di dasar halaman panjang tepinya di
  **581px** dari layar **776px** — terlihat tanpa menggulir.
- Membuka ulang 007 → lencana `sudah dinilai · 20 · 12 · 21 · 13 · 18`.

`node --test tests/*.test.mjs` 319 lulus 0 gagal; `periksa_impor.py` bersih;
`diff` web/ vs live/ sama.
