### PR TITLE
fix: Cek Nilai jumps to a nomor dada as it is typed

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=37">
+  <link rel="stylesheet" href="style.css?v=38">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -5079,8 +5079,8 @@ button.pill-number:hover { filter: brightness(.95); }
    kotak besar. Lomba berkriteria banyak mengecil di aturan berikutnya, karena
    di sana lima kotak harus muat berjajar. */
 .cek-isian .small-input {
-  font-size: 1.5rem; min-height: 54px;
-  width: 100%; min-width: 0; max-width: 8rem;
+  font-size: 1.6rem; min-height: 58px;
+  width: 100%; min-width: 0; max-width: 9.5rem;
 }
 /* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
    muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada

--- a/live/style.css
+++ b/live/style.css
@@ -5071,7 +5071,7 @@ button.pill-number:hover { filter: brightness(.95); }
    "Penanganan" sendiri lebih lebar dari itu — tanpa ini kata itu meluap
    keluar kolomnya dan menimpa kriteria sebelahnya. */
 .cek-isian .isian-nama {
-  font-size: .7rem; line-height: 1.15;
+  font-size: .62rem; line-height: 1.1;
   overflow-wrap: anywhere; hyphens: auto;
 }
 /* SATU KRITERIA DAPAT KOTAK LEBIH LEBAR. Tidak ada yang berebut tempat di
@@ -5082,12 +5082,34 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 1.6rem; min-height: 58px;
   width: 100%; min-width: 0; max-width: 9.5rem;
 }
-/* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
-   muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada
-   yang berebut tempat. */
+/* KOTAK mm:ss LEBIH LEBAR DARI KOTAK ANGKA, bukan lebih sempit.
+   `input.small-input.input-waktu { width: 5.6rem }` di bagian tabel menang
+   atas `.cek-isian .small-input { width: 100% }` — kekhususan 0,2,1 lawan
+   0,2,0 — jadi "00:13" berdiri di kotak 90px sementara angka satu digit di
+   lomba sebelahnya dapat 152px. Terbalik: yang isinya lima huruf justru yang
+   paling sempit, dan di HP isinya terpotong.
+
+   Yang dilakukan MENGALAHKAN aturan itu di sini, bukan menambah aturan untuk
+   membatalkannya di tempat lain (CLAUDE.md 15.12) — 5.6rem tetap benar untuk
+   lembar pos, tempat satu baris memuat belasan kolom. */
+.cek-isian input.small-input.input-waktu { width: 100%; max-width: 10.5rem; }
+/* Lomba berkriteria BANYAK: yang mengalah LEBAR kotaknya, bukan besar
+   angkanya. Lima kotak tidak akan pernah muat selebar kotak tunggal di layar
+   430px — itu aritmetika, bukan pilihan — tapi angka DI DALAMNYA tidak punya
+   alasan ikut mengecil, dan angka itulah yang dicocokkan dengan tulisan
+   tangan di foto.
+
+   Jadi hurufnya hampir sebesar kotak tunggal dan paddingnya yang dirampingkan:
+   12px kiri-kanan pada kotak selebar 52px berarti separuh kotaknya kosong.
+   Nilai kriteria selalu dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang
+   dibebaskan padding memang jatuh ke angkanya. */
 .cek-angka:has(.isian-baris + .isian-baris) .small-input {
-  font-size: 1.05rem; min-height: 44px; max-width: none;
+  font-size: 1.35rem; min-height: 52px; max-width: none;
+  padding-left: .25rem; padding-right: .25rem;
 }
