### PR TITLE
feat: Cek Nilai di laptop muat satu layar, foto berjajar tanpa menggulir

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=27">
+  <link rel="stylesheet" href="style.css?v=28">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4980,3 +4980,119 @@ button.pill-number:hover { filter: brightness(.95); }
   display: flex; align-items: center; justify-content: center;
 }
 .cek-foto img { display: block; width: 100%; height: 100%; object-fit: contain; }
+
+/* ---------------------------------------------------------------------------
+   CEK NILAI DI LAPTOP: SATU LAYAR, SEBANYAK MUNGKIN FOTO, TANPA MENGGULIR.
+
+   Layar ini dipakai untuk MENGECEK — mata melompat dari angka yang diketik ke
+   tulisan tangan di fotonya, lomba demi lomba, ratusan kali. Satu kolom
+   menurun memaksa gerakan yang membunuh pekerjaan itu: terukur di 1440x820
+   dengan Pos 1 (lima lomba, lima foto), halamannya 3239px sementara layarnya
+   820px — harus menggulir 2419px, dan yang terlihat tanpa menggulir CUMA SATU
+   FOTO dari lima.
+
+   Di sini lomba dijejer MENYAMPING dan tingginya dikunci ke layar, jadi
+   kelimanya terlihat sekaligus dan tidak ada yang perlu digulir.
+
+   Kenapa 1000px, bukan 561px seperti ambang HP yang lain: di bawah itu lima
+   kolom masing-masing sempit sekali, dan foto selebar 150px tidak menjawab
+   pertanyaan yang membuat orang membuka layar ini. Di HP dan tablet sempit,
+   satu kolom menurun tetap bentuk yang benar — di sana menggulir memang
+   satu-satunya cara, dan fotonya besar.
+   --------------------------------------------------------------------------- */
+@media (min-width: 1000px) {
+  /* Setinggi layar, dan lebar penuh: `wide` mematoknya 1080px, dan patokan itu
+     yang menentukan berapa kolom muat. `--kepala` diukur JavaScript, karena
+     tinggi header berubah mengikuti panjang nama akun. */
+  .isi.cek {
+    max-width: none;
+    height: calc(100dvh - var(--kepala, 52px));
+    display: flex;
+    flex-direction: column;
+    gap: .6rem;
+    padding: .6rem .8rem;
+    overflow: hidden;
+  }
+  /* Kartu kendali (pilih pos + navigasi) dan identitas regu dirampingkan:
+     tiap piksel yang mereka pakai diambil dari tinggi foto. */
+  .isi.cek > .card { margin-bottom: 0; padding: .55rem .8rem; flex: 0 0 auto; }
+  .isi.cek .cek-identitas { margin-bottom: 0; }
+
+  /* Kendali dan identitas SEBARIS, bukan bertumpuk. Dua blok bertumpuk di
+     atas memakan ~170px; sebaris ~90px, dan selisihnya jatuh ke foto. */
+  .isi.cek .baris-pilih { margin: 0; }
+  .isi.cek .cek-navigasi { margin: 0; }
+  .isi.cek .cek-posisi { margin: 0; }
+  /* `.isi.cek > .card`, BUKAN `:first-of-type`. Saudara pertama di dalam
+     .isi adalah <div id="pita-antrean">, dan `div:first-of-type` menunjuk
+     DIA — bukan kartu ini — jadi aturannya tidak pernah mengenai apa pun dan
+     kartunya tetap `display: block` setinggi 163px. Terukur di browser, bukan
+     dibaca (CLAUDE.md 15.9 dan 15.12). Wadah lomba tidak ikut kena karena ia
+     bersarang di dalam #cek-isi, bukan anak langsung .isi. */
+  .isi.cek > .card {
+    display: flex; align-items: end; gap: 1rem 1.4rem; flex-wrap: wrap;
+  }
+  /* Identitas regu ikut sebaris, bukan blok sendiri di bawahnya: dua blok
+     bertumpuk memakan 304px dari 762px yang ada, dan seluruh selisihnya
+     jatuh ke tinggi foto. */
+  .isi.cek .cek-identitas { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .isi.cek .cek-identitas .card-identity {
+    flex: 1 1 auto; padding: .5rem .8rem; margin-bottom: 0;
+  }
+  .isi.cek .cek-identitas .card-identity .nama { font-size: 1.1rem; }
+  .isi.cek .cek-identitas .card-identity .detail { font-size: .85rem; }
+  .isi.cek .cek-kunci { margin-top: 0; flex: 0 0 auto; }
+
+  #cek-isi { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: .6rem; }
+  /* Wadah lomba mengisi sisa tinggi, dan ISINYA yang menyesuaikan — bukan
+     sebaliknya. `min-height: 0` wajib: anak flex bawaannya tidak boleh
+     menyusut di bawah tinggi isinya, dan tanpa itu wadah ini mendorong
+     halaman jadi lebih tinggi daripada layar, persis yang sedang diperbaiki. */
+  #cek-isi > .card {
+    flex: 1; min-height: 0; margin-bottom: 0; padding: .7rem;
+    display: grid;
+    /* 185px, bukan 230px. Diukur: pada 230px lima lomba Pos 1 TIDAK muat di
+       laptop 1024px, gridnya membungkus jadi dua baris, dan tinggi yang
+       dibagi dua membuat fotonya runtuh jadi 35px — tidak terbaca sama
+       sekali, dan justru kebalikan dari yang diminta layar ini.
+
+       170px, bukan 185: pada 185 kelima kolom plus empat celah berjumlah
+       976px dari ~976px yang tersedia di laptop 1024 — persis di ambangnya,
+       dan ia tetap membungkus. Angka pertama minmax cuma BATAS BAWAH; `1fr`
+       yang melebarkan kolomnya di layar besar, jadi menurunkannya tidak
+       mengecilkan apa pun di 1440 atau 1920. Terukur, bukan ditaksir. */
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: .8rem;
+    /* Katup pengaman, bukan keadaan biasa: lomba berkriteria banyak
+       (Pembidaian, lima kotak) bisa melebihi tinggi layar di layar pendek.
+       Yang menggulir kemudian kotak lombanya, bukan seluruh halaman. */
+    overflow: auto;
+  }
+  /* Garis pemisah jadi TEGAK, karena lombanya sekarang bersebelahan.
+     Garis mendatar di antara kolom yang berjajar memisahkan hal yang salah. */
+  .isi.cek .cek-lomba {
+    padding: 0 0 0 .8rem;
+    border-top: 0;
+    border-left: 1px solid var(--garis);
+    display: flex; flex-direction: column; min-height: 0;
+  }
+  .isi.cek .cek-lomba:first-child { padding-left: 0; border-left: 0; }
+  /* Kotak isian dirampingkan: 52px x lima kriteria memakan tinggi yang
+     seluruhnya diambil dari foto. Tetap di atas 16px supaya iOS tidak
+     memaksa zoom saat kotaknya disentuh (aturan di kepala berkas ini). */
+  .isi.cek .cek-isian { margin: .3rem 0; gap: .35rem; }
+  .isi.cek .cek-isian .small-input { font-size: 1.15rem; min-height: 42px; }
+  .isi.cek .cek-isian [data-simpan-lomba] { min-width: 0; width: 100%; }
+
+  /* FOTO MENGISI SISA TINGGI KOLOMNYA. Inilah yang membuat "sebanyak mungkin"
+     berarti sesuatu: tingginya tidak dipatok angka tetap melainkan apa pun
+     yang tersisa sesudah nama, kotak isian, dan tombolnya. */
+  /* `min-height` di sini adalah PAGAR, bukan ukuran: kalau suatu tahun
+     lombanya bertambah sampai gridnya tetap membungkus, foto yang runtuh
+     jadi puluhan piksel tidak menjawab apa pun. Di bawah pagar ini yang
+     mengalah wadahnya — ia menggulir (overflow: auto di atas) — dan fotonya
+     tetap terbaca. */
+  .isi.cek .cek-foto { flex: 1; min-height: 150px; margin-top: .3rem; }
+  .isi.cek .cek-foto .fg-petak { height: 100%; }
+  .isi.cek .cek-lomba .foto-navigasi { margin-top: .25rem; flex: 0 0 auto; }
+}

