### PR TITLE
feat: foto slip bisa diputar 90 derajat, dan putarannya tersimpan

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -13,14 +13,16 @@ kelima `juara` beserta `v_kejuaraan_publik` dan `hasil_kejuaraan_semua()` —
 mendarat sesudah penghitungan itu, jadi angka view dan fungsi di bagian 2
 kurang satu masing-masing; `0164` menulis ulang view yang sama untuk
 membawa kolom skornya dan tidak mengubah jumlahnya. Disegarkan lagi
-31 Agustus 2026 sampai migrasi `0166`, dan cakupannya SEMPIT: yang
+31 Agustus 2026 sampai migrasi `0167`, dan cakupannya SEMPIT: yang
 diperiksa hanya jumlah migrasi beserta bagian singgahan `cache_live_score`
 di bawah. `0165` menambah satu fungsi, `minta_segarkan_live_score()`,
 dan `0166` menambah satu view (`v_lomba_pos`) beserta dua fungsi
 (`lomba_komponen()` dan bentuk tiga-argumen `nilai_tergembok()`) sambil
-menjadikan gembok nilai PER LOMBA — sehingga angka view dan fungsi di
-bagian 2 kurang satu dan tiga. Isi bagian 2 sampai 9
-selebihnya belum dibaca ulang baris demi baris terhadap `0119`-`0166`.
+menjadikan gembok nilai PER LOMBA; `0167` menambah satu kolom
+(`foto_lembar.putaran`) dan satu fungsi (`putar_foto_lembar()`) supaya foto
+slip yang terlanjur masuk miring bisa diputar tanpa menyentuh berkasnya —
+sehingga angka view dan fungsi di bagian 2 kurang satu dan empat. Isi bagian 2 sampai 9
+selebihnya belum dibaca ulang baris demi baris terhadap `0119`-`0167`.
 
 Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
@@ -85,7 +87,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-166 migrasi, `0001` sampai `0166`, dijalankan berurutan tanpa lubang penomoran.
+167 migrasi, `0001` sampai `0167`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=29">
+  <link rel="stylesheet" href="style.css?v=30">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -1006,6 +1006,14 @@ export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blo
   return { path, ukuran: blob.size };
 }
 
