### PR TITLE
fix: Menaksir asks for "Hasil Taksir", not "Selisih Taksir"

### DIFF
--- a/supabase/migrations/0168_judul_isian_menaksir.sql
+++ b/supabase/migrations/0168_judul_isian_menaksir.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- hrcd-rekap : 0168_judul_isian_menaksir.sql
+--
+-- Judul kotak isian Menaksir jadi "Hasil Taksir". Yang diketik memang bukan
+-- selisih lagi.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA JUDULNYA TERTINGGAL
+--
+-- 0039 memasang "Selisih Taksir" waktu petugas memang mengetik SELISIH
+-- taksiran regu terhadap jarak sebenarnya. 0085 membalik aturannya — yang
+-- diketik ANGKA YANG DITULIS PESERTA apa adanya, dan mesin skor yang
+-- menghitung selisihnya terhadap `wahana.jawaban_benar` — lalu 0086
+-- memindahkan satuannya ke sentimeter. Keduanya membetulkan `petunjuk`,
+-- `tingkat`, `rentang_mentah_maks` dan `satuan`; tidak satu pun menyentuh
+-- `judul_isian`.
+--
+-- Jadi sejak 0085 layar Input Nilai Pos menuliskan "Selisih Taksir" di atas
+-- kotak yang menunggu HASIL taksir. Blangko kertasnya sudah benar — lembar
+-- Menaksir mencetak "Hasil Taksir" dari cabang khususnya sendiri di app.js —
+-- sehingga kertas dan layar menyuruh dua hal yang berbeda untuk satu kotak
+-- yang sama.
+--
+-- Kerusakannya persis yang ditakutkan 0039, cuma terbalik arahnya: petugas
+-- yang menurut judul mengetik selisih 1 untuk taksiran 7,55 m mengirim
+-- nilai mentah 1 cm, dan tangganya membaca |1 - 855| = 854 cm — nol poin.
+-- Tidak ada galat, tidak ada rentang yang dilanggar, dan yang terlihat cuma
+-- satu lomba yang seluruh pesertanya kebetulan buruk.
+--
+-- ---------------------------------------------------------------------------
+-- PETUNJUKNYA IKUT DITEGASKAN
+--
+-- `petunjuk` — baris kecil di bawah judul — sudah dibetulkan 0085 jadi
+-- "(meter)". Ia ditulis ulang di sini dengan nilai yang sama, bukan karena
+-- diragukan, melainkan karena judul dan petunjuk adalah SATU kalimat di layar
+-- dan di kertas: "Selisih Taksir / (selisih meter)" salah dua kali, dan
+-- membetulkan separuhnya meninggalkan kata "selisih" tepat di bawah judul yang
+-- baru. Nilainya sama dengan yang dipasang 0085, jadi di produksi baris ini
+-- tidak mengubah apa pun; yang dijaganya database mana pun yang urutan
+-- konfigurasinya berbeda — database dev, misalnya, menjalankan ulang 0038
+-- sesudah 0085 dan sampai hari ini masih berbunyi "(selisih meter)".
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA DIISI, BUKAN DIKOSONGKAN
+--
+-- Dikosongkan pun layar akan menurunkan "Hasil taksir" sendiri dari
+-- `satuan = 'meter'` (judulIsian() di app.js). Tapi cadangan itu berlaku untuk
+-- SETIAP komponen bersatuan meter yang mungkin dibuat panitia tahun depan,
+-- dan 0039 sudah menulis kenapa bentuk `bertingkat` membawa judulnya sendiri:
+-- angkanya bisa berarti apa saja, dan yang tahu artinya cuma yang mengatur
+-- komponennya.
+-- ============================================================================
+
+do $blok$
+declare
+  v_baris integer;
+  v_edisi smallint := edisi_aktif();
+begin
+  update wahana set judul_isian = 'Hasil Taksir',
+                    petunjuk    = '(meter)'
+  where edisi = v_edisi and kode = 'menaksir';
+
+  get diagnostics v_baris = row_count;
+
+  -- Dilaporkan, bukan diandaikan: di database uji konfigurasi XXXVII belum
+  -- terpasang, baris `menaksir` memang tidak ada, dan UPDATE ini tidak
+  -- mengenai apa pun. Itu keadaan yang sah (pelajaran 0035).
+  if v_baris = 0 then
+    raise notice '0168: komponen `menaksir` tidak ada di edisi % — dilewati.', v_edisi;
+  else
+    raise notice '0168: judul isian Menaksir jadi "Hasil Taksir", petunjuk "(meter)".';
+  end if;
+end;
+$blok$;

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -119,7 +119,7 @@ ULANG="0032_konfigurasi_xxxvii 0033_nama_pos_xxxvii 0034_nama_pos_final
        0038_petunjuk_menaksir 0039_judul_isian 0054_kolom_lomba
        0076_bidai_dan_lomba_soal 0087_kim_dua_lomba 0091_intern_golongan
        0093_configure_fifo_capacity 0105_expand_kloter_capacity
