### PR TITLE
docs: one answer about how many staging points there are

### DIFF
--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -280,9 +280,18 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    `0118`), bukan di kode.
 7. Konsekuensi bagi sistem: layar keberangkatan harus menampilkan **beberapa
    kloter sekaligus dalam status berbeda**, bukan satu kloter per layar.
-8. **Ada 3 staging.** Verifikasi kehadiran regu dilakukan **di staging**, bukan
-   di garis start: setelah masuk staging, peserta cukup menunggu sampai
-   benar-benar diberangkatkan.
+8. **Tiga kloter selalu siap, di dua titik tunggu.** Kloter berikutnya berdiri
+   di garis start (Pemberangkatan), dua sesudahnya menunggu di Staging 1 dan
+   Staging 2, dan sisanya masih di upacara — susunan yang sama dengan
+   CLAUDE.md pasal 10.3. Verifikasi kehadiran regu dilakukan **di titik
+   tunggunya**, bukan saat ia sampai di garis start: begitu masuk staging,
+   peserta cukup menunggu sampai benar-benar diberangkatkan.
+
+   Pasal ini berbunyi "Ada 3 staging" sampai 2 September 2026 — tiga titik
+   tunggu DI LUAR garis start, jadi empat kloter siap sekaligus — sementara
+   pasal 10.3 menyebut namanya satu per satu dan hanya menemukan tiga posisi.
+   Tidak ada apa pun di kode yang bisa memutuskan mana yang benar; pemilik
+   acara memilih yang tiga.
 9. **Panitia kertas dan panitia laptop duduk bersebelahan**, dan urutan
    kerjanya searah:
    1. Panitia **kertas** mencentang semua regu yang berangkat, menulis tangan


### PR DESCRIPTION
## What

`docs/alur-lomba.md` section 6 point 8 now describes the same arrangement as
CLAUDE.md 10.3: **three kloter ready, at two holding points beside the start
line.**

## Why

The two documents disagreed about a physical arrangement on the morning of the
event:

| | says |
| --- | --- |
| `alur-lomba.md` (5 Aug) | "Ada 3 staging", and verification happens at staging *"bukan di garis start"* — so three holding points **beside** the start line, four kloter ready at once |
| CLAUDE.md 10.3 (16 Aug) | Kloter 1 at Pemberangkatan, 2 at Staging 1, 3 at Staging 2 — three positions in total |

Nothing in the code can settle it: `grep -rn staging` hits only the docs, and
`departure-calculator.mjs` models no positions at all. So it went to the event
owner, who chose **three ready kloter and two holding points**.

## Notes

The older sentence is quoted in place rather than deleted. Someone standing in
the field tomorrow may remember a third holding point, and it is cheaper for
them to read that the count was decided on 2 September than to conclude the
document never knew.

`node --test tests/*.test.mjs` 378 pass, including the two that read this file
as a contract (`docs_access_roles`, `docs_printed_kloter`) — several of their
patterns use `\s+`, so line breaks near the edit matter.