### PR TITLE
docs: say plainly that the runbook's row count does not reconcile

### DIFF
--- a/docs/runbook-sekolah.md
+++ b/docs/runbook-sekolah.md
@@ -187,6 +187,22 @@ Nama resmi yang berbeda tetap disimpan di kolom `nama_resmi`
 `sekolah_alamat.json`, jadi tidak ada yang hilang.
 
 Hasil: **1.102 baris peserta → 201 klaster**, dari 326 tulisan mentah.
+
+> **Angka 1.102 itu tidak tutup dengan bagian 2 dan 3, dan tidak bisa
+> dihitung ulang.** 1.254 baris dikurangi 151 yang bukan sekolah adalah
+> 1.103, bukan 1.102 — selisih satu baris yang tidak dijelaskan di mana pun.
+> Keempat `.xlsx` sumbernya tidak ada di repo (dan memang tidak boleh ada:
+> isinya nama peserta), jadi tidak ada cara memutuskan mana dari ketiga angka
+> itu yang meleset. Dibiarkan apa adanya, dengan catatan ini, karena
+> membetulkan salah satunya secara sepihak cuma memindahkan selisihnya ke
+> tempat lain.
+>
+> Yang di sebelah kanan panah TIDAK bergantung pada ketiganya. 201 klaster,
+> 189 sekolah, dan 209 hari ini semuanya bisa dihitung ulang dari
+> `tools/data/sekolah_nama.json` dan `sekolah_alamat.json` yang ADA di repo —
+> `python tools/periksa_sekolah.py` mencetak dua yang terakhir tiap kali
+> dijalankan. Kalau salah satu angka di halaman ini perlu dipercaya, percaya
+> yang itu.
 Penggabungan lewat NPSN di bagian 7 memangkasnya lagi jadi **189 sekolah** —
 angka putaran pertama, atas empat edisi lama saja. Pendaftaran XXXVII
 menambahkannya jadi **209**; keadaan hari ini ada di bagian 11.


### PR DESCRIPTION
## What

A note in `docs/runbook-sekolah.md` section 5 recording that its participant-row
arithmetic does not close, and pointing at the figures that can be recomputed.

## Why

Section 2 counts **1.254** participant rows, section 3 discards **151** that are
not schools, and section 5 carries on from **1.102**. That is 1.103. Nothing in
the document accounts for the missing row, and only category 1 of the four
discard categories carries a row count, so 151 cannot be decomposed either.

It cannot be recomputed. The four source `.xlsx` are not in the repo and must
not be — they hold participant names. Picking one of the three figures to
"correct" would only move the discrepancy somewhere else, so the note says
which numbers are doubtful (any of the three) and leaves them standing.

What the note also does is send the reader to the numbers that *are* checkable:
everything right of the arrow — 201 clusters, 189 schools, 209 today — comes
from `tools/data/`, which is in the repo, and `periksa_sekolah.py` prints the
last two every time it runs.

## Notes

`python tools/periksa_sekolah.py` → *209 sekolah, 210 baris alamat (191
keyakinan tinggi, 210 lengkap dengan kode pos). Belum ketemu: 0.*
`node --test tests/*.test.mjs` 378 pass.