### PR TITLE
docs: redraw the two diagrams from today's tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ Gambaran lengkapnya di `docs/final-architecture.md`.
 | `docs/rancangan-b.md` | Cetak biru implementasi yang dipakai membangun | Catatan keputusan |
 | `docs/runbook-sekolah.md` | Cara membakukan daftar sekolah dari tulisan pembina | Berlaku |
 | `docs/sekolah-belum-tuntas.md` | Sekolah yang alamatnya masih perlu ditanyakan | Daftar kerja |
-| `docs/arsitektur-hrcd.svg` | Diagram lapisan teknis — Cloudflare, Supabase, penerbitan rekap | **Basi** — capnya "sampai migrasi 0153" |
-| `docs/alur-hrcd.svg` | Diagram alur acara — pendaftaran sampai klasemen | Basi — "4 golongan", sejak `0091` enam |
+| `docs/arsitektur-hrcd.svg` | Diagram lapisan teknis — Cloudflare, Supabase, penerbitan rekap | Berlaku — cap `0169` |
+| `docs/alur-hrcd.svg` | Diagram alur acara — pendaftaran sampai klasemen | Berlaku |
 
-Kedua SVG belum digambar ulang sejak 30 Agustus 2026, dan angkanya jangan
-dipercaya sebelum dihitung ulang: `arsitektur-hrcd.svg` menghitung 153 migrasi
-(sekarang 169) dan capnya menyebut empat fase live tanpa `juara`, sementara
-`alur-hrcd.svg` masih menulis "4 golongan dinilai terpisah" padahal Intern PA
-dan Intern PI menjadikannya enam sejak `0091`. Bentuk lapisan dan urutan
-alurnya sendiri masih betul — yang basi angkanya.
+Angka di `arsitektur-hrcd.svg` dihitung dari database, bukan dikira-kira, dan
+capnya menyebut sampai migrasi berapa ia berlaku. Kalau cap itu tertinggal jauh
+dari `supabase/migrations/`, angkanya jangan dipercaya sebelum dihitung ulang —
+itulah gunanya cap itu ada.
 
 `desain-sistem.md` dan `rancangan-b.md` merekam **keputusan pada saat itu**,
 bukan keadaan hari ini. Keduanya sengaja dipertahankan apa adanya karena 61

--- a/docs/alur-hrcd.svg
+++ b/docs/alur-hrcd.svg
@@ -206,7 +206,7 @@
       <text x="1508" y="465" font-size="15" font-weight="700" fill="#FFFFFF" text-anchor="middle">8</text>
       <text x="1242" y="546" font-size="21" font-weight="700" fill="#1A1A1A">Klasemen</text>
       <text x="1242" y="573" font-size="14.5" fill="#6B6B6B">Total pos − penalti</text>
-      <text x="1242" y="595" font-size="14.5" fill="#6B6B6B">4 golongan dinilai terpisah</text>
+      <text x="1242" y="595" font-size="14.5" fill="#6B6B6B">6 golongan dinilai terpisah</text>
     </g>
 
     <!-- Panah baris 2 -->

--- a/docs/arsitektur-hrcd.svg
+++ b/docs/arsitektur-hrcd.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1200" width="1600" height="1200" role="img" aria-label="Arsitektur teknis HRCD Rekap: pengguna, tiga Worker Cloudflare, Supabase, penerbitan rekap live, siklus kertas, serta susunan pos dan lomba">
   <title>Arsitektur sistem HRCD Rekap</title>
-  <desc>Digambar dari tree per 30 Agustus 2026, sampai migrasi 0153. Angka tabel, view, RPC, policy, check dan pemicu dihitung dari database, bukan dikira-kira.</desc>
+  <desc>Digambar dari tree per 2 September 2026, sampai migrasi 0169. Angka tabel, view, RPC, policy, check dan pemicu dihitung dari database, bukan dikira-kira.</desc>
 
   <defs>
     <marker id="mh" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -39,7 +39,7 @@
   <text x="95" y="57" font-size="25" font-weight="700" fill="#FFFFFF" text-anchor="middle">HRCD</text>
   <text x="172" y="59" font-size="30" font-weight="700" fill="#1A1A1A">ARSITEKTUR SISTEM</text>
   <text x="32" y="92" font-size="13" fill="#666666">Hiking Rally Ciradyka — alur teknis dari pendaftaran sampai juara diumumkan</text>
-  <text x="32" y="112" font-size="11" fill="#999999">Digambar dari tree per 30 Agustus 2026 · sampai migrasi 0153 · angkanya dihitung dari database, bukan dikira-kira</text>
+  <text x="32" y="112" font-size="11" fill="#999999">Digambar dari tree per 2 September 2026 · sampai migrasi 0169 · angkanya dihitung dari database, bukan dikira-kira</text>
 
   <!-- ================== LEGENDA ================== -->
   <g font-size="12" fill="#333333">
@@ -121,18 +121,18 @@
   <text x="568" y="374" font-size="10.5" fill="#666666">48 policy · yang menjaga pintu boleh(fitur) dari akun_hak, BUKAN peran</text>
 
   <rect x="552" y="394" width="372" height="52" rx="8" fill="#FFFFFF" stroke="#D5EDE3"/>
-  <text x="568" y="416" font-size="13" font-weight="700" fill="#1A1A1A">26 RPC dipanggil layar</text>
+  <text x="568" y="416" font-size="13" font-weight="700" fill="#1A1A1A">28 RPC dipanggil layar</text>
   <text x="568" y="435" font-size="10.5" fill="#666666">security definer · berhasil seluruhnya atau batal seluruhnya</text>
 
   <rect x="552" y="456" width="372" height="52" rx="8" fill="#FFFFFF" stroke="#D5EDE3"/>
