### PR TITLE
fix: penanda dan gembok Cek Nilai memakai gaya lembar pos, judul di tengah

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=33">
+  <link rel="stylesheet" href="style.css?v=34">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4934,7 +4934,6 @@ button.pill-number:hover { filter: brightness(.95); }
    penukaran yang salah arah. */
 .cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .15rem; }
 .cek-status, .cek-gembok { flex: 0 0 auto; }
-.cek-gembok { color: var(--tinta-lembut); }
 
 /* KABAR, BUKAN TOMBOL. Angkanya disimpan sendiri begitu diubah; yang tersisa
    cuma memberi tahu sudah sampai database atau belum.
@@ -4950,20 +4949,24 @@ button.pill-number:hover { filter: brightness(.95); }
    Lebarnya dipatok supaya kotak isian di sebelahnya tidak bergeser tiap kali
    penandanya berganti — baris yang berjoget saat mengetik terbaca seperti
    layar yang salah. */
+/* Warnanya datang dari `.badge-yellow` / `.badge-green` / `.badge-red` yang
+   dipasang JavaScript — kelas yang sama persis dengan lembar pos, bukan warna
+   yang ditulis ulang di sini. Menuliskannya ulang berarti dua tempat yang
+   suatu hari tidak sepakat soal "kuning yang mana".
+
+   Yang tersisa di sini cuma ukurannya: lebarnya dipatok supaya kotak isian di
+   sebelahnya tidak bergeser tiap kali penandanya berganti. Baris yang berjoget
+   saat mengetik terbaca seperti layar yang salah. */
 .cek-status {
-  display: inline-flex; align-items: center; justify-content: center;
-  min-width: 28px; height: 28px;
-  font-size: 1.2rem; font-weight: 800; line-height: 1;
-  font-variant-numeric: tabular-nums;
+  justify-content: center;
+  min-width: 30px; min-height: 26px; padding: .2rem .4rem;
+  line-height: 1;
 }
-.cek-status[data-keadaan="belum"],
-.cek-status[data-keadaan="menyimpan"] { color: var(--kuning); }
-.cek-status[data-keadaan="tersimpan"] { color: var(--hijau); }
-.cek-status[data-keadaan="gagal"] {
-  color: var(--bahaya); cursor: pointer;
-  border-radius: var(--radius-kecil);
-}
-.cek-status[data-keadaan="gagal"]:hover { background: var(--bahaya-muda); }
+/* Kosong = tidak ada apa-apa yang perlu dikatakan. Tanpa ini pil kosong tetap
+   memakan tempat dan terbaca seperti penanda yang gagal digambar. */
+.cek-status:empty { min-width: 30px; background: none; padding: 0; }
+.cek-status[data-keadaan="gagal"] { cursor: pointer; }
+.cek-status[data-keadaan="gagal"]:hover { filter: brightness(.94); }
 
 /* TERGEMBOK: kotaknya jadi abu-abu, lambang simpannya pudar.
    Dua isyarat untuk satu keadaan, dan keduanya perlu — kotak abu-abu
@@ -4976,11 +4979,11 @@ button.pill-number:hover { filter: brightness(.95); }
   color: var(--tinta-lembut);
   cursor: not-allowed;
 }
-/* Tergembok memerah, dan itu bukan peringatan melainkan KEADAAN: merah di
-   sistem ini dipakai untuk yang menghentikan, dan gembok tertutup memang
-   menghentikan penyimpanan. */
-.cek-gembok.tergembok { color: var(--bahaya); }
-.cek-gembok.tergembok:hover { background: var(--bahaya-muda); }
+/* Tergembok HIJAU, bukan merah — aturan yang sama dengan lembar pos, dan
+   alasannya sudah ditulis di sana: gembok tertutup berarti "sudah diperiksa
+   dan benar", sekelas dengan centang hijau di sebelahnya. Merah akan
+   membacanya sebagai galat, padahal ia justru keadaan yang dituju. */
+.cek-gembok.tergembok { color: var(--utama); }
 /* Belum lengkap dipucatkan, bukan disembunyikan: yang menekan perlu tahu
    gemboknya ADA dan kenapa ia belum bisa dipakai — judulnya menyebut berapa
    kriteria yang masih kosong. */
