### PR TITLE
fix: dev database groups KIM as one lomba, unlike production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,14 +384,28 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    more penilaian. Most of the system only ever modelled two — `pos` and
    `wahana` — and every place that treats a wahana as a lomba is wrong in the
    same way.
-2. **Pos 3 has three lomba, not seven.**
+2. **Pos 3 has four lomba, not seven.**
    - **Pembidaian** — Diagnosis dan Penanganan Awal `0–25`, Teknik Bidai
      `0–25`, Kecepatan dan Kerja Sama `0–20`, Posisi Bidai `0–15`, Kerapihan
      dan Kebersihan `0–15`. They sum to 100, and **that sum is what must be
      preserved** if the weights are rebalanced again — it is what sets
      Pembidaian's weight against every other lomba (migration `0076`).
-   - **KIM** — KIM Lihat `0–10`, KIM Cium `0–10`
+   - **Kim Lihat** — `0–10`
+   - **Kim Cium** — `0–10`
    - **Logika** — 20 soal, enter the number correct `0–20`, 5 points each
+
+   **Kim Lihat and Kim Cium are two lomba, not two criteria of one** (migration
+   `0087`), and this clause said "three lomba — **KIM** — KIM Lihat, KIM Cium"
+   until 1 September 2026, long after 0087 had shipped. In the field a regu
+   does ten Lihat questions, then ten Cium questions, each on its own answer
+   sheet filled in by the PESERTA — the same shape as Tebak Simpul, not the
+   judge-fills-columns shape of Pembidaian. So they need two blangko, two
+   photo columns, and two `kode_lomba` (`kim-lihat`, `kim-cium`).
+
+   **The photo column is the reason this matters more than tidiness.** Photos
+   key on `kode_lomba`. One key for both lomba means one column holding two
+   different answer sheets, and nobody notices until a nilai is disputed and
+   the sheet that should settle it is the wrong one.
 3. **A soal lomba takes ONE number: how many answers were correct.** The form
    is `benar_per_total` and the points are `poin_maks × benar / total_soal` —
    so "5 points per correct answer" is written as `poin_maks` 50 over 10 soal,
@@ -420,7 +434,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    Kekompakan `0–30`, Kerapihan `0–20`.
 5. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
    Semangat `0–20`, Penampilan `0–20`.
-6. **One lomba is one form per lomba.** Pos 3 prints three blangko masters,
+6. **One lomba is one form per lomba.** Pos 3 prints four blangko masters,
    not seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
    judge writes every criterion on the sheet in front of them — a sheet per
    criterion would have the same regu handed five pieces of paper at one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,14 +382,28 @@ Guidance for Claude Code when working in this repository.
    more penilaian. Most of the system only ever modelled two — `pos` and
    `wahana` — and every place that treats a wahana as a lomba is wrong in the
    same way.
-2. **Pos 3 has three lomba, not seven.**
+2. **Pos 3 has four lomba, not seven.**
    - **Pembidaian** — Diagnosis dan Penanganan Awal `0–25`, Teknik Bidai
      `0–25`, Kecepatan dan Kerja Sama `0–20`, Posisi Bidai `0–15`, Kerapihan
      dan Kebersihan `0–15`. They sum to 100, and **that sum is what must be
      preserved** if the weights are rebalanced again — it is what sets
      Pembidaian's weight against every other lomba (migration `0076`).
-   - **KIM** — KIM Lihat `0–10`, KIM Cium `0–10`
+   - **Kim Lihat** — `0–10`
+   - **Kim Cium** — `0–10`
    - **Logika** — 20 soal, enter the number correct `0–20`, 5 points each
