### PR TITLE
fix: tombol SIMPAN NILAI tidak lagi menutupi kotak Nomor dada

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=24">
+  <link rel="stylesheet" href="style.css?v=25">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4679,6 +4679,33 @@ button.pill-number:hover { filter: brightness(.95); }
 
    `bottom` diberi jarak untuk menu bawah HP yang setinggi 56px + safe area,
    supaya keduanya tidak bertumpuk. */
+/* KARTUNYA HARUS `overflow: visible`, dan tanpa itu tombol di bawah menutupi
+   kotak Nomor dada.
+
+   `.card { overflow-x: auto }` berlaku untuk SEMUA kartu, dan menurut aturan
+   CSS `overflow-y` ikut menjadi `auto` begitu `overflow-x` bukan `visible`.
+   Kartu Input Pos v2 karena itu diam-diam menjadi scroll container — dan
+   `position: sticky` menempel pada scrollport TERDEKAT, yaitu kartu itu
+   sendiri, bukan layar.
+
+   Akibatnya persis kebalikan dari yang dimaksud. Selama regu belum dipilih
+   kartunya pendek, jadi tombol yang seharusnya turun ke dasar LAYAR malah
+   dijepit ke dasar KARTU — naik ke atas, menimpa kotak Nomor dada. Terukur
+   di iframe 390px: kotaknya 183–239, tombolnya mulai 197. Empat puluh dua
+   piksel menutupi kotak yang justru harus diketik lebih dulu, dan petugas
+   tidak bisa memasukkan satu nilai pun.
+
+   Ini jebakan yang SAMA dengan yang sudah tercatat di layar Kejuaraan
+   (`.kejuaraan-bagian .card { overflow: visible }`), muncul lagi lewat gejala
+   yang sama sekali berbeda. Kartu ini tidak memuat tabel lebar, jadi gunting
+   mendatar itu memang tidak pernah ia butuhkan.
+
+   Yang diperbaiki KARTUNYA, bukan tombolnya. Mengganti `sticky` jadi `static`
+   juga menghilangkan tumpang tindihnya, tapi sekaligus membuang gunanya:
+   dengan foto terpasang tombolnya berakhir 357px di bawah lipatan, dan dengan
+   papan ketik terbuka bahkan regu tanpa foto pun menuntut menggulir. */
+#v2-kartu { overflow: visible; }
+
 .v2-simpan-lekat {
   position: sticky; bottom: .6rem; z-index: 5;
   margin-top: .7rem; min-height: 60px; font-size: 1.2rem;

--- a/tests/input_pos_v2_simpan_tidak_menimpa.test.mjs
+++ b/tests/input_pos_v2_simpan_tidak_menimpa.test.mjs
@@ -1,0 +1,51 @@
+// ============================================================================
+// hrcd-rekap : tests/input_pos_v2_simpan_tidak_menimpa.test.mjs
+// Tombol SIMPAN NILAI tidak boleh menutupi kotak Nomor dada.
+//
+// Terukur di iframe 390px sebelum perbaikan: kotak Nomor dada 183-239,
+// tombolnya mulai 197 — empat puluh dua piksel menutupi kotak yang justru
+// harus diketik lebih dulu, jadi petugas tidak bisa memasukkan satu nilai pun.
+//
+// SEBABNYA BUKAN TOMBOLNYA. `.card { overflow-x: auto }` berlaku untuk semua
+// kartu, dan menurut aturan CSS `overflow-y` ikut jadi `auto` begitu
+// `overflow-x` bukan `visible`. Kartu Input Pos v2 karena itu diam-diam
+// menjadi scroll container, dan `position: sticky` menempel pada scrollport
+// TERDEKAT — kartu itu sendiri, bukan layar. Selama regu belum dipilih
+// kartunya pendek, jadi tombol yang seharusnya turun ke dasar layar malah
+// dijepit ke dasar kartu: naik, menimpa kotaknya.
+//
+// Jebakan yang sama sudah pernah tercatat di layar Kejuaraan
+// (`.kejuaraan-bagian .card { overflow: visible }`) dan muncul lagi lewat
+// gejala yang sama sekali berbeda. Karena itu ia dijaga mesin sekarang.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+test("kartu Input Pos v2 bukan scroll container", () => {
+  assert.match(css, /#v2-kartu \{ overflow: visible; \}/,
+    "kartu Input Pos v2 kembali mewarisi `.card { overflow-x: auto }` — "
+    + "tombol SIMPAN NILAI akan menempel ke dasar KARTU, bukan ke layar, "
+    + "dan menimpa kotak Nomor dada");
+});
+
+test("tombol simpan tetap menempel — perbaikannya di kartu, bukan di tombol", () => {
+  // Mengganti `sticky` jadi `static` juga menghilangkan tumpang tindihnya,
+  // dan sekaligus membuang gunanya: dengan foto terpasang tombolnya berakhir
+  // 357px di bawah lipatan, dan dengan papan ketik terbuka bahkan regu tanpa
+  // foto pun menuntut menggulir.
+  const blok = css.slice(css.indexOf(".v2-simpan-lekat {"));
+  assert.match(blok.slice(0, 200), /position: sticky; bottom: \.6rem;/,
+    "tombol simpan tidak lagi menempel di dasar layar");
+});
+
+test("`.card { overflow-x: auto }` masih ada dan masih beralasan", () => {
+  // Kalau suatu hari aturan ini dibuang, kedua penambal di atasnya jadi
+  // sampah yang menyesatkan — dan tes ini yang memberi tahu.
+  assert.match(css, /\.card \{ overflow-x: auto; \}/,
+    "`.card { overflow-x: auto }` hilang — periksa apakah #v2-kartu dan "
+    + ".kejuaraan-bagian .card masih perlu membatalkannya");
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 24, sidik: "08affd619abc" },
+  "style.css": { versi: 25, sidik: "8ad6bcea87fd" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=22">
+  <link rel="stylesheet" href="style.css?v=23">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -4679,6 +4679,33 @@ button.pill-number:hover { filter: brightness(.95); }
 
    `bottom` diberi jarak untuk menu bawah HP yang setinggi 56px + safe area,
    supaya keduanya tidak bertumpuk. */
+/* KARTUNYA HARUS `overflow: visible`, dan tanpa itu tombol di bawah menutupi
+   kotak Nomor dada.
+
+   `.card { overflow-x: auto }` berlaku untuk SEMUA kartu, dan menurut aturan
+   CSS `overflow-y` ikut menjadi `auto` begitu `overflow-x` bukan `visible`.
+   Kartu Input Pos v2 karena itu diam-diam menjadi scroll container — dan
+   `position: sticky` menempel pada scrollport TERDEKAT, yaitu kartu itu
+   sendiri, bukan layar.
+
+   Akibatnya persis kebalikan dari yang dimaksud. Selama regu belum dipilih
+   kartunya pendek, jadi tombol yang seharusnya turun ke dasar LAYAR malah
+   dijepit ke dasar KARTU — naik ke atas, menimpa kotak Nomor dada. Terukur
+   di iframe 390px: kotaknya 183–239, tombolnya mulai 197. Empat puluh dua
+   piksel menutupi kotak yang justru harus diketik lebih dulu, dan petugas
+   tidak bisa memasukkan satu nilai pun.
+
+   Ini jebakan yang SAMA dengan yang sudah tercatat di layar Kejuaraan
+   (`.kejuaraan-bagian .card { overflow: visible }`), muncul lagi lewat gejala
+   yang sama sekali berbeda. Kartu ini tidak memuat tabel lebar, jadi gunting
+   mendatar itu memang tidak pernah ia butuhkan.
+
+   Yang diperbaiki KARTUNYA, bukan tombolnya. Mengganti `sticky` jadi `static`
+   juga menghilangkan tumpang tindihnya, tapi sekaligus membuang gunanya:
+   dengan foto terpasang tombolnya berakhir 357px di bawah lipatan, dan dengan
+   papan ketik terbuka bahkan regu tanpa foto pun menuntut menggulir. */
+#v2-kartu { overflow: visible; }
+
 .v2-simpan-lekat {
   position: sticky; bottom: .6rem; z-index: 5;
   margin-top: .7rem; min-height: 60px; font-size: 1.2rem;


### PR DESCRIPTION
## What

`#v2-kartu { overflow: visible; }` — satu baris di kartu Input Nilai Pos v2.

## Why

Di layar Input Nilai Pos v2, selama regu belum dipilih, tombol SIMPAN NILAI
naik dan menimpa kotak Nomor dada. Terukur di iframe 390px: kotaknya `183–239`,
tombolnya mulai `197` — **42px menutupi kotak yang justru harus diketik lebih
dulu**, jadi petugas tidak bisa memasukkan satu nilai pun. Dilaporkan panitia
dengan tangkapan layar dari HP.

**Sebabnya bukan tombolnya.** `.card { overflow-x: auto }` berlaku untuk semua
kartu, dan menurut aturan CSS `overflow-y` ikut menjadi `auto` begitu
`overflow-x` bukan `visible`. Kartu Input Pos v2 karena itu diam-diam menjadi
scroll container, dan `position: sticky` menempel pada scrollport **terdekat** —
kartu itu sendiri, bukan layar. Kartu yang pendek menjepit tombolnya ke dasar
kartu, jadi tombol yang seharusnya turun ke dasar layar malah naik.

Jebakan yang **sama** sudah tercatat di layar Kejuaraan
(`.kejuaraan-bagian .card { overflow: visible }`) dan muncul lagi lewat gejala
yang sama sekali berbeda. Sekarang ia dijaga mesin.

## Notes

Yang diperbaiki kartunya, bukan tombolnya. Mengganti `sticky` jadi `static`
juga menghilangkan tumpang tindihnya, tapi sekaligus membuang gunanya: dengan
foto terpasang tombolnya berakhir 357px di bawah lipatan, dan dengan papan ketik
terbuka bahkan regu tanpa foto pun menuntut menggulir. Kartu ini tidak memuat
tabel lebar, jadi gunting mendatar itu memang tidak pernah ia butuhkan.

Diukur di browser, bukan dibaca (CLAUDE.md 15.9):

- tumpang tindih **nol** di 320, 360, 390, 430, 500, 560, 561, 700 dan 900px;
- tidak ada penggulir mendatar di kartunya di lebar mana pun;
- sticky-nya tetap bekerja — pada layar setinggi 440px (meniru papan ketik
  terbuka) tombolnya terpaku 64px di atas dasar layar saat halaman digulir,
  lalu lepas dengan benar di ujung kartu.

Tiga tes baru menjaga ketiganya, termasuk satu yang berbunyi kalau
`.card { overflow-x: auto }` suatu hari dibuang — tanpa itu kedua penambal
`overflow: visible` jadi sampah yang menyesatkan.

340 tes JS lulus.
