### PR TITLE
docs: bring every markdown file back in line with the tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,14 +158,15 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    | `bde75b8` | 28 Aug | committed and pushed while the working copy sat on `main` after a merge |
    | `199b0d6` `a245426` | 30 Aug | the same thing again, twice in a row, minutes after merging #718 |
 
-   Leave all nine as they are: undoing any of them means force-pushing the
+   Leave all ten as they are: undoing any of them means force-pushing the
    default branch, which is worse than untidy history. Verify the count with
    `git log --first-parent` and check each commit's parent count — a commit
    reached as a merge's *second* parent is normal and must not be counted.
 
    **This clause said "two" until 27 August 2026, when a branch audit found
    seven; `bde75b8` made it eight the next day, and `199b0d6`/`a245426` made
-   it ten two days after that.** The five from 17 August were never recorded. A stale count is not a cosmetic error: whoever runs the
+   it ten two days after that.** The five from 17 August were never
+   recorded. A stale count is not a cosmetic error: whoever runs the
    check next reads five false alarms and cannot tell known history from fresh
    damage. If the number changes again, change it HERE — do not leave the
    discrepancy for the next reader.
@@ -190,8 +191,11 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    that way; what found it was a production apply failing on a column rename
    that CI should have caught first. Add the migration to `tests/run.sh` in the
    same commit that creates it.
-6. **Three deploy paths, and only one of them is automatic in the obvious
-   way.** The panitia site is connected to Git and ships on every merge. The
+6. **Three deploy paths, and two of them ship on their own.** The panitia site
+   has TWO routes at once: Cloudflare's Git integration, plus
+   `deploy-panitia.yml`, which a push to `main` touching `web/**` starts. A
+   Git build once hung for over forty minutes with nothing in the repo able
+   to retry it, so both run now and the later one wins. The
    peserta site must **never** be connected to Git — Cloudflare would serve the
    `pra`-phase `live.json` committed in `live/` and blank the rekap — so it
    ships through `publish-live.yml`, which regenerates that file from the
@@ -200,9 +204,12 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    `apply-migration.yml` with the file path, deliberately, after the PR lands.
 7. `CLAUDE.md` and `AGENTS.md` are the same document twice — byte-identical
    apart from the first heading and the intro paragraph. Every edit to one
-   lands in the other in the same commit. No workflow checks this
-   (`shared-files.yml` only compares `web/` against `live/`), and the pair has
-   already drifted 21 lines once, losing all of section 5's rules 9-12.
+   lands in the other in the same commit. `shared-files.yml` compares the pair
+   itself now — `tail -n +5 CLAUDE.md` against `tail -n +7 AGENTS.md`, because
+   AGENTS.md carries a second intro paragraph CLAUDE.md does not — but it only
+   runs when dispatched (section 16.5), so nothing catches the drift on its
+   own. The pair has already drifted 21 lines once, losing all of section 5's
+   rules 9-12.
 
 8. **Nothing records which migrations have been applied.**
    `apply-migration.yml` runs ONE file at a time, by hand, and writes no
@@ -221,8 +228,14 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    **It covered ten migrations until 30 August 2026, while its own header
    described it as a general check.** The other 152 were not examined at all
    and it still reported green — the very shape of mistake section 13.3
-   describes. It now checks **111** and NAMES the **51** it cannot, so the
+   describes. It now checks **112** and NAMES the **51** it cannot, so the
    question stays open instead of being closed by silence.
+
+   **Those 163 stop at `0163`.** `0164`-`0169` are in NEITHER list, so the
+   check still reports green over six migrations it never looked at — the same
+   mistake one edition younger. A migration is not covered until its
+   fingerprint sits in part 1 or its name in part 2, added in the commit that
+   creates the file, exactly as section 7.5 asks of `tests/run.sh`.
 
    **A migration with no fingerprint is not a problem.** It means nothing is
    left to check: a younger migration rewrote its objects, or it only touched
@@ -236,8 +249,10 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    directions: after migration N its fingerprint must read ADA, and before
    migration N it must read BELUM. The second direction is the one usually
    missing — without it `select true` passes. Twenty fingerprints survived a
-   looser rule and were caught by that harness. It rebuilds the database 162
-   times, so it is deliberately not part of `tests/run.sh`.
+   looser rule and were caught by that harness. It builds ONE database from
+   zero and re-runs the checker after every migration — 170 steps in
+   `tests/run.sh` order today — so it is deliberately not part of
+   `tests/run.sh`.
 
    **Production runs PostgreSQL 17.6; a laptop on 18.x will disagree with it
    in ways that look like missing migrations.** PostgreSQL 18 records NOT NULL
@@ -285,7 +300,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    tint, no watermark, no example number printed inside. Speckle on white is
    still readable; speckle over a tint is not.
 8. These rules live in `web/style.css` under `@media print`, and `live/` holds
-   a byte-identical copy — section 7.5 applies to CSS the same way, and
+   a byte-identical copy — section 7.7 applies to CSS the same way, and
    `shared-files.yml` enforces that pair.
 9. **Form per lomba is A5 landscape — 210 × 148 mm, one form per page.**
    Half an A4 cut across, so any copier can duplicate it 2-up onto A4 and the
@@ -306,11 +321,15 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    hundreds of times in a shift, and a sentence that teaches something learned
    once is re-read on every one of them.
 2. **A title, a labelled field, and a button name are usually the whole
-   interface.** "Buka gembok 001?" above a required field labelled "Alasan
-   membuka" already says everything the paragraph "Alasannya dicatat di
-   riwayat, dan itulah satu-satunya penjelasan yang tersisa…" said — in a
-   quarter of the height, on a phone where the field it explained had been
-   pushed down the screen to make room for it.
+   interface.** The gembok dialog was the example: "Buka gembok 001?" above a
+   required field labelled "Alasan membuka" said everything the paragraph
+   "Alasannya dicatat di riwayat, dan itulah satu-satunya penjelasan yang
+   tersisa…" said — in a quarter of the height, on a phone where the field it
+   explained had been pushed down the screen to make room for it. **That
+   dialog is gone since 0166** — Cek Nilai now opens a gembok straight away
+   with the fixed reason "Dibuka dari Cek Nilai", and no screen has an
+   "Alasan membuka" field any more — so do not go looking for it to copy.
+   What survived is the lesson, not the field.
 3. **Cut anything that repeats the title, the field label, or the button next
    to it.** Two labels for one fact do not reinforce each other.
 4. **Keep text that carries a fact the reader cannot get from the screen
@@ -370,12 +389,12 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    window.** Panitia and pembina both plan their morning from it, and "kloter
    9, kira-kira 08:45" is the answer to the question they actually ask.
 6. **An estimate is never a record.** `kloter.jam_berangkat` is typed by the
-   recorder from a real clock at a real moment (alur 12.4) and it is what
+   recorder from a real clock at a real moment (alur 6.4, 6.9) and it is what
    penalties are computed from. The estimate exists to plan the morning; the
    two must never be stored in the same column, and a screen showing both must
    say which is which.
 7. **07:00 and 10:00 are configuration, not constants.** They belong beside
-   the other per-edition numbers, for the same reason as section 6.4 of
+   the other per-edition numbers, for the same reason as section 2.2 of
    rancangan-b: next year's panitia change the window without touching code.
 
 ## 11. Pos, lomba, penilaian
@@ -390,8 +409,15 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
      dan Kebersihan `0–15`. They sum to 100, and **that sum is what must be
      preserved** if the weights are rebalanced again — it is what sets
      Pembidaian's weight against every other lomba (migration `0076`).