@@ -5024,20 +5027,19 @@ button.pill-number:hover { filter: brightness(.95); }
    antara keduanya. */
 .cek-lomba { padding: .7rem 0; border-top: 1px solid var(--garis); }
 .cek-lomba:first-child { border-top: 0; padding-top: 0; }
-/* Nama di atas, angkanya tepat di bawahnya, KEDUANYA RATA KIRI — lalu
-   fotonya. Sebelumnya angkanya didorong ke tepi kanan, jadi membandingkan
-   tulisan tangan di foto dengan angka yang diketik menuntut mata menyeberang
-   selebar layar dan turun; sekarang keduanya di satu kolom yang sama. */
-.cek-kepala { display: flex; flex-direction: column; align-items: flex-start; gap: .15rem; }
-.cek-nama { font-weight: 700; }
-.cek-angka { display: flex; gap: .9rem; flex-wrap: wrap; align-items: baseline; }
-/* Angkanya sengaja besar: ia satu-satunya hal di kartu ini yang sedang
-   dibandingkan dengan sesuatu, dan pembandingnya tulisan tangan di foto
-   sebesar layar. */
-.cek-butir { font-size: 1.6rem; font-weight: 800; font-variant-numeric: tabular-nums; }
-.cek-butir-nama {
-  display: block; font-size: .75rem; font-weight: 400; color: var(--tinta-lembut);
-}
+/* Judul lomba DI TENGAH, sejajar dengan kotak isian dan fotonya yang juga di
+   tengah kolomnya. Rata kiri membuat judulnya berdiri sendirian di satu sisi
+   sementara semua yang menjelaskannya berdiri di tengah. */
+.cek-kepala { display: flex; flex-direction: column; align-items: center; gap: .15rem; }
+.cek-nama { font-weight: 700; text-align: center; }
+
+/* `.cek-angka` DULU DIDEFINISIKAN DUA KALI di berkas ini, dan yang belakangan
+   menang tanpa suara (CLAUDE.md 15.6). Yang kedua milik versi lama layar ini —
+   angka baca-saja berukuran besar, bersama `.cek-butir` — dan markup-nya sudah
+   tidak ada lagi di app.js sejak kotak isian menggantikannya. Sisa aturannya
+   diam-diam membalikkan pembungkus kotak isian dari kolom jadi baris, dan itu
+   baru terlihat pada lomba berkriteria banyak (Pembidaian, lima kotak).
+   Dibuang, bukan ditimpa. */
 .cek-kosong { font-size: .85rem; font-weight: 400; color: var(--tinta-lembut); }
 /* Foto SELEBAR KARTU, bukan petak kecil berjajar. Yang dibaca di sini tulisan
    tangan — "JUMLAH KATA YANG BENAR: 1" — dan petak 7rem tidak menjawab

--- a/tests/cek_nilai_simpan_otomatis.test.mjs
+++ b/tests/cek_nilai_simpan_otomatis.test.mjs
@@ -83,14 +83,29 @@ test("kuning dan hijau tidak jadi satu-satunya pembeda", () => {
     "penanda tersimpan bukan centang");
   assert.match(app, /sel\.title = "Belum tersimpan";/,
     "keadaannya tidak disebut dengan kata untuk pembaca layar");
-  assert.match(css, /\.cek-status\[data-keadaan="belum"\],\s*\r?\n\.cek-status\[data-keadaan="menyimpan"\] \{ color: var\(--kuning\); \}/,
-    "penanda belum tersimpan tidak lagi kuning");
-  assert.match(css, /\.cek-status\[data-keadaan="tersimpan"\] \{ color: var\(--hijau\); \}/,
-    "penanda tersimpan tidak lagi hijau");
+  // Warnanya datang dari kelas `.badge-*` yang SAMA dengan lembar pos, bukan
+  // ditulis ulang di sini: dua tempat yang masing-masing menulis "kuning"
+  // suatu hari tidak sepakat kuning yang mana.
+  assert.match(app, /belum: "badge-yellow", menyimpan: "badge-yellow",/,
+    "penanda belum tersimpan tidak lagi memakai pil kuning lembar pos");
+  assert.match(app, /tersimpan: "badge-green", gagal: "badge-red"/,
+    "penanda tersimpan tidak lagi memakai pil hijau lembar pos");
+  assert.doesNotMatch(css, /\.cek-status\[data-keadaan="[^"]+"\] \{ color:/,
+    "warna penanda ditulis ulang di CSS — seharusnya datang dari .badge-*");
+});
+
+test("gembok tergembok HIJAU, sama dengan lembar pos", () => {
+  // Alasannya sudah ditulis di lembar pos: gembok tertutup berarti "sudah
+  // diperiksa dan benar", sekelas dengan centang hijau di sebelahnya. Merah
+  // akan membacanya sebagai galat, padahal ia justru keadaan yang dituju.
+  assert.match(css, /\.cek-gembok\.tergembok \{ color: var\(--utama\); \}/,
+    "gembok tertutup tidak lagi hijau — merah membacanya sebagai galat");
+  assert.match(app, /class="gembok cek-gembok"/,
+    "gembok Cek Nilai tidak lagi memakai kelas .gembok yang sama dengan lembar pos");
 });
 
 test("lebar penanda dipatok supaya barisnya tidak berjoget", () => {
-  assert.match(css, /\.cek-status \{[\s\S]{0,200}min-width: 28px;/,
+  assert.match(css, /\.cek-status \{[\s\S]{0,200}min-width: 30px;/,
     "lebar penanda tidak dipatok — kotak isian bergeser tiap kali penandanya "
     + "berganti, dan baris yang berjoget saat mengetik terbaca seperti layar "
     + "yang salah");

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 33, sidik: "b387b96a9984" },
+  "style.css": { versi: 34, sidik: "8f310718f194" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=31">
+  <link rel="stylesheet" href="style.css?v=32">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9849,7 +9849,7 @@ async function layarCekNilai() {
                      kalau ia LUPA menekannya. -->
                 <div class="cek-baris-aksi">
                   <span class="cek-status" data-status="${esc(l.kode)}"></span>
-                  <button type="button" class="icon-button cek-gembok"
+                  <button type="button" class="gembok cek-gembok"
                           data-gembok="${esc(l.kode)}"></button>
                 </div>
               </div>
@@ -10205,6 +10205,17 @@ async function layarCekNilai() {
     const sel = elIsi.querySelector(`[data-status="${CSS.escape(kode)}"]`);
     if (!sel) return;
     sel.dataset.keadaan = keadaan || "";
+    /* Pil `.badge` yang SAMA dengan lembar pos — kuning, hijau, merah. Dua
+       layar yang menceritakan hal yang sama tidak boleh memakai dua bentuk
+       berbeda: panitia yang berpindah di antara keduanya sepanjang pagi
+       harus bisa membacanya tanpa belajar dua kali.
+
+       Kelas dasarnya dipasang ulang tiap kali, bukan ditambah-kurang satu
+       per satu: penanda yang pernah merah lalu jadi hijau tidak boleh
+       menyisakan sisa kelas lamanya. */
+    const pil = { belum: "badge-yellow", menyimpan: "badge-yellow",
+                  tersimpan: "badge-green", gagal: "badge-red" }[keadaan];
+    sel.className = "cek-status" + (pil ? ` badge ${pil}` : "");
     if (keadaan === "belum" || keadaan === "menyimpan") {
       sel.textContent = "\u2026";
       sel.title = "Belum tersimpan";

--- a/web/style.css
+++ b/web/style.css
@@ -4934,7 +4934,6 @@ button.pill-number:hover { filter: brightness(.95); }
    penukaran yang salah arah. */
 .cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .15rem; }
 .cek-status, .cek-gembok { flex: 0 0 auto; }
