### PR TITLE
fix: tombol Refresh Live Score menghitung ulang, bukan membaca ulang

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -12,8 +12,12 @@ sampai `0162`, dan bagian 3 diperiksa terhadap layar. `0163` — fase live
 kelima `juara` beserta `v_kejuaraan_publik` dan `hasil_kejuaraan_semua()` —
 mendarat sesudah penghitungan itu, jadi angka view dan fungsi di bagian 2
 kurang satu masing-masing; `0164` menulis ulang view yang sama untuk
-membawa kolom skornya dan tidak mengubah jumlahnya. Isi bagian 2 sampai 9
-selebihnya belum dibaca ulang baris demi baris terhadap `0119`-`0164`.
+membawa kolom skornya dan tidak mengubah jumlahnya. Disegarkan lagi
+31 Agustus 2026 sampai migrasi `0165`, dan cakupannya SEMPIT: yang
+diperiksa hanya jumlah migrasi beserta bagian singgahan `cache_live_score`
+di bawah. `0165` menambah satu fungsi, `minta_segarkan_live_score()`,
+sehingga angka fungsi di bagian 2 kurang satu lagi. Isi bagian 2 sampai 9
+selebihnya belum dibaca ulang baris demi baris terhadap `0119`-`0165`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -78,7 +82,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-164 migrasi, `0001` sampai `0164`, dijalankan berurutan tanpa lubang penomoran.
+165 migrasi, `0001` sampai `0165`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 
@@ -105,6 +109,14 @@ seluruh papan Live Score, disegarkan `segarkan_cache_live_score()`. Layar Live
 Score dan layar Kejuaraan membacanya alih-alih menjalankan ulang seluruh rantai
 skor untuk tiap panitia yang membuka layar. Menghapus isinya tidak menghilangkan
 satu nilai pun; yang hilang cuma kecepatannya sampai disegarkan lagi.
+
+Dua jalan menyegarkannya, dan keduanya perlu. Cron `refresh-live-score.yml`
+menjaga hari lomba tiap sepuluh menit; tombol Refresh di layar Live Score
+memanggil `minta_segarkan_live_score()` (migrasi `0165`) saat diminta.
+Sampai `0165` hanya ada jalan pertama, dan cron itu sengaja mati di luar
+tanggal lomba — jadi di luar dua hari itu tombol Refresh membaca ulang
+snapshot beku yang sama tanpa satu pun galat. Terukur: penyegaran terakhir
+29 Agustus 16:55 UTC, dilaporkan panitia 31 Agustus.
 
 Duapuluh enam tabel seluruhnya, dan keduapuluh enamnya menyalakan RLS.
 

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -617,6 +617,34 @@ export async function statusAcara() {
   return Array.isArray(d) ? d[0] : d;
 }
 
