### PR TITLE
chore: drop the two client wrappers the deleted screen left behind

### DIFF
--- a/live/js/api.js
+++ b/live/js/api.js
@@ -809,17 +809,16 @@ export async function riwayatPendaftaran(kode) {
     "&select=*&order=changed_at.desc,id.desc");
 }
 
-/** Kelengkapan input per pos — satu baris per pos, bukan per regu.
- *
- *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5
- *  baris hanya untuk menghitungnya sendiri di browser adalah pekerjaan yang
- *  sudah bisa dilakukan database dalam satu query. Daftar regu yang belum
- *  lengkap TIDAK perlu diambil terpisah — `v_rekap_penuh` sudah membawa
- *  nilai tiap komponen, jadi layar bisa menyaringnya dari data yang sama. */
-export async function kelengkapanPos() {
-  if (K.mode === "dev") return baca("/kelengkapan-pos");
-  return baca(null, "v_kelengkapan_pos?select=*&order=pos.asc");
-}
+/* `v_rekap_penuh` dan `v_kelengkapan_pos` TIDAK punya pembungkus sendiri lagi.
+   Keduanya lahir untuk layar Rekapitulasi, yang dihapus 27 Agustus 2026 (#606),
+   dan sejak itu tidak ada satu layar pun yang membacanya langsung — yang
+   membacanya `cache_live_score` di database, dan di mode dev jalur di bawah
+   ini yang menirunya. Pembungkus tanpa layar terbaca seperti fitur yang masih
+   hidup (tes unused_batch_api). Kedua view-nya sendiri tetap ada dan tetap
+   dipakai; yang dibuang cuma pintu client-nya.
+
+   Rute `/rekap-penuh` dan `/kelengkapan-pos` di tests/dev_server.py KARENA ITU
+   tetap ada: yang memanggilnya sekarang tiruan snapshot di bawah. */
 
 /** Snapshot privat untuk papan Live Score panitia.
  *
@@ -838,17 +837,6 @@ export async function cacheLiveScore() {
     "cache_live_score?select=dibuat_pada,data&tunggal=eq.true");
   if (!d.length) throw new ErrorApi("Cache Live Score belum tersedia.");
   return { dibuat_pada: d[0].dibuat_pada, ...d[0].data };
-}
-
-/** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
- *
- *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena
- *  RLS akan memotong nilai_mentah pos lain dan Nilai Total-nya jadi salah
- *  (lihat kepala migrasi 0027). ~300 baris, dimuat sekali lalu disaring dan
- *  diurutkan di browser — pola yang sama dengan seluruh layar meja. */
-export async function rekapPenuh() {
-  if (K.mode === "dev") return baca("/rekap-penuh");
-  return baca(null, "v_rekap_penuh?select=*&order=nomor_dada.asc");
 }
 
 /** Seluruh regu + nilai yang sudah tersimpan untuk satu pos. Satu permintaan

--- a/tests/unused_batch_api.test.mjs
+++ b/tests/unused_batch_api.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 
 const api = await readFile(new URL("../web/js/api.js", import.meta.url), "utf8");
 const dev = await readFile(new URL("dev_server.py", import.meta.url), "utf8");
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
 
 
 test("wrapper batch tanpa pemanggil tidak dipublikasikan", () => {
@@ -15,4 +16,24 @@ test("wrapper batch tanpa pemanggil tidak dipublikasikan", () => {
   assert.doesNotMatch(dev, /u\.path == "\/batch"/);
   // RPC tetap tersedia bila kelak layar koreksi pendamping benar-benar dibuat.
   assert.match(dev, /"ubah_pendamping":\s*\["p_kode", "p_jumlah"\]/);
+});
+
+
+// Layar Rekapitulasi dihapus 27 Agustus 2026 (#606) dan kedua pembungkusnya
+// ikut, tetapi VIEW-nya tidak: `cache_live_score` yang membacanya sekarang, dan
+// di mode dev tiruan snapshot memanggil rutenya langsung. Jadi yang dijaga di
+// sini dua arah sekaligus — pintu client-nya hilang, jalur dev-nya tetap ada.
+//
+// Arah kedua itu yang membuat tes ini bukan sekadar pencatat penghapusan:
+// membuang rutenya juga akan mematikan papan Live Score di laptop, satu-satunya
+// tempat layar bisa dibuka sebelum merge (CLAUDE.md 17.2).
+test("pembungkus layar Rekapitulasi ikut hilang bersama layarnya", () => {
+  assert.doesNotMatch(api, /\brekapPenuh\b/);
+  assert.doesNotMatch(api, /\bkelengkapanPos\b/);
+  assert.doesNotMatch(app, /\brekapPenuh\b/);
+  assert.doesNotMatch(app, /\bkelengkapanPos\b/);
+  assert.match(dev, /u\.path == "\/rekap-penuh"/);
+  assert.match(dev, /u\.path == "\/kelengkapan-pos"/);
+  assert.match(api, /baca\("\/rekap-penuh"\)/);
+  assert.match(api, /baca\("\/kelengkapan-pos"\)/);
 });

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -809,17 +809,16 @@ export async function riwayatPendaftaran(kode) {
     "&select=*&order=changed_at.desc,id.desc");
 }
 
-/** Kelengkapan input per pos — satu baris per pos, bukan per regu.
- *
- *  Sengaja agregat: layar memanggilnya tiap 20 detik, dan menarik 300 × 5
- *  baris hanya untuk menghitungnya sendiri di browser adalah pekerjaan yang
- *  sudah bisa dilakukan database dalam satu query. Daftar regu yang belum
- *  lengkap TIDAK perlu diambil terpisah — `v_rekap_penuh` sudah membawa
- *  nilai tiap komponen, jadi layar bisa menyaringnya dari data yang sama. */
-export async function kelengkapanPos() {
-  if (K.mode === "dev") return baca("/kelengkapan-pos");
-  return baca(null, "v_kelengkapan_pos?select=*&order=pos.asc");
-}
+/* `v_rekap_penuh` dan `v_kelengkapan_pos` TIDAK punya pembungkus sendiri lagi.
+   Keduanya lahir untuk layar Rekapitulasi, yang dihapus 27 Agustus 2026 (#606),
+   dan sejak itu tidak ada satu layar pun yang membacanya langsung — yang
+   membacanya `cache_live_score` di database, dan di mode dev jalur di bawah
+   ini yang menirunya. Pembungkus tanpa layar terbaca seperti fitur yang masih
+   hidup (tes unused_batch_api). Kedua view-nya sendiri tetap ada dan tetap
+   dipakai; yang dibuang cuma pintu client-nya.
+
+   Rute `/rekap-penuh` dan `/kelengkapan-pos` di tests/dev_server.py KARENA ITU
+   tetap ada: yang memanggilnya sekarang tiruan snapshot di bawah. */
 
 /** Snapshot privat untuk papan Live Score panitia.
  *
@@ -838,17 +837,6 @@ export async function cacheLiveScore() {
     "cache_live_score?select=dibuat_pada,data&tunggal=eq.true");
   if (!d.length) throw new ErrorApi("Cache Live Score belum tersedia.");
   return { dibuat_pada: d[0].dibuat_pada, ...d[0].data };
-}
-
-/** Rekapitulasi lengkap seluruh regu × seluruh pos — layar #/rekap.
- *
- *  Hanya admin dan meja: view-nya sendiri yang menolak operator pos, karena
- *  RLS akan memotong nilai_mentah pos lain dan Nilai Total-nya jadi salah
- *  (lihat kepala migrasi 0027). ~300 baris, dimuat sekali lalu disaring dan
- *  diurutkan di browser — pola yang sama dengan seluruh layar meja. */
-export async function rekapPenuh() {
-  if (K.mode === "dev") return baca("/rekap-penuh");
-  return baca(null, "v_rekap_penuh?select=*&order=nomor_dada.asc");
 }
 
 /** Seluruh regu + nilai yang sudah tersimpan untuk satu pos. Satu permintaan

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -20,7 +20,7 @@ import {
   koreksiJamBerangkat,
   daftarPos, komponenPos, lembarPos, lembarPosSatu, simpanNilaiPos, hapusNilaiPos,
   rentangNomorDada,
-  komponenSemua, rekapPenuh, kelengkapanPos, cacheLiveScore,
+  komponenSemua, cacheLiveScore,
   riwayatNilai, riwayatPendaftaran,
   kunciNilaiPos, bukaKunciNilaiPos, putarFotoLembar,
   unggahFotoLembar, daftarFotoLembar, fotoLembarPos, tautanFoto,


### PR DESCRIPTION
## What

`rekapPenuh()` and `kelengkapanPos()` leave `web/js/api.js` (and its `live/`
copy) and leave app.js's import list. `tests/unused_batch_api.test.mjs` gains a
second case that guards the removal in both directions.

## Why

Layar Rekapitulasi went on 27 August 2026 (#606) and took its route with it,
but both wrappers stayed, called from nowhere. `tools/periksa_impor.py` only
checks the other direction — a name used without being imported — so nothing
complained.

The repo already settled what to do with a client path that has no screen:
that test's first case removes `lihatBatch`/`ubahPendamping` for exactly this
reason, because a wrapper with no caller reads like a feature that still works.

## Notes

**Both views stay, and so do the dev routes.** `cache_live_score` reads
`v_rekap_penuh` and `v_kelengkapan_pos` in production, and in dev mode
`cacheLiveScore()` imitates that snapshot by calling `/rekap-penuh` and
`/kelengkapan-pos` directly. The new test asserts that too — removing those
routes would blank the Live Score board on a laptop, the one place a screen can
be opened before a merge (CLAUDE.md 17.2).

Verified against `hrcd_dev`: Live Score renders with its Status panel, Input
Nilai Pos lists its rows, Cek Nilai opens, no console errors.
`node --test tests/*.test.mjs` 378 pass, `periksa_impor.py` clean, all four
`web/` ↔ `live/` copies identical.