+
+   **Kim Lihat and Kim Cium are two lomba, not two criteria of one** (migration
+   `0087`), and this clause said "three lomba — **KIM** — KIM Lihat, KIM Cium"
+   until 1 September 2026, long after 0087 had shipped. In the field a regu
+   does ten Lihat questions, then ten Cium questions, each on its own answer
+   sheet filled in by the PESERTA — the same shape as Tebak Simpul, not the
+   judge-fills-columns shape of Pembidaian. So they need two blangko, two
+   photo columns, and two `kode_lomba` (`kim-lihat`, `kim-cium`).
+
+   **The photo column is the reason this matters more than tidiness.** Photos
+   key on `kode_lomba`. One key for both lomba means one column holding two
+   different answer sheets, and nobody notices until a nilai is disputed and
+   the sheet that should settle it is the wrong one.
 3. **A soal lomba takes ONE number: how many answers were correct.** The form
    is `benar_per_total` and the points are `poin_maks × benar / total_soal` —
    so "5 points per correct answer" is written as `poin_maks` 50 over 10 soal,
@@ -418,7 +432,7 @@ Guidance for Claude Code when working in this repository.
    Kekompakan `0–30`, Kerapihan `0–20`.
 5. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
    Semangat `0–20`, Penampilan `0–20`.
-6. **One lomba is one form per lomba.** Pos 3 prints three blangko masters,
+6. **One lomba is one form per lomba.** Pos 3 prints four blangko masters,
    not seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
    judge writes every criterion on the sheet in front of them — a sheet per
    criterion would have the same regu handed five pieces of paper at one

--- a/supabase/checks/lomba_per_pos.sql
+++ b/supabase/checks/lomba_per_pos.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- hrcd-rekap : supabase/checks/lomba_per_pos.sql
+-- Lomba apa saja yang ADA di produksi, per pos. MEMBACA SAJA.
+--
+-- KENAPA PERLU DIPERIKSA, BUKAN DIBACA DARI KODE
+--
+-- Pengelompokan lomba tidak ada di kode; ia DATA — `wahana.lomba` dan
+-- `wahana.kode_lomba`. Dua migrasi mengubahnya (0076 mengelompokkan Pembidaian,
+-- 0087 memisahkan KIM jadi dua), dan keduanya UPDATE tanpa jejak: kalau salah
+-- satu tidak pernah dijalankan, atau dijalankan dengan urutan yang salah,
+-- tidak ada satu pun galat yang muncul. Yang terlihat cuma layar yang
+-- mengelompokkan lomba dengan cara yang tidak diharapkan siapa pun.
+--
+-- Itu BUKAN kemungkinan teoretis. `tests/dev_database.sh` menjalankan 0076
+-- SESUDAH seed, yaitu sesudah 0087 — jadi di database dev, 0076 memasang
+-- kembali `lomba = 'KIM'` yang baru saja dikosongkan 0087, dan KIM tergambar
+-- sebagai SATU lomba. Produksi menjalankan migrasi berurutan dan seharusnya
+-- tidak begitu; berkas ini yang membuktikannya, alih-alih menduganya.
+--
+-- Jalankan lewat apply-migration.yml. Tidak mengubah apa pun.
+-- ============================================================================
+
+\echo '=== 0. Versi server ==='
+select version();
+
+\echo ''
+\echo '=== 1. Lomba per pos, beserta kunci tetap dan jumlah kriterianya ==='
+-- Penyatuannya sama dengan kelompokLomba() di layar: coalesce(lomba, name).
+-- KRITERIA DIHITUNG DARI NAMA BERBEDA, bukan jumlah baris: satu penilaian yang
+-- ditawarkan ke beberapa golongan menempati beberapa baris wahana
+-- (CLAUDE.md 11.9), jadi menghitung barisnya akan melaporkan Logika
+-- berkriteria dua.
+select pos,
+       coalesce(lomba, name)                   as lomba,
+       count(distinct name)                    as kriteria,
+       count(*)                                as baris_wahana,
+       string_agg(distinct coalesce(kode_lomba, '(kosong)'), ', ') as kunci_foto
+from wahana
+where edisi = edisi_aktif()
+group by pos, coalesce(lomba, name)
+order by pos, 2;
+
+\echo ''
+\echo '=== 2. KIM: dua lomba (benar) atau satu (0087 tidak berlaku)? ==='
+select case
+         when count(*) filter (where coalesce(lomba, name) = 'KIM') > 0
+           then 'SATU LOMBA — 0087 TIDAK BERLAKU di sini'
+         else 'DUA LOMBA — 0087 berlaku'
+       end as keadaan_kim,
+       string_agg(kode || ' -> lomba=' || coalesce(lomba, '(kosong)')
+                       || ', kunci=' || coalesce(kode_lomba, '(kosong)'),
+                  '; ' order by sort_order)
+from wahana
+where edisi = edisi_aktif() and kode like 'kim%';
+
+\echo ''
+\echo '=== 3. Pembidaian: lima kriteria satu lomba (benar)? ==='
+select count(*) as komponen_bidai,
+       count(distinct coalesce(lomba, name)) as jadi_berapa_lomba,
+       string_agg(distinct coalesce(kode_lomba, '(kosong)'), ', ') as kunci_foto
+from wahana
+where edisi = edisi_aktif() and kode like 'bidai%';
+
+\echo ''
+\echo '=== 4. Foto yang kunci lombanya TIDAK dikenal lagi ==='
+-- Foto yang menyandang kunci yang sudah tidak ada di v_lomba_pos tidak akan
+-- ketemu dari layar mana pun. Angkanya di sini supaya diketahui, bukan
+-- ditemukan belakangan saat sebuah nilai dipertanyakan.
+select f.pos, f.kode_lomba, count(*) as foto
+from foto_lembar f
+where not exists (select 1 from v_lomba_pos l
+                  where l.edisi = edisi_aktif() and l.pos = f.pos and l.kode = f.kode_lomba)
+group by f.pos, f.kode_lomba
+order by f.pos, f.kode_lomba;

