### PR TITLE
fix: the date sits above the payment code on Data Peserta cards

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=40">
+  <link rel="stylesheet" href="style.css?v=41">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3445,18 +3445,28 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   /* Nomor garis ditulis EKSPLISIT, sama seperti Meja Pembayaran — bentuk `-1`
      di sana membuat isinya balik ke kolom pertama dan bertumpuk. */
-  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
+  /* TANGGAL DI ATAS KODE BAYAR, dan regunya pindah ke bawah nama sekolah.
+     Susunannya tetap TIGA baris — menaruh tanggal di barisnya sendiri
+     selebar kartu akan menambah baris keempat dan mengembalikan tinggi yang
+     baru saja dihemat. Pasangan kanannya terbaca wajar: sekolah, lalu berapa
+     regu yang ia kirim. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 1 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 2 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 2; }
   .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
   /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
      lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
      sejajar dengan apa pun di atas maupun di bawahnya. */
   .table-peserta tbody tr[data-baris] > td[data-label="Regu"] { text-align: left; }
+  /* TIPIS: kecil, tidak tebal, dan warnanya lembut. Ia berdiri tepat di atas
+     kode pembayaran yang tebal dan berhuruf mesin ketik — kalau bobotnya
+     sepadan, keduanya berebut jadi baris pertama yang dibaca, padahal yang
+     dicari orang di layar ini kodenya. */
   .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"] {
-    font-size: .8rem; color: var(--tinta-lembut);
+    font-size: .72rem; font-weight: 400; color: var(--tinta-lembut);
+    line-height: 1.2;
   }
   /* Kotak isian MENGISI selnya. Aturan kembarnya sudah ada, tapi terkurung di
      blok `min-width: 901px` — jadi di rentang kartu kotaknya memakai lebar

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 40, sidik: "09a9bd28e8f9" },
+  "style.css": { versi: 41, sidik: "81c33421e833" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=38">
+  <link rel="stylesheet" href="style.css?v=39">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -3445,18 +3445,28 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   /* Nomor garis ditulis EKSPLISIT, sama seperti Meja Pembayaran — bentuk `-1`
      di sana membuat isinya balik ke kolom pertama dan bertumpuk. */
-  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
+  /* TANGGAL DI ATAS KODE BAYAR, dan regunya pindah ke bawah nama sekolah.
+     Susunannya tetap TIGA baris — menaruh tanggal di barisnya sendiri
+     selebar kartu akan menambah baris keempat dan mengembalikan tinggi yang
+     baru saja dihemat. Pasangan kanannya terbaca wajar: sekolah, lalu berapa
+     regu yang ia kirim. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 1 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 2 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 2; }
   .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
   /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
      lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
      sejajar dengan apa pun di atas maupun di bawahnya. */
   .table-peserta tbody tr[data-baris] > td[data-label="Regu"] { text-align: left; }
+  /* TIPIS: kecil, tidak tebal, dan warnanya lembut. Ia berdiri tepat di atas
+     kode pembayaran yang tebal dan berhuruf mesin ketik — kalau bobotnya
+     sepadan, keduanya berebut jadi baris pertama yang dibaca, padahal yang
+     dicari orang di layar ini kodenya. */
   .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"] {
-    font-size: .8rem; color: var(--tinta-lembut);
+    font-size: .72rem; font-weight: 400; color: var(--tinta-lembut);
+    line-height: 1.2;
   }
   /* Kotak isian MENGISI selnya. Aturan kembarnya sudah ada, tapi terkurung di
      blok `min-width: 901px` — jadi di rentang kartu kotaknya memakai lebar


### PR DESCRIPTION
## What

On the Data Peserta phone card the date moves above the payment code and gets
lighter; the regu count moves under the school.

## Why

Asked for directly. Keeping it inside three rows is the part worth explaining:
a full-width row of its own would add a fourth and hand back the height the
card had just saved. The regu count under the school reads as what it is --
the school, then how many regu it sent.

Thin means all three at once: .72rem, weight 400, soft ink. The code beneath is
16.8px, bold, typewriter; matching weights would have the two compete to be the
first line read, and the code is what people come here looking for.

## Notes

Measured against `hrcd_dev` at 390px and 430px: date above the code at 11.52px
weight 400, card 154px (five shorter than before), nothing crossing the card
edge, no horizontal scroll, four cards in a 900px viewport.

Local: 377/377 JS tests. `style.css` synced to `live/`, both `?v=` raised with
the fingerprint.