-.cek-gembok { color: var(--tinta-lembut); }
 
 /* KABAR, BUKAN TOMBOL. Angkanya disimpan sendiri begitu diubah; yang tersisa
    cuma memberi tahu sudah sampai database atau belum.
@@ -4950,20 +4949,24 @@ button.pill-number:hover { filter: brightness(.95); }
    Lebarnya dipatok supaya kotak isian di sebelahnya tidak bergeser tiap kali
    penandanya berganti — baris yang berjoget saat mengetik terbaca seperti
    layar yang salah. */
+/* Warnanya datang dari `.badge-yellow` / `.badge-green` / `.badge-red` yang
+   dipasang JavaScript — kelas yang sama persis dengan lembar pos, bukan warna
+   yang ditulis ulang di sini. Menuliskannya ulang berarti dua tempat yang
+   suatu hari tidak sepakat soal "kuning yang mana".
+
+   Yang tersisa di sini cuma ukurannya: lebarnya dipatok supaya kotak isian di
+   sebelahnya tidak bergeser tiap kali penandanya berganti. Baris yang berjoget
+   saat mengetik terbaca seperti layar yang salah. */
 .cek-status {
-  display: inline-flex; align-items: center; justify-content: center;
-  min-width: 28px; height: 28px;
-  font-size: 1.2rem; font-weight: 800; line-height: 1;
-  font-variant-numeric: tabular-nums;
+  justify-content: center;
+  min-width: 30px; min-height: 26px; padding: .2rem .4rem;
+  line-height: 1;
 }
