### PR TITLE
chore: photos can be opened on a laptop, and two guards get a second direction

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -958,6 +958,28 @@ export const simpanKejuaraanTerjauh = (sekolahId) =>
 
 const BUCKET = "lembar";
 
+/* GUDANG BERKAS DEV. Dev server menyimpan byte-nya di direktori sementara dan
+   melayaninya kembali lewat /storage/<path> — lihat keterangan panjangnya di
+   tests/dev_server.py.
+
+   Sampai 1 September 2026 mode dev membuang gambarnya dan mengembalikan peta
+   tautan KOSONG, jadi tidak satu pun foto pernah tergambar di laptop dan
+   seluruh alur gambar — menggeser, memutar, mengurutkan, menghapus — tidak
+   pernah dijalankan sekali pun di luar produksi.
+
+   Ketiganya hanya berjalan saat `K.mode === "dev"`. Di produksi tidak ada
+   satu baris pun di bawah ini yang tersentuh. */
+const gudangDev = (path) => `${K.devUrl}/storage/${path.split("/").map(encodeURIComponent).join("/")}`;
+
+async function simpanGudangDev(path, blob) {
+  await fetch(gudangDev(path), { method: "POST", body: blob });
+}
+
+async function hapusGudangDev(path) {
+  try { await fetch(gudangDev(path), { method: "DELETE" }); }
+  catch { /* berkas yatim di direktori sementara tidak merugikan siapa pun */ }
+}
+
 /** Nama objek di bucket. Prefiks pertama WAJIB `pos<n>` — itulah yang dipagari
  *  policy storage.objects, dan RPC catat_foto_lembar menolak path yang tidak
  *  cocok dengan posnya. */