-       0118_jeda_kloter_maksimal"
+       0118_jeda_kloter_maksimal 0168_judul_isian_menaksir"
 
 # Yang dilewati WAJIB dijalankan lagi di suatu tempat. Kalau tidak, ia tidak
 # dijalankan sama sekali — kerusakan yang sama dengan berhenti di 0011, dan
@@ -282,6 +282,11 @@ run supabase/migrations/0024_komponen_pos.sql
 #     Urutannya sesudah 0093 dan sebelum 0118, sama dengan nomornya di
 #     tests/run.sh: 0093 membuat 60, 0105 menaikkannya jadi 75, lalu
 #     assert 0118 memeriksa sebaran jamnya atas jumlah yang benar.
+#   * 0168 harus SESUDAH 0039, dan itu satu-satunya alasan ia ada di daftar
+#     ini. 0039 memasang judul isian Menaksir "Selisih Taksir" dan 0168
+#     menggantinya dengan "Hasil Taksir"; di glob urutannya benar, tapi 0039
+#     dijalankan ULANG sesudah seed, jadi tanpa baris ini dev memasang
+#     kembali judul yang sudah diganti produksi — persis jebakan KIM di atas.
 for m in $ULANG; do
   run "supabase/migrations/$m.sql"
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -729,6 +729,11 @@ run supabase/migrations/0166_gembok_per_lomba.sql
 run tests/sql/118_gembok_per_lomba.sql
 run supabase/migrations/0167_putaran_foto.sql
 run tests/sql/119_putaran_foto.sql
+# 0168 mengubah satu baris konfigurasi (`wahana.judul_isian` Menaksir). Di
+# database uji `menaksir` tidak ada, jadi UPDATE-nya melapor dilewati — sama
+# seperti 0035, 0038 dan 0039 di atas. Yang menjalankannya dengan konfigurasi
+# produksi tests/dev_database.sh.
+run supabase/migrations/0168_judul_isian_menaksir.sql
 
 # tests/sql/bentuk_lomba_produksi.sql SENGAJA TIDAK DIJALANKAN DI SINI, dan itu
 # perlu disebut karena CLAUDE.md 7.5 melatih pembaca mengharapkan sebaliknya.


### PR DESCRIPTION
## What

Migration `0168` sets the Menaksir component's `judul_isian` to
**Hasil Taksir** and restates its `petunjuk` as **(meter)**.

Added to `tests/run.sh` (reports "dilewati" there — the test database has no
`menaksir` row) and to the `ULANG` list in `tests/dev_database.sh`, after
`0039`, so the dev database stops reinstalling the old title.

## Why

`0039` named the box "Selisih Taksir" when the officer typed the difference
between the regu's estimate and the real distance. `0085` reversed that: what
is typed now is the participant's own number, and the scoring engine computes
`abs(nilai_1 - jawaban_benar)`. It fixed `petunjuk`, `tingkat`, `satuan` and
the raw range — but not `judul_isian`.

So the paper blangko printed "Hasil Taksir" while the screen asked for
"Selisih Taksir", for the same box. An officer following the screen types 1
for an estimate of 7,55 m, the ladder reads |1 − 855| cm, and the regu gets
zero with no error anywhere.

## Notes

Verified locally: `tests/run.sh` green on PostgreSQL 17.11, and the Input
Nilai Pos v2 screen for Menaksir rendered against `hrcd_dev` reads
"Hasil Taksir / (meter)".