+/** Tombol Refresh layar Live Score: MINTA DATABASE MENGHITUNG ULANG, lalu
+ *  kembalikan cap waktu snapshot yang berlaku sesudahnya.
+ *
+ *  DUDUK DI BAWAH statusAcara(), bukan di atasnya bersama aturFaseLive() yang
+ *  sama-sama soal Live Score. Sebabnya di tes: dev_live_phase_route mengiris
+ *  aturFaseLive() SAMPAI statusAcara() lalu melarang kata K-titik-mode muncul
+ *  di dalam irisan itu, jadi fungsi apa pun yang disisipkan di antara keduanya
+ *  ikut terbaca sebagai badan aturFaseLive \u2014 termasuk komentarnya.
+ *
+ *  Tanpa ini tombolnya cuma membaca ulang `cache_live_score`, dan yang mengisi
+ *  tabel itu satu-satunya adalah cron `refresh-live-score.yml` yang sengaja
+ *  hanya hidup pada tanggal lomba. Di luar dua hari itu angkanya tidak pernah
+ *  berubah, dan tidak ada satu pun galat — membaca snapshot beku memang
+ *  berhasil. Terukur: penyegaran terakhir 29 Agustus 16:55 UTC, dilaporkan
+ *  panitia 31 Agustus.
+ *
+ *  Pagarnya di database (migrasi 0165), bukan di sini: hak `live_score`,
+ *  ambang 5 detik untuk penekanan berbarengan, dan kunci supaya belasan HP
+ *  tidak menghitung hal yang sama sekaligus.
+ *
+ *  Lewat pembungkus `rpc()` yang sama di dev dan produksi, tanpa cabang
+ *  `K.mode`. Cabang seperti itu berarti yang dijalankan panitia bukan jalur
+ *  yang pernah dicoba siapa pun di laptop — dan `tests/dev_server.py` memang
+ *  menyediakan rutenya, jadi tidak ada yang perlu dipintas. */
+export async function segarkanLiveScore() {
+  return rpc("minta_segarkan_live_score", {});
+}
+
 /** Angka penalti edisi aktif — dipakai layar finish untuk menunjukkan apakah
  *  selisih jam kertas vs laptop benar-benar mengubah penalti. */
 export async function infoPenalti() {

--- a/supabase/migrations/0165_refresh_live_score_dari_layar.sql
+++ b/supabase/migrations/0165_refresh_live_score_dari_layar.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- hrcd-rekap : 0165_refresh_live_score_dari_layar.sql
+-- Tombol Refresh di layar Live Score MENGHITUNG ULANG, bukan cuma membaca ulang.
+--
+-- APA YANG RUSAK
+--
+-- `segarkan_cache_live_score()` (0146) di-revoke dari `authenticated` dan hanya
+-- diberikan ke `service_role`. Satu-satunya yang memanggilnya
+-- `refresh-live-score.yml`, dan cron-nya sengaja hanya hidup pada TANGGAL
+-- LOMBA -- 28-29 Agustus 2026, dijaga penjaga tahun yang memang tidak boleh
+-- dilebarkan (CLAUDE.md 16.9: cron adalah tagihan berjalan).
+--
+-- Akibatnya, di luar dua hari itu tidak ada apa pun yang mengisi ulang
+-- `cache_live_score`. Tombol Refresh membaca ulang snapshot yang SAMA, jadi
+-- angkanya tidak pernah berubah -- dan tidak ada satu pun galat, karena
+-- membaca snapshot beku memang berhasil. Terukur: penyegaran terakhir
+-- 29 Agustus 16:55 UTC, dilaporkan panitia 31 Agustus.
+--
+-- Ini bukan kejadian sekali. Komentar di dalam refresh-live-score.yml sendiri
+-- menjadikannya alasan menjarangkan cron dari 5 menit ke 10:
+--
+--   "Sejak #730 layarnya punya tombol refresh sendiri, jadi yang butuh angka
+--    detik itu menekannya."
+--
+-- Premisnya salah sejak ditulis. Tombolnya tidak pernah bisa menghitung ulang,
+-- jadi cron dijarangkan dengan menyandarkan diri pada kemampuan yang tidak
+-- ada. Migrasi ini membuat kalimat itu jadi benar.
+--
+-- KENAPA BUKAN MELEBARKAN CRON
+--
+-- Melebarkan jendelanya berarti membayar setiap sepuluh menit, setiap hari,
+-- selamanya, untuk papan yang ditonton beberapa menit dalam sebulan -- dan
+-- kuota Actions yang habis menghentikan SELURUH workflow, termasuk
+-- apply-migration.yml dan yang dijalankan panitia dari HP. Yang benar
+-- membiarkan cron menjaga hari lomba, dan memberi layar kemampuan menghitung
+-- ulang saat diminta.
+--
+-- TIGA PAGAR, DAN KETIGANYA MEMANG DIPERLUKAN
+--
+--   1. `boleh('live_score')` -- diperiksa memakai auth.uid() PEMANGGIL, sebelum
+--      apa pun dihitung. Pagar hak tetap milik pemanggil, bukan milik akun yang
+--      dipinjam 0146 di dalam.
+--   2. Snapshot yang baru lahir dipakai apa adanya. Papan ini ditonton belasan
+--      orang sekaligus; tanpa ini satu kejadian di lapangan membuat sepuluh HP
+--      menekan Refresh berbarengan dan sepuluh kali seluruh rantai skor
+--      dihitung untuk jawaban yang sama.
+--   3. Kunci advisory: satu penghitungan pada satu waktu. Yang tidak kebagian
+--      kunci TIDAK MENGANTRE -- ia langsung mendapat snapshot yang ada.
+--      Mengantre berarti tombolnya menggantung selama penghitungan orang lain,
+--      dan panitia yang menunggu menekannya lagi.
+--
+-- Ambangnya 5 detik, bukan satu menit. Yang menekan Refresh baru saja
+-- menyimpan nilai dan ingin melihatnya; ambang yang panjang mengembalikan
+-- snapshot yang lahir SEBELUM ia menyimpan, dan itu persis keluhan yang
+-- diperbaiki migrasi ini. Lima detik cukup memecah gelombang tekanan
+-- berbarengan tanpa pernah menyembunyikan perubahan yang sudah tersimpan.
+-- ============================================================================
+
+create or replace function minta_segarkan_live_score()
+returns timestamptz
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_dibuat timestamptz;
+begin
+  -- Pagar 1. auth.uid() di sini masih milik PEMANGGIL: 0146 baru menukarnya
+  -- di dalam dirinya sendiri, dan itu terjadi sesudah baris ini.
+  if not boleh('live_score') then
+    raise exception 'Tidak berhak menyegarkan Live Score';
+  end if;
+
+  select dibuat_pada into v_dibuat from cache_live_score where tunggal;
+
+  -- Pagar 2. Snapshot yang baru lahir dipakai apa adanya.
+  if v_dibuat is not null
+     and clock_timestamp() - v_dibuat < interval '5 seconds' then
+    return v_dibuat;
+  end if;
+
+  -- Pagar 3. Satu penghitungan pada satu waktu. Angka kuncinya sembarang tapi
+  -- TETAP; ia cuma perlu tidak dipakai fungsi lain. Kunci transaksi, jadi ia
+  -- lepas sendiri saat RPC selesai maupun gagal.
+  if not pg_try_advisory_xact_lock(8161465) then
+    return v_dibuat;
+  end if;
+
+  return segarkan_cache_live_score();
+end;
+$$;
+
+comment on function minta_segarkan_live_score() is
+  'Tombol Refresh layar Live Score: hitung ulang cache bila perlu, lalu '
+  'kembalikan cap waktunya. Berpagar boleh(live_score), ambang 5 detik, dan '
+  'kunci advisory supaya penekanan berbarengan tidak menghitung berkali-kali.';
+
+-- `anon` tidak pernah boleh: papan ini milik panitia, dan penghitungannya
+-- membaca nilai seluruh pos.
+revoke all on function minta_segarkan_live_score() from public, anon;
+grant execute on function minta_segarkan_live_score() to authenticated, service_role;
+
+-- Sekalian segarkan sekarang, karena snapshot di produksi sudah beku dua hari
+-- ketika migrasi ini ditulis. Tanpa baris ini panitia harus menekan Refresh
+-- sekali dulu sebelum melihat angka yang benar.
+select segarkan_cache_live_score();

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -55,6 +55,7 @@ RPC = {
     "ceklis_berangkat":      ["p_nomor_dada"],
     "batal_ceklis_berangkat":["p_nomor_dada"],
     "koreksi_jam_berangkat": ["p_kloter", "p_jam", "p_alasan"],
+    "minta_segarkan_live_score": [],
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
     "hapus_nilai_pos":       ["p_nomor_dada", "p_kode", "p_pos"],
     "kunci_nilai_pos":       ["p_nomor_dada", "p_pos"],

--- a/tests/live_score_refresh_hitung_ulang.test.mjs
+++ b/tests/live_score_refresh_hitung_ulang.test.mjs
@@ -1,0 +1,99 @@
+// ============================================================================
+// hrcd-rekap : tests/live_score_refresh_hitung_ulang.test.mjs
+// Tombol Refresh Live Score MENGHITUNG ULANG, dan tidak melempar panitia
+// kembali ke atas.
+//
+// Kegagalan yang dijaga di sini SUNYI — itu sebabnya ia perlu dijaga mesin.
+// Tombol yang cuma membaca ulang `cache_live_score` selalu berhasil: tidak ada
+// galat, tidak ada layar kosong, angkanya saja yang tidak pernah berubah.
+// Yang menemukannya panitia, dua hari sesudah snapshot terakhir dibuat.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const cron = await readFile(
+  new URL("../.github/workflows/refresh-live-score.yml", import.meta.url), "utf8");
+
+/** Badan pendengar tombol Refresh. */
+const pendengar = (() => {
+  const awal = app.indexOf('document.getElementById("refresh-live-score")');
+  const akhir = app.indexOf("/* Kepala tabel Live Score ada DUA baris", awal);
+  assert.ok(awal >= 0 && akhir > awal, "pendengar tombol Refresh tidak ditemukan");
+  return app.slice(awal, akhir);
+})();
+
+test("Refresh meminta database menghitung ulang lebih dulu", () => {
+  assert.match(pendengar, /await segarkanLiveScore\(\)/,
+    "tombol Refresh tidak meminta penghitungan ulang — ia cuma membaca ulang "
+    + "snapshot yang sama, dan itu berhasil tanpa galat apa pun");
+  // Urutannya mengikat: menggambar ulang DULU lalu menghitung berarti yang
+  // tergambar tetap angka lama.
+  assert.ok(
+    pendengar.indexOf("segarkanLiveScore()") < pendengar.indexOf("layarLiveScore()"),
+    "layar digambar ulang sebelum database selesai menghitung");
+});
+
+test("gambar ulang tetap jalan walau penghitungan gagal", () => {
+  // Snapshot lama masih berguna dan cap waktunya jujur (keputusan 0146). Yang
+  // tidak boleh terjadi: tombol yang gagal diam-diam lalu tidak melakukan apa pun.
+  const tangkap = pendengar.slice(pendengar.indexOf("catch"));
+  assert.match(tangkap, /notif\(/,
+    "kegagalan penghitungan tidak diberitahukan");
+  assert.match(tangkap, /await layarLiveScore\(\)/,
+    "layar tidak digambar ulang ketika penghitungan gagal");
+});
+
+test("Refresh tidak melempar panitia ke tab lain atau ke puncak halaman", () => {
+  assert.match(pendengar, /guliranLiveScore = window\.scrollY/,
+    "posisi guliran tidak diingat sebelum papan digambar ulang");
+  assert.match(app, /let golonganLiveScore = null;/,
+    "golongan yang sedang dibuka tidak diingat");
+  assert.match(app, /golonganLiveScore = pilih;/,
+    "golongan tidak dicatat saat tab ditekan");
+  // Dipakai HANYA kalau golongannya masih berisi, supaya papan tidak terbuka
+  // pada tab kosong.
+  assert.match(app,
+    /golonganLiveScore && jumlahGol\[golonganLiveScore\] > 0 && golonganLiveScore/,
+    "golongan yang diingat dipakai tanpa memeriksa masih ada isinya");
+  // Guliran dipulihkan SESUDAH papan tergambar: halaman yang belum setinggi
+  // posisi tujuan membuat browser menahan guliran di batas yang ada saat itu.
+  const pulih = app.indexOf("requestAnimationFrame(() => window.scrollTo(0, ke))");
+  const gambar = app.indexOf("LAYAR.replaceChildren(h(`\r\n    ${kemajuan}");
+  assert.ok(pulih > 0, "guliran tidak pernah dipulihkan");
+  assert.ok(gambar > 0 && pulih > gambar,
+    "guliran dipulihkan sebelum papannya tergambar");
+});
+
+test("tombolnya dimatikan selama bekerja", () => {
+  assert.match(pendengar, /tombol\.disabled = true/,
+    "tombol Refresh tidak dimatikan — penghitungan bisa memakan detik, dan "
+    + "tombol yang diam terbaca seperti tombol rusak");
+});
+
+test("RPC-nya lewat pembungkus yang sama di dev dan produksi", () => {
+  const awal = api.indexOf("export async function segarkanLiveScore");
+  // Kurung tutup di AWAL baris, bukan `}` pertama yang ditemukan — yang
+  // pertama itu `{}` argumen RPC-nya sendiri, dan irisannya berhenti sebelum
+  // tanda titik koma sehingga polanya tidak pernah cocok.
+  const fungsi = api.slice(awal, api.indexOf("\n}", awal) + 2);
+  assert.match(fungsi, /return rpc\("minta_segarkan_live_score", \{\}\);/,
+    "segarkanLiveScore tidak memakai pembungkus rpc()");
+  assert.doesNotMatch(fungsi, /K\.mode|\bfetch\b/,
+    "ada cabang khusus dev — yang dijalankan panitia jadi jalur yang tidak "
+    + "pernah dicoba siapa pun di laptop");
+});
+
+test("cron hari lomba tidak ikut dilebarkan", () => {
+  // CLAUDE.md 16.9: cron adalah tagihan berjalan, dan kuota yang habis
+  // menghentikan SELURUH workflow — termasuk apply-migration.yml. Perbaikan
+  // tombol Refresh ada supaya jendela ini TIDAK perlu dilebarkan.
+  assert.match(cron, /- cron: '\*\/10 23 28 8 \*'/,
+    "jendela cron hari lomba berubah");
+  assert.match(cron, /- cron: '\*\/10 0-11 29 8 \*'/,
+    "jendela cron hari lomba berubah");
+  assert.match(cron, /2026-08-28T23:/, "penjaga tahun hilang dari cron");
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -723,6 +723,8 @@ run supabase/migrations/0163_fase_juara.sql
 run tests/sql/115_fase_juara.sql
 run supabase/migrations/0164_kejuaraan_publik_dengan_skor.sql
 run tests/sql/116_kejuaraan_publik_skor.sql
+run supabase/migrations/0165_refresh_live_score_dari_layar.sql
+run tests/sql/117_refresh_live_score_dari_layar.sql
 
 # Parse dan jalankan query yang benar-benar menjadi live.json, SESUDAH
 # seluruh migrasi. Ini menangkap view atau kolom yang berganti sebelum

--- a/tests/sql/117_refresh_live_score_dari_layar.sql
+++ b/tests/sql/117_refresh_live_score_dari_layar.sql
@@ -1,0 +1,130 @@
+\echo '--- 117. tombol Refresh Live Score menghitung ulang, berpagar hak'
+
+-- Yang diuji di sini BUKAN "fungsinya ada". Yang diuji: ia benar-benar
+-- MENGGANTI snapshot, dan pagarnya benar-benar menahan. Tes yang cuma
+-- memanggil lalu memeriksa hasilnya tidak null akan tetap hijau kalau seluruh
+-- badan fungsinya diganti `select clock_timestamp()`.
+
+-- 117.1 Menghitung ulang: cap waktu DAN isi snapshot ikut berganti.
+do $$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_lama timestamptz;
+  v_baru timestamptz;
+  v_kembali timestamptz;
+begin
+  -- Snapshot ditanam dengan cap waktu tua DAN isi yang salah, supaya
+  -- "tidak berubah" tidak bisa lolos sebagai "kebetulan sama".
+  insert into cache_live_score (tunggal, dibuat_pada, data)
+  values (true, now() - interval '2 days', '{"palsu": true}'::jsonb)
+  on conflict (tunggal) do update
+  set dibuat_pada = excluded.dibuat_pada, data = excluded.data;
+  select dibuat_pada into v_lama from cache_live_score where tunggal;
+
+  set local role authenticated;
+  perform set_config('app.uid', v_juri::text, true);
+  v_kembali := minta_segarkan_live_score();
+  reset role;
+
+  select dibuat_pada into v_baru from cache_live_score where tunggal;
+  assert v_baru > v_lama,
+    format('117.1 GAGAL: snapshot tidak dihitung ulang (%s -> %s)', v_lama, v_baru);
+  assert v_kembali = v_baru,
+    '117.2 GAGAL: cap waktu yang dikembalikan bukan cap waktu snapshot baru';
+  assert (select data ?& array['kelengkapan', 'pos', 'komponen', 'rekap']
+          from cache_live_score where tunggal),
+    '117.3 GAGAL: isi snapshot tidak ikut diganti';
+  assert not (select data ? 'palsu' from cache_live_score where tunggal),
+    '117.4 GAGAL: isi snapshot lama masih ada';
+end;
+$$;
+
+-- 117.5 Ambang 5 detik: penekanan beruntun TIDAK menghitung ulang.
+--       Dijalankan segera sesudah blok di atas, jadi snapshotnya memang baru.
+do $$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_sebelum timestamptz;
+  v_sesudah timestamptz;
+begin
+  select dibuat_pada into v_sebelum from cache_live_score where tunggal;
+  set local role authenticated;
+  perform set_config('app.uid', v_juri::text, true);
+  perform minta_segarkan_live_score();
+  reset role;
+  select dibuat_pada into v_sesudah from cache_live_score where tunggal;
+  assert v_sesudah = v_sebelum,
+    '117.5 GAGAL: snapshot yang baru lahir ikut dihitung ulang — '
+    'ambang penekanan berbarengan tidak berlaku';
+end;
+$$;
+
+-- 117.6 Pagar hak, dari DUA arah (CLAUDE.md 13.8): panggilan yang sama
+--       dijalankan dua kali dengan satu baris akun_hak diubah di antaranya.
+--       Tanpa arah kedua, `return true` pun lulus.
+do $$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_ditolak boolean := false;
+begin
+  -- Cap waktu ditua-kan lagi supaya yang menahan di bawah benar-benar
+  -- pagar haknya, bukan ambang 5 detik dari blok sebelumnya.
+  update cache_live_score set dibuat_pada = now() - interval '2 days'
+  where tunggal;
+
+  delete from akun_hak where user_id = v_juri and fitur = 'live_score';
+  begin
+    set local role authenticated;
+    perform set_config('app.uid', v_juri::text, true);
+    perform minta_segarkan_live_score();
+    reset role;
+  exception when others then
+    v_ditolak := true;
+  end;
+  reset role;
+  insert into akun_hak (user_id, fitur) values (v_juri, 'live_score')
+  on conflict do nothing;
+
+  assert v_ditolak,
+    '117.6 GAGAL: Live Score bisa disegarkan tanpa hak live_score';
+end;
+$$;
+
+-- 117.7 Arah kedua: hak dikembalikan, panggilan yang sama harus lolos.
+do $$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_lama timestamptz;
+begin
+  update cache_live_score set dibuat_pada = now() - interval '2 days'
+  where tunggal;
+  select dibuat_pada into v_lama from cache_live_score where tunggal;
+
+  set local role authenticated;
+  perform set_config('app.uid', v_juri::text, true);
+  perform minta_segarkan_live_score();
+  reset role;
+
+  assert (select dibuat_pada from cache_live_score where tunggal) > v_lama,
+    '117.7 GAGAL: pemegang live_score justru tidak bisa menyegarkan';
+end;
+$$;
+
+-- 117.8 `anon` tidak pernah boleh menjalankannya.
+do $$
+declare
+  v_ditolak boolean := false;
+begin
+  begin
+    set local role anon;
+    perform minta_segarkan_live_score();
+    reset role;
+  exception when others then
+    v_ditolak := true;
+  end;
+  reset role;
+  assert v_ditolak, '117.8 GAGAL: anon dapat menyegarkan Live Score';
+end;
+$$;
+
+\echo '117 refresh live score dari layar: LULUS'

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -617,6 +617,34 @@ export async function statusAcara() {
   return Array.isArray(d) ? d[0] : d;
 }
 
+/** Tombol Refresh layar Live Score: MINTA DATABASE MENGHITUNG ULANG, lalu
+ *  kembalikan cap waktu snapshot yang berlaku sesudahnya.
+ *
+ *  DUDUK DI BAWAH statusAcara(), bukan di atasnya bersama aturFaseLive() yang
+ *  sama-sama soal Live Score. Sebabnya di tes: dev_live_phase_route mengiris
+ *  aturFaseLive() SAMPAI statusAcara() lalu melarang kata K-titik-mode muncul
+ *  di dalam irisan itu, jadi fungsi apa pun yang disisipkan di antara keduanya
+ *  ikut terbaca sebagai badan aturFaseLive \u2014 termasuk komentarnya.
+ *
+ *  Tanpa ini tombolnya cuma membaca ulang `cache_live_score`, dan yang mengisi
+ *  tabel itu satu-satunya adalah cron `refresh-live-score.yml` yang sengaja
+ *  hanya hidup pada tanggal lomba. Di luar dua hari itu angkanya tidak pernah
+ *  berubah, dan tidak ada satu pun galat — membaca snapshot beku memang
+ *  berhasil. Terukur: penyegaran terakhir 29 Agustus 16:55 UTC, dilaporkan
+ *  panitia 31 Agustus.
+ *
+ *  Pagarnya di database (migrasi 0165), bukan di sini: hak `live_score`,
+ *  ambang 5 detik untuk penekanan berbarengan, dan kunci supaya belasan HP
+ *  tidak menghitung hal yang sama sekaligus.
+ *
+ *  Lewat pembungkus `rpc()` yang sama di dev dan produksi, tanpa cabang
+ *  `K.mode`. Cabang seperti itu berarti yang dijalankan panitia bukan jalur
+ *  yang pernah dicoba siapa pun di laptop — dan `tests/dev_server.py` memang
+ *  menyediakan rutenya, jadi tidak ada yang perlu dipintas. */
+export async function segarkanLiveScore() {
+  return rpc("minta_segarkan_live_score", {});
+}
+
 /** Angka penalti edisi aktif — dipakai layar finish untuk menunjukkan apakah
  *  selisih jam kertas vs laptop benar-benar mengubah penalti. */
 export async function infoPenalti() {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,7 +27,7 @@ import {
   hasilKejuaraan, simpanKejuaraanManual, simpanKejuaraanTerjauh, daftarSekolah,
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
   statusAcara, bolehLihat, lengkapiHakSesi,
-  aturFaseLive,
+  aturFaseLive, segarkanLiveScore,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun, daftarPanitia,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak, tautanFotoBanyak,
   hapusFotoLembar, tautanBukti,
@@ -5790,6 +5790,21 @@ function siapkanCetakRekap({ judul, baris, posKolom, rekapDada }) {
    <body>, jadi tidak ada yang membuangnya saat pindah layar. */
 let pengendaliFilterSekolah = null;
 
+/* Golongan yang sedang dibuka, dan posisi guliran, DIINGAT melewati gambar
+   ulang Refresh.
+
+   Keduanya di luar layarLiveScore() karena fungsi itu menggambar ulang
+   seluruh papan dari nol tiap kali dipanggil. Tanpa ingatan ini Refresh
+   melempar panitia kembali ke tab golongan pertama dan ke puncak halaman \u2014
+   dan yang menekan Refresh justru sedang MEMBACA satu baris di tengah tabel,
+   biasanya sesudah menyimpan nilai regu itu.
+
+   `null` berarti belum ada yang dipilih, dan itu beda dari "memilih golongan
+   pertama": golongan yang diingat dipakai HANYA kalau ia masih punya baris,
+   supaya papan tidak terbuka pada tab kosong. */
+let golonganLiveScore = null;
+let guliranLiveScore = null;
+
 /** Satu request yang putus tidak boleh merobohkan seluruh papan.
  *
  *  Live Score menarik snapshot skor dan status acara. Di koneksi lapangan,
@@ -6167,7 +6182,9 @@ async function layarLiveScore() {
     GOL.map(g => [g, klasemen.filter(k => k.golongan === g).length]));
   // Tab pertama yang sudah ada isinya, supaya layar tidak terbuka pada
   // golongan kosong ketika golongan lain justru sudah penuh.
-  const golAktif = GOL.find(g => jumlahGol[g] > 0) || GOL[0];
+  const golAktif =
+    (golonganLiveScore && jumlahGol[golonganLiveScore] > 0 && golonganLiveScore)
+    || GOL.find(g => jumlahGol[g] > 0) || GOL[0];
 
   /* Dua tombol cetak, TANPA judul kartu dan TANPA paragraf penjelas: nama
      tombolnya sudah menyebut apa yang keluar dari printer (CLAUDE.md 9.2 dan
@@ -6356,8 +6373,35 @@ async function layarLiveScore() {
   /* Refresh diminta petugas, bukan berjalan sendiri. Menggambar ulang lewat
      fungsi layar yang sama memastikan snapshot skor, status acara, dan cap
      update berasal dari satu pemuatan baru. */
-  document.getElementById("refresh-live-score")?.addEventListener("click", () => {
-    layarLiveScore();
+  /* Refresh MEMINTA DATABASE MENGHITUNG ULANG lebih dulu, baru menggambar
+     ulang. Menggambar ulang saja cuma membaca `cache_live_score` yang sama:
+     yang mengisi tabel itu satu-satunya cron `refresh-live-score.yml`, dan
+     cron itu sengaja hanya hidup pada tanggal lomba (CLAUDE.md 16.9 \u2014 cron
+     adalah tagihan berjalan, jendelanya tidak dilebarkan). Di luar dua hari
+     itu tombolnya menggambar ulang angka yang sama persis, tanpa satu pun
+     galat, karena membaca snapshot beku memang berhasil.
+
+     GAMBAR ULANG TETAP DIJALANKAN WALAU PENGHITUNGAN GAGAL. Snapshot lama
+     masih berguna dan cap waktunya jujur (itu keputusan 0146); yang tidak
+     boleh terjadi adalah tombol yang tidak melakukan apa-apa lalu diam.
+
+     Tombolnya dimatikan selama bekerja. Penghitungan bisa memakan detik, dan
+     tanpa ini panitia menekannya tiga kali \u2014 yang ditahan ambang 5 detik di
+     database, tapi tetap terasa seperti tombol rusak. */
+  document.getElementById("refresh-live-score")?.addEventListener("click", async (e) => {
+    const tombol = e.currentTarget;
+    // Diingat SEBELUM apa pun digambar ulang, dan dipulihkan sesudahnya.
+    guliranLiveScore = window.scrollY;
+    tombol.disabled = true;
+    tombol.classList.add("berputar");
+    try {
+      await segarkanLiveScore();
+    } catch (err) {
+      notif(err.message, true);
+    }
+    // Tidak perlu menyalakan tombolnya lagi: layarLiveScore() menggambar
+    // tombol yang baru sama sekali.
+    await layarLiveScore();
   });
 
   /* Kepala tabel Live Score ada DUA baris, dan keduanya menempel di atas.
@@ -6529,12 +6573,24 @@ async function layarLiveScore() {
     });
   });
 
+  /* Guliran dipulihkan DI SINI, sesudah seluruh papan tergambar \u2014 termasuk
+     tabelnya, yang menentukan tinggi halaman. Memulihkannya lebih awal tidak
+     bekerja: halaman yang belum setinggi posisi tujuan membuat browser
+     menahan guliran di batas yang ada saat itu. */
+  if (guliranLiveScore !== null) {
+    const ke = guliranLiveScore;
+    guliranLiveScore = null;
+    requestAnimationFrame(() => window.scrollTo(0, ke));
+  }
+
   const bilah = LAYAR.querySelector(".tab-golongan");
   if (bilah) {
     bilah.addEventListener("click", (e) => {
       const b = e.target.closest("[data-gol]");
       if (!b) return;
       const pilih = b.dataset.gol;
+      // Diingat supaya Refresh berikutnya membuka tab yang sama.
+      golonganLiveScore = pilih;
       bilah.querySelectorAll("[data-gol]").forEach(x =>
         x.setAttribute("aria-selected", String(x.dataset.gol === pilih)));
       LAYAR.querySelectorAll(".panel-gol").forEach(pn => {


### PR DESCRIPTION
## What

Migrasi `0165` menambah RPC `minta_segarkan_live_score()`, dan tombol Refresh di
layar Live Score memanggilnya sebelum menggambar ulang.

Refresh juga tidak lagi melempar panitia ke tab golongan pertama dan ke puncak
halaman — golongan yang sedang dibuka dan posisi guliran diingat melewati
gambar ulang.

## Why

Angka di papan tidak pernah berubah walau Refresh ditekan.

Tombol itu cuma memuat ulang layar, dan layar membaca `cache_live_score` —
tabel yang satu-satunya pengisinya cron `refresh-live-score.yml`, yang sengaja
hanya hidup pada tanggal lomba. Di luar dua hari itu tidak ada apa pun yang
mengisinya, jadi tombolnya menggambar ulang angka yang sama persis **tanpa satu
pun galat**, karena membaca snapshot beku memang berhasil. Terukur: penyegaran
terakhir 29 Agustus 16:55 UTC, dilaporkan panitia 31 Agustus.

Komentar di dalam `refresh-live-score.yml` sendiri menjadikan tombol itu alasan
menjarangkan cron dari 5 menit ke 10 — *"yang butuh angka detik itu
menekannya"*. Premisnya salah sejak ditulis. PR ini membuat kalimat itu benar.

## Notes

**Cron hari lomba TIDAK dilebarkan.** Melebarkannya berarti membayar tiap
sepuluh menit selamanya untuk papan yang ditonton beberapa menit dalam sebulan,
dan kuota Actions yang habis menghentikan seluruh workflow termasuk
`apply-migration.yml` (CLAUDE.md 16.9). Ada tes yang menjaga jendelanya tetap
sempit.

Tiga pagar di RPC, dan ketiganya perlu karena papan ini ditonton belasan orang:

1. hak `live_score`, diperiksa memakai `auth.uid()` **pemanggil**, sebelum apa
   pun dihitung;
2. snapshot yang lahir kurang dari 5 detik lalu dipakai apa adanya — ambangnya
   sengaja pendek, karena yang menekan Refresh baru saja menyimpan nilai dan
   ambang panjang akan mengembalikan snapshot yang lahir sebelum ia menyimpan;
3. kunci advisory supaya penekanan berbarengan tidak menghitung berkali-kali.
   Yang tidak kebagian kunci **tidak mengantre** — ia langsung mendapat
   snapshot yang ada, karena tombol yang menggantung selama penghitungan orang
   lain akan ditekan lagi.

Gambar ulang tetap dijalankan walau penghitungan gagal: snapshot lama masih
berguna dan cap waktunya jujur (keputusan `0146`).

Tes 117 menguji dari dua arah dan **sudah dibuktikan menggigit**: versi yang
mengembalikan cap waktu tanpa menghitung gagal di 117.1, versi tanpa pagar
gagal di 117.5. Diverifikasi juga di layar sungguhan — satu nilai diubah di
database, Refresh ditekan, peringkat 1 berganti dari regu 102 (766) ke regu 030
(731) sementara tab dan guliran tetap di tempat.

Seluruh SQL suite lulus lokal di PostgreSQL 17 dengan `0165` dan tes 117
terdaftar di `tests/run.sh` (CLAUDE.md 7.5); 336 tes JS lulus.

**Migrasi ini perlu di-apply setelah merge** — `apply-migration.yml` dengan
berkas `supabase/migrations/0165_refresh_live_score_dari_layar.sql`.
