### PR TITLE
fix: Data Peserta stops scrolling sideways at 941-1062px

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=45">
+  <link rel="stylesheet" href="style.css?v=46">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -2306,7 +2306,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
      Di bawah 900px ia sudah jadi kartu dan seluruh angka di sini tidak
      berlaku. */
-  .table-peserta { table-layout: fixed; min-width: 980px; }
+  /* `min-width` 858px, DITURUNKAN DARI AMBANGNYA, bukan dipilih.
+
+     Ambang blok ini 941px, dan di lebar itu pembungkus tabelnya 858px —
+     sisanya, 83px, dimakan padding layar dan padding kartu. Jadi 858 adalah
+     tabel TERSEMPIT yang mungkin ada di rentang ini, dan mematoknya di situ
+     berarti patokan ini tidak pernah menjadi penyebab penggulir mendatar.
+
+     Angkanya sempat 980px, dan itu 122px lebih lebar daripada yang muat: di
+     941-1062px tabelnya dipaksa melebihi pembungkusnya, jadi Data Peserta
+     menggulir ke samping dan kolom WhatsApp berada di luar layar. Yang
+     menariknya bukan bahwa angkanya salah melainkan bahwa dokumen di repo ini
+     sudah menuliskan aturannya lebih dulu — "kalau kolom ditambah, min-width
+     naik, dan ambang ini harus ikut naik" — lalu aturannya sendiri dilanggar
+     tanpa ada yang menyadarinya, karena satu-satunya yang bisa melihatnya
+     adalah mengukur di browser (bagian 15.9).
+
+     Terukur, 941-1200px: tanpa penggulir mendatar dan tanpa satu sel pun yang
+     isinya meluap. Kalau ambangnya kelak digeser, angka ini ikut: ia selalu
+     ambang dikurangi 83. */
+  .table-peserta { table-layout: fixed; min-width: 858px; }
 
   .table-peserta > thead > tr > th:nth-child(1) { width: 16%; }
   .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 45, sidik: "4af1f0996a1d" },
+  "style.css": { versi: 46, sidik: "a9d364b3f742" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=43">
+  <link rel="stylesheet" href="style.css?v=44">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -2306,7 +2306,26 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 
      Di bawah 900px ia sudah jadi kartu dan seluruh angka di sini tidak
      berlaku. */
-  .table-peserta { table-layout: fixed; min-width: 980px; }
+  /* `min-width` 858px, DITURUNKAN DARI AMBANGNYA, bukan dipilih.
+
+     Ambang blok ini 941px, dan di lebar itu pembungkus tabelnya 858px —
+     sisanya, 83px, dimakan padding layar dan padding kartu. Jadi 858 adalah
+     tabel TERSEMPIT yang mungkin ada di rentang ini, dan mematoknya di situ
+     berarti patokan ini tidak pernah menjadi penyebab penggulir mendatar.
+
+     Angkanya sempat 980px, dan itu 122px lebih lebar daripada yang muat: di
+     941-1062px tabelnya dipaksa melebihi pembungkusnya, jadi Data Peserta
+     menggulir ke samping dan kolom WhatsApp berada di luar layar. Yang
+     menariknya bukan bahwa angkanya salah melainkan bahwa dokumen di repo ini
+     sudah menuliskan aturannya lebih dulu — "kalau kolom ditambah, min-width
+     naik, dan ambang ini harus ikut naik" — lalu aturannya sendiri dilanggar
+     tanpa ada yang menyadarinya, karena satu-satunya yang bisa melihatnya
+     adalah mengukur di browser (bagian 15.9).
+
+     Terukur, 941-1200px: tanpa penggulir mendatar dan tanpa satu sel pun yang
+     isinya meluap. Kalau ambangnya kelak digeser, angka ini ikut: ia selalu
+     ambang dikurangi 83. */
+  .table-peserta { table-layout: fixed; min-width: 858px; }
 
   .table-peserta > thead > tr > th:nth-child(1) { width: 16%; }
   .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }


### PR DESCRIPTION
## What

`.table-peserta { min-width: 980px }` becomes `858px`.

## Why

The rule lives inside `@media (min-width: 941px)`. At 941px the table's wrapper
is 858px wide, so a 980px pin forced the table 122px past the space it had: the
board scrolled sideways and the WhatsApp column sat off screen, all the way up
to 1062px.

858 is derived, not chosen: the threshold minus the 83px that screen padding
and card padding take. It is therefore the narrowest table this range can ever
hold, which means the pin can never be the cause of a sideways scroll again.
If the threshold moves, the number moves with it — the comment says so.

What makes this more than a one-line change is that the rule was already
written down in `final-architecture.md` — *"kalau kolom ditambah, `min-width`
naik, dan ambang ini harus ikut naik"* — and was broken anyway, because nothing
except measuring in a browser can see it (CLAUDE.md 15.9).

## Notes

Measured against `hrcd_dev` at 901, 941, 960, 1000, 1063, 1200 and 1440px:
no horizontal scrollbar and no cell whose content overflows, at any of them.
Before the change, 960px gave a 877px wrapper holding a 980px table.

`style.css` is shared, so `live/index.html` → `v=46` and `web/index.html` →
`v=44`. `node --test tests/*.test.mjs` 378 pass.