--- a/tests/dev/bentuk_lomba_produksi.sql
+++ b/tests/dev/bentuk_lomba_produksi.sql
@@ -1,0 +1,99 @@
+-- ============================================================================
+-- hrcd-rekap : tests/dev/bentuk_lomba_produksi.sql
+-- CLAUDE.md bagian 11 ditulis sebagai kode: berapa lomba di tiap pos, dan
+-- berapa kriteria di tiap lomba.
+--
+-- DI LUAR tests/sql/, dan itu disengaja: ia BUKAN bagian dari suite bernomor
+-- di tests/run.sh. Database yang dibangun run.sh memakai konfigurasi edisi
+-- lama dengan sengaja (Kompas, Poros Bumi, PBB di Pos 2, KIM di Pos 4),
+-- karena itulah yang menguji migrasi terhadap data yang sudah berisi —
+-- memaksakan bentuk produksi di sana cuma akan memaksa fixture-nya berbohong.
+--
+-- Tempatnya di tests/dev/ dan bukan tests/sql/ supaya pagar pendaftaran di
+-- kepala run.sh tetap berlaku penuh atas seluruh isi tests/sql/. Yang
+-- menjalankan berkas ini tests/dev_database.sh.
+--
+-- KENAPA INI PERLU DIUJI PADAHAL TIDAK ADA KODENYA
+--
+-- Pengelompokan lomba bukan kode; ia DATA — kolom `wahana.lomba`, dibaca
+-- `coalesce(lomba, name)` (CLAUDE.md 11.8). Yang mengubahnya cuma UPDATE di
+-- dalam migrasi, dan sebuah UPDATE yang mengenai nol baris TIDAK BERBUNYI.
+-- Jadi seluruh bentuk lomba bisa bergeser tanpa satu pun galat, dan yang
+-- terlihat cuma blangko yang tercetak dengan jumlah lembar yang aneh atau
+-- kolom foto yang menampung dua lomba sekaligus.
+--
+-- Itu sudah terjadi: sampai 1 September 2026 `tests/dev_database.sh`
+-- menjalankan 0054 SESUDAH 0087, jadi `lomba = 'KIM'` yang sengaja
+-- dikosongkan 0087 terpasang kembali dan KIM tergambar sebagai satu lomba
+-- berkriteria dua. Seluruh tes lulus selama itu, karena tidak ada satu pun
+-- yang menanyakan bentuknya.
+--
+-- KRITERIA DIHITUNG DARI NAMA BERBEDA, BUKAN JUMLAH BARIS. Satu penilaian
+-- yang ditawarkan ke beberapa golongan menempati beberapa baris `wahana`
+-- (CLAUDE.md 11.9), jadi menghitung barisnya akan melaporkan Logika
+-- berkriteria dua.
+-- ============================================================================
+
+do $penjaga$
+declare
+  r           record;
+  v_lihat     text;
+  v_cium      text;
+  v_diperiksa integer := 0;
+begin
+  for r in
+    select coalesce(lomba, name) as lomba, count(distinct name) as kriteria
+    from wahana
+    where edisi = edisi_aktif()
+    group by coalesce(lomba, name)
+  loop
+    -- Yang diperiksa hanya lomba yang dipatok CLAUDE.md bagian 11. Isi Pos 1
+    -- dan Pos 2 memang berganti tiap edisi, jadi mematoknya di sini akan
+    -- membuat tes ini gagal setiap kali panitia berikutnya mengubah lomba.
+    if r.lomba = 'Pembidaian' then
+      assert r.kriteria = 5,
+        format('Pembidaian %s kriteria, seharusnya 5 (CLAUDE.md 11.2)', r.kriteria);
+      v_diperiksa := v_diperiksa + 1;
+    elsif r.lomba = 'PBB' then
+      assert r.kriteria = 4,
+        format('PBB %s kriteria, seharusnya 4 (CLAUDE.md 11.4)', r.kriteria);
+      v_diperiksa := v_diperiksa + 1;
+    elsif r.lomba = 'Yel-Yel' then
+      assert r.kriteria = 4,
+        format('Yel-Yel %s kriteria, seharusnya 4 (CLAUDE.md 11.5)', r.kriteria);
+      v_diperiksa := v_diperiksa + 1;
+    elsif r.lomba = 'KIM' then
+      raise exception
+        'KIM masih SATU lomba. Kim Lihat dan Kim Cium dua lomba terpisah '
+        'sejak migrasi 0087 — periksa urutan daftar ULANG di dev_database.sh.';
+    end if;
+  end loop;
+
+  assert v_diperiksa = 3,
+    format('%s dari 3 lomba berkriteria banyak ditemukan — Pembidaian, PBB '
+           'dan Yel-Yel semestinya ada di edisi ini', v_diperiksa);
+
+  -- Keduanya harus berdiri sebagai lomba tersendiri, bukan sekadar tidak
+  -- bernama "KIM".
+  assert (select count(distinct coalesce(lomba, name)) from wahana
+          where edisi = edisi_aktif() and kode in ('kim_lihat', 'kim_cium')) = 2,
+         'Kim Lihat dan Kim Cium tidak berdiri sebagai dua lomba.';
+
+  -- Kunci fotonya harus BERBEDA. Kalau sama, keduanya berbagi satu kolom foto
+  -- dan lembar jawaban Cium tergambar di bawah nilai Lihat — kerusakan yang
+  -- tidak terlihat sampai seseorang mempertanyakan sebuah nilai.
+  select kode_lomba into v_lihat
+    from wahana where edisi = edisi_aktif() and kode = 'kim_lihat';
+  select kode_lomba into v_cium
+    from wahana where edisi = edisi_aktif() and kode = 'kim_cium';
+  assert v_lihat is not null and v_cium is not null,
+         'Kunci foto KIM kosong — foto tidak akan ketemu dari layar mana pun.';
+  assert v_lihat is distinct from v_cium,
+         format('Kim Lihat dan Kim Cium berbagi kunci foto %L', v_lihat);
+
+  -- `raise notice` memakai % polos; %L cuma milik format(), dan di sini ia
+  -- mencetak "kim-lihatL".
+  raise notice 'bentuk lomba sesuai CLAUDE.md 11 — KIM dua lomba, '
+               'kunci foto % dan %.', v_lihat, v_cium;
+end;
+$penjaga$;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -109,13 +109,15 @@ LEWATI_DULU="0076_bidai_dan_lomba_soal 0118_jeda_kloter_maksimal
              0133_kelas_organisasi_regu 0134_kelas_organisasi_tanpa_simbol
              0137_riwayat_pendaftaran 0138_riwayat_pelaku_kosong
              0146_cache_live_score 0147_waktu_nol_pos_2
