### PR TITLE
fix: kolom identitas Rekap Nilai sejajar di setiap bagian

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=25">
+  <link rel="stylesheet" href="style.css?v=26">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -1786,6 +1786,81 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      ditulis lagi karena aturan layarnya duduk di luar @media print. */
   .rekap-cetak .print-table th.rekap-batas,
   .rekap-cetak .print-table td.rekap-batas { border-right-width: 1.5pt; }
+
+  /* ---- KOLOM IDENTITAS DIPATOK, SAMA DI SETIAP BAGIAN ----
+
+     Bagian 1 dan Bagian 2 adalah DUA TABEL TERPISAH, dan `table-layout: auto`
+     mengukur masing-masing dari isinya sendiri. Hasilnya kolom yang sama tidak
+     berbaris: terukur Regu 38,1mm di Bagian 1 lawan 43,8mm di Bagian 2, dan
+     Organisasi 39,1 lawan 45,1. Yang membacanya menyusuri satu regu dari
+     bagian atas ke bagian bawah, dan tepi kolom yang berpindah memutus garis
+     pandang itu.
+
+     Sebabnya bukan datanya melainkan tetangganya: kepala kolom Bagian 1
+     ("Pengetahuan Umum", "Balap Karung") lebih lebar daripada kepala Bagian 2,
+     jadi sisa untuk nama lebih sedikit di sana. Karena itu yang dipatok kolom
+     identitasnya, dan yang MENGALAH kolom pos di tengah — persis seperti tabel
+     Meja Pembayaran di layar, tempat kolom pertama dan terakhir dipertemukan
+     dan yang di antaranya dibiarkan berbeda (CLAUDE.md 15.2).
+
+     `fixed`, bukan `auto`: di bawah `auto` lebar yang dipatok cuma usulan, dan
+     isi yang lebih lebar tetap mendorongnya. Di bawah `fixed` patokannya
+     mengikat, dan yang tidak dipatok membagi rata sisanya.
+
+     HANYA BARIS KEPALA PERTAMA yang menentukan lebar di bawah `fixed`
+     (CLAUDE.md 15.5), dan di baris itu kolom pos berupa sel ber-colspan —
+     jadi kedua belas kolom pos membagi rata sisa 60%. Rantai anak dipakai
+     supaya patokan ini tidak bocor ke baris kepala kedua maupun ke badan.
+
+     ANGKANYA DARI PENGUKURAN, dan yang diukur KATA TUNGGAL TERPANJANG di
+     tiap kolom — karena kata itulah yang tidak bisa dibungkus, dan yang akan
+     dipatah di tengah kalau kolomnya kurang. Diukur atas data 143 regu:
+
+       kepala pos  "Kepramukaan"  16,7mm   (lalu "Pengetahuan" ~16,5)
+       Regu        "RANGGAYUNAN"  18,7mm
+       Organisasi  "Al-Mu'aawanah" 18,2mm
+       Total       "Total"        ~10mm
+
+     Dari 281mm yang tersedia: 2,8 + 4,2 + 7,5 + 7,5 + 3,8 = 25,8% dipatok, dan
+     74,2% sisanya dibagi dua belas kolom pos = 6,18% masing-masing. Semua di
+     atas kebutuhannya, jadi tidak ada satu kata pun yang dipatah:
+
+       #           2,8%   7,9mm
+       No Dada     4,2%  11,8mm
+       Regu        7,5%  21,1mm
+       Organisasi  7,5%  21,1mm
+       Total       3,8%  10,7mm
+       tiap pos    6,18% 17,4mm
+
+     Pembagiannya sempit di kedua ujung, dan itu memang batasnya: 8% untuk
+     nama membuat kolom pos 17,0mm dan "Kepramukaan" (15,5mm isi) dipatah;
+     7% membuat kolom nama 19,7mm dan "RANGGAYUNAN" (18,7mm) yang dipatah.
+     Jangan menggeser angka ini tanpa mengukur ulang KEDUA sisinya.
+
+     DUA BELAS adalah jumlah kolom pos HARI INI (Pos 1 enam, Pos 2 enam di
+     Bagian 1; Pos 3 empat + PBB + Yel-Yel + enam perjalanan di Bagian 2).
+     Kalau lomba bertambah tahun depan, jatah per kolom mengecil sendiri —
+     ukur ulang kata terpanjangnya sebelum menganggapnya masih muat. */
+  .rekap-cetak .print-table { table-layout: fixed; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(1) { width: 2%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(2) { width: 3.3%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(3) { width: 7.4%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(4) { width: 7.4%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:last-child { width: 3.4%; }
+  /* KEPALA KOLOM HARUS BOLEH MEMBUNGKUS, dan ini bukan aturan mubazir.
+
+     `.pos-kol { white-space: nowrap }` duduk DI LUAR `@media print` — ia
+     ditulis untuk papan Live Score di layar, tempat kolom memang tidak boleh
+     patah — dan karena itu ia ikut terbawa ke kertas. Akibatnya "Pengetahuan
+     Umum" dan "Balap Karung" menolak membungkus: di bawah `auto` mereka
+     melebarkan kolomnya sampai tabelnya tidak muat, dan di bawah `fixed`
+     mereka MELUAP menimpa kolom sebelahnya. Terlihat di cetakan: "Semaphore"
+     menabrak "Tebak Simpul", "Pengetahuan U" menabrak "Nilai".
+
+     Kekhususan (0,2,1) mengalahkan `.pos-kol` (0,1,0), jadi ia menang tanpa
+     bergantung pada urutan berkas (CLAUDE.md 15.12). `overflow-wrap` menyusul
+     untuk kata tunggal yang tetap lebih lebar dari kolomnya. */
+  .rekap-cetak .print-table th { white-space: normal; overflow-wrap: break-word; }
 }
 
 @page { margin: 12mm; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 25, sidik: "8ad6bcea87fd" },
+  "style.css": { versi: 26, sidik: "335f78c55593" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/live_score_rekap_print.test.mjs
+++ b/tests/live_score_rekap_print.test.mjs
@@ -230,3 +230,47 @@ test("bagian rekap mengalir, tidak memaksa satu halaman masing-masing", () => {
   assert.match(css, /\.rekap-cetak \.print-table thead \{ display: table-header-group; \}/,
     "kepala tabel tidak diulang saat satu bagian terbelah antar halaman");
 });
+
+test("kolom identitas dipatok, sama di setiap bagian", () => {
+  // Bagian 1 dan Bagian 2 adalah DUA TABEL TERPISAH; di bawah `auto` masing-
+  // masing mengukur dari isinya sendiri dan kolom yang sama tidak berbaris —
+  // terukur Regu 38,1mm lawan 43,8mm sebelum patokan ini.
+  assert.match(css, /\.rekap-cetak \.print-table \{ table-layout: fixed; \}/,
+    "tabel rekap kembali `auto` — lebar kolom identitas akan berbeda antar bagian");
+
+  // Angkanya datang dari pengukuran kata tunggal terpanjang tiap kolom, dan
+  // pembagiannya sempit di KEDUA ujung: menaikkan kolom nama mematahkan
+  // "Kepramukaan" di kepala pos, menurunkannya mematahkan "RANGGAYUNAN".
+  // Jangan ubah tanpa mengukur ulang keduanya.
+  const patokan = [
+    ["th:nth-child(1)", "2%"],
+    ["th:nth-child(2)", "3.3%"],
+    ["th:nth-child(3)", "7.4%"],
+    ["th:nth-child(4)", "7.4%"],
+    ["th:last-child", "3.4%"],
+  ];
+  for (const [sel, lebar] of patokan) {
+    const baris = `.rekap-cetak .print-table > thead > tr:first-child > ${sel} `
+      + `{ width: ${lebar}; }`;
+    assert.ok(css.includes(baris),
+      `patokan lebar hilang atau berubah tanpa diukur ulang: ${baris}`);
+  }
+
+  // Rantai anak, bukan selektor keturunan: patokan ini tidak boleh bocor ke
+  // baris kepala kedua maupun ke sel badan (CLAUDE.md 15.5).
+  assert.doesNotMatch(css, /\.rekap-cetak \.print-table th:nth-child\(\d\) \{ width:/,
+    "patokan lebar memakai selektor keturunan — ia akan mengenai baris kepala "
+    + "kedua dan sel badan juga");
+});
+
+test("kepala kolom cetak boleh membungkus, melawan .pos-kol", () => {
+  // `.pos-kol { white-space: nowrap }` duduk DI LUAR @media print — ia ditulis
+  // untuk papan Live Score di layar — dan karena itu ikut terbawa ke kertas.
+  // Tanpa pembatalan ini "Pengetahuan Umum" dan "Semaphore" MELUAP menimpa
+  // kolom sebelahnya di bawah `fixed`.
+  assert.ok(css.includes(
+    ".rekap-cetak .print-table th { white-space: normal; overflow-wrap: break-word; }"),
+    "kepala kolom cetak kembali menolak membungkus");
+  assert.match(css, /\.pos-kol \{[\s\S]{0,140}white-space: nowrap;/,
+    "`.pos-kol` tidak lagi nowrap — periksa apakah pembatalan di atas masih perlu");
+});

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=23">
+  <link rel="stylesheet" href="style.css?v=24">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -1786,6 +1786,81 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      ditulis lagi karena aturan layarnya duduk di luar @media print. */
   .rekap-cetak .print-table th.rekap-batas,
   .rekap-cetak .print-table td.rekap-batas { border-right-width: 1.5pt; }
+
+  /* ---- KOLOM IDENTITAS DIPATOK, SAMA DI SETIAP BAGIAN ----
+
+     Bagian 1 dan Bagian 2 adalah DUA TABEL TERPISAH, dan `table-layout: auto`
+     mengukur masing-masing dari isinya sendiri. Hasilnya kolom yang sama tidak
+     berbaris: terukur Regu 38,1mm di Bagian 1 lawan 43,8mm di Bagian 2, dan
+     Organisasi 39,1 lawan 45,1. Yang membacanya menyusuri satu regu dari
+     bagian atas ke bagian bawah, dan tepi kolom yang berpindah memutus garis
+     pandang itu.
+
+     Sebabnya bukan datanya melainkan tetangganya: kepala kolom Bagian 1
+     ("Pengetahuan Umum", "Balap Karung") lebih lebar daripada kepala Bagian 2,
+     jadi sisa untuk nama lebih sedikit di sana. Karena itu yang dipatok kolom
+     identitasnya, dan yang MENGALAH kolom pos di tengah — persis seperti tabel
+     Meja Pembayaran di layar, tempat kolom pertama dan terakhir dipertemukan
+     dan yang di antaranya dibiarkan berbeda (CLAUDE.md 15.2).
+
+     `fixed`, bukan `auto`: di bawah `auto` lebar yang dipatok cuma usulan, dan
+     isi yang lebih lebar tetap mendorongnya. Di bawah `fixed` patokannya
+     mengikat, dan yang tidak dipatok membagi rata sisanya.
+
+     HANYA BARIS KEPALA PERTAMA yang menentukan lebar di bawah `fixed`
+     (CLAUDE.md 15.5), dan di baris itu kolom pos berupa sel ber-colspan —
+     jadi kedua belas kolom pos membagi rata sisa 60%. Rantai anak dipakai
+     supaya patokan ini tidak bocor ke baris kepala kedua maupun ke badan.
+
+     ANGKANYA DARI PENGUKURAN, dan yang diukur KATA TUNGGAL TERPANJANG di
+     tiap kolom — karena kata itulah yang tidak bisa dibungkus, dan yang akan
+     dipatah di tengah kalau kolomnya kurang. Diukur atas data 143 regu:
+
+       kepala pos  "Kepramukaan"  16,7mm   (lalu "Pengetahuan" ~16,5)
+       Regu        "RANGGAYUNAN"  18,7mm
+       Organisasi  "Al-Mu'aawanah" 18,2mm
+       Total       "Total"        ~10mm
+
+     Dari 281mm yang tersedia: 2,8 + 4,2 + 7,5 + 7,5 + 3,8 = 25,8% dipatok, dan
+     74,2% sisanya dibagi dua belas kolom pos = 6,18% masing-masing. Semua di
+     atas kebutuhannya, jadi tidak ada satu kata pun yang dipatah:
+
+       #           2,8%   7,9mm
+       No Dada     4,2%  11,8mm
+       Regu        7,5%  21,1mm
+       Organisasi  7,5%  21,1mm
+       Total       3,8%  10,7mm
+       tiap pos    6,18% 17,4mm
+
+     Pembagiannya sempit di kedua ujung, dan itu memang batasnya: 8% untuk
+     nama membuat kolom pos 17,0mm dan "Kepramukaan" (15,5mm isi) dipatah;
+     7% membuat kolom nama 19,7mm dan "RANGGAYUNAN" (18,7mm) yang dipatah.
+     Jangan menggeser angka ini tanpa mengukur ulang KEDUA sisinya.
+
+     DUA BELAS adalah jumlah kolom pos HARI INI (Pos 1 enam, Pos 2 enam di
+     Bagian 1; Pos 3 empat + PBB + Yel-Yel + enam perjalanan di Bagian 2).
+     Kalau lomba bertambah tahun depan, jatah per kolom mengecil sendiri —
+     ukur ulang kata terpanjangnya sebelum menganggapnya masih muat. */
+  .rekap-cetak .print-table { table-layout: fixed; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(1) { width: 2%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(2) { width: 3.3%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(3) { width: 7.4%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:nth-child(4) { width: 7.4%; }
+  .rekap-cetak .print-table > thead > tr:first-child > th:last-child { width: 3.4%; }
+  /* KEPALA KOLOM HARUS BOLEH MEMBUNGKUS, dan ini bukan aturan mubazir.
+
+     `.pos-kol { white-space: nowrap }` duduk DI LUAR `@media print` — ia
+     ditulis untuk papan Live Score di layar, tempat kolom memang tidak boleh
+     patah — dan karena itu ia ikut terbawa ke kertas. Akibatnya "Pengetahuan
+     Umum" dan "Balap Karung" menolak membungkus: di bawah `auto` mereka
+     melebarkan kolomnya sampai tabelnya tidak muat, dan di bawah `fixed`
+     mereka MELUAP menimpa kolom sebelahnya. Terlihat di cetakan: "Semaphore"
+     menabrak "Tebak Simpul", "Pengetahuan U" menabrak "Nilai".
+
+     Kekhususan (0,2,1) mengalahkan `.pos-kol` (0,1,0), jadi ia menang tanpa
+     bergantung pada urutan berkas (CLAUDE.md 15.12). `overflow-wrap` menyusul
+     untuk kata tunggal yang tetap lebih lebar dari kolomnya. */
+  .rekap-cetak .print-table th { white-space: normal; overflow-wrap: break-word; }
 }
 
 @page { margin: 12mm; }


### PR DESCRIPTION
## What

`No Dada`, `Regu`, `Organisasi` dan `Total` selebar sama di Bagian 1 dan
Bagian 2, sehingga satu regu bisa disusuri lurus dari bagian atas ke bagian
bawah. Yang mengalah kolom pos di tengah, persis seperti yang diminta.

## Why

Sebelumnya Regu **38,1mm** di Bagian 1 lawan **43,8mm** di Bagian 2; Organisasi
39,1 lawan 45,1. Keduanya tabel terpisah dan `table-layout: auto` mengukur
masing-masing dari isinya sendiri — kepala kolom Bagian 1 ("Pengetahuan Umum",
"Balap Karung") lebih lebar daripada kepala Bagian 2, jadi sisa untuk nama
lebih sedikit di sana.

Sama seperti tabel Meja Pembayaran di layar: kolom yang harus bertemu dipatok,
yang di antaranya dibiarkan berbeda (CLAUDE.md 15.2).

## Notes

**`.pos-kol { white-space: nowrap }` ternyata duduk di LUAR `@media print`.**
Ia ditulis untuk papan Live Score di layar dan ikut terbawa ke kertas: di bawah
`auto` ia melebarkan kolomnya sampai tabelnya tidak muat — sebagian dari sebab
29 kolom butuh 347mm — dan di bawah `fixed` ia **meluap menimpa kolom
sebelahnya** ("Semaphore" menabrak "Tebak Simpul"). Dibatalkan lewat
kekhususan, bukan urutan berkas.

Angkanya dari pengukuran **kata tunggal terpanjang** tiap kolom, karena kata
itulah yang tidak bisa dibungkus:

| Kolom | Kata terpanjang | Butuh |
| --- | --- | --- |
| kepala pos | "Kepramukaan" | 16,2mm |
| Regu | "RANGGAYUNAN" | 18,7mm |
| Organisasi | "Al-Mu'aawanah" | 18,2mm |

Pembagiannya sempit di **kedua** ujung dan itu memang batasnya: 8% untuk nama
mematahkan "Kepramukaan", 7% mematahkan "RANGGAYUNAN".

Hasil terukur atas 143 regu:

- identitas **5,61 / 9,25 / 20,74 / 20,74 / 9,53mm** — identik di kedelapan bagian
- **nol** kata dipatah di tengah, **nol** sel meluap
- tabel 280,6mm dari 281mm yang tersedia

Harganya dua halaman pada cetak seluruh regu (8 → 10), karena nama membungkus
jadi dua baris di kolom yang lebih sempit. **Cetak per sekolah tetap satu
halaman** (MAN Darussalam, 6 regu, 4 bagian → 1 halaman, dihitung dari PDF
cetak sungguhan).

Permintaan menggabungkan Kontrak/Kloter/Berangkat/Datang/Anggota/Penalti dengan
Pos 3/4/5 **sudah terpenuhi sejak #763** — keenamnya memang sudah satu bagian
dengan ketiga pos itu.

342 tes JS lulus.
