### PR TITLE
fix: bagian Rekap Nilai mengalir, tidak satu halaman masing-masing

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=23">
+  <link rel="stylesheet" href="style.css?v=24">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -1718,6 +1718,35 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page rekap-cetak { size: A4 landscape; margin: 8mm; }
   .rekap-cetak { page: rekap-cetak; }
 
+  /* ---- BAGIAN REKAP MENGALIR, TIDAK MEMAKSA HALAMAN BARU ----
+
+     Aturan umum `.print-page` memaksa satu bagian satu halaman, dan untuk
+     daftar kloter itu memang yang diinginkan: tiap petugas garis start
+     memegang kertasnya sendiri. Untuk rekap ia menghambur-hamburkan kertas.
+     Terukur: mencetak MA IPHI Pamarican — satu regu — menghasilkan DUA
+     halaman yang masing-masing terisi 12%.
+
+     Di sini bagian-bagiannya dibiarkan mengalir, jadi satu sekolah kecil
+     keluar satu halaman dan yang besar memakai sebanyak yang memang perlu.
+
+     Selektornya `.print-page.rekap-cetak`, bukan `.rekap-cetak` saja. Aturan
+     yang dibatalkan berkekhususan (0,1,0) dan menang lewat urutan berkas;
+     mengandalkan urutan berarti aturan ini berhenti bekerja begitu ada yang
+     memindahkan blok (CLAUDE.md 15.12). Dua kelas = (0,2,0), menang tanpa
+     bergantung pada letak. */
+  .print-page.rekap-cetak { break-after: auto; page-break-after: auto; }
+  /* Jarak antar bagian yang kini berbagi halaman. Tanpa ini kepala bagian
+     kedua menempel pada garis penutup tabel di atasnya dan terbaca seperti
+     bagian dari tabel yang sama. */
+  .rekap-cetak + .rekap-cetak { margin-top: 7mm; }
+  /* Judul tidak boleh tertinggal sendirian di kaki halaman sementara tabelnya
+     pindah ke halaman berikutnya. */
+  .rekap-cetak h1,
+  .rekap-cetak .lembar-kepala { break-after: avoid; page-break-after: avoid; }
+  /* Kepala tabel diulang di tiap halaman waktu satu bagian terbelah — tabel
+     29 kolom tanpa kepala di halaman kedua tidak bisa dibaca sama sekali. */
+  .rekap-cetak .print-table thead { display: table-header-group; }
+
   .rekap-cetak h1 { font-size: 11pt; margin-bottom: .2rem; }
   .rekap-cetak .lembar-kepala { font-size: 8pt; margin: 0; }
   .rekap-cetak .print-table { margin-top: 3pt; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 23, sidik: "ecc91c5f7209" },