+             0165_refresh_live_score_dari_layar
              0157_direktori_sekolah_ciamis 0158_rapikan_alamat_direktori
              0159_lebur_kembar_direktori 0160_kode_pos_dan_nama_tersisa
-             0161_lebur_kembar_ejaan 0162_lebur_smp_al_fadliliyah"
+             0161_lebur_kembar_ejaan 0162_lebur_smp_al_fadliliyah
+             0166_gembok_per_lomba 0167_putaran_foto"
 ULANG="0032_konfigurasi_xxxvii 0033_nama_pos_xxxvii 0034_nama_pos_final
        0035_tangga_menaksir 0036_kriteria_bidai 0037_petunjuk_kolom
        0038_petunjuk_menaksir 0039_judul_isian 0054_kolom_lomba
-       0076_bidai_dan_lomba_soal 0091_intern_golongan
+       0076_bidai_dan_lomba_soal 0087_kim_dua_lomba 0091_intern_golongan
        0093_configure_fifo_capacity 0105_expand_kloter_capacity
        0118_jeda_kloter_maksimal"
 
@@ -249,6 +251,26 @@ run supabase/migrations/0024_komponen_pos.sql
 #     (`where lomba = 'Pembidaian'`) menemukan kelima barisnya dan jumlah 100
 #     itu benar-benar diperiksa. Tanpa 0054 ia melapor "Pembidaian tidak ada di
 #     database ini" dan penjaganya diam.
