### PR TITLE
fix: a rotated slip stays rotated on the other two screens

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=44">
+  <link rel="stylesheet" href="style.css?v=45">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -2685,6 +2685,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   border: 1px solid var(--garis); border-radius: 8px; background: var(--kertas);
 }
 .foto-galeri img { display: block; width: 100%; height: 100%; object-fit: cover; }
+/* Sudut putarnya (migrasi 0167), alasan yang sama dengan .foto-lembar di
+   bawah: yang sudah ditegakkan di Cek Nilai harus tegak di sini juga.
+
+   Caranya pun sama — 90 dan 270 MENUKAR lebar dengan tinggi lewat `cqh`/`cqw`.
+   Versi pertama memakai satu `scale(4/3)`, karena petaknya `aspect-ratio: 3/4`
+   dan angkanya kelihatan bisa dihitung di kepala. Ia meleset 3px: rasio itu
+   berlaku untuk KOTAK LUAR, dan garis 1px di tiap sisi membuat kotak isinya
+   137x183, bukan 3:4 persis. Terukur, bukan dibaca (bagian 15.9) — dan
+   pelajarannya bukan angkanya kurang teliti melainkan menghitung sendiri apa
+   yang bisa ditanyakan ke kotaknya. */
+.foto-galeri .fg-petak { container-type: size; }
+.foto-galeri li[data-putar="90"] img,
+.foto-galeri li[data-putar="270"] img {
+  position: absolute; left: 50%; top: 50%;
+  width: 100cqh; height: 100cqw;
+}
+.foto-galeri li[data-putar="90"] img  { transform: translate(-50%, -50%) rotate(90deg); }
+.foto-galeri li[data-putar="180"] img { transform: rotate(180deg); }
+.foto-galeri li[data-putar="270"] img { transform: translate(-50%, -50%) rotate(270deg); }
 .fg-kosong {
   display: flex; align-items: center; justify-content: center;
   font-size: .8rem; color: var(--tinta-lembut); text-align: center;
@@ -4827,6 +4846,31 @@ button.pill-number:hover { filter: brightness(.95); }
 .foto-lembar img {
   display: block; width: 100%; height: 100%; object-fit: contain;
 }
+/* SUDUT PUTARNYA IKUT DI SINI JUGA (migrasi 0167).
+
+   Keputusan pemiliknya berbunyi "sekali diputar, foto itu tegak untuk siapa
+   pun, besok maupun DI LAYAR LAIN" — dan sampai baris ini ditulis cuma Cek
+   Nilai yang memutarnya. Petugas yang menegakkan slip di sana tetap melihatnya
+   miring di layar tempat ia mengetik angkanya, yaitu justru layar yang paling
+   sering membuka foto itu.
+
+   90 dan 270 MENUKAR lebar dengan tinggi. Gambar yang cuma diputar tanpa
+   ditukar ukurannya meluap keluar petaknya dan separuh slipnya terpotong —
+   kebalikan dari gunanya.
+
+   Satuannya `cqh`/`cqw`, bukan `--petak-w`/`--petak-h` yang dipakai Cek Nilai.
+   Di sana tinggi petaknya ditentukan sisa ruang layar, jadi hanya JavaScript
+   yang tahu angkanya; di sini petaknya 100% x 60vh — CSS sudah tahu keduanya,
+   dan satu container query menggantikan satu ResizeObserver. */
+.foto-lembar { container-type: size; }
+.foto-lembar[data-putar="90"] img,
+.foto-lembar[data-putar="270"] img {
+  position: absolute; left: 50%; top: 50%;
+  width: 100cqh; height: 100cqw;
+}
+.foto-lembar[data-putar="90"] img  { transform: translate(-50%, -50%) rotate(90deg); }
+.foto-lembar[data-putar="180"] img { transform: rotate(180deg); }
+.foto-lembar[data-putar="270"] img { transform: translate(-50%, -50%) rotate(270deg); }
 .foto-lembar-kosong { font-size: .85rem; color: var(--tinta-lembut); }
 
 /* Tombol simpan MENEMPEL di dasar layar selama kartunya lebih tinggi daripada

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 44, sidik: "595e46c07ab5" },
+  "style.css": { versi: 45, sidik: "4af1f0996a1d" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=42">
+  <link rel="stylesheet" href="style.css?v=43">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4686,7 +4686,8 @@ async function layarInputPos() {
           const ke = daftar.length - i;            // terbaru dulu, jadi dihitung mundur
           const kapan = f.diunggah_pada ? tanggalJam(f.diunggah_pada) : "";
           const judul = `Foto ${ke} ${namaLomba}${kapan ? ` · ${kapan}` : ""}`;
-          return `<li data-id="${esc(f.id)}" data-ke="${esc(String(ke))}">
+          return `<li data-id="${esc(f.id)}" data-ke="${esc(String(ke))}"
+                      data-putar="${esc(String(f.putaran || 0))}">
             ${url
               ? `<a class="fg-petak" href="${esc(url)}" target="_blank" rel="noopener"
                     title="${esc(judul)}">
@@ -8507,7 +8508,7 @@ async function gambarLombaNilai(l) {
         <button type="button" class="ubin-silang" data-hapus-foto="${esc(f.id)}"
                 title="Hapus foto ${i + 1}"
                 aria-label="Hapus foto ${i + 1}">${ikon("x")}</button>` : "";
-      return `<div class="foto-lembar">
+      return `<div class="foto-lembar" data-putar="${esc(String(f.putaran || 0))}">
         ${url
           ? `<a class="foto-tautan" href="${esc(url)}" target="_blank" rel="noopener"
                 title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"

--- a/web/style.css
+++ b/web/style.css
@@ -2685,6 +2685,25 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   border: 1px solid var(--garis); border-radius: 8px; background: var(--kertas);
 }
 .foto-galeri img { display: block; width: 100%; height: 100%; object-fit: cover; }
+/* Sudut putarnya (migrasi 0167), alasan yang sama dengan .foto-lembar di
+   bawah: yang sudah ditegakkan di Cek Nilai harus tegak di sini juga.
+
+   Caranya pun sama — 90 dan 270 MENUKAR lebar dengan tinggi lewat `cqh`/`cqw`.
+   Versi pertama memakai satu `scale(4/3)`, karena petaknya `aspect-ratio: 3/4`
+   dan angkanya kelihatan bisa dihitung di kepala. Ia meleset 3px: rasio itu
+   berlaku untuk KOTAK LUAR, dan garis 1px di tiap sisi membuat kotak isinya
+   137x183, bukan 3:4 persis. Terukur, bukan dibaca (bagian 15.9) — dan
+   pelajarannya bukan angkanya kurang teliti melainkan menghitung sendiri apa
+   yang bisa ditanyakan ke kotaknya. */
+.foto-galeri .fg-petak { container-type: size; }
+.foto-galeri li[data-putar="90"] img,
+.foto-galeri li[data-putar="270"] img {
+  position: absolute; left: 50%; top: 50%;
+  width: 100cqh; height: 100cqw;
+}
+.foto-galeri li[data-putar="90"] img  { transform: translate(-50%, -50%) rotate(90deg); }
+.foto-galeri li[data-putar="180"] img { transform: rotate(180deg); }
+.foto-galeri li[data-putar="270"] img { transform: translate(-50%, -50%) rotate(270deg); }
 .fg-kosong {
   display: flex; align-items: center; justify-content: center;
   font-size: .8rem; color: var(--tinta-lembut); text-align: center;
@@ -4827,6 +4846,31 @@ button.pill-number:hover { filter: brightness(.95); }
 .foto-lembar img {
   display: block; width: 100%; height: 100%; object-fit: contain;
 }
+/* SUDUT PUTARNYA IKUT DI SINI JUGA (migrasi 0167).
+
+   Keputusan pemiliknya berbunyi "sekali diputar, foto itu tegak untuk siapa
+   pun, besok maupun DI LAYAR LAIN" — dan sampai baris ini ditulis cuma Cek
+   Nilai yang memutarnya. Petugas yang menegakkan slip di sana tetap melihatnya
+   miring di layar tempat ia mengetik angkanya, yaitu justru layar yang paling
+   sering membuka foto itu.
+
+   90 dan 270 MENUKAR lebar dengan tinggi. Gambar yang cuma diputar tanpa
+   ditukar ukurannya meluap keluar petaknya dan separuh slipnya terpotong —
+   kebalikan dari gunanya.
+
+   Satuannya `cqh`/`cqw`, bukan `--petak-w`/`--petak-h` yang dipakai Cek Nilai.
+   Di sana tinggi petaknya ditentukan sisa ruang layar, jadi hanya JavaScript
+   yang tahu angkanya; di sini petaknya 100% x 60vh — CSS sudah tahu keduanya,
+   dan satu container query menggantikan satu ResizeObserver. */
+.foto-lembar { container-type: size; }
+.foto-lembar[data-putar="90"] img,
+.foto-lembar[data-putar="270"] img {
+  position: absolute; left: 50%; top: 50%;
+  width: 100cqh; height: 100cqw;
+}
+.foto-lembar[data-putar="90"] img  { transform: translate(-50%, -50%) rotate(90deg); }
+.foto-lembar[data-putar="180"] img { transform: rotate(180deg); }
+.foto-lembar[data-putar="270"] img { transform: translate(-50%, -50%) rotate(270deg); }
 .foto-lembar-kosong { font-size: .85rem; color: var(--tinta-lembut); }
 
 /* Tombol simpan MENEMPEL di dasar layar selama kartunya lebih tinggi daripada


### PR DESCRIPTION
## What

The photo strip on **Input Nilai Pos v2** and the photo gallery on **Input
Nilai Pos** now carry `foto_lembar.putaran` as `data-putar` and turn the image
the way Cek Nilai already does.

## Why

Migration `0167` records the owner's decision in as many words: *"sekali
diputar, foto itu tegak untuk siapa pun, besok maupun di layar lain."* Only
Cek Nilai implemented it. The officer who straightens a slip there still met
it sideways on Input Nilai Pos v2 — the screen that opens that photo most
often, because it is where the number is typed from it — and in the gallery
behind the camera button on Input Nilai Pos.

90° and 270° **swap width for height**. An image merely turned overflows its
box and loses half the slip, which is the opposite of the point.

The swap uses `cqh`/`cqw` rather than Cek Nilai's JS-set `--petak-w/--petak-h`.
There the box height is whatever the one-screen layout leaves over, so only
JavaScript knows the number; these two boxes are `100% × 60vh` and
`aspect-ratio: 3 / 4`, so CSS already knows both and one container query
replaces one ResizeObserver.

The gallery first used a single `scale(4/3)` computed from its aspect ratio.
It fell 3px short — the ratio governs the border box, and 1px of border per
side leaves 137×183 inside. Measured, not read (CLAUDE.md 15.9).

## Notes

Verified against `hrcd_dev` at all four angles, desktop (card 674×567) and
phone (iframe 412px, card 311×514): the image stays inside its box, stays
centred, and no horizontal scrollbar appears. Cek Nilai is untouched — the new
rule is scoped `.foto-galeri .fg-petak`, not the bare `.fg-petak` the two
screens share — and still rotates as before.

Foto Jawaban is deliberately left alone: its tiles only ever show photos that
are not yet linked to a nomor dada, and nothing can rotate those — the rotate
button lives in Cek Nilai, which iterates linked photos.

`style.css` is shared, so `live/index.html` → `v=45` and `web/index.html` →
`v=43`. `node --test tests/*.test.mjs` 377 pass.