### PR TITLE
feat: daftar regu yang belum dinilai di lomba yang dibuka

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=21">
+  <link rel="stylesheet" href="style.css?v=22">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4409,8 +4409,34 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Nama lombanya DI TENGAH. Bar atas sudah menyebut posnya, jadi kartu ini
    cuma memikul satu kata — dan kata itu yang menjawab "angka yang saya ketik
    ini masuk ke lomba mana?", satu-satunya pertanyaan yang mahal kalau salah. */
-.baris-lomba { padding-top: .7rem; padding-bottom: .7rem; text-align: center; }
-.lomba-judul { margin: 0; }
+.baris-lomba {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .8rem; padding-top: .7rem; padding-bottom: .7rem;
+}
+/* Judulnya tetap di TENGAH kartunya walau ada tombol di kanan: `flex: 1` di
+   kedua sisi tombol akan memindahkannya, jadi yang dipakai margin otomatis di
+   kiri judul dan tombol yang lebarnya sendiri di kanan. */
+.baris-lomba .lomba-judul { margin: 0 auto; }
+.baris-lomba .button { flex: 0 0 auto; }
+
+/* Daftar regu yang belum dinilai. Satu baris satu tombol selebar dialog —
+   yang ditekan sambil berdiri, dan nomor dada di kiri berbaris lurus supaya
+   mata menyusurinya tanpa membaca namanya lebih dulu. */
+.daftar-belum { list-style: none; margin: 0; padding: 0;
+  max-height: 55vh; overflow-y: auto; }
+.daftar-belum li { margin-bottom: .4rem; }
+.daftar-belum button {
+  display: grid; grid-template-columns: max-content 1fr; gap: .1rem .7rem;
+  width: 100%; min-height: 52px; padding: .5rem .7rem; text-align: left;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kartu); color: inherit;
+}
+.daftar-belum button:hover { border-color: var(--utama); }
+.daftar-belum button:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.db-dada { grid-area: 1 / 1 / 3 / 2; align-self: center;
+  font-weight: 800; font-size: 1.2rem; font-variant-numeric: tabular-nums; }
+.db-nama { font-weight: 700; line-height: 1.2; }
+.db-sekolah { font-size: .8rem; color: var(--tinta-lembut); line-height: 1.2; }
 
 /* Foto Jawaban: judul di kiri, jumlahnya di bawahnya, dua tombol di kanan.
    Bentuk yang sama dengan baris foto di dialog lembar pos lama, supaya

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 21, sidik: "4e4c6630966d" },
+  "style.css": { versi: 22, sidik: "87aa299b3a8e" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=19">
+  <link rel="stylesheet" href="style.css?v=20">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7751,9 +7751,10 @@ function gambarPemilihLomba(katalog) {
  *  papan ketik naik dan halamannya tergulir; kartu ini ikut bergulir bersama
  *  isinya. Yang dijawabnya satu pertanyaan yang mahal kalau salah — "angka
  *  yang saya ketik ini masuk ke lomba mana?" */
-const kepalaLomba = (l) => `
+const kepalaLomba = (l, tambahan = "") => `
   <div class="card baris-lomba">
     <h2 class="lomba-judul">${esc(l.nama)}</h2>
+    ${tambahan}
   </div>`;
 
 /* ---------------------------------------------------------------------------
@@ -7772,7 +7773,9 @@ async function gambarLombaNilai(l) {
 
   LAYAR.replaceChildren(h(`
     <div id="pita-antrean"></div>
-    ${kepalaLomba(l)}
+    ${kepalaLomba(l, `<button type="button"
+        class="button button-secondary button-small" id="v2-belum"
+        >Belum dinilai</button>`)}
     <div class="card" id="v2-kartu" style="border-color:var(--utama)">
       <div class="field" style="margin-bottom:0">
         <label for="v2-dada">Nomor dada</label>