-   - **Kim Lihat** — `0–10`
-   - **Kim Cium** — `0–10`
+   - **Kim Lihat** — ten objects, raw `0–10`, worth **100 points**
+   - **Kim Cium** — ten objects, raw `0–10`, worth **100 points**
+
+     **Those `0–10` are RAW ranges, not weights.** Pembidaian's five numbers
+     are points and they sum to 100; Kim's are counts of correct objects
+     scaled to `poin_maks` 100 each. Read the two kinds as one and Pos 3
+     comes out at 220 instead of **400**, and Kim starts to look like a lomba
+     someone ought to raise. What sets any pos's weight is the sum of
+     `poin_maks` over its `wahana` rows — never the count of its lomba.
    - **Logika** — 20 soal, enter the number correct `0–20`, 5 points each
 
    **Kim Lihat and Kim Cium are two lomba, not two criteria of one** (migration
@@ -416,8 +442,11 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 
    Today: Pos 1 **Keagamaan** and **Kepramukaan** (10 soal, max 50), Pos 2
    **Kesehatan** and **Pengetahuan Umum** (10 soal, max 50), Pos 3 **Logika**
-   (20 soal, max 100). Each is its own lomba — `lomba` NULL — so each prints
-   its own blangko and gets its own photo column.
+   (20 soal, max 100). Each is its own lomba — `lomba` NULL — so each gets its
+   own photo column. **None of them prints a blangko**: the peserta answer on
+   the question sheet itself, so `siapkanCetakBlangko()` drops every lomba
+   whose components are all `type = 'soal'`, and a pos holding nothing else
+   prints no master at all and says why.
 
    **The half weight is deliberate — confirmed by the event owner, not an
    oversight.** Every other lomba maxes at 100 and the klasemen sums points as
@@ -434,8 +463,13 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    Kekompakan `0–30`, Kerapihan `0–20`.
 5. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
    Semangat `0–20`, Penampilan `0–20`.
-6. **One lomba is one form per lomba.** Pos 3 prints four blangko masters,
-   not seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
+6. **One lomba is one form per lomba.** Pos 3 prints THREE blangko masters —
+   Pembidaian, Kim Lihat, Kim Cium — not seven and not four; Pos 4 prints one,
+   not four. **A soal lomba prints no blangko at all.** Logika is the fourth
+   lomba at Pos 3 and it gets no sheet, because the peserta answer on the
+   question paper itself: `siapkanCetakBlangko()` drops every lomba whose
+   components are all `type = 'soal'`, and a pos holding nothing else prints
+   nothing and says so. A regu is judged once at a lomba and the
    judge writes every criterion on the sheet in front of them — a sheet per
    criterion would have the same regu handed five pieces of paper at one
    station.
@@ -445,7 +479,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 8. **The lomba level is `wahana.lomba`** (migration `0054`). `NULL` means the
    component is its own lomba, which is right for most rows — Semaphore,
    Menaksir, Bakiak — so only grouped components carry a value. Read it as
-   `coalesce(lomba, name)`; `kelompokLomba()` in `app.js` does exactly that.
+   `coalesce(lomba, name)`; `kelompokLomba()` in `util.js` does exactly that.
    Do **not** go back to splitting the `kode` prefix: `bidai_`, `kim_`, `pbb_`,
    `yel_` are a naming habit that nothing enforces, and it works right up until
    an edition names two unrelated components with the same first word.
@@ -619,8 +653,8 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 4. **Sebabnya bukan kemalasan.** `rekap.json` duduk di CDN dan bisa diminta
    siapa pun yang tahu alamatnya. Satu-satunya jaminan bahwa nilai belum bocor
    adalah nilainya MEMANG TIDAK ADA di berkas itu — bukan ada tapi tidak
-   digambar. `publish-live.yml` punya empat pagar "BOCOR" yang menegakkan itu,
-   dan tidak satu pun boleh dilonggarkan demi kenyamanan tampilan.
+   digambar. `publish-live.yml` punya sembilan pagar "BOCOR" yang menegakkan
+   itu, dan tidak satu pun boleh dilonggarkan demi kenyamanan tampilan.
 5. **`komponen_terisi` boleh terbit sejak `progres`; `nilai` hanya di
    `penuh`** (migrasi 0072). Centang tidak menyebut satu angka pun, jadi ia
    aman terbit lebih awal — dan itulah yang membuat "masking" di halaman
@@ -678,8 +712,9 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 
 ## 15. CSS tabel: dari layar lebar sampai HP
 
-1. **Setiap tabel data melewati TIGA rentang, bukan dua.** Meja Pembayaran dan
-   Meja Daftar Ulang dua-duanya begitu, dan aturan yang benar di satu rentang
+1. **Setiap tabel data melewati TIGA rentang, bukan dua.** Meja Pembayaran,
+   Meja Daftar Ulang, dan Data Peserta (`.table-peserta`) ketiganya begitu,
+   dan aturan yang benar di satu rentang
    bisa merusak yang lain:
    - **≤ 900px** — barisnya bukan tabel lagi melainkan **kartu**
      (`.data-table:not(.table-tetap) … { display: block }`). Patokan lebar
@@ -688,9 +723,9 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
      `@media (min-width: 901px) and (max-width: 940px)` yang mengaturnya.
    - **≥ 941px** — tabel `fixed`, dipasangkan dengan tabel rinciannya.
 2. **Contoh yang benar adalah Meja Pembayaran, tiru bentuknya.** Induk enam
-   kolom `18/24/6/12/15/25`, rincian lima kolom `18/24/18/15/25`. Dua-duanya
+   kolom `18/24/6/12/20/20`, rincian lima kolom `18/24/18/20/20`. Dua-duanya
    berjumlah **100**, kolom pertamanya bertemu di 18% dan kolom terakhirnya di
-   25% — itulah yang membuat angka rupiah tiap regu jatuh tepat di bawah
+   20% — itulah yang membuat angka rupiah tiap regu jatuh tepat di bawah
    tombol "Tandai Lunas". Kolom di antaranya boleh berbeda; yang harus
    bertemu cuma yang berpasangan.
 3. **Di bawah `table-layout: fixed`, kolom yang tidak dipatok dapat NOL —
@@ -778,9 +813,11 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 5. **No check runs by itself any more — CI is dispatched deliberately.**
    `sql-tests.yml` and `shared-files.yml` carry `workflow_dispatch` and nothing
    else: no `push`, no `pull_request`. Every check they perform runs on a
-   laptop in well under a minute, and rule 1 already requires it there. The one
-   workflow still triggered automatically is `publish-live.yml`, and that is a
-   deploy, not a check.
+   laptop in well under a minute, and rule 1 already requires it there. Three
+   workflows still fire on their own — `publish-live.yml` (push to `live/**`,
+   plus the event cron), `deploy-panitia.yml` (push to `web/**`) and
+   `refresh-live-score.yml` (event cron only). Two deploys and one cache
+   refresh; not a check among them.
 6. **What costs money is the NUMBER of runs, not their length.** GitHub rounds
    every JOB up to a whole minute, so a 7-second check and a 50-second check
    bill exactly the same. One measured day: 24 of 60 runs were a second copy of
@@ -799,11 +836,12 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
-   run from their phones. The event-only exception in `publish-live.yml` runs
-   every 15 minutes from 08:00 through 23:45 WIB on 29 August 2026. Cron has no
-   year field, so the first step rejects every scheduled run outside that exact
-   date before reading the database or deploying. Do not widen its window or
-   remove that year guard.
+   run from their phones. There are two event-only exceptions, both on
+   29 August 2026 and both between 06:00 and 18:59 WIB: `publish-live.yml`
+   every 15 minutes, and `refresh-live-score.yml` every 10. Cron has no year
+   field, so each one's first step rejects every scheduled run outside that
+   exact date before reading the database or deploying. Do not widen either
+   window or remove those year guards.
 
 ## 17. Selama acara berjalan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,15 @@ Guidance for Claude Code when working in this repository.
    | `bde75b8` | 28 Aug | committed and pushed while the working copy sat on `main` after a merge |
    | `199b0d6` `a245426` | 30 Aug | the same thing again, twice in a row, minutes after merging #718 |
 
-   Leave all nine as they are: undoing any of them means force-pushing the
+   Leave all ten as they are: undoing any of them means force-pushing the
    default branch, which is worse than untidy history. Verify the count with
    `git log --first-parent` and check each commit's parent count — a commit
    reached as a merge's *second* parent is normal and must not be counted.
 
    **This clause said "two" until 27 August 2026, when a branch audit found
    seven; `bde75b8` made it eight the next day, and `199b0d6`/`a245426` made
-   it ten two days after that.** The five from 17 August were never recorded. A stale count is not a cosmetic error: whoever runs the
+   it ten two days after that.** The five from 17 August were never
+   recorded. A stale count is not a cosmetic error: whoever runs the
    check next reads five false alarms and cannot tell known history from fresh
    damage. If the number changes again, change it HERE — do not leave the
    discrepancy for the next reader.
@@ -188,8 +189,11 @@ Guidance for Claude Code when working in this repository.
    that way; what found it was a production apply failing on a column rename
    that CI should have caught first. Add the migration to `tests/run.sh` in the
    same commit that creates it.
-6. **Three deploy paths, and only one of them is automatic in the obvious
-   way.** The panitia site is connected to Git and ships on every merge. The
+6. **Three deploy paths, and two of them ship on their own.** The panitia site
+   has TWO routes at once: Cloudflare's Git integration, plus
+   `deploy-panitia.yml`, which a push to `main` touching `web/**` starts. A
+   Git build once hung for over forty minutes with nothing in the repo able
+   to retry it, so both run now and the later one wins. The
    peserta site must **never** be connected to Git — Cloudflare would serve the
    `pra`-phase `live.json` committed in `live/` and blank the rekap — so it
    ships through `publish-live.yml`, which regenerates that file from the
@@ -198,9 +202,12 @@ Guidance for Claude Code when working in this repository.
    `apply-migration.yml` with the file path, deliberately, after the PR lands.
 7. `CLAUDE.md` and `AGENTS.md` are the same document twice — byte-identical
    apart from the first heading and the intro paragraph. Every edit to one
-   lands in the other in the same commit. No workflow checks this
-   (`shared-files.yml` only compares `web/` against `live/`), and the pair has
-   already drifted 21 lines once, losing all of section 5's rules 9-12.
+   lands in the other in the same commit. `shared-files.yml` compares the pair
+   itself now — `tail -n +5 CLAUDE.md` against `tail -n +7 AGENTS.md`, because
+   AGENTS.md carries a second intro paragraph CLAUDE.md does not — but it only
+   runs when dispatched (section 16.5), so nothing catches the drift on its
+   own. The pair has already drifted 21 lines once, losing all of section 5's
+   rules 9-12.
 
 8. **Nothing records which migrations have been applied.**
    `apply-migration.yml` runs ONE file at a time, by hand, and writes no
@@ -219,8 +226,14 @@ Guidance for Claude Code when working in this repository.
    **It covered ten migrations until 30 August 2026, while its own header
    described it as a general check.** The other 152 were not examined at all
    and it still reported green — the very shape of mistake section 13.3
-   describes. It now checks **111** and NAMES the **51** it cannot, so the
+   describes. It now checks **112** and NAMES the **51** it cannot, so the
    question stays open instead of being closed by silence.
+
+   **Those 163 stop at `0163`.** `0164`-`0169` are in NEITHER list, so the
+   check still reports green over six migrations it never looked at — the same
+   mistake one edition younger. A migration is not covered until its
+   fingerprint sits in part 1 or its name in part 2, added in the commit that
+   creates the file, exactly as section 7.5 asks of `tests/run.sh`.
 
    **A migration with no fingerprint is not a problem.** It means nothing is
    left to check: a younger migration rewrote its objects, or it only touched
@@ -234,8 +247,10 @@ Guidance for Claude Code when working in this repository.
    directions: after migration N its fingerprint must read ADA, and before
    migration N it must read BELUM. The second direction is the one usually
    missing — without it `select true` passes. Twenty fingerprints survived a
-   looser rule and were caught by that harness. It rebuilds the database 162
-   times, so it is deliberately not part of `tests/run.sh`.
+   looser rule and were caught by that harness. It builds ONE database from
+   zero and re-runs the checker after every migration — 170 steps in
+   `tests/run.sh` order today — so it is deliberately not part of
+   `tests/run.sh`.
 
    **Production runs PostgreSQL 17.6; a laptop on 18.x will disagree with it
    in ways that look like missing migrations.** PostgreSQL 18 records NOT NULL
@@ -283,7 +298,7 @@ Guidance for Claude Code when working in this repository.
    tint, no watermark, no example number printed inside. Speckle on white is
    still readable; speckle over a tint is not.
 8. These rules live in `web/style.css` under `@media print`, and `live/` holds
-   a byte-identical copy — section 7.5 applies to CSS the same way, and
+   a byte-identical copy — section 7.7 applies to CSS the same way, and
    `shared-files.yml` enforces that pair.
 9. **Form per lomba is A5 landscape — 210 × 148 mm, one form per page.**
    Half an A4 cut across, so any copier can duplicate it 2-up onto A4 and the
@@ -304,11 +319,15 @@ Guidance for Claude Code when working in this repository.
    hundreds of times in a shift, and a sentence that teaches something learned
    once is re-read on every one of them.
 2. **A title, a labelled field, and a button name are usually the whole
-   interface.** "Buka gembok 001?" above a required field labelled "Alasan
-   membuka" already says everything the paragraph "Alasannya dicatat di
-   riwayat, dan itulah satu-satunya penjelasan yang tersisa…" said — in a
-   quarter of the height, on a phone where the field it explained had been
-   pushed down the screen to make room for it.
+   interface.** The gembok dialog was the example: "Buka gembok 001?" above a
+   required field labelled "Alasan membuka" said everything the paragraph
+   "Alasannya dicatat di riwayat, dan itulah satu-satunya penjelasan yang
+   tersisa…" said — in a quarter of the height, on a phone where the field it
+   explained had been pushed down the screen to make room for it. **That
+   dialog is gone since 0166** — Cek Nilai now opens a gembok straight away
+   with the fixed reason "Dibuka dari Cek Nilai", and no screen has an
+   "Alasan membuka" field any more — so do not go looking for it to copy.
+   What survived is the lesson, not the field.
 3. **Cut anything that repeats the title, the field label, or the button next
    to it.** Two labels for one fact do not reinforce each other.
 4. **Keep text that carries a fact the reader cannot get from the screen
@@ -368,12 +387,12 @@ Guidance for Claude Code when working in this repository.
    window.** Panitia and pembina both plan their morning from it, and "kloter
    9, kira-kira 08:45" is the answer to the question they actually ask.
 6. **An estimate is never a record.** `kloter.jam_berangkat` is typed by the
-   recorder from a real clock at a real moment (alur 12.4) and it is what
+   recorder from a real clock at a real moment (alur 6.4, 6.9) and it is what
    penalties are computed from. The estimate exists to plan the morning; the
    two must never be stored in the same column, and a screen showing both must
    say which is which.
 7. **07:00 and 10:00 are configuration, not constants.** They belong beside
-   the other per-edition numbers, for the same reason as section 6.4 of
+   the other per-edition numbers, for the same reason as section 2.2 of
    rancangan-b: next year's panitia change the window without touching code.
 
 ## 11. Pos, lomba, penilaian
@@ -388,8 +407,15 @@ Guidance for Claude Code when working in this repository.
      dan Kebersihan `0–15`. They sum to 100, and **that sum is what must be
      preserved** if the weights are rebalanced again — it is what sets
      Pembidaian's weight against every other lomba (migration `0076`).
-   - **Kim Lihat** — `0–10`
-   - **Kim Cium** — `0–10`
+   - **Kim Lihat** — ten objects, raw `0–10`, worth **100 points**
+   - **Kim Cium** — ten objects, raw `0–10`, worth **100 points**
+
+     **Those `0–10` are RAW ranges, not weights.** Pembidaian's five numbers
+     are points and they sum to 100; Kim's are counts of correct objects
+     scaled to `poin_maks` 100 each. Read the two kinds as one and Pos 3
+     comes out at 220 instead of **400**, and Kim starts to look like a lomba
+     someone ought to raise. What sets any pos's weight is the sum of
+     `poin_maks` over its `wahana` rows — never the count of its lomba.
    - **Logika** — 20 soal, enter the number correct `0–20`, 5 points each
 
    **Kim Lihat and Kim Cium are two lomba, not two criteria of one** (migration
@@ -414,8 +440,11 @@ Guidance for Claude Code when working in this repository.
 
    Today: Pos 1 **Keagamaan** and **Kepramukaan** (10 soal, max 50), Pos 2
    **Kesehatan** and **Pengetahuan Umum** (10 soal, max 50), Pos 3 **Logika**
-   (20 soal, max 100). Each is its own lomba — `lomba` NULL — so each prints
-   its own blangko and gets its own photo column.
+   (20 soal, max 100). Each is its own lomba — `lomba` NULL — so each gets its
+   own photo column. **None of them prints a blangko**: the peserta answer on
+   the question sheet itself, so `siapkanCetakBlangko()` drops every lomba
+   whose components are all `type = 'soal'`, and a pos holding nothing else
+   prints no master at all and says why.
 
    **The half weight is deliberate — confirmed by the event owner, not an
    oversight.** Every other lomba maxes at 100 and the klasemen sums points as
@@ -432,8 +461,13 @@ Guidance for Claude Code when working in this repository.
    Kekompakan `0–30`, Kerapihan `0–20`.
 5. **Pos 5 is one lomba, Yel-Yel** — Kreativitas `0–35`, Kekompakan `0–25`,
    Semangat `0–20`, Penampilan `0–20`.
-6. **One lomba is one form per lomba.** Pos 3 prints four blangko masters,
-   not seven; Pos 4 prints one, not four. A regu is judged once at a lomba and the
+6. **One lomba is one form per lomba.** Pos 3 prints THREE blangko masters —
+   Pembidaian, Kim Lihat, Kim Cium — not seven and not four; Pos 4 prints one,
+   not four. **A soal lomba prints no blangko at all.** Logika is the fourth
+   lomba at Pos 3 and it gets no sheet, because the peserta answer on the
+   question paper itself: `siapkanCetakBlangko()` drops every lomba whose
+   components are all `type = 'soal'`, and a pos holding nothing else prints
+   nothing and says so. A regu is judged once at a lomba and the
    judge writes every criterion on the sheet in front of them — a sheet per
    criterion would have the same regu handed five pieces of paper at one
    station.
@@ -443,7 +477,7 @@ Guidance for Claude Code when working in this repository.
 8. **The lomba level is `wahana.lomba`** (migration `0054`). `NULL` means the
    component is its own lomba, which is right for most rows — Semaphore,
    Menaksir, Bakiak — so only grouped components carry a value. Read it as
-   `coalesce(lomba, name)`; `kelompokLomba()` in `app.js` does exactly that.
+   `coalesce(lomba, name)`; `kelompokLomba()` in `util.js` does exactly that.
    Do **not** go back to splitting the `kode` prefix: `bidai_`, `kim_`, `pbb_`,
    `yel_` are a naming habit that nothing enforces, and it works right up until
    an edition names two unrelated components with the same first word.
@@ -617,8 +651,8 @@ Guidance for Claude Code when working in this repository.
 4. **Sebabnya bukan kemalasan.** `rekap.json` duduk di CDN dan bisa diminta
    siapa pun yang tahu alamatnya. Satu-satunya jaminan bahwa nilai belum bocor
    adalah nilainya MEMANG TIDAK ADA di berkas itu — bukan ada tapi tidak
-   digambar. `publish-live.yml` punya empat pagar "BOCOR" yang menegakkan itu,
-   dan tidak satu pun boleh dilonggarkan demi kenyamanan tampilan.
+   digambar. `publish-live.yml` punya sembilan pagar "BOCOR" yang menegakkan
+   itu, dan tidak satu pun boleh dilonggarkan demi kenyamanan tampilan.
 5. **`komponen_terisi` boleh terbit sejak `progres`; `nilai` hanya di
    `penuh`** (migrasi 0072). Centang tidak menyebut satu angka pun, jadi ia
    aman terbit lebih awal — dan itulah yang membuat "masking" di halaman
@@ -676,8 +710,9 @@ Guidance for Claude Code when working in this repository.
 
 ## 15. CSS tabel: dari layar lebar sampai HP
 
-1. **Setiap tabel data melewati TIGA rentang, bukan dua.** Meja Pembayaran dan
-   Meja Daftar Ulang dua-duanya begitu, dan aturan yang benar di satu rentang
+1. **Setiap tabel data melewati TIGA rentang, bukan dua.** Meja Pembayaran,
+   Meja Daftar Ulang, dan Data Peserta (`.table-peserta`) ketiganya begitu,
+   dan aturan yang benar di satu rentang
    bisa merusak yang lain:
    - **≤ 900px** — barisnya bukan tabel lagi melainkan **kartu**
      (`.data-table:not(.table-tetap) … { display: block }`). Patokan lebar
@@ -686,9 +721,9 @@ Guidance for Claude Code when working in this repository.
      `@media (min-width: 901px) and (max-width: 940px)` yang mengaturnya.
    - **≥ 941px** — tabel `fixed`, dipasangkan dengan tabel rinciannya.
 2. **Contoh yang benar adalah Meja Pembayaran, tiru bentuknya.** Induk enam
-   kolom `18/24/6/12/15/25`, rincian lima kolom `18/24/18/15/25`. Dua-duanya
+   kolom `18/24/6/12/20/20`, rincian lima kolom `18/24/18/20/20`. Dua-duanya
    berjumlah **100**, kolom pertamanya bertemu di 18% dan kolom terakhirnya di
-   25% — itulah yang membuat angka rupiah tiap regu jatuh tepat di bawah
+   20% — itulah yang membuat angka rupiah tiap regu jatuh tepat di bawah
    tombol "Tandai Lunas". Kolom di antaranya boleh berbeda; yang harus
    bertemu cuma yang berpasangan.
 3. **Di bawah `table-layout: fixed`, kolom yang tidak dipatok dapat NOL —
@@ -776,9 +811,11 @@ Guidance for Claude Code when working in this repository.
 5. **No check runs by itself any more — CI is dispatched deliberately.**
    `sql-tests.yml` and `shared-files.yml` carry `workflow_dispatch` and nothing
    else: no `push`, no `pull_request`. Every check they perform runs on a
-   laptop in well under a minute, and rule 1 already requires it there. The one
-   workflow still triggered automatically is `publish-live.yml`, and that is a
-   deploy, not a check.
+   laptop in well under a minute, and rule 1 already requires it there. Three
+   workflows still fire on their own — `publish-live.yml` (push to `live/**`,
+   plus the event cron), `deploy-panitia.yml` (push to `web/**`) and
+   `refresh-live-score.yml` (event cron only). Two deploys and one cache
+   refresh; not a check among them.
 6. **What costs money is the NUMBER of runs, not their length.** GitHub rounds
    every JOB up to a whole minute, so a 7-second check and a 50-second check
    bill exactly the same. One measured day: 24 of 60 runs were a second copy of
@@ -797,11 +834,12 @@ Guidance for Claude Code when working in this repository.
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
-   run from their phones. The event-only exception in `publish-live.yml` runs
-   every 15 minutes from 08:00 through 23:45 WIB on 29 August 2026. Cron has no
-   year field, so the first step rejects every scheduled run outside that exact
-   date before reading the database or deploying. Do not widen its window or
-   remove that year guard.
+   run from their phones. There are two event-only exceptions, both on
+   29 August 2026 and both between 06:00 and 18:59 WIB: `publish-live.yml`
+   every 15 minutes, and `refresh-live-score.yml` every 10. Cron has no year
+   field, so each one's first step rejects every scheduled run outside that
+   exact date before reading the database or deploying. Do not widen either
+   window or remove those year guards.
 
 ## 17. Selama acara berjalan
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,20 @@ Gambaran lengkapnya di `docs/final-architecture.md`.
 | `docs/rancangan-b.md` | Cetak biru implementasi yang dipakai membangun | Catatan keputusan |
 | `docs/runbook-sekolah.md` | Cara membakukan daftar sekolah dari tulisan pembina | Berlaku |
 | `docs/sekolah-belum-tuntas.md` | Sekolah yang alamatnya masih perlu ditanyakan | Daftar kerja |
-| `docs/arsitektur-hrcd.svg` | Diagram lapisan teknis — Cloudflare, Supabase, penerbitan rekap | Berlaku |
-| `docs/alur-hrcd.svg` | Diagram alur acara — pendaftaran sampai klasemen | Berlaku |
+| `docs/arsitektur-hrcd.svg` | Diagram lapisan teknis — Cloudflare, Supabase, penerbitan rekap | **Basi** — capnya "sampai migrasi 0153" |
+| `docs/alur-hrcd.svg` | Diagram alur acara — pendaftaran sampai klasemen | Basi — "4 golongan", sejak `0091` enam |
+
+Kedua SVG belum digambar ulang sejak 30 Agustus 2026, dan angkanya jangan
+dipercaya sebelum dihitung ulang: `arsitektur-hrcd.svg` menghitung 153 migrasi
+(sekarang 169) dan capnya menyebut empat fase live tanpa `juara`, sementara
+`alur-hrcd.svg` masih menulis "4 golongan dinilai terpisah" padahal Intern PA
+dan Intern PI menjadikannya enam sejak `0091`. Bentuk lapisan dan urutan
+alurnya sendiri masih betul — yang basi angkanya.
 
 `desain-sistem.md` dan `rancangan-b.md` merekam **keputusan pada saat itu**,
-bukan keadaan hari ini. Keduanya sengaja dipertahankan apa adanya karena 42
-komentar di kode — tersebar di migrasi, tes, dan SPA — menunjuk ke nomor
+bukan keadaan hari ini. Keduanya sengaja dipertahankan apa adanya karena 61
+komentar di kode — tersebar di 32 berkas: migrasi, tes, SPA, workflow,
+gateway, dan berkas konfigurasi Cloudflare — menunjuk ke nomor
 bagiannya (`rancangan-b.md 11.9`, `bagian 4`, dan seterusnya). Kalau isinya
 berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 
@@ -35,26 +43,36 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 ├── docs/                     # spesifikasi, catatan keputusan, arsitektur
 ├── web/                      # SPA statis — layar panitia (panitia-hrcd37)
 │   ├── index.html            # layar panitia (butuh login)
-│   ├── js/                   # api.js, app.js, util.js
+│   ├── js/                   # api.js, app.js, util.js, dan dua modul murni
+│   │                         # hitung: departure-calculator.mjs dan
+│   │                         # nomor-dada-series.mjs
 │   ├── style.css             # seluruh gaya, termasuk aturan cetak
 │   ├── config.js             # URL Supabase + gateway (bukan rahasia)
 │   ├── _headers              # aturan cache Cloudflare
 │   └── wrangler.toml         # deploy Workers static assets
 ├── live/                     # situs PESERTA (hrcd37) — Worker TERPISAH:
 │   ├── daftar.html           # form pendaftaran publik
-│   ├── index.html            # rekap live (cari sekolah → centang per pos)
-│   ├── live.json             # ±1 KB: fase + versi, INI yang di-poll tiap menit
-│   ├── rekap.json            # baris regu + klasemen, diambil sekali per versi
+│   ├── index.html            # papan Live Score peserta; isinya ikut fase
+│   ├── live.json             # ±1 KB: fase, versi, ringkasan, dan kemajuan
+│   │                         # input per pos — INI yang di-poll tiap menit
+│   ├── rekap.json            # baris regu + klasemen + daftar juara,
+│   │                         # diambil sekali per versi
 │   ├── live.js, live.css     # halaman rekap — tidak ada di web/
 │   ├── js/daftar.js          # logika form pendaftaran — tidak ada di web/
+│   ├── js/school-search.mjs  # pencocokan nama sekolah — tidak ada di web/
 │   └── config.js, style.css, js/api.js, js/util.js
 │                             # SALINAN dari web/ — jangan diedit di sini,
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0153
-│   ├── checks/               # SQL manual — flow_test & cleanup_smoke MENGUBAH
-│   │                         # data; live_json.sql dipakai Publish rekap live
+│   ├── migrations/           # skema database, urut 0001..0169
+│   ├── checks/               # 30 SQL manual, dan 12 di antaranya MENGUBAH
+│   │                         # data (flow_test, cleanup_data_uji,
+│   │                         # cleanup_smoke, seed_data_uji, kloter_dari_stok,
+│   │                         # simulasi_end_to_end, atur_fase_live, …) — baca
+│   │                         # kepala berkasnya dulu. live_json.sql dipakai
+│   │                         # Publish rekap live; status_migrasi.sql melapor
+│   │                         # migrasi mana yang jejaknya ada di produksi
 │   └── seed.sql              # konfigurasi edisi + baris wajib
 ├── scripts/                  # provision_accounts.py, change_password.py,
 │                             # set_shared_password.py, delete_storage_objects.py
@@ -62,14 +80,19 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 │                             # periksa_impor.py, periksa_sekolah.py,
 │                             # periksa_urutan_golongan.py, normalize_sekolah.py,
 │                             # pratinjau_cetak.py, seed_regu_uji.py,
-│                             # simulasi_end_to_end.py
+│                             # simulasi_end_to_end.py, dan data/ —
+│                             # sekolah_nama.json + sekolah_alamat.json
 ├── tests/
 │   ├── sql/                  # harness + tes constraint, alur, skor, kloter, rekap
 │   ├── run.sh                # jalankan semuanya di database lokal
 │   ├── dev_database.sh       # siapkan database hrcd_dev untuk dicoba manual
 │   ├── dev_server.py         # tiruan Supabase untuk mencoba layar
 │   ├── static_server.py      # penyaji web/ tanpa cache
-│   └── concurrency_test.py   # uji daftar ulang serentak dari banyak meja
+│   ├── concurrency_test.py   # uji daftar ulang serentak dari banyak meja
+│   ├── *.test.mjs            # 85 berkas tes layar + modul (node --test)
+│   └── status_migrasi_check.sh
+│                             # menguji jejak status_migrasi.sql dua arah;
+│                             # lambat, sengaja di luar run.sh
 ├── .github/workflows/        # 10 workflow (lihat final-architecture.md)
 ├── CLAUDE.md                 # konvensi kerja
 └── AGENTS.md                 # aturan sama dengan CLAUDE.md (judul + pembuka beda)
@@ -77,7 +100,11 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 
 ## Menjalankan tes
 
-Butuh PostgreSQL 16 (lokal atau portable, tanpa Supabase):
+Butuh PostgreSQL (lokal atau portable, tanpa Supabase) — pakai **17**, versi
+mayor yang sama dengan produksi (17.6). Tes SQL sendiri lulus di 16, dan itu
+yang dipakai container CI, tetapi katalog Postgres berbeda antar versi mayor:
+di laptop 18.x `supabase/checks/status_migrasi.sql` melaporkan 22 sidik jari
+BELUM padahal migrasinya sudah masuk (CLAUDE.md pasal 7.8).
 
 ```bash
 PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
@@ -107,9 +134,12 @@ ada yang menjalankannya di mana pun.**
 Untuk mencoba layarnya (butuh tiga terminal):
 
 ```bash
-bash tests/dev_database.sh     # siapkan database hrcd_dev
-python tests/dev_server.py     # tiruan Supabase di :8787
-python tests/static_server.py  # layar panitia di :8788 (tanpa cache)
+# siapkan database hrcd_dev
+PSQL=/path/ke/psql PGPORT=5432 PGPASSWORD=... bash tests/dev_database.sh
+# tiruan Supabase di :8787
+PGPORT=5432 PGPASSWORD=... python tests/dev_server.py
+# layar panitia di :8788 (tanpa cache)
+python tests/static_server.py
 ```
 
 Sebelum membuka `:8788`, ganti `mode: "supabase"` jadi `mode: "dev"` di
@@ -156,10 +186,25 @@ gh workflow run "Apply migration to Supabase" --ref main \
 Atau dari HP: **Actions → Apply migration to Supabase → Run workflow**. Pastikan
 log-nya mencetak `MIGRASI BERHASIL`.
 
-Merge juga TIDAK men-deploy folder `live/`. Situs peserta — form pendaftaran
-dan rekap live — hanya terbit lewat **Actions → Publish rekap live**, termasuk
-kalau yang berubah cuma `daftar.html`. Yang otomatis terbit tiap push ke `main`
-hanya `web/`, lewat koneksi Git Cloudflare.
+Tidak ada yang mencatat migrasi mana yang sudah diterapkan, jadi berkas yang
+tidak pernah dijalankan gagal diam-diam — sepuluh pernah begitu, dan yang
+menemukannya pembina yang pendaftarannya ditolak enam hari kemudian. Sebelum
+percaya sebuah migrasi sudah hidup, jalankan pemeriksanya lewat workflow yang
+sama — `-f berkas=supabase/checks/status_migrasi.sql`. Ia melapor jejak tiap
+migrasi di database dan tidak mengubah apa pun.
+
+Situs peserta — form pendaftaran dan rekap live — hanya terbit lewat
+**Publish rekap live**: workflow itu menulis ulang `live.json` dan `rekap.json`
+dari database dulu, baru men-deploy folder `live/`. Karena itu project `hrcd37`
+di Cloudflare tidak boleh tersambung Git. Ia sudah ikut jalan sendiri saat push
+ke `main` menyentuh `live/**`, jadi merge yang cuma mengubah `daftar.html` pun
+menerbitkannya; tombol Run workflow tetap ada untuk menerbitkan ulang tanpa
+mengubah satu berkas pun.
+
+Layar panitia punya DUA jalur, dan keduanya jalan tiap push ke `main` yang
+menyentuh `web/**`: koneksi Git Cloudflare, dan workflow **Deploy layar
+panitia**. Yang kedua ditambahkan karena build di dashboard pernah menggantung
+lebih dari empat puluh menit tanpa meninggalkan jejak apa pun di GitHub.
 
 ## Kontribusi
 

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -5,7 +5,7 @@ Ciradyka (HRCD) sebagai dasar perancangan sistem `hrcd-rekap`.
 
 Isinya adalah hasil penjelasan panitia, bukan rancangan teknis. Keputusan
 teknologi sudah diambil dan sudah berjalan, tetapi perbandingan dan alasannya
-sengaja tidak dibahas di sini — lihat bagian 13.5 dan `final-architecture.md`.
+sengaja tidak dibahas di sini — lihat bagian 13.6 dan `final-architecture.md`.
 
 > **Penting:** aturan penilaian **berubah setiap tahun**. Semua angka di dokumen
 > ini adalah konfigurasi edisi berjalan, bukan spesifikasi permanen. Lihat
@@ -45,9 +45,20 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 4. Skala peserta konsisten di kisaran 300 regu, dengan batas atas sekitar 500.
 5. Sistem terbagi menjadi **dua wajah yang terpisah**:
    - **Aplikasi panitia** — satu link yang sama untuk semua panitia, dengan
-     akses yang dibedakan per akun (bagian 8.8).
+     akses yang dibedakan per akun (bagian 8.10).
    - **Tampilan live untuk peserta** — halaman publik tanpa login, berisi
-     **klasemen penuh empat golongan**, dibuka **bertahap**: selama lomba
+     **klasemen empat golongan Eksternal** (Intern tidak masuk papan), dibuka
+     **bertahap** lewat lima fase: `pra`, `progres` (centang per pos tanpa
+     satu angka nilai pun, ditambah kloter, kontrak waktu, jam berangkat, dan
+     jam datang regu itu sendiri, supaya jamnya bisa dicocokkan sebelum
+     hasilnya final), `penuh`, `top10` (maksimal sepuluh regu berperingkat per
+     golongan, migrasi `0145`), dan `juara` (papan diganti daftar juara,
+     migrasi `0163`). Nilai dan peringkat **disajikan statis dan diperbarui
+     berkala** — ratusan HP penonton tidak boleh bisa membebani jalur input
+     panitia. Yang dibaca LANGSUNG dari database cuma dua hal yang tidak
+     memuat satu nilai pun: fase yang sedang berlaku (migrasi `0070`) dan
+     jumlah pendaftar selama fase `pra`. Keduanya hanya boleh MEMPERKETAT
+     tampilan, tidak pernah menampilkan lebih dari isi berkas yang terbit.
      hanya progres tanpa angka nilai — centang per pos, ditambah kloter,
      kontrak waktu, jam berangkat, dan jam datang regu itu sendiri, supaya
      jamnya bisa dicocokkan sebelum hasilnya final — nilai dan peringkat
@@ -61,11 +72,19 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    bukan per individu.
 2. Satu regu bersifat seragam: satu golongan dan satu jenis kelamin. Sekolah
    yang mengirim 2 regu misalnya mengirim 5 Penggalang PA dan 5 Penggalang PI.
-3. Terdapat **empat klasemen yang dinilai terpisah**:
+3. Terdapat **enam klasemen yang dinilai terpisah** (migrasi `0091`):
    - Penegak PA (SMA, putra)
    - Penegak PI (SMA, putri)
    - Penggalang PA (SMP, putra)
    - Penggalang PI (SMP, putri)
+   - Intern PA (tuan rumah, putra)
+   - Intern PI (tuan rumah, putri)
+
+   Keempat golongan Eksternal dinilai penuh. Regu **Intern** semuanya berasal
+   dari satu sekolah — tuan rumah — dan hanya dinilai dari lima lomba soal
+   tulis ditambah ketepatan waktu; lomba lapangan, penalti tanpa checkout,
+   penalti anggota, dan nilai pos terlewat tidak berlaku bagi mereka. Papan
+   peserta pun hanya memuat keempat golongan Eksternal.
 4. Sebuah regu memakai **dua identitas secara berurutan**:
    - **Kode pembayaran** — terbit **saat pendaftaran** dan terikat pada seluruh
      regu dalam satu batch (bagian 3). Menjadi referensi saat membayar, lalu —
@@ -80,13 +99,22 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    sebagai kemudahan: sekolah yang mengirim 10 regu tidak perlu mengisi form 10
    kali. Satu pengisian mendaftarkan beberapa regu sekaligus dalam satu batch,
    dan sistem tetap memperlakukan tiap regu sebagai baris tersendiri (poin 3).
-2. Urutan pertanyaan di form:
+2. Urutan pertanyaan di form. **Yang pertama ditanyakan jenis pesertanya —
+   Eksternal atau Internal** (migrasi `0091`, `0133`). Jalur Internal berbeda
+   di tiga tempat: sekolahnya sudah terisi sendiri — SMAN 1 Ciamis, tuan
+   rumah — dan tidak bisa diganti, pertanyaan menginap tidak muncul sama
+   sekali, dan tiap regunya justru mengisi kelas atau organisasi asalnya.
+   Sesudah itu:
    1. **Asal sekolah.** Ketikan dicocokkan ke database sekolah — jika sekolahnya
       dikenal, muncul sebagai pilihan dropdown otomatis; jika tidak ada, diisi
       manual (dan sekolah baru itu masuk ke database).
    2. **Konfirmasi alamat.** Jika sekolah dipilih dari database, alamatnya
-      ditampilkan agar pendaftar memastikan sekolah yang dimaksud benar —
-      penting karena banyak sekolah bernama sama di kota berbeda.
+      ditampilkan agar pendaftar memastikan sekolah yang dimaksud benar.
+      Alamat itu **hanya untuk dilihat**: sejak migrasi `0061` kunci sekolah
+      adalah `kunci_sekolah(nama)`, jadi alamat yang diketik pembina tidak
+      melahirkan baris sekolah baru dan tidak menimpa alamat kurasi. Dua
+      sekolah senama di tempat berbeda dibedakan di dalam NAMANYA sendiri —
+      `MAN 3 Ciamis` dan `MAN 3 Tasikmalaya` — karena NPSN-nya berbeda.
    3. **Butuh penginapan?** Jawaban ya memasukkan seluruh batch ke skema
       penempatan barak (bagian 11).
    4. **Mendaftarkan berapa regu?** — tidak pernah diketik. Pendaftar menaikkan
@@ -109,6 +137,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    6. **Satu Contact Person** untuk keseluruhan batch: nama (wajib) dan nomor
       WhatsApp. Namanya disimpan sebagai `pendaftaran.nama_kontak` dan itulah
       yang dipanggil panitia saat menghubungi sekolah.
+   7. **Pembayaran** — transfer atau tunai, dipilih pembina di form itu juga
+      dan wajib diisi (migrasi `0121`, `0122`). Yang memilih transfer
+      MENGUNGGAH foto buktinya; berkasnya masuk bucket privat `bukti`, dan
+      tanpa bukti itu pendaftarannya tidak bisa dikirim.
 3. Setelah dikirim, sistem **memecah batch menjadi satu baris per regu** —
    5 regu menjadi 5 baris — yang tetap terikat pada satu tagihan bersama.
 4. Begitu form dikirim, terbit **kode pembayaran yang terikat pada regu-regu
@@ -126,9 +158,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 7. **Tidak ada pengembalian dana.** Regu yang batal setelah membayar tidak
    digantikan, dan kloternya tetap berjalan dengan jumlah regu berkurang.
 8. Konsekuensi bagi sistem: perlu **master data sekolah** (nama + alamat) yang
-   tumbuh dari tahun ke tahun — sumber dropdown otomatis di form, dan sekaligus
-   kunci penyebaran kloter per sekolah (bagian 5) serta penempatan barak
-   (bagian 11).
+   tumbuh dari tahun ke tahun — sumber dropdown otomatis di form, identitas
+   pendaftaran, dan dasar penempatan barak (bagian 11). **Sekolah tidak lagi
+   memengaruhi kloter**: sejak migrasi `0092` penempatan otomatis murni FIFO
+   berkuota jenis regu (bagian 5.4).
 
 ## 4. Daftar ulang
 
@@ -146,14 +179,21 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    atau tertinggal di kardus lain — jadi sistem tidak boleh menebak nomor
    mana yang tersedia secara fisik. Urutannya: petugas menyebut regu ini
    nomornya ini, lalu sistem memastikan nomor itu ada di stok, belum
-   dipensiunkan, dan belum dipakai regu lain. Nomor yang sudah dipakai
-   ditolak dengan pesan, bukan diterima diam-diam.
+   dipensiunkan, belum dipakai regu lain, dan **berada di deret yang benar**.
+   Nomor yang sudah dipakai ditolak dengan pesan, bukan diterima diam-diam.
+
+   **Ada DUA deret** (migrasi `0116`): Eksternal 1–500, Intern 1001–1250. Kain
+   kedua set sama-sama bertulis 001, jadi kain Intern bertulis 001 diketik
+   1001 — dan yang tampil di seluruh layar, kertas, dan papan peserta adalah
+   1001, bukan terjemahan yang cuma hidup di satu layar.
 6. **Pengisian nomor dada dilakukan sekaligus per sekolah**, bukan satu regu
    satu kali. Sekolah dengan 10 regu mengisi 10 nomor dada dalam satu
-   transaksi di meja. Ini menjadi dasar pembagian kloter — lihat bagian 5.
+   transaksi di meja. Urutan selesainya transaksi itulah yang menentukan
+   kloternya — lihat bagian 5.4. Sekolahnya sendiri tidak menentukan apa pun.
 7. **Kloternya tetap ditentukan sistem** (bagian 5.3). Yang manual hanya
-   nomor dadanya; penyebaran kloter justru tidak boleh diserahkan ke petugas
-   karena bertumpu pada keadaan seluruh sekolah, bukan satu meja saja.
+   nomor dadanya; urutan FIFO dan kuota 5 Eksternal + 3 Intern dijaga di dalam
+   `daftar_ulang_batch`, bukan oleh petugas satu meja yang tidak bisa melihat
+   apa yang baru saja terisi di meja sebelah.
 8. **Peserta wajib mengonfirmasi datanya sendiri, termasuk nomor dada,
    sebelum kertas dicetak.** Yang dikonfirmasi: nama regu, asal sekolah,
    golongan, dan nomor dada tiap regu.
@@ -182,8 +222,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    nomor dadanya, tidak ada yang bisa ditunjukkan selain riwayat perubahan di
    `history`, dan riwayat itu mencatat panitia yang mengetik — bukan peserta
    yang mengiyakan.
-9. Setelah daftar ulang ditutup, **lembar penilaian dicetak** untuk dibagikan ke
-   petugas lapangan (bagian 8.8).
+9. **Lembar penilaian tidak menunggu daftar ulang ditutup.** Blangko per lomba
+   kosong, jadi ia master yang bisa dicetak kapan saja lalu difotokopi; lembar
+   cadangan justru sengaja dicetak LEBIH DULU, sebelum pendaftaran ditutup,
+   supaya regu yang menyusul tetap punya barisnya (bagian 8.8).
 
 ## 5. Kloter dan kontrak waktu
 
@@ -200,7 +242,11 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 6. Set manual tidak memiliki batas kuota atau jumlah; ini sengaja agar petugas
    dapat mencatat keadaan lapangan apa adanya.
 7. Perkiraan waktu K1–K75 dibagi merata sepanjang 07:00–10:00, sekitar dua
-   setengah menit antar-kloter untuk jumlah tersebut.
+   setengah menit antar-kloter untuk jumlah tersebut — tetapi jendela itu
+   **batas atas, bukan perintah menyebar** (migrasi `0118`). Jaraknya diambil
+   yang lebih kecil antara pembagian rata dan `edisi.interval_berangkat_menit`
+   (5 menit, keputusan pemilik acara), supaya dua kloter tidak dijadwalkan
+   berjarak tiga jam hanya karena kloternya sedikit.
 8. **Satu kloter boleh berisi golongan campuran.** Penggalang dan Penegak, putra
    dan putri, dapat berangkat dalam kloter yang sama; hanya Intern dan Eksternal
    yang mempunyai kuota otomatis terpisah.
@@ -229,8 +275,9 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    memasukkannya ke sistem.
 5. Saat keberangkatan, panitia menceklis **per nomor dada** bahwa regu tersebut
    benar-benar berangkat.
-6. Jarak antar keberangkatan kloter biasanya **3–5 menit**. Angka pastinya belum
-   ditetapkan — lihat bagian 13.
+6. Jarak antar keberangkatan kloter **paling banyak 5 menit** — ditetapkan
+   pemilik acara dan disimpan di `edisi.interval_berangkat_menit` (migrasi
+   `0118`), bukan di kode.
 7. Konsekuensi bagi sistem: layar keberangkatan harus menampilkan **beberapa
    kloter sekaligus dalam status berbeda**, bukan satu kloter per layar.
 8. **Ada 3 staging.** Verifikasi kehadiran regu dilakukan **di staging**, bukan
@@ -269,8 +316,10 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 ## 7. Rute dan pos
 
 1. Terdapat **5 pos utama** di sepanjang rute (Pos 1–5), masing-masing dengan
-   soal dan wahana yang berbeda. Susunan XXXVII: 1 Kepramukaan, 2 Halang
-   Rintang, 3 P3K, 4 PBB, 5 Yel-Yel.
+   lombanya sendiri. Susunan XXXVII: 1 Kepramukaan, 2 Halang
+   Rintang, 3 P3K, 4 PBB, 5 Yel-Yel. **Soal kertas hanya masuk di Pos 1, 2,
+   dan 3** (migrasi `0076`); Pos 4 dan Pos 5 masing-masing satu lomba saja,
+   tanpa soal.
 
    **Pos 0 dan Pos 6 bukan pos penilaian.** Keduanya tempat yang sama —
    garis start dan garis finish — dan peserta menyebutnya Pos 0 saat berangkat,
@@ -304,10 +353,19 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    Ia bukan cabang tersendiri di kode: sebuah baris di tabel `pos` bertanda
    `bayangan`, dengan komponen penilaiannya sendiri, dan bobotnya diatur
    seperti pos mana pun. Yang membedakan hanya kata di judul layar dan di
-   kertas. Nomor posnya melanjutkan pos utama — pos bayangan pertama bernomor
-   6.
-3. Di setiap pos utama ada dua hal yang dinilai, dan **keduanya berasal dari
-   tempat yang berbeda**:
+   kertas. Nomor posnya melanjutkan pos utama, dan nomor mana yang bebas
+   ditentukan tata letak edisi itu — di XXXVII nomor 6 SUDAH dipakai garis
+   finish (`Kedatangan`, migrasi `0032`), jadi pos bayangan pertama tidak bisa
+   bernomor 6.
+
+   **Edisi XXXVII sendiri tidak memuat satu pun pos bayangan yang dinilai.**
+   Baris `Kostum` dari XXXVI dibuang bersama migrasi `0032`/`0033`, dan
+   nomornya dipakai garis finish. Yang tersisa di lapangan cuma tempat
+   pengambilan kertas soal ("Alur peserta di satu pos", butir 4); mesin
+   penilaiannya tetap ada dan siap dipakai lagi kalau edisi berikutnya
+   memakainya.
+3. Di pos yang menerima soal — Pos 1, 2, dan 3 di edisi XXXVII — ada dua hal
+   yang dinilai, dan **keduanya berasal dari tempat yang berbeda**:
    - **Wahana** — tantangan fisik seperti merangkak, berlari, atau memanjat,
      berbeda-beda tergantung pos. Dikerjakan **dan** dinilai di pos itu juga.
    - **Soal kertas** — diambil regu di **pos bayangan tepat sebelum pos ini**,
@@ -444,9 +502,10 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    ke nomor dada dan lomba yang tepat. Alasannya di bagian 8.5.
 4. **Pos bayangan tidak menahan regu.** Yang terjadi di sana cuma pengambilan
    kertas; regu tidak dinilai wahana apa pun dan langsung melanjutkan
-   perjalanan. Penilaian yang melekat pada pos bayangan — kostum, kekompakan,
-   kesopanan — berjalan dengan mengamati regu yang lewat, bukan dengan
-   menghentikannya (butir 2 di atas).
+   perjalanan. Kalau edisinya memang memasang penilaian pada pos bayangan —
+   kostum, kekompakan, kesopanan — penilaian itu berjalan dengan mengamati
+   regu yang lewat, bukan dengan menghentikannya (butir 2 di atas). Edisi
+   XXXVII tidak memasangnya sama sekali (bagian 7.2).
 5. **Yang dibawa regu keluar dari Pos 1 adalah kertas soal Pos 2.** Regu yang
    berjalan tanpa kertas soal berarti ada yang terlewat di Pos Bayangan 2, dan
    itu baru ketahuan di pos berikutnya ketika ia tidak punya apa-apa untuk
@@ -472,7 +531,8 @@ Jalur lomba    tiap lomba punya jurinya sendiri
       tersebut (Tebak Simpul Penggalang `0–5`, Penegak `0–10`).
    5. Kertas dimasukkan ke **kotak penilaian** di pos itu.
    6. Kotaknya diserahkan ke tim IT untuk diinput.
-   7. Tim IT **mengurutkan kertasnya menurut nomor dada**, 001 sampai 500,
+   7. Tim IT **mengurutkan kertasnya menurut nomor dada** — 001 sampai 500
+      untuk Eksternal, lalu 1001 sampai 1250 untuk Intern (migrasi `0116`) —
       lalu memasukkannya berurutan.
 
    Bentuk ini bukan selera, melainkan tuntutan dua hal yang terjadi bersamaan.
@@ -483,7 +543,7 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    lalu disalin belakangan. Salinan itulah yang hilang.
 
    Dan satu regu **tidak pernah selesai di semua lomba pada saat yang sama**.
-   Lembar berisi 30 regu baru bisa berpindah setelah baris terakhir terisi;
+   Lembar berisi 40 regu baru bisa berpindah setelah baris terakhir terisi;
    kertas per regu berpindah begitu regunya selesai.
 
 4. **Nomor dada adalah kepala kertas itu, bukan salah satu kolomnya.** Seluruh
@@ -536,17 +596,27 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    muncul satu kali pun di seluruh migrasi itu. Tidak ada jalur dari foto ke
    nilai, bahkan kalau suatu hari ada yang menginginkannya.
 
-   Penautan otomatis pun berhenti kalau ragu: slip menyebut nomor dada DAN
-   nama regu, dan kalau keduanya tidak menunjuk regu yang sama, fotonya
-   ditinggal belum tertaut untuk diputuskan orang. Foto yang tertaut ke regu
-   yang salah bukan sekadar tidak berguna — ia bukti yang membantah nilai yang
-   benar.
+   **Penautan otomatis BELUM DIBANGUN.** `cara_taut = 'mesin'` hidup di
+   constraint migrasi `0074`, tetapi tidak ada satu layar pun yang pernah
+   menuliskannya: `tautkanFoto()` berdefault `"tangan"` dan satu-satunya
+   pemanggilnya mengirim `"tangan"` secara eksplisit. Aturan berikut berlaku
+   KALAU KELAK jalur itu dibangun, bukan gambaran yang sudah berjalan — dan
+   batasnya tetap sah sekarang: penautan otomatis berhenti kalau ragu, slip
+   menyebut nomor dada DAN nama regu, dan kalau keduanya tidak menunjuk regu
+   yang sama fotonya ditinggal belum tertaut untuk diputuskan orang. Foto yang
+   tertaut ke regu yang salah bukan sekadar tidak berguna — ia bukti yang
+   membantah nilai yang benar.
 
    Tombolnya kamera di tiap baris lembar Input Pos; gambarnya masuk bucket
    privat `lembar` sesudah dikecilkan jadi abu-abu 1400px di HP, ~70 KB
    per foto.
-6. Operator IT memasukkannya ke sistem dengan kunci **nomor dada**, lewat layar
-   Input Pos — satu regu satu baris, tersimpan sendiri tanpa tombol Simpan.
+6. Operator IT memasukkannya ke sistem dengan kunci **nomor dada**, lewat dua
+   layar yang menulis lewat pintu yang sama (`simpan_nilai_massal`):
+   **Input Nilai Pos** — satu tabel selebar pos, satu regu satu baris,
+   tersimpan sendiri tanpa tombol Simpan, dipakai meja IT dan satu-satunya
+   tempat blangko bisa dicetak — dan **Input Nilai Pos v2**, yang mulai dari
+   pemilih lomba lintas pos lalu menggambar satu regu satu layar dengan tombol
+   SIMPAN NILAI, dipakai juri yang memegang satu lomba sepagian.
 
    **Upload massal BELUM DIBANGUN.** Rencananya masih berdiri dan RPC-nya
    sudah menerimanya (`simpan_nilai_massal` sudah punya `p_sumber = 'upload'`
@@ -564,7 +634,8 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    regu hanya form tabel cadangan; **blangko per lomba sengaja kosong**, karena
    regu datang ke pos dengan urutan acak dan slip yang sudah bernama harus
    dicari dulu di tumpukan 500 lembar sebelum bisa dipakai. Di blangko, nomor
-   dada ditulis tangan petugas di kotak besar pojok kiri atas. Kolomnya tidak pernah ditulis tangan di berkas mana pun — ia
+   dada ditulis tangan petugas di kotak besar pojok kiri atas. Kolomnya tidak
+   pernah ditulis tangan di berkas mana pun — ia
    lahir dari tabel `wahana`, sehingga kertas tahun depan ikut berubah sendiri
    begitu konfigurasi penilaiannya diganti.
 
@@ -573,12 +644,15 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    | Bentuk | Isi | Dipakai |
    | --- | --- | --- |
    | **Form per lomba** | **A5 melintang**, satu lomba, **satu regu** | di wahana, lalu masuk kotak (poin 3) |
-   | **Form tabel per pos** | satu halaman, semua lomba, 30 regu | **cadangan** — slip habis atau sinyal mati |
+   | **Form tabel per pos** | satu halaman, semua lomba, 40 regu | **cadangan** — slip habis atau sinyal mati |
    | **Form tabel per pos online** | layar Input Pos | tim IT memasukkan isi kotak |
 
    **Form per lomba adalah bentuk yang paling banyak dicetak, dan jumlahnya
-   besar.** 500 regu di pos berisi tiga lomba berarti **1.500 kertas untuk Pos
-   1 saja**. Karena itu yang dicetak dari layar adalah **master**-nya, bukan
+   besar.** Pos 1 memuat lima lomba, tetapi hanya tiga yang berblangko —
+   **lomba soal tulis tidak punya blangko sama sekali**, karena peserta
+   menjawab di lembar soalnya sendiri dan lembar itulah yang dikumpulkan. Jadi
+   500 regu di Pos 1 tetap berarti **1.500 kertas untuk pos itu saja**. Karena
+   itu yang dicetak dari layar adalah **master**-nya, bukan
    tumpukannya: satu halaman per lomba, lalu diperbanyak dengan mesin
    fotokopi. Ukurannya **A5 melintang** — separuh A4 dipotong mendatar,
    sehingga mesin fotokopi mana pun dapat menggandakannya 2-up ke A4 dan
@@ -643,8 +717,9 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    bertambah satu: kertas yang hanya memuat satu lomba tidak punya cukup bahan
    untuk menghitungnya.
 
-9. Sebuah **server pemantau** menampilkan status kelengkapan input — pos mana
-   yang sudah menyetor dan pos mana yang belum.
+9. **Cincin kelengkapan di layar Live Score** menampilkan status input per pos
+   — berapa persen regu yang nilainya sudah lengkap di pos itu, dari
+   `v_kelengkapan_pos`. Tidak ada server pemantau tersendiri.
 10. **Satu link untuk semua panitia, akses dibedakan per akun.** Setiap akun
    hanya melihat dan menyentuh bagiannya sendiri:
 
@@ -678,31 +753,42 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 1. **Aturan penilaian berubah setiap tahun.** Sistem harus dapat diubah tanpa
    mengubah kode. Yang berikut ini adalah konfigurasi edisi berjalan, bukan
    aturan tetap.
-2. **Yang setara adalah LOMBA, bukan pos.** Satuan penilaian adalah lomba, dan
-   tiap lomba bernilai maksimum **100**. Maksimum sebuah pos karena itu bukan
-   angka tetap melainkan hasil hitungan:
+2. **Yang setara adalah LOMBA, bukan pos.** Satuan penilaian adalah lomba.
+   Lomba lapangan bernilai maksimum **100**; kelima lomba soal tulis yang
+   dipasang migrasi `0076` sengaja **setengahnya — 50** (Logika 100, karena
+   soalnya 20). Maksimum sebuah pos karena itu bukan angka tetap melainkan
+   hasil hitungan:
 
    ```
-   maksimum pos = 100 × jumlah lomba di pos itu
+   maksimum pos = jumlah poin maksimum seluruh lomba di pos itu
    ```
 
-   Pos berisi tiga lomba bernilai 300; pos berisi satu lomba bernilai 100; pos
-   berisi lima lomba bernilai 500. Tidak ada batas atas yang perlu dijaga —
-   angkanya mengikuti apa pun yang panitia susun tahun itu.
+   Pos berisi tiga lomba lapangan bernilai 300; pos berisi satu lomba bernilai
+   100; pos berisi tiga lomba lapangan ditambah dua lomba soal bernilai 400.
+   Tidak ada batas atas yang perlu dijaga — angkanya mengikuti apa pun yang
+   panitia susun tahun itu.
 
    Edisi XXXVII kebetulan begini:
 
    | Pos | Lomba | Maksimum |
    | --- | --- | --- |
-   | 1 Kepramukaan | Semaphore, Tebak Simpul, Menaksir | 300 |
-   | 2 Halang Rintang | Bakiak, Lari Balok, Balap Karung | 300 |
-   | 3 P3K | Bidai, Kim Lihat, Kim Cium | 300 |
+   | 1 Kepramukaan | Semaphore, Tebak Simpul, Menaksir (100 masing-masing) + Keagamaan, Kepramukaan (50) | 400 |
+   | 2 Halang Rintang | Bakiak, Lari Balok, Balap Karung (100 masing-masing) + Kesehatan, Pengetahuan Umum (50) | 400 |
+   | 3 P3K | Pembidaian, Kim Lihat, Kim Cium, Logika (100 masing-masing) | 400 |
    | 4 PBB | PBB | 100 |
    | 5 Yel-Yel | Yel-Yel | 100 |
 
-   Akibatnya nyata dan disengaja: regu yang sempurna di Pos 1 mendapat 300,
-   yang sempurna di PBB mendapat 100 — Pos 1 tiga kali lebih menentukan
+   Akibatnya nyata dan disengaja: regu yang sempurna di Pos 1 mendapat 400,
+   yang sempurna di PBB mendapat 100 — Pos 1 empat kali lebih menentukan
    peringkat. Itu bukan ketimpangan, melainkan cara menghitung yang mengikuti
+   POIN seluruh lomba yang benar-benar dikerjakan regu di sana: Pos 1 punya
+   lima lomba, dua di antaranya bernilai 50.
+
+   **Bobot setengah lomba soal juga disengaja** dan diputuskan pemilik acara
+   (migrasi `0076`): menaikkan `poin_maks` jadi 100 tetap membuat "satu benar
+   5 poin" benar, karena rumusnya membagi dengan `total_soal` — jadi godaan
+   "membetulkannya" nyata. Jangan, kecuali pemilik acara berkata lain. Itu
+   bukan ketimpangan, melainkan cara menghitung yang mengikuti
    jumlah lomba yang benar-benar dikerjakan regu di sana.
 
    Satu hal yang perlu diperhatikan saat menyusun pos tahun depan: **memindah
@@ -722,7 +808,9 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    waktu lebih kecil terhadap targetnya menempati peringkat lebih tinggi.
    Selisih sebenarnya tetap dicatat bertanda sampai satuan menit supaya layar
    dapat menjelaskan apakah regu datang terlalu cepat atau terlambat.
-5. Peringkat dihitung **terpisah untuk keempat golongan** (bagian 2.3).
+5. Peringkat dihitung **terpisah untuk keenam golongan** (bagian 2.3) —
+   `rank() over (partition by golongan ...)`. Regu yang belum tercatat tiba
+   tidak diperingkat sama sekali (migrasi `0143`).
 6. Yang wajib dapat dikonfigurasi ulang setiap tahun:
    - Daftar pos dan bobotnya
    - Rumus konversi data mentah menjadi poin, per wahana dan per soal
@@ -771,6 +859,9 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 
 ### Pengurangan lain di luar penalti waktu
 
+Ketiga pengurangan di bawah **tidak berlaku bagi regu Intern** (migrasi
+`0091`): mereka hanya menerima poin lomba soal tulis dikurangi penalti waktu.
+
 7. **Belum tercatat tiba** di meja Kedatangan: tetap ditampilkan di Live Score
    tanpa peringkat, **tidak dapat masuk enam besar**, dan tidak dikenai
    pengurangan skor.
@@ -814,9 +905,10 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 
 ## 13. Yang belum diputuskan
 
-1. **Skema wahana dan interval keberangkatan.** Ditunda sebagai analisis
-   tersendiri; akan dibahas terpisah bersama panitia. Interval biasanya 3–5
-   menit, tetapi angkanya belum ditetapkan.
+1. **Skema wahana.** Ditunda sebagai analisis tersendiri; akan dibahas
+   terpisah bersama panitia. Interval keberangkatan sendiri **sudah
+   ditetapkan**: paling banyak 5 menit, di `edisi.interval_berangkat_menit`
+   (migrasi `0118`, bagian 6.6).
 
    Kerangka perhitungan yang akan dipakai nanti, dicatat di sini agar siap
    dipakai. Kapasitas sebuah pos adalah `jumlah jalur / batas waktu wahana`
@@ -835,12 +927,12 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    Data yang diperlukan untuk analisis ini, per pos: berapa regu dapat
    mengerjakan wahana secara serentak, dan berapa batas waktu pengerjaannya.
 
-   Besar lompatan kloter (bagian 5.6) juga ditentukan di analisis yang sama,
-   karena bergantung pada interval keberangkatan.
-2. **Angka rumus konversi data mentah menjadi poin.** Bentuk-bentuknya sudah
-   selesai dirancang dan berjalan; yang belum ditentukan tinggal angkanya
-   untuk edisi berjalan. Panitia menegaskan **semua kombinasi mungkin
-   terjadi**, dan keenam bentuk berikut sudah terpasang:
+
+2. **Bentuk rumus konversi data mentah menjadi poin.** Bentuknya sudah selesai
+   dirancang dan berjalan, dan angka XXXVII-nya sudah terpasang serta
+   dikonfirmasi panitia (migrasi `0035`, `0036`, `0076`, `0085`, `0086`).
+   Panitia menegaskan **semua kombinasi mungkin terjadi**, dan keenam bentuk
+   berikut sudah terpasang:
 
    | Bentuk | Contoh data mentah |
    | --- | --- |
@@ -854,8 +946,8 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    Karena bentuknya bisa berubah tiap tahun dan tiap wahana, konfigurasi
    konversi dirancang luwes untuk menampung semuanya: keenam bentuk di atas
    ada di fungsi `hitung_poin()`, dan tiap komponen pos diatur lewat satu
-   baris konfigurasi, bukan lewat kode. Angka yang terpasang sekarang adalah
-   angka HRCD XXXVI sebagai titik awal.
+   baris konfigurasi, bukan lewat kode. Angka HRCD XXXVI sempat jadi titik
+   awal, tetapi seluruhnya sudah diganti angka XXXVII.
 3. **Arti singkatan `IMPK`.** Muncul di contoh lembar nilai yang dulu tertulis
    di bagian 8, dan tidak pernah dijelaskan siapa pun. Contohnya sendiri sudah
    diganti — format kertas sekarang lahir dari tabel `wahana`, bukan dari
@@ -865,17 +957,25 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    ```
    No Dada - Nama Regu - Nama Sekolah - Golongan | Penilaian (Ikuti Skala) | IMPK (benar = v) - Nilai Pos 3
    ```
-4. **Apakah foto berkala tetap diwajibkan setelah kertas berpindah fisik**
-   (bagian 8.5). Alur kotak penilaian membuat foto bukan lagi jalur utama,
+4. **Siapa yang bertanggung jawab atas kotak penilaian sejak pos tutup sampai
+   isinya masuk sistem.** Alur kotak penilaian membuat foto bukan lagi jalur
+   utama, tetapi kotak yang hilang atau tertinggal di pos adalah satu-satunya
+   cara nilai lenyap tanpa jejak — dan itu justru risiko yang dulu dihindari
+   dengan tidak memindahkan kertas sama sekali.
+
+   Pertanyaan fotonya sendiri **sudah terjawab** (bagian 8.5): slip difoto di
+   meja IT sambil nilainya diketik (migrasi `0047`), dan foto borongan di pos
+   punya jalan pulang lewat layar Foto Jawaban (migrasi `0074`).
    tetapi kotak yang hilang atau tertinggal di pos adalah satu-satunya cara
    nilai lenyap tanpa jejak — dan itu justru risiko yang dulu dihindari dengan
    tidak memindahkan kertas sama sekali. Kalau foto tidak diwajibkan, perlu
    disepakati siapa yang bertanggung jawab atas kotak sejak pos tutup sampai
    isinya masuk sistem.
-5. **Satu pembacaan pada bagian 10 yang belum dipastikan:**
-   - Pengurangan −20 karena anggota tidak lengkap — apakah dihitung per orang
-     yang hilang (2 orang berarti −40) atau tetap −20 berapa pun jumlahnya?
-     Dokumen ini mengasumsikan per orang.
+5. **Pengurangan −20 karena anggota tidak lengkap dihitung PER ORANG di
+   sistem** — `(5 - anggota_hadir) * penalti_per_anggota_hilang` di
+   `v_total_skor`, jadi 2 orang hilang berarti −40. Bentuk itu sudah berjalan
+   sejak migrasi `0005`; yang masih menunggu jawaban pemilik acara cuma apakah
+   memang itu yang dimaksudkan.
 6. **Teknologi yang dipakai: SUDAH DIPUTUSKAN dan sudah berjalan.** Panitia
    memilih Kandidat B — Supabase + frontend statis di Cloudflare — dengan
    syarat keras UI/UX harus mudah diajarkan. Google Sheets sempat direncanakan

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -10,7 +10,12 @@
 > blok keputusan di bagian 8, catatan di bagian 7.1, dan tanda **Selesai** di
 > bagian 9. Maka kalimat di bagian 4 seperti "Cloudflare Pages", "tanpa server
 > custom", `FOR UPDATE SKIP LOCKED`, atau tabel `riwayat` menggambarkan RENCANA
-> saat itu — beberapa di antaranya memang berubah saat dibangun.
+> saat itu — beberapa di antaranya memang berubah saat dibangun, dan DUA tidak
+> pernah dibangun sama sekali: **Realtime** (bagian 4.1 poin 2 — tidak ada satu
+> langganan pun di `web/js/`; layar panitia menyegarkan diri dengan polling
+> berkala, rekap peserta lewat penerbitan berkas) dan **Google Sheets sebagai
+> jendela baca** (bagian 8.1 beserta blok keputusan di bagian 8 — tidak ada
+> tombol export CSV di layar mana pun).
 >
 > **Untuk keadaan sistem sekarang, baca `final-architecture.md`.**
 
@@ -40,11 +45,11 @@ Ringkasan dari `alur-lomba.md` — setiap kandidat dipetakan ke daftar ini:
 | R4 | Kloter otomatis FIFO saat itu juga: 5 Eksternal + 3 Intern, 75 kloter dengan headroom untuk perkiraan 300+50 regu; set manual tanpa batas |
 | R5 | Layar garis start: antrean 4 tahap, konfirmasi kontrak waktu, jam berangkat per kloter + ceklis per regu |
 | R6 | Input nilai per pos: link + akun/password sendiri per pos; input manual **dan** upload massal Excel/CSV dengan layar preview yang memvalidasi |
-| R7 | Mesin skor yang bisa dikonfigurasi panitia tanpa programmer: 5 bentuk konversi, bobot pos, rumus penalti, pengurangan lain |
+| R7 | Mesin skor yang bisa dikonfigurasi panitia tanpa programmer: 6 bentuk konversi, bobot pos, rumus penalti, pengurangan lain |
 | R8 | Meja closing: jam datang **diketik manual dan bisa di-edit**, bukan timestamp server |
 | R9 | Dashboard pemantau: pos mana sudah input untuk regu mana |
-| R10 | Klasemen 4 golongan terpisah, seri dipecah dengan selisih menit |
-| R11 | Cetak lembar nilai per pos, terisi identitas regu, setelah daftar ulang tutup |
+| R10 | Klasemen per golongan terpisah (empat saat ditulis; enam sejak `0091` menambahkan Intern PA dan Intern PI), seri dipecah dengan selisih menit |
+| R11 | Cetak lembar nilai: blangko **per lomba** yang sengaja KOSONG (master A5 yang difotokopi), plus form tabel per pos berisi identitas regu sebagai cadangan — dicetak lebih dulu, sebelum pendaftaran ditutup |
 | R12 | Penempatan barak dihitung sistem (ruangan + kapasitas, 1 sekolah 1 ruangan diutamakan) |
 | R13 | Riwayat perubahan: siapa mengubah apa, kapan |
 | R14 | Meja bisa berubah fungsi tanpa admin |
@@ -290,9 +295,14 @@ kloter, validasi upload — semuanya berjalan di browser.
 | Kecepatan layar | Lambat (1–4 dtk) | Cepat | Cepat | **Paling cepat** |
 | Titik gagal khas | Kuota eksekusi + salah edit | Lupa keep-alive + bus factor SQL | Tebing kuota baca | Hardware + manusia |
 
-Semua kandidat berbagi satu batas yang sama pada R7: lima bentuk konversi yang
-sudah dienumerasi bisa diubah panitia sendiri, tetapi bentuk rumus yang **benar-
-benar baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
+Semua kandidat berbagi satu batas yang sama pada R7: bentuk konversi yang sudah
+dienumerasi bisa diubah panitia sendiri, tetapi bentuk rumus yang **benar-benar
+baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
+
+> **Penanda hasil.** Terbukti persis begitu: lima bentuk saat dokumen ini
+> ditulis, dan `bertingkat` menyusul sebagai yang keenam lewat migrasi `0022` —
+> ditambahkan pemilik, di kode (`hitung_poin` bertambah satu argumen), bukan
+> oleh panitia di layar konfigurasi.
 
 ### 7.1 Dua kebutuhan yang ditambahkan setelah dokumen ini ditulis
 
@@ -320,9 +330,13 @@ benar baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
 > jujur Kandidat A di bagian 8.3 (ketiga permintaan terbaru terbukti bisa
 > dilakukan Sheets), panitia memilih B secara eksplisit, dengan satu syarat
 > yang dipegang sebagai kebutuhan keras: **UI/UX harus mudah — panitia bisa
-> diajari selama tampilannya mudah.** Google Sheets tidak dibuang: ia tetap
-> hidup sebagai jendela baca (bagian 8.1). Frontend di Cloudflare
-> (bagian 8.2). Rancangan detail menyusul di `rancangan-b.md`.
+> diajari selama tampilannya mudah.** Google Sheets waktu itu tidak dibuang:
+> ia dipertahankan sebagai jendela baca (bagian 8.1) — **tetapi bagian itu
+> tidak pernah dibangun.** Tidak ada tombol export CSV di layar mana pun dan
+> tidak ada satu baris Sheets di kode; yang akhirnya memenuhi janji "tampilan
+> Excel" adalah bentuk tabel layar panitia sendiri, yang sengaja meniru
+> spreadsheet. Frontend di Cloudflare (bagian 8.2). Rancangan detail menyusul
+> di `rancangan-b.md`.
 
 > Catatan riwayat: revisi sebelumnya sempat salah mencatat "panitia mencoret
 > Kandidat A" — panitia tidak pernah mencoretnya; keputusan baru diambil
@@ -367,6 +381,12 @@ benar baru** tetap butuh pemilik menyentuh kode — di kandidat mana pun.
    tahunan disimpan sebagai spreadsheet yang bisa dibuka selamanya tanpa
    sistem berjalan. Panitia tidak kehilangan tampilan Excel-nya; mereka hanya
    berhenti menjadikannya tempat kebenaran data.
+
+   > **Penanda hasil: poin 4 ini rencana yang tidak jadi.** Export CSV/Sheets
+   > tidak ada di layar mana pun (`rancangan-b.md` menjadwalkannya ke Tahap 4),
+   > dan tempel-dari-Excel juga belum dibangun (`alur-lomba.md` 8.6). Yang
+   > akhirnya memenuhi kebutuhan "tampilan Excel" ada di blok keputusan
+   > bagian 8.
 
 ### 8.2 Cloudflare vs Vercel untuk frontend statis
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -6,31 +6,48 @@ dokumen ini, **dokumen ini yang benar** — keduanya catatan keputusan, ditulis
 sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
-sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0164`:
-angka tabel, view, RPC, policy, check dan pemicu DIHITUNG ULANG dari database
-sampai `0162`, dan bagian 3 diperiksa terhadap layar. `0163` — fase live
-kelima `juara` beserta `v_kejuaraan_publik` dan `hasil_kejuaraan_semua()` —
-mendarat sesudah penghitungan itu, jadi angka view dan fungsi di bagian 2
-kurang satu masing-masing; `0164` menulis ulang view yang sama untuk
-membawa kolom skornya dan tidak mengubah jumlahnya. Disegarkan lagi
-31 Agustus 2026 sampai migrasi `0169`, dan cakupannya SEMPIT: yang
-diperiksa hanya jumlah migrasi beserta bagian singgahan `cache_live_score`
-di bawah. `0165` menambah satu fungsi, `minta_segarkan_live_score()`,
-dan `0166` menambah satu view (`v_lomba_pos`) beserta dua fungsi
-(`lomba_komponen()` dan bentuk tiga-argumen `nilai_tergembok()`) sambil
-menjadikan gembok nilai PER LOMBA; `0167` menambah satu kolom
-(`foto_lembar.putaran`) dan satu fungsi (`putar_foto_lembar()`) supaya foto
-slip yang terlanjur masuk miring bisa diputar tanpa menyentuh berkasnya —
-sehingga angka view dan fungsi di bagian 2 kurang satu dan empat. `0168` dan `0169`
-tidak mengubah satu pun angka itu: keduanya hanya membetulkan kolom
-konfigurasi pada baris `wahana` — `0168` judul dan petunjuk `menaksir`
-("Hasil Taksir", "(meter)"), menyusul 0085 yang membalik arti angka yang
-diketik tetapi meninggalkan judulnya; `0169` mengosongkan `judul_isian`
-kelima lomba soal supaya layar menurunkan "Jumlah benar" sendiri, sama
-seperti Semaphore. Isi bagian 2 sampai 9
-selebihnya belum dibaca ulang baris demi baris terhadap `0119`-`0169`.
+sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0164`, lalu
+2 September 2026 sampai migrasi `0169`.
 
-Dua diagram menemani dokumen ini dan digambar dari tree yang sama:
+Dokumen ini sengaja TIDAK memuat jumlah view, RPC, policy, check, atau pemicu.
+Angka-angka itu berubah tiap beberapa migrasi, tidak ada satu tes pun yang
+menjaganya, dan pembukuan lamanya sempat berminggu-minggu menyuruh pembaca
+membetulkan "angka view dan fungsi di bagian 2" yang tidak pernah ada di
+teksnya — yang memuatnya `arsitektur-hrcd.svg`, bukan berkas ini. Yang dijaga
+`tests/final_architecture.test.mjs` cuma jumlah migrasi dan tabel rute.
+
+Yang DIPERIKSA pada penyegaran 2 September: jumlah migrasi, tabel rute, baris
+`#/pos2`, blangko per lomba, seluruh bagian 3b beserta pagar
+`publish-live.yml`, tabel deploy dan daftar workflow, ukuran aset dan
+`live/_headers`, blok menjalankan lokal, prosa Rekapitulasi — yang ditulis
+ulang jadi cetakan, karena layarnya sudah dihapus 27 Agustus 2026 — serta
+daftar di bagian 8. Yang BELUM: "Cara skor dihitung", "Kunci daftar ulang",
+dan bagian 4, 6, dan 7 — belum dibaca baris demi baris terhadap
+`0119`-`0169`.
+
+Lima migrasi terakhir yang mengubah isi dokumen ini: `0165` menambah
+`minta_segarkan_live_score()`, yang jadi tombol Refresh di layar Live Score;
+`0166` menjadikan gembok nilai PER LOMBA lewat `v_lomba_pos`,
+`lomba_komponen()`, dan bentuk tiga-argumen `nilai_tergembok()`; `0167`
+menambah `foto_lembar.putaran` beserta `putar_foto_lembar()` supaya foto slip
+yang terlanjur masuk miring bisa diputar tanpa menyentuh berkasnya —
+dihormati layar Cek Nilai, Input Nilai Pos, dan Input Nilai Pos v2; `0168`
+membetulkan judul dan petunjuk `menaksir` ("Hasil Taksir", "(meter)"),
+menyusul `0085` yang membalik arti angka yang diketik tetapi meninggalkan
+judulnya; `0169` mengosongkan `judul_isian` kelima lomba soal supaya layar
+menurunkan "Jumlah benar" sendiri, sama seperti Semaphore.
+
+Bersamaan dengan `0169`, bentuk pengisian "soal" DIBUANG dari Input Nilai Pos
+v2 — `jenisLomba()` di `web/js/util.js` tinggal "waktu" dan "nilai", dan
+kelima lomba soal tulis kini diisi seperti Semaphore: satu regu satu layar,
+satu kotak "Jumlah benar", foto per regu. Foto borongan tetap ada, tapi hanya
+di layar Foto Jawaban.
+
+Dua diagram menemani dokumen ini, dan `arsitektur-hrcd.svg` TERTINGGAL dari
+tree: cap di kakinya berbunyi "sampai migrasi 0153" dan angka di sebelahnya —
+26 tabel · 68 check · 27 pemicu · 153 migrasi — dihitung 30 Agustus 2026.
+Jumlah migrasinya sekarang 169; jangan memercayai yang lain sebelum dihitung
+ulang. `alur-hrcd.svg` tidak memuat angka yang bisa basi. Yang tergambar:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
 [`alur-hrcd.svg`](alur-hrcd.svg) — alur acaranya dari pendaftaran sampai
 klasemen. Keduanya SVG, jadi teksnya bisa dicari dan angkanya bisa dibetulkan
@@ -245,7 +262,10 @@ fungsi terpasang, supaya salinan berikutnya tidak lolos lagi.
 
 ## 3. Layar panitia
 
-SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
+SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login. Rute boleh
+berbuntut — `#/pos2/1:semaphore` — dan `pangkalRute()` memotong buntutnya
+sebelum tabel `RUTE` dibaca, `ekorRute()` mengembalikannya. Buntutnya ada
+supaya tombol Back HP mengembalikan pemilih lomba, bukan melompat ke Home.
 
 | Rute | Layar | Kerjanya |
 | --- | --- | --- |
@@ -258,7 +278,7 @@ SPA satu berkas dengan rute hash, di `web/js/app.js`. Butuh login.
 | `#/keberangkatan` | Keberangkatan | ceklis hadir, kontrak waktu, pindah kloter, berangkatkan |
 | `#/finish` | Kedatangan | catat jam datang + anggota hadir |
 | `#/pos` | Input Nilai Pos | lembar penilaian satu pos, satu baris per regu |
-| `#/pos2` | Input Nilai Pos v2 | pilih satu lomba lintas pos, lalu bentuk pengisiannya sendiri: stopwatch untuk lomba waktu, foto borongan + nilai untuk lomba soal, kotak per kriteria untuk sisanya |
+| `#/pos2` | Input Nilai Pos v2 | pilih satu lomba lintas pos — alamatnya jadi `#/pos2/<pos>:<kode_lomba>` supaya Back HP kembali ke pemilihnya — lalu satu regu satu layar: ketik nomor dada, isi kotak tiap kriteria, foto slipnya, simpan. Lomba waktu mendapat stopwatch yang mengisi kotak detiknya; lomba soal tulis memakai bentuk yang sama persis, satu kotak "Jumlah benar". Foto borongan hanya ada di `#/foto` |
 | `#/cek-nilai` | Cek Nilai | satu regu satu layar, `‹ nomor dada ›` per regu: foto slip di sebelah angka yang diketik darinya, dan angkanya boleh dibetulkan serta dikunci di tempat. Pemegang `pengaturan` — dipakai admin server, bukan juri |
 | `#/live-score` | Live Score | pemegang hak `live_score` — cincin kemajuan per pos, lalu podium ENAM tempat per golongan (Juara 1-3 di satu baris, Harapan 1-3 di baris berikutnya) dan tabel rinci; saklar fase hanya untuk pemegang `pengaturan` |
 | `#/kejuaraan` | Kejuaraan | hasil juara dari skor, Juara Umum dari poin juara, Yel Yel dari poin Pos 5 per golongan, Peserta Terbanyak dari nomor dada Eksternal, dan pilihan manual panitia: Kostum dan Terfavorit per golongan, Pangkalan Terjauh satu SEKOLAH untuk seluruh acara |
@@ -276,8 +296,14 @@ Dua layar penilaian sengaja dipisah PERAN, bukan cuma tampilan. `#/pos2`
 dipagari `pos` dan dipakai juri beserta tim input per lomba; `#/cek-nilai`
 dipagari `pengaturan` dan dipakai admin server. Pemisahan itu yang membuat
 layar pemeriksa boleh mengubah nilai: yang memeriksa memang bukan yang
-mengetik. Selama Cek Nilai masih dipagari `pos`, setiap juri bisa mengunci
-nilai regu mana pun di posnya — termasuk lomba yang bukan pegangannya.
+mengetik. Gemboknya sendiri PER LOMBA sejak `0166` — Pos 1 punya lima gembok,
+bukan satu — dan kuncinya `coalesce(lomba, name)` lewat `v_lomba_pos`, persis
+kunci yang dipakai kolom foto. Yang perlu diketahui: pagar di dalam
+`kunci_nilai_pos()` dan `buka_kunci_nilai_pos()` masih `boleh('pos')` ditambah
+`pos_saya()`, jadi seorang juri pos yang berhasil memanggil RPC-nya tetap bisa
+mengunci lomba yang bukan pegangannya di posnya sendiri. Yang menutup pintu itu
+di lapangan adalah layarnya, yang hanya muncul untuk pemegang `pengaturan` —
+bukan RPC-nya.
 
 `juri_pos` wajib membawa satu nomor `pos`; pagar tulis membatasinya ke pos itu.
 `koordinator_pos` mendapat paket hak yang sama tetapi kolom `pos` wajib kosong,
@@ -355,7 +381,8 @@ Setiap master berukuran **A5 landscape (210 × 148 mm), satu halaman per
 lomba**. Panitia mencetak satu master lalu memperbanyaknya 2-up di kertas A4
 dengan mesin fotokopi; mencetak ratusan salinan dari browser hanya menghabiskan
 toner untuk pekerjaan yang lebih cepat dilakukan mesin fotokopi. Karena itu
-Pos 3 yang punya tiga lomba menghasilkan tiga halaman, berapa pun jumlah regu.
+Pos 3 yang punya EMPAT lomba menghasilkan tiga halaman — Logika lomba soal,
+jadi ia tidak ikut — berapa pun jumlah regu.
 
 Nomor dada dan nilai mentah mendapat ruang tulis terbesar. Kertas tidak
 memuat Nilai Pos karena juri hanya menulis data mentah; skor tetap dihitung
@@ -414,53 +441,44 @@ agregat/rincian lomba tanpa sekaligus memperoleh nomor WhatsApp pembina.
 
 ---
 
-### Layar Rekapitulasi
+### Rekapitulasi — cetakan Live Score, bukan layar
 
-Lembar Rekapitulasi lengkap, dan bentuknya sengaja meniru spreadsheet yang
-dipakai panitia selama tujuh tahun: satu baris per regu, **satu kolom per
+**Layar Rekapitulasi dihapus 27 Agustus 2026 (#606).** Pekerjaannya pindah dua
+arah: menyapu regu yang bolong dikerjakan di layar Input Nilai Pos lewat
+saringan "Belum Input" dan "Belum Foto" — per pos, di tempat orangnya memang
+bekerja, bukan satu tabel raksasa lintas pos — sementara persen kelengkapan
+per pos duduk di panel Status layar Live Score.
+
+Yang tersisa dari layar itu KERTASNYA, dan bentuknya tidak berubah: tombol
+Cetak Rekap Nilai di Live Score menyusun satu baris per regu, **satu kolom per
 komponen** — bukan satu kolom per pos — Nilai Pos di ujung tiap kelompok, lalu
-kolom waktu, lalu Nilai Total. Kolomnya dibangun dari tabel `wahana`, jadi
-penilaian tahun depan mengubah tabel dan tabelnya ikut berubah sendiri.
+kolom perjalanan (kontrak, kloter, berangkat, datang, anggota, penalti)
+sebagai satu kelompok utuh, lalu Total. Kolomnya tetap dibangun dari tabel
+`wahana`, jadi penilaian tahun depan mengubah tabel dan kertasnya ikut berubah
+sendiri. Empat kolom identitas dan kolom Total dicetak ulang di SETIAP lembar,
+karena kertas ini beredar sebagai lembaran lepas dan lembar tanpa nomor dada
+tidak bisa dicocokkan dengan apa pun; pembelahan halaman selalu jatuh DI
+ANTARA pos, tidak pernah di tengah kolom sebuah pos.
 
-Bahannya satu view, `v_rekap_penuh` (migrasi `0027`). Empat hal yang
-menentukannya:
+**Yang tercetak persis yang tergambar.** Barisnya datang dari klasemen yang
+sedang tampil, jadi ia sudah tersaring ke regu yang SUDAH BERANGKAT dan sudah
+terurut — kertas yang diam-diam berbeda dari layar yang tombolnya baru ditekan
+adalah kertas yang salah. Rantainya tetap bertumpu pada `v_rekap_penuh`
+(migrasi `0027`, poin per komponen `0107`), tetapi tidak lagi dibaca langsung
+oleh layar mana pun: `cache_live_score` (`0146`) yang menghitungnya sekali,
+dan layar membaca singgahan itu.
 
-1. **Tidak bisa mengubah apa pun.** Satu-satunya pintu tulis nilai tetap
-   `#/pos`, yang memaksa operator menyebut posnya dan dijaga RLS. Angka yang
-   bisa diketik dari dua tempat cepat atau lambat akan melewatkan salah satu
-   pagarnya.
-2. **Tidak menghitung apa pun.** Nilai Pos, penalti, total, dan peringkat
-   semuanya datang jadi dari database — alasan yang sama dengan layar Input
-   Pos. Peringkatnya bahkan di-`left join` dari `v_klasemen`, bukan dihitung
-   ulang, supaya tidak ada mesin peringkat kedua.
-3. **Yang membuka layar ditentukan hak `rekap`, bukan nama peran.** Paket
-   `juri_pos` tidak membawa hak itu, tetapi admin boleh mencentangkannya tanpa
-   mengganti peran. Sejak `0069`, policy baca nilai menerima pemegang `rekap`
-   atau `live_score` lintas pos; isolasi pos tetap berlaku pada jalur tulis.
-4. **Menyegarkan diri tiap 20 detik, tanpa menggeser apa pun.** Operator pos
-   menyimpan satu baris, dan koordinator yang menatap layar ini melihat
-   angkanya masuk tanpa menekan apa pun. Pembacanya belasan orang, bukan
-   ribuan seperti halaman peserta, jadi membaca langsung dari database di
-   sini memang murah — pertimbangan yang persis kebalikan dari bagian 3b.
+**Dua hal hilang bersama layarnya, dan pemilik acara memilih begitu:** alarm
+"N sudah closing tapi belum lengkap", dan penanda pos yang diam lebih dari 30
+menit. Sapuan per pos menemukan regu yang bolong, tetapi tidak memberi tahu
+bahwa sebuah pos berhenti menyetor — itu harus disadari sendiri dari angka
+yang tidak menyusut.
 
-**Kerangkanya dibangun SEKALI; yang diperbarui hanya `<tbody>`, kartu
-kelengkapan, dan beberapa angka kecil.** Ini bukan optimasi, melainkan syarat
-supaya layar ini bisa dipakai sama sekali. Tabelnya ±38 kolom dan dibaca
-sambil digeser ke samping; menggambar ulang seluruh kartu — yang dulu terjadi
-tiap 20 detik — berarti:
-
-- geseran samping kembali ke kolom pertama, tiap 20 detik. Orang yang sedang
-  membandingkan Pos 4 dilempar balik ke Nomor Dada;
-- kotak cari diganti kotak baru di tengah orang mengetik, jadi mengetik `001`
-  terputus di huruf kedua;
-- posisi gulir, fokus papan ketik, dan teks yang sedang disorot ikut hilang.
-
-Pembungkus `.table-wrapper` yang memegang geseran, kotak cari, dan kepala
-tabel karena itu **tidak pernah diganti**. Listener saringan dan kartu pos
-dipasang lewat delegasi pada pembungkus yang tetap itu, bukan pada tombol
-yang ikut tergambar ulang. Hasilnya layar yang boleh dibiarkan terbuka
-seharian dan tetap diam di tempat yang ditinggalkan — seperti spreadsheet,
-yang memang bentuk yang dikenal panitia.
+Hak `rekap` TIDAK ikut dihapus; ia bukan hanya milik layar itu. Dan kait
+`segarkanDiTempat` yang lahir di sini justru hidup terus — sekarang layar
+Input Nilai Pos yang mendaftarkannya (bagian 7 nomor 10), dan pelajarannya
+tetap: layar yang keadaannya sendiri berharga tidak boleh digambar ulang dari
+nol hanya untuk menyegarkan angkanya.
 
 Aturan yang sama berlaku untuk **kembali dari tab lain**. Bagian 7 nomor 10
 menjelaskan bahwa seluruh SPA memuat ulang dirinya saat layarnya dilihat
@@ -568,7 +586,7 @@ Satu pertanyaan yang dijawab halaman ini sepanjang lomba, dan hanya itu:
 **"nilai regu saya sudah masuk belum, atau hilang?"** Jawabannya centang per
 pos — bukan angka.
 
-Tiga aturan membentuk seluruh halaman ini:
+Lima aturan membentuk seluruh halaman ini:
 
 1. **Sebelum lomba dimulai, tidak ada rekap sama sekali.** Selama
    `fase_live` masih `pra`, `v_progres_publik` mengembalikan nol baris dan
@@ -590,6 +608,15 @@ Tiga aturan membentuk seluruh halaman ini:
    dada, regu, organisasi, peringkat, serta Total. Regu yang belum tercatat
    tiba tidak ikut; poin per pos dan rincian penalti tidak ditulis ke berkas
    publiknya.
+5. **Fase `juara` mengganti papan dengan DAFTAR JUARA, dan tidak ada yang
+   lain.** `v_klasemen_publik` dan `v_progres_publik` sama-sama mengembalikan
+   nol baris di fase ini, jadi berkas yang terbit memang tidak memuat satu
+   baris papan pun — aturan 1 dipenuhi tanpa satu pagar tambahan. Daftar
+   juara terbit BESERTA angkanya (migrasi `0163`, kolom skornya `0164`),
+   memakai kelas yang sama dengan layar panitia `#/kejuaraan` supaya angkanya
+   jatuh di tempat yang sama di dua layar. Menurunkan saklarnya kembali ke
+   Live TIDAK mengembalikan papan sampai rekap diterbitkan ulang: berkas fase
+   juara memang tidak memuatnya.
 
 ### Yang menjaga kejutan adalah database, bukan tampilan
 
@@ -598,8 +625,10 @@ mengembalikan **nol baris** dan `v_progres_publik` tidak punya satu pun kolom
 berisi angka nilai. Jadi `live.json` yang terbit memang **tidak memuat**
 nilai — bukan memuatnya lalu disembunyikan CSS, yang bisa dibuka siapa pun
 dengan membuka alamat berkasnya langsung. Admin dapat memindah fase ke
-`top10` untuk menerbitkan papan ringkas atau ke `penuh` untuk menerbitkan
-klasemen empat golongan beserta rinciannya.
+`top10` untuk menerbitkan papan ringkas, ke `penuh` untuk menerbitkan
+klasemen empat golongan beserta rinciannya, atau ke `juara` untuk mengganti
+papan dengan daftar juara — di fase itu kedua view papan mengembalikan nol
+baris, jadi yang terbit memang hanya juaranya.
 
 `tests/sql/09_rekap_publik.sql` menjaga janji itu dari dua arah: klasemen
 harus nol baris di fase progres, dan `v_progres_publik` diperiksa **lewat
@@ -634,8 +663,8 @@ sudah terbit.
 
 | Sumber | Besar | Isinya | Kapan diambil |
 | --- | --- | --- | --- |
-| `live.json` | ±1 KB | fase, edisi, daftar pos, ringkasan, dan `versi` | di-poll tiap 60 detik |
-| `rekap.json` | puluhan KB | seluruh baris regu + klasemen | sekali per `versi`, dan hanya kalau dibutuhkan |
+| `live.json` | ±1 KB | fase, edisi, daftar pos, ringkasan, kemajuan input per pos, dan `versi` | di-poll tiap 60 detik |
+| `rekap.json` | puluhan KB | seluruh baris regu + klasemen + daftar juara | sekali per `versi`, dan hanya kalau dibutuhkan |
 | `v_fase_live` | satu nilai | fase database yang hanya boleh memperketat | tiap 15 detik saat halaman terlihat |
 
 Pemisahan ini yang menahan bebannya. Pesertanya **1.500–3.000 orang** dan
@@ -673,9 +702,13 @@ tanpa menambah kalimat yang harus dibaca berulang kali; umur dalam kurung sudah
 menunjukkan bahwa datanya tertinggal.
 
 Sebelum di-deploy, workflow memeriksa berkasnya sendiri: JSON harus terurai,
-kunci wajib harus ada, klasemen harus kosong di fase `pra` dan `progres`, serta
-fase `top10` tidak boleh membawa regu tanpa peringkat atau lebih dari sepuluh
-regu per golongan.
+kunci wajib harus ada, klasemen harus kosong di luar fase `penuh` dan
+`top10`, fase `top10` tidak boleh membawa regu tanpa peringkat atau lebih
+dari sepuluh regu per golongan, daftar juara tidak boleh terbit di luar fase
+`juara`, dan fase `juara` tidak boleh membawa satu baris papan pun. Kolom
+daftar juara dijaga dengan DAFTAR IZIN, bukan daftar larangan: kolom yang
+TIDAK dikenal yang menghentikan penerbitan, karena `hasil_kejuaraan()` duduk
+di atas `pendaftaran` — satu tabel yang juga memuat nomor WA pembina.
 JSON yang rusak akan membuat halaman rekap kosong tanpa pesan apa pun, dan
 tidak ada yang menyadarinya sampai ada peserta yang bertanya.
 
@@ -725,8 +758,9 @@ jam 24 sudah melakukannya sendiri — `04:00` tidak pernah bisa dikira `16:00`.
 
 ### Bentuk tabel meja menurut lebar layar
 
-Meja Pembayaran dan Meja Daftar Ulang melewati tiga rentang. Angkanya
-ditentukan isi tabel, bukan ukuran jempol:
+Meja Pembayaran, Meja Daftar Ulang, dan Data Peserta melewati tiga rentang
+yang sama, meski `min-width` masing-masing berbeda — 820px, 790px, dan 980px.
+Angkanya ditentukan isi tabel, bukan ukuran jempol:
 
 | Lebar | Bentuk |
 | --- | --- |
@@ -739,8 +773,11 @@ scrollbar. **Kalau kolom ditambah, `min-width` naik — dan ambang ini harus iku
 naik**, kalau tidak tabelnya menggeser ke samping dan kolom paling kanan (kolom
 tombol) hilang dari layar tanpa petunjuk apa pun.
 
-Meja Daftar Ulang berkolom tiga: Kode Bayar, Sekolah, tombol "Isi N Nomor Dada".
-Jumlah regu tidak punya kolom sendiri — angkanya sudah tercetak di dalam tombol.
+Meja Daftar Ulang berkolom empat: Kode Bayar, Sekolah, tombol "Isi N Nomor
+Dada", dan tombol "Tukar nomor rusak…". Jumlah regu tidak punya kolom
+sendiri — angkanya sudah tercetak di dalam tombol. Tabel rinciannya diberi
+satu sel kosong di ujung supaya jumlah kolomnya sama: di bawah `fixed` dua
+tabel hanya sejajar kalau kolomnya sama banyak.
 
 ---
 
@@ -782,8 +819,8 @@ menyatukannya ke satu baris — yang hilang kenyamanan, bukan kebenaran.
 
 | Yang di-deploy | Cara | Pemicu |
 | --- | --- | --- |
-| Layar panitia (`web/`) | Cloudflare Workers, tersambung Git | otomatis tiap push ke `main` |
-| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | **otomatis** tiap push ke `main` yang menyentuh `live/**` atau `live_json.sql` (#235); pada 29 Agustus 2026 pukul 08:00-23:59 WIB juga terbit tiap 15 menit |
+| Layar panitia (`web/`) | DUA jalur sekaligus: Cloudflare Workers tersambung Git, dan GitHub Actions `deploy-panitia.yml` | Git integration jalan tiap push ke `main`; Actions hanya kalau push itu menyentuh `web/**`. Tombol Run workflow bekerja dari HP saat salah satunya menggantung — build Cloudflare pernah diam 40+ menit tanpa meninggalkan jejak di GitHub |
+| Situs peserta (`live/`) | GitHub Actions `publish-live.yml` | **otomatis** tiap push ke `main` yang menyentuh `live/**` atau `live_json.sql` (#235); pada 29 Agustus 2026 pukul 06:00-18:59 WIB juga terbit tiap 15 menit |
 | Gateway Worker | GitHub Actions `deploy-gateway.yml` | manual |
 | Migrasi database | GitHub Actions `apply-migration.yml` | manual, satu berkas per jalan |
 
@@ -803,7 +840,9 @@ satu berkas hidup di dua akar tanpa disalin, dan repo ini sengaja tanpa build
 step yang bisa menyalinnya saat deploy.
 
 Jadi salinannya dititipkan di git, dan workflow `shared-files.yml` yang
-membuatnya tidak bisa membusuk: tiap PR membandingkan `live/` dengan acuannya
+membuatnya tidak bisa membusuk — TAPI ia harus dijalankan sendiri:
+`workflow_dispatch` saja, tidak ada `pull_request` (CLAUDE.md 16.5). Yang
+dibandingkannya `live/` dengan acuannya
 di `web/` dan gagal kalau menyimpang. Duplikasi yang diam adalah bug yang
 menunggu; duplikasi yang berteriak tiap kali menyimpang cuma sedikit berisik.
 **`web/` yang jadi acuan** — jangan pernah mengedit salinannya.
@@ -831,8 +870,10 @@ saat layar memanggil RPC lama dan gagal.
 ### Cache
 
 `web/_headers` menyetel `Cache-Control: no-cache` untuk semua aset: browser
-boleh menyimpan, tapi wajib bertanya dulu. Asetnya kecil (±220 KB seluruhnya,
-`js/app.js` sendiri 119 KB), jadi biayanya hampir nol — dan tanpa itu,
+boleh menyimpan, tapi wajib bertanya dulu. Asetnya ±970 KB seluruhnya
+(`js/app.js` sendiri ±484 KB, `style.css` ±279 KB), tapi `no-cache` berarti
+yang menyeberang saat tidak ada perubahan cuma jawaban 304 — jadi biayanya
+tetap hampir nol, dan tanpa itu,
 perbaikan mendadak pagi hari-H tidak akan sampai ke panitia.
 
 `live/_headers` **berbeda dengan sengaja**, karena pembacanya ribuan HP dan
@@ -848,16 +889,25 @@ bukan menimpanya dengan yang paling spesifik: selama `/*` masih menyetel
 `no-cache, public, max-age=3600, immutable` — dan `no-cache` yang menang,
 sehingga berkasnya ditanyakan ulang tiap kali walau alamatnya sudah memuat
 versinya. Tiap jenis berkas di folder itu karena itu menyebut aturannya
-sendiri, termasuk halaman HTML yang disebut dua kali karena Workers
-menyajikannya di dua alamat (`/` dan `/index.html`).
+sendiri, termasuk halaman HTML yang disebut EMPAT kali karena Workers
+menyajikan tiap berkas di dua alamat (`/` dan `/index.html`, `/daftar` dan
+`/daftar.html`).
 
 ### Workflow lain
 
 | Workflow | Nama di Actions | Untuk siapa |
 | --- | --- | --- |
-| `sql-tests.yml` | SQL Tests | otomatis tiap PR dan push ke `main` |
+| `sql-tests.yml` | SQL Tests | developer — `workflow_dispatch` saja |
+| `shared-files.yml` | Shared files | developer — `workflow_dispatch` saja |
+| `refresh-live-score.yml` | Refresh Live Score cache | cron tiap 10 menit pada hari lomba (06:00-18:59 WIB), plus tombol |
 | `provision-accounts.yml` | Provision akun panitia | panitia, dari HP |
 | `change-password.yml` | Ganti password akun panitia | panitia, dari HP |
+| `set-shared-password.yml` | Setel password bersama semua akun | panitia, dari HP |
+
+**Tidak ada satu check pun yang berjalan sendiri.** `sql-tests.yml` dan
+`shared-files.yml` cuma punya `workflow_dispatch`: keduanya selesai di laptop
+dalam hitungan detik, dan pasal 16.1 sudah mewajibkannya di sana. Yang masih
+terpicu otomatis cuma deploy — `publish-live.yml` dan `deploy-panitia.yml`.
 
 Nama workflow mengikuti pembacanya: yang dijalankan panitia berbahasa Indonesia,
 yang hanya dibaca developer berbahasa Inggris. Nama berkasnya selalu Inggris
@@ -889,10 +939,16 @@ transaksi dengan `SET LOCAL app.uid` dan `SET LOCAL ROLE`, sehingga policy yang
 sama dengan produksi ikut menggigit.
 
 ```bash
-bash tests/dev_database.sh     # siapkan database hrcd_dev
-python tests/dev_server.py     # tiruan Supabase di :8787
-python tests/static_server.py  # layar panitia di :8788, tanpa cache
+PSQL=... PGPORT=5432 PGPASSWORD=... bash tests/dev_database.sh  # hrcd_dev
+PGPORT=5432 PGPASSWORD=... python tests/dev_server.py  # tiruan Supabase :8787
+python tests/static_server.py                # layar panitia :8788, tanpa cache
 ```
+
+`PGPORT` bawaan `dev_database.sh` adalah 55432 — port database uji sekali
+pakai, bukan server yang ada di laptop — jadi ia hampir selalu perlu
+disebutkan. Samakan versi mayor servernya dengan produksi (PostgreSQL 17.6):
+laptop pada 18.x akan berbeda pendapat dengan produksi dengan cara yang
+terbaca seperti migrasi yang hilang.
 
 Ganti `mode` di `web/config.js` jadi `"dev"` untuk menunjuk ke sana.
 
@@ -945,7 +1001,9 @@ Dikumpulkan dari kesalahan yang benar-benar terjadi, bukan daftar teoretis.
     berkedip. Tapi "memuat ulang" berarti **menggambar ulang dari nol**, dan
     di layar yang keadaannya sendiri berharga — geseran samping, saringan,
     isi kotak cari — itu membuang persis apa yang sedang dipakai orangnya.
-    Layar Rekapitulasi karena itu mendaftarkan `segarkanDiTempat`, dan yang
+    Layar Input Nilai Pos karena itu mendaftarkan `segarkanDiTempat` — kait
+    yang dibuat untuk Layar Rekapitulasi dan diwarisi darinya setelah layar
+    itu dihapus (#606) — dan yang
     dijalankan saat tab-nya kembali hanya pengambilan angkanya. Layar baru
     yang dipantau lama harus melakukan hal yang sama; yang tidak, tetap aman
     dengan perilaku bawaan.
@@ -956,33 +1014,21 @@ Dikumpulkan dari kesalahan yang benar-benar terjadi, bukan daftar teoretis.
 
 Diketahui basi, sengaja dibiarkan, supaya tidak ada yang mengira sudah dicek:
 
-- **Bagian 5 masih menjelaskan Layar Rekapitulasi**, padahal layarnya dihapus
-  27 Agustus 2026 (#606). Rutenya sudah dibuang dari tabel rute, prosanya
-  belum. Isinya tidak seluruhnya mati dan karena itu tidak bisa sekadar
-  dihapus: `v_rekap_penuh` masih dipakai (`0107`), hak `rekap` masih menjaga
-  empat hal lain, dan kait `segarkanDiTempat` justru masih hidup — sekarang
-  yang mendaftarkannya layar Input Nilai Pos, bukan layar itu. Bagian 7 nomor
-  10 juga masih menyebutnya sebagai contoh.
-- **Empat tes di `tests/championship_ui.test.mjs` gagal di `main`**, dan yang
-  tertinggal adalah TESNYA, bukan layarnya. Ia masih menuntut empat judul
-  section per golongan ("Penegak PA", "Penggalang PI", …) yang dirapikan #703,
-  serta kotak cari `Nomor dada / nama regu / asal sekolah…` beserta saringan
-  "Eksternal yang sudah tiba" — padahal sejak `0153` Pangkalan Terjauh memilih
-  SEKOLAH, bukan regu. Layarnya sendiri dibuka dan benar.
 - **Beberapa RPC masih mencetak nomor dada mentah** di pesan galatnya
   (`nomor dada % tidak dikenal` di `catat_closing` dan `pindah_kloter`, antara
   lain), padahal di layar selalu tiga digit. Migrasi `0020` baru membetulkan
   `berangkatkan_kloter`; sisanya menunggu karena tiap perbaikan menuntut
   seluruh badan fungsinya disalin ulang.
 - **Cron rekap live hanya hidup pada hari-H.** `publish-live.yml` berjalan
-  tiap 15 menit pada 29 Agustus 2026 pukul 08:00-23:45 WIB. GitHub cron tidak
+  tiap 15 menit pada 29 Agustus 2026 pukul 06:00-18:59 WIB. GitHub cron tidak
   punya kolom tahun, jadi langkah pertama memeriksa tanggal lengkap dan
   berhenti sebelum membaca database atau deploy pada tahun lain. Di luar
   jendela itu, halaman rekap hanya terbit saat ada push yang menyentuh `live/`
   atau saat tombol Run workflow ditekan.
 - **Upload massal nilai belum ada.** `rancangan-b.md` bagian 6 menjelaskan
   jalur tempel-dari-Excel lengkap dengan layar preview. Yang sudah dibangun
-  baru input tabelnya (`#/pos`) — yang sebenarnya sudah menutup sebagian besar
+  baru input tabelnya (`#/pos`) dan input per lomba (`#/pos2`) — yang
+  sebenarnya sudah menutup sebagian besar
   kebutuhannya, karena satu layar memuat seluruh lembar sekaligus. RPC-nya
   (`simpan_nilai_massal`) memang sudah menerima banyak baris sekaligus, jadi
   yang kurang hanya pengurai tempelan dan preview-nya.

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -2,8 +2,9 @@
 
 > **CATATAN KEPUTUSAN — bukan keadaan sekarang.**
 > Ini cetak biru yang dipakai membangun sistem, ditulis sebelum kodenya ada.
-> Ia **sengaja dipertahankan apa adanya**: 42 komentar di kode — tersebar di
-> migrasi, tes, SPA, dan Worker — menunjuk ke nomor bagian dokumen ini
+> Ia **sengaja dipertahankan apa adanya**: 61 komentar di kode, tersebar di 32
+> berkas — migrasi, tes, SPA, situs peserta, Worker, `web/_headers`, dan
+> `publish-live.yml` — menunjuk ke nomor bagian dokumen ini
 > (`rancangan-b.md 11.9`, `bagian 4`, `2.2.1`, dan seterusnya). Menulis ulang
 > isinya akan memutus seluruh penunjuk itu, termasuk yang tertanam di migrasi
 > yang sudah diterapkan dan tidak boleh diedit.
@@ -13,25 +14,61 @@
 >
 > - **Google Sheets tidak pernah dipakai.** Tidak ada di kode mana pun.
 > - **Halaman live sudah ada, tapi bentuknya lain** (bagian 7):
->   `live/index.html` + `live/live.json` di Worker situs peserta sendiri,
+>   `live/index.html` + **dua** berkas data — `live/live.json` (fase dan
+>   ringkasan, di-poll tiap 60 detik) dan `live/rekap.json` (seluruh baris
+>   regu, diambil sekali per `versi`) — di Worker situs peserta sendiri,
 >   diterbitkan workflow `publish-live.yml` — bukan `live.html` di Cloudflare
 >   Pages seperti tertulis di bawah.
 > - **Chip "Jam sekarang" tidak ada.** Jam berangkat justru diisi otomatis;
->   jam datang dikosongkan dengan keterangan "Kosong = jam saat tombol ditekan."
+>   jam datang dikosongkan dan dipindahkan ke panel tertutup "Perbaiki jam
+>   atau jumlah anggota", dengan pesan "Kosongkan untuk memakai jam saat
+>   tombol ditekan."
 > - **Meja Pembayaran bukan alur ketik-kode → kartu**, melainkan tabel berisi
 >   semua invoice dengan kotak cari dan saringan.
 > - **Keberangkatan bukan papan 4 kolom**, melainkan satu pita chip berisi
 >   semua kloter + satu tabel 5 kolom untuk kloter terpilih.
-> - **Beranda hanya punya dua lencana angka**, bukan tiga.
+> - **Beranda punya empat lencana angka**: dua antrean (menunggu
+>   pembayaran, lunas belum bernomor) dan dua kemajuan berantai
+>   (Keberangkatan `berangkat/siap`, Kedatangan `datang/berangkat`).
 > - **Export CSV belum ada** (dijadwalkan Tahap 4 di bagian 13).
 > - Aturan tampilan di bagian 10.1 sudah banyak berubah — ambang responsif,
 >   perilaku kepala di HP, dan ukuran sasaran sentuh.
+> - **Pipeline import nilai di bagian 6 tidak pernah dibangun.** Tidak ada
+>   textarea tempel, tidak ada pemilih `.csv`, tidak ada preview per baris.
+>   Nilai masuk lewat `#/pos` (lembar satu pos, satu baris per regu) dan
+>   `#/pos2` (satu regu satu layar), dan buktinya foto lembar jawaban
+>   (`foto_lembar`), bukan hasil paste dari Excel.
+> - **Supabase Realtime tidak dipakai sama sekali.** Layar yang disebut
+>   "live" memakai denyut polling dan tombol muat ulang.
+> - **Cloudflare Pages tidak dipakai.** Layar panitia dan situs peserta
+>   sama-sama Cloudflare Worker static assets, gateway-nya Worker biasa.
+>   Situs peserta hanya terbit lewat `publish-live.yml`; layar panitia lewat
+>   Git integration Cloudflare DAN `deploy-panitia.yml`, dua jalur yang
+>   sengaja dibiarkan berdampingan.
+> - **Banyak nama tabel dan kolom berubah** (migrasi 0012 dan 0014):
+>   `riwayat` → `history`, `ruangan` → `room`, `wahana.jenis` → `type`,
+>   `wahana.bentuk` → `form`, `sekolah.nama/alamat` → `name/address`.
+>   Nama di bagian 2 adalah nama rancangan, bukan nama di database.
+> - **Peran dan hak akses ditulis ulang** (0057-0058, 0064, 0075): lima
+>   peran, dan yang menjaga pintu `boleh(fitur)` — bukan `peran()`.
+>   Seluruh bagian 3 menggambarkan mekanisme yang sudah diganti.
+> - **Golongan ada enam, bukan empat** (0091): empat Eksternal ditambah
+>   `intern_pa` dan `intern_pi`. Papan panitia memakai keenamnya; papan
+>   PESERTA tetap empat, karena Intern dibuang di batas penerbitan.
+> - **Fase live ada lima, bukan tiga** (0145 `top10`, 0163 `juara`).
+> - **Akun panitia bisa dibuat dari layar Akun** (`#/account`) lewat gateway
+>   Worker, dan dari HP lewat `provision-accounts.yml`. Kalimat "dari SPA
+>   memang mustahil" di 3.4 dan 11.14 sudah tidak benar.
+> - **Layar Monitoring, Konfigurasi, Barak, dan Riwayat tidak pernah
+>   dibangun** sebagai layar tersendiri; daftar rute yang benar-benar ada
+>   di `final-architecture.md` bagian 3.
 >
 > **Untuk keadaan sistem sekarang, baca `final-architecture.md`.**
 
 Cetak biru implementasi untuk keputusan di `desain-sistem.md` bagian 8:
 **Supabase (Postgres + Auth + RLS + Realtime) + SPA statis di Cloudflare +
-Google Sheets sebagai jendela baca.** Syarat keras panitia berlaku di seluruh
+Google Sheets sebagai jendela baca.** Dari ketiganya, Realtime dan Google
+Sheets tidak pernah dipakai. Syarat keras panitia berlaku di seluruh
 dokumen: **setiap layar harus bisa dipakai panitia baru setelah satu kali
 diperagakan.**
 
@@ -44,19 +81,33 @@ penyelesaiannya dicatat di bagian 11.
 
 1. **Supabase free tier** — satu-satunya backend. Postgres memegang seluruh
    data dan konfigurasi; Auth memegang akun panitia; RLS menegakkan batas
-   akses; Realtime menghidupkan layar pemantau. Tidak ada server custom.
-2. **SPA statis di Cloudflare Pages** — HTML + JS polos berbahasa Indonesia,
-   tanpa framework berat, deploy = `git push`. Satu link untuk semua panitia.
-3. **Halaman live publik** — file statis (`live.html` + `live.json`) di
-   Cloudflare Pages, di-regenerate berkala oleh GitHub Actions. Penonton
-   **tidak pernah** menyentuh Supabase.
-4. **Satu Cloudflare Worker kecil** — gateway form pendaftaran publik:
-   memverifikasi Turnstile (anti-spam gratis) + rate limit, baru meneruskan ke
-   database. Satu-satunya jalur tulis dari luar.
+   akses. Tidak ada server custom. (Realtime dirancang untuk menghidupkan
+   layar pemantau, tetapi tidak pernah dipakai: yang terpasang denyut
+   polling + tombol muat ulang di tiap layar.)
+2. **SPA statis di Cloudflare Workers static assets** — HTML + JS polos
+   berbahasa Indonesia, tanpa framework berat, deploy tetap = push ke `main`
+   yang menyentuh `web/**`. Dua jalur berjalan berdampingan dengan sengaja:
+   Git integration Cloudflare dan workflow `deploy-panitia.yml`, supaya build
+   yang menggantung tidak menahan perbaikan. Satu link untuk semua panitia.
+3. **Halaman live publik** — file statis (`live/index.html` + `live.json` +
+   `rekap.json`) di Worker situs peserta sendiri, di-regenerate GitHub
+   Actions. Penonton tidak pernah mengambil rekap dari Supabase; yang dibaca
+   langsung cuma dua view kecil — `v_fase_live` tiap 15 detik, yang hanya
+   boleh MEMPERKETAT fase dan tidak pernah membuka lebih banyak daripada isi
+   berkas, dan `v_publik_ringkas` selama fase `pra` untuk jumlah pendaftar.
+4. **Satu Cloudflare Worker gateway** — pintu form pendaftaran publik dan,
+   sejak layar Akun ada, pengelolaan akun panitia: rate limit per IP + batas
+   ukuran payload, baru meneruskan ke database. Turnstile tetap ada tetapi
+   opsional, dan untuk edisi 37 dimatikan. Satu-satunya jalur tulis dari luar
+   untuk DATA pendaftaran — bukti transfer diunggah pembina langsung ke
+   bucket `bukti` lewat policy anon (0123), di luar Worker.
 5. **Google Sheets** — jendela baca: tombol Export CSV di semua layar daftar,
    arsip tahunan berupa spreadsheet.
-6. Seluruh komponen Rp 0 tanpa kartu kredit: Supabase Free, Cloudflare
-   Pages/Workers Free, GitHub Free (Actions cron), Turnstile Free.
+6. Seluruh komponen Rp 0 tanpa kartu kredit: Supabase Free, Cloudflare Workers
+   Free, GitHub Free, Turnstile Free (tidak dipakai untuk edisi 37). Kuota
+   Actions ditagih per JOB yang dibulatkan ke menit penuh, jadi yang mahal
+   jumlah run — itu sebabnya check dijalankan di laptop dan cron dibatasi ke
+   tanggal lomba (CLAUDE.md 16).
 
 ## 2. Model data
 
@@ -64,7 +115,7 @@ penyelesaiannya dicatat di bagian 11.
 
 | Tabel | Isi | Penjaga kebenaran |
 | --- | --- | --- |
-| `sekolah` | Master sekolah (nama + alamat), tumbuh tiap tahun; sumber autocomplete | `UNIQUE (nama, alamat)` |
+| `sekolah` | Master sekolah (nama + alamat), tumbuh tiap tahun; sumber autocomplete | `UNIQUE (nama, alamat)` di rancangan; sejak migrasi 0061 kuncinya `unique (kunci_sekolah(name))` — alamat tidak lagi jadi pembeda, karena satu koma beda melahirkan sekolah kembar |
 | `pendaftaran` | Satu baris per batch (per pengisian form): kode pembayaran, butuh barak, jumlah pendamping, kontak WA, status | `UNIQUE (kode_pembayaran)`; status `menunggu_pembayaran → lunas / batal` — tanpa bentuk "lunas sebagian" |
 | `regu` | Satu baris per regu: nama, ketua, golongan, nomor dada, kloter, kontrak, batal | `UNIQUE (nomor_dada)` — nomor ganda **mustahil**, bukan dihindari; `UNIQUE (kloter_nomor, urutan_kloter)` menjaga urutan unik, sedangkan kuota hanya berlaku pada penempatan otomatis; nomor dada & kloter lahir bersama (`CHECK` berpasangan) |
 | `nomor_dada_stok` | Stok fisik nomor yang disiapkan admin (mis. 1–500) | Nomor tersedia = belum ada di `regu.nomor_dada`; satu sumber kebenaran, tanpa flag yang bisa basi |
@@ -73,11 +124,11 @@ penyelesaiannya dicatat di bagian 11.
 | `keberangkatan_regu` | Ceklis berangkat per regu; keberadaan baris = berangkat | `PK (regu_id)` — ceklis ganda mustahil |
 | `nilai_mentah` | Data mentah per regu per komponen: `nilai_1`, `nilai_2` (khusus benar−salah), sumber `manual/upload` | `UNIQUE (regu_id, wahana_id)`; RLS pos |
 | `closing_regu` | Checkout: `jam_datang` **diketik & bisa di-edit**, `anggota_hadir` (0–5) | `PK (regu_id)`; upsert = mekanisme edit yang sah |
-| `ruangan` | Daftar ruang kelas barak + kapasitas orang | — |
+| `ruangan` (di database: `room` sejak 0014) | Daftar ruang kelas barak + kapasitas orang | — |
 | `penempatan_barak` | Hasil alokasi; satu sekolah **boleh** terpecah ke >1 ruangan bila terpaksa | `UNIQUE (pendaftaran_id, ruangan_id)` |
 | `akun_panitia` | Peta `auth.uid` → peran (`admin/registrasi/gerbang/juri_pos/koordinator_pos`) + nomor pos + aktif; hak sesungguhnya di `akun_hak` (migrasi 0057-0058) | Rotasi tahunan tanpa menyentuh policy |
-| `riwayat` | Audit otomatis via trigger: siapa, kapan, tabel, nilai lama → baru, + `regu_id` agar bisa dicari per regu | Append-only; tidak bisa dimatikan dari klien |
-| `status_acara` | **Satu baris** saklar hari-H: `daftar_ulang_ditutup`, `fase_live` (`pra/progres/penuh`), `konfigurasi_terkunci` | Trigger menolak edit konfigurasi saat terkunci (kecuali admin) |
+| `riwayat` (di database: `history` sejak 0012) | Audit otomatis via trigger `catat_riwayat()`: `changed_by`, `changed_at`, `table_name`, `old_value` → `new_value`, + `regu_id` agar bisa dicari per regu | Append-only; tidak bisa dimatikan dari klien |
+| `status_acara` | **Satu baris** saklar hari-H: `daftar_ulang_ditutup`, `fase_live` (`pra/progres/penuh`; sejak 0145 dan 0163 juga `top10` dan `juara`), `konfigurasi_terkunci` | Trigger menolak edit konfigurasi saat terkunci (kecuali admin) |
 
 ### 2.2 Tabel konfigurasi (diedit admin tiap edisi)
 
@@ -85,38 +136,56 @@ penyelesaiannya dicatat di bagian 11.
 | --- | --- | --- |
 | `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | Kuota otomatis 5 Eksternal + 3 Intern, perkiraan 300 Eksternal + 50 Intern, `kloter_maks=75`, jendela 07:00–10:00 |
 | `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
-| `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis`): bentuk konversi + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
+| `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis` — di database `type` sejak 0014): bentuk konversi (`bentuk`, di database `form`) + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
 | `kontrak_opsi` | Pilihan kontrak waktu | `('3 jam',180), ('3,5 jam',210), ('4 jam',240)` |
 | `konfig_penalti` | Semua angka penalti, **kolom bernama** — pelajar baca satu baris, paham semua aturan | `blok_menit=1, penalti_per_blok=1, penalti_tanpa_checkout=0, penalti_per_anggota_hilang=20, nilai_pos_terlewat=0` |
 
-1. `wahana.kode` dibatasi `CHECK` huruf-kecil/angka/underscore — kode ini
-   dipakai sebagai **header kolom lembar cetak sekaligus header import**,
-   sehingga kertas, foto, hasil AI, dan paste selalu memakai kosakata yang
-   sama persis.
+1. `wahana.kode` dibatasi `CHECK` huruf-kecil/angka/underscore. Rencananya
+   kode ini jadi **header kolom lembar cetak sekaligus header import**,
+   supaya kertas, foto, hasil AI, dan paste memakai kosakata yang sama
+   persis — alasan itu yang dikutip komentar `0001_schema.sql`. Yang
+   terpasang lain: blangko memakai `wahana.name` + `petunjuk`, judul kotak
+   isiannya dari `judul_isian` (0039; diisi ulang 0168 untuk Menaksir,
+   dikosongkan 0169 untuk lomba soal supaya layar menurunkannya sendiri),
+   dan tidak ada import yang membaca header apa pun. `kode` tinggal kunci
+   internal — yang menyamakan kertas dan layar adalah nama.
 2. Konfigurasi berkunci `edisi`; data operasional hanya milik edisi aktif dan
    diarsip lalu dikosongkan tiap tahun (bagian 9.3).
 
 ## 3. Aturan akses
 
-1. **Tiga peran, satu link:**
+1. **Lima peran, satu link** (rancangan ini menulis tiga; `koordinator_pos`
+   lahir di 0075, dan nama `meja`/`operator_pos` diganti di 0058):
 
    | Peran | Contoh akun | Boleh |
    | --- | --- | --- |
    | `admin` | `admin.ciradyka` | Semua tabel, semua layar, konfigurasi |
-   | `juri_pos` | `pos1hrcd37` … `pos5hrcd37` | `nilai_mentah` **hanya** baris `pos = pos_saya()` — ditegakkan RLS, devtools tidak menolong |
+   | `juri_pos` | `pos1hrcd37` … `pos5hrcd37` | MENULIS `nilai_mentah` **hanya** baris `pos = pos_saya()` — ditegakkan `v_lembar_pos` dan `simpan_nilai_massal`, devtools tidak menolong. MEMBACA dibuka lintas pos sejak 0069 untuk pemegang `rekap`/`live_score` |
    | `registrasi` | `meja1hrcd37` … | Pendaftaran, pembayaran, daftar ulang, daftar kloter |
    | `gerbang` | `gerbang1hrcd37` … | Keberangkatan dan kedatangan — satu tempat, dua nama menurut arah lari (migrasi 0025) |
 
 2. Dua fungsi helper `peran()` dan `pos_saya()` (membaca `akun_panitia` dari
    `auth.uid()`) dipakai seluruh policy; hanya akun `aktif=true` yang lolos.
-3. **Anon nyaris nol**: hanya `SELECT sekolah` (autocomplete form, tanpa PII).
-   Form publik menulis lewat gateway Worker (bagian 8), penonton membaca file
-   statis (bagian 7) — **tidak ada jalur anon lain ke database**.
+   **Sejak migrasi 0064 tidak lagi begitu:** yang menjaga pintu `boleh(fitur)`
+   atas matriks centang `akun_hak`, `peran()` cuma mengisi centang awal lewat
+   `paket_peran()`, dan kolomnya bernama `is_active` (0014). Jangan menambah
+   perbandingan `peran() = '...'` baru — itu mengembalikan dua mekanisme untuk
+   satu pertanyaan, dan yang satu tidak bisa diubah panitia (CLAUDE.md 13.1).
+3. **Anon nyaris nol**: dirancang hanya `SELECT sekolah` (autocomplete form,
+   tanpa PII). Yang terpasang lebih luas — anon juga membaca
+   `v_edisi_publik`, `v_fase_live`, `v_publik_ringkas`, `v_kelengkapan_publik`
+   dan `v_kejuaraan_publik`, memanggil `nama_regu_dipakai()`, dan mengunggah
+   bukti transfer ke storage. Yang menahan bocor karena itu bukan ketiadaan
+   jalur, melainkan pagar fase di dalam view-view itu (bagian 14 CLAUDE.md).
+   Form publik tetap menulis lewat gateway Worker (bagian 8), penonton tetap
+   membaca file statis (bagian 7).
 4. **Rotasi tahunan**: akun membawa akhiran edisi. Tiap edisi: akun lama
-   `aktif=false` (jejak riwayat utuh), ±10 akun baru dibuat pemilik lewat
-   dashboard Supabase (±10 menit, bagian dari ritual Januari — dari SPA statis
-   memang mustahil membuat akun, dan itu disengaja). Login memakai username;
-   layar login menambahkan akhiran domain email tetap secara otomatis.
+   `aktif=false` (jejak riwayat utuh), ±10 akun baru dibuat pemegang hak
+   `akun` dari layar Akun (`#/account`, lewat gateway Worker) atau massal
+   lewat `provision-accounts.yml` dari HP. Rancangan ini menulis "dari SPA
+   statis memang mustahil" — itu benar sampai layar Akun ada, dan yang
+   membatasinya sekarang hak `akun`, bukan ketiadaan jalur. Login memakai
+   username; layar login menambahkan `@ciradyka.com` secara otomatis.
 
 ## 4. Transaksi inti (RPC)
 
@@ -184,14 +253,17 @@ Panitia: *"nanti kloter final akan diprint."* Itu mengubah sifat datanya.
 3. Kolom `kloter.dicetak_pada` menandai kertas yang sudah keluar. Penempatan
    otomatis dan manual tetap boleh menambah regu; tambahan setelah cetak diberi
    tanda sisipan agar petugas staging diberi tahu.
-4. **Penandaan terjadi SETELAH dialog cetak ditutup**, dan operator ditanya
-   "kertasnya sudah keluar dengan benar?" — kalau cetakan batal, kloternya
-   belum dianggap tercetak.
+4. **Penandaan terjadi sendiri sesudah `window.print()`**, tanpa bertanya.
+   Dialog "kertasnya sudah keluar dengan benar?" dibuang: tidak ada layar yang
+   membaca `dicetak_pada`, dan sejak 0066 ia tidak memagari apa pun, jadi
+   pertanyaannya menghentikan petugas demi catatan yang tidak dibaca siapa
+   pun. Akibat yang diterima: cetakan yang dibatalkan tetap tercatat.
 5. **Bentuk kertasnya**: satu kloter per lembar (`break-after: page`), kolom
    No Dada besar, plus kolom kosong "Hadir" untuk dicentang tangan, dan tempat
    menulis jam berangkat + nama petugas.
-6. Cetak biasa hanya memuat kloter yang belum ditandai dan menuliskan
-   **Perkiraan jam berangkat**. Jam nyata tetap catatan terpisah.
+6. Cetak memuat **semua** kloter yang terlihat di pratayang, termasuk yang
+   sudah pernah dicetak — mencetak ulang selalu boleh. Kertasnya menuliskan
+   **Perkiraan jam berangkat**; jam nyata tetap catatan terpisah.
 
 ### 4.3 Pindah kloter hari-H, dan kenapa sisipan wajib berteriak
 
@@ -227,12 +299,13 @@ dua bentuk dari data yang sama:
 | Bentuk | Pembaca | Isi khasnya |
 | --- | --- | --- |
 | **Staging** | Petugas di 3 staging | Kolom centang kehadiran, tempat menulis jam berangkat sebenarnya, tanda ★ untuk sisipan |
-| **Umum** | Papan pengumuman utama & barak | Perkiraan jam berangkat dicetak besar; **kotak catatan pembina** untuk menulis jam berangkat sebenarnya |
+| **Umum** | Papan pengumuman utama & barak | Perkiraan jam berangkat dicetak besar; catatan "bersiap 15 menit sebelumnya, jam sebenarnya bisa bergeser". Kotak catatan pembina yang dirancang di bawah tidak jadi dicetak |
 
 Kotak pembina itu bukan hiasan: pembina regu memang mencatat jam berangkat
 untuk klarifikasi, karena target kedatangan — dan karenanya penalti waktu —
 dihitung dari jam berangkat + kontrak waktu. Memberi mereka tempat menulis di
-lembar resmi membuat klarifikasi berpijak pada angka yang sama.
+lembar resmi akan membuat klarifikasi berpijak pada angka yang sama. **Belum
+dikerjakan**: lembar Umum yang tercetak hari ini tidak punya kotak itu.
 
 ## 5. Mesin skor — hitung-saat-baca, tanpa tombol "hitung ulang"
 
@@ -241,7 +314,9 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
    dan edit konfigurasi langsung berlaku pada muat ulang layar berikutnya.
 2. Rantainya:
    1. `hitung_poin(bentuk, …)` — satu fungsi `IMMUTABLE` berisi satu `CASE`
-      untuk kelima bentuk: `kecil_baik`/`besar_baik` = interpolasi linear
+      untuk keenam bentuk (`bertingkat` menyusul di 0022, dan sejak 0085 ia
+      membaca selisih terhadap jawaban benar): `kecil_baik`/`besar_baik` =
+      interpolasi linear
       `raw_terbaik→poin_maks` … `raw_terburuk→0` (di-clamp), `biner`,
       `benar_per_total`, `benar_kurang_salah` (clamp ke ≥0).
    2. `v_poin_wahana` — nilai mentah → poin per komponen.
@@ -256,15 +331,25 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
       penalti checkout sama-sama 0; regunya tetap terlihat di Live Score tanpa
       peringkat dan tidak dapat masuk enam besar.
    6. `v_klasemen` — `rank() OVER (PARTITION BY golongan ORDER BY total DESC,
-      |selisih_menit| ASC)` — empat klasemen, tie-break ketepatan waktu sudah
-      tertanam. Regu `batal` dan yang tidak pernah berangkat tidak ikut
-      diperingkat.
+      |selisih_menit| ASC)` — enam klasemen sejak 0091 (empat Eksternal +
+      `intern_pa`/`intern_pi`), tie-break ketepatan waktu sudah tertanam. Regu
+      `batal`, yang tidak pernah berangkat, dan sejak 0143 yang belum tercatat
+      tiba tidak ikut diperingkat.
 3. View pendukung: `v_monitoring_input` (matriks regu × pos),
    `v_keberangkatan` (papan garis start), `v_lembar_nilai` (cetak, urut nomor
    dada), `v_kwitansi`, `v_barak`, `v_progres_publik` (baris aman-publik tanpa
    angka).
 
 ## 6. Pipeline import nilai (jalur tersibuk hari-H)
+
+> **Tidak pernah dibangun.** Tidak ada textarea tempel, pemilih `.csv`,
+> deteksi delimiter, maupun preview per baris di kode mana pun. Nilai masuk
+> satu regu satu layar lewat `#/pos` dan `#/pos2`; foto lembar jawaban
+> (`foto_lembar`) yang menggantikan alur foto → AI → Excel → paste.
+> `simpan_nilai_massal` tetap satu-satunya jalur tulis nilai (butir 4 di
+> bawah masih berlaku), hanya saja ia selalu dipanggil `p_sumber = 'manual'`
+> dengan isi satu regu. Bagian ini dipertahankan karena
+> `supabase/migrations/0004_rpcs.sql` menunjuk ke nomornya.
 
 1. **Tahap tempel**: textarea besar menerima paste langsung dari Excel/Sheets
    (TSV) + pemilih file .csv. File .xlsx sengaja **tidak** di-parse — operator
@@ -296,33 +381,48 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
 
 ## 7. Halaman live publik — statis, bertahap, nol beban
 
-1. `live.html` + `live.json` di Cloudflare Pages; halaman memuat ulang
-   `live.json` tiap 60 detik dan menampilkan cap "Diperbarui 10:35". Ratusan
-   HP penonton hanya menyentuh hosting statis — bandwidth gratis tak terbatas,
-   **nol request ke Supabase**.
+1. `live/index.html` + `live.json` + `rekap.json` di Worker situs peserta;
+   halaman memuat ulang `live.json` tiap 60 detik dan menampilkan cap
+   "Update terakhir" dari jam saat berkasnya DIBUAT di server. 1.500-3.000 HP
+   peserta hanya menyentuh hosting statis — bandwidth gratis tak terbatas.
+   Yang tersisa ke Supabase cuma dua view kecil: `v_fase_live` tiap 15 detik
+   dan `v_publik_ringkas` selama fase `pra`.
 2. Regenerasi: workflow GitHub Actions (`publish-live.yml`) — cron 15 menit
-   pada 29 Agustus 2026 pukul 08:00-23:45 WIB + tombol manual. Tahun diperiksa
-   langkah pertama karena format cron hanya membawa tanggal dan bulan. Tiga
-   langkah yang bisa
-   dibaca pelajar: baca view publik memakai **service role key dari GitHub
-   Secrets** (bukan anon — anon tidak bisa baca apa pun) → tulis `live.json` →
-   deploy ke Pages. Hanya 64 penerbitan terjadwal pada hari-H ≪ kuota gratis
-   2.000 menit/bulan.
+   pada 29 Agustus 2026 pukul 06:00-18:59 WIB (dua baris cron, karena 06:00
+   WIB jatuh 23:00 UTC hari sebelumnya) + tombol manual + push yang menyentuh
+   `live/**`. Tahun diperiksa langkah pertama karena format cron hanya membawa
+   tanggal dan bulan. Langkah yang bisa dibaca pelajar: jalankan
+   `supabase/checks/live_json.sql` lewat `SUPABASE_DB_URL` dari GitHub Secrets
+   (tersambung sebagai pemilik database — anon tidak bisa baca apa pun) →
+   tulis `live.json` + `rekap.json` → periksa berkasnya sendiri → deploy
+   folder `live/` ke Worker peserta. ~52 penerbitan terjadwal pada hari-H ≪
+   kuota gratis 2.000 menit/bulan.
 3. **Bertahap sebagai data, bukan kode**: `status_acara.fase_live` menentukan
-   isi view publik — `pra` (jumlah pendaftar per golongan), `progres` (per
-   regu: sudah lewat pos mana, **tanpa angka**), `penuh` (klasemen 4 golongan
-   setelah closing). Admin memindah fase dari layar konfigurasi.
+   isi view publik — `pra` (jumlah pendaftar per golongan, keenamnya),
+   `progres` (per regu: sudah lewat pos mana, **tanpa angka**), `penuh`
+   (klasemen empat golongan Eksternal setelah closing; Intern PA/PI sengaja
+   dibuang di batas penerbitan), lalu `top10` (0145: maksimal sepuluh regu
+   berperingkat per golongan, tanpa poin per pos) dan `juara` (0163: papan
+   diganti daftar juara, beserta angkanya sejak 0164). Saklarnya di layar
+   Live Score, lewat RPC `atur_fase_live`, hanya untuk pemegang `pengaturan`.
 
 ## 8. Gateway form publik
 
-1. Form pendaftaran mengirim ke **satu Worker Cloudflare kecil** (±50 baris,
+1. Form pendaftaran mengirim ke **satu Worker Cloudflare** (587 baris,
    satu-satunya kode "server" di seluruh sistem): verifikasi token
-   **Turnstile** (CAPTCHA gratis tanpa kartu) + rate limit per IP + batas
-   ukuran payload → baru memanggil `submit_pendaftaran`.
+   **Turnstile** — opsional, dan untuk edisi 37 sengaja dimatikan karena
+   pendaftarannya tidak pernah disalahgunakan — + rate limit per IP + batas
+   ukuran payload → baru memanggil `submit_pendaftaran`. Worker yang sama juga
+   melayani pembuatan dan reset akun panitia untuk layar Akun.
 2. Kunci-kunci rahasia (Turnstile secret, service role) hidup di Worker/GitHub
    Secrets — **tidak pernah** di SPA.
 
 ## 9. Jendela Sheets & arsip
+
+> **Belum ada satu pun dari bagian ini.** Tidak ada tombol Export CSV di layar
+> mana pun, tidak ada serialisasi CSV di browser, dan Google Sheets tidak
+> dipakai — lihat catatan di kepala dokumen. Arsip tahunan belum punya
+> prosedur tertulis selain "Bersihkan data" (CLAUDE.md 12.4).
 
 1. **Export CSV di semua layar daftar**, posisi tombol sama di header setiap
    layar; serialisasi di browser, UTF-8 ber-BOM agar Excel membukanya bersih;
@@ -370,7 +470,8 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
     (upload, preview, password — bukan unggah/pratinjau/kata sandi).
 13. **Semua layar — termasuk layar panitia — wajib jalan di HP.** Panitia
     memakai HP, bukan hanya laptop. Diperiksa terukur pada lebar 390 px untuk
-    keenam layar panitia: tidak ada elemen yang meluber, halaman tidak pernah
+    layar panitia yang ada saat itu (enam; sekarang 16): tidak ada elemen yang
+    meluber, halaman tidak pernah
     menggeser ke samping, dan tidak ada sasaran sentuh di bawah 36 px. Tabel
     lebar menggeser di dalam kartunya sendiri, bukan menyeret seluruh halaman;
     di HP kepala memecah judul ke barisnya sendiri agar tombol tetap terjangkau
@@ -391,33 +492,43 @@ lembar resmi membuat klarifikasi berpijak pada angka yang sama.
 
 ### 10.2 Inventaris layar
 
+> **Daftar rancangan, bukan daftar layar yang ada.** Kolom Peran memakai nama
+> yang mati sejak 0058 (`meja` → `registrasi`, `operator_pos` → `juri_pos`),
+> dan hak sebenarnya ditentukan centang `akun_hak`, bukan peran. Monitoring,
+> Konfigurasi, Barak, dan Riwayat tidak pernah dibangun sebagai layar
+> tersendiri. Rute yang benar-benar ada di `final-architecture.md` bagian 3.
+
 | Layar | Peran | Inti |
 | --- | --- | --- |
 | Login | semua | Username + password; akhiran email ditambah otomatis |
 | Beranda meja | meja | Pemilih fungsi + lencana angka dari data nyata (batch menunggu verifikasi, batch lunas belum bernomor, regu belum closing) |
-| Form pendaftaran | publik | Bagian 3 alur, **satu halaman** (bukan wizard — lihat 10.4): 5 bagian bernomor, autocomplete sekolah dari master (dimuat sekali, difilter di browser), blok per regu muncul mengikuti stepper, tombol Kirim menempel di bawah dengan total hidup; hasil akhir menampilkan kode pembayaran besar-besar |
+| Form pendaftaran | publik | Bagian 3 alur, **satu halaman** (bukan wizard — lihat 10.4): 7 bagian bernomor dinamis (Peserta, Asal sekolah, Menginap, Jumlah regu, Identitas regu, Contact Person, Pembayaran; bagian Menginap dilewati untuk Intern), autocomplete sekolah dari master (dimuat sekali, difilter di browser), blok per regu muncul mengikuti stepper, tombol Kirim menempel di bawah dengan total hidup; hasil akhir menampilkan kode pembayaran besar-besar |
 | Meja pembayaran | meja | Ketik kode → kartu batch → "Tandai Lunas" → panel sukses langsung menawarkan "Cetak Kwitansi" (satu alur, bukan dua); "Batalkan (salah)" memanggil `batalkan_verifikasi` |
 | Meja daftar ulang | meja | Cari kode/sekolah → buka "Isi N Nomor Dada" → **ketik nomor dari kain fisik per regu** (nama regu + kategori + ketua terlihat, Enter = regu berikutnya) → satu tombol "Simpan N Nomor Dada" → kloter terisi otomatis dan dibacakan; jalur "Tukar nomor" untuk stok rusak |
 | Garis start | meja | Papan 4 kolom **turunan otomatis** dari kloter terakhir yang berangkat: N berangkat / N+1–N+2 siap / N+3 konfirmasi kontrak. Operator hanya punya dua aksi: ceklis regu + tombol besar "BERANGKATKAN" (jam diketik). Papan bergeser sendiri — operator tidak pernah memutuskan apa yang maju |
-| Input pos — manual | operator_pos | Loop ketik-Enter 5 detik; hanya komponen pos sendiri yang tampil |
-| Input pos — upload massal | operator_pos | Pipeline bagian 6 |
+| Input Nilai Pos (`#/pos`) | juri_pos | Lembar satu pos, satu baris per regu, plus cetak blangko |
+| Input Nilai Pos v2 (`#/pos2`) | juri_pos | Pilih satu lomba lintas pos, satu regu satu layar: stopwatch untuk lomba waktu, kotak per kriteria untuk sisanya. Foto borongan pindah ke layar Foto Jawaban (`#/foto`) |
 | Meja closing | meja | Ketik nomor dada → kartu regu → jam datang (kosong + chip "Jam sekarang") + anggota hadir (default 5) → Enter; dirancang setara arus 10 regu / 5 menit; catatan kertas tetap jadi cadangan resmi di meja |
-| Monitoring | semua panitia | Matriks regu × pos live (Realtime); kolom closing ikut live |
-| Klasemen (admin) | admin | Empat tab golongan; **tanpa tombol hitung ulang** — selalu segar karena hitung-saat-baca; Export CSV |
-| Konfigurasi (admin) | admin | Tab per tabel konfigurasi; editor baris dengan bahasa manusia + kolom "contoh hasil" live (ubah `raw_terbaik` → contoh konversi ikut berubah); saklar `fase_live`, `daftar_ulang_ditutup`, `konfigurasi_terkunci` |
-| Cetak | admin/meja | Lembar nilai per pos (aktif setelah `daftar_ulang_ditutup`; urut nomor dada; header kolom = `wahana.kode` dari konfigurasi) + kwitansi; print CSS browser |
-| Barak | meja/admin | Panel kebutuhan (+pendamping) vs kapasitas; tombol "Susun Ulang"; hasil bisa dikoreksi manual sebelum ditempel |
-| Riwayat | admin | Cari per nomor dada / tabel / akun; baca-saja |
+| Monitoring | — | **Tidak dibangun.** `v_monitoring_input` ada di database tetapi tidak dibaca layar mana pun; kemajuan per pos dibaca dari Live Score (`#/live-score`), dan tidak ada Realtime |
+| Live Score (`#/live-score`) | pemegang `live_score` | Enam tab golongan; podium enam tempat + tabel rinci; tombol segarkan singgahan (`minta_segarkan_live_score`, 0165); saklar fase hanya untuk pemegang `pengaturan`. Tanpa Export CSV |
+| Konfigurasi (admin) | — | **Tidak dibangun.** Konfigurasi diubah lewat migrasi (mis. 0034 nama pos, 0076 bobot kriteria, 0089 penalti, 0109 kontrak, 0168-0169 judul isian). Dari ketiga saklarnya hanya `fase_live` punya tombol, di layar Live Score lewat `atur_fase_live` |
+| Cetak | — | Bukan layar tersendiri: blangko "LEMBAR CADANGAN" dicetak dari Input Nilai Pos (header kolom = `wahana.name` + petunjuk, bukan `kode`, dan tanpa pagar `daftar_ulang_ditutup`), kwitansi dari Pembayaran, daftar kloter dari `#/cetak-kloter`; print CSS browser |
+| Barak | — | **Tidak dibangun.** `susun_barak` dan `v_barak` ada di database tetapi tidak dipanggil layar mana pun |
+| Riwayat | — | Bukan layar pencarian: riwayat dibuka sebagai dialog per baris di layar terkait, dari `v_riwayat_nilai` dan `v_riwayat_pendaftaran` (0137) |
 | Live publik | tanpa login | Bagian 7 |
 
 ### 10.3 Empat alur tersibuk (target waktu per transaksi)
 
-1. **Daftar ulang batch** (target ≤ 40 detik/sekolah/meja): sebut kode → kartu
-   tampil → konfirmasi lisan nama regu + sekolah → satu tombol → bacakan hasil
-   → serahkan nomor dada fisik.
-2. **Import massal pos** (berjalan sepanjang lomba): foto masuk WA → AI →
-   Excel → copy → paste → mata menyapu kolom identitas → commit. Operator
-   kedua di pos memvalidasi sambil operator pertama menerima foto berikutnya.
+1. **Daftar ulang batch** (target ≤ 40 detik/sekolah/meja): cari kode/sekolah
+   → kartu tampil → konfirmasi lisan nama regu + sekolah → **ketik nomor dari
+   kain fisik per regu** (Enter = regu berikutnya) → satu tombol "Simpan N
+   Nomor Dada" → kloter terisi otomatis dan dibacakan.
+2. **Nilai per lomba** (berjalan sepanjang lomba): foto lembar jawaban
+   diunggah dari HP ke layar Foto Jawaban (`#/foto`) → ditautkan ke nomor dada
+   → angkanya diketik satu regu satu layar di `#/pos2`, dengan foto slipnya
+   terlihat di sebelahnya. Yang gagal terkirim mengantre di `localStorage` HP
+   petugas sampai ada sinyal; yang ditolak server dilaporkan merah saat itu
+   juga. (Alur AI → Excel → paste di bagian 6 tidak pernah dibangun.)
 3. **Serbuan closing**: baris depan mencatat di kertas (nomor dada + jam +
    jumlah orang), baris belakang mengetik dari kertas — layar dirancang untuk
    penyalinan cepat, bukan hanya pencatatan langsung; jam diketik membuat
@@ -489,6 +600,9 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
 1. Wizard tepat untuk form panjang dengan banyak percabangan. Form ini pendek:
    lima pertanyaan dengan satu percabangan kecil (barak → jumlah pendamping).
    Memecahnya jadi enam layar hanya menambah lima klik tanpa manfaat.
+   (Sekarang tujuh bagian dengan dua percabangan — jenis peserta dan barak —
+   plus bagian Pembayaran beserta upload bukti transfer; alasannya tidak
+   berubah.)
 2. Yang hilang gara-gara wizard justru hal yang paling menenangkan orang awam:
    **melihat seluruh isi form sebelum mulai** — "oh, saya perlu menyiapkan
    nama-nama regunya dulu". Wizard menyembunyikan itu.
@@ -496,9 +610,10 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
    riwayat per langkah (tombol back HP) dan pemulihan draf per langkah tidak
    lagi diperlukan. Kodenya ikut menyusut, sejalan dengan CLAUDE.md §6.
 4. Yang tetap dijaga meski satu halaman:
-   - Bagian **bernomor 1–5** sebagai penunjuk urutan tanpa memaksa pindah layar.
+   - Bagian **bernomor**, sekarang 1–7 dan dihitung dinamis supaya pendaftar
+     Intern yang melewati bagian menginap tetap membaca urutan tanpa lubang.
    - Tombol Kirim **menempel di bawah layar** dengan ringkasan hidup
-     ("3 regu · Rp 750.000") — pada form panjang, aksi utama tidak boleh
+     ("3 regu · Rp 525.000") — pada form panjang, aksi utama tidak boleh
      tenggelam di ujung gulungan.
    - Galat ditampilkan **sekaligus** di tempatnya masing-masing, ditambah satu
      ringkasan yang tiap barisnya bisa diketuk untuk melompat ke isiannya.
@@ -537,7 +652,10 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
     bagi regu yang memang tidak ikut.
 13. **Urutan lembar cetak dikanonkan**: nomor dada menaik, di view dan layar.
 14. **Akun dibuat pemilik setahun sekali lewat dashboard** — dari SPA memang
-    mustahil, dan 10 menit/tahun bukan alasan menambah server.
+    mustahil, dan 10 menit/tahun bukan alasan menambah server. **Sudah
+    dibalik**: layar Akun (`#/account`) membuat, menonaktifkan, dan mereset
+    akun lewat gateway Worker, dan `provision-accounts.yml` melakukannya
+    massal dari HP. Servernya tidak ditambah — gateway yang sudah ada dipakai.
 
 ## 12. Batas yang diterima secara sadar
 
@@ -550,9 +668,13 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
    tanpa dependensi parser.
 4. **Pembayaran sebagian tidak punya bentuk data** — sesuai keputusan panitia;
    layar pembayaran menampilkan teks arahan "daftarkan batch lebih kecil".
-5. **Supabase pause**: keep-alive = cron GitHub Actions mingguan yang menyentuh
-   tabel heartbeat + ritual cek Januari; jendela pemulihan 1 tahun menjadikan
-   kelalaian dapat dipulihkan, bukan fatal.
+5. **Supabase pause**: rencananya keep-alive = cron GitHub Actions mingguan
+   yang menyentuh tabel heartbeat + ritual cek Januari. **Tidak pernah
+   dibuat** — tidak ada tabel heartbeat maupun workflow keep-alive di repo,
+   dan cron yang ada hanya `publish-live.yml` serta `refresh-live-score.yml`,
+   dua-duanya terkunci ke tanggal lomba. Yang tersisa: jendela pemulihan
+   1 tahun, jadi kelalaian tetap dapat dipulihkan. Sebelum menambah cron
+   mingguan, hitung dulu tagihannya (CLAUDE.md 16.9).
 
 ## 13. Urutan implementasi
 
@@ -561,8 +683,8 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
 | 1. Fondasi | Struktur repo, migrasi SQL lengkap (tabel + RLS + fungsi + view), seed konfigurasi edisi 37, seed contoh | Tes SQL: nomor dada ganda tertolak, RLS pos menggigit, contoh konversi & penalti cocok dengan dokumen ini |
 | 2. Meja | Login, beranda meja, form pendaftaran + gateway Worker, pembayaran, daftar ulang | Alur daftar → bayar → nomor dada jalan penuh di lingkungan uji |
 | 3. Hari-H | Garis start, input pos (manual + massal), closing, monitoring | Simulasi input 500 regu × 5 pos |
-| 4. Admin | Konfigurasi, klasemen, cetak, barak, riwayat | Panitia bisa mengubah aturan skor tanpa menyentuh kode |
-| 5. Publik | Live page + GitHub Actions + fase bertahap + keep-alive | Halaman live berjalan tanpa satu request pun ke Supabase |
+| 4. Admin | Konfigurasi, klasemen, cetak, barak, riwayat | **Tidak tercapai.** Klasemen jadi Live Score dan cetak menempel di layar masing-masing; Konfigurasi, Barak, dan Riwayat tidak dibangun. Aturan skor masih diubah lewat migrasi SQL, bukan dari layar |
+| 5. Publik | Live page + GitHub Actions + fase bertahap (kini lima) | Halaman live tidak mengambil rekap dari Supabase — hanya `v_fase_live` tiap 15 detik, yang cuma boleh memperketat, dan `v_publik_ringkas` selama fase `pra`. Keep-alive tidak dibuat |
 | 6. Gladi | Seed 300 regu sintetis, drill semua meja, ukur waktu per transaksi terhadap target 10.3 | Angka gladi terlampir di repo |
 
 Setiap tahap masuk lewat PR sendiri mengikuti konvensi CLAUDE.md.

--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -65,7 +65,7 @@ Totalnya 1.254 baris peserta.
 
 1. **Nama kelas** — `X MIPA 1`, `12 ips 4`, `10 IPS 5` (71 nama, 126 baris).
    Hanya muncul di XXXV dan XXXVI, dan itu petunjuknya: ini kontingen **tuan
-   rumah**, SMA Negeri 1 Ciamis (`docs/alur-lomba.md` bagian 34), yang menulis
+   rumah**, SMA Negeri 1 Ciamis (`docs/alur-lomba.md` bagian 1.2), yang menulis
    kelasnya alih-alih sekolahnya. Tidak ada yang hilang dengan membuangnya —
    SMAN 1 Ciamis sudah ada di daftar dengan namanya sendiri.
 2. **Organisasi dan ekstrakurikuler** — OSIS, MPK, KIR, FORSA, Nuansa,
@@ -149,7 +149,7 @@ berpasangan, dan urutannya penting — "biasa diucapkan" duluan.
 ### Yang menentukan sekolah itu satu atau dua adalah NPSN — bukan namanya
 
 Nama boleh sama; NPSN tidak pernah. **NPSN dicek hanya kalau benar-benar
-ragu** — bukan untuk 189 sekolah satu per satu, tapi untuk yang namanya
+ragu** — bukan untuk 209 sekolah satu per satu, tapi untuk yang namanya
 mencurigakan mirip. Begitu dua NPSN berbeda, itu dua sekolah, titik, dan
 tidak ada kesamaan alamat atau ejaan yang mengubahnya.
 
@@ -187,7 +187,9 @@ Nama resmi yang berbeda tetap disimpan di kolom `nama_resmi`
 `sekolah_alamat.json`, jadi tidak ada yang hilang.
 
 Hasil: **1.102 baris peserta → 201 klaster**, dari 326 tulisan mentah.
-Penggabungan lewat NPSN di bagian 7 memangkasnya lagi jadi **189 sekolah**.
+Penggabungan lewat NPSN di bagian 7 memangkasnya lagi jadi **189 sekolah** —
+angka putaran pertama, atas empat edisi lama saja. Pendaftaran XXXVII
+menambahkannya jadi **209**; keadaan hari ini ada di bagian 11.
 
 ---
 
@@ -480,35 +482,48 @@ mirip dan petunjuk yang lebih baik.
 | Berkas | Isi |
 | --- | --- |
 | `tools/normalize_sekolah.py` | langkah 2–5: baca Excel, buang non-sekolah, bakukan, kelompokkan |
-| `tools/data/sekolah_nama.json` | 189 sekolah: nama baku, semua ejaan, jumlah peserta, petunjuk alamat |
+| `tools/data/sekolah_nama.json` | 209 sekolah: nama baku, semua ejaan, jumlah peserta, petunjuk alamat |
 | `tools/data/sekolah_alamat.json` | hasil pencarian alamat: NPSN, jalan, desa, kecamatan, kabupaten, kode pos, keyakinan, sumber |
-| `tools/periksa_sekolah.py` | penjaga: kedua berkas di atas masih saling cocok, dan bentuk isiannya masih menuruti bagian 7 dan 8 |
-| [`sekolah-belum-tuntas.md`](sekolah-belum-tuntas.md) | daftar kerja: 21 sekolah yang belum bisa dipakai, kenapa, dan apa yang ditanyakan ke pembinanya |
+| `tools/periksa_sekolah.py` | penjaga: kedua berkas di atas masih saling cocok, bentuk isiannya masih menuruti bagian 7 dan 8, dan `sekolah-belum-tuntas.md` memuat persis baris yang keyakinannya belum `tinggi` |
+| [`sekolah-belum-tuntas.md`](sekolah-belum-tuntas.md) | daftar kerja: 19 baris yang keyakinannya belum `tinggi`, kenapa, dan apa yang ditanyakan ke pembinanya |
 
 Jalankan `normalize_sekolah.py` dari direktori berisi keempat berkas `.xlsx`.
-`periksa_sekolah.py` jalan dari mana saja, dan ikut jalan di CI lewat
-`shared-files.yml` — bagian 7 sudah membuktikan daftar yang tidak diperiksa
-mesin akan menyimpang tanpa suara.
+Keluarannya `sekolah.json` di direktori itu juga, **bukan**
+`tools/data/sekolah_nama.json` — bandingkan dulu, baru salin.
+
+`periksa_sekolah.py` jalan dari mana saja: `python tools/periksa_sekolah.py`.
+Ia juga satu langkah di `shared-files.yml`, tapi workflow itu
+`workflow_dispatch` saja dan tidak jalan sendiri (CLAUDE.md bagian 16.5) —
+jalankan di laptop sebelum membuka PR. Bagian 7 sudah membuktikan daftar yang
+tidak diperiksa mesin akan menyimpang tanpa suara.
 
 ---
 
-## 11. Keadaan sekarang (17 Agustus 2026)
+## 11. Keadaan daftar kurasi (30 Agustus 2026)
 
-**189 sekolah, 188 sudah punya alamat.** 169 berkeyakinan `tinggi`, 178 lengkap
-dengan kode pos, tersebar di 24 kabupaten/kota. Berkas alamatnya berisi 190
-baris, bukan 189 — lihat catatan SMK Bhakti Kencana di bawah.
+**209 sekolah, semuanya sudah punya alamat.** 191 berkeyakinan `tinggi`, 19
+`sedang`, dan seluruhnya lengkap dengan kode pos, tersebar di 24
+kabupaten/kota. Berkas alamatnya berisi 210 baris, bukan 209 — lihat catatan
+SMK Bhakti Kencana di bawah.
 
-Dua belas baris masih tanpa kode pos: dua sekolah yang memang belum ketemu, dan
-sepuluh yang angkanya bertabrakan antar sumber (lihat bagian 9) — dikosongkan,
-bukan ditebak.
+Bagian ini soal kedua berkas JSON. Keadaan tabel `sekolah` di produksi ada di
+bagian 13.6.
 
-Yang berkeyakinan `sedang` hampir semuanya bukan soal sekolahnya, melainkan
-soal **kode posnya**: identitas dan alamat jalan sudah dari Data Referensi
-Kemendikdasmen, tapi halaman itu memang tidak memuat kolom kode pos, jadi
-angkanya datang dari cermin Dapodik atau direktori kode pos per desa. Contoh
-paling jelas `SMPN 1 Purwadadi`: satu direktori menulis 46385, satu lagi 46380,
-dan yang 46385 salah satunya data sekolahnya sendiri — jadi 46385 yang dipakai,
-dengan keyakinan `sedang` dan alasannya ditulis di `catatan`.
+Tidak ada lagi baris tanpa kode pos. Yang dulu dikosongkan karena angkanya
+bertabrakan antar sumber (lihat bagian 9) sudah dipastikan lewat direktori kode
+pos per desa; dua baris yang angkanya masih disengketakan tetap terpasang dan
+terdaftar di [`sekolah-belum-tuntas.md`](sekolah-belum-tuntas.md) bagian C.
+
+Dari 19 yang berkeyakinan `sedang`, **dua belas soal sekolahnya sendiri** —
+dua kandidat yang sama-sama meyakinkan, atau nama yang tidak ada di Dapodik —
+dan tinggal **dua** yang soal kode posnya; lima sisanya sudah beres dan tinggal
+labelnya. Pembagiannya ada di
+[`sekolah-belum-tuntas.md`](sekolah-belum-tuntas.md) bagian A, C, dan D.
+
+Contoh yang soal kode pos, `SMPN 1 Purwadadi`: satu direktori menulis 46385,
+satu lagi 46380, dan yang 46385 salah satunya data sekolahnya sendiri — jadi
+46385 yang dipakai, dengan keyakinan `sedang` dan alasannya ditulis di
+`catatan`.
 
 Dari tiga belas yang tersisa di putaran pertama, **sebelas selesai**, dan
 tujuh di antaranya selesai tanpa pencarian baru sama sekali: petunjuknya sudah
@@ -529,8 +544,9 @@ ada di `sekolah_nama.json` sejak awal, hanya tidak pernah sampai ke agennya
 | SMPN 1 Purwadadi | **Ciamis**, NPSN 20252422 — bukan yang di Subang |
 | MTsN Rajadesa | MTsN 13 Ciamis, Jl. Cipancur No. 06. NPSN 20278700 |
 
-**Dua sisanya tidak akan selesai dengan mencari lebih keras.** Keduanya sudah
-disisir dari sisi alamat, bukan cuma dari sisi nama, dan buntu:
+**Dua sekolah tidak pernah ketemu, dan barisnya sudah dibuang** — keputusan
+pemilik acara, 30 Agustus 2026. Keduanya sudah disisir dari sisi alamat, bukan
+cuma dari sisi nama, dan buntu:
 
 - **SMK Nusantara 1 Bekasi** — Jl. Kapten Tendean tidak ada di Bekasi, dan
   tidak ada sekolah menengah di Jl. Kapten Tendean Jakarta Selatan. Kelima SMK
@@ -539,12 +555,20 @@ disisir dari sisi alamat, bukan cuma dari sisi nama, dan buntu:
   SMPN 5 Banjarsari di Desa Kalijaya, Kec. Banjaranyar, tapi namanya tidak
   cocok, jadi sengaja tidak diisikan.
 
-Yang dibutuhkan satu pertanyaan ke pembinanya — dan bukan cuma dua ini.
-Seluruh 21 baris yang keyakinannya belum `tinggi` sudah didaftar di
+Yang dibutuhkan satu pertanyaan ke pembinanya. Seluruh **19** baris yang
+keyakinannya belum `tinggi` sudah didaftar di
 [`sekolah-belum-tuntas.md`](sekolah-belum-tuntas.md), lengkap dengan kalimat
 yang tinggal disalin ke pembinanya. `periksa_sekolah.py` menjaga daftar itu
 tetap sama persis dengan isi datanya, jadi ia menyusut sendiri begitu satu
-sekolah beres — atau CI-nya merah.
+sekolah beres — atau skripnya gagal. Ia tidak jalan sendiri di CI mana pun;
+cara menjalankannya ada di bagian 10.
+
+Satu akibat dari membuang kedua baris tadi: keduanya lahir dari
+`normalize_sekolah.py` atas spreadsheet edisi lama, jadi **menjalankan ulang
+skrip itu akan memunculkan keduanya kembali** — hapus lagi, jangan dicari
+lagi. Daftar `BELUM_KETEMU` di `tools/periksa_sekolah.py` sengaja
+dipertahankan meski kosong; ia satu-satunya cara menandai "sekolah ini memang
+tidak punya alamat".
 
 **Yang masih menggantung selain itu:**
 
@@ -558,20 +582,30 @@ sekolah beres — atau CI-nya merah.
    baris peserta yang tidak menyebut daerahnya sama sekali — salah satunya
    berpetunjuk `Jl. Ir. H. Juanda`, yang bukan alamat kedua sekolah itu.
    Tanyakan ke pembinanya.
-2. **Kode pos 46383 di sekolah-sekolah Kec. Banjaranyar perlu diperiksa.**
+2. **Kode pos Kec. Banjaranyar sudah dibetulkan, jebakannya belum hilang.**
    Banjaranyar mekar dari Banjarsari tahun 2015 dan cermin Dapodik masih
-   memakai kode lama; Desa Kalijaya, Banjaranyar tercatat 46384. Yang benar-
-   benar di Kec. Banjarsari tetap 46383. Yang perlu dicek: `SMAN 2 Banjarsari`
-   (NPSN 20255008, Desa Cigayam).
-3. **`MA Agrowisata Shaleha` dan `MTs Serba Bakti Suryalaya` tidak punya
-   NPSN** — madrasah di bawah Kemenag/EMIS memang tidak selalu ada di Dapodik.
-   Alamatnya ketemu lewat sekolah saudara di kompleks yang sama. Itu bukan
-   cacat, tapi berarti pemeriksaan kembar lewat NPSN (bagian 7) tidak bisa
-   menjangkau keduanya.
+   memakai kode lama; desa yang ikut pindah memakai 46384, yang benar-benar di
+   Kec. Banjarsari tetap 46383. `SMAN 2 Banjarsari` (NPSN 20255008, Desa
+   Cigayam) sudah dipindah ke 46384 oleh `0159`, dan `SMPN 6 Banjarsari` (Desa
+   Cikupa) memang sudah begitu. Yang menyentuh kode pos Banjaranyar berikutnya
+   tetap harus memeriksa **desanya** dulu, bukan kecamatannya.
+3. **Empat sekolah tidak punya NPSN, dan sebabnya dua macam.**
+   `MA Agrowisata Shaleha` dan `MTs Serba Bakti Suryalaya` ada di bawah
+   Kemenag/EMIS, bukan Dapodik. `MA Adzkia` dan `SMA IT Nurul Huda` belum
+   terdaftar di Data Referensi sama sekali — yang terakhir bahkan bukan
+   madrasah, jadi alasan Kemenag tidak berlaku untuknya. Keempatnya
+   beralamat pinjaman dari sekolah saudara di kompleks yang sama, dan
+   pemilik acara membenarkan kedua yang terakhir pada 30 Agustus 2026. Itu
+   bukan cacat, tapi berarti pemeriksaan kembar lewat NPSN (bagian 7) tidak
+   bisa menjangkau keempatnya. Daftarnya `TANPA_NPSN` di
+   `tools/periksa_sekolah.py` — yang berikutnya didaftarkan di situ, bukan
+   dibiarkan lolos.
 
-**188 sekolah sudah terpasang di tabel `sekolah` produksi** (17 Agustus 2026,
-migrasi 0061–0063). Yang belum masuk cuma dua yang alamatnya memang belum
-ketemu. Caranya, beserta yang salah dulu baru betul, ada di bagian 12.
+**188 sekolah pertama terpasang di tabel `sekolah` produksi pada 17 Agustus
+2026** lewat migrasi 0061–0063; caranya, beserta yang salah dulu baru betul,
+ada di bagian 12. Sesudah itu pendaftaran XXXVII (`0154`–`0156`) dan impor
+direktori Kabupaten Ciamis (`0157`–`0162`) menambahkannya jauh lebih banyak —
+keadaan produksi hari ini ada di bagian 13.6, bukan di sini.
 
 Pagar kembarnya **sudah terpasang**: `unique index` atas
 `kunci_sekolah(name)`, dan `submit_pendaftaran` mencari sekolahnya lewat
@@ -649,14 +683,20 @@ SMPT RIYADLUL ULUM WADDAWAH   ->  SMP Terpadu Riyadlul Ulum Waddawah
 nama yang benar-benar ada di produksi. Enam baris, disebut satu per satu, tidak
 ada normalisasi yang perlu dipercaya.
 
-**Sebelum cetak blangko, jalankan `supabase/checks/sekolah_kembar.sql`.**
-Ia melapor pasangan baris `sekolah` yang bedanya cuma tanda baca, huruf `h`,
-huruf status Dapodik, sisipan satu kata, atau kata terakhir yang sama — hal-hal
-yang `kunci_sekolah()` sengaja lewatkan. Ia TIDAK melebur apa pun; yang
-memutuskan tetap manusia, lewat NPSN. Diuji atas 217 nama produksi: lima dari
-enam baris kembar yang pernah ada tertangkap, tanpa satu pun lapor palsu. Yang
-keenam, `MAN Darussalam` lawan `MAN 1 Ciamis`, tidak punya satu huruf pun yang
-sama dan hanya bisa dibuktikan NPSN — yang tidak disimpan tabel `sekolah`.
+**Sebelum cetak blangko — dan sesudah SETIAP impor (bagian 13.3) — jalankan
+`supabase/checks/sekolah_kembar.sql`.** Enam aturan: bedanya cuma tanda baca,
+huruf `h` dan huruf ganda, huruf status Dapodik, sisipan satu kata, kata
+terakhirnya nama diri yang sama, atau — dan ini yang tidak membandingkan nama
+sama sekali — jalan DAN desanya sama persis dengan jenjang yang sama. Semuanya
+hal yang `kunci_sekolah()` sengaja lewatkan. Ia TIDAK melebur apa pun; yang
+memutuskan tetap manusia, lewat NPSN.
+
+Keenam baris kembar yang pernah ada sekarang tertangkap. Yang terakhir,
+`MAN Darussalam` lawan `MAN 1 Ciamis`, tidak punya satu huruf pun yang sama
+dan dulu hanya bisa dibuktikan NPSN — aturan jalan+desa itulah yang
+menutupnya, dan yang menemukannya kejadian nyata: impor `0157` menghidupkan
+kembali baris yang `0154` baru saja lebur. Yang masih lolos, dan ini yang
+perlu diingat: sekolah yang pindah alamat dan berganti nama sekaligus.
 
 **Kalau mengulanginya tahun depan:** cocokkan ke daftar kurasi memakai `kunci()`
 Python, cetak pasangannya, baca, baru rakit migrasinya. Jangan serahkan
@@ -713,8 +753,9 @@ def kunci_sql(n):
 ### 12.6 Yang sengaja tidak dipasang
 
 **Dua sekolah berkeyakinan `rendah`** — `SMK Nusantara 1 Bekasi` dan
-`SMPN 1 Kalijaya` — tidak ikut. Keduanya sudah disisir dari sisi alamat, bukan
-cuma dari sisi nama, dan buntu.
+`SMPN 1 Kalijaya` — tidak ikut, karena keduanya buntu (bagian 11). Barisnya
+sendiri dibuang dari kedua berkas JSON pada 30 Agustus 2026, jadi hari ini
+tidak ada satu pun baris `rendah` yang tersisa untuk dicari.
 
 Memasang tebakan lebih buruk daripada tidak memasang apa-apa. Pembina yang
 tidak menemukan sekolahnya akan mengetiknya sendiri, dan jalan itu memang
@@ -744,7 +785,7 @@ daripada dibiarkan mengajarkan yang salah.
 
 Gantinya satu kalimat yang membawa fakta yang tidak ada di layar dan mahal
 kalau tidak diketahui: nama yang persis sama akan **menyatu** dengan sekolah
-itu, jadi tambahkan kabupatennya. Ini `CLAUDE.md` bagian 9.4 dan 9.7 — form
+itu, jadi tambahkan kabupatennya. Ini `CLAUDE.md` bagian 9.4 dan 9.8 — form
 pendaftaran diisi sekali, oleh orang yang belum pernah dilatih dan tidak punya
 tempat bertanya.
 

--- a/docs/sekolah-belum-tuntas.md
+++ b/docs/sekolah-belum-tuntas.md
@@ -1,6 +1,6 @@
 # Sekolah yang belum tuntas
 
-Delapan belas dari 210 baris di `tools/data/sekolah_alamat.json` belum bisa
+Sembilan belas dari 210 baris di `tools/data/sekolah_alamat.json` belum bisa
 dipakai apa adanya. Halaman ini daftar kerjanya: apa yang kurang, kenapa, dan
 apa yang harus ditanyakan.
 
@@ -25,8 +25,11 @@ Yang di bawah ini sisanya.
    jawabannya dari pembina — sebutkan tanggalnya.
 3. **Hapus barisnya dari halaman ini di commit yang sama.**
    `tools/periksa_sekolah.py` membandingkan daftar ini dengan isi datanya dan
-   gagal di CI kalau keduanya tidak cocok. Itu disengaja: daftar kerja yang
-   tidak ikut menyusut berhenti dipercaya, lalu berhenti dibaca.
+   gagal kalau keduanya tidak cocok — tapi ia tidak jalan sendiri. Sejak
+   `shared-files.yml` cuma `workflow_dispatch`, tidak ada pemicu otomatis
+   yang membacanya, jadi jalankan `python tools/periksa_sekolah.py` di laptop
+   sebelum membuka PR. Pemeriksaannya disengaja: daftar kerja yang tidak ikut
+   menyusut berhenti dipercaya, lalu berhenti dibaca.
 
 ---
 
@@ -91,11 +94,14 @@ mencarinya lagi.
 
 > **Banjarsari dan Banjaranyar dulu satu kecamatan, dan cermin Dapodik belum
 > semuanya menyusul.** Banjaranyar mekar dari Banjarsari tahun 2015; desa yang
-> ikut pindah memakai **46384**, bukan 46383. Dua baris kurasi masih tidak
+> ikut pindah memakai **46384**, bukan 46383. Dua baris kurasi sempat tidak
 > sepakat soal ini — `SMAN 2 Banjarsari` (Desa Cigayam, Kec. Banjaranyar)
 > memakai 46383 sementara `SMPN 6 Banjarsari` (Desa Cikupa, kecamatan yang
-> sama) memakai 46384. Keduanya nol regu tahun ini, jadi tidak mendesak, tetapi
-> yang menyentuh kode pos Banjaranyar berikutnya harus memeriksa desanya dulu.
+> sama) memakai 46384 — dan justru ketidaksepakatan itu yang membuat
+> kesalahannya terlihat. Migrasi `0159` membetulkan yang pertama jadi 46384,
+> jadi keduanya sekarang sepakat. Cerminnya belum tentu ikut, jadi yang
+> menyentuh kode pos Banjaranyar berikutnya tetap harus memeriksa desanya
+> dulu.
 >
 > Catatan ini dulu menempel pada baris `SMPN 1 Kalijaya` di bagian B. Barisnya
 > dihapus; peringatannya tidak.
@@ -110,12 +116,14 @@ alamat yang dicetak sekolahnya sendiri. Alasan lengkapnya di
 ---
 
 > **`MTsN 1 Ciamis` diputuskan 30 Agustus 2026: 46211.** Situs resmi sekolahnya
-> menulis 46251, tetapi desanya Panyingkiran, dan 46211 dipakai dua direktori
-> kode pos yang berbeda serta **delapan belas sekolah kurasi lain di Kec.
-> Ciamis tanpa kecuali** — Ciamis 46211, Kertasari 46213, Maleber 46214,
-> Sindangrasa 46215, Linggasari 46216, Imbanagara 46219. Angka 46251 tidak ada
-> di Kec. Ciamis, dan juga tidak di Sindangkasih (46268) maupun Cikoneng
-> (46261) yang bersebelahan.
+> menulis 46251, tetapi desanya Panyingkiran, dan dua direktori kode pos yang
+> berbeda sama-sama menulis 46211 untuk desa itu. Yang menguatkan: kode pos
+> tiap desa di Kec. Ciamis cocok dengan direktori **tanpa kecuali** — Ciamis
+> 46211, Kertasari 46213, Maleber 46214, Sindangrasa 46215, Linggasari 46216,
+> Imbanagara 46219 — delapan belas baris kurasi waktu itu, dua puluh sekarang
+> (`0156` menambah SMK LPS 1 dan 2 di Maleber). Angka 46251 tidak ada di Kec.
+> Ciamis, dan juga tidak di Sindangkasih (46268) maupun Cikoneng (46261) yang
+> bersebelahan.
 >
 > `tests/sql/107` menjaga 46251 tidak diam-diam kembali.
 
@@ -166,10 +174,13 @@ Kolom petunjuk itu **bukan alamat** — runbook bagian 1 menyebutnya arah, bukan
 sumber kebenaran. Tetapi sebagai pemilih di antara dua alamat yang sama-sama
 resmi, ia persis yang dibutuhkan. Simpan kolomnya untuk edisi berikutnya.
 
-Tiga di antaranya tidak selesai penuh dan pindah ke bagian A: `MA Bahrul
-Anwar` (desanya dikosongkan Dapodik), `MA Adzkia` dan `SMA IT Nurul Huda`
-(tidak punya NPSN). Ketiganya sudah punya alamat yang bisa dipakai berkirim
-surat; yang kurang cuma satu kalimat dari pembina.
+Tiga di antaranya sempat pindah ke bagian A, dan ketiganya sudah selesai juga
+30 Agustus 2026 — bukan oleh pembina, melainkan oleh pemilik acara: desa
+`MA Bahrul Anwar` dikonfirmasi Mekarsari (Dapodik mengosongkannya), lalu
+`MA Adzkia` dan `SMA IT Nurul Huda` dibenarkan satu tempat dengan MTs/SMP
+saudaranya. Ketiganya `tinggi` sekarang dan sudah tidak ada di bagian A. Dua
+yang terakhir memang tetap tanpa NPSN; itu bukan cacat, melainkan sebabnya
+keduanya didaftar di `TANPA_NPSN` pada `tools/periksa_sekolah.py`.
 
 **`SMK Lps Ciamis` sudah terjawab, 30 Agustus 2026.** Di Jl. R.E. Martadinata
 No. 23 memang ada dua sekolah — SMK LPS 1 (NPSN 20211529) dan SMK LPS 2


### PR DESCRIPTION
## What

All nine markdown files audited claim by claim against the code, migrations,
workflows and tests, then every proposed edit checked a second time by a reader
whose job was to refuse it. **178 edits survived; four were refused as wrong.**

| File | edits |
| --- | --- |
| `docs/rancangan-b.md` | 52 |
| `docs/alur-lomba.md` | 38 |
| `docs/final-architecture.md` | 26 |
| `CLAUDE.md` + `AGENTS.md` | 20 (applied to both) |
| `docs/runbook-sekolah.md` | 18 |
| `README.md` | 13 |
| `docs/desain-sistem.md` | 7 |
| `docs/sekolah-belum-tuntas.md` | 5 |

## Why

The heaviest findings are the ones that would have sent someone the wrong way.

- **`final-architecture.md` still described Layar Rekapitulasi as a running
  screen.** It was deleted on 27 August 2026 (#606) — there is no `#/rekap`
  route and `rekapPenuh()` is never called. The section now says where the work
  went (Input Pos filters, the Live Score Status panel) and describes what
  actually survives: the printout Live Score builds through
  `siapkanCetakRekap()`, still rooted in `v_rekap_penuh` but read through the
  `cache_live_score` snapshot rather than directly. The two alarms that died
  with the screen are recorded, because the owner chose that knowingly.
- **README's three-terminal recipe failed as written** — it dropped the `PGPORT`
  and `PGPASSWORD` the commands need, and both default to the CI container's
  55432. That is the one instruction CLAUDE.md 17.2 makes mandatory before a
  merge during the event.
- **CLAUDE.md 7.7 said no workflow compares CLAUDE.md with AGENTS.md.**
  `shared-files.yml` has compared them for a while. 7.4 said "leave all nine"
  under a table of ten. 7.8 said the checker covers 111 migrations — it covers
  112, and neither of its lists mentions `0164`-`0169`, so it reports green over
  six migrations it never looked at.
- **16.9 described the event-day cron as 08:00–23:45** with one self-triggering
  workflow. It is 06:00–18:59, and there are three.
- **11.6 said Pos 3 prints four blangko masters.** It prints three: a soal lomba
  gets no sheet at all, because the peserta answer on the question paper.
- **README marked both SVG diagrams "Berlaku".** Neither has been redrawn since
  30 August: `arsitektur-hrcd.svg` counts 153 migrations and names four live
  phases without `juara`, `alur-hrcd.svg` still says four golongan.

Refreshed wherever they appear: 169 migrations, 85 test files, 30 SQL checks,
61 pointers into the design notes across 32 files, six golongan, five live
phases. `rancangan-b.md` and `desain-sistem.md` keep their section numbering —
61 code comments point at those numbers, including one in the header of
`simpan_nilai_massal` — and now say plainly which parts were never built:
Google Sheets, Realtime, Cloudflare Pages, the paste-a-CSV import pipeline, and
the Monitoring / Konfigurasi / Barak / Riwayat screens.

## Notes

What was deliberately **kept**: every recorded lesson that explains why a rule
exists, every owner decision still in force, and every warning about a trap
that can still happen. Only claims that are false today were removed.

Verified: `node --test tests/*.test.mjs` 377 pass — including the three that
read the docs as a contract (`docs_access_roles`, `docs_printed_kloter`,
`final_architecture`); `diff <(tail -n +5 CLAUDE.md) <(tail -n +7 AGENTS.md)`
empty, the invariant `shared-files.yml` enforces; `periksa_impor.py` and
`periksa_sekolah.py` clean; no broken internal links; section headings in
`rancangan-b.md` and `alur-lomba.md` byte-identical to before.