+#   * 0087 harus SESUDAH 0054, dan ini ikatan yang paling mudah terlewat
+#     karena arahnya TERBALIK dari yang lain. Yang lain ada di daftar ini
+#     supaya sesuatu DIKERJAKAN; 0087 ada di sini supaya sesuatu DIBATALKAN.
+#     0054 mengisi `lomba` untuk baris ber-kode `kim_`, dan 0087 justru
+#     mengosongkannya lagi karena Kim Lihat dan Kim Cium adalah dua lomba
+#     terpisah, bukan dua kriteria satu lomba. Di glob urutannya benar; di
+#     sini 0054 dijalankan ULANG sesudahnya, jadi tanpa baris ini ia memasang
+#     kembali `lomba = 'KIM'` yang sudah dikosongkan produksi.
+#
+#     Diamnya sempurna: `kode_lomba` tetap terpisah (0087 sudah lewat di
+#     glob), seluruh tes lulus, dan yang berbeda dari produksi cuma satu hal
+#     — KIM tergambar sebagai SATU lomba berkriteria dua. Itu terbawa ke
+#     laporan: pengukuran tata letak Cek Nilai 31 Agustus 2026 menyebut
+#     "KIM, 2 kriteria" sebagai fakta tentang produksi, padahal produksi
+#     punya dua lomba berkriteria satu dan dua kolom foto terpisah.
+#
+#     Pelajaran yang lebih luas daripada KIM: sebuah migrasi di daftar ULANG
+#     dijalankan DI LUAR urutan nomornya, jadi ia bisa membatalkan migrasi
+#     yang lebih muda. Sebelum menambahkan satu ke daftar ini, cari migrasi
+#     sesudahnya yang menyentuh kolom yang sama.
 #   * 0091 harus SESUDAH 0076 agar lima komponen Soal Tulis yang disalin untuk
 #     Intern sudah ada. 0093 menyiapkan 60 kloter setelah edisi aktif lahir;
 #     0105 menambah headroom-nya menjadi 75, dan ia HARUS ikut diulang di
@@ -348,6 +370,24 @@ run supabase/migrations/0138_riwayat_pelaku_kosong.sql
 run supabase/migrations/0146_cache_live_score.sql
 run supabase/migrations/0147_waktu_nol_pos_2.sql
 