+/* Jarak antar kotak dirapatkan di baris berkriteria banyak: .3rem x 4 celah
+   adalah 19px yang seluruhnya diambil dari kotaknya. */
+.cek-angka:has(.isian-baris + .isian-baris) { gap: .15rem; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 38, sidik: "5396ad842773" },
+  "style.css": { versi: 38, sidik: "f211ee84ab52" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 37, sidik: "a693d8d79802" },
+  "style.css": { versi: 38, sidik: "5396ad842773" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=35">
+  <link rel="stylesheet" href="style.css?v=36">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -10367,20 +10367,48 @@ async function layarCekNilai() {
    *  dikembalikan ke nomor yang sedang terbuka — kotak yang ditinggalkan
    *  berisi nomor yang tidak sedang dilihat siapa pun berbohong tentang
    *  layar di bawahnya. */
-  const lompat = () => {
+  const lompat = (tutupPapanKetik) => {
     const cari = Number(elDada.value);
+    if (!cari) return;
     const i = lembar.findIndex(r => Number(r.nomor_dada) === cari);
     if (i < 0) {
       notif(`Nomor ${dada3(cari)} tidak ada di pos ini.`, true);
       elDada.value = lembar.length ? dada3(lembar[indeks].nomor_dada) : "";
       return;
     }
-    elDada.blur();
+    if (tutupPapanKetik) elDada.blur();
     ke(i);
   };
-  elDada.addEventListener("change", lompat, { signal: sinyal });
+  /* MENCARI SAMBIL DIKETIK, bukan menunggu Enter — dan di HP itu bukan
+     kenyamanan melainkan syarat.
+
+     Papan ketik angka iPhone TIDAK PUNYA tombol Enter. Selama layar ini cuma
+     mendengar `change` dan Enter, satu-satunya cara memicunya adalah mengetuk
+     ke tempat lain di layar, dan tidak ada apa pun yang memberitahukan itu:
+     nomornya sudah tertulis di kotak, papan ketiknya masih terbuka, dan
+     layarnya tidak bergerak. Dilaporkan begitu, 1 September 2026 — "ketika
+     dipilih 100 tidak muncul", dengan kotak berisi 100 dan layar masih di
+     regu 002.
+
+     Kedua kotak nomor dada lain (layar input dan Finish) sudah lama mencari
+     sambil diketik. Layar ini yang tertinggal.
+
+     DITUNDA 400 ms: "1", "10", "100" adalah tiga keadaan, dan dua yang
+     pertama akan menggambar ulang layar beserta memuat fotonya untuk regu
+     yang bukan tujuan siapa pun.
+
+     TIDAK menutup papan ketik, tidak seperti jalur Enter. Petugas yang masih
+     mengetik angka ketiganya tidak boleh kehilangan papan ketiknya di angka
+     kedua. */
+  let jedaLompat = null;
+  elDada.addEventListener("input", () => {
+    clearTimeout(jedaLompat);
+    jedaLompat = setTimeout(() => lompat(false), 400);
+  }, { signal: sinyal });
+  elDada.addEventListener("change", () => { clearTimeout(jedaLompat); lompat(true); },
+    { signal: sinyal });
   elDada.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") { e.preventDefault(); lompat(); }
+    if (e.key === "Enter") { e.preventDefault(); clearTimeout(jedaLompat); lompat(true); }
   }, { signal: sinyal });
   // Isi kotak dipilih saat diketuk, jadi nomor berikutnya tinggal diketik
   // menimpa — aturan yang sama dengan kotak nomor dada di layar input.

--- a/web/style.css
+++ b/web/style.css
@@ -5079,8 +5079,8 @@ button.pill-number:hover { filter: brightness(.95); }
    kotak besar. Lomba berkriteria banyak mengecil di aturan berikutnya, karena
    di sana lima kotak harus muat berjajar. */
 .cek-isian .small-input {
-  font-size: 1.5rem; min-height: 54px;
-  width: 100%; min-width: 0; max-width: 8rem;
+  font-size: 1.6rem; min-height: 58px;
+  width: 100%; min-width: 0; max-width: 9.5rem;
 }
 /* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
    muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada

--- a/web/style.css
+++ b/web/style.css
@@ -5071,7 +5071,7 @@ button.pill-number:hover { filter: brightness(.95); }
    "Penanganan" sendiri lebih lebar dari itu — tanpa ini kata itu meluap
    keluar kolomnya dan menimpa kriteria sebelahnya. */
 .cek-isian .isian-nama {
-  font-size: .7rem; line-height: 1.15;
+  font-size: .62rem; line-height: 1.1;
   overflow-wrap: anywhere; hyphens: auto;
 }
 /* SATU KRITERIA DAPAT KOTAK LEBIH LEBAR. Tidak ada yang berebut tempat di
@@ -5082,12 +5082,34 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: 1.6rem; min-height: 58px;
   width: 100%; min-width: 0; max-width: 9.5rem;
 }
-/* Lomba berkriteria BANYAK: kotaknya lebih kecil, karena lima kotak harus
-   muat berjajar di satu kolom. Satu kriteria tetap besar — di sana tidak ada
-   yang berebut tempat. */
+/* KOTAK mm:ss LEBIH LEBAR DARI KOTAK ANGKA, bukan lebih sempit.
+   `input.small-input.input-waktu { width: 5.6rem }` di bagian tabel menang
+   atas `.cek-isian .small-input { width: 100% }` — kekhususan 0,2,1 lawan
+   0,2,0 — jadi "00:13" berdiri di kotak 90px sementara angka satu digit di
+   lomba sebelahnya dapat 152px. Terbalik: yang isinya lima huruf justru yang
+   paling sempit, dan di HP isinya terpotong.
+
+   Yang dilakukan MENGALAHKAN aturan itu di sini, bukan menambah aturan untuk
+   membatalkannya di tempat lain (CLAUDE.md 15.12) — 5.6rem tetap benar untuk
+   lembar pos, tempat satu baris memuat belasan kolom. */
+.cek-isian input.small-input.input-waktu { width: 100%; max-width: 10.5rem; }
+/* Lomba berkriteria BANYAK: yang mengalah LEBAR kotaknya, bukan besar
+   angkanya. Lima kotak tidak akan pernah muat selebar kotak tunggal di layar
+   430px — itu aritmetika, bukan pilihan — tapi angka DI DALAMNYA tidak punya
+   alasan ikut mengecil, dan angka itulah yang dicocokkan dengan tulisan
+   tangan di foto.
+
+   Jadi hurufnya hampir sebesar kotak tunggal dan paddingnya yang dirampingkan:
+   12px kiri-kanan pada kotak selebar 52px berarti separuh kotaknya kosong.
+   Nilai kriteria selalu dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang
+   dibebaskan padding memang jatuh ke angkanya. */
 .cek-angka:has(.isian-baris + .isian-baris) .small-input {
-  font-size: 1.05rem; min-height: 44px; max-width: none;
+  font-size: 1.35rem; min-height: 52px; max-width: none;
+  padding-left: .25rem; padding-right: .25rem;
 }
+/* Jarak antar kotak dirapatkan di baris berkriteria banyak: .3rem x 4 celah
+   adalah 19px yang seluruhnya diambil dari kotaknya. */
+.cek-angka:has(.isian-baris + .isian-baris) { gap: .15rem; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */


### PR DESCRIPTION
## What

* The nomor dada box on Cek Nilai searches as you type, debounced 400 ms.
  Enter and losing focus still jump immediately.
* The nilai box on that screen goes from 8rem to 9.5rem.

## Why

The box waited for Enter or for the field to lose focus. An iPhone numeric
keypad has no Enter key, so the only way to trigger it was to tap elsewhere on
the screen, and nothing says so: the number is already in the box, the keypad
is still up, and the screen does not move. The checkmark on the keypad's
accessory bar did not help either.

The other two nomor dada boxes, on Input Nilai Pos and Finish, have searched as
you type for a long time. This screen was the one left behind.

The typed path deliberately does not close the keypad, unlike Enter -- someone
still typing the third digit must not lose the keyboard on the second.

## Notes

Debouncing matters here: "1", "10" and "100" are three states, and the first
two would each redraw the screen and fetch photos for a regu nobody is going
to.

Lomba with several criteria keep their box width -- they have their own rule,
and five boxes still have to fit in one row.

Measured against `hrcd_dev`: typing 100 with no Enter and no blur lands on
100/143 with focus still in the box. Pos 3 and Pos 4 keep their widths,
everything centred to 0.0px, no overflow, no horizontal scroll.

Local: 377/377 JS tests. `style.css` synced to `live/`, both `?v=` raised with
the fingerprint.