### PR TITLE
fix: Cek Nilai lines up the check, the box and the padlock

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=36">
+  <link rel="stylesheet" href="style.css?v=37">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -1014,7 +1014,13 @@ export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blo
 export const putarFotoLembar = (id, putaran) =>
   rpc("putar_foto_lembar", { p_id: id, p_putaran: putaran });
 
-/** Foto satu regu di satu pos, terbaru dulu. */
+/** Foto satu regu di satu pos, YANG PERTAMA DIUNGGAH LEBIH DULU.
+ *
+ *  Urutannya `desc` sampai 1 September 2026, dan itu keliru begitu satu lomba
+ *  punya lebih dari satu lembar: yang difoto berurutan halaman 1 lalu halaman
+ *  2, dan menampilkan yang terbaru dulu membalik halamannya. Petugas yang
+ *  mencocokkan nilai dengan lembar jawaban membaca halaman 2 sebagai halaman
+ *  pertama. */
 export async function daftarFotoLembar(pos, nomorDada) {
   if (K.mode === "dev") {
     return baca(`/foto-lembar?pos=${encodeURIComponent(pos)}` +
@@ -1023,7 +1029,7 @@ export async function daftarFotoLembar(pos, nomorDada) {
   return baca(null,
     `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}` +
     `&nomor_dada=eq.${encodeURIComponent(nomorDada)}` +
-    `&select=*&order=diunggah_pada.desc`);
+    `&select=*&order=diunggah_pada.asc`);
 }
 
 /** Foto slip SELURUH regu di satu pos, sekali ambil.

--- a/live/style.css
+++ b/live/style.css
@@ -201,15 +201,38 @@ button { font: inherit; cursor: pointer; }
    layar sebesar ini bedanya bukan selera: kursor di atas tombol yang diam
    terbaca sebagai tombol MATI, dan yang dilakukan orang berikutnya adalah
    mengkliknya dua kali. */
-.button-secondary:hover:not(:disabled) {
-  /* --garis, bukan --kertas. Tombol putih berdiri di dua alas: kartu putih dan
-     kertas abu halaman. Warna sehalus --kertas memang terlihat di atas kartu,
-     tapi di atas kertas ia MENJADI alasnya — tombolnya lenyap, persis
-     kebalikan dari yang diminta. Yang lebih tua satu tingkat terlihat di
-     dua-duanya, dan tepinya ikut menua supaya perubahannya tidak bergantung
-     pada satu isyarat saja. */
-  background: var(--garis);
-  border-color: #d3d5dc;
+/* `@media (hover: hover)` BUKAN kehalusan — tanpanya aturan ini BERBOHONG di
+   HP. Safari iOS menempelkan `:hover` pada elemen yang TERAKHIR disentuh dan
+   menahannya sampai sesuatu yang lain disentuh, jadi tombol yang baru saja
+   ditekan tinggal abu di layar. Warnanya `--garis`, yaitu warna yang di
+   aplikasi ini berarti "mati" — dan panah foto yang tinggal abu sesudah
+   ditekan terbaca persis sebagai panah yang tidak bisa ditekan lagi.
+
+   Dilaporkan begitu, 1 September 2026: "ketika digeser ke 2/2 yang abu malah
+   yang kiri, seharusnya yang kanan". Panahnya tidak pernah terbalik; yang
+   terlihat sisa sentuhan terakhir. */
+@media (hover: hover) {
+  .button-secondary:hover:not(:disabled) {
+    /* --garis, bukan --kertas. Tombol putih berdiri di dua alas: kartu putih
+       dan kertas abu halaman. Warna sehalus --kertas memang terlihat di atas
+       kartu, tapi di atas kertas ia MENJADI alasnya — tombolnya lenyap,
+       persis kebalikan dari yang diminta. Yang lebih tua satu tingkat
+       terlihat di dua-duanya, dan tepinya ikut menua supaya perubahannya
+       tidak bergantung pada satu isyarat saja. */
+    background: var(--garis);
+    border-color: #d3d5dc;
+  }
+}
+/* TOMBOL PUTIH YANG MATI HARUS TERLIHAT MATI. Sampai 1 September 2026 tidak
+   ada satu pun aturan `:disabled` untuk .button-secondary, jadi panah foto
+   yang sudah di ujung tergambar persis sama dengan yang masih bisa ditekan —
+   petugas menekannya berkali-kali dan tidak terjadi apa-apa.
+
+   Bentuknya pun berubah, bukan cuma warnanya: kursor larangan menjawab
+   pertanyaan yang sama untuk yang sulit membedakan abu dari putih. */
+.button-secondary:disabled {
+  opacity: .4;
+  cursor: not-allowed;
 }
 .button-danger {
   background: #fff;
@@ -4913,7 +4936,6 @@ button.pill-number:hover { filter: brightness(.95); }
    berdiri di baris sendiri, dan tinggi yang dimakannya diambil dari foto — di
    layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
    penukaran yang salah arah. */
-.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .15rem; }
 .cek-status, .cek-gembok { flex: 0 0 auto; }
 
 /* KABAR, BUKAN TOMBOL. Angkanya disimpan sendiri begitu diubah; yang tersisa
@@ -4983,9 +5005,38 @@ button.pill-number:hover { filter: brightness(.95); }
    tempat ia terbaca sebagai milik seluruh kelompok — bukan milik kotak
    pertama. */
 .cek-isian {
-  display: flex; align-items: center; justify-content: center;
-  gap: .35rem; margin: .4rem 0 .2rem;
+  display: grid;
+  grid-template-columns: auto minmax(0, max-content) auto;
+  align-items: center; gap: .35rem; margin: .4rem 0 .2rem;
 }
+/* Cermin di kiri dan gembok di kanan sama lebarnya lewat SATU aturan, jadi
+   kolom tengah benar-benar berada di tengah. Ini bukan cara pertama yang
+   dicoba: `1fr auto 1fr` gagal karena kolom kanan punya lebar minimum
+   (gemboknya) sementara kolom kiri kosong bisa jadi nol, dan di bawah tekanan
+   ruang keduanya berhenti sama besar. Terukur di 430px dengan Pembidaian:
+   kolomnya jadi `0px 342px 0px` dan gemboknya meluap 31px keluar kartu. */
+.cek-gembok, .cek-isian > .cek-imbang { width: 2rem; }
+.cek-isian > .cek-imbang { grid-column: 1; }
+/* Kolom tengah MEMELUK isinya (`max-content`), supaya gembok berdiri TEPAT di
+   sebelah kotak — bukan di tepi kartu dengan ruang kosong di antaranya. Untuk
+   satu kriteria bedanya 83px, yaitu seluruh alasan gembok itu ditaruh di
+   sebelah nilainya.
+
+   Minimumnya tetap 0, dan itu yang mencegah meluap: lima kriteria Pembidaian
+   melebihi lebar kartu, jadi kolomnya dipotong dan kotak-kotak di dalamnya
+   (`flex: 1 1 0; min-width: 0`) yang menyusut. Dengan `auto` — minimumnya
+   min-content — kolomnya menolak menyusut dan gemboknya meluap keluar kartu,
+   terukur 31px di 430px. */
+.cek-isian > .cek-angka { grid-column: 2; justify-content: center; }
+.cek-isian > .cek-gembok { grid-column: 3; justify-self: start; }
+/* Kotaknya DI TENGAH BARIS, gemboknya menempel di kanannya — bukan keduanya
+   didempetkan lalu dipusatkan bersama. Bedanya kelihatan begitu gemboknya
+   berganti bentuk atau hilang: dengan satu kelompok yang dipusatkan, kotak
+   isian ikut bergeser, dan kotak yang berpindah tempat saat nilainya dikunci
+   memaksa mata mencarinya lagi di setiap lomba.
+
+   Kolom kiri kosong dan kanan berisi gembok, dua-duanya `1fr`, jadi lebarnya
+   sama berapa pun lebar gemboknya dan kotak isian jatuh tepat di tengah. */
 /* KRITERIA BERJAJAR KE KANAN, TIDAK ADA YANG TURUN KE BAWAH — bentuk yang
    sama dengan lembar pos, tempat tiap kriteria punya kolomnya sendiri.
 
@@ -5015,10 +5066,21 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Nama kriteria mengecil dan boleh membungkus: ia yang paling panjang
    ("Diagnosis dan Penanganan Awal") dan paling jarang dibaca ulang — yang
    dibaca berkali-kali angkanya. */
-.cek-isian .isian-nama { font-size: .7rem; line-height: 1.15; }
+/* `anywhere` supaya nama panjang boleh dipatah DI TENGAH KATA. Pembidaian
+   punya "Diagnosis dan Penanganan Awal" di atas kotak selebar 58px, dan
+   "Penanganan" sendiri lebih lebar dari itu — tanpa ini kata itu meluap
+   keluar kolomnya dan menimpa kriteria sebelahnya. */
+.cek-isian .isian-nama {
+  font-size: .7rem; line-height: 1.15;
+  overflow-wrap: anywhere; hyphens: auto;
+}
+/* SATU KRITERIA DAPAT KOTAK LEBIH LEBAR. Tidak ada yang berebut tempat di
+   barisnya, dan angka yang dibaca ratusan kali sepagi lebih murah dibaca di
+   kotak besar. Lomba berkriteria banyak mengecil di aturan berikutnya, karena
+   di sana lima kotak harus muat berjajar. */
 .cek-isian .small-input {
-  font-size: 1.4rem; min-height: 52px;
-  width: 100%; min-width: 0; max-width: 6.5rem;
+  font-size: 1.5rem; min-height: 54px;
+  width: 100%; min-width: 0; max-width: 8rem;
 }
 /* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
    muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada
@@ -5034,8 +5096,21 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Judul lomba DI TENGAH, sejajar dengan kotak isian dan fotonya yang juga di
    tengah kolomnya. Rata kiri membuat judulnya berdiri sendirian di satu sisi
    sementara semua yang menjelaskannya berdiri di tengah. */
-.cek-kepala { display: flex; flex-direction: column; align-items: center; gap: .15rem; }
-.cek-nama { font-weight: 700; text-align: center; }
+/* JUDULNYA TETAP DI TENGAH walau ada penanda di kanannya, dan itu yang
+   menentukan bentuk ini. Kalau judul dan penanda sekadar didempetkan lalu
+   dipusatkan bersama, judulnya bergeser ke kiri saat penandanya muncul dan
+   bergeser lagi tiap kali penandanya berganti dari titik-titik ke centang —
+   yaitu setiap kali sebuah nilai disimpan.
+
+   `1fr auto 1fr` membuat kolom kiri yang kosong selalu selebar kolom kanan
+   yang berisi penanda, jadi judul di kolom tengah jatuh tepat di tengah
+   apa pun isi kanannya. */
+.cek-kepala {
+  display: grid; grid-template-columns: 1fr auto 1fr;
+  align-items: center; gap: .35rem;
+}
+.cek-nama { grid-column: 2; font-weight: 700; text-align: center; }
+.cek-kepala > .cek-status { grid-column: 3; justify-self: start; }
 
 /* `.cek-angka` DULU DIDEFINISIKAN DUA KALI di berkas ini, dan yang belakangan
    menang tanpa suara (CLAUDE.md 15.6). Yang kedua milik versi lama layar ini —

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -178,7 +178,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "where pos = %s",
                     (p.get("pos") or 0,), uid=p.get("uid")))
             elif u.path == "/foto-lembar":
-                # Foto satu regu di satu pos, terbaru dulu — dipakai dialog
+                # Foto satu regu di satu pos, yang pertama diunggah lebih
+                # dulu (halaman 1 sebelum halaman 2) — dipakai dialog
                 # Foto Jawaban di lembar pos dan layar Cek Nilai. Rute ini
                 # sempat TIDAK ADA di sini sementara web/js/api.js sudah
                 # memanggilnya, jadi kedua layar itu tidak bisa dibuka di
@@ -186,7 +187,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q(
                     "select * from v_foto_lembar "
                     "where pos = %s and nomor_dada = %s "
-                    "order by diunggah_pada desc",
+                    "order by diunggah_pada asc",
                     (p.get("pos") or 0, p.get("dada") or 0), uid=p.get("uid")))
             elif u.path == "/foto-belum-taut":
                 # nomor_dada NULL = foto borongan yang belum ditautkan (0074).

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 36, sidik: "507e2adb3f9a" },
+  "style.css": { versi: 37, sidik: "a693d8d79802" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=34">
+  <link rel="stylesheet" href="style.css?v=35">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -1014,7 +1014,13 @@ export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blo
 export const putarFotoLembar = (id, putaran) =>
   rpc("putar_foto_lembar", { p_id: id, p_putaran: putaran });
 
-/** Foto satu regu di satu pos, terbaru dulu. */
+/** Foto satu regu di satu pos, YANG PERTAMA DIUNGGAH LEBIH DULU.
+ *
+ *  Urutannya `desc` sampai 1 September 2026, dan itu keliru begitu satu lomba
+ *  punya lebih dari satu lembar: yang difoto berurutan halaman 1 lalu halaman
+ *  2, dan menampilkan yang terbaru dulu membalik halamannya. Petugas yang
+ *  mencocokkan nilai dengan lembar jawaban membaca halaman 2 sebagai halaman
+ *  pertama. */
 export async function daftarFotoLembar(pos, nomorDada) {
   if (K.mode === "dev") {
     return baca(`/foto-lembar?pos=${encodeURIComponent(pos)}` +
@@ -1023,7 +1029,7 @@ export async function daftarFotoLembar(pos, nomorDada) {
   return baca(null,
     `v_foto_lembar?pos=eq.${encodeURIComponent(pos)}` +
     `&nomor_dada=eq.${encodeURIComponent(nomorDada)}` +
-    `&select=*&order=diunggah_pada.desc`);
+    `&select=*&order=diunggah_pada.asc`);
 }
 
 /** Foto slip SELURUH regu di satu pos, sekali ambil.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -9751,8 +9751,17 @@ async function layarCekNilai() {
              dilakukan ratusan kali. */
           return `
             <section class="cek-lomba">
+              <!-- CEKLIS DI SEBELAH KANAN JUDUL, dan judulnya TETAP di tengah.
+                   Ketiga selnya disusun 1fr auto 1fr, jadi lebar penandanya
+                   tidak ikut menentukan di mana judulnya jatuh — kalau
+                   keduanya sekadar didempetkan di tengah, judulnya bergeser
+                   ke kiri saat penandanya muncul, dan bergeser lagi saat
+                   berganti dari titik-titik ke centang. Judul yang berjoget
+                   tiap kali nilai disimpan terbaca seperti layar yang salah.
+                   -->
               <div class="cek-kepala">
                 <span class="cek-nama">${esc(l.nama)}</span>
+                <span class="cek-status" data-status="${esc(l.kode)}"></span>
               </div>
               <!-- SATU BARIS: kotak isian, lambang simpan, lambang gembok.
                    Sebelumnya tombol "Simpan" selebar kolomnya berdiri di baris
@@ -9763,6 +9772,14 @@ async function layarCekNilai() {
                    Ketiganya berurutan sesuai cara dipakainya: baca angkanya,
                    betulkan kalau perlu, simpan, lalu gembok. -->
               <div class="cek-isian" data-isian="${esc(l.kode)}">
+                <!-- CERMIN GEMBOK. Kotak isian hanya benar-benar di tengah
+                     kalau kedua sisinya memesan tempat yang sama; dengan
+                     gembok di kanan saja, kotaknya terdorong ke kiri sebanyak
+                     separuh lebar gembok. Selebar gemboknya, tak terlihat, dan
+                     bukan sekadar jarak kosong: lebarnya datang dari aturan
+                     yang sama dengan gemboknya, jadi keduanya tidak bisa
+                     berselisih suatu hari. -->
+                <span class="cek-imbang" aria-hidden="true"></span>
                 <!-- Kotak isian dibungkus supaya lambang di sebelahnya berdiri
                      di kanan SELURUH kelompoknya, bukan di kanan kotak
                      terakhir. Pembidaian punya lima kriteria bertumpuk; tanpa
@@ -9787,11 +9804,8 @@ async function layarCekNilai() {
                      tombol yang tidak pernah perlu ditekan, dan tombol seperti
                      itu justru membuat orang ragu apakah angkanya tersimpan
                      kalau ia LUPA menekannya. -->
-                <div class="cek-baris-aksi">
-                  <span class="cek-status" data-status="${esc(l.kode)}"></span>
-                  <button type="button" class="gembok cek-gembok"
-                          data-gembok="${esc(l.kode)}"></button>
-                </div>
+                <button type="button" class="gembok cek-gembok"
+                        data-gembok="${esc(l.kode)}"></button>
               </div>
               <div class="cek-foto" data-foto="${esc(l.kode)}"></div>
               <!-- Panah dan penghitung, disembunyikan sampai lombanya

--- a/web/style.css
+++ b/web/style.css
@@ -201,15 +201,38 @@ button { font: inherit; cursor: pointer; }
    layar sebesar ini bedanya bukan selera: kursor di atas tombol yang diam
    terbaca sebagai tombol MATI, dan yang dilakukan orang berikutnya adalah
    mengkliknya dua kali. */
-.button-secondary:hover:not(:disabled) {
-  /* --garis, bukan --kertas. Tombol putih berdiri di dua alas: kartu putih dan
-     kertas abu halaman. Warna sehalus --kertas memang terlihat di atas kartu,
-     tapi di atas kertas ia MENJADI alasnya — tombolnya lenyap, persis
-     kebalikan dari yang diminta. Yang lebih tua satu tingkat terlihat di
-     dua-duanya, dan tepinya ikut menua supaya perubahannya tidak bergantung
-     pada satu isyarat saja. */
-  background: var(--garis);
-  border-color: #d3d5dc;
+/* `@media (hover: hover)` BUKAN kehalusan — tanpanya aturan ini BERBOHONG di
+   HP. Safari iOS menempelkan `:hover` pada elemen yang TERAKHIR disentuh dan
+   menahannya sampai sesuatu yang lain disentuh, jadi tombol yang baru saja
+   ditekan tinggal abu di layar. Warnanya `--garis`, yaitu warna yang di
+   aplikasi ini berarti "mati" — dan panah foto yang tinggal abu sesudah
+   ditekan terbaca persis sebagai panah yang tidak bisa ditekan lagi.
+
+   Dilaporkan begitu, 1 September 2026: "ketika digeser ke 2/2 yang abu malah
+   yang kiri, seharusnya yang kanan". Panahnya tidak pernah terbalik; yang
+   terlihat sisa sentuhan terakhir. */
+@media (hover: hover) {
+  .button-secondary:hover:not(:disabled) {
+    /* --garis, bukan --kertas. Tombol putih berdiri di dua alas: kartu putih
+       dan kertas abu halaman. Warna sehalus --kertas memang terlihat di atas
+       kartu, tapi di atas kertas ia MENJADI alasnya — tombolnya lenyap,
+       persis kebalikan dari yang diminta. Yang lebih tua satu tingkat
+       terlihat di dua-duanya, dan tepinya ikut menua supaya perubahannya
+       tidak bergantung pada satu isyarat saja. */
+    background: var(--garis);
+    border-color: #d3d5dc;
+  }
+}
+/* TOMBOL PUTIH YANG MATI HARUS TERLIHAT MATI. Sampai 1 September 2026 tidak
+   ada satu pun aturan `:disabled` untuk .button-secondary, jadi panah foto
+   yang sudah di ujung tergambar persis sama dengan yang masih bisa ditekan —
+   petugas menekannya berkali-kali dan tidak terjadi apa-apa.
+
+   Bentuknya pun berubah, bukan cuma warnanya: kursor larangan menjawab
+   pertanyaan yang sama untuk yang sulit membedakan abu dari putih. */
+.button-secondary:disabled {
+  opacity: .4;
+  cursor: not-allowed;
 }
 .button-danger {
   background: #fff;
@@ -4913,7 +4936,6 @@ button.pill-number:hover { filter: brightness(.95); }
    berdiri di baris sendiri, dan tinggi yang dimakannya diambil dari foto — di
    layar yang seluruh gunanya membandingkan angka dengan tulisan tangan, itu
    penukaran yang salah arah. */
-.cek-baris-aksi { display: flex; align-items: center; justify-content: center; gap: .15rem; }
 .cek-status, .cek-gembok { flex: 0 0 auto; }
 
 /* KABAR, BUKAN TOMBOL. Angkanya disimpan sendiri begitu diubah; yang tersisa
@@ -4983,9 +5005,38 @@ button.pill-number:hover { filter: brightness(.95); }
    tempat ia terbaca sebagai milik seluruh kelompok — bukan milik kotak
    pertama. */
 .cek-isian {
-  display: flex; align-items: center; justify-content: center;
-  gap: .35rem; margin: .4rem 0 .2rem;
+  display: grid;
+  grid-template-columns: auto minmax(0, max-content) auto;
+  align-items: center; gap: .35rem; margin: .4rem 0 .2rem;
 }
+/* Cermin di kiri dan gembok di kanan sama lebarnya lewat SATU aturan, jadi
+   kolom tengah benar-benar berada di tengah. Ini bukan cara pertama yang
+   dicoba: `1fr auto 1fr` gagal karena kolom kanan punya lebar minimum
+   (gemboknya) sementara kolom kiri kosong bisa jadi nol, dan di bawah tekanan
+   ruang keduanya berhenti sama besar. Terukur di 430px dengan Pembidaian:
+   kolomnya jadi `0px 342px 0px` dan gemboknya meluap 31px keluar kartu. */
+.cek-gembok, .cek-isian > .cek-imbang { width: 2rem; }
+.cek-isian > .cek-imbang { grid-column: 1; }
+/* Kolom tengah MEMELUK isinya (`max-content`), supaya gembok berdiri TEPAT di
+   sebelah kotak — bukan di tepi kartu dengan ruang kosong di antaranya. Untuk
+   satu kriteria bedanya 83px, yaitu seluruh alasan gembok itu ditaruh di
+   sebelah nilainya.
+
+   Minimumnya tetap 0, dan itu yang mencegah meluap: lima kriteria Pembidaian
+   melebihi lebar kartu, jadi kolomnya dipotong dan kotak-kotak di dalamnya
+   (`flex: 1 1 0; min-width: 0`) yang menyusut. Dengan `auto` — minimumnya
+   min-content — kolomnya menolak menyusut dan gemboknya meluap keluar kartu,
+   terukur 31px di 430px. */
+.cek-isian > .cek-angka { grid-column: 2; justify-content: center; }
+.cek-isian > .cek-gembok { grid-column: 3; justify-self: start; }
+/* Kotaknya DI TENGAH BARIS, gemboknya menempel di kanannya — bukan keduanya
+   didempetkan lalu dipusatkan bersama. Bedanya kelihatan begitu gemboknya
+   berganti bentuk atau hilang: dengan satu kelompok yang dipusatkan, kotak
+   isian ikut bergeser, dan kotak yang berpindah tempat saat nilainya dikunci
+   memaksa mata mencarinya lagi di setiap lomba.
+
+   Kolom kiri kosong dan kanan berisi gembok, dua-duanya `1fr`, jadi lebarnya
+   sama berapa pun lebar gemboknya dan kotak isian jatuh tepat di tengah. */
 /* KRITERIA BERJAJAR KE KANAN, TIDAK ADA YANG TURUN KE BAWAH — bentuk yang
    sama dengan lembar pos, tempat tiap kriteria punya kolomnya sendiri.
 
@@ -5015,10 +5066,21 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Nama kriteria mengecil dan boleh membungkus: ia yang paling panjang
    ("Diagnosis dan Penanganan Awal") dan paling jarang dibaca ulang — yang
    dibaca berkali-kali angkanya. */
-.cek-isian .isian-nama { font-size: .7rem; line-height: 1.15; }
+/* `anywhere` supaya nama panjang boleh dipatah DI TENGAH KATA. Pembidaian
+   punya "Diagnosis dan Penanganan Awal" di atas kotak selebar 58px, dan
+   "Penanganan" sendiri lebih lebar dari itu — tanpa ini kata itu meluap
+   keluar kolomnya dan menimpa kriteria sebelahnya. */
+.cek-isian .isian-nama {
+  font-size: .7rem; line-height: 1.15;
+  overflow-wrap: anywhere; hyphens: auto;
+}
+/* SATU KRITERIA DAPAT KOTAK LEBIH LEBAR. Tidak ada yang berebut tempat di
+   barisnya, dan angka yang dibaca ratusan kali sepagi lebih murah dibaca di
+   kotak besar. Lomba berkriteria banyak mengecil di aturan berikutnya, karena
+   di sana lima kotak harus muat berjajar. */
 .cek-isian .small-input {
-  font-size: 1.4rem; min-height: 52px;
-  width: 100%; min-width: 0; max-width: 6.5rem;
+  font-size: 1.5rem; min-height: 54px;
+  width: 100%; min-width: 0; max-width: 8rem;
 }
 /* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
    muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada
@@ -5034,8 +5096,21 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Judul lomba DI TENGAH, sejajar dengan kotak isian dan fotonya yang juga di
    tengah kolomnya. Rata kiri membuat judulnya berdiri sendirian di satu sisi
    sementara semua yang menjelaskannya berdiri di tengah. */
-.cek-kepala { display: flex; flex-direction: column; align-items: center; gap: .15rem; }
-.cek-nama { font-weight: 700; text-align: center; }
+/* JUDULNYA TETAP DI TENGAH walau ada penanda di kanannya, dan itu yang
+   menentukan bentuk ini. Kalau judul dan penanda sekadar didempetkan lalu
+   dipusatkan bersama, judulnya bergeser ke kiri saat penandanya muncul dan
+   bergeser lagi tiap kali penandanya berganti dari titik-titik ke centang —
+   yaitu setiap kali sebuah nilai disimpan.
+
+   `1fr auto 1fr` membuat kolom kiri yang kosong selalu selebar kolom kanan
+   yang berisi penanda, jadi judul di kolom tengah jatuh tepat di tengah
+   apa pun isi kanannya. */
+.cek-kepala {
+  display: grid; grid-template-columns: 1fr auto 1fr;
+  align-items: center; gap: .35rem;
+}
+.cek-nama { grid-column: 2; font-weight: 700; text-align: center; }
+.cek-kepala > .cek-status { grid-column: 3; justify-self: start; }
 
 /* `.cek-angka` DULU DIDEFINISIKAN DUA KALI di berkas ini, dan yang belakangan
    menang tanpa suara (CLAUDE.md 15.6). Yang kedua milik versi lama layar ini —


### PR DESCRIPTION
## What

* The status check moves beside the lomba title; the padlock stays beside the
  box. Both rows are three columns, and the input row carries an invisible
  mirror of the padlock in the first column so the two sides reserve the same
  width.
* The middle track hugs its content, with a minimum of 0.
* A single-criterion lomba gets a wider box, 8rem instead of 6.5rem.
* Criterion names may break mid-word.
* Photos are listed oldest first (`daftarFotoLembar`, and the dev server route).
* `.button-secondary` gets a `:disabled` style, and its `:hover` moves behind
  `@media (hover: hover)`.

## Why

Letting a badge and a centred title centre together shifts the title left when
the badge appears, and again whenever it turns from dots to a tick -- once per
save. Three columns keep the title fixed.

Hugging the content puts the padlock 5.6px from the box instead of 83px away at
the card edge, which is the entire reason it sits next to the value. The 0
minimum is what keeps Pembidaian's five criteria inside the card: the track is
cut and the boxes shrink. With a plain `auto` the padlock spilled 31px out.

Photos are pages of one answer sheet, photographed in order; newest-first
reversed them.

An arrow at the end of the photo strip looked identical to a working one --
there was no `:disabled` rule for white buttons anywhere in the file. And
Safari iOS keeps `:hover` on the last element touched, so the grey it left
behind read as an arrow that had gone dead.

## Notes

Measured on the real screen against `hrcd_dev` at 430px and 1280px across
Pos 1, 3 and 4: title and box 0.0px off centre in every case, padlock 5.6px
from the last box, no element overflowing, no horizontal page scroll.

Photo ordering and the arrow states could not be exercised end to end locally:
`tautanFotoBanyak()` returns `{}` in dev mode, so photos never get URLs on a
laptop. The arrow fix is CSS and was verified rendered; the ordering change is
one keyword in two places plus the dev route.

Local: 373/373 JS tests. `style.css` and `js/api.js` synced to `live/`, both
`?v=` numbers raised with the fingerprint.