### PR TITLE
fix: no date on Data Peserta phone cards

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=41">
+  <link rel="stylesheet" href="style.css?v=42">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3445,29 +3445,25 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   /* Nomor garis ditulis EKSPLISIT, sama seperti Meja Pembayaran — bentuk `-1`
      di sana membuat isinya balik ke kolom pertama dan bertumpuk. */
-  /* TANGGAL DI ATAS KODE BAYAR, dan regunya pindah ke bawah nama sekolah.
-     Susunannya tetap TIGA baris — menaruh tanggal di barisnya sendiri
-     selebar kartu akan menambah baris keempat dan mengembalikan tinggi yang
-     baru saja dihemat. Pasangan kanannya terbaca wajar: sekolah, lalu berapa
-     regu yang ia kirim. */
-  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 1 / 1; }
+  /* TANGGAL TIDAK DIGAMBAR SAMA SEKALI DI KARTU HP.
+     Ia sempat diletakkan di atas kode bayar dan diredupkan, dan itu masih
+     terlalu banyak: satu pendaftaran dicari lewat kodenya atau sekolahnya,
+     tidak pernah lewat jamnya, dan di layar 430px tiap baris yang tidak
+     dicari siapa pun mengambil satu kartu dari yang muat sekaligus.
+
+     Tabel di layar lebar TETAP memuatnya — di sana ia tidak menghalangi
+     apa pun, dan pertanyaan "pendaftaran ini masuk kapan" memang ditanyakan
+     sesekali, dari laptop. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { display: none; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 2 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
   /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
      lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
      sejajar dengan apa pun di atas maupun di bawahnya. */
   .table-peserta tbody tr[data-baris] > td[data-label="Regu"] { text-align: left; }
-  /* TIPIS: kecil, tidak tebal, dan warnanya lembut. Ia berdiri tepat di atas
-     kode pembayaran yang tebal dan berhuruf mesin ketik — kalau bobotnya
-     sepadan, keduanya berebut jadi baris pertama yang dibaca, padahal yang
-     dicari orang di layar ini kodenya. */
-  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"] {
-    font-size: .72rem; font-weight: 400; color: var(--tinta-lembut);
-    line-height: 1.2;
-  }
   /* Kotak isian MENGISI selnya. Aturan kembarnya sudah ada, tapi terkurung di
      blok `min-width: 901px` — jadi di rentang kartu kotaknya memakai lebar
      bawaan <input> (~180px), meluap keluar selnya yang 118px, dan menimpa

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 41, sidik: "81c33421e833" },
+  "style.css": { versi: 42, sidik: "a232cadb61db" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=39">
+  <link rel="stylesheet" href="style.css?v=40">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -3445,29 +3445,25 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   /* Nomor garis ditulis EKSPLISIT, sama seperti Meja Pembayaran — bentuk `-1`
      di sana membuat isinya balik ke kolom pertama dan bertumpuk. */
-  /* TANGGAL DI ATAS KODE BAYAR, dan regunya pindah ke bawah nama sekolah.
-     Susunannya tetap TIGA baris — menaruh tanggal di barisnya sendiri
-     selebar kartu akan menambah baris keempat dan mengembalikan tinggi yang
-     baru saja dihemat. Pasangan kanannya terbaca wajar: sekolah, lalu berapa
-     regu yang ia kirim. */
-  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { grid-area: 1 / 1; }
+  /* TANGGAL TIDAK DIGAMBAR SAMA SEKALI DI KARTU HP.
+     Ia sempat diletakkan di atas kode bayar dan diredupkan, dan itu masih
+     terlalu banyak: satu pendaftaran dicari lewat kodenya atau sekolahnya,
+     tidak pernah lewat jamnya, dan di layar 430px tiap baris yang tidak
+     dicari siapa pun mengambil satu kartu dari yang muat sekaligus.
+
+     Tabel di layar lebar TETAP memuatnya — di sana ia tidak menghalangi
+     apa pun, dan pertanyaan "pendaftaran ini masuk kapan" memang ditanyakan
+     sesekali, dari laptop. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { display: none; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 2 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
   /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
      lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
      sejajar dengan apa pun di atas maupun di bawahnya. */
   .table-peserta tbody tr[data-baris] > td[data-label="Regu"] { text-align: left; }
-  /* TIPIS: kecil, tidak tebal, dan warnanya lembut. Ia berdiri tepat di atas
-     kode pembayaran yang tebal dan berhuruf mesin ketik — kalau bobotnya
-     sepadan, keduanya berebut jadi baris pertama yang dibaca, padahal yang
-     dicari orang di layar ini kodenya. */
-  .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"] {
-    font-size: .72rem; font-weight: 400; color: var(--tinta-lembut);
-    line-height: 1.2;
-  }
   /* Kotak isian MENGISI selnya. Aturan kembarnya sudah ada, tapi terkurung di
      blok `min-width: 901px` — jadi di rentang kartu kotaknya memakai lebar
      bawaan <input> (~180px), meluap keluar selnya yang 118px, dan menimpa


### PR DESCRIPTION
## What

The date cell is `display: none` in the card range. The wide table keeps it.

## Why

It was moved above the payment code and dimmed an hour ago, and that was still
too much. A registration is found by its code or its school, never by its
timestamp, and at 430px every line nobody looks for costs one of the cards that
fit at once.

On a laptop it blocks nothing, and "when did this one come in" does get asked
occasionally.

## Notes

The card is back to code and school, regu, then the two fields; four still fit
in a 900px viewport.

Verified against `hrcd_dev`: the cell is `display: none` at 430px and drawn
again at 1200px with its value intact, nothing crosses the card edge, no
horizontal scroll.

Local: 377/377 JS tests. `style.css` synced to `live/`, both `?v=` raised with
the fingerprint.