### PR TITLE
fix: criteria boxes sit side by side when there is room

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=42">
+  <link rel="stylesheet" href="style.css?v=43">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4877,7 +4877,36 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* ---------- kotak isian kriteria ---------- */
 
-.isian-lomba { display: flex; flex-direction: column; gap: .5rem; margin-top: .7rem; }
+/* SATU KOLOM DI HP SEMPIT, MENYAMPING BEGITU ADA TEMPAT.
+
+   Pembidaian punya lima kriteria. Ditumpuk lurus ke bawah kelimanya setinggi
+   596px — lebih tinggi daripada ruang yang tersisa di HP sesudah kepala layar
+   dan kartu regu, jadi kotak terakhir dan tombol SIMPAN tidak pernah terlihat
+   bersamaan, dan petugas menggulir bolak-balik di antara keduanya.
+
+   `minmax(9.5rem, 1fr)` DIUKUR, bukan ditaksir (bagian 15.9 dan 15.11).
+   9.5rem = 152px, dan yang menentukan angkanya BUKAN nama kriteria yang
+   panjang — nama boleh membungkus — melainkan isi terlebar yang bisa masuk
+   satu kotak: sepasang kotak benar/salah 4rem berjarak .3rem, plus padding
+   .5rem di dua sisi, = 149px. Di bawah itu isinya meluap keluar kotaknya,
+   karena track yang sudah dipatok `1fr` tidak melar mengikuti isinya.
+
+   Terukur di browser atas markup Pembidaian sungguhan, lebar 320-1200px:
+
+     320-360px   1 kolom   596px
+     390-430px   2 kolom   400px
+     560-600px   3 kolom   264px
+     700-760px   4 kolom   264px
+     >= 900px    5 kolom   128px
+
+   Tidak ada penggulir mendatar dan tidak ada isi yang meluap di satu lebar
+   pun — termasuk pada dua bentuk isian yang tidak dipakai edisi ini tetapi
+   CSS-nya masih hidup: pasangan benar/salah dan kotak centang. */
+.isian-lomba {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  gap: .5rem; margin-top: .7rem;
+}
 /* DITUMPUK DAN DI TENGAH, bukan nama di kiri dan kotak di kanan.
 
    Sejajar dengan judul lombanya yang juga di tengah, dan itu yang membuat

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 42, sidik: "a232cadb61db" },
+  "style.css": { versi: 43, sidik: "cbe5c0c68e69" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=40">
+  <link rel="stylesheet" href="style.css?v=41">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -4877,7 +4877,36 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* ---------- kotak isian kriteria ---------- */
 
-.isian-lomba { display: flex; flex-direction: column; gap: .5rem; margin-top: .7rem; }
+/* SATU KOLOM DI HP SEMPIT, MENYAMPING BEGITU ADA TEMPAT.
+
+   Pembidaian punya lima kriteria. Ditumpuk lurus ke bawah kelimanya setinggi
+   596px — lebih tinggi daripada ruang yang tersisa di HP sesudah kepala layar
+   dan kartu regu, jadi kotak terakhir dan tombol SIMPAN tidak pernah terlihat
+   bersamaan, dan petugas menggulir bolak-balik di antara keduanya.
+
+   `minmax(9.5rem, 1fr)` DIUKUR, bukan ditaksir (bagian 15.9 dan 15.11).
+   9.5rem = 152px, dan yang menentukan angkanya BUKAN nama kriteria yang
+   panjang — nama boleh membungkus — melainkan isi terlebar yang bisa masuk
+   satu kotak: sepasang kotak benar/salah 4rem berjarak .3rem, plus padding
+   .5rem di dua sisi, = 149px. Di bawah itu isinya meluap keluar kotaknya,
+   karena track yang sudah dipatok `1fr` tidak melar mengikuti isinya.
+
+   Terukur di browser atas markup Pembidaian sungguhan, lebar 320-1200px:
+
+     320-360px   1 kolom   596px
+     390-430px   2 kolom   400px
+     560-600px   3 kolom   264px
+     700-760px   4 kolom   264px
+     >= 900px    5 kolom   128px
+
+   Tidak ada penggulir mendatar dan tidak ada isi yang meluap di satu lebar
+   pun — termasuk pada dua bentuk isian yang tidak dipakai edisi ini tetapi
+   CSS-nya masih hidup: pasangan benar/salah dan kotak centang. */
+.isian-lomba {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  gap: .5rem; margin-top: .7rem;
+}
 /* DITUMPUK DAN DI TENGAH, bukan nama di kiri dan kotak di kanan.
 
    Sejajar dengan judul lombanya yang juga di tengah, dan itu yang membuat


### PR DESCRIPTION
## What

`.isian-lomba` in Input Nilai Pos v2 becomes
`grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr))` instead of a
flex column.

Measured in the browser over the real Pembidaian markup, 320–1200px:

| width | columns | height |
| --- | --- | --- |
| 320–360 | 1 | 596px |
| 390–430 | 2 | 400px |
| 560–600 | 3 | 264px |
| 700–760 | 4 | 264px |
| ≥ 900 | 5 | 128px |

A one-criterion lomba — Semaphore, Keagamaan, Bakiak — is one full-width
column exactly as before.

## Why

Five criteria stacked straight down came to 596px, more than the room left on
a phone under the header and the regu card. The last box and SIMPAN NILAI were
never on screen together, so the officer scrolled between the number they had
just written and the button that saves it.

`9.5rem` is not the longest criterion name — names are allowed to wrap. It is
the widest thing that can sit inside one box: a benar/salah pair of two `4rem`
inputs `.3rem` apart plus `.5rem` padding either side, 149px. Below that the
content spills out of its box, because a track already pinned at `1fr` does
not stretch to fit its contents.

## Notes

Measured, not read (CLAUDE.md 15.9): no horizontal scrollbar and no overflow
at any width, including the two input shapes this edisi does not use but whose
CSS is still live — the benar/salah pair and the checkbox. Checked in the real
screen against `hrcd_dev` at 412px (2 columns, 400px, was 596) and at 1920px
(4 columns, 264px), plus PBB and Yel-Yel at 2 columns and 226px.

`style.css` is shared, so `live/index.html` goes to `v=43` and
`web/index.html` to `v=41`; `node --test tests/*.test.mjs` 377 pass.