+/** Putar satu foto slip. Sudutnya DISIMPAN (migrasi 0167); berkasnya tidak
+ *  disentuh, yang memutar layar saat menggambar.
+ *
+ *  Mengembalikan sudut yang berlaku sesudahnya — database yang menormalkan,
+ *  jadi 360 kembali sebagai 0 dan layar tidak perlu menghitung sendiri. */
+export const putarFotoLembar = (id, putaran) =>
+  rpc("putar_foto_lembar", { p_id: id, p_putaran: putaran });
+
 /** Foto satu regu di satu pos, terbaru dulu. */
 export async function daftarFotoLembar(pos, nomorDada) {
   if (K.mode === "dev") {

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -823,7 +823,20 @@ const TARGET_BYTES = 150 * 1024;
 export async function kecilkanFoto(file) {
   let gambar;
   try {
-    gambar = await createImageBitmap(file);
+    /* `imageOrientation: "from-image"` — dan tanpa itu foto slip dari HP
+       masuk MIRING, permanen.
+
+       Kamera HP hampir tidak pernah memutar pikselnya; ia menyimpan foto apa
+       adanya lalu menitipkan arah tegaknya di tag EXIF. createImageBitmap()
+       bawaannya MENGABAIKAN tag itu, dan kanvas di bawah menulis ulang
+       gambarnya jadi JPEG baru tanpa EXIF sama sekali. Jadi miringnya bukan
+       ditampilkan — ia TERPANGGANG ke dalam berkasnya, dan tidak ada layar
+       yang bisa membatalkannya lagi.
+
+       Foto yang sudah terlanjur tersimpan sebelum baris ini tetap miring;
+       itu yang ditangani `foto_lembar.putaran` (migrasi 0167). Baris ini
+       menghentikan yang baru. */
+    gambar = await createImageBitmap(file, { imageOrientation: "from-image" });
   } catch {
     throw new Error("Berkas ini tidak bisa dibaca sebagai gambar. Coba foto ulang.");
   }
@@ -965,7 +978,15 @@ const IKON = {
   "settings":
     '<path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" /> <circle cx="12" cy="12" r="3" />',
   "square-pen":
-    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /> <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />'
+    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /> <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />',
+  // Disket. Lambangnya sudah lama tidak dikenali sebagai benda oleh yang
+  // memakainya, tapi ia tetap lambang "simpan" yang paling terbaca di layar
+  // mana pun — sama seperti gagang telepon untuk "telepon".
+  "save":
+    '<path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" /> <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" /> <path d="M7 3v4a1 1 0 0 0 1 1h7" />',
+  // Panah memutar searah jarum jam: foto diputar 90 derajat tiap ketukan.
+  "rotate-cw":
+    '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /> <path d="M21 3v5h-5" />'
 };
 
 /** Satu ikon garis, siap ditempel ke template. Nama yang tidak dikenal

--- a/live/style.css
+++ b/live/style.css
@@ -4925,13 +4925,31 @@ button.pill-number:hover { filter: brightness(.95); }
    regunya menempel ke kotak lomba di bawahnya dan keduanya terbaca sebagai
    satu blok — padahal yang satu identitas dan yang satu lagi nilai. */
 .cek-identitas { margin-bottom: .9rem; }
-/* Gembok per lomba: Simpan dan gembok berdampingan, di bawah kotak nilainya.
-   Gemboknya cukup lambang — yang membedakan terkunci dari tidak adalah
-   BENTUKNYA, tertutup atau terbuka, dan kata "Kunci Nilai" lima kali di satu
-   layar mengajarkan satu hal yang dipelajari sekali (CLAUDE.md 9.1). */
-.cek-baris-aksi { display: flex; align-items: center; gap: .4rem; }
-.cek-baris-aksi [data-simpan-lomba] { flex: 1; }
-.cek-gembok { flex: 0 0 auto; color: var(--tinta-lembut); }
+/* SATU BARIS: kotak isian, lambang simpan, lambang gembok — berurutan sesuai
+   cara dipakainya (baca angkanya, betulkan, simpan, gembok).
+
+   Keduanya cukup lambang. Tombol "Simpan" bertulisan selebar kolomnya dulu
+   berdiri di baris sendiri, dan tinggi yang dimakannya diambil dari foto — di
+   layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
+   penukaran yang salah arah. */
+.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .5rem; }
+.cek-simpan, .cek-gembok { flex: 0 0 auto; }
+.cek-simpan { color: var(--utama); }
+.cek-simpan:hover:not(:disabled) { background: var(--utama-muda); }
+.cek-gembok { color: var(--tinta-lembut); }
+
+/* TERGEMBOK: kotaknya jadi abu-abu, lambang simpannya pudar.
+   Dua isyarat untuk satu keadaan, dan keduanya perlu — kotak abu-abu
+   mengatakan "tidak bisa diketik", lambang simpan yang pudar mengatakan
+   "tidak ada yang bisa disimpan". Gemboknya sendiri TIDAK dipudarkan: ia
+   satu-satunya jalan keluar dari keadaan ini, dan tombol pudar terbaca
+   seperti tombol mati. */
+.cek-isian input:disabled {
+  background: var(--garis);
+  color: var(--tinta-lembut);
+  cursor: not-allowed;
+}
+.cek-simpan:disabled { opacity: .3; cursor: not-allowed; }
 /* Tergembok memerah, dan itu bukan peringatan melainkan KEADAAN: merah di
    sistem ini dipakai untuk yang menghentikan, dan gembok tertutup memang
    menghentikan penyimpanan. */
@@ -4994,6 +5012,52 @@ button.pill-number:hover { filter: brightness(.95); }
   display: flex; align-items: center; justify-content: center;
 }
 .cek-foto img { display: block; width: 100%; height: 100%; object-fit: contain; }
+
+/* ---- PUTARAN FOTO ----
+
+   Kamera HP menyimpan foto apa adanya dan menitipkan arah tegaknya di EXIF;
+   kompresi unggahan dulu mengabaikannya, jadi sebagian slip terpanggang
+   miring. Sudut putarnya disimpan per foto (migrasi 0167) dan DITERAPKAN DI
+   SINI — berkasnya tidak pernah disentuh.
+
+   90 dan 270 MENUKAR LEBAR DENGAN TINGGI, dan itu bagian yang mudah terlewat:
+   gambar yang cuma diberi `rotate(90deg)` tetap diukur browser memakai kotak
+   aslinya, jadi sesudah diputar ia meluap keluar petaknya dan separuh slipnya
+   hilang. Karena itu ukurannya ditukar lebih dulu — lebarnya jadi tinggi
+   petak, tingginya jadi lebar petak — lalu diputar dari titik tengahnya.
+
+   `--petak-w` dan `--petak-h` diisi JavaScript lewat ResizeObserver: tinggi
+   petak berubah mengikuti tinggi layar (tata letak satu-layar mengambil sisa
+   ruang), jadi angka tetap apa pun akan benar di satu ukuran saja. */
+.fg-petak { position: relative; }
+.fg-buka { display: block; width: 100%; height: 100%; }
+.cek-foto .fg-buka img { width: 100%; height: 100%; object-fit: contain; }
+
+.fg-petak[data-putar="90"] .fg-buka img,
+.fg-petak[data-putar="270"] .fg-buka img {
+  width: var(--petak-h, 100%);
+  height: var(--petak-w, 100%);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+}
+.fg-petak[data-putar="90"] .fg-buka img  { transform: translate(-50%, -50%) rotate(90deg); }
+.fg-petak[data-putar="180"] .fg-buka img { transform: rotate(180deg); }
+.fg-petak[data-putar="270"] .fg-buka img { transform: translate(-50%, -50%) rotate(270deg); }
+
+/* Tombol putar mengambang di pojok petaknya. Latar putih separuh tembus,
+   bukan ikon telanjang: slip adalah kertas putih, dan lambang abu-abu di
+   atasnya hilang sama sekali. */
+.fg-putar {
+  position: absolute; right: .3rem; bottom: .3rem; z-index: 2;
+  min-width: 34px; min-height: 34px;
+  background: rgba(255, 255, 255, .86);
+  border: 1px solid var(--garis);
+  border-radius: var(--radius-kecil);
+  color: var(--tinta);
+}
+.fg-putar:hover:not(:disabled) { background: #fff; }
+.fg-putar .ikon { width: 1.05rem; height: 1.05rem; }
 
 /* ---------------------------------------------------------------------------
    CEK NILAI DI LAPTOP: SATU LAYAR, SEBANYAK MUNGKIN FOTO, TANPA MENGGULIR.

--- a/supabase/migrations/0167_putaran_foto.sql
+++ b/supabase/migrations/0167_putaran_foto.sql
@@ -1,0 +1,134 @@
+-- ============================================================================
+-- hrcd-rekap : 0167_putaran_foto.sql
+-- Foto slip yang masuk MIRING bisa diputar, dan putarannya tersimpan.
+--
+-- KENAPA FOTONYA MIRING SAMA SEKALI
+--
+-- Kamera HP hampir tidak pernah memutar pikselnya; ia menyimpan foto apa
+-- adanya lalu menitipkan arah tegaknya di tag EXIF. `createImageBitmap()` di
+-- web/js/util.js dipanggil TANPA `imageOrientation: "from-image"`, jadi tag
+-- itu diabaikan, dan kanvas di bawahnya menulis ulang gambarnya jadi JPEG
+-- baru tanpa EXIF sama sekali.
+--
+-- Artinya miringnya bukan sekadar salah tampil -- ia TERPANGGANG ke dalam
+-- berkasnya. Tidak ada layar yang bisa membatalkannya dengan membaca ulang
+-- berkasnya, karena tidak ada lagi yang memberi tahu arah tegaknya.
+--
+-- Panggilan itu sudah dibetulkan bersama migrasi ini, jadi foto BARU masuk
+-- tegak. Yang ditangani di sini foto yang SUDAH TERLANJUR tersimpan.
+--
+-- KENAPA PUTARANNYA DISIMPAN, BUKAN DIPUTAR DI LAYAR SAJA
+--
+-- Keputusan pemilik acara: sekali diputar, foto itu tegak untuk siapa pun,
+-- besok maupun di layar lain. Layar Cek Nilai dibuka ratusan kali, dan
+-- putaran yang hilang tiap kali pindah regu berarti pekerjaan yang sama
+-- diulang ratusan kali.
+--
+-- YANG DISIMPAN SUDUTNYA, BUKAN GAMBARNYA
+--
+-- Berkasnya TIDAK disentuh. Memutar piksel berarti membaca ulang, memutar,
+-- dan menulis ulang JPEG-nya -- satu putaran mutu setiap kali, pada berkas
+-- yang justru sudah dimampatkan habis-habisan demi kuota. Sudutnya cuma satu
+-- angka, layar yang memutarnya saat menggambar, dan membatalkannya sama
+-- murahnya dengan memasangnya.
+-- ============================================================================
+
+alter table foto_lembar
+  add column if not exists putaran smallint not null default 0;
+
+-- Empat sudut saja. Sudut bebas tidak menjawab pertanyaan apa pun di sini:
+-- yang miring adalah foto yang kameranya dipegang menyamping, dan itu selalu
+-- kelipatan 90.
+alter table foto_lembar drop constraint if exists foto_lembar_putaran_check;
+alter table foto_lembar add constraint foto_lembar_putaran_check
+  check (putaran in (0, 90, 180, 270));
+
+comment on column foto_lembar.putaran is
+  'Sudut putar saat DIGAMBAR, derajat searah jarum jam (0/90/180/270). '
+  'Berkasnya tidak disentuh.';
+
+-- ---------------------------------------------------------------------------
+-- View ikut membawanya, kalau tidak layar tidak pernah tahu harus memutar.
+-- Salinan persis definisi yang berjalan, dengan satu kolom ditambahkan.
+-- ---------------------------------------------------------------------------
+create or replace view v_foto_lembar as
+select f.id,
+    r.nomor_dada,
+    f.pos,
+    f.kode_lomba,
+    f.nama_lomba,
+    f.path,
+    f.ukuran_bytes,
+    coalesce(a.username, '(tidak dikenal)'::text) as oleh,
+    f.diunggah_pada,
+    f.cara_taut,
+    f.ditaut_pada,
+    coalesce(t.username, '(tidak dikenal)'::text) as ditaut_oleh,
+    -- DI UJUNG, bukan di tengah. `create or replace view` menuntut nama dan
+    -- urutan kolom yang sudah ada tidak berubah; menyisipkan kolom baru di
+    -- tengah menggeser nama kolom sesudahnya dan PostgreSQL menolaknya dengan
+    -- "cannot change name of view column".
+    f.putaran
+   from foto_lembar f
+     left join regu r on r.id = f.regu_id
+     left join akun_panitia a on a.user_id = f.diunggah_oleh
+     left join akun_panitia t on t.user_id = f.ditaut_oleh
+  where boleh('rekap'::text) or boleh('pos'::text) and (pos_saya() is null or f.pos = pos_saya());
+
+-- ---------------------------------------------------------------------------
+-- Memutar.
+--
+-- Pagar haknya DISALIN dari hapus_foto_lembar: hak `pos`, lalu isolasi pos
+-- untuk operator pos. Yang TIDAK disalin kewajiban alasan -- menghapus foto
+-- membuang bukti dan memang harus dipertanggungjawabkan, memutar tidak
+-- membuang apa pun dan bisa dibatalkan dengan mengetuk tiga kali lagi.
+-- Memaksa alasan untuk itu cuma menambah kotak yang diisi asal-asalan.
+-- ---------------------------------------------------------------------------
+create or replace function putar_foto_lembar(p_id uuid, p_putaran smallint)
+returns smallint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare v_pos smallint; v_baru smallint;
+begin
+  if not boleh('pos') then
+    raise exception 'tidak berhak: pos';
+  end if;
+
+  -- Dinormalkan di sini, bukan dipercayakan ke layar: 360 dan -90 adalah cara
+  -- yang wajar untuk mengatakan 0 dan 270, dan menolaknya cuma memindahkan
+  -- perhitungan itu ke setiap pemanggil.
+  v_baru := ((coalesce(p_putaran, 0)::int % 360) + 360) % 360;
+  if v_baru not in (0, 90, 180, 270) then
+    raise exception 'putaran harus kelipatan 90, bukan %', p_putaran;
+  end if;
+
+  select pos into v_pos from foto_lembar where id = p_id;
+  if not found then
+    raise exception 'foto tidak dikenal';
+  end if;
+  if pos_saya() is not null and v_pos is distinct from pos_saya() then
+    raise exception 'operator pos % tidak boleh memutar foto pos %',
+      pos_saya(), v_pos;
+  end if;
+
+  update foto_lembar set putaran = v_baru where id = p_id;
+  return v_baru;
+end;
+$$;
+
+revoke all on function putar_foto_lembar(uuid, smallint) from public, anon;
+grant execute on function putar_foto_lembar(uuid, smallint) to authenticated, service_role;
+
+comment on function putar_foto_lembar(uuid, smallint) is
+  'Putar satu foto slip saat digambar. Berkasnya tidak disentuh.';
+
+do $$
+begin
+  assert (select count(*) from foto_lembar where putaran not in (0, 90, 180, 270)) = 0,
+    '0167 GAGAL: ada putaran di luar 0/90/180/270';
+  raise notice '0167: kolom putaran terpasang, % foto (semuanya mulai dari 0)',
+    (select count(*) from foto_lembar);
+end;
+$$;

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -56,6 +56,7 @@ RPC = {
     "batal_ceklis_berangkat":["p_nomor_dada"],
     "koreksi_jam_berangkat": ["p_kloter", "p_jam", "p_alasan"],
     "minta_segarkan_live_score": [],
+    "putar_foto_lembar":     ["p_id", "p_putaran"],
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
     "hapus_nilai_pos":       ["p_nomor_dada", "p_kode", "p_pos"],
     "kunci_nilai_pos":       ["p_nomor_dada", "p_pos", "p_lomba"],

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 29, sidik: "0ea15ab3b6e3" },
+  "style.css": { versi: 30, sidik: "386840bef4ac" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/putaran_foto.test.mjs
+++ b/tests/putaran_foto.test.mjs
@@ -1,0 +1,102 @@
+// ============================================================================
+// hrcd-rekap : tests/putaran_foto.test.mjs
+// Foto slip yang masuk miring bisa diputar, dan putarannya tersimpan.
+//
+// AKAR MASALAHNYA DI UNGGAHAN, bukan di layar. Kamera HP menyimpan foto apa
+// adanya dan menitipkan arah tegaknya di EXIF; `createImageBitmap()` dipanggil
+// tanpa `imageOrientation: "from-image"`, jadi tag itu diabaikan dan kanvas di
+// bawahnya menulis ulang gambarnya tanpa EXIF sama sekali. Miringnya TERPANGGANG
+// ke dalam berkasnya.
+//
+// Dua hal karena itu dijaga di sini: panggilan yang menghormati EXIF (supaya
+// foto BARU masuk tegak), dan putaran tersimpan (untuk yang sudah terlanjur).
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
+const util = await readFile(new URL("../web/js/util.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+const mig = await readFile(
+  new URL("../supabase/migrations/0167_putaran_foto.sql", import.meta.url), "utf8");
+
+test("unggahan menghormati orientasi EXIF", () => {
+  assert.match(util,
+    /createImageBitmap\(file, \{ imageOrientation: "from-image" \}\)/,
+    "kompresi foto kembali mengabaikan EXIF — foto baru akan masuk MIRING "
+    + "secara permanen, karena kanvas menulis ulang tanpa tag orientasinya");
+});
+
+test("kolom putaran hanya menerima kelipatan 90", () => {
+  assert.match(mig, /check \(putaran in \(0, 90, 180, 270\)\)/,
+    "batasan sudut hilang — sudut bebas tidak menjawab pertanyaan apa pun di sini");
+  assert.match(mig, /add column if not exists putaran smallint not null default 0/,
+    "foto lama tidak lagi mulai dari tegak");
+});
+
+test("kolom baru ditambahkan DI UJUNG view, bukan di tengah", () => {
+  // `create or replace view` menuntut nama dan urutan kolom yang sudah ada
+  // tidak berubah; menyisipkan di tengah menggeser nama kolom sesudahnya dan
+  // PostgreSQL menolaknya dengan "cannot change name of view column".
+  const view = mig.slice(mig.indexOf("create or replace view v_foto_lembar"),
+                         mig.indexOf("-- Memutar."));
+  const dituat = view.indexOf("ditaut_oleh");
+  const putaran = view.indexOf("f.putaran");
+  assert.ok(dituat > 0 && putaran > dituat,
+    "kolom putaran disisipkan sebelum kolom yang sudah ada — "
+    + "create or replace view akan menolaknya");
+});
+
+test("sudut dinormalkan di database, bukan di layar", () => {
+  // Layar menghitung `(lama + 90) % 360` dan mengirim apa adanya; yang
+  // memutuskan sudut yang berlaku tetap satu tempat.
+  assert.match(mig, /v_baru := \(\(coalesce\(p_putaran, 0\)::int % 360\) \+ 360\) % 360;/,
+    "normalisasi sudut hilang dari database");
+  assert.match(api, /rpc\("putar_foto_lembar", \{ p_id: id, p_putaran: putaran \}\)/,
+    "putarFotoLembar tidak memanggil RPC-nya");
+});
+
+test("layar memutar seketika lalu mengembalikannya kalau server menolak", () => {
+  const awal = app.indexOf('const tombol = e.target.closest("[data-putar-foto]");');
+  const akhir = app.indexOf("/** Kotak isian dan tombol simpan mati", awal);
+  assert.ok(awal >= 0 && akhir > awal, "penangan putar tidak ditemukan");
+  const putar = app.slice(awal, akhir);
+
+  // Diputar SEBELUM menunggu jaringan: memutar adalah gerakan yang diulang
+  // sambil membaca, dan menunggu tiap ketukan membuatnya terasa rusak.
+  const pasang = putar.indexOf("petak.dataset.putar = String(baru)");
+  const kirim = putar.indexOf("await putarFotoLembar");
+  assert.ok(pasang >= 0 && pasang < kirim,
+    "layar menunggu server sebelum memutar — tiap ketukan jadi terasa lambat");
+  assert.match(putar, /petak\.dataset\.putar = String\(lama\);/,
+    "sudutnya tidak dikembalikan saat server menolak");
+  // Petaknya dibungkus <a> yang membuka foto penuh.
+  assert.match(putar, /e\.preventDefault\(\);\s*\r?\n\s*e\.stopPropagation\(\);/,
+    "memutar ikut membuka tab baru karena kliknya tidak ditahan");
+});
+
+test("90 dan 270 MENUKAR lebar dengan tinggi", () => {
+  // Gambar yang cuma diberi rotate(90deg) tetap diukur browser memakai kotak
+  // aslinya, jadi sesudah diputar ia meluap keluar petaknya dan separuh
+  // slipnya hilang. Diukur: keempat sudut muat di dalam petaknya.
+  assert.match(css,
+    /\.fg-petak\[data-putar="90"\] \.fg-buka img,\s*\r?\n\s*\.fg-petak\[data-putar="270"\] \.fg-buka img \{\s*\r?\n\s*width: var\(--petak-h, 100%\);\s*\r?\n\s*height: var\(--petak-w, 100%\);/,
+    "putaran 90/270 tidak lagi menukar lebar dengan tinggi — gambarnya akan "
+    + "meluap keluar petaknya");
+  assert.match(app, /pt\.style\.setProperty\("--petak-w"/,
+    "ukuran petak tidak diukur ke CSS — putaran 90 tidak punya angka");
+});
+
+test("keadaan tergembok: kotak abu-abu, lambang simpan pudar, gembok TIDAK", () => {
+  assert.match(css, /\.cek-isian input:disabled \{[\s\S]{0,120}background: var\(--garis\);/,
+    "kotak isian tidak lagi jadi abu-abu saat tergembok");
+  assert.match(css, /\.cek-simpan:disabled \{ opacity: \.3; cursor: not-allowed; \}/,
+    "lambang simpan tidak lagi pudar saat tergembok");
+  // Gemboknya sendiri tidak boleh dipudarkan: ia satu-satunya jalan keluar
+  // dari keadaan ini, dan tombol pudar terbaca seperti tombol mati.
+  assert.doesNotMatch(css, /\.cek-gembok:disabled \{[^}]*opacity/,
+    "gembok ikut dipudarkan — padahal ia satu-satunya jalan membukanya lagi");
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -727,6 +727,8 @@ run supabase/migrations/0165_refresh_live_score_dari_layar.sql
 run tests/sql/117_refresh_live_score_dari_layar.sql
 run supabase/migrations/0166_gembok_per_lomba.sql
 run tests/sql/118_gembok_per_lomba.sql
+run supabase/migrations/0167_putaran_foto.sql
+run tests/sql/119_putaran_foto.sql
 
 # Parse dan jalankan query yang benar-benar menjadi live.json, SESUDAH
 # seluruh migrasi. Ini menangkap view atau kolom yang berganti sebelum

--- a/tests/sql/119_putaran_foto.sql
+++ b/tests/sql/119_putaran_foto.sql
@@ -1,0 +1,88 @@
+\echo '--- 119. putaran foto: tersimpan, dinormalkan, berpagar pos'
+
+do $$
+declare v_id uuid; v_hasil smallint; v_ditolak boolean := false;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  select id into v_id from foto_lembar limit 1;
+  if v_id is null then
+    -- Harness tanpa foto: tanam satu, lalu dibuang lagi di akhir.
+    insert into foto_lembar (pos, kode_lomba, nama_lomba, path, ukuran_bytes,
+                             diunggah_oleh)
+    values (1, 'uji-putaran', 'Uji Putaran', 'pos1/uji/putaran.jpg', 1000,
+            '00000000-0000-0000-0000-00000000000a')
+    returning id into v_id;
+  end if;
+
+  -- 119.1 Bawaannya nol — foto lama tidak boleh tiba-tiba miring.
+  assert (select putaran from foto_lembar where id = v_id) = 0,
+    '119.1 GAGAL: putaran bawaan bukan 0';
+
+  -- 119.2 Tersimpan, bukan cuma dikembalikan.
+  v_hasil := putar_foto_lembar(v_id, 90::smallint);
+  assert v_hasil = 90, format('119.2 GAGAL: kembalian %s, bukan 90', v_hasil);
+  assert (select putaran from foto_lembar where id = v_id) = 90,
+    '119.2 GAGAL: putaran tidak tersimpan di barisnya';
+
+  -- 119.3 Dinormalkan: 360 sama dengan 0, -90 sama dengan 270. Layar yang
+  --       menghitung sendiri "putaran + 90" akan mengirim 360 pada ketukan
+  --       keempat, dan menolaknya cuma memindahkan perhitungan itu ke sana.
+  assert putar_foto_lembar(v_id, 360::smallint) = 0,
+    '119.3 GAGAL: 360 tidak dinormalkan jadi 0';
+  assert putar_foto_lembar(v_id, (-90)::smallint) = 270,
+    '119.3 GAGAL: -90 tidak dinormalkan jadi 270';
+
+  -- 119.4 Sudut yang bukan kelipatan 90 ditolak.
+  begin
+    perform putar_foto_lembar(v_id, 45::smallint);
+  exception when others then v_ditolak := true;
+  end;
+  assert v_ditolak, '119.4 GAGAL: sudut 45 diterima';
+
+  -- 119.5 Foto yang tidak ada ditolak, bukan diam-diam tidak mengubah apa pun.
+  v_ditolak := false;
+  begin
+    perform putar_foto_lembar('00000000-0000-0000-0000-0000000000ff'::uuid, 90::smallint);
+  exception when others then v_ditolak := true;
+  end;
+  assert v_ditolak, '119.5 GAGAL: memutar foto yang tidak ada tidak ditolak';
+
+  -- Dikembalikan ke tegak supaya tes sesudahnya tidak menemukan foto miring
+  -- yang tidak pernah mereka putar.
+  perform putar_foto_lembar(v_id, 0::smallint);
+  delete from foto_lembar where kode_lomba = 'uji-putaran';
+end;
+$$;
+
+-- 119.6 Pagar hak, DUA ARAH (CLAUDE.md 13.8). Tanpa arah kedua, `return true`
+--       pun lulus.
+do $$
+declare
+  v_juri uuid := '00000000-0000-0000-0000-000000000001';
+  v_id uuid; v_ditolak boolean := false;
+begin
+  insert into foto_lembar (pos, kode_lomba, nama_lomba, path, ukuran_bytes, diunggah_oleh)
+  values (1, 'uji-putaran', 'Uji Putaran', 'pos1/uji/hak.jpg', 1000,
+          '00000000-0000-0000-0000-00000000000a')
+  returning id into v_id;
+
+  delete from akun_hak where user_id = v_juri and fitur = 'pos';
+  begin
+    perform set_config('app.uid', v_juri::text, true);
+    perform putar_foto_lembar(v_id, 90::smallint);
+  exception when others then v_ditolak := true;
+  end;
+  insert into akun_hak (user_id, fitur) values (v_juri, 'pos') on conflict do nothing;
+  assert v_ditolak, '119.6 GAGAL: foto bisa diputar tanpa hak pos';
+
+  -- Arah kedua: hak dikembalikan, panggilan yang sama harus lolos.
+  perform set_config('app.uid', v_juri::text, true);
+  assert putar_foto_lembar(v_id, 90::smallint) = 90,
+    '119.7 GAGAL: pemegang hak pos justru tidak bisa memutar';
+
+  delete from foto_lembar where id = v_id;
+end;
+$$;
+
+\echo '119 putaran foto: LULUS'

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=27">
+  <link rel="stylesheet" href="style.css?v=28">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -1006,6 +1006,14 @@ export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blo
   return { path, ukuran: blob.size };
 }
 
+/** Putar satu foto slip. Sudutnya DISIMPAN (migrasi 0167); berkasnya tidak
+ *  disentuh, yang memutar layar saat menggambar.
+ *
+ *  Mengembalikan sudut yang berlaku sesudahnya — database yang menormalkan,
+ *  jadi 360 kembali sebagai 0 dan layar tidak perlu menghitung sendiri. */
+export const putarFotoLembar = (id, putaran) =>
+  rpc("putar_foto_lembar", { p_id: id, p_putaran: putaran });
+
 /** Foto satu regu di satu pos, terbaru dulu. */
 export async function daftarFotoLembar(pos, nomorDada) {
   if (K.mode === "dev") {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -22,7 +22,7 @@ import {
   rentangNomorDada,
   komponenSemua, rekapPenuh, kelengkapanPos, cacheLiveScore,
   riwayatNilai, riwayatPendaftaran,
-  kunciNilaiPos, bukaKunciNilaiPos,
+  kunciNilaiPos, bukaKunciNilaiPos, putarFotoLembar,
   unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto,
   hasilKejuaraan, simpanKejuaraanManual, simpanKejuaraanTerjauh, daftarSekolah,
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
@@ -9814,6 +9814,14 @@ async function layarCekNilai() {
               <div class="cek-kepala">
                 <span class="cek-nama">${esc(l.nama)}</span>
               </div>
+              <!-- SATU BARIS: kotak isian, lambang simpan, lambang gembok.
+                   Sebelumnya tombol "Simpan" selebar kolomnya berdiri di baris
+                   sendiri di bawah angkanya, dan tinggi yang dimakannya diambil
+                   dari foto — di layar yang seluruh gunanya membandingkan
+                   angka dengan tulisan tangan, itu penukaran yang salah arah.
+
+                   Ketiganya berurutan sesuai cara dipakainya: baca angkanya,
+                   betulkan kalau perlu, simpan, lalu gembok. -->
               <div class="cek-isian" data-isian="${esc(l.kode)}">
                 ${angka}
                 <!-- GEMBOK DI SEBELAH NILAINYA, dan cukup lambangnya saja.
@@ -9827,9 +9835,11 @@ async function layarCekNilai() {
                      Judulnya tetap ada untuk pembaca layar dan untuk yang
                      menahan kursor di atasnya. -->
                 <div class="cek-baris-aksi">
-                  <button type="button" class="button button-primary button-small"
-                          data-simpan-lomba="${esc(l.kode)}">Simpan</button>
-                  <button type="button" class="icon-button icon-button-inline cek-gembok"
+                  <button type="button" class="icon-button cek-simpan"
+                          data-simpan-lomba="${esc(l.kode)}"
+                          title="Simpan ${esc(l.nama)}"
+                          aria-label="Simpan ${esc(l.nama)}">${ikon("save")}</button>
+                  <button type="button" class="icon-button cek-gembok"
                           data-gembok="${esc(l.kode)}"></button>
                 </div>
               </div>
@@ -9900,15 +9910,87 @@ async function layarCekNilai() {
       el.replaceChildren(h(milik.map((f, i) => {
         const url = peta[f.path];
         const judul = `Foto ${i + 1}${f.diunggah_pada ? ` · ${tanggalJam(f.diunggah_pada)}` : ""}`;
-        return url
-          ? `<a class="fg-petak" href="${esc(url)}" target="_blank" rel="noopener"
-                title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"
-                loading="lazy"></a>`
-          : `<span class="fg-petak fg-kosong">tautan gagal</span>`;
+        if (!url) return `<span class="fg-petak fg-kosong">tautan gagal</span>`;
+        /* Sudutnya dibawa `data-putar`, bukan gaya sebaris: yang memutar CSS,
+           dan CSS perlu tahu 90/270 supaya bisa MENUKAR lebar dengan tinggi.
+           Gambar yang cuma diputar tanpa ditukar ukurannya meluap keluar
+           petaknya — separuh slipnya hilang, dan itu kebalikan dari gunanya.
+
+           Tombol putarnya DI DALAM petak, bukan di bawahnya: ia milik foto
+           tepat di belakangnya, dan di kolom berisi dua foto kepemilikan itu
+           harus terbaca tanpa dihitung. */
+        return `<div class="fg-petak" data-putar="${esc(String(f.putaran || 0))}">
+            <a class="fg-buka" href="${esc(url)}" target="_blank" rel="noopener"
+               title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"
+               loading="lazy"></a>
+            <button type="button" class="icon-button fg-putar"
+                    data-putar-foto="${esc(f.id)}"
+                    title="Putar 90°" aria-label="Putar foto 90 derajat"
+              >${ikon("rotate-cw")}</button>
+          </div>`;
       }).join("")));
       if (nav) pasangGeserCek(el, nav);
+      ukurPetak(el);
     });
   }
+
+  /** Ukuran petak foto, dituliskan ke CSS.
+   *
+   *  Putaran 90 dan 270 menukar lebar dengan tinggi, dan CSS tidak bisa
+   *  membaca ukuran elemen sendiri — jadi diukur di sini. Tingginya berubah
+   *  mengikuti tinggi layar (tata letak satu-layar mengambil sisa ruang),
+   *  jadi angka tetap apa pun akan benar di satu ukuran saja.
+   *
+   *  Diukur ulang saat petaknya berubah ukuran; pengamatnya dilepas bersama
+   *  sinyal layar. */
+  function ukurPetak(wadah) {
+    const pasang = () => wadah.querySelectorAll(".fg-petak").forEach(pt => {
+      const k = pt.getBoundingClientRect();
+      pt.style.setProperty("--petak-w", `${Math.round(k.width)}px`);
+      pt.style.setProperty("--petak-h", `${Math.round(k.height)}px`);
+    });
+    pasang();
+    const pengamat = new ResizeObserver(pasang);
+    pengamat.observe(wadah);
+    putusSaatPindah(sinyal, pengamat);
+  }
+
+  /* Memutar foto. Sudutnya DISIMPAN (0167), jadi sekali diputar ia tegak
+     untuk siapa pun dan di layar mana pun — bukan cuma sampai pindah regu.
+
+     Petaknya diputar SEKETIKA, sebelum jawaban server datang: memutar adalah
+     gerakan yang diulang sambil membaca, dan menunggu jaringan tiap ketukan
+     membuatnya terasa rusak. Kalau server menolak, sudutnya dikembalikan dan
+     galatnya disebut.
+
+     Satu pendengar di wadahnya, bukan satu per tombol: petaknya dibuang dan
+     dibuat lagi tiap kali regunya berganti, dan pendengar yang menempel
+     padanya ikut menumpuk. */
+  elIsi.addEventListener("click", async (e) => {
+    const tombol = e.target.closest("[data-putar-foto]");
+    if (!tombol) return;
+    // Petaknya memuat <a> yang membuka foto penuh; tanpa ini memutar ikut
+    // membuka tab baru.
+    e.preventDefault();
+    e.stopPropagation();
+    if (tombol.disabled) return;
+
+    const petak = tombol.closest(".fg-petak");
+    const lama = Number(petak.dataset.putar) || 0;
+    const baru = (lama + 90) % 360;
+    petak.dataset.putar = String(baru);
+    tombol.disabled = true;
+    try {
+      const jadi = await putarFotoLembar(tombol.dataset.putarFoto, baru);
+      // Server yang menormalkan; angkanya dipakai apa adanya supaya layar dan
+      // database tidak pernah berbeda pendapat soal sudut yang berlaku.
+      if (jadi !== null && jadi !== undefined) petak.dataset.putar = String(jadi);
+    } catch (err) {
+      petak.dataset.putar = String(lama);
+      notif(err.message, true);
+    }
+    tombol.disabled = false;
+  }, { signal: sinyal });
 
   /** Kotak isian dan tombol simpan mati saat nilainya terkunci.
    *

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -823,7 +823,20 @@ const TARGET_BYTES = 150 * 1024;
 export async function kecilkanFoto(file) {
   let gambar;
   try {
-    gambar = await createImageBitmap(file);
+    /* `imageOrientation: "from-image"` — dan tanpa itu foto slip dari HP
+       masuk MIRING, permanen.
+
+       Kamera HP hampir tidak pernah memutar pikselnya; ia menyimpan foto apa
+       adanya lalu menitipkan arah tegaknya di tag EXIF. createImageBitmap()
+       bawaannya MENGABAIKAN tag itu, dan kanvas di bawah menulis ulang
+       gambarnya jadi JPEG baru tanpa EXIF sama sekali. Jadi miringnya bukan
+       ditampilkan — ia TERPANGGANG ke dalam berkasnya, dan tidak ada layar
+       yang bisa membatalkannya lagi.
+
+       Foto yang sudah terlanjur tersimpan sebelum baris ini tetap miring;
+       itu yang ditangani `foto_lembar.putaran` (migrasi 0167). Baris ini
+       menghentikan yang baru. */
+    gambar = await createImageBitmap(file, { imageOrientation: "from-image" });
   } catch {
     throw new Error("Berkas ini tidak bisa dibaca sebagai gambar. Coba foto ulang.");
   }
@@ -965,7 +978,15 @@ const IKON = {
   "settings":
     '<path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" /> <circle cx="12" cy="12" r="3" />',
   "square-pen":
-    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /> <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />'
+    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /> <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />',
+  // Disket. Lambangnya sudah lama tidak dikenali sebagai benda oleh yang
+  // memakainya, tapi ia tetap lambang "simpan" yang paling terbaca di layar
+  // mana pun — sama seperti gagang telepon untuk "telepon".
+  "save":
+    '<path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" /> <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" /> <path d="M7 3v4a1 1 0 0 0 1 1h7" />',
+  // Panah memutar searah jarum jam: foto diputar 90 derajat tiap ketukan.
+  "rotate-cw":
+    '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /> <path d="M21 3v5h-5" />'
 };
 
 /** Satu ikon garis, siap ditempel ke template. Nama yang tidak dikenal

--- a/web/style.css
+++ b/web/style.css
@@ -4925,13 +4925,31 @@ button.pill-number:hover { filter: brightness(.95); }
    regunya menempel ke kotak lomba di bawahnya dan keduanya terbaca sebagai
    satu blok — padahal yang satu identitas dan yang satu lagi nilai. */
 .cek-identitas { margin-bottom: .9rem; }
-/* Gembok per lomba: Simpan dan gembok berdampingan, di bawah kotak nilainya.
-   Gemboknya cukup lambang — yang membedakan terkunci dari tidak adalah
-   BENTUKNYA, tertutup atau terbuka, dan kata "Kunci Nilai" lima kali di satu
-   layar mengajarkan satu hal yang dipelajari sekali (CLAUDE.md 9.1). */
-.cek-baris-aksi { display: flex; align-items: center; gap: .4rem; }
-.cek-baris-aksi [data-simpan-lomba] { flex: 1; }
-.cek-gembok { flex: 0 0 auto; color: var(--tinta-lembut); }
+/* SATU BARIS: kotak isian, lambang simpan, lambang gembok — berurutan sesuai
+   cara dipakainya (baca angkanya, betulkan, simpan, gembok).
+
+   Keduanya cukup lambang. Tombol "Simpan" bertulisan selebar kolomnya dulu
+   berdiri di baris sendiri, dan tinggi yang dimakannya diambil dari foto — di
+   layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
+   penukaran yang salah arah. */
+.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .5rem; }
+.cek-simpan, .cek-gembok { flex: 0 0 auto; }
+.cek-simpan { color: var(--utama); }
+.cek-simpan:hover:not(:disabled) { background: var(--utama-muda); }
+.cek-gembok { color: var(--tinta-lembut); }
+
+/* TERGEMBOK: kotaknya jadi abu-abu, lambang simpannya pudar.
+   Dua isyarat untuk satu keadaan, dan keduanya perlu — kotak abu-abu
+   mengatakan "tidak bisa diketik", lambang simpan yang pudar mengatakan
+   "tidak ada yang bisa disimpan". Gemboknya sendiri TIDAK dipudarkan: ia
+   satu-satunya jalan keluar dari keadaan ini, dan tombol pudar terbaca
+   seperti tombol mati. */
+.cek-isian input:disabled {
+  background: var(--garis);
+  color: var(--tinta-lembut);
+  cursor: not-allowed;
+}
+.cek-simpan:disabled { opacity: .3; cursor: not-allowed; }
 /* Tergembok memerah, dan itu bukan peringatan melainkan KEADAAN: merah di
    sistem ini dipakai untuk yang menghentikan, dan gembok tertutup memang
    menghentikan penyimpanan. */
@@ -4994,6 +5012,52 @@ button.pill-number:hover { filter: brightness(.95); }
   display: flex; align-items: center; justify-content: center;
 }
 .cek-foto img { display: block; width: 100%; height: 100%; object-fit: contain; }
+
+/* ---- PUTARAN FOTO ----
+
+   Kamera HP menyimpan foto apa adanya dan menitipkan arah tegaknya di EXIF;
+   kompresi unggahan dulu mengabaikannya, jadi sebagian slip terpanggang
+   miring. Sudut putarnya disimpan per foto (migrasi 0167) dan DITERAPKAN DI
+   SINI — berkasnya tidak pernah disentuh.
+
+   90 dan 270 MENUKAR LEBAR DENGAN TINGGI, dan itu bagian yang mudah terlewat:
+   gambar yang cuma diberi `rotate(90deg)` tetap diukur browser memakai kotak
+   aslinya, jadi sesudah diputar ia meluap keluar petaknya dan separuh slipnya
+   hilang. Karena itu ukurannya ditukar lebih dulu — lebarnya jadi tinggi
+   petak, tingginya jadi lebar petak — lalu diputar dari titik tengahnya.
+
+   `--petak-w` dan `--petak-h` diisi JavaScript lewat ResizeObserver: tinggi
+   petak berubah mengikuti tinggi layar (tata letak satu-layar mengambil sisa
+   ruang), jadi angka tetap apa pun akan benar di satu ukuran saja. */
+.fg-petak { position: relative; }
+.fg-buka { display: block; width: 100%; height: 100%; }
+.cek-foto .fg-buka img { width: 100%; height: 100%; object-fit: contain; }
+
+.fg-petak[data-putar="90"] .fg-buka img,
+.fg-petak[data-putar="270"] .fg-buka img {
+  width: var(--petak-h, 100%);
+  height: var(--petak-w, 100%);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+}
+.fg-petak[data-putar="90"] .fg-buka img  { transform: translate(-50%, -50%) rotate(90deg); }
+.fg-petak[data-putar="180"] .fg-buka img { transform: rotate(180deg); }
+.fg-petak[data-putar="270"] .fg-buka img { transform: translate(-50%, -50%) rotate(270deg); }
+
+/* Tombol putar mengambang di pojok petaknya. Latar putih separuh tembus,
+   bukan ikon telanjang: slip adalah kertas putih, dan lambang abu-abu di
+   atasnya hilang sama sekali. */
+.fg-putar {
+  position: absolute; right: .3rem; bottom: .3rem; z-index: 2;
+  min-width: 34px; min-height: 34px;
+  background: rgba(255, 255, 255, .86);
+  border: 1px solid var(--garis);
+  border-radius: var(--radius-kecil);
+  color: var(--tinta);
+}
+.fg-putar:hover:not(:disabled) { background: #fff; }
+.fg-putar .ikon { width: 1.05rem; height: 1.05rem; }
 
 /* ---------------------------------------------------------------------------
    CEK NILAI DI LAPTOP: SATU LAYAR, SEBANYAK MUNGKIN FOTO, TANPA MENGGULIR.


### PR DESCRIPTION
## What

Tombol putar 90° di pojok tiap foto slip di layar Cek Nilai. Sudutnya
**tersimpan** (migrasi `0167`), jadi sekali diputar foto itu tegak untuk siapa
pun, besok maupun di layar lain.

Baris aksinya juga dirapikan jadi **input — lambang simpan — lambang gembok**.

## Why

**Akar masalahnya di unggahan, bukan di layar.** Kamera HP menyimpan foto apa
adanya dan menitipkan arah tegaknya di tag EXIF. `createImageBitmap()` dipanggil
**tanpa** `imageOrientation: "from-image"`, jadi tag itu diabaikan, dan kanvas di
bawahnya menulis ulang gambarnya jadi JPEG baru **tanpa EXIF sama sekali**.

Miringnya bukan salah tampil — ia **terpanggang ke dalam berkasnya**, dan tidak
ada layar yang bisa membatalkannya dengan membaca ulang berkasnya. Panggilan itu
dibetulkan, jadi foto **baru** masuk tegak; `putaran` menangani yang sudah
terlanjur.

## Notes

**Yang disimpan sudutnya, bukan gambarnya.** Memutar piksel berarti membaca dan
menulis ulang JPEG-nya — satu putaran mutu setiap kali, pada berkas yang justru
sudah dimampatkan habis-habisan demi kuota.

**90 dan 270 menukar lebar dengan tinggi**, dan itu bagian yang mudah terlewat:
gambar yang cuma diberi `rotate(90deg)` tetap diukur browser memakai kotak
aslinya, jadi sesudah diputar ia meluap keluar petaknya dan separuh slipnya
hilang. Ukuran petaknya diukur JavaScript karena ia mengikuti tinggi layar.

Diukur di keempat sudut dengan `style.css` asli:

| Putar | Gambar | Petak | Meluap | Di dalam |
| --- | --- | --- | --- | --- |
| 0 | 174×418 | 176×420 | tidak | ya |
| 90 | 176×420 | 176×420 | tidak | ya |
| 180 | 174×418 | 176×420 | tidak | ya |
| 270 | 176×420 | 176×420 | tidak | ya |

**Baris aksi.** Tombol "Simpan" bertulisan selebar kolomnya dulu berdiri di
baris sendiri, dan tinggi yang dimakannya diambil dari foto — di layar yang
seluruh gunanya membandingkan angka dengan tulisan tangan, itu penukaran yang
salah arah.

Saat tergembok: kotaknya abu-abu, lambang simpannya pudar. Gemboknya sendiri
**tidak** dipudarkan — ia satu-satunya jalan keluar, dan tombol pudar terbaca
seperti tombol mati.

**Satu jebakan migrasi**, ditemukan saat menjalankannya: kolom baru harus
ditambahkan **di ujung** `v_foto_lembar`. `create or replace view` menuntut nama
dan urutan kolom yang sudah ada tidak berubah, dan menyisipkan di tengah ditolak
dengan "cannot change name of view column". Ada tesnya.

SQL suite lulus (`0167` dan tes 119 terdaftar di `tests/run.sh`); tes 119
memeriksa pagar hak dari dua arah dan normalisasi sudut (360→0, −90→270).
366 tes JS lulus.

**Migrasi ini perlu di-apply setelah merge** — `apply-migration.yml` dengan
berkas `supabase/migrations/0167_putaran_foto.sql`.
