### PR TITLE
feat: Cek Nilai menyimpan sendiri, tombol simpan diganti penanda keadaan

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=31">
+  <link rel="stylesheet" href="style.css?v=32">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4933,10 +4933,37 @@ button.pill-number:hover { filter: brightness(.95); }
    layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
    penukaran yang salah arah. */
 .cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .5rem; }
-.cek-simpan, .cek-gembok { flex: 0 0 auto; }
-.cek-simpan { color: var(--utama); }
-.cek-simpan:hover:not(:disabled) { background: var(--utama-muda); }
+.cek-status, .cek-gembok { flex: 0 0 auto; }
 .cek-gembok { color: var(--tinta-lembut); }
+
+/* KABAR, BUKAN TOMBOL. Angkanya disimpan sendiri begitu diubah; yang tersisa
+   cuma memberi tahu sudah sampai database atau belum.
+
+     titik-titik KUNING  belum tersimpan (baru diketik, atau sedang di jalan)
+     centang HIJAU       sudah tersimpan
+     seru MERAH          gagal — ketuk untuk mengulang
+
+   Kuning dan hijau sengaja tidak jadi SATU-SATUNYA pembeda: bentuknya pun
+   berbeda (titik-titik lawan centang), jadi yang sulit membedakan merah dari
+   hijau tetap bisa membacanya. Judulnya menyebutkannya dengan kata.
+
+   Lebarnya dipatok supaya kotak isian di sebelahnya tidak bergeser tiap kali
+   penandanya berganti — baris yang berjoget saat mengetik terbaca seperti
+   layar yang salah. */
+.cek-status {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 28px; height: 28px;
+  font-size: 1.2rem; font-weight: 800; line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.cek-status[data-keadaan="belum"],
+.cek-status[data-keadaan="menyimpan"] { color: var(--kuning); }
+.cek-status[data-keadaan="tersimpan"] { color: var(--hijau); }
+.cek-status[data-keadaan="gagal"] {
+  color: var(--bahaya); cursor: pointer;
+  border-radius: var(--radius-kecil);
+}
+.cek-status[data-keadaan="gagal"]:hover { background: var(--bahaya-muda); }
 
 /* TERGEMBOK: kotaknya jadi abu-abu, lambang simpannya pudar.
    Dua isyarat untuk satu keadaan, dan keduanya perlu — kotak abu-abu
@@ -4949,7 +4976,6 @@ button.pill-number:hover { filter: brightness(.95); }
   color: var(--tinta-lembut);
   cursor: not-allowed;
 }
-.cek-simpan:disabled { opacity: .3; cursor: not-allowed; }
 /* Tergembok memerah, dan itu bukan peringatan melainkan KEADAAN: merah di
    sistem ini dipakai untuk yang menghentikan, dan gembok tertutup memang
    menghentikan penyimpanan. */

--- a/tests/cek_nilai_simpan_otomatis.test.mjs
+++ b/tests/cek_nilai_simpan_otomatis.test.mjs
@@ -1,0 +1,97 @@
+// ============================================================================
+// hrcd-rekap : tests/cek_nilai_simpan_otomatis.test.mjs
+// Cek Nilai menyimpan sendiri saat angkanya diubah — tidak ada tombol simpan.
+//
+// Yang tersisa cuma KABAR: titik-titik kuning berarti belum sampai database,
+// centang hijau berarti sudah. Tombol simpan pada layar yang menyimpan sendiri
+// adalah tombol yang tidak pernah perlu ditekan, dan tombol seperti itu justru
+// membuat orang ragu apakah angkanya tersimpan kalau ia lupa menekannya.
+//
+// KETIGA PENDENGARNYA PERLU, dan itu yang paling mudah dirusak:
+//   input     menandai kuning sejak ketukan pertama
+//   change    menyimpan saat kotaknya ditinggalkan dengan isi berbeda
+//   focusout  jaring pengaman — mengetik ulang angka yang SAMA memicu `input`
+//             tapi tidak selalu `change`, jadi tanpa ini penanda kuningnya
+//             menggantung selamanya
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+test("tidak ada lagi tombol simpan di Cek Nilai", () => {
+  assert.doesNotMatch(app, /data-simpan-lomba/,
+    "tombol simpan kembali ada — layar ini menyimpan sendiri, dan tombol yang "
+    + "tidak pernah perlu ditekan membuat orang ragu kalau ia lupa menekannya");
+  assert.match(app, /<span class="cek-status" data-status=/,
+    "penanda keadaan hilang — panitia tidak bisa tahu angkanya sudah tersimpan");
+});
+
+test("ketiga pendengar simpan-otomatis terpasang", () => {
+  for (const [peristiwa, alasan] of [
+    ["input", "penanda kuning tidak muncul sejak ketukan pertama"],
+    ["change", "angka yang diubah tidak pernah tersimpan"],
+    ["focusout", "mengetik ulang angka yang SAMA meninggalkan penanda kuning selamanya"],
+  ]) {
+    const pola = new RegExp(
+      `elIsi\\.addEventListener\\("${peristiwa}", \\(e\\) => \\{[\\s\\S]{0,320}?data-isian`);
+    assert.match(app, pola, `pendengar \`${peristiwa}\` hilang — ${alasan}`);
+  }
+});
+
+test("satu pintu simpan, bersama layar input", () => {
+  // kirimNilaiRegu() memegang keempat aturannya: kotak tak terbaca tidak
+  // menyentuh angka lama, kotak kosong berarti hapus, angka yang sama tidak
+  // dikirim ulang, gagal jaringan masuk antrean. Menyalinnya ke sini berarti
+  // empat aturan itu punya dua tempat yang suatu hari berbeda.
+  const awal = app.indexOf("  async function simpanLomba(kode) {");
+  const akhir = app.indexOf("  /* SIMPAN SENDIRI SAAT DIUBAH", awal);
+  assert.ok(awal >= 0 && akhir > awal, "simpanLomba tidak ditemukan");
+  const fungsi = app.slice(awal, akhir);
+  assert.match(fungsi, /await kirimNilaiRegu\(\{ pos: nomorPos, kolom: l\.kolom, regu: r, wadah \}\)/,
+    "simpanLomba tidak lagi lewat pintu yang sama dengan layar input");
+  // Lomba tergembok tidak dikirim: server akan menolaknya, dan penolakan yang
+  // bisa dihindari lebih baik tidak dibuat.
+  assert.match(fungsi, /if \(lombaTerkunci\(\)\.has\(kode\)\) return;/,
+    "lomba tergembok tetap dikirim dan dijamin ditolak server");
+  // Dua simpanan berbarengan untuk lomba yang sama akan saling mendahului.
+  assert.match(fungsi, /sedangSimpan\.(has|add|delete)\(kode\)/,
+    "tidak ada penjaga simpanan berbarengan");
+});
+
+test("antre tetap KUNING, bukan hijau", () => {
+  // Yang masuk antrean BELUM sampai database. Centang hijau di situ berbohong
+  // tentang satu-satunya hal yang ditanyakan panitia.
+  // Dibatasi ke simpanLomba: cabang `antre` yang sama ada di layar lain, dan
+  // yang pertama ditemukan di berkas ini bukan milik Cek Nilai.
+  const fungsi = app.slice(app.indexOf("  async function simpanLomba(kode) {"),
+                           app.indexOf("  /* SIMPAN SENDIRI SAAT DIUBAH"));
+  const potong = fungsi.slice(fungsi.indexOf('if (jawab.hasil === "antre")'));
+  assert.match(potong, /statusLomba\(kode, "belum"\)/,
+    "nilai yang masuk antrean ditandai tersimpan — padahal belum sampai");
+});
+
+test("kuning dan hijau tidak jadi satu-satunya pembeda", () => {
+  // Sekitar satu dari dua belas laki-laki sulit membedakan merah dari hijau.
+  // Bentuknya pun berbeda: titik-titik lawan centang.
+  assert.match(app, /sel\.textContent = "\\u2026";/,
+    "penanda belum tersimpan bukan titik-titik");
+  assert.match(app, /sel\.textContent = "\\u2713";/,
+    "penanda tersimpan bukan centang");
+  assert.match(app, /sel\.title = "Belum tersimpan";/,
+    "keadaannya tidak disebut dengan kata untuk pembaca layar");
+  assert.match(css, /\.cek-status\[data-keadaan="belum"\],\s*\r?\n\.cek-status\[data-keadaan="menyimpan"\] \{ color: var\(--kuning\); \}/,
+    "penanda belum tersimpan tidak lagi kuning");
+  assert.match(css, /\.cek-status\[data-keadaan="tersimpan"\] \{ color: var\(--hijau\); \}/,
+    "penanda tersimpan tidak lagi hijau");
+});
+
+test("lebar penanda dipatok supaya barisnya tidak berjoget", () => {
+  assert.match(css, /\.cek-status \{[\s\S]{0,200}min-width: 28px;/,
+    "lebar penanda tidak dipatok — kotak isian bergeser tiap kali penandanya "
+    + "berganti, dan baris yang berjoget saat mengetik terbaca seperti layar "
+    + "yang salah");
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 31, sidik: "6720a5b12b49" },
+  "style.css": { versi: 32, sidik: "7e48fa453a44" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/putaran_foto.test.mjs
+++ b/tests/putaran_foto.test.mjs
@@ -90,11 +90,9 @@ test("90 dan 270 MENUKAR lebar dengan tinggi", () => {
     "ukuran petak tidak diukur ke CSS — putaran 90 tidak punya angka");
 });
 
-test("keadaan tergembok: kotak abu-abu, lambang simpan pudar, gembok TIDAK", () => {
+test("keadaan tergembok terbaca dari kotaknya, dan gembok TIDAK dipudarkan", () => {
   assert.match(css, /\.cek-isian input:disabled \{[\s\S]{0,120}background: var\(--garis\);/,
     "kotak isian tidak lagi jadi abu-abu saat tergembok");
-  assert.match(css, /\.cek-simpan:disabled \{ opacity: \.3; cursor: not-allowed; \}/,
-    "lambang simpan tidak lagi pudar saat tergembok");
   // Gemboknya sendiri tidak boleh dipudarkan: ia satu-satunya jalan keluar
   // dari keadaan ini, dan tombol pudar terbaca seperti tombol mati.
   assert.doesNotMatch(css, /\.cek-gembok:disabled \{[^}]*opacity/,

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=29">
+  <link rel="stylesheet" href="style.css?v=30">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9838,11 +9838,17 @@ async function layarCekNilai() {
 
                      Judulnya tetap ada untuk pembaca layar dan untuk yang
                      menahan kursor di atasnya. -->
+                <!-- TIDAK ADA TOMBOL SIMPAN. Angkanya disimpan sendiri
+                     begitu diubah, dan yang tersisa cuma KABAR: titik-titik
+                     kuning berarti belum sampai ke database, centang hijau
+                     berarti sudah.
+
+                     Tombol simpan pada layar yang menyimpan sendiri adalah
+                     tombol yang tidak pernah perlu ditekan, dan tombol seperti
+                     itu justru membuat orang ragu apakah angkanya tersimpan
+                     kalau ia LUPA menekannya. -->
                 <div class="cek-baris-aksi">
-                  <button type="button" class="icon-button cek-simpan"
-                          data-simpan-lomba="${esc(l.kode)}"
-                          title="Simpan ${esc(l.nama)}"
-                          aria-label="Simpan ${esc(l.nama)}">${ikon("save")}</button>
+                  <span class="cek-status" data-status="${esc(l.kode)}"></span>
                   <button type="button" class="icon-button cek-gembok"
                           data-gembok="${esc(l.kode)}"></button>
                 </div>
@@ -9879,6 +9885,7 @@ async function layarCekNilai() {
       });
     });
     gambarKunci();
+    statusAwal();
     matikanSaatTerkunci();
 
     let foto = [];
@@ -10015,8 +10022,7 @@ async function layarCekNilai() {
     const kunci = lombaTerkunci();
     elIsi.querySelectorAll("[data-isian]").forEach(wadah => {
       const mati = kunci.has(wadah.dataset.isian);
-      wadah.querySelectorAll("input, [data-simpan-lomba]")
-        .forEach(el => { el.disabled = mati; });
+      wadah.querySelectorAll("input").forEach(el => { el.disabled = mati; });
     });
   }
 
@@ -10181,45 +10187,148 @@ async function layarCekNilai() {
     } catch { /* angkanya sudah tersimpan; yang basi cuma ringkasannya */ }
   }
 
-  /* Simpan per lomba, bukan satu tombol untuk seluruh regu. Yang dibetulkan
-     admin satu lomba pada satu waktu — ia baru saja membandingkannya dengan
-     fotonya — dan tombol di ujung halaman menuntut menggulir melewati empat
-     lomba lain yang tidak sedang dipersoalkan. */
-  elIsi.addEventListener("click", async (e) => {
-    const b = e.target.closest("[data-simpan-lomba]");
-    if (!b || b.disabled || !lembar.length) return;
-    const r = lembar[indeks];
-    const l = lombaPos().find(x => x.kode === b.dataset.simpanLomba);
-    const wadah = elIsi.querySelector(
-      `[data-isian="${CSS.escape(b.dataset.simpanLomba)}"]`);
-    if (!l || !wadah) return;
+  /** Kabar keadaan satu lomba: sudah sampai database atau belum.
+   *
+   *  Kosakatanya SAMA dengan lembar pos (statusBaris di layar Input Pos), dan
+   *  itu disengaja: dua layar yang menceritakan hal yang sama tidak boleh
+   *  memakai dua lambang berbeda.
+   *
+   *    belum      titik-titik KUNING  diketik, belum dikirim
+   *    menyimpan  titik-titik KUNING  sedang di jalan
+   *    tersimpan  centang HIJAU       sudah masuk database
+   *    gagal      seru MERAH          tidak sampai; ketuk untuk mengulang
+   *
+   *  `belum` dan `menyimpan` sengaja terlihat SAMA bagi yang membacanya.
+   *  Bedanya cuma soal teknis — sudah dikirim atau belum — dan yang
+   *  ditanyakan panitia satu: "angka ini sudah aman atau belum?" */
+  function statusLomba(kode, keadaan, pesan) {
+    const sel = elIsi.querySelector(`[data-status="${CSS.escape(kode)}"]`);
+    if (!sel) return;
+    sel.dataset.keadaan = keadaan || "";
+    if (keadaan === "belum" || keadaan === "menyimpan") {
+      sel.textContent = "\u2026";
+      sel.title = "Belum tersimpan";
+    } else if (keadaan === "tersimpan") {
+      sel.textContent = "\u2713";
+      sel.title = "Sudah tersimpan";
+    } else if (keadaan === "gagal") {
+      sel.textContent = "!";
+      sel.title = pesan || "Gagal menyimpan \u2014 ketuk untuk mengulang";
+    } else {
+      sel.textContent = "";
+      sel.title = "";
+    }
+  }
 
-    b.disabled = true;
-    const jawab = await kirimNilaiRegu({ pos: nomorPos, kolom: l.kolom, regu: r, wadah });
-    b.disabled = false;
+  /** Keadaan awal tiap lomba, dibaca dari angka yang memang ada di database.
+   *
+   *  Lomba yang seluruh kriterianya terisi ditandai TERSIMPAN; yang kosong
+   *  tidak ditandai apa-apa. Menandai yang kosong dengan centang akan
+   *  mengatakan "aman" tentang sesuatu yang belum ada. */
+  function statusAwal() {
+    if (!lembar.length) return;
+    const r = lembar[indeks];
+    lombaPos().forEach(l => {
+      const dipakai = l.kolom.map(kol => varianUntuk(kol, r.golongan)).filter(Boolean);
+      const terisi = dipakai.filter(k => (r.nilai || {})[k.kode] !== undefined).length;
+      statusLomba(l.kode, dipakai.length && terisi === dipakai.length ? "tersimpan" : "");
+    });
+  }
+
+  /** Menyimpan satu lomba. Dipanggil sendiri saat angkanya berubah — tidak ada
+   *  tombol simpan lagi.
+   *
+   *  Yang mengirim tetap kirimNilaiRegu(), satu pintu bersama layar input:
+   *  keempat aturannya (kotak tak terbaca tidak menyentuh angka lama, kotak
+   *  kosong berarti hapus, angka yang sama tidak dikirim ulang, gagal jaringan
+   *  masuk antrean) berlaku sama di sini karena memang kode yang sama. */
+  const sedangSimpan = new Set();
+  async function simpanLomba(kode) {
+    if (!lembar.length || sedangSimpan.has(kode)) return;
+    const r = lembar[indeks];
+    const l = lombaPos().find(x => x.kode === kode);
+    const wadah = elIsi.querySelector(`[data-isian="${CSS.escape(kode)}"]`);
+    if (!l || !wadah) return;
+    // Lomba yang tergembok tidak dikirim sama sekali: server akan menolaknya,
+    // dan penolakan yang bisa dihindari lebih baik tidak dibuat.
+    if (lombaTerkunci().has(kode)) return;
+
+    sedangSimpan.add(kode);
+    statusLomba(kode, "menyimpan");
+    let jawab;
+    try {
+      jawab = await kirimNilaiRegu({ pos: nomorPos, kolom: l.kolom, regu: r, wadah });
+    } finally {
+      sedangSimpan.delete(kode);
+    }
 
     if (jawab.hasil === "takTerbaca") {
+      statusLomba(kode, "gagal", `${jawab.nama.join(", ")}: bukan angka yang bisa dibaca`);
       notif(`${jawab.nama.join(", ")}: isinya bukan angka/waktu yang bisa `
             + "dibaca. Angka lamanya TIDAK diubah.", true);
       return;
     }
-    if (jawab.hasil === "kosong") { notif("Tidak ada angka yang berubah.", true); return; }
+    if (jawab.hasil === "kosong") {
+      // Tidak ada yang berubah — bukan galat, dan bukan pula kabar. Diam.
+      statusAwal();
+      return;
+    }
     if (jawab.hasil === "ditolak") {
+      statusLomba(kode, "gagal", jawab.pesan);
       notif(`${dada3(r.nomor_dada)}.\n${kapital(jawab.pesan)}`, true);
       return;
     }
     if (jawab.hasil === "antre") {
+      // Masih titik-titik kuning, karena memang belum sampai. Pita antrean di
+      // atas layar yang menceritakan sisanya.
+      statusLomba(kode, "belum");
       notif(`${dada3(r.nomor_dada)} BELUM terkirim — masuk antrean, `
             + "dikirim otomatis saat ada sinyal.", true);
       gambarPitaAntrean();
       return;
     }
-    notif(`${dada3(r.nomor_dada)} ${l.nama} tersimpan.`);
-    /* Barisnya dibaca ulang, tapi layarnya TIDAK digambar ulang: admin sedang
-       menatap foto di tengah halaman, dan menggambar ulang melempar
-       gulirannya. Yang perlu ikut berubah cuma tombol gemboknya. */
+    statusLomba(kode, "tersimpan");
+    /* Barisnya dibaca ulang, tapi layarnya TIDAK digambar ulang: panitia
+       sedang menatap foto, dan menggambar ulang melempar gulirannya. Yang
+       perlu ikut berubah cuma gemboknya — kelengkapan lomba menentukan boleh
+       tidaknya digembok. */
     await segarkanBaris(Number(r.nomor_dada));
     gambarKunci();
+  }
+
+  /* SIMPAN SENDIRI SAAT DIUBAH, dengan pola yang sama persis dengan lembar
+     pos — dan ketiga pendengarnya perlu, bukan satu:
+
+       input     menandai kuning sejak KETUKAN PERTAMA. Di antara mengetik dan
+                 meninggalkan kotak bisa lewat semenit, dan selama itu angkanya
+                 cuma ada di layar.
+       change    menyimpan saat kotaknya ditinggalkan dengan isi yang berbeda.
+       focusout  jaring pengaman: mengetik ulang angka yang SAMA memicu `input`
+                 tapi tidak selalu memicu `change`, jadi tanpa ini penanda
+                 kuningnya menggantung selamanya. */
+  elIsi.addEventListener("input", (e) => {
+    const wadah = e.target.closest("[data-isian]");
+    if (wadah) statusLomba(wadah.dataset.isian, "belum");
+  }, { signal: sinyal });
+
+  elIsi.addEventListener("change", (e) => {
+    const wadah = e.target.closest("[data-isian]");
+    if (wadah) simpanLomba(wadah.dataset.isian);
+  }, { signal: sinyal });
+
+  elIsi.addEventListener("focusout", (e) => {
+    const wadah = e.target.closest("[data-isian]");
+    if (!wadah) return;
+    const sel = elIsi.querySelector(`[data-status="${CSS.escape(wadah.dataset.isian)}"]`);
+    if (sel && sel.dataset.keadaan === "belum") simpanLomba(wadah.dataset.isian);
+  }, { signal: sinyal });
+
+  /* Penanda GAGAL bisa diketuk untuk mengulang. Satu-satunya keadaan yang
+     menuntut tindakan, dan tanpa jalan mengulang panitia harus mengetik ulang
+     angka yang sudah benar di layarnya. */
+  elIsi.addEventListener("click", (e) => {
+    const sel = e.target.closest(".cek-status");
+    if (sel && sel.dataset.keadaan === "gagal") simpanLomba(sel.dataset.status);
   }, { signal: sinyal });
 
   const ke = (i) => {

--- a/web/style.css
+++ b/web/style.css
@@ -4933,10 +4933,37 @@ button.pill-number:hover { filter: brightness(.95); }
    layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
    penukaran yang salah arah. */
 .cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .5rem; }
-.cek-simpan, .cek-gembok { flex: 0 0 auto; }
-.cek-simpan { color: var(--utama); }
-.cek-simpan:hover:not(:disabled) { background: var(--utama-muda); }
+.cek-status, .cek-gembok { flex: 0 0 auto; }
 .cek-gembok { color: var(--tinta-lembut); }
+
+/* KABAR, BUKAN TOMBOL. Angkanya disimpan sendiri begitu diubah; yang tersisa
+   cuma memberi tahu sudah sampai database atau belum.
+
+     titik-titik KUNING  belum tersimpan (baru diketik, atau sedang di jalan)
+     centang HIJAU       sudah tersimpan
+     seru MERAH          gagal — ketuk untuk mengulang
+
+   Kuning dan hijau sengaja tidak jadi SATU-SATUNYA pembeda: bentuknya pun
+   berbeda (titik-titik lawan centang), jadi yang sulit membedakan merah dari
+   hijau tetap bisa membacanya. Judulnya menyebutkannya dengan kata.
+
+   Lebarnya dipatok supaya kotak isian di sebelahnya tidak bergeser tiap kali
+   penandanya berganti — baris yang berjoget saat mengetik terbaca seperti
+   layar yang salah. */
+.cek-status {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 28px; height: 28px;
+  font-size: 1.2rem; font-weight: 800; line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.cek-status[data-keadaan="belum"],
+.cek-status[data-keadaan="menyimpan"] { color: var(--kuning); }
+.cek-status[data-keadaan="tersimpan"] { color: var(--hijau); }
+.cek-status[data-keadaan="gagal"] {
+  color: var(--bahaya); cursor: pointer;
+  border-radius: var(--radius-kecil);
+}
+.cek-status[data-keadaan="gagal"]:hover { background: var(--bahaya-muda); }
 
 /* TERGEMBOK: kotaknya jadi abu-abu, lambang simpannya pudar.
    Dua isyarat untuk satu keadaan, dan keduanya perlu — kotak abu-abu
@@ -4949,7 +4976,6 @@ button.pill-number:hover { filter: brightness(.95); }
   color: var(--tinta-lembut);
   cursor: not-allowed;
 }
-.cek-simpan:disabled { opacity: .3; cursor: not-allowed; }
 /* Tergembok memerah, dan itu bukan peringatan melainkan KEADAAN: merah di
    sistem ini dipakai untuk yang menghentikan, dan gembok tertutup memang
    menghentikan penyimpanan. */


### PR DESCRIPTION
## What

Tidak ada lagi tombol simpan di Cek Nilai. Angkanya tersimpan begitu diubah, dan
yang tersisa cuma kabar di sebelah kotaknya:

| Lambang | Arti |
| --- | --- |
| **…** kuning | belum tersimpan (baru diketik, atau sedang di jalan) |
| **✓** hijau | sudah masuk database |
| **!** merah | gagal — ketuk untuk mengulang |

## Why

Tombol simpan pada layar yang menyimpan sendiri adalah tombol yang tidak pernah
perlu ditekan, dan tombol seperti itu justru membuat orang ragu apakah angkanya
tersimpan kalau ia **lupa** menekannya.

## Notes

**Polanya ditiru, bukan dibuat baru.** Lembar pos sudah menyimpan sendiri sejak
lama, dan ketiga pendengarnya perlu semua:

- `input` — menandai kuning sejak **ketukan pertama**. Di antara mengetik dan
  meninggalkan kotak bisa lewat semenit, dan selama itu angkanya cuma ada di
  layar.
- `change` — menyimpan saat kotaknya ditinggalkan dengan isi berbeda.
- `focusout` — jaring pengaman: mengetik ulang angka yang **sama** memicu
  `input` tapi tidak selalu `change`, jadi tanpa ini penanda kuningnya
  menggantung selamanya.

Kosakata lambangnya juga sama dengan lembar pos — dua layar yang menceritakan
hal yang sama tidak boleh memakai dua lambang berbeda.

Yang mengirim tetap `kirimNilaiRegu()`, **satu pintu** bersama layar input:
keempat aturannya (kotak tak terbaca tidak menyentuh angka lama, kotak kosong
berarti hapus, angka yang sama tidak dikirim ulang, gagal jaringan masuk
antrean) berlaku sama karena memang kode yang sama.

Tiga keputusan yang layak disebut:

- **Yang masuk antrean tetap kuning, bukan hijau.** Ia belum sampai database,
  dan centang hijau di situ berbohong tentang satu-satunya hal yang ditanyakan
  panitia.
- **Kuning dan hijau bukan satu-satunya pembeda** — bentuknya pun berbeda
  (titik-titik lawan centang), dan judulnya menyebutkannya dengan kata.
- **Lomba tergembok tidak dikirim sama sekali** — server akan menolaknya, dan
  penolakan yang bisa dihindari lebih baik tidak dibuat.

Diverifikasi di layar sungguhan, bukan hanya lewat tes sumber: ✓ hijau → diketik
88 → **… kuning** → **✓ hijau**, dan nilainya **di database** benar-benar
berpindah dari 127 ke 88 tanpa satu pun tombol ditekan.

372 tes JS lulus.