+# 0165 ditunda karena alasan yang SAMA dengan 0146, satu tingkat di atasnya:
+# barisnya yang terakhir memanggil `segarkan_cache_live_score()` — fungsi yang
+# baru lahir di 0146, dan 0146 sendiri ditunda ke sini. Di glob panggilan itu
+# berbunyi 'function ... does not exist' dan skripnya BERHENTI, jadi 0166 dan
+# 0167 tidak pernah dijalankan dan tidak ada satu pun layar yang bisa dibuka
+# di laptop (CLAUDE.md 17.6).
+#
+# Aman ditunda: yang ditinggalkannya cuma satu fungsi
+# `minta_segarkan_live_score()`, dan tidak ada migrasi mana pun sesudahnya
+# yang memanggilnya — diperiksa 1 September 2026.
+#
+# INI PELAJARAN YANG BERULANG, bukan kejadian sekali. Sebuah migrasi ditunda
+# ke ujung berkas ini, lalu migrasi BARU yang memakai buatannya ditulis
+# kemudian oleh orang yang tidak tahu penundaan itu ada. Yang perlu diperiksa
+# saat menulis migrasi yang memanggil fungsi migrasi lama: apakah yang
+# membuatnya ada di LEWATI_DULU di atas?
+run supabase/migrations/0165_refresh_live_score_dari_layar.sql
+
 # 0154 DIJALANKAN ULANG PALING AKHIR, karena ia membetulkan baris `sekolah`
 # yang baru lahir di 0129-0132. Di glob ia berjalan jauh sebelum keempat
 # migrasi impor itu, jadi tidak menemukan satu baris pun untuk dilebur maupun
@@ -364,5 +404,43 @@ run supabase/migrations/0159_lebur_kembar_direktori.sql
 run supabase/migrations/0160_kode_pos_dan_nama_tersisa.sql
 run supabase/migrations/0161_lebur_kembar_ejaan.sql
 run supabase/migrations/0162_lebur_smp_al_fadliliyah.sql
+
+# 0166 DAN 0167 PALING AKHIR, dan sebabnya bukan isinya melainkan 0091.
+#
+# 0091 ada di daftar ULANG di atas, dan di antara isinya ada
+# `create or replace view v_lembar_pos` dengan daftar kolom versi 0091. 0166
+# menambahkan kolom `lomba_terkunci` ke view itu; menjalankan 0091 sesudahnya
+# berarti MENGHAPUS kolom, dan PostgreSQL menolaknya mentah-mentah:
+# "cannot drop columns from view". Skripnya berhenti di situ.
+#
+# Ini bukan kekhususan 0166. `create or replace view` TIDAK BISA menyusutkan
+# view, jadi migrasi mana pun di daftar ULANG yang menyusun ulang sebuah view
+# akan menabrak migrasi lebih muda yang menambah kolom ke view yang sama.
+# Obatnya selalu sama: jalankan yang lebih muda SESUDAH daftar ULANG selesai,
+# bukan di glob.
+#
+# Ada untungnya sekalian, dan ini yang selama ini diam: 0091 juga menimpa
+# BADAN v_lembar_pos dengan versi 0091, membuang perbaikan 0095 (jawaban
+# benar) tanpa satu pun galat karena daftar kolomnya kebetulan sama. Menaruh
+# 0166 di sini memasang kembali definisi terakhirnya, jadi dev memakai view
+# yang sama dengan produksi.
+run supabase/migrations/0166_gembok_per_lomba.sql
+run supabase/migrations/0167_putaran_foto.sql
+
+# ============================================================================
+# BENTUK LOMBA HARUS SAMA DENGAN PRODUKSI, dan itu diperiksa, bukan dipercaya.
+#
+# Daftar ULANG di atas menjalankan migrasi DI LUAR urutan nomornya, jadi satu
+# migrasi di daftar itu bisa membatalkan migrasi yang lebih muda tanpa satu pun
+# galat. Persis itu yang terjadi pada KIM sampai 1 September 2026: 0054 diulang
+# sesudah 0087 dan memasang kembali `lomba = 'KIM'`, dan selama itu dev
+# menggambar KIM sebagai satu lomba berkriteria dua sementara produksi punya
+# dua lomba dengan dua kolom foto terpisah.
+#
+# HANYA DI SINI, tidak di tests/run.sh. Database tes memakai konfigurasi edisi
+# lama dengan sengaja, jadi berkas ini satu-satunya tempat konfigurasi produksi
+# benar-benar disusun ulang — dan karena itu satu-satunya tempat bentuknya bisa
+# ditanyakan dengan jujur. Alasan lengkapnya di ujung tests/run.sh.
+run tests/dev/bentuk_lomba_produksi.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -730,6 +730,25 @@ run tests/sql/118_gembok_per_lomba.sql
 run supabase/migrations/0167_putaran_foto.sql
 run tests/sql/119_putaran_foto.sql
 
