### PR TITLE
fix: a dialog closes when the screen changes under it

### DIFF
--- a/live/js/util.js
+++ b/live/js/util.js
@@ -724,7 +724,22 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
       if (m.tipe === "jam") jamPasang[i] = pasangKotakJam(`dlg-${i}`);
     });
 
-    const tutup = hasil => { el.remove(); resolve(hasil); };
+    /* PINDAH LAYAR MENUTUP DIALOG, dan itu bukan kerapian.
+
+       Dialog ini menempel di `document.body`, bukan di dalam #layar — ia harus,
+       karena ia menutupi seluruh layar. Akibatnya `LAYAR.replaceChildren()`
+       yang menggambar layar berikutnya TIDAK menyentuhnya: petugas yang
+       membuka Foto Jawaban di Input Nilai Pos lalu menekan Back mendarat di
+       layar berikutnya dengan overlay layar penuh milik layar sebelumnya masih
+       terpasang di atasnya, lengkap dengan `pointer-events`. Membukanya dua
+       kali menumpuk dua.
+
+       Batal, bukan sekadar dibuang: yang memanggil sedang `await` di baris
+       berikutnya, dan `null` sudah berarti "dibatalkan" bagi semuanya. Elemen
+       yang cuma dihapus meninggalkan janji yang tidak pernah selesai. */
+    const pergi = new AbortController();
+    const tutup = hasil => { pergi.abort(); el.remove(); resolve(hasil); };
+    window.addEventListener("hashchange", () => tutup(null), { signal: pergi.signal });
     if (pasang) pasang(el, tutup);
     el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -724,7 +724,22 @@ export function dialog({ judul, kartuHtml = "", medan = [], labelAksi = "Simpan"
       if (m.tipe === "jam") jamPasang[i] = pasangKotakJam(`dlg-${i}`);
     });
 
-    const tutup = hasil => { el.remove(); resolve(hasil); };
+    /* PINDAH LAYAR MENUTUP DIALOG, dan itu bukan kerapian.
+
+       Dialog ini menempel di `document.body`, bukan di dalam #layar — ia harus,
+       karena ia menutupi seluruh layar. Akibatnya `LAYAR.replaceChildren()`
+       yang menggambar layar berikutnya TIDAK menyentuhnya: petugas yang
+       membuka Foto Jawaban di Input Nilai Pos lalu menekan Back mendarat di
+       layar berikutnya dengan overlay layar penuh milik layar sebelumnya masih
+       terpasang di atasnya, lengkap dengan `pointer-events`. Membukanya dua
+       kali menumpuk dua.
+
+       Batal, bukan sekadar dibuang: yang memanggil sedang `await` di baris
+       berikutnya, dan `null` sudah berarti "dibatalkan" bagi semuanya. Elemen
+       yang cuma dihapus meninggalkan janji yang tidak pernah selesai. */
+    const pergi = new AbortController();
+    const tutup = hasil => { pergi.abort(); el.remove(); resolve(hasil); };
+    window.addEventListener("hashchange", () => tutup(null), { signal: pergi.signal });
     if (pasang) pasang(el, tutup);
     el.querySelector("[data-batal]")?.addEventListener("click", () => tutup(null));
     el.addEventListener("click", e => { if (e.target === el) tutup(null); });


### PR DESCRIPTION
## What

`dialog()` now closes itself on `hashchange`, resolving `null` — the same
value every caller already reads as "cancelled".

## Why

Open **Foto Jawaban** on Input Nilai Pos, press Back: the dialog is still
there. A full-screen overlay belonging to the screen you just left, sitting on
top of the new one with `pointer-events: auto` and `z-index: 60`. Open it
twice and two of them stack.

`dialog()` appends to `document.body` — it has to, because it covers the whole
screen — so the `LAYAR.replaceChildren()` that draws the next screen never
touches it, and nothing else was tied to navigation.

It affects every caller of `dialog()`, not just the photo gallery: the delete
reason, the gembok confirmation, the riwayat, the account menu.

Resolving rather than just detaching matters: the caller is `await`ing on the
next line, and an element that is only removed leaves a promise that never
settles.

## Notes

Reproduced and fixed against `hrcd_dev`: open the photo dialog on
`#/pos` (Pos 3, regu 101), `history.back()` → one overlay before, zero after.
Dialogs still behave normally afterwards — the nested delete flow (gallery
dialog → reason dialog → OK) still returns its value and deletes the row, with
the outer gallery left open as before.

`node --test tests/*.test.mjs` 377 pass, `periksa_impor.py` clean,
`web/js/util.js` and `live/js/util.js` identical.