+  "style.css": { versi: 24, sidik: "08affd619abc" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/live_score_rekap_print.test.mjs
+++ b/tests/live_score_rekap_print.test.mjs
@@ -125,8 +125,10 @@ test("kolom dibelah antar-lembar, selalu di ANTARA pos", () => {
     "kolom Total tidak ada di kepala tiap lembar");
   assert.match(cetakan, /\}\$\{selTotal\(k\)\}<\/tr>/,
     "kolom Total tidak ada di badan tiap lembar");
-  assert.match(cetakan, /Lembar \$\{i \+ 1\}\/\$\{LEMBAR\.length\}/,
-    "halaman tidak menyebut lembar keberapa dari berapa");
+  // "Bagian", bukan "Lembar": bagian-bagiannya mengalir dan bisa berbagi satu
+  // halaman kertas, jadi menyebutnya lembar akan membohongi yang memegangnya.
+  assert.match(cetakan, /Bagian \$\{i \+ 1\}\/\$\{LEMBAR\.length\}/,
+    "halaman tidak menyebut bagian keberapa dari berapa");
 });
 
 test("satu bagian per golongan, bukan satu tabel campuran", () => {
@@ -208,4 +210,23 @@ test("kertas A4 melintang dan hurufnya tidak di bawah 7pt", () => {
     assert.ok(Number(tebal) >= 0.75,
       `garis ${tebal}pt di bawah batas 0,75pt (CLAUDE.md 8.5)`);
   }
+});
+
+
+test("bagian rekap mengalir, tidak memaksa satu halaman masing-masing", () => {
+  // Terukur: mencetak sekolah bersatu regu menghasilkan DUA halaman yang
+  // masing-masing terisi 12% sebelum perbaikan ini.
+  assert.match(css,
+    /\.print-page\.rekap-cetak \{ break-after: auto; page-break-after: auto; \}/,
+    "bagian rekap masih memaksa halaman baru masing-masing");
+  // Dua kelas, bukan satu: aturan yang dibatalkan berkekhususan sama dan
+  // menang lewat urutan berkas (CLAUDE.md 15.12).
+  assert.doesNotMatch(css, /^\s*\.rekap-cetak \{ break-after: auto/m,
+    "pembatalannya bergantung pada urutan berkas, bukan kekhususan");
+  assert.match(css, /\.rekap-cetak \+ \.rekap-cetak \{ margin-top: 7mm; \}/,
+    "tidak ada jarak antar bagian yang berbagi halaman");
+  assert.match(css, /\.rekap-cetak \.lembar-kepala \{ break-after: avoid/,
+    "judul bagian bisa tertinggal sendirian di kaki halaman");
+  assert.match(css, /\.rekap-cetak \.print-table thead \{ display: table-header-group; \}/,
+    "kepala tabel tidak diulang saat satu bagian terbelah antar halaman");
 });

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=21">
+  <link rel="stylesheet" href="style.css?v=22">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5639,8 +5639,11 @@ const KOLOM_NILAI_PER_LEMBAR = 12;
  *  diumumkan. Golongan karena itu TIDAK jadi kolom ke-30: ia judul bagian,
  *  tempat ia terbaca sekali per halaman alih-alih diulang di tiap baris.
  *
- *  TIAP GOLONGAN DIBELAH LAGI JADI BEBERAPA LEMBAR, sebanyak yang diperlukan
- *  KOLOM_NILAI_PER_LEMBAR di atas. Pembelahannya selalu jatuh DI ANTARA pos,
+ *  TIAP GOLONGAN DIBELAH LAGI JADI BEBERAPA BAGIAN, sebanyak yang diperlukan
+ *  KOLOM_NILAI_PER_LEMBAR di atas. Bagian adalah potongan KOLOM, bukan
+ *  potongan kertas: bagian-bagiannya MENGALIR, jadi sekolah bersatu regu
+ *  keluar satu halaman berisi dua bagian bertumpuk, bukan dua halaman yang
+ *  masing-masing terisi 12% (terukur, dan itu keluhan yang memperbaikinya). Pembelahannya selalu jatuh DI ANTARA pos,
  *  tidak pernah di tengah-tengah pos: kepala "Pos 3 \u00b7 P3K" membentang di atas
  *  kolom-kolomnya, dan pos yang terbelah dua lembar akan mencetak kepala itu
  *  dua kali di atas separuh kolomnya masing-masing.
@@ -5762,12 +5765,17 @@ function siapkanCetakRekap({ judul, baris, posKolom, rekapDada }) {
     LEMBAR.map((lembar, i) => `
     <section class="print-page rekap-cetak">
       <h1>REKAP NILAI \u00b7 ${esc(judul)} \u00b7 ${esc(GOLONGAN_LABEL[g] || g)}</h1>
-      <!-- "Lembar 1/2" ditulis di tiap halaman karena kertas ini berpindah
-           tangan sebagai lembaran lepas. Lembar kedua yang berdiri sendiri
-           tanpa penanda terbaca seperti rekap yang kehilangan separuh
-           kolomnya. -->
+      <!-- "Bagian 1/2", BUKAN "Lembar 1/2". Bagian-bagian ini mengalir dan
+           bisa berbagi satu halaman kertas: sekolah bersatu regu keluar satu
+           halaman, bukan dua yang masing-masing terisi 12%. Menyebutnya
+           lembar akan membohongi yang memegangnya — ia mencari lembar kedua
+           yang tidak pernah keluar dari printer.
+
+           Penandanya tetap ditulis karena kertas ini berpindah tangan sebagai
+           lembaran lepas: bagian kedua yang berdiri sendiri tanpa penanda
+           terbaca seperti rekap yang kehilangan separuh kolomnya. -->
       <p class="lembar-kepala">${esc(EDISI ? EDISI.name : "")} \u00b7
-         ${esc(String(isi.length))} regu \u00b7 Lembar ${i + 1}/${LEMBAR.length}
+         ${esc(String(isi.length))} regu \u00b7 Bagian ${i + 1}/${LEMBAR.length}
          \u00b7 Dicetak ${esc(dicetak)}</p>
       <table class="print-table">
         <thead>

--- a/web/style.css
+++ b/web/style.css
@@ -1718,6 +1718,35 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   @page rekap-cetak { size: A4 landscape; margin: 8mm; }
   .rekap-cetak { page: rekap-cetak; }
 
+  /* ---- BAGIAN REKAP MENGALIR, TIDAK MEMAKSA HALAMAN BARU ----
+
+     Aturan umum `.print-page` memaksa satu bagian satu halaman, dan untuk
+     daftar kloter itu memang yang diinginkan: tiap petugas garis start
+     memegang kertasnya sendiri. Untuk rekap ia menghambur-hamburkan kertas.
+     Terukur: mencetak MA IPHI Pamarican — satu regu — menghasilkan DUA
+     halaman yang masing-masing terisi 12%.
+
+     Di sini bagian-bagiannya dibiarkan mengalir, jadi satu sekolah kecil
+     keluar satu halaman dan yang besar memakai sebanyak yang memang perlu.
+
+     Selektornya `.print-page.rekap-cetak`, bukan `.rekap-cetak` saja. Aturan
+     yang dibatalkan berkekhususan (0,1,0) dan menang lewat urutan berkas;
+     mengandalkan urutan berarti aturan ini berhenti bekerja begitu ada yang
+     memindahkan blok (CLAUDE.md 15.12). Dua kelas = (0,2,0), menang tanpa
+     bergantung pada letak. */
+  .print-page.rekap-cetak { break-after: auto; page-break-after: auto; }
+  /* Jarak antar bagian yang kini berbagi halaman. Tanpa ini kepala bagian
+     kedua menempel pada garis penutup tabel di atasnya dan terbaca seperti
+     bagian dari tabel yang sama. */
+  .rekap-cetak + .rekap-cetak { margin-top: 7mm; }
+  /* Judul tidak boleh tertinggal sendirian di kaki halaman sementara tabelnya
+     pindah ke halaman berikutnya. */
+  .rekap-cetak h1,
+  .rekap-cetak .lembar-kepala { break-after: avoid; page-break-after: avoid; }
+  /* Kepala tabel diulang di tiap halaman waktu satu bagian terbelah — tabel
+     29 kolom tanpa kepala di halaman kedua tidak bisa dibaca sama sekali. */
+  .rekap-cetak .print-table thead { display: table-header-group; }
+
   .rekap-cetak h1 { font-size: 11pt; margin-bottom: .2rem; }
   .rekap-cetak .lembar-kepala { font-size: 8pt; margin: 0; }
   .rekap-cetak .print-table { margin-top: 3pt; }


### PR DESCRIPTION
## What

Bagian Rekap Nilai tidak lagi memaksa halaman kertas baru masing-masing. Jumlah
kolomnya **tidak** dikurangi — seluruh 29 kolom tetap tercetak; yang berubah
cuma cara bagiannya ditempatkan di kertas.

Penandanya berganti dari "Lembar 1/2" jadi "Bagian 1/2".

## Why

Mencetak sekolah bersatu regu menghasilkan **dua halaman yang masing-masing
terisi 12%**. Sekolah berenam regu di dua golongan menghasilkan **empat**.

Aturan umum `.print-page` memaksa satu bagian satu halaman, dan untuk daftar
kloter itu memang yang diinginkan — tiap petugas garis start memegang kertasnya
sendiri. Untuk rekap ia menghambur-hamburkan kertas.

Terukur di browser atas data 143 regu:

| Cetak | Regu | Sebelum | Sesudah |
| --- | --- | --- | --- |
| MA IPHI Pamarican | 1 | 2 halaman | **1** |
| MA Sirnarasa | 1 | 2 halaman | **1** |
| MAN Darussalam | 6 | 4 halaman | **1** |
| SMAN 1 Sukadana | 12 | 4 halaman | **1** |
| seluruh regu | 143 | 8 halaman | **7** |

## Notes

Selektornya `.print-page.rekap-cetak`, bukan `.rekap-cetak` saja. Aturan yang
dibatalkan berkekhususan sama dan menang lewat urutan berkas; mengandalkan
urutan berarti aturan ini berhenti bekerja begitu ada yang memindahkan bloknya
(CLAUDE.md 15.12). Ada tes yang menjaga bentuk selektornya.

Tiga hal ikut supaya aliran itu tidak melahirkan masalah lain:

- jarak 7mm antar bagian yang kini berbagi halaman — tanpa itu kepala bagian
  kedua menempel pada garis penutup tabel di atasnya dan terbaca seperti bagian
  dari tabel yang sama;
- `break-after: avoid` pada judul supaya ia tidak tertinggal sendirian di kaki
  halaman sementara tabelnya pindah;
- `display: table-header-group` supaya kepala tabel diulang saat satu bagian
  terbelah — tabel 29 kolom tanpa kepala di halaman kedua tidak bisa dibaca
  sama sekali.

"Bagian", bukan "Lembar": bagian-bagian ini bisa berbagi satu halaman kertas
sekarang, jadi menyebutnya lembar akan membuat yang memegangnya mencari lembar
kedua yang tidak pernah keluar dari printer.

337 tes JS lulus. Diverifikasi di layar sungguhan, bukan di halaman contoh:
cetakan dibangun untuk lima sekolah berbeda dan tinggi halamannya diukur
terhadap tinggi A4 melintang.
