### PR TITLE
fix: lambang simpan dan gembok pindah ke kanan input, bukan di bawahnya

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=30">
+  <link rel="stylesheet" href="style.css?v=31">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4963,13 +4963,24 @@ button.pill-number:hover { filter: brightness(.95); }
    yang berpindah antara dua layar tidak boleh menemui dua bentuk untuk satu
    hal. Tombol simpannya di bawah kotaknya, bukan di ujung halaman: yang
    dibetulkan satu lomba pada satu waktu. */
+/* SATU BARIS MENDATAR: kotak isian, lalu lambang simpan dan gembok di
+   KANANNYA. Sebelumnya lambangnya duduk di baris sendiri di bawah kotak, dan
+   tinggi yang dimakannya diambil dari foto — di layar yang seluruh gunanya
+   membandingkan angka dengan tulisan tangan, itu penukaran yang salah arah.
+
+   `align-items: center` dan bukan `flex-start`: untuk lomba berkriteria
+   banyak (Pembidaian, lima kotak) lambangnya berdiri di tengah tumpukan,
+   tempat ia terbaca sebagai milik seluruh kelompok — bukan milik kotak
+   pertama. */
 .cek-isian {
-  display: flex; flex-direction: column; align-items: center; gap: .5rem;
-  margin: .4rem 0 .2rem;
+  display: flex; align-items: center; justify-content: center;
+  gap: .5rem; margin: .4rem 0 .2rem;
 }
+/* Kotak isian yang menyusut, bukan lambangnya. Lambang 34px yang mengecil
+   berhenti bisa disentuh; kotak yang mengecil masih terbaca. */
+.cek-angka { display: flex; flex-direction: column; gap: .35rem; min-width: 0; flex: 1; }
 .cek-isian .isian-baris { border: 0; padding: 0; gap: .25rem; }