-.cek-status[data-keadaan="belum"],
-.cek-status[data-keadaan="menyimpan"] { color: var(--kuning); }
-.cek-status[data-keadaan="tersimpan"] { color: var(--hijau); }
-.cek-status[data-keadaan="gagal"] {
-  color: var(--bahaya); cursor: pointer;
-  border-radius: var(--radius-kecil);
-}
-.cek-status[data-keadaan="gagal"]:hover { background: var(--bahaya-muda); }
+/* Kosong = tidak ada apa-apa yang perlu dikatakan. Tanpa ini pil kosong tetap
+   memakan tempat dan terbaca seperti penanda yang gagal digambar. */
+.cek-status:empty { min-width: 30px; background: none; padding: 0; }
+.cek-status[data-keadaan="gagal"] { cursor: pointer; }
+.cek-status[data-keadaan="gagal"]:hover { filter: brightness(.94); }
 
 /* TERGEMBOK: kotaknya jadi abu-abu, lambang simpannya pudar.
    Dua isyarat untuk satu keadaan, dan keduanya perlu — kotak abu-abu
@@ -4976,11 +4979,11 @@ button.pill-number:hover { filter: brightness(.95); }
   color: var(--tinta-lembut);
   cursor: not-allowed;
 }
-/* Tergembok memerah, dan itu bukan peringatan melainkan KEADAAN: merah di
-   sistem ini dipakai untuk yang menghentikan, dan gembok tertutup memang
-   menghentikan penyimpanan. */
-.cek-gembok.tergembok { color: var(--bahaya); }
-.cek-gembok.tergembok:hover { background: var(--bahaya-muda); }
+/* Tergembok HIJAU, bukan merah — aturan yang sama dengan lembar pos, dan
+   alasannya sudah ditulis di sana: gembok tertutup berarti "sudah diperiksa
+   dan benar", sekelas dengan centang hijau di sebelahnya. Merah akan
+   membacanya sebagai galat, padahal ia justru keadaan yang dituju. */
+.cek-gembok.tergembok { color: var(--utama); }
 /* Belum lengkap dipucatkan, bukan disembunyikan: yang menekan perlu tahu
    gemboknya ADA dan kenapa ia belum bisa dipakai — judulnya menyebut berapa
    kriteria yang masih kosong. */
@@ -5024,20 +5027,19 @@ button.pill-number:hover { filter: brightness(.95); }
    antara keduanya. */
 .cek-lomba { padding: .7rem 0; border-top: 1px solid var(--garis); }
 .cek-lomba:first-child { border-top: 0; padding-top: 0; }
