### PR TITLE
feat: nomor dada boxes show three digits while being typed

### DIFF
--- a/tests/nomor_dada_tiga_digit.test.mjs
+++ b/tests/nomor_dada_tiga_digit.test.mjs
@@ -1,0 +1,59 @@
+// ============================================================================
+// hrcd-rekap : tests/nomor_dada_tiga_digit.test.mjs
+// Setiap kotak nomor dada menampilkan tiga digit sambil diketik.
+//
+// Yang dijaga di sini bukan dada3() — itu sudah lama ada dan dipakai di
+// puluhan tempat — melainkan bahwa SETIAP kotak isian nomor dada memakainya.
+// Kotak nomor dada tersebar di tiga layar yang ditulis pada waktu berbeda, dan
+// yang keempat akan ditulis oleh orang yang tidak tahu aturan ini ada.
+//
+// Kotak `type="number"` DILARANG untuk nomor dada: kotak number membuang nol
+// di depan apa pun yang ditulis ke dalamnya, jadi "001" mustahil tergambar di
+// sana. Itu bukan pilihan gaya melainkan satu-satunya sebab layar Cek Nilai
+// tidak bisa ikut ketika aturan ini dipasang.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+
+/** Baris <input> yang id-nya memuat "dada". Komentar dibuang lebih dulu supaya
+ *  penjelasan yang menyebut type="number" tidak ikut terbaca sebagai markup. */
+const kotakDada = app
+  .replace(/<!--[\s\S]*?-->/g, "")
+  .match(/<input[^>]*id="[^"]*dada[^"]*"[^>]*>/g) || [];
+
+test("ada kotak nomor dada untuk diperiksa", () => {
+  assert.ok(kotakDada.length >= 3,
+    `cuma ${kotakDada.length} kotak nomor dada ditemukan — pola pencariannya `
+    + "mungkin sudah tidak cocok, dan tes yang tidak menemukan apa-apa selalu hijau");
+});
+
+test("tidak ada kotak nomor dada bertipe number", () => {
+  for (const k of kotakDada) {
+    assert.doesNotMatch(k, /type="number"/,
+      `kotak number membuang nol di depan, jadi "001" tidak akan pernah `
+      + `tergambar: ${k.replace(/\s+/g, " ").slice(0, 90)}`);
+  }
+});
+
+test("tiap kotak nomor dada dipasangi tiga digit", () => {
+  const id = [...app.matchAll(/<input[^>]*id="([^"]*dada[^"]*)"/g)].map(m => m[1]);
+  // Definisi fungsinya sendiri tidak dihitung — ia juga berbunyi "pasangDada3(".
+  const dipasang = [...app.matchAll(/(?<!function )pasangDada3\((\w+)/g)].map(m => m[1]);
+  assert.equal(dipasang.length, id.length,
+    `${id.length} kotak nomor dada (${id.join(", ")}) tapi ${dipasang.length} `
+    + "pemasangan pasangDada3 — satu layar tidak ikut");
+});
+
+test("nol mengosongkan kotaknya", () => {
+  // Tanpa cabang ini "001" yang dihapus satu huruf jadi "00", dibaca 0, lalu
+  // dipasang kembali jadi "000" — dan kotaknya tidak akan pernah bisa
+  // dikosongkan lagi.
+  const awal = app.indexOf("function pasangDada3(");
+  const fungsi = app.slice(awal, app.indexOf("\n}", awal));
+  assert.match(fungsi, /n === 0 \? "" : dada3\(n\)/,
+    "kotak nomor dada tidak bisa dikosongkan lagi dengan menghapus");
+});

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2607,6 +2607,40 @@ async function layarKeberangkatan() {
 
 /* ============================ CETAK DAFTAR KLOTER ======================== */
 
+/** Kotak nomor dada MENAMPILKAN tiga digit sambil diketik: 1 jadi 001, 10
+ *  jadi 010 — bentuk yang sama dengan angka yang tercetak di dada peserta dan
+ *  di seluruh layar lain, yang sudah lama lewat dada3().
+ *
+ *  YANG BERUBAH CUMA TAMPILANNYA. Setiap pembaca kotak ini memakai
+ *  `Number(value)`, dan `Number("001")` tetap 1 — tidak ada satu pun
+ *  pencarian, penyimpanan, atau perbandingan yang perlu tahu soal ini.
+ *
+ *  Nomor Intern empat digit tidak dipotong: dada3() melewatkan apa pun di atas
+ *  999 apa adanya (migrasi 0116), jadi 1000 tetap 1000.
+ *
+ *  ANGKA NOL MENGOSONGKAN KOTAKNYA, dan itu bukan kebetulan melainkan
+ *  syarat supaya kotaknya masih bisa dikosongkan. Tanpa itu "001" yang
+ *  dihapus satu huruf jadi "00", dibaca 0, lalu dipasang kembali jadi "000" —
+ *  dan petugas tidak akan pernah bisa menghapus isinya. Tidak ada nomor dada
+ *  0, jadi tidak ada yang hilang.
+ *
+ *  Kursornya dikembalikan ke ujung karena mengubah `value` memindahkannya ke
+ *  awal, dan huruf berikutnya akan mendarat di depan angkanya. */
+function pasangDada3(el, sinyal) {
+  const rapikan = () => {
+    const angka = el.value.replace(/\D/g, "");
+    if (!angka) return;
+    const n = Number(angka);
+    const baru = n === 0 ? "" : dada3(n);
+    if (baru === el.value) return;
+    el.value = baru;
+    try { el.setSelectionRange(baru.length, baru.length); } catch { /* abaikan */ }
+  };
+  const opsi = sinyal ? { signal: sinyal } : undefined;
+  el.addEventListener("input", rapikan, opsi);
+  el.addEventListener("change", rapikan, opsi);
+}
+
 async function layarCetakKloter() {
   pasangKepala("Daftar Kloter");
   LAYAR.replaceChildren(h(pemuat()));
@@ -3036,6 +3070,7 @@ function layarFinish() {
   `));
 
   const inp = document.getElementById("dada");
+  pasangDada3(inp);
   const kotak = document.getElementById("kartu-regu");
   const tombol = document.getElementById("sampai");
   const inpJam = pasangKotakJam("jam");
@@ -8281,6 +8316,7 @@ async function gambarLombaNilai(l) {
   kirimAntrean();
 
   const inp = document.getElementById("v2-dada");
+  pasangDada3(inp, sinyal);
   const kotakRegu = document.getElementById("v2-regu");
   const wadah = document.getElementById("v2-isian");
   const tombol = document.getElementById("v2-simpan");
@@ -9624,8 +9660,12 @@ async function layarCekNilai() {
       <div class="cek-navigasi">
         <button type="button" class="button button-secondary cek-panah"
                 id="cek-mundur" aria-label="Regu sebelumnya">&lsaquo;</button>
-        <input type="number" id="cek-dada" class="cek-dada" inputmode="numeric"
-               min="1" aria-label="Nomor dada yang sedang dilihat">
+        <!-- type=text, BUKAN number: kotak number membuang nol di depan
+             apa pun yang ditulis ke dalamnya, jadi "001" mustahil tergambar
+             di sana. inputmode tetap numeric supaya papan ketik HP tetap
+             angka. -->
+        <input type="text" id="cek-dada" class="cek-dada" inputmode="numeric"
+               autocomplete="off" aria-label="Nomor dada yang sedang dilihat">
         <button type="button" class="button button-secondary cek-panah"
                 id="cek-maju" aria-label="Regu berikutnya">&rsaquo;</button>
       </div>
@@ -9663,6 +9703,7 @@ async function layarCekNilai() {
 
   const elPos = document.getElementById("cek-pos");
   const elDada = document.getElementById("cek-dada");
+  pasangDada3(elDada, sinyal);
   const elPosisi = document.getElementById("cek-posisi");
   const elIsi = document.getElementById("cek-isi");
   const elMundur = document.getElementById("cek-mundur");
@@ -9691,7 +9732,7 @@ async function layarCekNilai() {
        "04" untuk menuju 042 akan melihat ketikannya diganti nomor yang sedang
        terbuka, di tengah ketikan. */
     if (document.activeElement !== elDada) {
-      elDada.value = lembar.length ? String(lembar[indeks].nomor_dada) : "";
+      elDada.value = lembar.length ? dada3(lembar[indeks].nomor_dada) : "";
     }
   }
 
@@ -10331,7 +10372,7 @@ async function layarCekNilai() {
     const i = lembar.findIndex(r => Number(r.nomor_dada) === cari);
     if (i < 0) {
       notif(`Nomor ${dada3(cari)} tidak ada di pos ini.`, true);
-      elDada.value = lembar.length ? String(lembar[indeks].nomor_dada) : "";
+      elDada.value = lembar.length ? dada3(lembar[indeks].nomor_dada) : "";
       return;
     }
     elDada.blur();


### PR DESCRIPTION
## What

Typing 1 shows 001, typing 10 shows 010, in every nomor dada box: `#dada`
(Finish), `#v2-dada` (Input Nilai Pos), `#cek-dada` (Cek Nilai). `#cek-dada`
stops being `type="number"`.

## Why

It is the shape printed on the bib, and the shape every other screen has shown
for a long time through `dada3()`. Only the display changes -- every reader
goes through `Number(value)`, and `Number("001")` is still 1.

A number box strips leading zeros from anything written into it, so `001`
could never appear in `#cek-dada`.

Zero clears the box. Without that, deleting one character from `001` leaves
`00`, which reads as 0 and is written back as `000`, and the box could never be
emptied again. There is no nomor dada 0.

## Notes

Four-digit Intern numbers are untouched: `dada3()` passes anything above 999
through unchanged (migration 0116).

Verified on all three real screens against `hrcd_dev`: 1 / 10 / 105 / 1000 give
001 / 010 / 105 / 1000, and one delete from 007 empties the box.

Local: 377/377 JS tests. No shared asset changed, so no `?v=` bump.