### PR TITLE
fix: printing Daftar Kloter no longer asks whether paper came out

### DIFF
--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -41,7 +41,14 @@ PORT = 8787
 
 # Argumen yang bertipe text[] di Postgres, bukan jsonb. Dipisah karena
 # keduanya sampai ke sini sebagai list JSON yang sama persis.
-ARRAY_TEKS = {"p_anggota"}
+# Argumen yang tujuannya ARRAY Postgres — apa pun jenis elemennya. Namanya
+# dulu ARRAY_TEKS dan isinya hanya "p_anggota", jadi `p_kloter` (smallint[])
+# ikut di-json.dumps dan Postgres menolaknya dengan "malformed array literal"
+# — persis kerusakan yang komentar di bawah sudah menjelaskan, cuma daftarnya
+# yang kurang satu. Akibatnya "Simpan waktu cetak" di layar Daftar Kloter
+# TIDAK PERNAH berhasil di laptop, dan tidak ada yang tahu karena jawabannya
+# cuma muncul sebagai notifikasi merah yang lewat.
+ARRAY_PG = {"p_anggota", "p_kloter"}
 
 # RPC yang boleh dipanggil layar, beserta urutan argumennya.
 RPC = {
@@ -478,14 +485,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 nilai = []
                 for k in urutan:
                     v = args.get(k)
-                    # Daftar yang tujuannya text[] diteruskan sebagai LIST
-                    # Python — psycopg2 mengubahnya jadi array Postgres. Kalau
-                    # ikut di-json.dumps seperti jsonb, yang sampai ke fungsi
-                    # teks '["a","b"]' dan Postgres menolaknya dengan
+                    # Daftar yang tujuannya array Postgres diteruskan sebagai
+                    # LIST Python — psycopg2 mengubahnya jadi array Postgres.
+                    # Kalau ikut di-json.dumps seperti jsonb, yang sampai ke
+                    # fungsi teks '["a","b"]' dan Postgres menolaknya dengan
                     # "malformed array literal". PostgREST di produksi memang
                     # sudah memetakannya sendiri; yang perlu diajari cuma
                     # tiruan ini.
-                    if isinstance(v, list) and k in ARRAY_TEKS:
+                    if isinstance(v, list) and k in ARRAY_PG:
                         pass
                     elif isinstance(v, (dict, list)):
                         v = json.dumps(v)

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2836,39 +2836,34 @@ async function layarCetakKloter() {
     // kertas yang salah, dan yang memegangnya peserta.
     siapkanCetakKloter(semuaKloter, bentuk, planning);
     window.print();
-    tanyaWaktuCetak(semuaKloter.map(([n]) => Number(n)));
+    catatWaktuCetak(semuaKloter.map(([n]) => Number(n)));
   }
 
-  /** Pertanyaan sesudah mencetak: kertasnya keluar atau tidak. Waktu cetak
-   *  adalah catatan cetak terakhir, bukan gembok — kloter yang sama selalu
-   *  bisa dicetak lagi (CLAUDE.md 12.1).
+  /** Waktu cetak dicatat SENDIRI, tanpa bertanya.
    *
-   *  DIALOG SENDIRI, BUKAN `confirm()` BAWAAN BROWSER, dan itu bukan soal
-   *  selera. `confirm()` MEMBLOKIR utas utama halaman sampai dijawab. Di
-   *  iPhone `window.print()` tidak menahan JavaScript: lembar cetak iOS baru
-   *  mulai menggambar preview-nya sesudah baris itu lewat, jadi `confirm()`
-   *  yang menyusul mengunci utas yang sedang dipakai menggambar — lembar
-   *  cetaknya berhenti di "Loading Preview…" selamanya, dan pertanyaannya
-   *  sendiri tertutup di belakangnya. Cetak kwitansi dan blangko pos tidak
-   *  pernah kena karena keduanya berhenti tepat sesudah `window.print()`.
+   *  Dulu ada dialog "Kertasnya sudah keluar?" supaya catatannya cuma ditulis
+   *  kalau kertasnya benar-benar keluar. Yang dibeli ketelitian itu tidak
+   *  sebanding harganya: TIDAK ADA SATU LAYAR PUN yang membaca `dicetak_pada`,
+   *  dan sejak 0066 ia tidak lagi memagari apa pun — pengacakan otomatis cuma
+   *  melihat `jam_berangkat` (CLAUDE.md 12.3). Jadi pertanyaannya menghentikan
+   *  petugas yang sedang mencetak demi ketelitian sebuah catatan yang tidak
+   *  pernah dibaca siapa pun.
    *
-   *  `dialog()` cuma menempelkan elemen di halaman lalu mengembalikan Promise,
-   *  jadi utasnya bebas. Overlay-nya sudah `display: none` di @media print,
-   *  jadi ia tidak ikut tercetak. */
-  async function tanyaWaktuCetak(nomor) {
-    const jawab = await dialog({
-      judul: "Kertasnya sudah keluar?",
-      kartuHtml: html`<div class="card card-identity" style="margin-bottom:.8rem">
-        <div class="nama">${String(nomor.length)} kloter</div>
-      </div>`,
-      labelAksi: "Simpan waktu cetak",
-    });
-    if (!jawab) return;
-    try {
-      const n = await tandaiKloterDicetak(nomor);
-      notif(`Waktu cetak ${n} kloter disimpan.`);
-      layarCetakKloter();
-    } catch (err) { notif(err.message, true); }
+   *  Akibat yang diterima: kloter yang lembar cetaknya dibatalkan tetap
+   *  tercatat pernah dicetak. Itu catatan yang keliru, bukan pekerjaan yang
+   *  rusak — mencetak ulang selalu boleh (CLAUDE.md 12.1).
+   *
+   *  Sesudah `window.print()`, bukan sebelumnya: di iPhone lembar cetak baru
+   *  mulai menggambar preview-nya sesudah baris itu lewat, dan apa pun yang
+   *  menahan utas di sana membuatnya berhenti di "Loading Preview..." selamanya.
+   *  Panggilan ini tidak menahan utas, tapi urutannya tetap dipertahankan.
+   *
+   *  Gagalnya tetap bersuara. Catatan yang tidak dibaca layar mana pun toh
+   *  masih ditanyakan orang ("kloter 12 dicetak jam berapa?"), dan gagal
+   *  menulis yang benar-benar diam tidak pernah bisa diperbaiki. */
+  async function catatWaktuCetak(nomor) {
+    try { await tandaiKloterDicetak(nomor); }
+    catch (err) { notif(`Waktu cetak tidak tersimpan: ${err.message}`, true); }
   }
 
   document.getElementById("cetak-petugas").addEventListener("click", () => cetak("staging"));


### PR DESCRIPTION
## What

* Remove the "Kertasnya sudah keluar?" dialog. The print timestamp is written
  automatically after `window.print()`.
* `tests/dev_server.py`: `p_kloter` joins `p_anggota` in the set of arguments
  that map to a Postgres array (renamed `ARRAY_TEKS` to `ARRAY_PG`).

## Why

No screen reads `dicetak_pada`, and since 0066 it gates nothing -- the
automatic assignment looks only at `jam_berangkat` (CLAUDE.md 12.3). The
dialog stopped an officer mid-print for the accuracy of a record nobody reads.

The dev server mapped only `p_anggota` to an array, so `p_kloter` was
json.dumps'd and Postgres rejected it with "malformed array literal" -- the
exact failure the comment beside that line already describes, with one name
missing. "Simpan waktu cetak" therefore never succeeded on a laptop, and
nothing said so.

## Notes

Accepted cost: a kloter whose print sheet is cancelled is still recorded as
printed. Printing again is always allowed (CLAUDE.md 12.1).

A failed write still raises a notification. Nothing reads the column from a
screen, but people do ask when a kloter was printed.

Verified on the real screen against `hrcd_dev`: print fires once, no dialog,
RPC returns 200, 18 kloter carry a timestamp afterwards.

Local: 373/373 JS tests. No shared asset changed, so no `?v=` bump.