--- a/tests/cek_nilai_satu_layar.test.mjs
+++ b/tests/cek_nilai_satu_layar.test.mjs
@@ -1,0 +1,77 @@
+// ============================================================================
+// hrcd-rekap : tests/cek_nilai_satu_layar.test.mjs
+// Cek Nilai di laptop: sebanyak mungkin foto dalam satu layar, tanpa menggulir.
+//
+// Layar ini dipakai untuk MENGECEK — mata melompat dari angka yang diketik ke
+// tulisan tangan di fotonya, lomba demi lomba, ratusan kali. Terukur sebelum
+// perbaikan, di 1440x820 dengan Pos 1 (lima lomba, lima foto): halaman 3239px
+// di layar 820px, harus menggulir 2419px, dan yang terlihat CUMA SATU FOTO.
+//
+// Sesudahnya, diukur di lima ukuran laptop: lima dari lima foto terlihat, nol
+// guliran.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+test("kelas layar di-toggle bersama wide dan lembar, bukan dipasang sendiri", () => {
+  // Kelas yang dipasang di layarnya sendiri akan TERTINGGAL waktu pindah
+  // layar, dan layar berikutnya ikut terpotong setinggi viewport.
+  assert.match(app, /LAYAR\.classList\.toggle\("cek", lebar === "cek"\);/,
+    "kelas `cek` tidak di-toggle di pasangKepala bersama wide dan lembar");
+  assert.match(app, /pasangKepala\("Cek Nilai", "cek"\);/,
+    "layar Cek Nilai tidak meminta tata letak satu-layar");
+});
+
+test("tinggi header diukur, tidak ditebak", () => {
+  // Header tumbuh sebaris lagi kalau nama akun panjang; angka tetap apa pun
+  // akan benar di satu ukuran dan memotong foto di ukuran lain.
+  assert.match(app, /LAYAR\.style\.setProperty\(\s*"--kepala"/,
+    "tinggi header tidak diukur ke dalam --kepala");
+  assert.match(css, /height: calc\(100dvh - var\(--kepala, \d+px\)\);/,
+    "tata letak tidak memakai tinggi header yang diukur");
+});
+
+test("pengamat header memakai sinyal layar yang SUDAH ADA", () => {
+  // sinyalLayarBaru() MEMBATALKAN sinyal sebelumnya. Panggilan kedua di layar
+  // yang sama membatalkan sinyal layar itu sendiri, dan muatPos() lalu
+  // berhenti di `if (sinyal.aborted) return` — layarnya menggantung di
+  // "Memuat…" selamanya, tanpa satu pun galat. Itu benar-benar terjadi saat
+  // tata letak ini dibangun.
+  const awal = app.indexOf("async function layarCekNilai()");
+  const akhir = app.indexOf("const RUTE = {", awal);
+  // Komentar dibuang dulu: alasan aturan ini justru dijelaskan di komentar
+  // tepat di atas kodenya, dan nama fungsinya disebut di sana.
+  const layar = app.slice(awal, akhir)
+    .replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+  assert.equal((layar.match(/sinyalLayarBaru\(\)/g) || []).length, 1,
+    "layarCekNilai memanggil sinyalLayarBaru() lebih dari sekali — panggilan "
+    + "kedua membatalkan sinyal layarnya sendiri");
+  assert.match(layar, /putusSaatPindah\(sinyal, pengamatKepala\)/,
+    "pengamat header tidak dilepas lewat sinyal layar");
+});
+
+test("lomba berjajar, foto mengisi sisa tinggi", () => {
+  const blok = css.slice(css.indexOf("@media (min-width: 1000px)"));
+  assert.match(blok, /grid-template-columns: repeat\(auto-fit, minmax\(170px, 1fr\)\);/,
+    "lebar minimum kolom berubah — pada 185px lima lomba tidak muat di laptop "
+    + "1024px dan gridnya membungkus jadi dua baris");
+  assert.match(blok, /\.isi\.cek \.cek-foto \{ flex: 1; min-height: 150px;/,
+    "foto tidak lagi mengisi sisa tinggi, atau pagar runtuhnya hilang");
+  assert.match(blok, /\.isi\.cek \.cek-foto \.fg-petak \{ height: 100%; \}/,
+    "petak foto kembali dipatok tinggi tetap");
+});
+
+test("selektor kartu kendali bukan :first-of-type", () => {
+  // Saudara pertama di dalam .isi adalah <div id="pita-antrean">, jadi
+  // `div:first-of-type` menunjuk DIA — aturannya tidak pernah mengenai apa pun
+  // dan kartunya tetap setinggi 163px. Terukur di browser.
+  const blok = css.slice(css.indexOf("@media (min-width: 1000px)"));
+  assert.doesNotMatch(blok, /\.isi\.cek > \.card:first-of-type/,
+    "kartu kendali kembali dipilih dengan :first-of-type, yang menunjuk "
+    + "#pita-antrean dan tidak mengenai kartunya");
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 27, sidik: "86d41ab4a77f" },
+  "style.css": { versi: 28, sidik: "9deb9ddfca39" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=25">
+  <link rel="stylesheet" href="style.css?v=26">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -182,6 +182,12 @@ function pasangKepala(judul, lebar = false) {
   document.title = `${judul} — ${namaAcara()}`;
   LAYAR.classList.toggle("wide", lebar === true);
   LAYAR.classList.toggle("lembar", lebar === "lembar");
+  /* "cek" = layar Cek Nilai: setinggi layar, tanpa gulir, foto berjajar.
+     Ikut di-toggle di SINI bersama dua yang lain, bukan dipasang sendiri di
+     layarnya — supaya ia ikut mati waktu pindah ke layar mana pun. Kelas yang
+     dipasang di layarnya sendiri akan tertinggal dan membuat layar berikutnya
+     terpotong setinggi viewport. */
+  LAYAR.classList.toggle("cek", lebar === "cek");
   if (s) document.getElementById("siapa").textContent =
     `${s.username} · ${EDISI ? EDISI.name : ""}`;
 }
@@ -9632,7 +9638,7 @@ async function layarCekNilai() {
     return;
   }
 
-  pasangKepala("Cek Nilai", true);
+  pasangKepala("Cek Nilai", "cek");
   LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
@@ -9693,6 +9699,30 @@ async function layarCekNilai() {
     </div>
     <div id="cek-isi"></div>
   `));
+
+  /* Tinggi header DIUKUR, tidak ditebak. Tata letak satu-layar di style.css
+     memakai `calc(100dvh - var(--kepala))`, dan header ini tumbuh sebaris
+     lagi kalau nama akun panjang atau layarnya sempit — angka tetap apa pun
+     akan benar di satu ukuran dan meninggalkan celah atau memotong foto di
+     ukuran lain.
+
+     Diukur ulang saat lebarnya berubah, karena di situ pula pembungkusan
+     headernya berubah. Pengamatnya dilepas saat pindah layar.
+
+     MEMAKAI `sinyal` YANG SUDAH ADA, bukan memanggil sinyalLayarBaru() lagi:
+     fungsi itu MEMBATALKAN sinyal sebelumnya sebelum memberi yang baru.
+     Panggilan kedua di layar yang sama membatalkan sinyal layar itu sendiri,
+     dan muatPos() lalu berhenti di `if (sinyal.aborted) return` — layarnya
+     menggantung di "Memuat…" selamanya, tanpa satu pun galat. */
+  const kepalaEl = document.getElementById("kepala");
+  if (kepalaEl) {
+    const ukurKepala = () => LAYAR.style.setProperty(
+      "--kepala", `${Math.round(kepalaEl.getBoundingClientRect().height)}px`);
+    ukurKepala();
+    const pengamatKepala = new ResizeObserver(ukurKepala);
+    pengamatKepala.observe(kepalaEl);
+    putusSaatPindah(sinyal, pengamatKepala);
+  }
 
   gambarPitaAntrean();
   kirimAntrean();

--- a/web/style.css
+++ b/web/style.css
@@ -4980,3 +4980,119 @@ button.pill-number:hover { filter: brightness(.95); }
   display: flex; align-items: center; justify-content: center;
 }
 .cek-foto img { display: block; width: 100%; height: 100%; object-fit: contain; }
+
+/* ---------------------------------------------------------------------------
+   CEK NILAI DI LAPTOP: SATU LAYAR, SEBANYAK MUNGKIN FOTO, TANPA MENGGULIR.
+
+   Layar ini dipakai untuk MENGECEK — mata melompat dari angka yang diketik ke
+   tulisan tangan di fotonya, lomba demi lomba, ratusan kali. Satu kolom
+   menurun memaksa gerakan yang membunuh pekerjaan itu: terukur di 1440x820
+   dengan Pos 1 (lima lomba, lima foto), halamannya 3239px sementara layarnya
+   820px — harus menggulir 2419px, dan yang terlihat tanpa menggulir CUMA SATU
+   FOTO dari lima.
+
+   Di sini lomba dijejer MENYAMPING dan tingginya dikunci ke layar, jadi
+   kelimanya terlihat sekaligus dan tidak ada yang perlu digulir.
+
+   Kenapa 1000px, bukan 561px seperti ambang HP yang lain: di bawah itu lima
+   kolom masing-masing sempit sekali, dan foto selebar 150px tidak menjawab
+   pertanyaan yang membuat orang membuka layar ini. Di HP dan tablet sempit,
+   satu kolom menurun tetap bentuk yang benar — di sana menggulir memang
+   satu-satunya cara, dan fotonya besar.
+   --------------------------------------------------------------------------- */
+@media (min-width: 1000px) {
+  /* Setinggi layar, dan lebar penuh: `wide` mematoknya 1080px, dan patokan itu
+     yang menentukan berapa kolom muat. `--kepala` diukur JavaScript, karena
+     tinggi header berubah mengikuti panjang nama akun. */
+  .isi.cek {
+    max-width: none;
+    height: calc(100dvh - var(--kepala, 52px));
+    display: flex;
+    flex-direction: column;
+    gap: .6rem;
+    padding: .6rem .8rem;
+    overflow: hidden;
+  }
+  /* Kartu kendali (pilih pos + navigasi) dan identitas regu dirampingkan:
+     tiap piksel yang mereka pakai diambil dari tinggi foto. */
+  .isi.cek > .card { margin-bottom: 0; padding: .55rem .8rem; flex: 0 0 auto; }
+  .isi.cek .cek-identitas { margin-bottom: 0; }
+
+  /* Kendali dan identitas SEBARIS, bukan bertumpuk. Dua blok bertumpuk di
+     atas memakan ~170px; sebaris ~90px, dan selisihnya jatuh ke foto. */
+  .isi.cek .baris-pilih { margin: 0; }
+  .isi.cek .cek-navigasi { margin: 0; }
+  .isi.cek .cek-posisi { margin: 0; }
+  /* `.isi.cek > .card`, BUKAN `:first-of-type`. Saudara pertama di dalam
+     .isi adalah <div id="pita-antrean">, dan `div:first-of-type` menunjuk
+     DIA — bukan kartu ini — jadi aturannya tidak pernah mengenai apa pun dan
+     kartunya tetap `display: block` setinggi 163px. Terukur di browser, bukan
+     dibaca (CLAUDE.md 15.9 dan 15.12). Wadah lomba tidak ikut kena karena ia
+     bersarang di dalam #cek-isi, bukan anak langsung .isi. */
+  .isi.cek > .card {
+    display: flex; align-items: end; gap: 1rem 1.4rem; flex-wrap: wrap;
+  }
+  /* Identitas regu ikut sebaris, bukan blok sendiri di bawahnya: dua blok
+     bertumpuk memakan 304px dari 762px yang ada, dan seluruh selisihnya
+     jatuh ke tinggi foto. */
+  .isi.cek .cek-identitas { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .isi.cek .cek-identitas .card-identity {
+    flex: 1 1 auto; padding: .5rem .8rem; margin-bottom: 0;
+  }
+  .isi.cek .cek-identitas .card-identity .nama { font-size: 1.1rem; }
+  .isi.cek .cek-identitas .card-identity .detail { font-size: .85rem; }
+  .isi.cek .cek-kunci { margin-top: 0; flex: 0 0 auto; }
+
+  #cek-isi { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: .6rem; }
+  /* Wadah lomba mengisi sisa tinggi, dan ISINYA yang menyesuaikan — bukan
+     sebaliknya. `min-height: 0` wajib: anak flex bawaannya tidak boleh
+     menyusut di bawah tinggi isinya, dan tanpa itu wadah ini mendorong
+     halaman jadi lebih tinggi daripada layar, persis yang sedang diperbaiki. */
+  #cek-isi > .card {
+    flex: 1; min-height: 0; margin-bottom: 0; padding: .7rem;
+    display: grid;
+    /* 185px, bukan 230px. Diukur: pada 230px lima lomba Pos 1 TIDAK muat di
+       laptop 1024px, gridnya membungkus jadi dua baris, dan tinggi yang
+       dibagi dua membuat fotonya runtuh jadi 35px — tidak terbaca sama
+       sekali, dan justru kebalikan dari yang diminta layar ini.
+
+       170px, bukan 185: pada 185 kelima kolom plus empat celah berjumlah
+       976px dari ~976px yang tersedia di laptop 1024 — persis di ambangnya,
+       dan ia tetap membungkus. Angka pertama minmax cuma BATAS BAWAH; `1fr`
+       yang melebarkan kolomnya di layar besar, jadi menurunkannya tidak
+       mengecilkan apa pun di 1440 atau 1920. Terukur, bukan ditaksir. */
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: .8rem;
+    /* Katup pengaman, bukan keadaan biasa: lomba berkriteria banyak
+       (Pembidaian, lima kotak) bisa melebihi tinggi layar di layar pendek.
+       Yang menggulir kemudian kotak lombanya, bukan seluruh halaman. */
+    overflow: auto;
+  }
+  /* Garis pemisah jadi TEGAK, karena lombanya sekarang bersebelahan.
+     Garis mendatar di antara kolom yang berjajar memisahkan hal yang salah. */
+  .isi.cek .cek-lomba {
+    padding: 0 0 0 .8rem;
+    border-top: 0;
+    border-left: 1px solid var(--garis);
+    display: flex; flex-direction: column; min-height: 0;
+  }
+  .isi.cek .cek-lomba:first-child { padding-left: 0; border-left: 0; }
+  /* Kotak isian dirampingkan: 52px x lima kriteria memakan tinggi yang
+     seluruhnya diambil dari foto. Tetap di atas 16px supaya iOS tidak
+     memaksa zoom saat kotaknya disentuh (aturan di kepala berkas ini). */
+  .isi.cek .cek-isian { margin: .3rem 0; gap: .35rem; }
+  .isi.cek .cek-isian .small-input { font-size: 1.15rem; min-height: 42px; }
+  .isi.cek .cek-isian [data-simpan-lomba] { min-width: 0; width: 100%; }
+
+  /* FOTO MENGISI SISA TINGGI KOLOMNYA. Inilah yang membuat "sebanyak mungkin"
+     berarti sesuatu: tingginya tidak dipatok angka tetap melainkan apa pun
+     yang tersisa sesudah nama, kotak isian, dan tombolnya. */
+  /* `min-height` di sini adalah PAGAR, bukan ukuran: kalau suatu tahun
+     lombanya bertambah sampai gridnya tetap membungkus, foto yang runtuh
+     jadi puluhan piksel tidak menjawab apa pun. Di bawah pagar ini yang
+     mengalah wadahnya — ia menggulir (overflow: auto di atas) — dan fotonya
+     tetap terbaca. */
+  .isi.cek .cek-foto { flex: 1; min-height: 150px; margin-top: .3rem; }
+  .isi.cek .cek-foto .fg-petak { height: 100%; }
+  .isi.cek .cek-lomba .foto-navigasi { margin-top: .25rem; flex: 0 0 auto; }
+}


### PR DESCRIPTION
## What

Di laptop (≥ 1000px) layar Cek Nilai menjejerkan lomba **menyamping** dan
mengunci tingginya ke layar, jadi seluruh fotonya terlihat sekaligus tanpa
menggulir. Di bawah 1000px tidak ada yang berubah.

## Why

Layar ini dipakai untuk **mengecek**: mata melompat dari angka yang diketik ke
tulisan tangan di fotonya, lomba demi lomba, ratusan kali. Satu kolom menurun
memaksa gerakan yang membunuh pekerjaan itu.

Terukur di 1440×820 dengan Pos 1 (lima lomba, lima foto): halamannya **3239px**
di layar **820px** — harus menggulir **2419px**, dan yang terlihat tanpa
menggulir **cuma satu foto dari lima**.

## Notes

Diukur di lima ukuran laptop; semuanya **5 dari 5 foto terlihat, nol guliran**:

| Layar | Petak foto |
| --- | --- |
| 1024×640 | 185×216 |
| 1280×720 | 236×296 |
| 1366×768 | 253×344 |
| 1440×820 | 268×396 |
| 1920×1080 | 364×656 |

Tinggi foto **tidak dipatok angka tetap** melainkan sisa tinggi sesudah nama,
kotak isian, dan tombolnya — itulah yang membuat "sebanyak mungkin" berarti
sesuatu. Kartu kendali dan identitas dirampingkan jadi sebaris: keduanya dulu
memakan 304px dari 762px yang ada, sekarang 161px, dan seluruh selisihnya jatuh
ke tinggi foto (252 → 396px).

Ambangnya 1000px. Diperiksa di 390, 768 dan 999px — tata letak HP **tidak
berubah sama sekali**, dan tidak ada penggulir mendatar di lebar mana pun.

Dua jebakan yang ditemukan dengan **mengukur**, bukan membaca (CLAUDE.md 15.9):

- `.isi.cek > .card:first-of-type` tidak mengenai apa pun — saudara pertama di
  dalam `.isi` adalah `<div id="pita-antrean">`, jadi `div:first-of-type`
  menunjuk dia. Kartunya tetap 163px sampai selektornya dibetulkan.
- `minmax(230px)` membuat lima lomba tidak muat di laptop 1024px; gridnya
  membungkus dan tinggi yang dibagi dua meruntuhkan foto jadi **35px** —
  kebalikan dari yang diminta. Sekarang 170px, dengan `min-height` sebagai
  pagar kalau lombanya bertambah tahun depan.

Satu bug yang saya buat lalu perbaiki, dicatat karena **diamnya total**:
`sinyalLayarBaru()` MEMBATALKAN sinyal sebelumnya, jadi panggilan kedua di layar
yang sama membatalkan sinyal layarnya sendiri dan `muatPos()` berhenti di
`if (sinyal.aborted) return`. Layarnya menggantung di "Memuat…" selamanya tanpa
satu pun galat. Ada tesnya sekarang.

351 tes JS lulus.
