### PR TITLE
fix: Input Nilai Pos drops two labels and clears the bottom menu

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=35">
+  <link rel="stylesheet" href="style.css?v=36">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -667,9 +667,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Di HP, pesan ini muncul TEPAT DI ATAS bar bawah, hampir selebar layar.
 
    Sebelumnya ia pil sempit di `bottom: 1.2rem` — yaitu DI BELAKANG bar Home /
-   Setelan / Keluar, yang tingginya 56px dan menempel di dasar layar. Pesan
-   terpenting di aplikasi ini ("nomor dada sudah dipakai regu lain") separuh
-   tertutup tombol Keluar.
+   Setelan / Keluar yang menempel di dasar layar. Pesan terpenting di aplikasi
+   ini ("nomor dada sudah dipakai regu lain") separuh tertutup tombol Keluar.
+
+   `--nav-bawah` DIUKUR JavaScript tiap kali layar berganti; 66px cuma cadangan
+   sebelum ukuran pertama masuk. Angka mati 56px yang dipakai di sini dulu
+   adalah `min-height` satu item menu, bukan tinggi menunya — terukur 65.4px —
+   jadi pesannya berhenti 2.6px di atas menu, yaitu menempel.
    
    Selebar layar bukan soal selera: pesannya menyebut DAFTAR nomor, dan pil
    yang menyempit ke lebar isinya memecah daftar itu jadi dua baris pendek di
@@ -677,7 +681,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 @media (max-width: 560px) {
   .notification {
     left: .75rem; right: .75rem; transform: none; max-width: none;
-    bottom: calc(56px + env(safe-area-inset-bottom) + .75rem);
+    bottom: calc(var(--nav-bawah, 66px) + .75rem);
   }
   .notification-close { margin-left: auto; }
 }
@@ -4635,33 +4639,10 @@ button.pill-number:hover { filter: brightness(.95); }
    cuma memikul satu kata — dan kata itu yang menjawab "angka yang saya ketik
    ini masuk ke lomba mana?", satu-satunya pertanyaan yang mahal kalau salah. */
 .baris-lomba {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .8rem; padding-top: .7rem; padding-bottom: .7rem;
+  display: flex; align-items: center; justify-content: center;
+  padding-top: .7rem; padding-bottom: .7rem;
 }
-/* Judulnya tetap di TENGAH kartunya walau ada tombol di kanan: `flex: 1` di
-   kedua sisi tombol akan memindahkannya, jadi yang dipakai margin otomatis di
-   kiri judul dan tombol yang lebarnya sendiri di kanan. */
-.baris-lomba .lomba-judul { margin: 0 auto; }
-.baris-lomba .button { flex: 0 0 auto; }
 