+# tests/sql/bentuk_lomba_produksi.sql SENGAJA TIDAK DIJALANKAN DI SINI, dan itu
+# perlu disebut karena CLAUDE.md 7.5 melatih pembaca mengharapkan sebaliknya.
+#
+# Ia memeriksa bentuk lomba KONFIGURASI PRODUKSI — Pembidaian lima kriteria,
+# PBB empat, Yel-Yel empat, KIM dua lomba terpisah. Database di sini memakai
+# konfigurasi edisi LAMA dengan sengaja (Kompas, Poros Bumi, PBB di Pos 2, KIM
+# di Pos 4), karena itulah yang menguji migrasinya terhadap data yang sudah
+# berisi. Memaksakan bentuk produksi di sini cuma akan memaksa fixture-nya
+# berbohong.
+#
+# Yang menjalankannya tests/dev_database.sh, satu-satunya yang menyusun ulang
+# konfigurasi produksi.
+#
+# Karena itu ia duduk di tests/dev/, BUKAN tests/sql/. Pagar di kepala berkas
+# ini menuntut setiap tests/sql/*.sql muncul pada sebuah baris `run`, dan
+# tuntutan itu benar — sebuah berkas SQL yang diam-diam tidak pernah
+# dijalankan persis kerusakan yang dijaganya. Yang salah bukan pagarnya
+# melainkan tempat berkasnya.
+
 # Parse dan jalankan query yang benar-benar menjadi live.json, SESUDAH
 # seluruh migrasi. Ini menangkap view atau kolom yang berganti sebelum
 # workflow publish menemukannya di produksi.


### PR DESCRIPTION
## What

`tests/dev_database.sh` rebuilt a database whose lomba grouping differed from
production, and it could not finish at all.

* Re-run `0087_kim_dua_lomba` after `0054_kolom_lomba`. The re-run list replays
  0054 after `seed.sql`, which refills `lomba` for `kim_` rows and undoes 0087.
* Defer `0165` to the end. Its last line calls `segarkan_cache_live_score()`,
  created by 0146, which is itself deferred -- so in the glob the script aborted
  and nothing after it ran.
* Defer `0166` and `0167` to the very end. 0091 is in the re-run list and
  recreates `v_lembar_pos` with its own column list; since 0166 added a column
  the re-run failed with "cannot drop columns from view".
* `tests/dev/bentuk_lomba_produksi.sql` asserts CLAUDE.md section 11:
  Pembidaian 5 criteria, PBB 4, Yel-Yel 4, Kim Lihat and Kim Cium two separate
  lomba with distinct photo keys.
* `supabase/checks/lomba_per_pos.sql` reports the same shape from production,
  read-only.
* CLAUDE.md / AGENTS.md 11.2 and 11.6: Pos 3 has four lomba, and KIM is two.

## Why

Nothing failed while the grouping was wrong. `kode_lomba` stayed split, the
whole suite passed, and the only visible difference was a screen that drew two
lomba as one with two criteria. That reached a report: a Cek Nilai layout
measurement on 31 August described "KIM, 2 criteria" as a fact about
production.

Deferring 0166 also stops 0091 from silently reverting the `v_lembar_pos` body
past 0095, which it had been doing undetected because the column lists matched.

## Notes

Production was verified and is correct: Kim Lihat and Kim Cium are two lomba
with photo keys `kim-lihat` and `kim-cium`, Pembidaian is one lomba with five
criteria, and no photo carries an unknown lomba key.

`tests/dev/bentuk_lomba_produksi.sql` deliberately sits outside `tests/sql/`.
The database `run.sh` builds uses an older edition configuration on purpose
(Kompas, Poros Bumi, PBB at Pos 2, KIM at Pos 4), so production shape cannot be
asserted there, and the registration guard over `tests/sql/` must stay
absolute.

No deployed asset changes.

Local: `tests/run.sh` all passed, 373/373 JS tests, `tests/dev_database.sh`
completes and its guard reports the production shape.