-  <text x="568" y="478" font-size="13" font-weight="700" fill="#1A1A1A">31 view berlapis</text>
+  <text x="568" y="478" font-size="13" font-weight="700" fill="#1A1A1A">33 view berlapis</text>
   <text x="568" y="497" font-size="10.5" fill="#666666">mentah → poin → total → peringkat · dihitung tiap dibaca, tidak disimpan</text>
 
   <rect x="552" y="518" width="372" height="52" rx="8" fill="#FFFFFF" stroke="#D5EDE3"/>
   <ellipse cx="576" cy="536" rx="9" ry="4" fill="#336791"/>
   <path d="M567 536 v10 a9 4 0 0 0 18 0 v-10" fill="#336791"/>
   <text x="594" y="541" font-size="13" font-weight="700" fill="#1A1A1A">PostgreSQL</text>
-  <text x="568" y="560" font-size="10.5" fill="#666666">26 tabel · 68 check · 27 pemicu · 153 migrasi · riwayat perubahan</text>
+  <text x="568" y="560" font-size="10.5" fill="#666666">26 tabel · 69 check · 27 pemicu · 169 migrasi · riwayat perubahan</text>
 
   <!-- ================== PENERBITAN REKAP ================== -->
   <text x="964" y="152" font-size="12" font-weight="700" fill="#666666" letter-spacing="1.6">PENERBITAN REKAP</text>
@@ -151,7 +151,7 @@
   <rect x="978" y="320" width="26" height="30" rx="4" fill="#E5397A"/>
   <text x="1020" y="336" font-size="14" font-weight="700" fill="#1A1A1A">live.json di CDN</text>
   <text x="1020" y="353" font-size="11" fill="#666666">berkas mati, bukan database · bandwidth tak terbatas</text>
-  <text x="978" y="378" font-size="11" fill="#333333">Fase pra / progres / penuh / top10 menentukan ISI</text>
+  <text x="978" y="378" font-size="11" fill="#333333">Fase pra / progres / penuh / top10 / juara menentukan ISI</text>
   <text x="978" y="395" font-size="11" fill="#333333">berkasnya, bukan cara menggambarnya: nilai yang belum</text>
   <text x="978" y="412" font-size="11" fill="#333333">boleh terbit memang TIDAK ADA di dalamnya.</text>
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -43,11 +43,12 @@ kelima lomba soal tulis kini diisi seperti Semaphore: satu regu satu layar,
 satu kotak "Jumlah benar", foto per regu. Foto borongan tetap ada, tapi hanya
 di layar Foto Jawaban.
 
-Dua diagram menemani dokumen ini, dan `arsitektur-hrcd.svg` TERTINGGAL dari
-tree: cap di kakinya berbunyi "sampai migrasi 0153" dan angka di sebelahnya —
-26 tabel · 68 check · 27 pemicu · 153 migrasi — dihitung 30 Agustus 2026.
-Jumlah migrasinya sekarang 169; jangan memercayai yang lain sebelum dihitung
-ulang. `alur-hrcd.svg` tidak memuat angka yang bisa basi. Yang tergambar:
+Dua diagram menemani dokumen ini, dan keduanya digambar dari tree yang sama:
+cap di kaki `arsitektur-hrcd.svg` berbunyi "sampai migrasi 0169", dan angka di
+sebelahnya — 26 tabel · 69 check · 27 pemicu · 169 migrasi · 33 view · 28 RPC ·
+48 policy — dihitung dari database, bukan dikira-kira. Cap itu ada supaya
+pembaca berikutnya bisa melihat sendiri kalau ia sudah tertinggal. Yang
+tergambar:
 [`arsitektur-hrcd.svg`](arsitektur-hrcd.svg) — lapisan teknisnya, dan
 [`alur-hrcd.svg`](alur-hrcd.svg) — alur acaranya dari pendaftaran sampai
 klasemen. Keduanya SVG, jadi teksnya bisa dicari dan angkanya bisa dibetulkan


### PR DESCRIPTION
## What

`docs/arsitektur-hrcd.svg` and `docs/alur-hrcd.svg` are brought up to the tree,
and README / `final-architecture.md` go back to describing both as current.

| | was | now |
| --- | --- | --- |
| migrasi | 153 | **169** |
| view | 31 | **33** |
| check | 68 | **69** |
| RPC dipanggil layar | 26 | **28** |
| tabel · pemicu · policy | 26 · 27 · 48 | unchanged |

Every delta reconciles with a migration: `0163` and `0166` each added a view,
`0167` added a check, `0165` and `0167` each added an RPC the SPA calls.
Counted on a PostgreSQL 17 server with all 169 migrations applied — the same
major version as production.

## Why

`arsitektur-hrcd.svg` states in its own footer that its numbers are *counted
from the database, not guessed*, which is exactly why a stale one is worth
fixing rather than tolerating: the caption gives the reader a reason to trust
it.

**The dangerous drift was not a number.** The caption read

> Fase pra / progres / penuh / top10 menentukan ISI

with `juara` missing — in a caption about which phase decides what may be
published. CLAUDE.md 14.1 records that exact failure about itself: a phase
nobody lists is a "BOCOR" guard nobody checks. `alur-hrcd.svg` said four
golongan; there have been six since `0091`.

## Notes

The new caption is one character-class longer, so it was measured rather than
counted: 287px wide inside a 338px box, and 3px narrower than the line beneath
it. Nothing else in either diagram moved — only text nodes changed, no
geometry.

`node --test tests/*.test.mjs` 378 pass.