@@ -7884,6 +7887,70 @@ async function gambarLombaNilai(l) {
   const segarkanStopwatch = waktu
     ? pasangStopwatch(document.getElementById("v2-kartu"), wadah, kotakWaktu, sinyal)
     : null;
+
+  /* SIAPA YANG BELUM DINILAI DI LOMBA INI.
+   *
+   *  Menjelang tutup pos, pertanyaannya berbalik: bukan lagi "regu ini
+   *  nilainya berapa" melainkan "siapa yang terlewat". Tanpa daftar ini
+   *  jawabannya cuma bisa dicari dengan mengetik nomor dada satu per satu
+   *  sampai ketemu yang kosong — di lomba berisi ratusan regu itu bukan
+   *  pekerjaan yang bisa diselesaikan.
+   *
+   *  Dibaca saat DITEKAN, bukan ikut dimuat bersama layarnya: lembar satu pos
+   *  memuat ratusan baris, dan pertanyaan ini ditanyakan beberapa kali sepagi
+   *  — bukan setiap kali satu regu dinilai. Di jaringan pos, permintaan yang
+   *  tidak ditanya siapa pun tetap dibayar.
+   *
+   *  Yang lombanya tidak berlaku untuk golongan regu itu TIDAK ikut dihitung
+   *  belum dinilai. Regu Penggalang tidak pernah punya Tebak Simpul Penegak,
+   *  dan menuduhnya terlewat adalah alarm yang tidak bisa dipenuhi siapa pun. */
+  document.getElementById("v2-belum")?.addEventListener("click", async () => {
+    const b = document.getElementById("v2-belum");
+    b.disabled = true;
+    let lembar;
+    try { lembar = await lembarPos(l.pos); }
+    catch (err) { b.disabled = false; notif(err.message, true); return; }
+    b.disabled = false;
+
+    const belum = lembar.filter(r => {
+      const dipakai = l.kolom.map(kol => varianUntuk(kol, r.golongan)).filter(Boolean);
+      if (!dipakai.length) return false;
+      const nilai = r.nilai || {};
+      return dipakai.every(k => !nilai[k.kode]);
+    });
+
+    if (!belum.length) {
+      await dialog({ judul: `${l.nama} — semua sudah dinilai`,
+        kartuHtml: `<p class="description">Tidak ada regu yang terlewat.</p>`,
+        labelAksi: "Tutup", bacaSaja: true });
+      return;
+    }
+
+    /* Ditekan = nomornya masuk ke kotak isian. Daftar yang cuma bisa dibaca
+       memaksa petugas mengingat tiga angka lalu mengetiknya sendiri, dan
+       nomor dada yang salah ingat mendaratkan nilai di regu lain. */
+    const janji = dialog({
+      judul: `Belum dinilai · ${belum.length} regu`,
+      kartuHtml: `<ul class="daftar-belum">${belum.map(r => html`
+        <li><button type="button" data-dada="${r.nomor_dada}">
+          <span class="db-dada">${dada3(r.nomor_dada)}</span>
+          <span class="db-nama">${r.nama_regu}</span>
+          <span class="db-sekolah">${r.nama_sekolah}</span>
+        </button></li>`).join("")}</ul>`,
+      labelAksi: "Tutup", bacaSaja: true,
+    });
+
+    // dialog() menempelkan kartunya SINKRON, jadi pendengarnya boleh dipasang
+    // sebelum janjinya ditunggu.
+    document.querySelector(".dialog .daftar-belum")?.addEventListener("click", (e) => {
+      const t = e.target.closest("[data-dada]");
+      if (!t) return;
+      document.querySelector(".dialog [data-batal]")?.click();
+      inp.value = t.dataset.dada;
+      inp.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await janji;
+  }, { signal: sinyal });
 
   inp.focus();
   gambarRiwayatNilai();

--- a/web/style.css
+++ b/web/style.css
@@ -4409,8 +4409,34 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Nama lombanya DI TENGAH. Bar atas sudah menyebut posnya, jadi kartu ini
    cuma memikul satu kata — dan kata itu yang menjawab "angka yang saya ketik
    ini masuk ke lomba mana?", satu-satunya pertanyaan yang mahal kalau salah. */
-.baris-lomba { padding-top: .7rem; padding-bottom: .7rem; text-align: center; }
-.lomba-judul { margin: 0; }
+.baris-lomba {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .8rem; padding-top: .7rem; padding-bottom: .7rem;
+}
+/* Judulnya tetap di TENGAH kartunya walau ada tombol di kanan: `flex: 1` di
+   kedua sisi tombol akan memindahkannya, jadi yang dipakai margin otomatis di
+   kiri judul dan tombol yang lebarnya sendiri di kanan. */
+.baris-lomba .lomba-judul { margin: 0 auto; }
+.baris-lomba .button { flex: 0 0 auto; }
+
+/* Daftar regu yang belum dinilai. Satu baris satu tombol selebar dialog —
+   yang ditekan sambil berdiri, dan nomor dada di kiri berbaris lurus supaya
+   mata menyusurinya tanpa membaca namanya lebih dulu. */
+.daftar-belum { list-style: none; margin: 0; padding: 0;
+  max-height: 55vh; overflow-y: auto; }
+.daftar-belum li { margin-bottom: .4rem; }
+.daftar-belum button {
+  display: grid; grid-template-columns: max-content 1fr; gap: .1rem .7rem;
+  width: 100%; min-height: 52px; padding: .5rem .7rem; text-align: left;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kartu); color: inherit;
+}
+.daftar-belum button:hover { border-color: var(--utama); }
+.daftar-belum button:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.db-dada { grid-area: 1 / 1 / 3 / 2; align-self: center;
+  font-weight: 800; font-size: 1.2rem; font-variant-numeric: tabular-nums; }
+.db-nama { font-weight: 700; line-height: 1.2; }
+.db-sekolah { font-size: .8rem; color: var(--tinta-lembut); line-height: 1.2; }
 
 /* Foto Jawaban: judul di kiri, jumlahnya di bawahnya, dua tombol di kanan.
    Bentuk yang sama dengan baris foto di dialog lembar pos lama, supaya


### PR DESCRIPTION
## What

Tombol "Belum dinilai" di kepala layar lomba. Ditekan, ia menampilkan regu yang
belum punya nilai di lomba itu; barisnya ditekan untuk langsung mengisi kotak
nomor dada.

## Why

Menjelang tutup pos pertanyaannya berbalik: bukan lagi "regu ini nilainya
berapa" melainkan **"siapa yang terlewat"**. Tanpa daftar ini jawabannya cuma
bisa dicari dengan mengetik nomor dada satu per satu sampai ketemu yang kosong
— di lomba berisi ratusan regu itu bukan pekerjaan yang bisa diselesaikan.

Barisnya **ditekan**, bukan cuma dibaca: daftar yang hanya bisa dibaca memaksa
petugas mengingat tiga angka lalu mengetiknya sendiri, dan nomor dada yang
salah ingat mendaratkan nilai di regu lain.

## Notes

**Dibaca saat ditekan, bukan saat layarnya dibuka.** Lembar satu pos memuat
ratusan baris, dan pertanyaan ini ditanyakan beberapa kali sepagi — bukan
setiap kali satu regu dinilai. Di jaringan pos, permintaan yang tidak ditanya
siapa pun tetap dibayar.

**Yang lombanya tidak berlaku untuk golongan regu itu tidak dihitung terlewat.**
Regu Penggalang tidak pernah punya Tebak Simpul Penegak.

**Diuji lokal** (pasal 16 dan 17.2) di iframe 390×780, `hrcd_dev` berisi 36
regu bernomor dada di Pos 1 dengan 7 sudah dinilai Semaphore:

- Tombol ditekan → dialog `Belum dinilai · 29 regu`, dan **29** baris —
  cocok dengan 36 − 7.
- Baris pertama berbunyi `006 · RHINO · SMAN 1 Baregbeg`.
- Ditekan → dialog tutup, kotak nomor dada terisi `6`, kartu regu memuat
  `006 · RHINO`, kotak nilainya siap, dan lencana "sudah dinilai" **tidak**
  muncul (benar, regu itu memang belum dinilai).
- Judul lomba tetap di tengah kartunya walau ada tombol di kanan.

`node --test tests/*.test.mjs` 319 lulus 0 gagal; `periksa_impor.py` bersih;
`diff` web/ vs live/ sama.