-/* Nama di atas, angkanya tepat di bawahnya, KEDUANYA RATA KIRI — lalu
-   fotonya. Sebelumnya angkanya didorong ke tepi kanan, jadi membandingkan
-   tulisan tangan di foto dengan angka yang diketik menuntut mata menyeberang
-   selebar layar dan turun; sekarang keduanya di satu kolom yang sama. */
-.cek-kepala { display: flex; flex-direction: column; align-items: flex-start; gap: .15rem; }
-.cek-nama { font-weight: 700; }
-.cek-angka { display: flex; gap: .9rem; flex-wrap: wrap; align-items: baseline; }
-/* Angkanya sengaja besar: ia satu-satunya hal di kartu ini yang sedang
-   dibandingkan dengan sesuatu, dan pembandingnya tulisan tangan di foto
-   sebesar layar. */
-.cek-butir { font-size: 1.6rem; font-weight: 800; font-variant-numeric: tabular-nums; }
-.cek-butir-nama {
-  display: block; font-size: .75rem; font-weight: 400; color: var(--tinta-lembut);
-}
+/* Judul lomba DI TENGAH, sejajar dengan kotak isian dan fotonya yang juga di
+   tengah kolomnya. Rata kiri membuat judulnya berdiri sendirian di satu sisi
+   sementara semua yang menjelaskannya berdiri di tengah. */
+.cek-kepala { display: flex; flex-direction: column; align-items: center; gap: .15rem; }
+.cek-nama { font-weight: 700; text-align: center; }
+
+/* `.cek-angka` DULU DIDEFINISIKAN DUA KALI di berkas ini, dan yang belakangan
+   menang tanpa suara (CLAUDE.md 15.6). Yang kedua milik versi lama layar ini —
+   angka baca-saja berukuran besar, bersama `.cek-butir` — dan markup-nya sudah
+   tidak ada lagi di app.js sejak kotak isian menggantikannya. Sisa aturannya
+   diam-diam membalikkan pembungkus kotak isian dari kolom jadi baris, dan itu
+   baru terlihat pada lomba berkriteria banyak (Pembidaian, lima kotak).
+   Dibuang, bukan ditimpa. */
 .cek-kosong { font-size: .85rem; font-weight: 400; color: var(--tinta-lembut); }
 /* Foto SELEBAR KARTU, bukan petak kecil berjajar. Yang dibaca di sini tulisan
    tangan — "JUMLAH KATA YANG BENAR: 1" — dan petak 7rem tidak menjawab


### PR DESCRIPTION
## What

Tiga hal, dan ketiganya soal dua layar yang menceritakan hal yang sama harus
terbaca sama:

- **Penanda** memakai pil `.badge` yang sama dengan lembar pos —
  `badge-yellow` / `badge-green` / `badge-red`.
- **Gembok** memakai kelas `.gembok` yang sama, dan tergembok jadi **hijau**
  bukan merah.
- **Judul lomba** di tengah.

## Why

Warnanya datang dari kelas `.badge-*`, bukan ditulis ulang di CSS Cek Nilai: dua
tempat yang masing-masing menulis "kuning" suatu hari tidak sepakat kuning yang
mana.

Gembok tertutup hijau karena alasannya **sudah tertulis di lembar pos**: ia
berarti "sudah diperiksa dan benar", sekelas dengan centang hijau di sebelahnya.
Merah membacanya sebagai galat, padahal ia justru keadaan yang dituju.

## Notes

**Satu bug yang ditemukan sambil mengerjakannya.** `.cek-angka` ternyata
**didefinisikan dua kali** di `style.css`, dan yang belakangan menang tanpa suara
(CLAUDE.md 15.6). Yang kedua milik versi lama layar ini — angka baca-saja
berukuran besar bersama `.cek-butir` — dan markup-nya sudah tidak ada lagi di
`app.js` sejak kotak isian menggantikannya.

Sisa aturan mati itu diam-diam membalikkan pembungkus kotak isian dari kolom
jadi baris. **Tidak terlihat pada lomba berkriteria satu**, yaitu hampir
semuanya; baru terlihat pada Pembidaian yang lima kriterianya berjajar ke
samping alih-alih bertumpuk. Aturan matinya dibuang, bukan ditimpa.

Diverifikasi di layar: Pos 3 menggambar tiga lomba (Pembidaian, KIM, Logika),
dan kelima kriteria Pembidaian bertumpuk di lima baris berbeda.

373 tes JS lulus.
