### PR TITLE
test: the Live Score guard stops depending on Windows line endings

### DIFF
--- a/tests/live_score_refresh_hitung_ulang.test.mjs
+++ b/tests/live_score_refresh_hitung_ulang.test.mjs
@@ -13,7 +13,14 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+// AKHIRAN BARIS DINORMALKAN, alasan yang sama dengan
+// tests/live_asset_version.test.mjs: checkout di Windows memberi CRLF dan di
+// Linux LF, sementara penanda `gambar` di bawah memuat pergantian baris DI
+// TENGAHNYA. Tanpa ini ia cuma ketemu di satu jenis mesin, dan satu alat yang
+// menulis ulang app.js dengan LF sudah cukup membuatnya berhenti ketemu —
+// lalu `pulih > gambar` menilai -1 dan pagarnya berhenti menjaga apa pun.
+const app = (await readFile(new URL("../web/js/app.js", import.meta.url), "utf8"))
+  .replace(/\r\n/g, "\n");
 const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
 const cron = await readFile(
   new URL("../.github/workflows/refresh-live-score.yml", import.meta.url), "utf8");
@@ -62,7 +69,7 @@ test("Refresh tidak melempar panitia ke tab lain atau ke puncak halaman", () => 
   // Guliran dipulihkan SESUDAH papan tergambar: halaman yang belum setinggi
   // posisi tujuan membuat browser menahan guliran di batas yang ada saat itu.
   const pulih = app.indexOf("requestAnimationFrame(() => window.scrollTo(0, ke))");
-  const gambar = app.indexOf("LAYAR.replaceChildren(h(`\r\n    ${kemajuan}");
+  const gambar = app.indexOf("LAYAR.replaceChildren(h(`\n    ${kemajuan}");
   assert.ok(pulih > 0, "guliran tidak pernah dipulihkan");
   assert.ok(gambar > 0 && pulih > gambar,
     "guliran dipulihkan sebelum papannya tergambar");


### PR DESCRIPTION
## What

`tests/live_score_refresh_hitung_ulang.test.mjs` normalizes `app.js` line
endings before matching, the way `tests/live_asset_version.test.mjs` already
does, and the marker drops its embedded `\r\n`.

## Why

One marker searched `app.js` for a literal CRLF in the middle of the string.
A checkout on Windows has CRLF and one on Linux has LF, so the marker only
matched on one kind of machine — and any tool that rewrites `app.js` with LF
is enough to stop it matching there too. That is how I met it.

It is not loud by design. `indexOf` returns `-1`, and the assertion it feeds is
`pulih > gambar`. It happens to fail loudly only because `gambar > 0` is
checked alongside; the same shape without that second check is exactly the
vacuous guard #788 was about.

## Notes

Verified both ways: the test passes with `app.js` in CRLF and with the same
file converted to LF. `node --test tests/*.test.mjs` 377 pass.