### PR TITLE
fix: kriteria Cek Nilai berjajar ke kanan, tidak ada yang turun ke bawah

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=34">
+  <link rel="stylesheet" href="style.css?v=35">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -5005,22 +5005,45 @@ button.pill-number:hover { filter: brightness(.95); }
   display: flex; align-items: center; justify-content: center;
   gap: .35rem; margin: .4rem 0 .2rem;
 }
-/* Kotak isian TIDAK melebar mengisi kolomnya. `flex: 1` di sini mendorong
-   penanda dan gembok ke tepi kanan yang jauh, dan mata harus menyeberangi
-   kolom kosong untuk membaca apakah angkanya sudah tersimpan — padahal
-   keduanya menceritakan angka yang sama.
+/* KRITERIA BERJAJAR KE KANAN, TIDAK ADA YANG TURUN KE BAWAH — bentuk yang
+   sama dengan lembar pos, tempat tiap kriteria punya kolomnya sendiri.
 
-   Ketiganya sekarang berdempet dan berdiri di tengah kolomnya. Yang menyusut
-   tetap kotaknya, bukan lambangnya: lambang 28px yang mengecil berhenti bisa
-   disentuh, kotak yang mengecil masih terbaca. */
+   Sebabnya bukan kerapian: yang ditumpuk ke bawah mendorong FOTO turun, dan
+   foto itulah alasan layar ini ada. Pembidaian lima kriteria bertumpuk
+   memakan lima kali tinggi satu kotak, seluruhnya diambil dari gambar yang
+   sedang dicocokkan dengan angkanya.
+
+   `nowrap`: kalau ruangnya kurang, yang mengalah LEBAR KOTAKNYA, bukan
+   susunannya. Satu kriteria yang membungkus ke baris kedua mengembalikan
+   persis masalah yang dihilangkan aturan ini, dan ia akan terjadi diam-diam
+   di pos tertentu saja.
+
+   Kotaknya juga TIDAK melebar mengisi kolomnya (`flex: 0 1 auto` pada
+   pembungkusnya): `flex: 1` mendorong penanda dan gembok ke tepi kanan yang
+   jauh, dan mata harus menyeberangi kolom kosong untuk membaca apakah
+   angkanya sudah tersimpan — padahal keduanya menceritakan angka yang sama. */
 .cek-angka {
-  display: flex; flex-direction: column; gap: .35rem;
+  display: flex; flex-direction: row; flex-wrap: nowrap;
+  align-items: flex-end; gap: .3rem;
   flex: 0 1 auto; min-width: 0;
 }
-.cek-isian .isian-baris { border: 0; padding: 0; gap: .25rem; }
+.cek-isian .isian-baris {
+  border: 0; padding: 0; gap: .15rem;
+  flex: 1 1 0; min-width: 0;
+}
+/* Nama kriteria mengecil dan boleh membungkus: ia yang paling panjang
+   ("Diagnosis dan Penanganan Awal") dan paling jarang dibaca ulang — yang
+   dibaca berkali-kali angkanya. */
+.cek-isian .isian-nama { font-size: .7rem; line-height: 1.15; }
 .cek-isian .small-input {
   font-size: 1.4rem; min-height: 52px;
   width: 100%; min-width: 0; max-width: 6.5rem;
+}
+/* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
+   muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada
+   yang berebut tempat. */
+.cek-angka:has(.isian-baris + .isian-baris) .small-input {
+  font-size: 1.05rem; min-height: 44px; max-width: none;
 }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 34, sidik: "8f310718f194" },
+  "style.css": { versi: 35, sidik: "eaadee62c2ad" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=32">
+  <link rel="stylesheet" href="style.css?v=33">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -5005,22 +5005,45 @@ button.pill-number:hover { filter: brightness(.95); }
   display: flex; align-items: center; justify-content: center;
   gap: .35rem; margin: .4rem 0 .2rem;
 }
