### PR TITLE
fix: Data Peserta cards read like Meja Pembayaran on a phone

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=39">
+  <link rel="stylesheet" href="style.css?v=40">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3406,6 +3406,72 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
 
+  /* ---------- KARTU HP DATA PESERTA ----------
+
+     BENTUKNYA MENIRU MEJA PEMBAYARAN, dan itu keputusan sadar: dua layar yang
+     menampilkan daftar pendaftaran yang sama tidak boleh menuntut dibaca
+     dengan dua cara. Kode pembayaran di kiri, sekolah di kanan, lalu satu
+     baris keterangan, lalu isian.
+
+     YANG DIBUANG LABEL KOLOMNYA. Kartu ini sebelumnya menuliskan "Tanggal:",
+     "Kode Bayar:", "Asal Sekolah:", "Regu:", "Contact Person:" dan
+     "WhatsApp:" — enam label untuk enam nilai, dan di layar 430px keenamnya
+     memakan lebih banyak tempat daripada nilai yang mereka namai. Satu kartu
+     jadi setinggi separuh layar, dan tiga kartu tidak muat sekaligus di layar
+     yang seluruh gunanya MEMBANDINGKAN pendaftaran.
+
+     Tanpa label pun kartunya tidak kabur, dengan alasan yang sama seperti
+     Meja Pembayaran: kode pembayaran bentuknya khas (huruf mesin ketik,
+     selalu diawali HRCD), sekolah satu-satunya nama tebal, tombol regu
+     menyebut satuannya sendiri, dan kedua kotak isian sudah menyebut dirinya
+     lewat contoh isian ("misal: Bu Rina", "misal: 08123456789") — yang satu
+     jelas nama orang, yang satu jelas nomor.
+
+     Tanggalnya DIREDUPKAN, bukan dibuang: ia satu-satunya yang menjawab
+     "pendaftaran ini masuk kapan" saat dua sekolah senama berdampingan, tapi
+     ia tidak pernah jadi alasan orang membuka layar ini. */
+  .data-table.table-peserta tbody tr[data-baris] > td[data-label]::before { content: none; }
+  .table-peserta tbody tr[data-baris] {
+    display: grid;
+    /* Kolom pertama DIPATOK, tidak `max-content` seperti Meja Pembayaran.
+       Bedanya karena kartu ini memuat KOTAK ISIAN, dan lebar bawaan sebuah
+       <input> ikut menentukan `max-content` kolomnya: terukur di 430px
+       kolomnya melar jadi 252px dan sisa kartunya tinggal 69px — nama sekolah,
+       tanggal, dan nomor WA semuanya terjepit. 9rem cukup untuk kode
+       pembayaran (terukur 118px) dan tidak bergantung pada isi sel mana pun. */
+    grid-template-columns: minmax(0, 9rem) minmax(0, 1fr);
+    gap: .25rem .7rem;
+    align-items: center;
+  }
+  /* Nomor garis ditulis EKSPLISIT, sama seperti Meja Pembayaran — bentuk `-1`
+     di sana membuat isinya balik ke kolom pertama dan bertumpuk. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
+  /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
+     lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
+     sejajar dengan apa pun di atas maupun di bawahnya. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"] { text-align: left; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"] {
+    font-size: .8rem; color: var(--tinta-lembut);
+  }
+  /* Kotak isian MENGISI selnya. Aturan kembarnya sudah ada, tapi terkurung di
+     blok `min-width: 901px` — jadi di rentang kartu kotaknya memakai lebar
+     bawaan <input> (~180px), meluap keluar selnya yang 118px, dan menimpa
+     kolom sebelahnya. Terukur di 430px sebelum baris ini ada. */
+  .table-peserta tbody tr[data-baris] .small-input {
+    width: 100%; min-width: 0;
+    /* RATA KIRI dua-duanya. `.small-input` menengahkan isinya karena kelas itu
+       lahir untuk kotak ANGKA di dalam tabel nilai; nomor WA yang mengambang
+       di tengah kotak selebar 173px tidak sejajar dengan satu pun tepi lain di
+       kartu ini, dan tepi kiri yang lurus dari atas ke bawah adalah seluruh
+       alasan bentuk kartu ini ditiru dari Meja Pembayaran. */
+    text-align: left;
+  }
+
   /* KARTU LEBAR (640px ke atas, tapi masih kartu): semuanya SATU BARIS, dan
      hanya tombolnya turun.
 

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 39, sidik: "103f2013fab3" },
+  "style.css": { versi: 40, sidik: "09a9bd28e8f9" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=37">
+  <link rel="stylesheet" href="style.css?v=38">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -3406,6 +3406,72 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   .table-bayar tbody tr[data-baris] > td:last-child { grid-area: 3 / 1 / auto / 4; }
 
+  /* ---------- KARTU HP DATA PESERTA ----------
+
+     BENTUKNYA MENIRU MEJA PEMBAYARAN, dan itu keputusan sadar: dua layar yang
+     menampilkan daftar pendaftaran yang sama tidak boleh menuntut dibaca
+     dengan dua cara. Kode pembayaran di kiri, sekolah di kanan, lalu satu
+     baris keterangan, lalu isian.
+
+     YANG DIBUANG LABEL KOLOMNYA. Kartu ini sebelumnya menuliskan "Tanggal:",
+     "Kode Bayar:", "Asal Sekolah:", "Regu:", "Contact Person:" dan
+     "WhatsApp:" — enam label untuk enam nilai, dan di layar 430px keenamnya
+     memakan lebih banyak tempat daripada nilai yang mereka namai. Satu kartu
+     jadi setinggi separuh layar, dan tiga kartu tidak muat sekaligus di layar
+     yang seluruh gunanya MEMBANDINGKAN pendaftaran.
+
+     Tanpa label pun kartunya tidak kabur, dengan alasan yang sama seperti
+     Meja Pembayaran: kode pembayaran bentuknya khas (huruf mesin ketik,
+     selalu diawali HRCD), sekolah satu-satunya nama tebal, tombol regu
+     menyebut satuannya sendiri, dan kedua kotak isian sudah menyebut dirinya
+     lewat contoh isian ("misal: Bu Rina", "misal: 08123456789") — yang satu
+     jelas nama orang, yang satu jelas nomor.
+
+     Tanggalnya DIREDUPKAN, bukan dibuang: ia satu-satunya yang menjawab
+     "pendaftaran ini masuk kapan" saat dua sekolah senama berdampingan, tapi
+     ia tidak pernah jadi alasan orang membuka layar ini. */
+  .data-table.table-peserta tbody tr[data-baris] > td[data-label]::before { content: none; }
+  .table-peserta tbody tr[data-baris] {
+    display: grid;
+    /* Kolom pertama DIPATOK, tidak `max-content` seperti Meja Pembayaran.
+       Bedanya karena kartu ini memuat KOTAK ISIAN, dan lebar bawaan sebuah
+       <input> ikut menentukan `max-content` kolomnya: terukur di 430px
+       kolomnya melar jadi 252px dan sisa kartunya tinggal 69px — nama sekolah,
+       tanggal, dan nomor WA semuanya terjepit. 9rem cukup untuk kode
+       pembayaran (terukur 118px) dan tidak bergantung pada isi sel mana pun. */
+    grid-template-columns: minmax(0, 9rem) minmax(0, 1fr);
+    gap: .25rem .7rem;
+    align-items: center;
+  }
+  /* Nomor garis ditulis EKSPLISIT, sama seperti Meja Pembayaran — bentuk `-1`
+     di sana membuat isinya balik ke kolom pertama dan bertumpuk. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
+  /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
+     lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
+     sejajar dengan apa pun di atas maupun di bawahnya. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"] { text-align: left; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"] {
+    font-size: .8rem; color: var(--tinta-lembut);
+  }
+  /* Kotak isian MENGISI selnya. Aturan kembarnya sudah ada, tapi terkurung di
+     blok `min-width: 901px` — jadi di rentang kartu kotaknya memakai lebar
+     bawaan <input> (~180px), meluap keluar selnya yang 118px, dan menimpa
+     kolom sebelahnya. Terukur di 430px sebelum baris ini ada. */
+  .table-peserta tbody tr[data-baris] .small-input {
+    width: 100%; min-width: 0;
+    /* RATA KIRI dua-duanya. `.small-input` menengahkan isinya karena kelas itu
+       lahir untuk kotak ANGKA di dalam tabel nilai; nomor WA yang mengambang
+       di tengah kotak selebar 173px tidak sejajar dengan satu pun tepi lain di
+       kartu ini, dan tepi kiri yang lurus dari atas ke bawah adalah seluruh
+       alasan bentuk kartu ini ditiru dari Meja Pembayaran. */
+    text-align: left;
+  }
+
   /* KARTU LEBAR (640px ke atas, tapi masih kartu): semuanya SATU BARIS, dan
      hanya tombolnya turun.
 


### PR DESCRIPTION
## What

The phone card for Data Peserta drops its per-value labels and takes the shape
Meja Pembayaran already uses: payment code left, school right, then `▸ N regu`
with the date, then the two contact fields side by side. Both fields are left
aligned.

## Why

Six labels for six values, and at 430px they took more room than the values
they named. One card ran half the screen and barely more than one fitted at a
time, on a screen whose whole purpose is comparing registrations. Four now fit.

Dropping the labels costs nothing for the same reason it costs nothing on Meja
Pembayaran: the payment code has a shape of its own, the school is the only
bold name, the regu button says its own unit, and both boxes announce
themselves through their example text.

## Notes

The first column is pinned at 9rem rather than `max-content`, and that is the
one difference from Meja Pembayaran worth knowing: this card holds inputs, and
an input's default width feeds the max-content of its track. Measured at 430px
the column blew out to 252px and left 69px for the school, the date and the
phone number.

`.small-input` centres its content because the class was born for number boxes
inside a scoring table; a phone number floating in the middle of a 173px box
lines up with nothing.

Measured against `hrcd_dev` at 390px, 430px and 700px: three rows, no labels
left, nothing crossing the card edge, no horizontal scroll, four cards visible
in a 900px viewport at every width.

Local: 377/377 JS tests. `style.css` synced to `live/`, both `?v=` raised with
the fingerprint.