-/* Daftar regu yang belum dinilai. Satu baris satu tombol selebar dialog —
-   yang ditekan sambil berdiri, dan nomor dada di kiri berbaris lurus supaya
-   mata menyusurinya tanpa membaca namanya lebih dulu. */
-.daftar-belum { list-style: none; margin: 0; padding: 0;
-  max-height: 55vh; overflow-y: auto; }
-.daftar-belum li { margin-bottom: .4rem; }
-.daftar-belum button {
-  display: grid; grid-template-columns: max-content 1fr; gap: .1rem .7rem;
-  width: 100%; min-height: 52px; padding: .5rem .7rem; text-align: left;
-  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
-  background: var(--kartu); color: inherit;
-}
-.daftar-belum button:hover { border-color: var(--utama); }
-.daftar-belum button:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
-.db-dada { grid-area: 1 / 1 / 3 / 2; align-self: center;
-  font-weight: 800; font-size: 1.2rem; font-variant-numeric: tabular-nums; }
-.db-nama { font-weight: 700; line-height: 1.2; }
-.db-sekolah { font-size: .8rem; color: var(--tinta-lembut); line-height: 1.2; }
 
 /* Foto Jawaban: judul di kiri, jumlahnya di bawahnya, dua tombol di kanan.
    Bentuk yang sama dengan baris foto di dialog lembar pos lama, supaya
@@ -4760,8 +4741,9 @@ button.pill-number:hover { filter: brightness(.95); }
    Foto Jawaban tetap berada di ATASNYA dalam urutan dokumen; yang berubah cuma
    tombolnya tidak ikut terdorong turun.
 
-   `bottom` diberi jarak untuk menu bawah HP yang setinggi 56px + safe area,
-   supaya keduanya tidak bertumpuk. */
+   `bottom` diberi jarak untuk menu bawah HP, dan tingginya DIUKUR — lihat
+   `--nav-bawah` di pasangKepala(). Angka mati 56px yang dipakai di sini dulu
+   adalah `min-height` satu item menu, bukan tinggi menunya. */
 /* KARTUNYA HARUS `overflow: visible`, dan tanpa itu tombol di bawah menutupi
    kotak Nomor dada.
 
@@ -4795,9 +4777,8 @@ button.pill-number:hover { filter: brightness(.95); }
   box-shadow: 0 4px 14px rgba(16, 24, 40, .18);
 }
 @media (max-width: 560px) {
-  .v2-simpan-lekat { bottom: calc(56px + env(safe-area-inset-bottom) + .5rem); }
+  .v2-simpan-lekat { bottom: calc(var(--nav-bawah, 66px) + .6rem); }
 }
-.cek-sudah { margin-top: .5rem; }
 
 /* ---------- kotak isian kriteria ---------- */
 

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 35, sidik: "eaadee62c2ad" },
+  "style.css": { versi: 36, sidik: "507e2adb3f9a" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=33">
+  <link rel="stylesheet" href="style.css?v=34">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -162,6 +162,29 @@ function pasangKepala(judul, lebar = false) {
   const nav = document.getElementById("bottom-nav");
   if (nav) {
     nav.hidden = !s;
+    /* TINGGI MENU BAWAH DIUKUR, TIDAK DITEBAK.
+
+       Yang menempel di atas menu ini — tombol SIMPAN NILAI dan pesan notifikasi
+       — dulu memesan tempat sebanyak `56px`. Angka itu `min-height` SATU ITEM
+       menu, bukan tinggi menunya: isinya (ikon 1.9rem + jarak + label .72rem +
+       padding) melewatinya, dan terukur di Chrome 430px menunya 65.4px. Jadi
+       tombol yang seharusnya berhenti 8px di atas menu justru menembusnya
+       1.4px, dan di layar sungguhan keduanya terbaca menempel.
+
+       Menaikkan tebakannya cuma memindahkan tanggal kedaluwarsanya: tingginya
+       ikut ukuran huruf peranti dan safe area, yang berbeda antar HP. Yang
+       benar mengukurnya — sama seperti `--kepala` di bawah, yang ada karena
+       alasan yang sama persis.
+
+       `padding-bottom: env(safe-area-inset-bottom)` ada DI DALAM menunya, jadi
+       angka ini sudah memuatnya; yang memakainya tidak boleh menambahkan
+       `env()` lagi. */
+    if (!nav.hidden) {
+      const tinggiNav = Math.round(nav.getBoundingClientRect().height);
+      if (tinggiNav > 0) {
+        document.documentElement.style.setProperty("--nav-bawah", `${tinggiNav}px`);
+      }
+    }
     const diHome = location.hash === "#/home" || location.hash === "";
     document.getElementById("nav-home")
       .setAttribute("aria-current", diHome ? "page" : "false");
@@ -8164,10 +8187,9 @@ function gambarPemilihLomba(katalog) {
  *  papan ketik naik dan halamannya tergulir; kartu ini ikut bergulir bersama
  *  isinya. Yang dijawabnya satu pertanyaan yang mahal kalau salah — "angka
  *  yang saya ketik ini masuk ke lomba mana?" */
-const kepalaLomba = (l, tambahan = "") => `
+const kepalaLomba = (l) => `
   <div class="card baris-lomba">
     <h2 class="lomba-judul">${esc(l.nama)}</h2>
-    ${tambahan}
   </div>`;
 
 /* ---------------------------------------------------------------------------
@@ -8186,9 +8208,7 @@ async function gambarLombaNilai(l) {
 
   LAYAR.replaceChildren(h(`
     <div id="pita-antrean"></div>
-    ${kepalaLomba(l, `<button type="button"
-        class="button button-secondary button-small" id="v2-belum"
-        >Belum dinilai</button>`)}
+    ${kepalaLomba(l)}
     <div class="card" id="v2-kartu" style="border-color:var(--utama)">
       <div class="field" style="margin-bottom:0">
         <label for="v2-dada">Nomor dada</label>
@@ -8300,70 +8320,6 @@ async function gambarLombaNilai(l) {
   const segarkanStopwatch = waktu
     ? pasangStopwatch(document.getElementById("v2-kartu"), wadah, kotakWaktu, sinyal)
     : null;
-
-  /* SIAPA YANG BELUM DINILAI DI LOMBA INI.
-   *
-   *  Menjelang tutup pos, pertanyaannya berbalik: bukan lagi "regu ini
-   *  nilainya berapa" melainkan "siapa yang terlewat". Tanpa daftar ini
-   *  jawabannya cuma bisa dicari dengan mengetik nomor dada satu per satu
-   *  sampai ketemu yang kosong — di lomba berisi ratusan regu itu bukan
-   *  pekerjaan yang bisa diselesaikan.
-   *
-   *  Dibaca saat DITEKAN, bukan ikut dimuat bersama layarnya: lembar satu pos
-   *  memuat ratusan baris, dan pertanyaan ini ditanyakan beberapa kali sepagi
-   *  — bukan setiap kali satu regu dinilai. Di jaringan pos, permintaan yang
-   *  tidak ditanya siapa pun tetap dibayar.
-   *
-   *  Yang lombanya tidak berlaku untuk golongan regu itu TIDAK ikut dihitung
-   *  belum dinilai. Regu Penggalang tidak pernah punya Tebak Simpul Penegak,
-   *  dan menuduhnya terlewat adalah alarm yang tidak bisa dipenuhi siapa pun. */
-  document.getElementById("v2-belum")?.addEventListener("click", async () => {
-    const b = document.getElementById("v2-belum");
-    b.disabled = true;
-    let lembar;
-    try { lembar = await lembarPos(l.pos); }
-    catch (err) { b.disabled = false; notif(err.message, true); return; }
-    b.disabled = false;
-
-    const belum = lembar.filter(r => {
-      const dipakai = l.kolom.map(kol => varianUntuk(kol, r.golongan)).filter(Boolean);
-      if (!dipakai.length) return false;
-      const nilai = r.nilai || {};
-      return dipakai.every(k => !nilai[k.kode]);
-    });
-
-    if (!belum.length) {
-      await dialog({ judul: `${l.nama} — semua sudah dinilai`,
-        kartuHtml: `<p class="description">Tidak ada regu yang terlewat.</p>`,
-        labelAksi: "Tutup", bacaSaja: true });
-      return;
-    }
-
-    /* Ditekan = nomornya masuk ke kotak isian. Daftar yang cuma bisa dibaca
-       memaksa petugas mengingat tiga angka lalu mengetiknya sendiri, dan
-       nomor dada yang salah ingat mendaratkan nilai di regu lain. */
-    const janji = dialog({
-      judul: `Belum dinilai · ${belum.length} regu`,
-      kartuHtml: `<ul class="daftar-belum">${belum.map(r => html`
-        <li><button type="button" data-dada="${r.nomor_dada}">
-          <span class="db-dada">${dada3(r.nomor_dada)}</span>
-          <span class="db-nama">${r.nama_regu}</span>
-          <span class="db-sekolah">${r.nama_sekolah}</span>
-        </button></li>`).join("")}</ul>`,
-      labelAksi: "Tutup", bacaSaja: true,
-    });
-
-    // dialog() menempelkan kartunya SINKRON, jadi pendengarnya boleh dipasang
-    // sebelum janjinya ditunggu.
-    document.querySelector(".dialog .daftar-belum")?.addEventListener("click", (e) => {
-      const t = e.target.closest("[data-dada]");
-      if (!t) return;
-      document.querySelector(".dialog [data-batal]")?.click();
-      inp.value = t.dataset.dada;
-      inp.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-    await janji;
-  }, { signal: sinyal });
 
   inp.focus();
   gambarRiwayatNilai();
@@ -8628,22 +8584,6 @@ async function gambarLombaNilai(l) {
     regu = r;
     kotakRegu.replaceChildren(h(kartuReguNilai(r)));
 
-    /* LENCANA "SUDAH DINILAI", dan ia menyebutkan angkanya.
-       Kotak yang sudah terisi memang sudah memperlihatkan angkanya, tetapi
-       juri yang mengetik cepat tidak membaca isi kotak — ia membaca kartu
-       regunya lalu langsung mengetik. Menimpa nilai orang lain harus jadi
-       tindakan sadar, dan satu lencana di tempat mata sudah berhenti lebih
-       murah daripada satu sengketa nilai. */
-    const sudah = l.kolom
-      .map(kol => varianUntuk(kol, r.golongan))
-      .filter(k => k && (r.nilai || {})[k.kode]);
-    if (sudah.length) {
-      const teks = sudah
-        .map(k => nilaiBagian(k, r.nilai[k.kode].nilai_1, r.nilai[k.kode].nilai_2).join(" / "))
-        .join(" · ");
-      kotakRegu.append(h(`<div class="cek-sudah">
-        <span class="badge badge-yellow">sudah dinilai · ${esc(teks)}</span></div>`));
-    }
 
     gambarIsian(r);
 

--- a/web/style.css
+++ b/web/style.css
@@ -667,9 +667,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 /* Di HP, pesan ini muncul TEPAT DI ATAS bar bawah, hampir selebar layar.
 
    Sebelumnya ia pil sempit di `bottom: 1.2rem` — yaitu DI BELAKANG bar Home /
-   Setelan / Keluar, yang tingginya 56px dan menempel di dasar layar. Pesan
-   terpenting di aplikasi ini ("nomor dada sudah dipakai regu lain") separuh
-   tertutup tombol Keluar.
+   Setelan / Keluar yang menempel di dasar layar. Pesan terpenting di aplikasi
+   ini ("nomor dada sudah dipakai regu lain") separuh tertutup tombol Keluar.
+
+   `--nav-bawah` DIUKUR JavaScript tiap kali layar berganti; 66px cuma cadangan
+   sebelum ukuran pertama masuk. Angka mati 56px yang dipakai di sini dulu
+   adalah `min-height` satu item menu, bukan tinggi menunya — terukur 65.4px —
+   jadi pesannya berhenti 2.6px di atas menu, yaitu menempel.
    
    Selebar layar bukan soal selera: pesannya menyebut DAFTAR nomor, dan pil
    yang menyempit ke lebar isinya memecah daftar itu jadi dua baris pendek di
@@ -677,7 +681,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 @media (max-width: 560px) {
   .notification {
     left: .75rem; right: .75rem; transform: none; max-width: none;
-    bottom: calc(56px + env(safe-area-inset-bottom) + .75rem);
+    bottom: calc(var(--nav-bawah, 66px) + .75rem);
   }
   .notification-close { margin-left: auto; }
 }
@@ -4635,33 +4639,10 @@ button.pill-number:hover { filter: brightness(.95); }
    cuma memikul satu kata — dan kata itu yang menjawab "angka yang saya ketik
    ini masuk ke lomba mana?", satu-satunya pertanyaan yang mahal kalau salah. */
 .baris-lomba {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: .8rem; padding-top: .7rem; padding-bottom: .7rem;
+  display: flex; align-items: center; justify-content: center;
+  padding-top: .7rem; padding-bottom: .7rem;
 }
-/* Judulnya tetap di TENGAH kartunya walau ada tombol di kanan: `flex: 1` di
-   kedua sisi tombol akan memindahkannya, jadi yang dipakai margin otomatis di
-   kiri judul dan tombol yang lebarnya sendiri di kanan. */
-.baris-lomba .lomba-judul { margin: 0 auto; }
-.baris-lomba .button { flex: 0 0 auto; }
 
-/* Daftar regu yang belum dinilai. Satu baris satu tombol selebar dialog —
-   yang ditekan sambil berdiri, dan nomor dada di kiri berbaris lurus supaya
-   mata menyusurinya tanpa membaca namanya lebih dulu. */
-.daftar-belum { list-style: none; margin: 0; padding: 0;
-  max-height: 55vh; overflow-y: auto; }
-.daftar-belum li { margin-bottom: .4rem; }
-.daftar-belum button {
-  display: grid; grid-template-columns: max-content 1fr; gap: .1rem .7rem;
-  width: 100%; min-height: 52px; padding: .5rem .7rem; text-align: left;
-  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
-  background: var(--kartu); color: inherit;
-}
-.daftar-belum button:hover { border-color: var(--utama); }
-.daftar-belum button:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
-.db-dada { grid-area: 1 / 1 / 3 / 2; align-self: center;
-  font-weight: 800; font-size: 1.2rem; font-variant-numeric: tabular-nums; }
-.db-nama { font-weight: 700; line-height: 1.2; }
-.db-sekolah { font-size: .8rem; color: var(--tinta-lembut); line-height: 1.2; }
 
 /* Foto Jawaban: judul di kiri, jumlahnya di bawahnya, dua tombol di kanan.
    Bentuk yang sama dengan baris foto di dialog lembar pos lama, supaya
@@ -4760,8 +4741,9 @@ button.pill-number:hover { filter: brightness(.95); }
    Foto Jawaban tetap berada di ATASNYA dalam urutan dokumen; yang berubah cuma
    tombolnya tidak ikut terdorong turun.
 
-   `bottom` diberi jarak untuk menu bawah HP yang setinggi 56px + safe area,
-   supaya keduanya tidak bertumpuk. */
+   `bottom` diberi jarak untuk menu bawah HP, dan tingginya DIUKUR — lihat
+   `--nav-bawah` di pasangKepala(). Angka mati 56px yang dipakai di sini dulu
+   adalah `min-height` satu item menu, bukan tinggi menunya. */
 /* KARTUNYA HARUS `overflow: visible`, dan tanpa itu tombol di bawah menutupi
    kotak Nomor dada.
 
@@ -4795,9 +4777,8 @@ button.pill-number:hover { filter: brightness(.95); }
   box-shadow: 0 4px 14px rgba(16, 24, 40, .18);
 }
 @media (max-width: 560px) {
-  .v2-simpan-lekat { bottom: calc(56px + env(safe-area-inset-bottom) + .5rem); }
+  .v2-simpan-lekat { bottom: calc(var(--nav-bawah, 66px) + .6rem); }
 }
-.cek-sudah { margin-top: .5rem; }
 
 /* ---------- kotak isian kriteria ---------- */
 


### PR DESCRIPTION
## What

* Remove the "Belum dinilai" button beside the lomba title, its dialog, its
  handler and its CSS. `kepalaLomba()` loses the now-unused `tambahan`
  parameter.
* Remove the "sudah dinilai · N" badge under the regu card.
* `pasangKepala()` measures the bottom menu into `--nav-bawah`. The sticky
  SIMPAN NILAI button and the notification both use it instead of a hardcoded
  `56px + env(safe-area-inset-bottom)`.

## Why

"Belum dinilai" read as a status label, in the place a status label goes, on a
card that could simultaneously say "sudah dinilai" about the regu below it.

The save button overlapped the menu by 1.4px, measured in Chrome at 430px:
`56px` is the `min-height` of one menu ITEM, not the height of the menu. Icon
1.9rem, gap, a .72rem label and padding come to 65.4px. Raising the guess only
moves the expiry date -- the height follows device font size and safe area, so
it is measured now, the same way `--kepala` already is. Gap after the change is
9.2px.

## Notes

Measured on the real screen served by `tests/dev_server.py` against `hrcd_dev`,
not on a sample page: regu 001 loaded with an existing nilai, page taller than
the viewport so the button was actually pinned. Both removed strings are absent
from the rendered DOM.

Local: 373/373 JS tests. `style.css` synced to `live/` and both `?v=` numbers
raised with the fingerprint in `tests/live_asset_version.test.mjs`.