### PR TITLE
fix: the migration checker stops skipping 0164-0169 in silence

### DIFF
--- a/supabase/checks/status_migrasi.sql
+++ b/supabase/checks/status_migrasi.sql
@@ -26,9 +26,18 @@
 -- daripada masalahnya lebih berbahaya daripada tidak ada pemeriksaan, karena ia
 -- menutup pertanyaannya.
 --
--- Sekarang keduanya disebutkan: 112 migrasi punya jejak yang diperiksa
--- (bagian 1), dan 51 tidak punya (bagian 2). Yang di bagian 2 bukan berarti
--- belum diterapkan — berarti tidak ada yang tersisa untuk diperiksa.
+-- Sekarang keduanya disebutkan: 116 migrasi punya jejak yang diperiksa
+-- (bagian 1), dan 53 tidak punya (bagian 2). 116 + 53 = 169, yaitu SELURUH
+-- migrasi yang ada — dan angka itu yang harus dijaga tiap kali berkas migrasi
+-- baru mendarat. Yang di bagian 2 bukan berarti belum diterapkan — berarti
+-- tidak ada yang tersisa untuk diperiksa.
+--
+-- Pernah tidak begitu: sampai 2 September 2026 kedua daftar berhenti di 0163,
+-- jadi 0164-0169 tidak disebut di mana pun dan pemeriksanya melapor hijau atas
+-- enam migrasi yang tidak pernah dilihatnya — bentuk kesalahan yang sama, satu
+-- edisi lebih muda. Nomor yang tidak ada di kedua daftar TIDAK muncul sebagai
+-- BELUM; ia tidak muncul sama sekali, dan itulah yang membuatnya sulit
+-- terlihat.
 --
 -- DARI MANA JEJAKNYA DATANG, DAN KENAPA BOLEH DIPERCAYA
 --
@@ -322,7 +331,15 @@ begin
   ('0161', 'row sekolah: {"name": "SMPN Satu Atap 1 Banjarsari", "address": "Banjar',
    $c$select exists (select 1 from sekolah t where position('{"name": "SMPN Satu Atap 1 Banjarsari", "address": "Banjaranyar, Kec. Banjaranyar, Kabupaten Ciamis, Jawa Barat 46384, Indonesia"}' in (to_jsonb(t) - 'id' - 'created_at' - 'updated_at' - 'dibuat_pada' - 'edisi' - 'sekolah_id')::text) > 0)$c$),
   ('0163', 'view v_kejuaraan_publik ada',
-   $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_kejuaraan_publik')$c$)
+   $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_kejuaraan_publik')$c$),
+  ('0164', 'view v_kejuaraan_publik: poin_juara di DAFTAR SELECT-nya, bukan cuma di tanda tangan fungsinya',
+   $c$select exists (select 1 from pg_views where schemaname = 'public' and viewname = 'v_kejuaraan_publik' and position('    poin_juara,' in definition) > 0)$c$),
+  ('0165', 'function minta_segarkan_live_score ada',
+   $c$select exists (select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace where n.nspname = 'public' and p.proname = 'minta_segarkan_live_score')$c$),
+  ('0166', 'constraint nilai_terkunci.nilai_terkunci_pkey: PRIMARY KEY (regu_id, pos, kode_lomba)',
+   $c$select exists (select 1 from pg_constraint where conrelid = 'nilai_terkunci'::regclass and conname = 'nilai_terkunci_pkey' and position('PRIMARY KEY (regu_id, pos, kode_lomba)' in pg_get_constraintdef(oid)) > 0)$c$),
+  ('0167', 'constraint foto_lembar.foto_lembar_putaran_check: CHECK ((putaran = ANY (ARRAY[0, 90, 180, 270])))',
+   $c$select exists (select 1 from pg_constraint where conrelid = 'foto_lembar'::regclass and conname = 'foto_lembar_putaran_check' and position('CHECK ((putaran = ANY (ARRAY[0, 90, 180, 270])))' in pg_get_constraintdef(oid)) > 0)$c$)
 ) as t(nomor, jejak, cek)
   loop
     begin
@@ -403,7 +420,9 @@ select nomor, berkas from (values
   ('0148', 'juara_umum_berdasarkan_poin'),
   ('0149', 'juara_umum_tanpa_poin_di_bawah'),
   ('0151', 'skor_juara_umum_enam_besar'),
-  ('0162', 'lebur_smp_al_fadliliyah')
+  ('0162', 'lebur_smp_al_fadliliyah'),
+  ('0168', 'judul_isian_menaksir'),
+  ('0169', 'judul_isian_soal')
 ) as t(nomor, berkas)
 order by nomor;
 


### PR DESCRIPTION
## What

`supabase/checks/status_migrasi.sql` gains fingerprints for `0164`–`0167` and
names `0168`/`0169` in its second list. Part 1 goes from 112 to 116, part 2
from 51 to 53, and **116 + 53 = 169** — every migration in the tree.

## Why

Both lists ended at `0163`, so six migrations were named in neither. A number
that is in neither list does not appear as BELUM — **it does not appear at
all**, which is why it took an audit to spot. The checker reported green over
migrations it had never looked at: the same mistake it was rewritten to end
(CLAUDE.md 13.3), one edition younger.

## The fingerprints, and why each one cannot drift

| | fingerprint |
| --- | --- |
| `0164` | `    poin_juara,` in `v_kejuaraan_publik`'s SELECT list — **four-space indent and all**. The name also appears in the FROM-clause signature, which `0163` already rendered, so the indent is the only thing that tells the two apart. |
| `0165` | `minta_segarkan_live_score` exists in `pg_proc`. |
| `0166` | `nilai_terkunci`'s primary key is `(regu_id, pos, kode_lomba)`. Before it, `(regu_id, pos)`. |
| `0167` | `foto_lembar_putaran_check` is `CHECK ((putaran = ANY (ARRAY[0, 90, 180, 270])))`. |

None rests on `pg_get_functiondef` output, on NOT NULL constraints, or on
anything else the header lists as differing between PostgreSQL versions.

`0168` and `0169` join part 2 for the reason part 2 exists: both only set
per-edition configuration on `wahana` rows, so a database without edisi 37 has
nothing to find. `0035`, `0038` and `0086` are already there for exactly that.

## Notes

`tests/status_migrasi_check.sh` — the harness that tests the checker from both
directions, ADA after migration N and BELUM before it — run against a
PostgreSQL **17.11** server, the same major version as production:

```
LULUS: 116 jejak, tiap satunya baru berbunyi ADA tepat di migrasinya.
```

Also run against `hrcd_dev`, where all 169 migrations are applied: the four new
fingerprints read ADA.