### PR TITLE
feat: cetak rekap nilai per sekolah dan seluruhnya dari Live Score

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=22">
+  <link rel="stylesheet" href="style.css?v=23">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -1051,6 +1051,44 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 .isi-filter input { width: 1rem; height: 1rem; }
 
+/* ---- Pemilih sekolah di dialog Cetak Rekap Nilai ----
+
+   Satu tombol selebar dialog per sekolah, digulir di dalam kotaknya sendiri.
+   `max-height` dipatok supaya tombol silang di pojok dan kotak carinya tidak
+   terdorong keluar layar begitu daftarnya panjang: 23 sekolah hari ini muat,
+   ratusan tahun depan tidak, dan yang pertama hilang dari layar justru kotak
+   cari yang dibutuhkan untuk memendekkannya.
+
+   Nama di kiri, jumlah regu di kanan — `space-between`, bukan dua kolom grid.
+   Nama sekolah panjangnya berbeda-beda dan boleh membungkus; angkanya selalu
+   satu atau dua digit dan tetap menempel di tepi kanan, jadi mata menyusurinya
+   lurus ke bawah dari baris ke baris. */
+/* Kotak carinya TIDAK memakai `.small-input`. Kelas itu berarti "kotak angka
+   di dalam tabel": `input.small-input` mematoknya 4,5rem dan meratakan isinya
+   ke tengah, jadi contoh isian "Ketik nama sekolah…" terpotong jadi "Ketik"
+   di kotak selebar tujuh huruf. Bentuknya disamakan dengan `.cari-filter`
+   milik saringan sekolah di tabel — pekerjaannya memang sama, dan orang di
+   meja ini sudah memakainya. */
+.cari-sekolah-cetak {
+  width: 100%; box-sizing: border-box; margin-top: .6rem;
+  padding: .45rem .6rem; border: 2px solid #9aa3ad; border-radius: 6px;
+  font-size: .9rem; font-family: inherit; background: #fff; color: #1c2430;
+}
+.cari-sekolah-cetak:focus {
+  outline: none; border-color: #00695c; box-shadow: 0 0 0 3px rgba(0,105,92,.18);
+}
+
+.daftar-cetak-sekolah {
+  display: flex; flex-direction: column; gap: .35rem;
+  max-height: 46vh; overflow-y: auto; margin-top: .6rem;
+}
+.daftar-cetak-sekolah .button[hidden] { display: none; }
+.pilih-sekolah-cetak {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .6rem; text-align: left; width: 100%; margin: 0;
+}
+.pilih-sekolah-cetak > span:first-child { flex: 1; }
+
 .kepala-klasemen { display: flex; align-items: center; gap: .5rem; margin: 0 0 .8rem; }
 .kepala-klasemen h2 { margin: 0; text-align: center; }
 .kepala-klasemen .sisi { flex: 1; display: flex; }
@@ -1644,6 +1682,81 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }
+
+  /* ---- REKAP NILAI: A4 MELINTANG, DUA LEMBAR PER GOLONGAN ----
+
+     Kertas ini DIBACA, bukan ditulisi, dan itu yang memisahkannya dari lembar
+     pos beberapa blok di atas. Lembar pos menjaga tinggi baris tetap rata
+     karena mata menyusuri mendatar dari nomor dada ke kotak yang akan ditulisi;
+     di sini tidak ada yang ditulisi, jadi nama yang membungkus cuma tidak enak
+     dilihat — sementara nama yang DIPOTONG kehilangan gunanya sebagai cek
+     silang. Karena itu tabelnya `auto`, bukan `fixed`: lebar diserahkan ke
+     isinya, dan yang terpanjang yang menentukan.
+
+     KENAPA DUA LEMBAR, dengan angka yang diukur di browser atas data 143 regu
+     (CLAUDE.md 15.9 dan 15.11), bukan ditaksir:
+
+       tersedia            281mm   (A4 melintang 297mm, margin 8mm dua sisi)
+       29 kolom, min-content 347,7mm   -> lebih 66mm, sepertiga kanan terpotong
+       23 kolom "Nilai"      261,8mm   -> sisa 19mm
+       11 kolom "Perjalanan" 112,5mm   -> sisa 168mm
+
+     min-content adalah selebar-sempitnya tabel itu bisa menjadi dengan setiap
+     nama sudah membungkus sehabis-habisnya. Jadi 347,7mm bukan lebar yang bisa
+     ditawar dengan mengatur persentase kolom — ia LANTAI-nya, dan lantainya
+     lebih tinggi daripada kertasnya.
+
+     Yang menghabiskannya kepala kolom, bukan angkanya: "Pengetahuan Umum",
+     "Kepramukaan", "Berangkat" adalah kata yang tidak bisa dipatahkan, dan
+     7pt adalah BATAS BAWAH huruf (CLAUDE.md 8.6) — di bawah itu fotokopi
+     menutup lubang huruf a, e, dan o. Kalau suatu tahun kolomnya bertambah
+     lagi, yang dibelah lembarnya — bukan ukuran hurufnya.
+
+     Padding 1,5pt dan huruf besar yang dimatikan berasal dari hitungan yang
+     sama: "BERANGKAT" di 7pt butuh ~15mm, "Berangkat" ~12mm, dan selisih 3mm
+     itu langsung jatuh ke kolom nama. */
+  @page rekap-cetak { size: A4 landscape; margin: 8mm; }
+  .rekap-cetak { page: rekap-cetak; }
+
+  .rekap-cetak h1 { font-size: 11pt; margin-bottom: .2rem; }
+  .rekap-cetak .lembar-kepala { font-size: 8pt; margin: 0; }
+  .rekap-cetak .print-table { margin-top: 3pt; }
+  /* Padding 1pt/1,5pt, bukan 1,5pt/2pt. Selisihnya 1pt per kolom, dan pada 17
+     kolom itu 6mm — diukur, dan itulah yang memindahkan lembar terlebar dari
+     284,7mm (terpotong) ke dalam kertas. */
+  .rekap-cetak .print-table th,
+  .rekap-cetak .print-table td {
+    font-size: 7pt; padding: 1pt 1.5pt; line-height: 1.15;
+  }
+  /* Huruf besar dimatikan untuk lebarnya, dan tebalnya yang menggantikan
+     tugasnya memisahkan kepala dari isi. Garis bawah tebal tetap ada dari
+     aturan `.print-table th` umum. */
+  .rekap-cetak .print-table th { text-transform: none; text-align: center; }
+  /* Sel ANGKA tidak boleh membungkus: "01:14" yang patah jadi dua baris
+     membaca seperti dua angka.
+
+     KEPALA KOLOM justru HARUS boleh membungkus, dan itu bukan selera:
+     dengan `nowrap` di kepala, lembar terlebar terukur 305,7mm dari 281mm
+     yang tersedia — "Pengetahuan Umum" dan "Balap Karung" sendirian memaksa
+     kolomnya selebar kalimatnya. Membungkus di spasinya membawanya ke
+     222,7mm. Kepala tabel memang dua baris, jadi tingginya sudah ada.
+
+     Keduanya dipisahkan lewat kelas, bukan lewat nth-child — nomor kolomnya
+     bergeser setiap kali sebuah lomba ditambahkan tahun depan (CLAUDE.md
+     15.5). */
+  .rekap-cetak .print-table td.text-center { white-space: nowrap; }
+  /* `break-word` dan BUKAN `anywhere`. Keduanya terbaca mirip dan hasilnya
+     berlawanan: `anywhere` ikut mengecilkan lebar min-content kolomnya, jadi
+     tabel `auto` memberi kolom Regu dan Organisasi hanya 14mm dan memotong
+     297 kata di tengah — "SINDANGKA/SIH". Diukur, bukan dibaca (CLAUDE.md
+     15.9). `break-word` menahan lebar kolomnya di kata terpanjang, jadi nama
+     hanya membungkus di spasi. */
+  .rekap-cetak .print-table td { overflow-wrap: break-word; }
+  /* Batas antar-pos: garis tegak yang lebih tebal, bukan raster (bagian 8.2).
+     Di layar `.rekap-batas` sudah punya arti yang sama; di kertas ia harus
+     ditulis lagi karena aturan layarnya duduk di luar @media print. */
+  .rekap-cetak .print-table th.rekap-batas,
+  .rekap-cetak .print-table td.rekap-batas { border-right-width: 1.5pt; }
 }
 
 @page { margin: 12mm; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 22, sidik: "87aa299b3a8e" },