-/* Kotak isian TIDAK melebar mengisi kolomnya. `flex: 1` di sini mendorong
-   penanda dan gembok ke tepi kanan yang jauh, dan mata harus menyeberangi
-   kolom kosong untuk membaca apakah angkanya sudah tersimpan — padahal
-   keduanya menceritakan angka yang sama.
+/* KRITERIA BERJAJAR KE KANAN, TIDAK ADA YANG TURUN KE BAWAH — bentuk yang
+   sama dengan lembar pos, tempat tiap kriteria punya kolomnya sendiri.
 
-   Ketiganya sekarang berdempet dan berdiri di tengah kolomnya. Yang menyusut
-   tetap kotaknya, bukan lambangnya: lambang 28px yang mengecil berhenti bisa
-   disentuh, kotak yang mengecil masih terbaca. */
+   Sebabnya bukan kerapian: yang ditumpuk ke bawah mendorong FOTO turun, dan
+   foto itulah alasan layar ini ada. Pembidaian lima kriteria bertumpuk
+   memakan lima kali tinggi satu kotak, seluruhnya diambil dari gambar yang
+   sedang dicocokkan dengan angkanya.
+
+   `nowrap`: kalau ruangnya kurang, yang mengalah LEBAR KOTAKNYA, bukan
+   susunannya. Satu kriteria yang membungkus ke baris kedua mengembalikan
+   persis masalah yang dihilangkan aturan ini, dan ia akan terjadi diam-diam
+   di pos tertentu saja.
+
+   Kotaknya juga TIDAK melebar mengisi kolomnya (`flex: 0 1 auto` pada
+   pembungkusnya): `flex: 1` mendorong penanda dan gembok ke tepi kanan yang
+   jauh, dan mata harus menyeberangi kolom kosong untuk membaca apakah
+   angkanya sudah tersimpan — padahal keduanya menceritakan angka yang sama. */
 .cek-angka {
-  display: flex; flex-direction: column; gap: .35rem;
+  display: flex; flex-direction: row; flex-wrap: nowrap;
+  align-items: flex-end; gap: .3rem;
   flex: 0 1 auto; min-width: 0;
 }
-.cek-isian .isian-baris { border: 0; padding: 0; gap: .25rem; }
+.cek-isian .isian-baris {
+  border: 0; padding: 0; gap: .15rem;
+  flex: 1 1 0; min-width: 0;
+}
+/* Nama kriteria mengecil dan boleh membungkus: ia yang paling panjang
+   ("Diagnosis dan Penanganan Awal") dan paling jarang dibaca ulang — yang
+   dibaca berkali-kali angkanya. */
+.cek-isian .isian-nama { font-size: .7rem; line-height: 1.15; }
 .cek-isian .small-input {
   font-size: 1.4rem; min-height: 52px;
   width: 100%; min-width: 0; max-width: 6.5rem;
+}
+/* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
+   muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada
+   yang berebut tempat. */
+.cek-angka:has(.isian-baris + .isian-baris) .small-input {
+  font-size: 1.05rem; min-height: 44px; max-width: none;
 }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di


### PR DESCRIPTION
## What

Kriteria satu lomba berjajar ke kanan dalam satu baris — bentuk yang sama
dengan lembar pos, tempat tiap kriteria punya kolomnya sendiri.

## Why

Sebabnya bukan kerapian: yang ditumpuk ke bawah **mendorong foto turun**, dan
foto itulah alasan layar ini ada. Pembidaian lima kriteria bertumpuk memakan
lima kali tinggi satu kotak, seluruhnya diambil dari gambar yang sedang
dicocokkan dengan angkanya.

## Notes

`nowrap`, bukan `wrap`: kalau ruangnya kurang, yang mengalah **lebar kotaknya**,
bukan susunannya. Satu kriteria yang membungkus ke baris kedua mengembalikan
persis masalah yang dihilangkan aturan ini, dan ia akan terjadi diam-diam di pos
tertentu saja.

Kotak lomba berkriteria banyak dikecilkan; yang berkriteria satu tetap besar,
karena di sana tidak ada yang berebut tempat.

Diukur di tiga pos — semuanya **satu baris**, nol meluap, nol guliran:

| Pos | Lomba | Kotak |
| --- | --- | --- |
| 1 | lima lomba × 1 kriteria | 104px |
| 3 | Pembidaian, 5 kriteria | 73px |
| 3 | KIM, 2 kriteria | 123px |
| 4 | PBB, 4 kriteria | 123px |

373 tes JS lulus.
