### PR TITLE
docs: it is the server version that matters, not the psql binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ yang dipakai container CI, tetapi katalog Postgres berbeda antar versi mayor:
 di laptop 18.x `supabase/checks/status_migrasi.sql` melaporkan 22 sidik jari
 BELUM padahal migrasinya sudah masuk (CLAUDE.md pasal 7.8).
 
+Yang dihitung versi **server**-nya, bukan `psql` yang dipakai memanggilnya:
+klien 18 menyambung ke server 17 tanpa masalah, dan `select version()` tetap
+menjawab 17. Jadi kalau satu-satunya `psql` yang bisa dijalankan di laptop
+kebetulan versi lain, `PSQL=` boleh menunjuk ke sana selama `PGPORT=` menunjuk
+ke server 17.
+
 ```bash
 PSQL=/path/ke/psql PGPORT=55432 PGPASSWORD=... bash tests/run.sh
 ```


### PR DESCRIPTION
## What

Four lines under "Menjalankan tes" saying that the PostgreSQL major version the
docs care about is the **server**'s, and that a client of another version can
call it.

## Why

Everything the repo says about version 17 — the 22 fingerprints that read a
false BELUM on 18, CLAUDE.md 7.8 — is about catalog behaviour, which lives in
the server. The README did not say so, and the obvious reading is that `psql`
itself has to be 17.

It came up for real: the PostgreSQL 17 `psql.exe` on this machine was blocked
by an Application Control policy mid-session, which looked like losing PG17
verification entirely. It was not. The 18 client against the 17 server on port
5433 answers `PostgreSQL 17.11` to `select version()`, and
`tests/status_migrasi_check.sh` ran green through it — that is where the
`LULUS: 116 jejak` in #798 came from.

## Notes

`node --test tests/*.test.mjs` 378 pass.