+  "style.css": { versi: 23, sidik: "ecc91c5f7209" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/live_score_poin.test.mjs
+++ b/tests/live_score_poin.test.mjs
@@ -12,6 +12,14 @@
 // Kalau suatu hari tabelnya dipindah ke fungsi tersendiri yang bisa dipanggil
 // langsung, tes ini yang pertama harus ditulis ulang — dan itu perbaikan,
 // bukan kerusakan.
+//
+// SEBELAH PANITIA SUDAH BEGITU. Sel kolom pos pindah ke selPosRegu(), karena
+// cetakan Rekap Nilai memakai aturan yang sama dan dua salinannya akan
+// menyimpang (CLAUDE.md 11.9). Jadi yang dipotong di bawah bukan lagi badan
+// kartuGolongan melainkan badan fungsi itu — DITAMBAH satu pemeriksaan bahwa
+// papannya memang memanggilnya. Tanpa yang kedua, seseorang bisa menuliskan
+// salinan kedua di dalam tabel dan tes ini tetap hijau: yang diperiksanya
+// fungsi yang tidak lagi dipakai siapa pun.
 // ============================================================================
 
 import assert from "node:assert/strict";
@@ -21,9 +29,18 @@ import test from "node:test";
 const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
 const live = await readFile(new URL("../live/live.js", import.meta.url), "utf8");
 
-/** Badan `kartuGolongan` di app.js — tabel Live Score panitia. Dipotong dari
- *  sumbernya supaya aturan di sini tidak salah mengenai layar Rekapitulasi,
- *  yang memang MASIH menggambar angka mentah dan memang harus begitu. */
+/** Badan `selPosRegu` di app.js — sel kolom pos papan Live Score panitia,
+ *  dan sel yang sama di cetakan Rekap Nilai. Dipotong dari sumbernya supaya
+ *  aturan di sini tidak salah mengenai layar Rekapitulasi, yang memang MASIH
+ *  menggambar angka mentah dan memang harus begitu. */
+const selPanitia = (() => {
+  const awal = app.indexOf("function selPosRegu(k, posKolom, rekapDada) {");
+  const akhir = app.indexOf("/** Blok cetak Rekap Nilai", awal);
+  assert.ok(awal >= 0 && akhir > awal, "selPosRegu tidak ditemukan di app.js");
+  return app.slice(awal, akhir);
+})();
+
+/** Badan `kartuGolongan` — tabel Live Score panitia itu sendiri. */
 const papanPanitia = (() => {
   const awal = app.indexOf("const kartuGolongan = (g) => {");
   const akhir = app.indexOf("const GOL = URUT_GOLONGAN;", awal);
@@ -42,12 +59,24 @@ const papanPeserta = (() => {
 test("sel lomba panitia membaca poin per komponen, bukan nilai mentah", () => {
   // Poin per komponen kini dijumlahkan per LOMBA sebelum digambar — sumbernya
   // tetap `poin` dari rekap.json (0107), yang berubah cuma pengelompokannya.
-  assert.match(papanPanitia, /ringkasLomba\(l, k\.golongan, p\.nomor, poinKomponen\)/,
+  assert.match(selPanitia, /const poinKomponen = rk\.poin \|\| \{\};/,
+    "selPosRegu tidak lagi mengambil poin per komponen dari rekap");
+  assert.match(selPanitia, /ringkasLomba\(l, k\.golongan, p\.nomor, poinKomponen\)/,
     "sel Live Score panitia tidak lagi membaca poin per komponen");
-  assert.match(papanPanitia, /selPoin\(r\.jumlah\)/,
+  assert.match(selPanitia, /angkaRapi\(r\.jumlah\)/,
     "sel Live Score panitia tidak menggambar jumlah poin lombanya");
-  assert.doesNotMatch(papanPanitia, /selRekap\(/,
-    "sel Live Score panitia kembali menggambar angka mentah lewat selRekap()");
+  assert.doesNotMatch(selPanitia, /selRekap\(|nilaiBagian\(/,
+    "sel Live Score panitia kembali menggambar angka mentah");
+});
+
+test("papan panitia memakai selPosRegu, bukan salinan kedua di dalam tabel", () => {
+  // Pagar untuk tes di atas: yang diperiksanya fungsi, jadi fungsi yang tidak
+  // dipanggil siapa pun akan tetap melaporkan hijau.
+  assert.match(papanPanitia, /\$\{selPosRegu\(k, posKolom, rekapDada\)/,
+    "tabel Live Score tidak lagi merakit sel pos lewat selPosRegu()");
+  assert.doesNotMatch(papanPanitia, /ringkasLomba\(/,
+    "aturan lomba-per-golongan ditulis ulang di dalam tabel — "
+    + "salinan kedua yang suatu hari berbeda pendapat dengan kertasnya");
 });
 
 test("sel lomba peserta membaca poin per komponen, bukan nilai mentah", () => {

--- a/tests/live_score_rekap_print.test.mjs
+++ b/tests/live_score_rekap_print.test.mjs
@@ -1,0 +1,211 @@
+// ============================================================================
+// hrcd-rekap : tests/live_score_rekap_print.test.mjs
+// Cetak Rekap Nilai dari layar Live Score — per sekolah dan seluruhnya.
+//
+// Diuji atas SUMBER, bukan atas DOM, dengan alasan yang sama seperti
+// live_score_poin.test.mjs: layarnya menuntut enam permintaan jaringan lebih
+// dulu, dan yang perlu dijaga di sini bentuk yang dipilih.
+//
+// Empat hal yang bisa rusak tanpa satu pun galat, dan itulah yang diperiksa:
+//
+//   1. kertas dan layar memakai perakit kolom yang SAMA. Dua salinan aturan
+//      "lomba mana yang berlaku untuk golongan ini" akan menyimpang, dan yang
+//      menyimpang tidak menggagalkan apa pun — ia cuma membuat keduanya saling
+//      membantah di depan pembina yang memegang keduanya (CLAUDE.md 11.9).
+//   2. kepala dan badan tabel sepasang. Kalau yang satu menambah kolom "Nilai"
+//      dan yang lain tidak, seluruh tabel bergeser satu kolom: nilai Pos 2
+//      tercetak di bawah judul Pos 3, dan kertas itu terlihat benar sampai ada
+//      yang mencocokkannya dengan layar.
+//   3. window.print() tetap di dalam giliran event tap. Safari iPhone
+//      memblokirnya sesudah `await`, dan yang gagal cuma DIAM — tombolnya
+//      ditekan, tidak ada yang keluar, tidak ada pesan.
+//   4. nol baris tidak menghasilkan kertas kosong.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+/** Badan `siapkanCetakRekap` — perakit kertasnya. */
+const cetakan = (() => {
+  const awal = app.indexOf("function siapkanCetakRekap({");
+  const akhir = app.indexOf("/* Dibatalkan tiap kali layar Live Score", awal);
+  assert.ok(awal >= 0 && akhir > awal, "siapkanCetakRekap tidak ditemukan");
+  return app.slice(awal, akhir);
+})();
+
+/** Bagian layar Live Score yang memasang kedua tombol cetak. */
+const pemasang = (() => {
+  const awal = app.indexOf("  /* ---- Cetak Rekap Nilai ----");
+  const akhir = app.indexOf("  /* Diperbarui DI TEMPAT", awal);
+  assert.ok(awal >= 0 && akhir > awal, "pemasang tombol cetak tidak ditemukan");
+  return app.slice(awal, akhir);
+})();
+
+test("kedua tombol ada di layar Live Score", () => {
+  assert.match(app, /id="cetak-rekap-sekolah"/,
+    "tombol Rekap Nilai per Sekolah tidak digambar");
+  assert.match(app, /id="cetak-rekap-semua"/,
+    "tombol Rekap Nilai Semua tidak digambar");
+  // Papan kosong tidak boleh menawarkan cetak: yang bisa dihasilkannya cuma
+  // kertas kosong.
+  assert.match(app, /const cetakRekap = !klasemen\.length \? "" :/,
+    "tombol cetak masih digambar saat belum ada regu yang bisa diperingkat");
+});
+
+test("kertas memakai perakit kolom yang sama dengan layar", () => {
+  assert.match(cetakan, /kepalaPosRekap\(posKolom\)/,
+    "kepala kolom kertas tidak lagi datang dari kepalaPosRekap()");
+  assert.match(cetakan, /selPosRegu\(k, posKolom, rekapDada\)/,
+    "sel kertas tidak lagi datang dari selPosRegu()");
+  assert.doesNotMatch(cetakan, /ringkasLomba\(|varianUntuk\(/,
+    "aturan lomba-per-golongan ditulis ulang di dalam perakit kertas");
+});
+
+test("kepala dan badan tiap lembar jumlah kolomnya sepasang", () => {
+  // Kolom pos datang dari satu sumber untuk kepala dan badan, jadi yang dijaga
+  // di sini kolom yang diketik DUA KALI — sekali sebagai <th rowspan="2">,
+  // sekali sebagai <td>. Di situlah keduanya bisa berselisih, dan selisih satu
+  // kolom menggeser seluruh tabel tanpa satu pun galat.
+  const identitasTh = (cetakan.match(/const kepalaIdentitas = `([\s\S]*?)`;/) || [])[1];
+  const identitasTd = (cetakan.match(/const selIdentitas = \(k\) => `([\s\S]*?)`;/) || [])[1];
+  assert.ok(identitasTh && identitasTd, "blok identitas kertas tidak ditemukan");
+  // `[ >]` dan bukan spasi saja: kolom Regu ditulis `<td>` tanpa atribut.
+  assert.equal((identitasTh.match(/<th[ >]/g) || []).length, 4,
+    "kolom identitas bukan 4 — # / No Dada / Regu / Organisasi");
+  assert.equal((identitasTd.match(/<td[ >]/g) || []).length, 4,
+    "sel identitas tidak sebanyak kepalanya");
+
+  // Kelompok perjalanan: enam kepala, enam sel. Nomornya diketik di `lebar`,
+  // dan `lebar` itulah yang dipakai pengepakan lembar di bawah — kalau ia
+  // berbohong, satu lembar diisi lebih banyak kolom daripada yang muat.
+  // Dibatasi sampai KELOMPOK ditutup: di bawahnya ada <th> Total milik
+  // template halaman, dan tanpa batas itu ia ikut terhitung sebagai kolom
+  // perjalanan.
+  const jalan = cetakan.slice(cetakan.indexOf("      lebar: 6,"),
+                              cetakan.indexOf("const LEMBAR = [];"));
+  const kepalaJalan = (jalan.match(/<th rowspan="2"/g) || []).length;
+  const selJalan = (jalan.slice(jalan.indexOf("sel: (k) =>")).match(/<td class="text-center/g) || []).length;
+  assert.equal(kepalaJalan, 6,
+    "kelompok perjalanan bukan 6 kolom — kontrak/kloter/berangkat/datang/"
+    + "anggota/penalti");
+  assert.equal(selJalan, kepalaJalan,
+    `kelompok perjalanan: ${kepalaJalan} kepala, ${selJalan} sel`);
+  assert.match(jalan, /lebar: 6,/,
+    "`lebar` kelompok perjalanan tidak sesuai jumlah kolomnya");
+});
+
+test("kolom dibelah antar-lembar, selalu di ANTARA pos", () => {
+  // 29 kolom tidak muat di A4 melintang — min-content terukur 347,7mm atas
+  // kertas 281mm. Pembelahannya yang membuat seluruh kolom tetap ikut
+  // tercetak; alasan lengkapnya di kepala siapkanCetakRekap().
+  assert.match(app, /const KOLOM_NILAI_PER_LEMBAR = 12;/,
+    "jatah kolom per lembar berubah tanpa diukur ulang — angkanya datang dari "
+    + "pengukuran di browser, lihat komentar di atasnya");
+  assert.match(cetakan, /const KELOMPOK = \[/,
+    "kolom tidak lagi dikelompokkan per pos");
+  // Kelompok dimasukkan UTUH: pos yang terbelah dua lembar akan mencetak
+  // kepala "Pos 3 · P3K" dua kali di atas separuh kolomnya masing-masing.
+  assert.match(cetakan, /akhir\.lebar \+ kel\.lebar <= KOLOM_NILAI_PER_LEMBAR/,
+    "kelompok tidak lagi dimasukkan utuh — pembelahan bisa jatuh di tengah pos");
+  assert.match(cetakan, /LEMBAR\.map\(\(lembar, i\) =>/,
+    "lembar tidak digambar per golongan");
+
+  // Tiap lembar berdiri sendiri: yang berpindah tangan tanpa nomor dada tidak
+  // bisa dicocokkan dengan apa pun, dan Total adalah angka yang paling sering
+  // dicari di lembar mana pun.
+  assert.match(cetakan, /\$\{kepalaIdentitas\}\$\{lembar\.kelompok\.map\(x => x\.atas\)/,
+    "kolom identitas tidak ikut di setiap lembar");
+  assert.match(cetakan, /\$\{selIdentitas\(k\)\}\$\{\s*\r?\n?\s*lembar\.kelompok\.map\(x => x\.sel\(k\)\)/,
+    "sel identitas tidak ikut di setiap lembar");
+  assert.match(cetakan, /<th rowspan="2">Total<\/th>/,
+    "kolom Total tidak ada di kepala tiap lembar");
+  assert.match(cetakan, /\}\$\{selTotal\(k\)\}<\/tr>/,
+    "kolom Total tidak ada di badan tiap lembar");
+  assert.match(cetakan, /Lembar \$\{i \+ 1\}\/\$\{LEMBAR\.length\}/,
+    "halaman tidak menyebut lembar keberapa dari berapa");
+});
+
+test("satu bagian per golongan, bukan satu tabel campuran", () => {
+  assert.match(cetakan, /URUT_GOLONGAN\s*\r?\n?\s*\.map\(g => \[g, baris\.filter/,
+    "kertas tidak lagi dipisah per golongan");
+  assert.match(cetakan, /GOLONGAN_LABEL\[g\] \|\| g/,
+    "judul bagian tidak menyebut golongannya");
+  // Peringkat adalah peringkat DI DALAM golongan; satu tabel campuran akan
+  // mencetak empat baris bernomor 1.
+  assert.doesNotMatch(cetakan, /<th rowspan="2">Golongan<\/th>/,
+    "golongan kembali jadi kolom ke-30, padahal ia sudah jadi judul bagian");
+});
+
+test("medali tidak ikut tercetak", () => {
+  // Emoji keluar sebagai gambar berwarna atau kotak kosong tergantung printer
+  // dan fon yang ada di alat itu.
+  assert.doesNotMatch(cetakan, /MEDALI\[/,
+    "kertas menggambar medali emoji, yang tidak bisa diandalkan di printer");
+  assert.match(cetakan, /esc\(String\(k\.peringkat \?\? ""\)\)/,
+    "kertas tidak menggambar angka peringkatnya");
+});
+
+test("print dipanggil tanpa melewati await, di kedua alur", () => {
+  // Komentarnya dibuang lebih dulu. Alasan aturan ini justru dijelaskan di
+  // komentar tepat di atas kodenya, dan kata "await" di dalam kalimat itu
+  // akan menggagalkan tes yang membaca sumbernya apa adanya.
+  const kode = pemasang.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+
+  const sebelumPrint = kode.slice(0, kode.indexOf("window.print();"));
+  assert.match(kode, /window\.print\(\);/, "window.print() tidak dipanggil");
+  assert.doesNotMatch(sebelumPrint, /\bawait\b/,
+    "Safari iPhone memblokir print bila ada await lebih dulu");
+
+  // Alur per sekolah: dialognya TIDAK di-await lalu dicetak sesudahnya —
+  // klik pada nama sekolah itu sendiri yang mencetak, masih di dalam
+  // giliran tap-nya.
+  assert.doesNotMatch(kode, /\bawait\b/,
+    "ada await di alur cetak — dialog pemilih sekolah tidak boleh ditunggu, "
+    + "karena print() sesudahnya mati di iPhone");
+  assert.match(kode, /tutup\(null\);\s*\r?\n\s*cetak\(nm,/,
+    "klik nama sekolah tidak langsung mencetak di dalam giliran tap-nya");
+});
+
+test("nol baris tidak menghasilkan kertas kosong", () => {
+  const posisiKosong = cetakan.indexOf("if (!jumlah) return 0;");
+  const posisiPasang = cetakan.lastIndexOf("document.body.appendChild");
+  assert.notEqual(posisiKosong, -1, "perakit kertas tidak menolak nol baris");
+  assert.ok(posisiKosong < posisiPasang,
+    "penolakan nol baris terjadi sesudah cetakan dipasang ke body");
+  assert.match(pemasang, /if \(!siapkanCetakRekap\(/,
+    "layar tidak memeriksa hasil perakit sebelum membuka dialog print");
+});
+
+test("daftar sekolah dibangun dari klasemen, bukan dari seluruh peserta", () => {
+  // Sekolah yang regunya belum satu pun berangkat tidak punya baris untuk
+  // dicetak, dan menawarkannya cuma menghasilkan kertas kosong.
+  assert.match(pemasang, /for \(const k of klasemen\) \{/,
+    "daftar sekolah di dialog tidak dibangun dari klasemen");
+  assert.match(pemasang, /localeCompare\(b\[0\], "id"\)/,
+    "daftar sekolah tidak diurutkan menurut abjad Indonesia");
+});
+
+test("kertas A4 melintang dan hurufnya tidak di bawah 7pt", () => {
+  assert.match(css, /@page rekap-cetak \{ size: A4 landscape;/,
+    "lembar rekap tidak diatur A4 melintang");
+  assert.match(css, /\.rekap-cetak \{ page: rekap-cetak; \}/,
+    "lembar rekap tidak memakai @page-nya sendiri");
+
+  // CLAUDE.md 8.6: di bawah 7pt fotokopi menutup lubang huruf a, e, dan o.
+  const blok = css.slice(css.indexOf("@page rekap-cetak"),
+                         css.indexOf("@page { margin: 12mm; }"));
+  assert.ok(blok.length > 0, "blok CSS lembar rekap tidak ditemukan");
+  for (const [, ukuran] of blok.matchAll(/font-size: ([\d.]+)pt/g)) {
+    assert.ok(Number(ukuran) >= 7,
+      `lembar rekap memakai ${ukuran}pt — batas bawahnya 7pt (CLAUDE.md 8.6)`);
+  }
+  // CLAUDE.md 8.5: garis di bawah 0,75pt hilang waktu difotokopi.
+  for (const [, tebal] of blok.matchAll(/border-right-width: ([\d.]+)pt/g)) {
+    assert.ok(Number(tebal) >= 0.75,
+      `garis ${tebal}pt di bawah batas 0,75pt (CLAUDE.md 8.5)`);
+  }
+});

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=20">
+  <link rel="stylesheet" href="style.css?v=21">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5521,22 +5521,270 @@ function layarButuhEdisi(judul) {
     async () => { try { EDISI = await infoEdisi(); } catch {} arahkan(); }));
 }
 
-/** Satu sel Live Score: POIN AKHIR komponen itu, bukan angka mentahnya.
+/** Kepala kolom pos untuk tabel rekap — SATU entri per pos, dua baris kepala
+ *  masing-masing. Dipakai papan Live Score DAN cetakannya.
  *
- *  Angka mentah tidak bisa dibandingkan antar kolom — "4" di Semaphore, "8.55"
- *  di Menaksir, dan "01:14" di Bakiak adalah tiga satuan yang berbeda, dan
- *  tidak satu pun menyebut sumbangannya ke Total di ujung baris. Papan ini
- *  dibaca justru oleh orang yang tidak memegang tangga poin tiap lomba:
- *  pembina, peserta, dan panitia yang bukan juri lomba itu.
+ *  Mengembalikan larik, bukan dua string jadi, karena kertas memerlukan
+ *  kelompoknya utuh: 29 kolom tidak muat di satu lembar A4 dan pembelahannya
+ *  harus jatuh di ANTARA pos, tidak pernah di tengah-tengah pos. Papan di
+ *  layar merangkainya kembali dengan join("") dan mendapat bentuk yang sama
+ *  seperti sebelumnya.
  *
- *  Angkanya datang JADI dari `v_rekap_penuh.poin` (migrasi 0107). Layar tidak
- *  menghitungnya sendiri — alasannya sama dengan Nilai Pos di layar Input Pos:
+ *  Sepasang mutlak dengan selPosRegu() di bawah. Yang satu memutuskan berapa
+ *  <th> yang digambar, yang lain berapa <td> — dan aturannya sama-sama
+ *  bergantung pada "pos ini punya lebih dari satu lomba atau tidak". Kalau
+ *  keduanya pernah berbeda pendapat, seluruh tabel bergeser satu kolom tanpa
+ *  satu pun galat: nilai Pos 2 tercetak di bawah judul Pos 3, dan kertas itu
+ *  terlihat benar sampai ada yang mencocokkannya dengan layar. `lebar` di tiap
+ *  entri adalah angka yang menyatukan keduanya.
+ *
+ *  Kolom "Nilai" per pos hanya digambar kalau posnya memuat LEBIH DARI SATU
+ *  lomba. Pos 4 cuma punya PBB dan Pos 5 cuma punya Yel-Yel: di sana
+ *  "PBB 82 | Nilai 82" adalah angka yang sama dua kali, bersebelahan. */
+const kepalaPosRekap = (posKolom) => posKolom.map(p => {
+  const satuLomba = p.lomba.length === 1;
+  const lebar = p.lomba.length + (satuLomba ? 0 : 1);
+  return {
+    lebar,
+    atas: `<th colspan="${lebar}" class="rekap-batas">Pos ${esc(String(p.nomor))} · ${esc(p.name)}</th>`,
+    bawah: p.lomba.map((l, i) =>
+      `<th class="pos-kol${satuLomba && i === p.lomba.length - 1
+        ? " rekap-batas" : ""}">${esc(l.nama)}</th>`).join("")
+      + (satuLomba ? "" : `<th class="pos-kol rekap-batas">Nilai</th>`),
+  };
+});
+
+/** Sel kolom pos untuk SATU regu — dipakai papan Live Score DAN cetakannya.
+ *
+ *  Mengembalikan TEKS beserta penandanya, bukan HTML jadi: papan membungkus
+ *  lomba yang tidak berlaku dengan <span class="sel-mati"> supaya ia pudar di
+ *  antara angka, sedangkan kertas cukup mencetak tanda hubungnya — pucat di
+ *  kertas yang difotokopi justru hilang (CLAUDE.md 8.4).
+ *
+ *  Satu tempat, karena dua salinan aturan "lomba mana yang berlaku untuk
+ *  golongan ini" persis bentuk kegagalan yang sudah terjadi di sistem ini
+ *  (CLAUDE.md 11.9, dan varianUntuk() di util.js ditulis untuk alasan yang
+ *  sama). Salinan yang menyimpang tidak menggagalkan apa pun — ia cuma
+ *  membuat layar dan kertas saling membantah di depan pembina yang sedang
+ *  memegang keduanya.
+ *
+ *  `berlaku === 0` berarti lomba itu memang bukan untuk golongan regu ini,
+ *  BUKAN berarti nilainya belum masuk. Poin per KOMPONEN (0107) mengisi sel
+ *  lomba, poin per POS mengisi kolom Nilai di ujung tiap kelompok — dua hal
+ *  berbeda, dua kunci berbeda (`pos.kode` lawan `pos`).
+ *
+ *  Yang keluar POIN AKHIR komponennya, bukan angka mentahnya. Angka mentah
+ *  tidak bisa dibandingkan antar kolom — "4" di Semaphore, "8.55" di Menaksir,
+ *  dan "01:14" di Bakiak adalah tiga satuan berbeda, dan tidak satu pun
+ *  menyebut sumbangannya ke Total di ujung baris. Papan dan kertas ini justru
+ *  dibaca orang yang tidak memegang tangga poin tiap lomba: pembina, peserta,
+ *  dan panitia yang bukan juri lomba itu.
+ *
+ *  Angkanya datang JADI dari `v_rekap_penuh.poin` (migrasi 0107). Tidak ada
+ *  yang dihitung di sini — alasannya sama dengan Nilai Pos di layar Input Pos:
  *  mesin skor kedua adalah mesin skor yang suatu hari berbeda pendapat dengan
  *  yang pertama.
  *
- *  Kosong berarti komponennya belum dinilai. Nol yang SUDAH dinilai tetap
+ *  Sel kosong berarti komponennya belum dinilai. Nol yang SUDAH dinilai tetap
  *  tergambar "0" — itu angka, bukan ketiadaan. */
-const selPoin = (v) => esc(angkaRapi(v));
+function selPosRegu(k, posKolom, rekapDada) {
+  const rk = rekapDada.get(k.nomor_dada) || {};
+  const poinKomponen = rk.poin || {};
+  const poin = k.poin_per_pos || {};
+  return posKolom.flatMap(p => {
+    const satuLomba = p.lomba.length === 1;
+    const sel = p.lomba.map((l, i) => {
+      const r = ringkasLomba(l, k.golongan, p.nomor, poinKomponen);
+      const batas = satuLomba && i === p.lomba.length - 1;
+      if (!r.berlaku) return { teks: "–", mati: true, batas };
+      return { teks: r.terisi ? angkaRapi(r.jumlah) : "–", batas };
+    });
+    if (!satuLomba) {
+      const v = poin[String(p.nomor)];
+      sel.push({ teks: v === undefined ? "–" : angkaRapi(v),
+                 nilai: true, batas: true });
+    }
+    return sel;
+  });
+}
+
+/** Berapa KOLOM NILAI yang muat di satu lembar, di luar empat kolom identitas
+ *  dan kolom Total yang selalu ikut.
+ *
+ *  DIUKUR DI BROWSER atas data 143 regu, bukan ditaksir (CLAUDE.md 15.9 dan
+ *  15.11). Pada 12 kolom nilai satu lembar berisi 17 kolom, dan lebar
+ *  min-content-nya \u2014 selebar-sempitnya tabel itu bisa menjadi dengan setiap
+ *  nama sudah membungkus di spasinya \u2014 terukur 222,7mm dari 281mm yang
+ *  tersedia (A4 melintang 297mm dikurangi margin 8mm dua sisi). Sisa 58mm,
+ *  dan sisa itulah yang membuat nama regu dan sekolah TIDAK PERNAH dipatah
+ *  di tengah kata.
+ *
+ *  Angka ini tidak boleh dinaikkan tanpa diukur ulang. Seluruh 29 kolom dalam
+ *  satu lembar pernah dicoba dan lebar min-content-nya 347,7mm \u2014 lebih 66mm
+ *  dari kertasnya, jadi sepertiga kanan tabel terpotong. Yang menghabiskannya
+ *  kepala kolom, bukan angkanya: "Pengetahuan Umum", "Kepramukaan",
+ *  "Berangkat" adalah kata yang tidak bisa dipatahkan, dan 7pt adalah BATAS
+ *  BAWAH huruf (CLAUDE.md 8.6). Kalau kolomnya bertambah lagi tahun depan,
+ *  yang bertambah lembarnya \u2014 bukan yang berkurang ukuran hurufnya. */
+const KOLOM_NILAI_PER_LEMBAR = 12;
+
+/** Blok cetak Rekap Nilai \u2014 isinya kolom yang SAMA dengan papan Live Score,
+ *  lewat kepalaPosRekap() dan selPosRegu() yang sama.
+ *
+ *  SATU BAGIAN PER GOLONGAN, bukan satu tabel campuran. Keempat golongan
+ *  berlomba terpisah (CLAUDE.md bagian 11), dan peringkat di kolom # adalah
+ *  peringkat DI DALAM golongannya \u2014 satu tabel campuran akan mencetak empat
+ *  baris bernomor 1 tanpa satu pun keterangan kenapa. Urutan bagiannya
+ *  URUT_GOLONGAN, sama dengan tab di layar dan dengan corong saat juara
+ *  diumumkan. Golongan karena itu TIDAK jadi kolom ke-30: ia judul bagian,
+ *  tempat ia terbaca sekali per halaman alih-alih diulang di tiap baris.
+ *
+ *  TIAP GOLONGAN DIBELAH LAGI JADI BEBERAPA LEMBAR, sebanyak yang diperlukan
+ *  KOLOM_NILAI_PER_LEMBAR di atas. Pembelahannya selalu jatuh DI ANTARA pos,
+ *  tidak pernah di tengah-tengah pos: kepala "Pos 3 \u00b7 P3K" membentang di atas
+ *  kolom-kolomnya, dan pos yang terbelah dua lembar akan mencetak kepala itu
+ *  dua kali di atas separuh kolomnya masing-masing.
+ *
+ *  Empat kolom identitas dan kolom Total ADA DI SETIAP LEMBAR. Itu yang
+ *  membuat tiap lembar berdiri sendiri: kertas ini beredar sebagai lembaran
+ *  lepas, dan lembar tanpa nomor dada tidak bisa dicocokkan dengan apa pun,
+ *  sementara Total adalah angka yang paling sering dicari di lembar mana pun.
+ *
+ *  Kolom perjalanan \u2014 kontrak, kloter, berangkat, datang, anggota, penalti \u2014
+ *  ikut sebagai satu kelompok utuh di belakang pos terakhir, dan urutan itu
+ *  yang membuatnya berguna: Penalti selalu dibaca dengan pertanyaan "dari
+ *  mana", dan jawabannya persis kolom-kolom di sebelahnya.
+ *
+ *  Nama regu dan sekolah MEMBUNGKUS, tidak dipotong: nama yang terpotong
+ *  kehilangan gunanya sebagai cek silang, sementara baris yang tingginya tidak
+ *  rata cuma tidak enak dilihat. Kertas ini DIBACA, bukan ditulisi \u2014 garis
+ *  pandang mendatar yang dijaga lembar pos (CLAUDE.md 8) tidak sedang
+ *  dipertaruhkan di sini.
+ *
+ *  Yang tercetak persis yang tergambar: `baris` datang dari klasemen layar,
+ *  jadi ia sudah tersaring ke regu yang SUDAH BERANGKAT dan sudah terurut.
+ *  Kertas yang diam-diam berbeda dari layar yang tombolnya baru saja ditekan
+ *  adalah kertas yang salah. Buka ulang layar untuk mengambil nilai terbaru.
+ *
+ *  Mengembalikan jumlah baris yang benar-benar masuk cetakan, supaya
+ *  pemanggilnya bisa menolak membuka dialog cetak untuk nol baris \u2014 kertas
+ *  kosong yang keluar dari printer tidak menjelaskan apa pun. */
+function siapkanCetakRekap({ judul, baris, posKolom, rekapDada }) {
+  document.getElementById("cetakan")?.remove();
+  const dicetak = tanggalJam(new Date().toISOString());
+  const kepalaPos = kepalaPosRekap(posKolom);
+
+  const isiGolongan = URUT_GOLONGAN
+    .map(g => [g, baris.filter(k => k.golongan === g)])
+    .filter(([, isi]) => isi.length);
+  const jumlah = isiGolongan.reduce((n, isi) => n + isi[1].length, 0);
+  if (!jumlah) return 0;
+
+  /* Empat kolom identitas, sama di setiap lembar. Angka peringkatnya saja,
+     TANPA medali: medali di papan adalah emoji, dan emoji di kertas keluar
+     sebagai gambar berwarna atau kotak kosong tergantung printer dan fon yang
+     ada di alat itu \u2014 dua hal yang tidak diketahui saat kertasnya dibangun.
+     Angkanya sendiri sudah menyebut peringkatnya. */
+  const kepalaIdentitas = `
+    <th rowspan="2">#</th>
+    <th rowspan="2">No Dada</th>
+    <th rowspan="2">Regu</th>
+    <th rowspan="2" class="rekap-batas">Organisasi</th>`;
+  const selIdentitas = (k) => `
+    <td class="text-center">${esc(String(k.peringkat ?? ""))}</td>
+    <td class="text-center">${esc(dada3(k.nomor_dada))}</td>
+    <td>${esc(k.nama_regu)}</td>
+    <td class="rekap-batas">${esc(k.nama_sekolah)}</td>`;
+  const selTotal = (k) =>
+    `<td class="text-center"><strong>${esc(angkaRapi(k.total))}</strong></td>`;
+
+  /* KELOMPOK KOLOM \u2014 satu per pos, lalu satu untuk perjalanan. `lebar` adalah
+     angka yang menjaga kepala dan badan tetap sepasang; ia datang dari
+     kepalaPosRekap() untuk pos, dan diketik sekali di sini untuk perjalanan.
+
+     Sel pos diiris dari selPosRegu() memakai `lebar` yang sama, jadi tidak ada
+     tempat kedua yang memutuskan kolom mana milik pos mana. */
+  const KELOMPOK = [
+    ...kepalaPos.map((kp, i) => {
+      const mulai = kepalaPos.slice(0, i).reduce((n, x) => n + x.lebar, 0);
+      return {
+        lebar: kp.lebar, atas: kp.atas, bawah: kp.bawah,
+        sel: (k) => selPosRegu(k, posKolom, rekapDada)
+          .slice(mulai, mulai + kp.lebar)
+          .map(sel => `<td class="text-center${sel.batas ? " rekap-batas" : ""}">${
+            esc(sel.teks)}</td>`).join(""),
+      };
+    }),
+    {
+      lebar: 6,
+      atas: `
+        <th rowspan="2">Kontrak</th>
+        <th rowspan="2">Kloter</th>
+        <th rowspan="2">Berangkat</th>
+        <th rowspan="2">Datang</th>
+        <th rowspan="2">Anggota</th>
+        <th rowspan="2" class="rekap-batas">Penalti</th>`,
+      bawah: "",
+      sel: (k) => {
+        const rk = rekapDada.get(k.nomor_dada) || {};
+        return `
+          <td class="text-center">${esc(kontrakTeks(rk.kontrak_menit))}</td>
+          <td class="text-center">${esc(rk.kloter ?? "\u2014")}</td>
+          <td class="text-center">${esc(rk.jam_berangkat
+            ? jamMenit(rk.jam_berangkat) : "\u2014")}</td>
+          <td class="text-center">${esc(rk.jam_datang
+            ? jamMenit(rk.jam_datang) : "\u2014")}</td>
+          <td class="text-center">${esc(rk.anggota_hadir ?? "\u2014")}</td>
+          <td class="text-center rekap-batas">${esc(angkaRapi(
+            Number(k.penalti_waktu) + Number(k.penalti_checkout)
+            + Number(k.penalti_anggota)))}</td>`;
+      },
+    },
+  ];
+
+  /* Dimasukkan ke lembar secara berurutan, kelompok demi kelompok utuh.
+     Satu kelompok yang sendirian sudah melebihi jatah tetap mendapat
+     lembarnya sendiri \u2014 membelahnya di tengah pos akan mencetak kepala pos
+     yang sama di dua lembar, dan itu lebih membingungkan daripada satu lembar
+     yang agak lebih penuh. */
+  const LEMBAR = [];
+  for (const kel of KELOMPOK) {
+    const akhir = LEMBAR[LEMBAR.length - 1];
+    if (akhir && akhir.lebar + kel.lebar <= KOLOM_NILAI_PER_LEMBAR) {
+      akhir.lebar += kel.lebar;
+      akhir.kelompok.push(kel);
+    } else {
+      LEMBAR.push({ lebar: kel.lebar, kelompok: [kel] });
+    }
+  }
+
+  const halaman = isiGolongan.flatMap(([g, isi]) =>
+    LEMBAR.map((lembar, i) => `
+    <section class="print-page rekap-cetak">
+      <h1>REKAP NILAI \u00b7 ${esc(judul)} \u00b7 ${esc(GOLONGAN_LABEL[g] || g)}</h1>
+      <!-- "Lembar 1/2" ditulis di tiap halaman karena kertas ini berpindah
+           tangan sebagai lembaran lepas. Lembar kedua yang berdiri sendiri
+           tanpa penanda terbaca seperti rekap yang kehilangan separuh
+           kolomnya. -->
+      <p class="lembar-kepala">${esc(EDISI ? EDISI.name : "")} \u00b7
+         ${esc(String(isi.length))} regu \u00b7 Lembar ${i + 1}/${LEMBAR.length}
+         \u00b7 Dicetak ${esc(dicetak)}</p>
+      <table class="print-table">
+        <thead>
+          <tr>${kepalaIdentitas}${lembar.kelompok.map(x => x.atas).join("")}
+              <th rowspan="2">Total</th></tr>
+          <tr>${lembar.kelompok.map(x => x.bawah).join("")}</tr>
+        </thead>
+        <tbody>
+          ${isi.map(k => `<tr>${selIdentitas(k)}${
+            lembar.kelompok.map(x => x.sel(k)).join("")}${selTotal(k)}</tr>`).join("")}
+        </tbody>
+      </table>
+    </section>`)).join("");
+
+  document.body.appendChild(h(`<div id="cetakan" class="printout">${halaman}</div>`));
+  return jumlah;
+}
 
 /* Dibatalkan tiap kali layar Live Score dibuka lagi: panel penyaring hidup di
    <body>, jadi tidak ada yang membuangnya saat pindah layar. */
@@ -5715,6 +5963,7 @@ async function layarLiveScore() {
       lomba: kelompokLomba(kolomPos(komponen.filter(k => k.pos === p.nomor))),
     }));
   const rekapDada = new Map(rekap.map(r => [r.nomor_dada, r]));
+  const kepalaPos = kepalaPosRekap(posKolom);
   /* KEEMPAT golongan selalu digambar, dengan urutan tetap — bukan hanya yang
      kebetulan sudah punya baris.
      Empat golongan berlomba TERPISAH: masing-masing punya juara sendiri, dan
@@ -5841,8 +6090,7 @@ async function layarLiveScore() {
                        memuat LEBIH DARI SATU lomba. Pos 4 cuma punya PBB dan
                        Pos 5 cuma punya Yel-Yel: di sana "PBB 82 | Nilai 82"
                        adalah angka yang sama dua kali, bersebelahan. -->
-                  ${posKolom.map(p => `<th colspan="${p.lomba.length + (p.lomba.length > 1 ? 1 : 0)}"
-                    class="rekap-batas">Pos ${esc(String(p.nomor))} · ${esc(p.name)}</th>`).join("")}
+                  ${kepalaPos.map(x => x.atas).join("")}
                   <!-- Lima kolom perjalanan mendahului Penalti, dan urutan
                        itu yang membuatnya berguna: Penalti selalu dibaca
                        dengan pertanyaan "dari mana", dan jawabannya persis
@@ -5865,49 +6113,27 @@ async function layarLiveScore() {
                        "0 – 5" di bawah kolom berisi 80 justru membantahnya.
                        Rentangnya tetap ada di layar Input Pos dan di
                        Rekapitulasi, tempat ia memang menjawab pertanyaan. -->
-                  ${posKolom.map(p => {
-                    const satuLomba = p.lomba.length === 1;
-                    return p.lomba.map((l, i) =>
-                      `<th class="pos-kol${satuLomba && i === p.lomba.length - 1
-                        ? " rekap-batas" : ""}">${esc(l.nama)}</th>`).join("")
-                      + (satuLomba ? "" : `<th class="pos-kol rekap-batas">Nilai</th>`);
-                  }).join("")}
+                  ${kepalaPos.map(x => x.bawah).join("")}
                 </tr>
               </thead>
               <tbody>
                 ${baris.map(k => {
                   const rk = rekapDada.get(k.nomor_dada) || {};
-                  // Poin per KOMPONEN (0107) untuk sel lomba, poin per POS
-                  // untuk kolom Nilai di ujung tiap kelompok. Dua hal berbeda,
-                  // dua kunci berbeda — `pos.kode` lawan `pos`.
-                  const poinKomponen = rk.poin || {};
-                  const poin = k.poin_per_pos || {};
                   return `
                   <tr data-sekolah="${esc(k.nama_sekolah || "")}">
                     <td class="rekap-rank">${MEDALI[k.peringkat] || ""}<span class="rank-angka">${esc(String(k.peringkat ?? ""))}</span></td>
                     <td class="angka">${esc(dada3(k.nomor_dada))}</td>
                     <td>${esc(k.nama_regu)}</td>
                     <td class="rekap-batas sub-kolom">${esc(k.nama_sekolah)}</td>
-                    ${posKolom.map(p => {
-                      const satuLomba = p.lomba.length === 1;
-                      return p.lomba.map((l, i) => {
-                        // Satu lomba bisa punya baris wahana berbeda per
-                        // golongan; yang berlaku untuk regu INI yang dibaca.
-                        // `berlaku === 0` berarti lomba ini memang bukan untuk
-                        // golongannya — bukan berarti nilainya belum masuk.
-                        const r = ringkasLomba(l, k.golongan, p.nomor, poinKomponen);
-                        const batas = satuLomba && i === p.lomba.length - 1
-                          ? " rekap-batas" : "";
-                        if (!r.berlaku)
-                          return `<td class="text-center${batas}"><span class="sel-mati">–</span></td>`;
-                        return `<td class="text-center${batas}">${
-                          r.terisi ? selPoin(r.jumlah) : "–"}</td>`;
-                      }).join("")
-                      + (satuLomba ? ""
-                        : `<td class="text-center pos-nilai rekap-batas">${
-                            poin[String(p.nomor)] === undefined
-                              ? "–" : esc(angkaRapi(poin[String(p.nomor)]))}</td>`);
-                    }).join("")}
+                    <!-- Satu lomba bisa punya baris wahana berbeda per golongan;
+                         yang berlaku untuk regu INI yang dibaca. Aturannya
+                         duduk di selPosRegu(), bersama kepalaPosRekap() —
+                         kertas rekap memakai keduanya juga. -->
+                    ${selPosRegu(k, posKolom, rekapDada).map(sel =>
+                      `<td class="text-center${sel.nilai ? " pos-nilai" : ""}${
+                        sel.batas ? " rekap-batas" : ""}">${
+                        sel.mati ? `<span class="sel-mati">${esc(sel.teks)}</span>`
+                                 : esc(sel.teks)}</td>`).join("")}
                     <td class="text-center">${esc(kontrakTeks(rk.kontrak_menit))}</td>
                     <td class="text-center">${esc(rk.kloter ?? "—")}</td>
                     <td class="text-center">${esc(rk.jam_berangkat
@@ -5942,6 +6168,26 @@ async function layarLiveScore() {
   // Tab pertama yang sudah ada isinya, supaya layar tidak terbuka pada
   // golongan kosong ketika golongan lain justru sudah penuh.
   const golAktif = GOL.find(g => jumlahGol[g] > 0) || GOL[0];
+
+  /* Dua tombol cetak, TANPA judul kartu dan TANPA paragraf penjelas: nama
+     tombolnya sudah menyebut apa yang keluar dari printer (CLAUDE.md 9.2 dan
+     9.9). Tempatnya di atas tab golongan, bukan di dalam panel golongan —
+     kertasnya memuat KEEMPAT golongan sekaligus, jadi tombol yang duduk di
+     dalam satu tab akan terbaca seperti "cetak tab ini saja".
+
+     Ikut hilang bersama papannya waktu belum ada regu yang bisa diperingkat:
+     tombol cetak di atas papan kosong cuma bisa menghasilkan kertas kosong. */
+  const cetakRekap = !klasemen.length ? "" : `
+    <div class="card">
+      <div class="option-row">
+        <button class="button button-primary" id="cetak-rekap-sekolah" type="button">
+          ${ikon("printer")} Rekap Nilai per Sekolah
+        </button>
+        <button class="button button-primary" id="cetak-rekap-semua" type="button">
+          ${ikon("printer")} Rekap Nilai Semua
+        </button>
+      </div>
+    </div>`;
 
   const tab = !klasemen.length ? "" : `
     <div class="tab-golongan" role="tablist" aria-label="Golongan">
@@ -5989,8 +6235,103 @@ async function layarLiveScore() {
      layar besar terbaca seperti hasil — dan itu yang diumumkan orang. */
   LAYAR.replaceChildren(h(`
     ${kemajuan}
+    ${cetakRekap}
     ${tab}
     ${papan}`));
+
+  /* ---- Cetak Rekap Nilai ----
+
+     `window.print()` HARUS tetap berada dalam giliran event tap: Safari
+     iPhone memblokirnya bila ada `await` lebih dulu, karena sesudah itu
+     panggilannya tidak lagi dianggap berasal langsung dari pengguna. Itu
+     yang membentuk kedua alur di bawah, dan yang paling terasa di alur per
+     sekolah — dialog pemilih TIDAK di-await lalu dicetak sesudahnya.
+     Sebaliknya, klik pada nama sekolah ITU SENDIRI yang membangun cetakan
+     dan memanggil print(), masih di dalam giliran tap-nya sendiri. */
+  const cetak = (judul, baris) => {
+    if (!siapkanCetakRekap({ judul, baris, posKolom, rekapDada })) {
+      notif("Tidak ada regu yang bisa dicetak.", true);
+      return;
+    }
+    window.print();
+  };
+
+  document.getElementById("cetak-rekap-semua")
+    ?.addEventListener("click", () => cetak("SEMUA REGU", klasemen));
+
+  document.getElementById("cetak-rekap-sekolah")?.addEventListener("click", () => {
+    /* Daftarnya dibangun dari KLASEMEN, bukan dari seluruh sekolah peserta.
+       Sekolah yang regunya belum satu pun berangkat tidak punya baris untuk
+       dicetak, dan menawarkannya cuma menghasilkan kertas kosong beserta
+       pertanyaan kenapa. Jumlah regunya ikut tertulis supaya petugas melihat
+       lebih dulu berapa baris yang akan keluar. */
+    const perSekolah = new Map();
+    for (const k of klasemen) {
+      const nm = k.nama_sekolah || "";
+      perSekolah.set(nm, (perSekolah.get(nm) || 0) + 1);
+    }
+    const daftar = [...perSekolah.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0], "id"));
+
+    dialog({
+      judul: "Rekap Nilai per Sekolah",
+      /* Satu tombol per sekolah, bukan pilihan yang harus disusul tombol
+         Cetak: menekan namanya SUDAH menyatakan maksudnya, dan tombol kedua
+         cuma menambah satu ketukan pada layar yang dipakai sambil berdiri
+         (CLAUDE.md 9.2). Kotak carinya ada karena 23 sekolah hari ini masih
+         bisa disapu mata dan ratusan tahun depan tidak — bentuknya sama
+         dengan saringan sekolah di tabel, yang sudah dipakai orang di meja
+         ini tanpa diberi tahu.
+
+         Penandanya `data-sekolah-cetak`, BUKAN `data-sekolah`: nama yang
+         kedua sudah dipakai baris tabel di layar yang SAMA untuk saringan
+         sekolah. closest() di bawah memang tidak akan pernah menemukan baris
+         itu — pendengarnya duduk di dalam dialog dan barisnya di luar — tapi
+         satu nama untuk dua arti di satu layar adalah perangkap yang menunggu
+         pembaca berikutnya.
+
+         Catatan ini ditulis DI SINI dan bukan sebagai komentar HTML di dalam
+         template di bawah, dengan alasan yang sama seperti catatan dialog() di
+         util.js: satu backtick di dalam komentar itu MENUTUP template
+         literal-nya, dan seluruh app.js berhenti diparse. Versi pertama
+         catatan ini mengutip nama penandanya dalam kutip miring dan melakukan
+         persis itu. */
+      kartuHtml: `
+        <input type="search" class="cari-sekolah-cetak"
+               placeholder="Ketik nama sekolah…" aria-label="Cari sekolah">
+        <div class="daftar-cetak-sekolah">
+          ${daftar.map(([nm, n]) => `
+            <button type="button" class="button pilih-sekolah-cetak"
+                    data-sekolah-cetak="${esc(nm)}">
+              <span>${esc(nm)}</span>
+              <span class="tab-hitung">${esc(String(n))}</span>
+            </button>`).join("")}
+        </div>`,
+      silangSaja: true,
+      pasang: (el, tutup) => {
+        const cari = el.querySelector(".cari-sekolah-cetak");
+        cari?.addEventListener("input", () => {
+          const q = cari.value.trim().toLowerCase();
+          el.querySelectorAll("[data-sekolah-cetak]").forEach(b => {
+            b.hidden = q.length > 0
+              && !b.dataset.sekolahCetak.toLowerCase().includes(q);
+          });
+        });
+        el.addEventListener("click", (e) => {
+          const b = e.target.closest("[data-sekolah-cetak]");
+          if (!b) return;
+          const nm = b.dataset.sekolahCetak;
+          // Ditutup DULU, lalu dicetak — keduanya di dalam giliran tap yang
+          // sama, jadi print() tetap sah di iPhone. Urutannya bukan selera:
+          // dialognya `position: fixed`, dan @media print membuang .overlay,
+          // tapi yang tertinggal terbuka akan menyambut petugas lagi begitu
+          // dialog cetak browser ditutup.
+          tutup(null);
+          cetak(nm, klasemen.filter(k => (k.nama_sekolah || "") === nm));
+        });
+      },
+    });
+  });
 
   /* Diperbarui DI TEMPAT, bukan dengan menggambar ulang layar.
      layarLiveScore() menarik snapshot dan status, lalu menggambar ulang

--- a/web/style.css
+++ b/web/style.css
@@ -1051,6 +1051,44 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 }
 .isi-filter input { width: 1rem; height: 1rem; }
 
+/* ---- Pemilih sekolah di dialog Cetak Rekap Nilai ----
+
+   Satu tombol selebar dialog per sekolah, digulir di dalam kotaknya sendiri.
+   `max-height` dipatok supaya tombol silang di pojok dan kotak carinya tidak
+   terdorong keluar layar begitu daftarnya panjang: 23 sekolah hari ini muat,
+   ratusan tahun depan tidak, dan yang pertama hilang dari layar justru kotak
+   cari yang dibutuhkan untuk memendekkannya.
+
+   Nama di kiri, jumlah regu di kanan — `space-between`, bukan dua kolom grid.
+   Nama sekolah panjangnya berbeda-beda dan boleh membungkus; angkanya selalu
+   satu atau dua digit dan tetap menempel di tepi kanan, jadi mata menyusurinya
+   lurus ke bawah dari baris ke baris. */
+/* Kotak carinya TIDAK memakai `.small-input`. Kelas itu berarti "kotak angka
+   di dalam tabel": `input.small-input` mematoknya 4,5rem dan meratakan isinya
+   ke tengah, jadi contoh isian "Ketik nama sekolah…" terpotong jadi "Ketik"
+   di kotak selebar tujuh huruf. Bentuknya disamakan dengan `.cari-filter`
+   milik saringan sekolah di tabel — pekerjaannya memang sama, dan orang di
+   meja ini sudah memakainya. */
+.cari-sekolah-cetak {
+  width: 100%; box-sizing: border-box; margin-top: .6rem;
+  padding: .45rem .6rem; border: 2px solid #9aa3ad; border-radius: 6px;
+  font-size: .9rem; font-family: inherit; background: #fff; color: #1c2430;
+}
+.cari-sekolah-cetak:focus {
+  outline: none; border-color: #00695c; box-shadow: 0 0 0 3px rgba(0,105,92,.18);
+}
+
+.daftar-cetak-sekolah {
+  display: flex; flex-direction: column; gap: .35rem;
+  max-height: 46vh; overflow-y: auto; margin-top: .6rem;
+}
+.daftar-cetak-sekolah .button[hidden] { display: none; }
+.pilih-sekolah-cetak {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .6rem; text-align: left; width: 100%; margin: 0;
+}
+.pilih-sekolah-cetak > span:first-child { flex: 1; }
+
 .kepala-klasemen { display: flex; align-items: center; gap: .5rem; margin: 0 0 .8rem; }
 .kepala-klasemen h2 { margin: 0; text-align: center; }
 .kepala-klasemen .sisi { flex: 1; display: flex; }
@@ -1644,6 +1682,81 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   /* Nama regu dan sekolah boleh membungkus di kertas — halaman punya lebar
      tetap, dan yang harus mengalah adalah teks, bukan kotak isiannya. */
   .print-table td { overflow-wrap: break-word; }
+
+  /* ---- REKAP NILAI: A4 MELINTANG, DUA LEMBAR PER GOLONGAN ----
+
+     Kertas ini DIBACA, bukan ditulisi, dan itu yang memisahkannya dari lembar
+     pos beberapa blok di atas. Lembar pos menjaga tinggi baris tetap rata
+     karena mata menyusuri mendatar dari nomor dada ke kotak yang akan ditulisi;
+     di sini tidak ada yang ditulisi, jadi nama yang membungkus cuma tidak enak
+     dilihat — sementara nama yang DIPOTONG kehilangan gunanya sebagai cek
+     silang. Karena itu tabelnya `auto`, bukan `fixed`: lebar diserahkan ke
+     isinya, dan yang terpanjang yang menentukan.
+
+     KENAPA DUA LEMBAR, dengan angka yang diukur di browser atas data 143 regu
+     (CLAUDE.md 15.9 dan 15.11), bukan ditaksir:
+
+       tersedia            281mm   (A4 melintang 297mm, margin 8mm dua sisi)
+       29 kolom, min-content 347,7mm   -> lebih 66mm, sepertiga kanan terpotong
+       23 kolom "Nilai"      261,8mm   -> sisa 19mm
+       11 kolom "Perjalanan" 112,5mm   -> sisa 168mm
+
+     min-content adalah selebar-sempitnya tabel itu bisa menjadi dengan setiap
+     nama sudah membungkus sehabis-habisnya. Jadi 347,7mm bukan lebar yang bisa
+     ditawar dengan mengatur persentase kolom — ia LANTAI-nya, dan lantainya
+     lebih tinggi daripada kertasnya.
+
+     Yang menghabiskannya kepala kolom, bukan angkanya: "Pengetahuan Umum",
+     "Kepramukaan", "Berangkat" adalah kata yang tidak bisa dipatahkan, dan
+     7pt adalah BATAS BAWAH huruf (CLAUDE.md 8.6) — di bawah itu fotokopi
+     menutup lubang huruf a, e, dan o. Kalau suatu tahun kolomnya bertambah
+     lagi, yang dibelah lembarnya — bukan ukuran hurufnya.
+
+     Padding 1,5pt dan huruf besar yang dimatikan berasal dari hitungan yang
+     sama: "BERANGKAT" di 7pt butuh ~15mm, "Berangkat" ~12mm, dan selisih 3mm
+     itu langsung jatuh ke kolom nama. */
+  @page rekap-cetak { size: A4 landscape; margin: 8mm; }
+  .rekap-cetak { page: rekap-cetak; }
+
+  .rekap-cetak h1 { font-size: 11pt; margin-bottom: .2rem; }
+  .rekap-cetak .lembar-kepala { font-size: 8pt; margin: 0; }
+  .rekap-cetak .print-table { margin-top: 3pt; }
+  /* Padding 1pt/1,5pt, bukan 1,5pt/2pt. Selisihnya 1pt per kolom, dan pada 17
+     kolom itu 6mm — diukur, dan itulah yang memindahkan lembar terlebar dari
+     284,7mm (terpotong) ke dalam kertas. */
+  .rekap-cetak .print-table th,
+  .rekap-cetak .print-table td {
+    font-size: 7pt; padding: 1pt 1.5pt; line-height: 1.15;
+  }
+  /* Huruf besar dimatikan untuk lebarnya, dan tebalnya yang menggantikan
+     tugasnya memisahkan kepala dari isi. Garis bawah tebal tetap ada dari
+     aturan `.print-table th` umum. */
+  .rekap-cetak .print-table th { text-transform: none; text-align: center; }
+  /* Sel ANGKA tidak boleh membungkus: "01:14" yang patah jadi dua baris
+     membaca seperti dua angka.
+
+     KEPALA KOLOM justru HARUS boleh membungkus, dan itu bukan selera:
+     dengan `nowrap` di kepala, lembar terlebar terukur 305,7mm dari 281mm
+     yang tersedia — "Pengetahuan Umum" dan "Balap Karung" sendirian memaksa
+     kolomnya selebar kalimatnya. Membungkus di spasinya membawanya ke
+     222,7mm. Kepala tabel memang dua baris, jadi tingginya sudah ada.
+
+     Keduanya dipisahkan lewat kelas, bukan lewat nth-child — nomor kolomnya
+     bergeser setiap kali sebuah lomba ditambahkan tahun depan (CLAUDE.md
+     15.5). */
+  .rekap-cetak .print-table td.text-center { white-space: nowrap; }
+  /* `break-word` dan BUKAN `anywhere`. Keduanya terbaca mirip dan hasilnya
+     berlawanan: `anywhere` ikut mengecilkan lebar min-content kolomnya, jadi
+     tabel `auto` memberi kolom Regu dan Organisasi hanya 14mm dan memotong
+     297 kata di tengah — "SINDANGKA/SIH". Diukur, bukan dibaca (CLAUDE.md
+     15.9). `break-word` menahan lebar kolomnya di kata terpanjang, jadi nama
+     hanya membungkus di spasi. */
+  .rekap-cetak .print-table td { overflow-wrap: break-word; }
+  /* Batas antar-pos: garis tegak yang lebih tebal, bukan raster (bagian 8.2).
+     Di layar `.rekap-batas` sudah punya arti yang sama; di kertas ia harus
+     ditulis lagi karena aturan layarnya duduk di luar @media print. */
+  .rekap-cetak .print-table th.rekap-batas,
+  .rekap-cetak .print-table td.rekap-batas { border-right-width: 1.5pt; }
 }
 
 @page { margin: 12mm; }


### PR DESCRIPTION
## What

Dua tombol baru di layar Live Score panitia, di atas tab golongan:

- **Rekap Nilai per Sekolah** — membuka pemilih berisi daftar sekolah beserta
  jumlah regunya, dengan kotak cari. Menekan nama sekolah langsung mencetak
  regu sekolah itu saja.
- **Rekap Nilai Semua** — mencetak seluruh regu yang sudah berangkat.

Isinya seluruh 29 kolom papan Live Score. Tiap golongan mendapat bagiannya
sendiri, dan tiap bagian dibelah jadi dua lembar A4 melintang.

Kepala kolom pos dan sel pos dipindah ke `kepalaPosRekap()` dan `selPosRegu()`,
lalu dipakai papan DAN kertas.

## Why

Panitia perlu memberikan rekap nilai ke pembina di meja, dan layar tidak bisa
diserahkan.

Aturan "lomba mana yang berlaku untuk golongan ini" sebelumnya hanya hidup di
dalam template tabel. Menyalinnya ke perakit kertas akan melahirkan salinan
kedua yang suatu hari berbeda pendapat — bentuk kegagalan yang sudah terjadi di
repo ini (CLAUDE.md 11.9), dan yang tidak menggagalkan apa pun: ia cuma membuat
layar dan kertas saling membantah di depan pembina yang memegang keduanya.

Tiap golongan dipisah karena peringkat di kolom `#` adalah peringkat DI DALAM
golongan; satu tabel campuran akan mencetak empat baris bernomor 1.

## Notes

**Dua lembar per golongan adalah hasil pengukuran, bukan pilihan tata letak.**
Diukur di browser atas 143 regu (CLAUDE.md 15.9 dan 15.11):

| | kolom | min-content | kertas 281mm |
| --- | --- | --- | --- |
| satu lembar, 29 kolom | 29 | 347,7mm | lebih 66mm, sepertiga kanan terpotong |
| Lembar 1 — Pos 1 & 2 | 17 | 222,7mm | sisa 58mm |
| Lembar 2 — Pos 3-5 + perjalanan | 17 | ~200mm | lega |

Yang menghabiskan lebarnya kepala kolom, bukan angkanya: "Pengetahuan Umum" dan
"Kepramukaan" tidak bisa dipatahkan, dan 7pt adalah batas bawah huruf supaya
fotokopi tidak menutup lubang a, e, dan o (CLAUDE.md 8.6). Pembelahannya selalu
jatuh di antara pos, dan empat kolom identitas beserta Total ikut di kedua
lembar supaya masing-masing berdiri sendiri. Sisa 58mm itulah yang membuat nama
regu dan sekolah tidak pernah dipatah di tengah kata.

`window.print()` tetap berada di dalam giliran event tap pada kedua alur:
dialog pemilih sekolah TIDAK ditunggu lalu dicetak sesudahnya, melainkan klik
pada nama sekolah itu sendiri yang membangun cetakan dan memanggil `print()`.
Safari iPhone memblokirnya sesudah `await`, dan yang gagal cuma diam.

Diverifikasi lokal: layar dibuka sungguhan dengan 143 regu di 4 golongan, baris
dihitung (40/41/28/34), cetakan diukur — 8 halaman semuanya muat 280,6mm dari
281mm dengan nol sel meluap, dan 29 kolom layar semuanya ada di gabungan dua
lembar. Nilai dibandingkan sel per sel layar lawan kertas untuk 143 regu: nol
selisih. 330 tes JS lulus, seluruh SQL suite lulus di PostgreSQL 17, ketiga
penjaga Python lulus, `live/style.css` sudah disamakan.