@@ -977,8 +999,11 @@ export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blo
   const path = namaObjekFoto(pos, kodeLomba, nomorDada);
 
   if (K.mode === "dev") {
-    // Dev server tidak punya Storage. Barisnya tetap dicatat supaya alur
-    // layarnya bisa dicoba tanpa Supabase.
+    // Gambarnya DISIMPAN, bukan dibuang: tanpa byte-nya layar Cek Nilai dan
+    // dialog Foto Jawaban tidak menggambar apa pun, dan keduanya tidak bisa
+    // diperiksa di laptop. Urutannya sama dengan produksi — gambar dulu,
+    // baris sesudahnya — supaya yang diuji alur yang sama.
+    await simpanGudangDev(path, blob);
     await rpc("catat_foto_lembar", {
       p_nomor_dada: nomorDada, p_pos: pos, p_kode_lomba: kodeLomba,
       p_nama_lomba: namaLomba, p_path: path, p_ukuran: blob.size,
@@ -1051,7 +1076,8 @@ export async function fotoLembarPos(pos) {
  *  URL tetap — dan itu memang yang diinginkan: link yang tidak kedaluwarsa
  *  akan beredar di WhatsApp selamanya. Satu jam cukup untuk melihatnya. */
 export async function tautanFoto(path) {
-  if (K.mode === "dev") return null;
+  if (!path) return null;
+  if (K.mode === "dev") return gudangDev(path);
   await pastikanSesiSegar();
   const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}/${path}`, {
     method: "POST",
@@ -1072,7 +1098,10 @@ export async function tautanFoto(path) {
  *  sebabnya pemanggil lama harus membuka jendela kosong lebih dulu lalu
  *  mengisinya belakangan. */
 export async function tautanFotoBanyak(paths) {
-  if (K.mode === "dev" || !paths.length) return {};
+  if (!paths.length) return {};
+  if (K.mode === "dev") {
+    return Object.fromEntries(paths.map(p => [p, gudangDev(p)]));
+  }
   await pastikanSesiSegar();
   const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}`, {
     method: "POST",
@@ -1102,7 +1131,11 @@ export async function tautanFotoBanyak(paths) {
  *  gagal" padahal fotonya memang sudah hilang cuma membuatnya menekan lagi. */
 export async function hapusFotoLembar(id, alasan) {
   const path = await rpc("hapus_foto_lembar", { p_id: id, p_alasan: alasan });
-  if (K.mode === "dev") return path;
+  if (K.mode === "dev") {
+    // Urutannya sama dengan produksi di bawah: baris dulu, objek sesudahnya.
+    if (path) await hapusGudangDev(path);
+    return path;
+  }
   if (path) {
     try {
       await pastikanSesiSegar();
@@ -1167,6 +1200,7 @@ export async function unggahFotoMasuk(pos, kodeLomba, namaLomba, blob) {
   };
 
   if (K.mode === "dev") {
+    await simpanGudangDev(path, blob);
     const id = await rpc("catat_foto_masuk", argumen);
     return { id, path, ukuran: blob.size };
   }

--- a/tests/dev/bentuk_lomba_check.sh
+++ b/tests/dev/bentuk_lomba_check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ============================================================================
+# hrcd-rekap : tests/dev/bentuk_lomba_check.sh
+# Menguji PENJAGANYA, bukan databasenya — dari DUA arah.
+#
+# tests/dev/bentuk_lomba_produksi.sql lulus pada 1 September 2026, dan itu
+# tidak membuktikan apa pun sendirian: `select true` juga lulus. Yang perlu
+# dibuktikan arah keduanya — bahwa ia MENOLAK saat bentuk lombanya memang
+# salah. Tanpa itu penjaganya bisa jadi hijau selamanya sambil tidak memeriksa
+# apa-apa, persis kerusakan yang CLAUDE.md 13.3 dan 7.8 jelaskan panjang lebar.
+#
+# Kerusakannya disuntikkan DI DALAM TRANSAKSI lalu dibatalkan, jadi database
+# dev tidak berubah sedikit pun.
+#
+#   PSQL=/path/ke/psql PGPORT=5433 PGPASSWORD=... bash tests/dev/bentuk_lomba_check.sh
+# ============================================================================
+set -euo pipefail
+
+PSQL="${PSQL:-psql}"
+export PGHOST="${PGHOST:-127.0.0.1}" PGPORT="${PGPORT:-55432}" PGUSER="${PGUSER:-postgres}"
+DB="${PGDATABASE:-hrcd_dev}"
+cd "$(dirname "$0")/../.."
+
+lulus=0
+gagal=0
+
+# Kerusakan yang harus DITOLAK, satu per satu. Tiap baris: keterangan lalu SQL
+# yang merusaknya.
+uji_tolak() {
+  local nama="$1" rusak="$2"
+  if "$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q >/dev/null 2>&1 <<SQL
+begin;
+$rusak
+\i tests/dev/bentuk_lomba_produksi.sql
+rollback;
+SQL
+  then
+    echo "  GAGAL  $nama — penjaganya DIAM" >&2
+    gagal=$((gagal + 1))
+  else
+    echo "  ok     $nama ditolak"
+    lulus=$((lulus + 1))
+  fi
+}
+
+echo "bentuk_lomba_produksi.sql, dua arah:"
+
+# --- arah 1: database yang BENAR harus lulus -------------------------------
+if "$PSQL" -d "$DB" -v ON_ERROR_STOP=1 -q -f tests/dev/bentuk_lomba_produksi.sql >/dev/null 2>&1; then
+  echo "  ok     database dev apa adanya lulus"
+  lulus=$((lulus + 1))
+else
+  echo "  GAGAL  database dev apa adanya DITOLAK — jalankan tests/dev_database.sh" >&2
+  gagal=$((gagal + 1))
+fi
+
+# --- arah 2: tiap kerusakan harus ditolak ----------------------------------
+uji_tolak "KIM disatukan lagi jadi satu lomba" \
+  "update wahana set lomba = 'KIM' where edisi = edisi_aktif() and kode like 'kim%';"
+
+uji_tolak "Kim Lihat dan Kim Cium berbagi satu kunci foto" \
+  "update wahana set kode_lomba = 'kim' where edisi = edisi_aktif() and kode like 'kim%';"
+
+uji_tolak "satu kriteria Pembidaian hilang" \
+  "delete from nilai_mentah n using wahana w where w.id = n.wahana_id and w.kode = 'bidai_kerapihan';
+   delete from wahana where edisi = edisi_aktif() and kode = 'bidai_kerapihan';"
+
+uji_tolak "satu kriteria PBB hilang" \
+  "delete from nilai_mentah n using wahana w where w.id = n.wahana_id and w.kode like 'pbb_%' and w.kode = (select min(kode) from wahana where edisi = edisi_aktif() and kode like 'pbb_%');
+   delete from wahana where edisi = edisi_aktif() and kode = (select min(kode) from wahana where edisi = edisi_aktif() and kode like 'pbb_%');"
+
+uji_tolak "Yel-Yel kehilangan satu kriteria" \
+  "delete from nilai_mentah n using wahana w where w.id = n.wahana_id and w.kode = (select min(kode) from wahana where edisi = edisi_aktif() and kode like 'yel_%');
+   delete from wahana where edisi = edisi_aktif() and kode = (select min(kode) from wahana where edisi = edisi_aktif() and kode like 'yel_%');"
+
+echo
+if [ "$gagal" -gt 0 ]; then
+  echo "$gagal dari $((lulus + gagal)) pemeriksaan GAGAL." >&2
+  exit 1
+fi
+echo "SEMUA LULUS ($lulus pemeriksaan)."

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -441,6 +441,10 @@ run supabase/migrations/0167_putaran_foto.sql
 # lama dengan sengaja, jadi berkas ini satu-satunya tempat konfigurasi produksi
 # benar-benar disusun ulang — dan karena itu satu-satunya tempat bentuknya bisa
 # ditanyakan dengan jujur. Alasan lengkapnya di ujung tests/run.sh.
+#
+# PENJAGANYA SENDIRI DIUJI DUA ARAH oleh tests/dev/bentuk_lomba_check.sh: ia
+# menyuntikkan lima kerusakan di dalam transaksi lalu membatalkannya, dan
+# menuntut kelimanya DITOLAK. Tanpa arah kedua, `select true` juga lulus.
 run tests/dev/bentuk_lomba_produksi.sql
 
 echo "hrcd_dev siap — akun: admin.ciradyka / meja1hrcd37 / pos1hrcd37 (password bebas di dev)"

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -13,10 +13,14 @@
 # Siapkan db-nya sekali dengan: bash tests/dev_database.sh
 # ============================================================================
 
+import hashlib
 import json
 import http.server
 import os
+import struct
+import tempfile
 import urllib.parse
+import zlib
 
 import psycopg2
 import psycopg2.extras
@@ -39,6 +43,65 @@ DSN = " ".join([
 ])
 PORT = 8787
 
+# ============================================================================
+# GUDANG BERKAS TIRUAN — supaya FOTO bisa dibuka di laptop.
+#
+# Sampai 1 September 2026 tidak bisa: tautanFotoBanyak() mengembalikan peta
+# kosong begitu modenya "dev", jadi tidak satu pun foto pernah mendapat URL
+# dan SELURUH jalur gambar — menggeser, memutar, mengurutkan, menghapus —
+# tidak pernah berjalan sekali pun di luar produksi. Dua kali dalam satu hari
+# itu menghalangi perbaikan yang terpaksa dikirim tanpa pernah dilihat
+# layarnya (CLAUDE.md 17.2).
+#
+# Yang dibutuhkan sederhana: tempat menaruh byte dan cara mengambilnya lagi.
+# BUKAN di dalam repo — berkas uji tidak boleh mengotori pohon kerja — jadi di
+# direktori sementara milik sistem. Isinya boleh hilang kapan saja: barisnya
+# ada di database, dan yang kehilangan bytenya digantikan gambar contoh.
+# ============================================================================
+GUDANG = os.path.join(tempfile.gettempdir(), "hrcd-dev-storage")
+
+
+def _jalur_gudang(path):
+    """Path objek -> berkas di disk, dengan nama yang tidak bisa keluar dari
+    GUDANG. Memakai nama aslinya apa adanya akan mengizinkan '../..'."""
+    kunci = hashlib.sha256(path.encode()).hexdigest()
+    return os.path.join(GUDANG, kunci)
+
+
+def _png_contoh(path):
+    """Gambar pengganti untuk objek yang barisnya ada tapi bytenya tidak —
+    baris lama, atau database yang dibangun ulang sesudah gudangnya terhapus.
+
+    Bukan kotak kosong: warnanya diturunkan dari path, jadi dua foto berbeda
+    TERLIHAT berbeda dan urutannya bisa diperiksa dengan mata. Ada pita gelap
+    di seperempat atas supaya PUTARAN 90/180/270 ikut terlihat — gambar
+    simetris tidak bisa membuktikan apa pun soal putaran.
+
+    Tegak 3:4, sama seperti slip yang difoto panitia.
+
+    Byte-nya ditulis sebagai ANGKA, bukan escape: berkas ini pernah rusak
+    karena satu "backslash-x-nol-nol" berubah jadi byte nol sungguhan saat
+    disunting lewat perkakas, dan Python menolak berkas yang memuatnya dengan
+    galat yang tidak menyebut barisnya."""
+    w, h = 240, 320
+    n = int(hashlib.sha256(path.encode()).hexdigest()[:6], 16)
+    warna = bytes((120 + n % 100, 120 + (n >> 8) % 100, 120 + (n >> 16) % 100))
+    gelap = bytes((40, 40, 40))
+    saring = bytes((0,))          # filter "None" di awal tiap baris PNG
+    baris = [saring + (gelap if y < h // 4 else warna) * w for y in range(h)]
+    mentah = b"".join(baris)
+
+    def bagian(tipe, data):
+        c = tipe + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    tanda = bytes((137, 80, 78, 71, 13, 10, 26, 10))
+    return (tanda
+            + bagian(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+            + bagian(b"IDAT", zlib.compress(mentah))
+            + bagian(b"IEND", b""))
+
+
 # Argumen yang bertipe text[] di Postgres, bukan jsonb. Dipisah karena
 # keduanya sampai ke sini sebagai list JSON yang sama persis.
 # Argumen yang tujuannya ARRAY Postgres — apa pun jenis elemennya. Namanya
@@ -49,6 +112,28 @@ PORT = 8787
 # TIDAK PERNAH berhasil di laptop, dan tidak ada yang tahu karena jawabannya
 # cuma muncul sebagai notifikasi merah yang lewat.
 ARRAY_PG = {"p_anggota", "p_kloter"}
+
+# Cast eksplisit per nama argumen. Postgres TIDAK meng-coerce literal
+# bertipe bebas menjadi smallint/uuid/timestamptz saat memilih overload
+# fungsi, jadi tanpa cast panggilannya gagal dengan "function ... does not
+# exist" — kalimat yang terbaca seperti migrasi yang belum jalan, padahal
+# fungsinya ada.
+#
+# Daftar ini pernah tertinggal DUA KALI dalam satu hari: `p_kloter` membuat
+# "Simpan waktu cetak" tidak pernah berhasil di laptop, dan `p_putaran`
+# membuat tombol putar foto diam-diam mengembalikan sudutnya. Karena itu
+# sekarang ada _periksa_cast() di bawah, yang membandingkan daftar ini dengan
+# tanda tangan fungsi yang SUNGGUHAN ada di database setiap kali server
+# dinyalakan.
+CAST_ARG = {
+    "p_baris": "::jsonb", "p_nomor": "::jsonb", "p_pos": "::smallint",
+    "p_menit": "::smallint", "p_kloter": "::smallint",
+    "p_anggota_hadir": "::smallint", "p_jumlah": "::smallint",
+    "p_regu": "::uuid", "p_jam": "::timestamptz",
+    "p_jam_datang": "::timestamptz", "p_id": "::uuid",
+    "p_putaran": "::smallint", "p_sekolah": "::uuid", "p_foto_id": "::uuid",
+    "p_regu_id": "::uuid", "p_anggota": "::text[]",
+}
 
 # RPC yang boleh dipanggil layar, beserta urutan argumennya.
 RPC = {
@@ -112,19 +197,56 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json")
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
         self.end_headers()
         self.wfile.write(raw)
 
     def do_OPTIONS(self):
         self._kirim(204, {})
 
+    def do_DELETE(self):
+        """Hapus objek gudang. Berkas yang memang tidak ada bukan kegagalan —
+        yang diminta pemanggil adalah keadaan 'tidak ada lagi', dan itu sudah
+        tercapai."""
+        u = urllib.parse.urlparse(self.path)
+        if not u.path.startswith("/storage/"):
+            return self._kirim(404, {"message": "tidak ada"})
+        path = urllib.parse.unquote(u.path[len("/storage/"):])
+        try:
+            os.remove(_jalur_gudang(path))
+        except FileNotFoundError:
+            pass
+        return self._kirim(200, {"path": path})
+
     def _badan(self):
         n = int(self.headers.get("Content-Length") or 0)
         return json.loads(self.rfile.read(n) or b"{}")
 
+    def _kirim_gambar(self, isi, tipe="image/png"):
+        self.send_response(200)
+        self.send_header("Content-Type", tipe)
+        self.send_header("Content-Length", str(len(isi)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        # Tanpa ini browser memakai salinan lamanya sesudah foto diputar atau
+        # diganti, dan yang tergambar bukan yang baru saja disimpan.
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(isi)
+
     # ------------------------------------------------------------------ GET
     def do_GET(self):
+        # Berkas gudang dilayani SEBELUM rute JSON: ia bukan API, dan
+        # jawabannya bukan JSON.
+        if self.path.startswith("/storage/"):
+            path = urllib.parse.unquote(self.path[len("/storage/"):].split("?")[0])
+            berkas = _jalur_gudang(path)
+            if os.path.exists(berkas):
+                with open(berkas, "rb") as f:
+                    return self._kirim_gambar(f.read(), "image/jpeg")
+            # Barisnya ada tapi bytenya tidak. Gambar contoh, bukan 404: yang
+            # sedang diuji tata letak dan alurnya, dan kotak rusak menghentikan
+            # keduanya lebih awal daripada yang perlu.
+            return self._kirim_gambar(_png_contoh(path))
         u = urllib.parse.urlparse(self.path)
         p = dict(urllib.parse.parse_qsl(u.query))
         try:
@@ -373,6 +495,15 @@ class Handler(http.server.BaseHTTPRequestHandler):
     # ----------------------------------------------------------------- POST
     def do_POST(self):
         u = urllib.parse.urlparse(self.path)
+        # Unggahan gudang: bytenya mentah, bukan JSON, jadi ia ditangani
+        # sebelum _badan() dipanggil.
+        if u.path.startswith("/storage/"):
+            path = urllib.parse.unquote(u.path[len("/storage/"):])
+            n = int(self.headers.get("Content-Length") or 0)
+            os.makedirs(GUDANG, exist_ok=True)
+            with open(_jalur_gudang(path), "wb") as f:
+                f.write(self.rfile.read(n))
+            return self._kirim(200, {"path": path, "ukuran": n})
         try:
             if u.path == "/login":
                 b = self._badan()
@@ -499,11 +630,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     nilai.append(v)
                 # Postgres tidak meng-coerce integer->smallint saat memilih
                 # overload fungsi — cast eksplisit per jenis argumen.
-                CAST = {"p_baris": "::jsonb", "p_nomor": "::jsonb", "p_pos": "::smallint",
-                        "p_menit": "::smallint", "p_kloter": "::smallint",
-                        "p_anggota_hadir": "::smallint", "p_jumlah": "::smallint",
-                        "p_regu": "::uuid", "p_jam": "::timestamptz",
-                        "p_jam_datang": "::timestamptz", "p_id": "::uuid"}
+                CAST = dict(CAST_ARG)
                 if nama == "tandai_kloter_dicetak":
                     CAST = {**CAST, "p_kloter": "::smallint[]"}
                 tanda = ", ".join("%s" + CAST.get(k, "") for k in urutan)
@@ -524,6 +651,58 @@ class Handler(http.server.BaseHTTPRequestHandler):
         print(f"[dev] {self.address_string()} {fmt % args}")
 
 
+def _periksa_cast():
+    """Bandingkan CAST_ARG dengan tanda tangan fungsi yang SUNGGUHAN ada di
+    database, lalu berteriak kalau ada yang tertinggal.
+
+    Ini ada karena dua kerusakan yang bentuknya sama persis dan dua-duanya
+    diam: satu argumen smallint atau uuid tanpa cast membuat Postgres tidak
+    menemukan overload-nya, dan pesannya berbunyi "function ... does not
+    exist" — kalimat yang mengarahkan pembacanya ke migrasi, bukan ke berkas
+    ini. Yang satu membuat "Simpan waktu cetak" tidak pernah berhasil, yang
+    satu lagi membuat tombol putar foto mengembalikan sudutnya sendiri.
+
+    TIDAK mematikan server. Yang dicetak peringatan, karena database yang
+    belum lengkap migrasinya juga akan memicunya, dan menolak menyala di situ
+    menghalangi satu-satunya alat untuk membetulkannya."""
+    perlu = ("smallint", "uuid", "timestamp", "date", "interval", "jsonb", "[]")
+    try:
+        with psycopg2.connect(DSN) as conn, conn.cursor() as cur:
+            cur.execute(r"""
+                select p.proname, an.nama, at.tipe
+                from pg_proc p
+                join pg_namespace n on n.oid = p.pronamespace and n.nspname = 'public',
+                     lateral unnest(p.proargnames) with ordinality as an(nama, i),
+                     lateral unnest(string_to_array(
+                         pg_get_function_identity_arguments(p.oid), ', ')
+                     ) with ordinality as at(tipe, j)
+                where an.i = at.j and an.nama like 'p\_%'
+            """)
+            tipe = {}
+            for fungsi, nama, tanda in cur.fetchall():
+                tipe.setdefault(fungsi, {})[nama] = tanda
+    except Exception as e:                       # noqa: BLE001
+        print(f"  (cast tidak diperiksa: {e})", flush=True)
+        return
+
+    kurang = []
+    for fungsi, args in RPC.items():
+        for a in args:
+            t = tipe.get(fungsi, {}).get(a)
+            if t and any(k in t for k in perlu) and a not in CAST_ARG:
+                kurang.append(f"{fungsi}({a} {t.split(' ', 1)[-1]})")
+    if kurang:
+        print("  PERINGATAN: argumen RPC tanpa cast di CAST_ARG:", flush=True)
+        for k in sorted(kurang):
+            print(f"    {k}", flush=True)
+        print("  Panggilannya akan gagal dengan 'function ... does not exist'.",
+              flush=True)
+    else:
+        print(f"  cast RPC lengkap ({len(RPC)} fungsi diperiksa)", flush=True)
+
+
 if __name__ == "__main__":
     print(f"dev server hrcd-rekap -> http://127.0.0.1:{PORT}  (db hrcd_dev @ 55432)")
+    print(f"  gudang berkas: {GUDANG}")
+    _periksa_cast()
     http.server.ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -958,6 +958,28 @@ export const simpanKejuaraanTerjauh = (sekolahId) =>
 
 const BUCKET = "lembar";
 
+/* GUDANG BERKAS DEV. Dev server menyimpan byte-nya di direktori sementara dan
+   melayaninya kembali lewat /storage/<path> — lihat keterangan panjangnya di
+   tests/dev_server.py.
+
+   Sampai 1 September 2026 mode dev membuang gambarnya dan mengembalikan peta
+   tautan KOSONG, jadi tidak satu pun foto pernah tergambar di laptop dan
+   seluruh alur gambar — menggeser, memutar, mengurutkan, menghapus — tidak
+   pernah dijalankan sekali pun di luar produksi.
+
+   Ketiganya hanya berjalan saat `K.mode === "dev"`. Di produksi tidak ada
+   satu baris pun di bawah ini yang tersentuh. */
+const gudangDev = (path) => `${K.devUrl}/storage/${path.split("/").map(encodeURIComponent).join("/")}`;
+
+async function simpanGudangDev(path, blob) {
+  await fetch(gudangDev(path), { method: "POST", body: blob });
+}
+
+async function hapusGudangDev(path) {
+  try { await fetch(gudangDev(path), { method: "DELETE" }); }
+  catch { /* berkas yatim di direktori sementara tidak merugikan siapa pun */ }
+}
+
 /** Nama objek di bucket. Prefiks pertama WAJIB `pos<n>` — itulah yang dipagari
  *  policy storage.objects, dan RPC catat_foto_lembar menolak path yang tidak
  *  cocok dengan posnya. */
@@ -977,8 +999,11 @@ export async function unggahFotoLembar(pos, kodeLomba, namaLomba, nomorDada, blo
   const path = namaObjekFoto(pos, kodeLomba, nomorDada);
 
   if (K.mode === "dev") {
-    // Dev server tidak punya Storage. Barisnya tetap dicatat supaya alur
-    // layarnya bisa dicoba tanpa Supabase.
+    // Gambarnya DISIMPAN, bukan dibuang: tanpa byte-nya layar Cek Nilai dan
+    // dialog Foto Jawaban tidak menggambar apa pun, dan keduanya tidak bisa
+    // diperiksa di laptop. Urutannya sama dengan produksi — gambar dulu,
+    // baris sesudahnya — supaya yang diuji alur yang sama.
+    await simpanGudangDev(path, blob);
     await rpc("catat_foto_lembar", {
       p_nomor_dada: nomorDada, p_pos: pos, p_kode_lomba: kodeLomba,
       p_nama_lomba: namaLomba, p_path: path, p_ukuran: blob.size,
@@ -1051,7 +1076,8 @@ export async function fotoLembarPos(pos) {
  *  URL tetap — dan itu memang yang diinginkan: link yang tidak kedaluwarsa
  *  akan beredar di WhatsApp selamanya. Satu jam cukup untuk melihatnya. */
 export async function tautanFoto(path) {
-  if (K.mode === "dev") return null;
+  if (!path) return null;
+  if (K.mode === "dev") return gudangDev(path);
   await pastikanSesiSegar();
   const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}/${path}`, {
     method: "POST",
@@ -1072,7 +1098,10 @@ export async function tautanFoto(path) {
  *  sebabnya pemanggil lama harus membuka jendela kosong lebih dulu lalu
  *  mengisinya belakangan. */
 export async function tautanFotoBanyak(paths) {
-  if (K.mode === "dev" || !paths.length) return {};
+  if (!paths.length) return {};
+  if (K.mode === "dev") {
+    return Object.fromEntries(paths.map(p => [p, gudangDev(p)]));
+  }
   await pastikanSesiSegar();
   const j = await kirim(`${K.supabaseUrl}/storage/v1/object/sign/${BUCKET}`, {
     method: "POST",
@@ -1102,7 +1131,11 @@ export async function tautanFotoBanyak(paths) {
  *  gagal" padahal fotonya memang sudah hilang cuma membuatnya menekan lagi. */
 export async function hapusFotoLembar(id, alasan) {
   const path = await rpc("hapus_foto_lembar", { p_id: id, p_alasan: alasan });
-  if (K.mode === "dev") return path;
+  if (K.mode === "dev") {
+    // Urutannya sama dengan produksi di bawah: baris dulu, objek sesudahnya.
+    if (path) await hapusGudangDev(path);
+    return path;
+  }
   if (path) {
     try {
       await pastikanSesiSegar();
@@ -1167,6 +1200,7 @@ export async function unggahFotoMasuk(pos, kodeLomba, namaLomba, blob) {
   };
 
   if (K.mode === "dev") {
+    await simpanGudangDev(path, blob);
     const id = await rpc("catat_foto_masuk", argumen);
     return { id, path, ukuran: blob.size };
   }


### PR DESCRIPTION
## What

* The dev server keeps uploaded bytes in a temporary directory and serves them
  from `/storage/<path>`; `tautanFoto`/`tautanFotoBanyak` return those URLs in
  dev, and delete removes the object.
* `_periksa_cast()` compares the dev RPC cast table against the real function
  signatures at startup and names anything missing. Five gaps were filled:
  `p_putaran`, `p_sekolah`, `p_foto_id`, `p_regu_id`, `p_anggota`.
* `tests/dev/bentuk_lomba_check.sh` tests the lomba-shape guard from the
  rejecting direction.

## Why

`tautanFotoBanyak()` returned an empty map the moment the mode was "dev", so no
photo ever got a URL and the whole image path -- swipe, rotate, order, delete --
had never run once outside production. It blocked work twice in one day.

Opening that path immediately found the bug it was built to find: the rotate
button silently reverted, because `p_putaran` is smallint and had no cast, so
Postgres answered "function ... does not exist". That is the same failure
`p_kloter` caused earlier today, which is why the table is no longer trusted to
be complete by hand.

Without a rejecting direction, `select true` passes the shape guard too
(CLAUDE.md 7.8).

## Notes

Nothing lands in the repo -- the store is under the system temp directory. It
may be wiped at any time: rows live in the database, and an object whose bytes
are gone is answered with a generated placeholder rather than a 404, so the
screen still renders. The placeholder's colour comes from the path and it
carries a dark band across the top quarter, so two photos look different and a
rotation is visible.

Every change is inside a `K.mode === "dev"` branch; production touches none of
it.

Verified end to end against `hrcd_dev` through the app's own `api.js`: two
photos uploaded, served as real JPEG bytes, drawn on Cek Nilai in upload order,
counter reading 1/2 with the left arrow disabled and the right one live, and
rotate moving 0 to 90 and staying there. The shape guard rejects all five
injected breakages and the startup check was confirmed to warn when an entry is
removed.

Local: 377/377 JS tests, `tests/dev/bentuk_lomba_check.sh` 6/6.