### PR TITLE
fix: Pembidaian uses the whole phone width

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=38">
+  <link rel="stylesheet" href="style.css?v=39">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -5104,12 +5104,25 @@ button.pill-number:hover { filter: brightness(.95); }
    Nilai kriteria selalu dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang
    dibebaskan padding memang jatuh ke angkanya. */
 .cek-angka:has(.isian-baris + .isian-baris) .small-input {
-  font-size: 1.35rem; min-height: 52px; max-width: none;
+  font-size: 1.5rem; min-height: 56px; max-width: none;
   padding-left: .25rem; padding-right: .25rem;
 }
 /* Jarak antar kotak dirapatkan di baris berkriteria banyak: .3rem x 4 celah
    adalah 19px yang seluruhnya diambil dari kotaknya. */
 .cek-angka:has(.isian-baris + .isian-baris) { gap: .15rem; }
+
+/* BARIS BERKRITERIA BANYAK MEMAKAI SELURUH LEBAR KARTU: cerminnya dibuang.
+   Cermin itu ada supaya kotak TUNGGAL jatuh tepat di tengah — kedua sisi
+   memesan lebar yang sama. Untuk lima kotak yang sudah memenuhi barisnya
+   "di tengah" tidak berarti apa-apa, sementara 32px + celahnya adalah 37px
+   yang seluruhnya bisa jatuh ke kotaknya. Terukur di 430px: 54px jadi 62px
+   hanya dari ini. */
+.cek-isian:has(.isian-baris + .isian-baris) {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+.cek-isian:has(.isian-baris + .isian-baris) > .cek-imbang { display: none; }
+.cek-isian:has(.isian-baris + .isian-baris) > .cek-angka { grid-column: 1; }
+.cek-isian:has(.isian-baris + .isian-baris) > .cek-gembok { grid-column: 2; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */
@@ -5155,6 +5168,14 @@ button.pill-number:hover { filter: brightness(.95); }
   scroll-snap-type: x mandatory; scrollbar-width: none;
 }
 .cek-foto::-webkit-scrollbar { display: none; }
+
+/* KARTU DAFTAR LOMBA DIRAMPINGKAN DI HP. Padding 18px di kiri dan kanan
+   adalah 37px yang diambil dari lima kotak Pembidaian dan dari lebar fotonya —
+   dua hal yang justru jadi alasan layar ini dibuka. Di layar lebar padding itu
+   tidak menghalangi apa pun, jadi yang berubah cuma rentang HP. */
+@media (max-width: 560px) {
+  #cek-isi > .card { padding-left: .5rem; padding-right: .5rem; }
+}
 /* Navigasinya menempel ke petak di atasnya, bukan mengambang di tengah
    antara dua lomba — ia milik foto tepat di atasnya, dan di daftar berisi
    lima lomba kepemilikan itu harus terbaca tanpa dihitung. */

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 38, sidik: "f211ee84ab52" },
+  "style.css": { versi: 39, sidik: "103f2013fab3" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=36">
+  <link rel="stylesheet" href="style.css?v=37">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -5104,12 +5104,25 @@ button.pill-number:hover { filter: brightness(.95); }
    Nilai kriteria selalu dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang
    dibebaskan padding memang jatuh ke angkanya. */
 .cek-angka:has(.isian-baris + .isian-baris) .small-input {
-  font-size: 1.35rem; min-height: 52px; max-width: none;
+  font-size: 1.5rem; min-height: 56px; max-width: none;
   padding-left: .25rem; padding-right: .25rem;
 }
 /* Jarak antar kotak dirapatkan di baris berkriteria banyak: .3rem x 4 celah
    adalah 19px yang seluruhnya diambil dari kotaknya. */
 .cek-angka:has(.isian-baris + .isian-baris) { gap: .15rem; }
+
+/* BARIS BERKRITERIA BANYAK MEMAKAI SELURUH LEBAR KARTU: cerminnya dibuang.
+   Cermin itu ada supaya kotak TUNGGAL jatuh tepat di tengah — kedua sisi
+   memesan lebar yang sama. Untuk lima kotak yang sudah memenuhi barisnya
+   "di tengah" tidak berarti apa-apa, sementara 32px + celahnya adalah 37px
+   yang seluruhnya bisa jatuh ke kotaknya. Terukur di 430px: 54px jadi 62px
+   hanya dari ini. */
+.cek-isian:has(.isian-baris + .isian-baris) {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+.cek-isian:has(.isian-baris + .isian-baris) > .cek-imbang { display: none; }
+.cek-isian:has(.isian-baris + .isian-baris) > .cek-angka { grid-column: 1; }
+.cek-isian:has(.isian-baris + .isian-baris) > .cek-gembok { grid-column: 2; }
 /* Satu garis per lomba, bukan satu kartu per lomba: yang dibandingkan
    angka dengan gambarnya SENDIRI, dan kartu bertumpuk memaksa menggulir di
    antara keduanya. */
@@ -5155,6 +5168,14 @@ button.pill-number:hover { filter: brightness(.95); }
   scroll-snap-type: x mandatory; scrollbar-width: none;
 }
 .cek-foto::-webkit-scrollbar { display: none; }
+
+/* KARTU DAFTAR LOMBA DIRAMPINGKAN DI HP. Padding 18px di kiri dan kanan
+   adalah 37px yang diambil dari lima kotak Pembidaian dan dari lebar fotonya —
+   dua hal yang justru jadi alasan layar ini dibuka. Di layar lebar padding itu
+   tidak menghalangi apa pun, jadi yang berubah cuma rentang HP. */
+@media (max-width: 560px) {
+  #cek-isi > .card { padding-left: .5rem; padding-right: .5rem; }
+}
 /* Navigasinya menempel ke petak di atasnya, bukan mengambang di tengah
    antara dua lomba — ia milik foto tepat di atasnya, dan di daftar berisi
    lima lomba kepemilikan itu harus terbaca tanpa dihitung. */


### PR DESCRIPTION
## What

* Rows with several criteria drop the invisible padlock mirror and use the full
  card width.
* The lomba card's horizontal padding drops from 18px to 8px on phones.
* Criterion digits go to 1.5rem, boxes to 56px tall.

## Why

Five boxes were 54px with 21.6px digits inside them, on a screen whose only job
is reading those numbers against a photo.

The mirror exists so a single box lands dead centre -- both sides reserve the
same width. For five boxes that already fill the row, "centred" means nothing,
so 37px goes back to the boxes. The card padding is another 37px taken from the
boxes and from the photo below them.

## Notes

Boxes: 54 to 66px at 430px, 46 to 58px at 390px, PBB 72 to 86px. Digits 24px,
close to the 25.6px a single-criterion lomba gets.

Single-criterion rows keep the mirror and stay centred to 0.0px.

Measured against `hrcd_dev` with every box forced to its widest value, at 390px,
430px and 1280px: no digit clipped, no horizontal scroll, and criterion labels
no longer break mid-word now that they have room.

Local: 377/377 JS tests. `style.css` synced to `live/`, both `?v=` raised with
the fingerprint.