### PR TITLE
fix: penanda dan gembok berdempet dengan kotaknya, bukan di tepi kanan

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=32">
+  <link rel="stylesheet" href="style.css?v=33">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4932,7 +4932,7 @@ button.pill-number:hover { filter: brightness(.95); }
    berdiri di baris sendiri, dan tinggi yang dimakannya diambil dari foto — di
    layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
    penukaran yang salah arah. */
-.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .5rem; }
+.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .15rem; }
 .cek-status, .cek-gembok { flex: 0 0 auto; }
 .cek-gembok { color: var(--tinta-lembut); }
 
@@ -5000,13 +5000,25 @@ button.pill-number:hover { filter: brightness(.95); }
    pertama. */
 .cek-isian {
   display: flex; align-items: center; justify-content: center;
-  gap: .5rem; margin: .4rem 0 .2rem;
+  gap: .35rem; margin: .4rem 0 .2rem;
 }
-/* Kotak isian yang menyusut, bukan lambangnya. Lambang 34px yang mengecil
-   berhenti bisa disentuh; kotak yang mengecil masih terbaca. */
-.cek-angka { display: flex; flex-direction: column; gap: .35rem; min-width: 0; flex: 1; }
+/* Kotak isian TIDAK melebar mengisi kolomnya. `flex: 1` di sini mendorong
+   penanda dan gembok ke tepi kanan yang jauh, dan mata harus menyeberangi
+   kolom kosong untuk membaca apakah angkanya sudah tersimpan — padahal
+   keduanya menceritakan angka yang sama.
+
+   Ketiganya sekarang berdempet dan berdiri di tengah kolomnya. Yang menyusut
+   tetap kotaknya, bukan lambangnya: lambang 28px yang mengecil berhenti bisa
+   disentuh, kotak yang mengecil masih terbaca. */
+.cek-angka {
+  display: flex; flex-direction: column; gap: .35rem;
+  flex: 0 1 auto; min-width: 0;
+}
 .cek-isian .isian-baris { border: 0; padding: 0; gap: .25rem; }
-.cek-isian .small-input { font-size: 1.4rem; min-height: 52px; width: 100%; }
+.cek-isian .small-input {
+  font-size: 1.4rem; min-height: 52px;
+  width: 100%; min-width: 0; max-width: 6.5rem;
+}
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 32, sidik: "7e48fa453a44" },
+  "style.css": { versi: 33, sidik: "b387b96a9984" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=30">
+  <link rel="stylesheet" href="style.css?v=31">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -4932,7 +4932,7 @@ button.pill-number:hover { filter: brightness(.95); }
    berdiri di baris sendiri, dan tinggi yang dimakannya diambil dari foto — di
    layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
    penukaran yang salah arah. */
-.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .5rem; }
+.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .15rem; }
 .cek-status, .cek-gembok { flex: 0 0 auto; }
 .cek-gembok { color: var(--tinta-lembut); }
 
@@ -5000,13 +5000,25 @@ button.pill-number:hover { filter: brightness(.95); }
    pertama. */
 .cek-isian {
   display: flex; align-items: center; justify-content: center;
-  gap: .5rem; margin: .4rem 0 .2rem;
+  gap: .35rem; margin: .4rem 0 .2rem;
 }
-/* Kotak isian yang menyusut, bukan lambangnya. Lambang 34px yang mengecil
-   berhenti bisa disentuh; kotak yang mengecil masih terbaca. */
-.cek-angka { display: flex; flex-direction: column; gap: .35rem; min-width: 0; flex: 1; }
+/* Kotak isian TIDAK melebar mengisi kolomnya. `flex: 1` di sini mendorong
+   penanda dan gembok ke tepi kanan yang jauh, dan mata harus menyeberangi
+   kolom kosong untuk membaca apakah angkanya sudah tersimpan — padahal
+   keduanya menceritakan angka yang sama.
+
+   Ketiganya sekarang berdempet dan berdiri di tengah kolomnya. Yang menyusut
+   tetap kotaknya, bukan lambangnya: lambang 28px yang mengecil berhenti bisa
+   disentuh, kotak yang mengecil masih terbaca. */
+.cek-angka {
+  display: flex; flex-direction: column; gap: .35rem;
+  flex: 0 1 auto; min-width: 0;
+}
 .cek-isian .isian-baris { border: 0; padding: 0; gap: .25rem; }
-.cek-isian .small-input { font-size: 1.4rem; min-height: 52px; width: 100%; }
+.cek-isian .small-input {
+  font-size: 1.4rem; min-height: 52px;
+  width: 100%; min-width: 0; max-width: 6.5rem;
+}
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */


### PR DESCRIPTION
## What

Penanda keadaan (**…** / **✓**) dan gembok sekarang berdiri tepat di sebelah
kotak isian, bukan terdorong ke tepi kanan kolomnya.

## Why

`.cek-angka { flex: 1 }` membuat kotak isian melebar mengisi kolomnya, dan
keduanya terdorong ke ujung. Mata harus menyeberangi kolom kosong untuk membaca
apakah angkanya sudah tersimpan — padahal keduanya menceritakan angka yang sama.

Terukur di 1440×820: jarak kotak ke penanda **68px → 5px**.

## Notes

Yang menyusut tetap kotaknya, bukan lambangnya — lambang 28px yang mengecil
berhenti bisa disentuh, kotak yang mengecil masih terbaca. Kotaknya dipatok
maksimal 6,5rem, cukup untuk "4.80" maupun "127".

Warnanya diperiksa dari yang **benar-benar tergambar**, bukan dari berkasnya:
titik-titik `rgb(178,106,0)` kuning, centang `rgb(46,125,50)` hijau — keduanya
warna sistem yang sama dipakai badge di layar lain, jadi kuning di sini berarti
hal yang sama dengan kuning di lembar pos.

372 tes JS lulus.