-.cek-isian .small-input { font-size: 1.4rem; min-height: 52px; }
-.cek-isian [data-simpan-lomba] { min-width: 8rem; }
+.cek-isian .small-input { font-size: 1.4rem; min-height: 52px; width: 100%; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */
@@ -5160,7 +5171,6 @@ button.pill-number:hover { filter: brightness(.95); }
      memaksa zoom saat kotaknya disentuh (aturan di kepala berkas ini). */
   .isi.cek .cek-isian { margin: .3rem 0; gap: .35rem; }
   .isi.cek .cek-isian .small-input { font-size: 1.15rem; min-height: 42px; }
-  .isi.cek .cek-isian [data-simpan-lomba] { min-width: 0; width: 100%; }
 
   /* FOTO MENGISI SISA TINGGI KOLOMNYA. Inilah yang membuat "sebanyak mungkin"
      berarti sesuatu: tingginya tidak dipatok angka tetap melainkan apa pun

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 30, sidik: "386840bef4ac" },
+  "style.css": { versi: 31, sidik: "6720a5b12b49" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=28">
+  <link rel="stylesheet" href="style.css?v=29">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9823,7 +9823,11 @@ async function layarCekNilai() {
                    Ketiganya berurutan sesuai cara dipakainya: baca angkanya,
                    betulkan kalau perlu, simpan, lalu gembok. -->
               <div class="cek-isian" data-isian="${esc(l.kode)}">
-                ${angka}
+                <!-- Kotak isian dibungkus supaya lambang di sebelahnya berdiri
+                     di kanan SELURUH kelompoknya, bukan di kanan kotak
+                     terakhir. Pembidaian punya lima kriteria bertumpuk; tanpa
+                     pembungkus ini lambangnya ikut turun ke baris kelima. -->
+                <div class="cek-angka">${angka}</div>
                 <!-- GEMBOK DI SEBELAH NILAINYA, dan cukup lambangnya saja.
                      Alurnya: panitia melihat foto slip di bawah, mencocokkan
                      dengan angka di atasnya, lalu mengetuk gembok. Kata

--- a/web/style.css
+++ b/web/style.css
@@ -4963,13 +4963,24 @@ button.pill-number:hover { filter: brightness(.95); }
    yang berpindah antara dua layar tidak boleh menemui dua bentuk untuk satu
    hal. Tombol simpannya di bawah kotaknya, bukan di ujung halaman: yang
    dibetulkan satu lomba pada satu waktu. */
+/* SATU BARIS MENDATAR: kotak isian, lalu lambang simpan dan gembok di
+   KANANNYA. Sebelumnya lambangnya duduk di baris sendiri di bawah kotak, dan
+   tinggi yang dimakannya diambil dari foto — di layar yang seluruh gunanya
+   membandingkan angka dengan tulisan tangan, itu penukaran yang salah arah.
+
+   `align-items: center` dan bukan `flex-start`: untuk lomba berkriteria
+   banyak (Pembidaian, lima kotak) lambangnya berdiri di tengah tumpukan,
+   tempat ia terbaca sebagai milik seluruh kelompok — bukan milik kotak
+   pertama. */
 .cek-isian {
-  display: flex; flex-direction: column; align-items: center; gap: .5rem;
-  margin: .4rem 0 .2rem;
+  display: flex; align-items: center; justify-content: center;
+  gap: .5rem; margin: .4rem 0 .2rem;
 }
+/* Kotak isian yang menyusut, bukan lambangnya. Lambang 34px yang mengecil
+   berhenti bisa disentuh; kotak yang mengecil masih terbaca. */
+.cek-angka { display: flex; flex-direction: column; gap: .35rem; min-width: 0; flex: 1; }
 .cek-isian .isian-baris { border: 0; padding: 0; gap: .25rem; }
-.cek-isian .small-input { font-size: 1.4rem; min-height: 52px; }
-.cek-isian [data-simpan-lomba] { min-width: 8rem; }
+.cek-isian .small-input { font-size: 1.4rem; min-height: 52px; width: 100%; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */
@@ -5160,7 +5171,6 @@ button.pill-number:hover { filter: brightness(.95); }
      memaksa zoom saat kotaknya disentuh (aturan di kepala berkas ini). */
   .isi.cek .cek-isian { margin: .3rem 0; gap: .35rem; }
   .isi.cek .cek-isian .small-input { font-size: 1.15rem; min-height: 42px; }
-  .isi.cek .cek-isian [data-simpan-lomba] { min-width: 0; width: 100%; }
 
   /* FOTO MENGISI SISA TINGGI KOLOMNYA. Inilah yang membuat "sebanyak mungkin"
      berarti sesuatu: tingginya tidak dipatok angka tetap melainkan apa pun


### PR DESCRIPTION
## What

Baris aksi Cek Nilai jadi `[input] [lambang simpan] [lambang gembok]` dalam satu
baris mendatar. Sebelumnya lambangnya berdiri di baris sendiri di bawah kotak.

## Why

Tinggi yang dimakan baris kedua itu diambil dari foto — di layar yang seluruh
gunanya membandingkan angka dengan tulisan tangan di fotonya, itu penukaran yang
salah arah.

Terukur di 1440×820 dengan lima lomba Pos 1:

| | Sebelum | Sesudah |
| --- | --- | --- |
| Tinggi baris isian | 95px | **49px** |
| Tinggi foto | 396px | **407px** |
| Guliran | 0 | 0 |

## Notes

Kotak isian dibungkus `.cek-angka` supaya lambangnya berdiri di kanan **seluruh
kelompoknya**, bukan di kanan kotak terakhir: Pembidaian punya lima kriteria
bertumpuk, dan tanpa pembungkus itu lambangnya ikut turun ke baris kelima.

Yang menyusut kotaknya, bukan lambangnya — lambang 40px yang mengecil berhenti
bisa disentuh, kotak yang mengecil masih terbaca.

Diverifikasi dengan mengukur posisi ketiganya: input x=25 (w=112), simpan x=205,
gembok x=253, ketiganya sejajar tengah. Keadaan tergembok ikut terlihat benar —
kotak abu-abu, lambang simpan pudar, gembok merah tertutup.

366 tes JS lulus.
