### PR TITLE
fix: Cek Nilai keeps its scroll position and stops eating the screen

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=46">
+  <link rel="stylesheet" href="style.css?v=47">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3216,18 +3216,31 @@ button.pill-number:hover { filter: brightness(.95); }
     z-index: 40;
   }
   .bottom-nav[hidden] { display: none; }
+  /* DIRAMPINGKAN dari 64px jadi 50px, dan yang dibayar dengan itu bukan
+     kenyamanan menekan: 50px masih di atas 44px, batas sasaran sentuh yang
+     dipakai iOS maupun Android, dan lebar tiap tombolnya seperempat layar —
+     yang menentukan meleset atau tidak justru lebar itu, bukan tingginya.
+
+     Yang dibeli: 14px dari bar plus 16px dari ruang di bawah halaman,
+     30px yang jatuh ke isi layar di setiap layar HP sekaligus. Di Cek Nilai
+     ia jatuh ke tinggi foto slip; di meja pembayaran ia satu baris tabel
+     lagi sebelum harus menggulir. */
   .bottom-nav-item {
     flex: 1;
-    display: flex; flex-direction: column; align-items: center; gap: .15rem;
-    padding: .45rem .2rem; min-height: 56px;
+    display: flex; flex-direction: column; align-items: center; gap: .1rem;
+    padding: .3rem .2rem; min-height: 48px;
     border: 0; background: none; font-family: inherit;
-    color: var(--tinta-lembut); font-size: .72rem; font-weight: 600;
+    color: var(--tinta-lembut); font-size: .7rem; font-weight: 600;
+    /* Label satu kata, jadi tinggi barisnya tidak perlu ruang untuk baris
+       kedua yang tidak akan pernah ada. 1.5 bawaan menyisakan 5px kosong di
+       atas dan di bawah "Home". */
+    line-height: 1.15;
     cursor: pointer;
   }
   .bottom-nav-icon {
-    font-size: 1.3rem; line-height: 1;
+    font-size: 1rem; line-height: 1;
     display: inline-flex; align-items: center; justify-content: center;
-    width: 2.6rem; height: 1.9rem; border-radius: 999px;
+    width: 2.2rem; height: 1.6rem; border-radius: 999px;
   }
 
   /* Satu warna per tujuan. Tiga ikon abu-abu sebaris menuntut label dibaca
@@ -3257,9 +3270,9 @@ button.pill-number:hover { filter: brightness(.95); }
      berakhir 3px DI BAWAH tepi atas bar. Di browser desktop insetnya nol dan
      jaraknya 31px, jadi cacat ini tidak pernah muncul waktu diukur di laptop.
 
-     6rem itu sendiri: tinggi bar 65px + jarak baca. Kalau tinggi bar diubah,
-     angka ini ikut. */
-  .isi { padding-bottom: calc(6rem + env(safe-area-inset-bottom)); }
+     5rem itu sendiri: tinggi bar 51px + jarak baca ~29px. Kalau tinggi bar
+     diubah, angka ini ikut — dulu 6rem waktu barnya 65px. */
+  .isi { padding-bottom: calc(5rem + env(safe-area-inset-bottom)); }
 }
 
 /* ============================================================================
@@ -5108,14 +5121,46 @@ button.pill-number:hover { filter: brightness(.95); }
   text-align: center; font-size: 1.45rem; font-weight: 700;
   letter-spacing: .05em; font-variant-numeric: tabular-nums;
 }
-.cek-posisi {
-  margin-top: .35rem; text-align: center;
-  font-size: .85rem; color: var(--tinta-lembut); font-variant-numeric: tabular-nums;
-}
+/* KARTU KENDALI DIRAMPINGKAN DI SELURUH RENTANG, bukan cuma di laptop.
+   Padding kartu bawaan 1.15rem atas dan bawah adalah 37px yang di HP diambil
+   langsung dari tinggi foto slip — dan foto slip itulah satu-satunya alasan
+   layar ini dibuka. Yang di dalamnya cuma satu dropdown dan sebaris panah,
+   keduanya sudah punya tinggi sentuhnya sendiri (46px), jadi tidak ada yang
+   menyusut karenanya. */
+.cek-kendali { padding: .6rem .8rem; }
+.cek-kendali .baris-pilih .field { margin-bottom: .5rem; }
+.cek-kendali .cek-navigasi { margin-top: 0; }
+
 /* Kartu identitas regu diberi jarak ke blok lomba pertama. Tanpa ini nama
    regunya menempel ke kotak lomba di bawahnya dan keduanya terbaca sebagai
    satu blok — padahal yang satu identitas dan yang satu lagi nilai. */
-.cek-identitas { margin-bottom: .9rem; }
+.cek-identitas { margin-bottom: .5rem; }
+
+/* IDENTITAS SEBARIS — "007 · RANCAKA · MA PUI Cijantung · Penegak PA".
+   Dua baris bertumpuk plus padding kartu penuh memakan 93px di HP, dan di
+   layar yang seluruh gunanya membandingkan angka dengan tulisan tangan di
+   foto, tinggi itu diambil dari fotonya.
+
+   `inline` dan bukan flex: yang diminta satu KALIMAT, dan kalimat yang tidak
+   muat harus membungkus di sela kata mana pun — bukan patah di batas dua
+   kotak flex, yang menyisakan separuh baris kosong sebelum nama sekolahnya
+   turun utuh ke baris kedua. Nama sekolah terpanjang di data sungguhan tetap
+   membungkus dengan rapi karena titik pemisahnya ikut mengalir.
+
+   UKURANNYA DIUKUR, BUKAN DITAKSIR (bagian 15.9 dan 15.11). Di iframe 393px —
+   lebar HP yang dipakai panitia — isi kartunya 333px, dan
+   "007 · RANCAKA · MA PUI Cijantung · Penegak PA" menuntut 328px pada 1rem
+   tebal + 0.85rem biasa. Pada ukuran sebelumnya (1.05 dan 0.9) ia menuntut
+   347px dan membungkus. Nama sekolah yang lebih panjang tetap turun ke baris
+   kedua, dan itu memang yang diminta: sebaris KALAU BISA, bukan dipaksa
+   sebaris sampai hurufnya tidak terbaca.
+
+   Nomor dadanya tetap ditulis walaupun kotak navigasi di atasnya sudah
+   memuatnya besar-besar: yang satu apa yang DIKETIK, yang satu apa yang
+   DITEMUKAN, dan seluruh guna kartu ini membandingkan keduanya. */
+.card-identity.identitas-sebaris { padding: .45rem .6rem; line-height: 1.3; }
+.identitas-sebaris .nama    { font-size: 1rem; font-weight: 800; }
+.identitas-sebaris .detail  { font-size: .85rem; margin-top: 0; }
 /* SATU BARIS: kotak isian, lambang simpan, lambang gembok — berurutan sesuai
    cara dipakainya (baca angkanya, betulkan, simpan, gembok).
 
@@ -5460,7 +5505,7 @@ button.pill-number:hover { filter: brightness(.95); }
      atas memakan ~170px; sebaris ~90px, dan selisihnya jatuh ke foto. */
   .isi.cek .baris-pilih { margin: 0; }
   .isi.cek .cek-navigasi { margin: 0; }
-  .isi.cek .cek-posisi { margin: 0; }
+  .isi.cek .cek-kendali .baris-pilih .field { margin-bottom: 0; }
   /* `.isi.cek > .card`, BUKAN `:first-of-type`. Saudara pertama di dalam
      .isi adalah <div id="pita-antrean">, dan `div:first-of-type` menunjuk
      DIA — bukan kartu ini — jadi aturannya tidak pernah mengenai apa pun dan

--- a/tests/cek_nilai_guliran.test.mjs
+++ b/tests/cek_nilai_guliran.test.mjs
@@ -1,0 +1,98 @@
+// ============================================================================
+// hrcd-rekap : tests/cek_nilai_guliran.test.mjs
+// Menekan panah di Cek Nilai TIDAK boleh melempar guliran ke atas.
+//
+// Terukur sebelum perbaikan, di iframe 393x700 dengan Pos 5: halaman 1016px,
+// petugas menggulir ke 300 untuk melihat foto slipnya, lalu menekan panah.
+// replaceChildren menggambar kerangka yang petak fotonya masih KOSONG,
+// halamannya menyusut jadi 700 — tepat setinggi layar — dan browser menjepit
+// gulirannya ke 0 karena tidak ada lagi yang bisa digulir. 60 ms kemudian
+// fotonya datang dan halamannya kembali 1016, tetapi gulirannya sudah
+// telanjur di atas.
+//
+// Akibatnya tiap satu regu berikutnya menuntut satu guliran lagi, dan layar
+// ini dipakai ratusan kali sepagi. Dilaporkan dari lapangan, 1 September 2026.
+//
+// Yang menjaganya BUKAN menyimpan lalu memulihkan angkanya — cara papan Live
+// Score — melainkan menahan TINGGI halamannya, karena halaman yang tidak
+// pernah memendek tidak perlu dipulihkan sama sekali. Memulihkan sesudah
+// fotonya datang akan MENGEDIP: di lapangan tautan foto bertanda tangan bisa
+// memakan setengah detik.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+/** Badan layarCekNilai saja — nama yang dicari di bawah juga muncul di layar
+ *  lain, dan tes yang menemukannya di sana lulus tanpa memeriksa apa pun. */
+const layarCek = (() => {
+  const awal = app.indexOf("async function layarCekNilai()");
+  return app.slice(awal, app.indexOf("const RUTE = {", awal));
+})();
+
+test("guliran halaman dipulihkan sesudah kerangkanya digambar ulang", () => {
+  assert.match(layarCek, /const gulirHalaman = halaman\.scrollTop;/,
+    "guliran halaman tidak diingat sebelum menggambar ulang");
+  assert.match(layarCek, /halaman\.scrollTop = gulirHalaman;/,
+    "guliran halaman tidak dipasang lagi sesudah menggambar ulang");
+});
+
+test("halaman ditahan setinggi semula DALAM DUA LANGKAH", () => {
+  // Langkah 1 sendirian meleset 16px: margin bawah kartu terakhir runtuh
+  // keluar dari #cek-isi selama tingginya auto, lalu terserap ke dalam begitu
+  // min-height memaksanya. Tinggi elemennya sama, tinggi halamannya tidak.
+  assert.match(layarCek, /elIsi\.style\.minHeight = `\$\{tinggiIsi\}px`;/,
+    "langkah 1 hilang — #cek-isi tidak dipatok setinggi ukurannya yang lama");
+  // Langkah 2 sendirian juga meleset: kerangka yang lebih pendek daripada
+  // layar membuat scrollHeight berhenti di tinggi layar — 700, bukan 400 —
+  // jadi kekurangan yang terbaca 198px dari 498px yang sebenarnya.
+  assert.match(layarCek,
+    /const kurang = tinggiHalaman - halaman\.scrollHeight;[\s\S]{0,120}tinggiIsi \+ kurang/,
+    "langkah 2 hilang — sisa kekurangannya tidak diukur dari halamannya");
+});
+
+test("patokan tinggi dilepas lewat finally, dan hanya oleh gambar terbaru", () => {
+  // Tanpa `finally` satu jalur keluar yang terlewat — permintaannya gagal,
+  // layarnya ditinggalkan, nomornya sudah berpindah — meninggalkan halaman
+  // yang tingginya terkunci di angka regu sebelumnya. Tanpa `iniGambar` dua
+  // ketukan panah beruntun membuat gambar yang lebih tua melepaskan patokan
+  // milik penggantinya, dan gulirannya melompat lagi.
+  assert.match(layarCek,
+    /finally \{ if \(iniGambar === gambarKe\) elIsi\.style\.minHeight = ""; \}/,
+    "patokan tinggi tidak dilepas lewat finally bertanda gambar terbaru");
+  assert.match(layarCek, /const iniGambar = \+\+gambarKe;/,
+    "nomor gambar tidak dinaikkan saat regunya berganti");
+});
+
+test("patokan tinggi TIDAK dipasang saat halamannya tidak sedang digulir", () => {
+  // Di tata letak satu layar (>= 1000px) `.isi.cek` setinggi layar dan
+  // `overflow: hidden`, jadi guliran halaman selalu 0. min-height di sana
+  // justru merusak: #cek-isi anak flex ber-`min-height: 0` yang memang HARUS
+  // boleh menyusut, dan mematoknya mendorong halaman jadi lebih tinggi
+  // daripada layar — persis yang sudah pernah diperbaiki di blok CSS-nya.
+  assert.match(layarCek, /if \(gulirHalaman > 0\) \{/,
+    "patokan tinggi dipasang tanpa memeriksa halamannya sedang digulir");
+  assert.match(css, /#cek-isi \{ flex: 1; min-height: 0;/,
+    "#cek-isi tidak lagi anak flex yang boleh menyusut — pagar di JS memakai "
+    + "itu sebagai alasannya");
+});
+
+test("guliran kotak lomba ikut dipasang lagi", () => {
+  // Yang menggulir di rentang >= 1000px kotak lombanya sendiri, dan kotak itu
+  // DIBUANG oleh replaceChildren.
+  assert.match(layarCek, /const kotakLama = elIsi\.querySelector\(":scope > \.card"\);/,
+    "guliran kotak lomba tidak diingat");
+  assert.match(layarCek, /if \(kotakBaru && gulirKotak\) kotakBaru\.scrollTop = gulirKotak;/,
+    "guliran kotak lomba tidak dipasang lagi");
+  // Di blok satu-layar, BUKAN yang di rentang HP — `#cek-isi > .card` ditulis
+  // dua kali, dan yang di 560px cuma mengatur padding.
+  const satuLayar = css.slice(css.indexOf("@media (min-width: 1000px)"));
+  const awal = satuLayar.indexOf("#cek-isi > .card {");
+  assert.ok(awal > 0, "aturan #cek-isi > .card hilang dari blok satu-layar");
+  assert.match(satuLayar.slice(awal, satuLayar.indexOf("}", awal)), /overflow: auto;/,
+    "kotak lomba tidak lagi menggulir sendiri — pemulihan di JS jadi sia-sia");
+});

--- a/tests/cek_nilai_kompak.test.mjs
+++ b/tests/cek_nilai_kompak.test.mjs
@@ -1,0 +1,101 @@
+// ============================================================================
+// hrcd-rekap : tests/cek_nilai_kompak.test.mjs
+// Kepala layar Cek Nilai di HP, dan menu bawah yang dipakai semua layar.
+//
+// Di HP layar ini menjawab satu pertanyaan: apakah angka yang tertulis sama
+// dengan tulisan tangan di foto slipnya. Tiap piksel yang dipakai DI ATAS
+// foto diambil DARI foto.
+//
+// Terukur di iframe 393x700 dengan Pos 5, sebelum perbaikan: 288px habis
+// sebelum satu angka pun terlihat, dan menu bawah beserta ruang di bawahnya
+// mengambil 161px lagi. Yang memakannya:
+//
+//   label "Pos" di atas dropdown yang isinya sudah berbunyi "Pos 5 — Yel-Yel"
+//   penghitung "7 / 181"
+//   kartu identitas dua baris
+//   penanda "1 lomba dikunci", yang mengulang gembok yang tergambar tepat di
+//     sebelah nilai lomba itu di layar yang sama
+//
+// Sesudahnya: kepala 155px, menu bawah 51px. Keempatnya kasus pasal 9.3 —
+// buang yang mengulang judul, label, atau tombol di sebelahnya.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+const layarCek = (() => {
+  const awal = app.indexOf("async function layarCekNilai()");
+  return app.slice(awal, app.indexOf("const RUTE = {", awal));
+})();
+
+test("dropdown pos berdiri tanpa label di atasnya", () => {
+  assert.doesNotMatch(layarCek, /<label for="cek-pos">/,
+    'label "Pos" kembali di atas dropdown yang isinya sudah menyebut "Pos"');
+  assert.match(layarCek, /<select id="cek-pos"[\s\S]{0,80}aria-label="Pos"/,
+    "dropdown pos kehilangan aria-label, satu-satunya nama yang tersisa "
+    + "untuk pembaca layar");
+});
+
+test("penghitung posisi tidak ada di mana pun", () => {
+  // "7 / 181" tidak pernah ditanya orang yang sedang mencocokkan satu regu,
+  // dan kedua ujung daftarnya sudah terbaca dari panah yang mati.
+  assert.doesNotMatch(app, /cek-posisi/,
+    "penghitung posisi kembali di layar Cek Nilai");
+  assert.doesNotMatch(css, /cek-posisi/,
+    "aturan penghitung posisi tertinggal di style.css");
+});
+
+test("kartu identitas Cek Nilai ringkas, Input Pos v2 tidak", () => {
+  assert.match(layarCek, /kartuReguNilai\(r, \{ ringkas: true \}\)/,
+    "Cek Nilai tidak lagi memakai kartu identitas ringkas");
+  // Di Input Pos v2 satu lomba terbuka pada satu waktu, jadi "berapa lomba
+  // pos ini yang sudah tergembok" memang tidak terbaca di tempat lain — di
+  // sana penanda itu satu-satunya tanda gembok di layar.
+  const pos2 = app.slice(app.indexOf("async function layarInputPos2()"),
+    app.indexOf("async function layarCekNilai()"));
+  assert.match(pos2, /kartuReguNilai\(r\)\)/,
+    "Input Nilai Pos v2 ikut memakai kartu ringkas dan kehilangan penanda "
+    + "gemboknya");
+});
+
+test("kartu ringkas satu baris, tanpa penanda gembok", () => {
+  const kartu = app.slice(app.indexOf("const kartuReguNilai ="),
+    app.indexOf("async function layarInputPos2()"));
+  const ringkas = kartu.slice(0, kartu.indexOf("</div>` : `"));
+  assert.doesNotMatch(ringkas, /lomba dikunci/,
+    "penanda gembok kembali di kartu ringkas — ia mengulang gembok yang "
+    + "tergambar di sebelah nilai tiap lomba di layar yang sama");
+  assert.match(ringkas, /<span class="nama">/,
+    "kartu ringkas kembali memakai <div>, yang memaksa dua baris");
+  // Diukur di iframe 393px: isi kartunya 333px, dan
+  // "007 · RANCAKA · MA PUI Cijantung · Penegak PA" menuntut 328px pada 1rem
+  // tebal + 0.85rem biasa. Pada 1.05/0.9 ia menuntut 347px dan membungkus.
+  assert.match(css, /\.identitas-sebaris \.nama\s+\{ font-size: 1rem;/,
+    "ukuran nama di kartu ringkas berubah — di 1.05rem barisnya membungkus "
+    + "pada lebar HP 393px");
+  assert.match(css, /\.identitas-sebaris \.detail\s+\{ font-size: \.85rem;/,
+    "ukuran detail di kartu ringkas berubah — lihat catatan yang sama");
+});
+
+test("menu bawah tetap sasaran sentuh yang sah sesudah dirampingkan", () => {
+  // 48px masih di atas 44px, batas yang dipakai iOS maupun Android. Di bawah
+  // itu perampingan berhenti jadi perampingan.
+  const nav = css.slice(css.indexOf(".bottom-nav-item {"));
+  const min = nav.match(/min-height: (\d+)px;/);
+  assert.ok(min, "menu bawah kehilangan batas tinggi sasaran sentuhnya");
+  assert.ok(Number(min[1]) >= 44,
+    `sasaran sentuh menu bawah ${min[1]}px, di bawah batas 44px`);
+});
+
+test("ruang di bawah halaman ikut tinggi bar, dan ikut safe-area", () => {
+  // Bar-nya sendiri menambahkan inset itu ke tingginya, jadi ruang yang tetap
+  // membuat baris terakhir berakhir DI BAWAH tepi atas bar di HP bergaris
+  // beranda. Di browser desktop insetnya nol dan cacat ini tidak muncul.
+  assert.match(css, /\.isi \{ padding-bottom: calc\(5rem \+ env\(safe-area-inset-bottom\)\); \}/,
+    "ruang di bawah halaman tidak lagi 5rem + safe-area — kalau tinggi bar "
+    + "diubah, angka ini ikut");
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 46, sidik: "a9d364b3f742" },
+  "style.css": { versi: 47, sidik: "cfd574db2e17" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=44">
+  <link rel="stylesheet" href="style.css?v=45">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -8107,15 +8107,29 @@ const posUntukAkun = (s, semuaPos) => {
  *  Sejak 0166 ia menyebut BERAPA lomba, bukan sekadar "dikunci". Gembok kini
  *  per lomba: "dikunci" pada regu yang satu dari lima lombanya tergembok
  *  membaca seperti seluruh nilainya beku, dan petugas berhenti mengetik yang
- *  sebenarnya masih boleh diisi. */
-const kartuReguNilai = (r) => `
+ *  sebenarnya masih boleh diisi.
+ *
+ *  `ringkas` MEMBUANG KEDUANYA — barisnya jadi satu, dan penanda gembok
+ *  hilang. Dipakai Cek Nilai, dan hanya di sana, karena di layar itu tiap
+ *  lomba sudah membawa gemboknya sendiri tepat di sebelah angkanya: penanda
+ *  "1 lomba dikunci" di kartu ini mengulang sesuatu yang tergambar dua
+ *  sentimeter di bawahnya (bagian 9.3), dan tinggi yang dimakannya diambil
+ *  dari foto slip. Layar Input Nilai Pos v2 TIDAK memakainya — di sana satu
+ *  lomba terbuka pada satu waktu, jadi "berapa lomba pos ini yang sudah
+ *  tergembok" memang tidak terbaca di tempat lain. */
+const kartuReguNilai = (r, { ringkas = false } = {}) => (ringkas ? `
+  <div class="card card-identity identitas-sebaris" style="margin:0">
+    ${html`<span class="nama">${dada3(r.nomor_dada)} · ${r.nama_regu}</span><span
+      class="detail"> · ${r.nama_sekolah} · ${
+      GOLONGAN_LABEL[r.golongan] || r.golongan}</span>`}
+  </div>` : `
   <div class="card card-identity" style="margin:0">
     ${html`<div class="nama">${dada3(r.nomor_dada)} · ${r.nama_regu}</div>
     <div class="detail">${r.nama_sekolah} · ${GOLONGAN_LABEL[r.golongan] || r.golongan}</div>`}
     ${(r.lomba_terkunci || []).length ? `<div style="margin-top:.4rem">
       <span class="badge badge-gray">${ikon("lock")} ${
         esc(String(r.lomba_terkunci.length))} lomba dikunci</span></div>` : ""}
-  </div>`;
+  </div>`);
 
 /* ---------------------------------------------------------------------------
    LAYAR 1 — pemilih lomba, lalu bentuk pengisiannya.
@@ -9183,11 +9197,16 @@ async function layarCekNilai() {
          admin cuma menerima satu notifikasi yang lalu hilang, lalu tidak ada
          satu pun tanda bahwa masih ada angka yang belum sampai. -->
     <div id="pita-antrean"></div>
-    <div class="card">
+    <div class="card cek-kendali">
+      <!-- DROPDOWN SAJA, tanpa label "Pos" di atasnya. Isi kotaknya sudah
+           berbunyi "Pos 5 — Yel-Yel", jadi labelnya mengulang kata yang
+           terbaca di dalam kotak yang ia labeli (bagian 9.3) — dan barisnya
+           memakan 23px yang di HP diambil langsung dari tinggi foto.
+           Atribut aria-label menggantikannya untuk pembaca layar. -->
       <div class="baris-pilih">
         <div class="field">
-          <label for="cek-pos">Pos</label>
-          <select id="cek-pos" class="select-small" ${posBoleh.length < 2 ? "disabled" : ""}>
+          <select id="cek-pos" class="select-small" aria-label="Pos"
+                  ${posBoleh.length < 2 ? "disabled" : ""}>
             ${posBoleh.map(p => `<option value="${esc(p.nomor)}"
               >${esc(judulPos(p))}</option>`).join("")}
           </select>
@@ -9215,7 +9234,11 @@ async function layarCekNilai() {
         <button type="button" class="button button-secondary cek-panah"
                 id="cek-maju" aria-label="Regu berikutnya">&rsaquo;</button>
       </div>
-      <div class="cek-posisi" id="cek-posisi"></div>
+      <!-- TIDAK ADA "7 / 181". Berapa nomor yang sudah dilewati bukan
+           pertanyaan yang ditanya orang yang sedang mencocokkan satu regu,
+           dan kedua ujung daftarnya sudah terbaca dari panah yang mati.
+           Barisnya memakan 20px, dan di HP tiap piksel di atas layar ini
+           diambil dari tinggi foto slip. -->
     </div>
     <div id="cek-isi"></div>
   `));
@@ -9250,7 +9273,6 @@ async function layarCekNilai() {
   const elPos = document.getElementById("cek-pos");
   const elDada = document.getElementById("cek-dada");
   pasangDada3(elDada, sinyal);
-  const elPosisi = document.getElementById("cek-posisi");
   const elIsi = document.getElementById("cek-isi");
   const elMundur = document.getElementById("cek-mundur");
   const elMaju = document.getElementById("cek-maju");
@@ -9270,8 +9292,6 @@ async function layarCekNilai() {
   }
 
   function perbaruiNavigasi() {
-    elPosisi.textContent = lembar.length
-      ? `${indeks + 1} / ${lembar.length}` : "0 / 0";
     elMundur.disabled = indeks <= 0;
     elMaju.disabled = indeks >= lembar.length - 1;
     /* Kotaknya JANGAN ditimpa selagi diketik: petugas yang sedang mengetik
@@ -9282,6 +9302,11 @@ async function layarCekNilai() {
     }
   }
 
+  /* Nomor gambar yang sedang berlaku. Dua ketukan panah beruntun berarti dua
+     gambarRegu() berjalan bersamaan, dan yang lebih tua tidak boleh
+     membereskan apa pun milik yang lebih muda. */
+  let gambarKe = 0;
+
   async function gambarRegu() {
     perbaruiNavigasi();
     if (!lembar.length) {
@@ -9290,10 +9315,73 @@ async function layarCekNilai() {
       return;
     }
 
+    const iniGambar = ++gambarKe;
     const r = lembar[indeks];
     const dada = Number(r.nomor_dada);
     const daftar = lombaPos();
     const nilai = r.nilai || {};
+
+    /* ================================================================
+       GULIRAN BERTAHAN SAAT PINDAH REGU — dan yang menjaganya BUKAN
+       menyimpan lalu memulihkan angkanya, melainkan menahan TINGGI
+       halamannya.
+
+       Yang terjadi tanpa ini, terukur di iframe 393x700 dengan Pos 5:
+       halaman 1016px, petugas menggulir ke 300 untuk melihat foto slip,
+       lalu menekan panah. replaceChildren menggambar kerangka yang
+       petak fotonya masih KOSONG, halamannya menyusut jadi 700 — tepat
+       setinggi layar — dan browser menjepit guliran ke 0 karena tidak
+       ada lagi yang bisa digulir. 60 ms kemudian fotonya datang dan
+       halamannya kembali 1016, tetapi gulirannya sudah telanjur di
+       atas. Jadi tiap satu regu berikutnya menuntut satu guliran lagi,
+       dan layar ini dipakai ratusan kali sepagi.
+
+       Menyimpan lalu memulihkan angkanya — cara papan Live Score —
+       tidak dipakai di sini karena ia MENGEDIP: di lapangan tautan
+       foto bertanda tangan bisa memakan setengah detik, dan setengah
+       detik melompat ke atas lalu turun lagi terbaca seperti layar
+       yang salah gambar. Halaman yang tidak pernah memendek tidak
+       perlu dipulihkan sama sekali.
+
+       HANYA SAAT HALAMANNYA MEMANG SEDANG DIGULIR. Di tata letak satu
+       layar (>= 1000px) `.isi.cek` setinggi layar dan `overflow:
+       hidden`, jadi guliran halaman selalu 0 — dan `min-height` di
+       sana justru merusak: #cek-isi anak flex ber-`min-height: 0`
+       yang memang HARUS boleh menyusut, dan mematoknya mendorong
+       halaman jadi lebih tinggi daripada layar, persis yang sudah
+       pernah diperbaiki di blok CSS-nya.
+
+       Yang menggulir di rentang itu kotak lombanya sendiri
+       (`#cek-isi > .card { overflow: auto }`), dan kotak itu DIBUANG
+       oleh replaceChildren — jadi ia yang disimpan lalu dipasang lagi.
+       Tingginya di sana tidak bergantung pada foto (fotonya `flex: 1`),
+       jadi memulihkannya seketika sudah benar dan tidak mengedip.
+
+       DUA LANGKAH, dan keduanya perlu — masing-masing sendirian
+       terukur MELESET:
+
+         1. patok #cek-isi setinggi ukurannya yang lama. Meleset 16px,
+            karena margin bawah kartu terakhir RUNTUH keluar dari
+            #cek-isi selama tingginya auto lalu terserap ke dalam
+            begitu min-height memaksanya. Tinggi elemennya sama,
+            tinggi halamannya tidak.
+         2. ukur sisa kekurangannya dari halamannya sendiri, lalu
+            tambahkan. Ini yang tidak bisa berdiri sendiri: tanpa
+            langkah 1 kerangkanya lebih pendek daripada layar, dan
+            `scrollHeight` berhenti di tinggi layar — 700, bukan 400 —
+            jadi yang terbaca cuma 198px kurang dari 498px yang
+            sebenarnya, dan tambalannya masih pendek.
+
+       Sesudah langkah 1 halamannya paling meleset selebar satu margin
+       yang runtuh, jadi lantai layar tidak lagi mengaburkan
+       pengukuran dan langkah 2 menutupnya persis.
+       ================================================================ */
+    const halaman = document.scrollingElement;
+    const gulirHalaman = halaman.scrollTop;
+    const tinggiHalaman = halaman.scrollHeight;
+    const tinggiIsi = Math.round(elIsi.getBoundingClientRect().height);
+    const kotakLama = elIsi.querySelector(":scope > .card");
+    const gulirKotak = kotakLama ? kotakLama.scrollTop : 0;
 
     /* Kerangkanya digambar LEBIH DULU, fotonya menyusul. Tautan foto
        bertanda tangan butuh satu perjalanan jaringan per regu, dan layar yang
@@ -9302,7 +9390,7 @@ async function layarCekNilai() {
       <!-- Tidak ada lagi blok gembok di kartu identitas: gemboknya sekarang
            duduk di sebelah nilai tiap lomba, tempat keputusannya benar-benar
            diambil. -->
-      <div class="cek-identitas">${kartuReguNilai(r)}</div>
+      <div class="cek-identitas">${kartuReguNilai(r, { ringkas: true })}</div>
       <div class="card">
         ${daftar.map(l => {
           const dipakai = l.kolom
@@ -9408,6 +9496,23 @@ async function layarCekNilai() {
         }).join("")}
       </div>`));
 
+    /* Halaman ditambal setinggi semula lalu gulirannya dikembalikan — dan
+       semuanya masih di dalam SATU tugas yang sama dengan replaceChildren di
+       atas, jadi browser tidak pernah sempat menggambar keadaan pendeknya.
+       Yang terlihat cuma hasil akhirnya: angka barunya, di tempat mata sudah
+       berada. */
+    if (gulirHalaman > 0) {
+      elIsi.style.minHeight = `${tinggiIsi}px`;
+      const kurang = tinggiHalaman - halaman.scrollHeight;
+      if (kurang > 0) elIsi.style.minHeight = `${tinggiIsi + kurang}px`;
+      halaman.scrollTop = gulirHalaman;
+    }
+    // Kotak lombanya baru — guliran di dalamnya dipasang lagi (lihat catatan
+    // panjang di atas). Di HP nilainya selalu 0 dan barisnya tidak berbuat apa
+    // pun; yang menggulir di sana halamannya.
+    const kotakBaru = elIsi.querySelector(":scope > .card");
+    if (kotakBaru && gulirKotak) kotakBaru.scrollTop = gulirKotak;
+
     /* <label for> butuh id, dan selKomponen menulis data-kode saja. Dipasang
        di sini, sesudah barisnya berdiri. */
     daftar.forEach(l => {
@@ -9424,6 +9529,23 @@ async function layarCekNilai() {
     statusAwal();
     matikanSaatTerkunci();
 
+    /* Fotonya menyusul, dan begitu ia mendarat halamannya boleh kembali
+       setinggi isinya sendiri. `iniGambar` menjaga supaya gambar yang sudah
+       didahului penggantinya tidak melepaskan patokan milik pengganti itu —
+       dua ketukan panah beruntun membuat keduanya berjalan bersamaan. */
+    try { await gambarFoto(dada); }
+    finally { if (iniGambar === gambarKe) elIsi.style.minHeight = ""; }
+  }
+
+  /** Foto slip tiap lomba, dipasang sesudah kerangkanya berdiri.
+   *
+   *  Terpisah dari gambarRegu() supaya patokan tinggi di sana bisa dilepas
+   *  lewat SATU `finally`: jalur keluar di bawah ada tiga — permintaannya
+   *  gagal, layarnya ditinggalkan, nomornya sudah berpindah — dan tiga baris
+   *  pelepasan yang harus diingat satu per satu adalah baris yang suatu hari
+   *  terlewat, meninggalkan halaman yang tingginya terkunci di angka regu
+   *  sebelumnya. */
+  async function gambarFoto(dada) {
     let foto = [];
     try { foto = await daftarFotoLembar(nomorPos, dada); }
     catch { foto = null; }

--- a/web/style.css
+++ b/web/style.css
@@ -3216,18 +3216,31 @@ button.pill-number:hover { filter: brightness(.95); }
     z-index: 40;
   }
   .bottom-nav[hidden] { display: none; }
+  /* DIRAMPINGKAN dari 64px jadi 50px, dan yang dibayar dengan itu bukan
+     kenyamanan menekan: 50px masih di atas 44px, batas sasaran sentuh yang
+     dipakai iOS maupun Android, dan lebar tiap tombolnya seperempat layar —
+     yang menentukan meleset atau tidak justru lebar itu, bukan tingginya.
+
+     Yang dibeli: 14px dari bar plus 16px dari ruang di bawah halaman,
+     30px yang jatuh ke isi layar di setiap layar HP sekaligus. Di Cek Nilai
+     ia jatuh ke tinggi foto slip; di meja pembayaran ia satu baris tabel
+     lagi sebelum harus menggulir. */
   .bottom-nav-item {
     flex: 1;
-    display: flex; flex-direction: column; align-items: center; gap: .15rem;
-    padding: .45rem .2rem; min-height: 56px;
+    display: flex; flex-direction: column; align-items: center; gap: .1rem;
+    padding: .3rem .2rem; min-height: 48px;
     border: 0; background: none; font-family: inherit;
-    color: var(--tinta-lembut); font-size: .72rem; font-weight: 600;
+    color: var(--tinta-lembut); font-size: .7rem; font-weight: 600;
+    /* Label satu kata, jadi tinggi barisnya tidak perlu ruang untuk baris
+       kedua yang tidak akan pernah ada. 1.5 bawaan menyisakan 5px kosong di
+       atas dan di bawah "Home". */
+    line-height: 1.15;
     cursor: pointer;
   }
   .bottom-nav-icon {
-    font-size: 1.3rem; line-height: 1;
+    font-size: 1rem; line-height: 1;
     display: inline-flex; align-items: center; justify-content: center;
-    width: 2.6rem; height: 1.9rem; border-radius: 999px;
+    width: 2.2rem; height: 1.6rem; border-radius: 999px;
   }
 
   /* Satu warna per tujuan. Tiga ikon abu-abu sebaris menuntut label dibaca
@@ -3257,9 +3270,9 @@ button.pill-number:hover { filter: brightness(.95); }
      berakhir 3px DI BAWAH tepi atas bar. Di browser desktop insetnya nol dan
      jaraknya 31px, jadi cacat ini tidak pernah muncul waktu diukur di laptop.
 
-     6rem itu sendiri: tinggi bar 65px + jarak baca. Kalau tinggi bar diubah,
-     angka ini ikut. */
-  .isi { padding-bottom: calc(6rem + env(safe-area-inset-bottom)); }
+     5rem itu sendiri: tinggi bar 51px + jarak baca ~29px. Kalau tinggi bar
+     diubah, angka ini ikut — dulu 6rem waktu barnya 65px. */
+  .isi { padding-bottom: calc(5rem + env(safe-area-inset-bottom)); }
 }
 
 /* ============================================================================
@@ -5108,14 +5121,46 @@ button.pill-number:hover { filter: brightness(.95); }
   text-align: center; font-size: 1.45rem; font-weight: 700;
   letter-spacing: .05em; font-variant-numeric: tabular-nums;
 }
-.cek-posisi {
-  margin-top: .35rem; text-align: center;
-  font-size: .85rem; color: var(--tinta-lembut); font-variant-numeric: tabular-nums;
-}
+/* KARTU KENDALI DIRAMPINGKAN DI SELURUH RENTANG, bukan cuma di laptop.
+   Padding kartu bawaan 1.15rem atas dan bawah adalah 37px yang di HP diambil
+   langsung dari tinggi foto slip — dan foto slip itulah satu-satunya alasan
+   layar ini dibuka. Yang di dalamnya cuma satu dropdown dan sebaris panah,
+   keduanya sudah punya tinggi sentuhnya sendiri (46px), jadi tidak ada yang
+   menyusut karenanya. */
+.cek-kendali { padding: .6rem .8rem; }
+.cek-kendali .baris-pilih .field { margin-bottom: .5rem; }
+.cek-kendali .cek-navigasi { margin-top: 0; }
+
 /* Kartu identitas regu diberi jarak ke blok lomba pertama. Tanpa ini nama
    regunya menempel ke kotak lomba di bawahnya dan keduanya terbaca sebagai
    satu blok — padahal yang satu identitas dan yang satu lagi nilai. */
-.cek-identitas { margin-bottom: .9rem; }
+.cek-identitas { margin-bottom: .5rem; }
+
+/* IDENTITAS SEBARIS — "007 · RANCAKA · MA PUI Cijantung · Penegak PA".
+   Dua baris bertumpuk plus padding kartu penuh memakan 93px di HP, dan di
+   layar yang seluruh gunanya membandingkan angka dengan tulisan tangan di
+   foto, tinggi itu diambil dari fotonya.
+
+   `inline` dan bukan flex: yang diminta satu KALIMAT, dan kalimat yang tidak
+   muat harus membungkus di sela kata mana pun — bukan patah di batas dua
+   kotak flex, yang menyisakan separuh baris kosong sebelum nama sekolahnya
+   turun utuh ke baris kedua. Nama sekolah terpanjang di data sungguhan tetap
+   membungkus dengan rapi karena titik pemisahnya ikut mengalir.
+
+   UKURANNYA DIUKUR, BUKAN DITAKSIR (bagian 15.9 dan 15.11). Di iframe 393px —
+   lebar HP yang dipakai panitia — isi kartunya 333px, dan
+   "007 · RANCAKA · MA PUI Cijantung · Penegak PA" menuntut 328px pada 1rem
+   tebal + 0.85rem biasa. Pada ukuran sebelumnya (1.05 dan 0.9) ia menuntut
+   347px dan membungkus. Nama sekolah yang lebih panjang tetap turun ke baris
+   kedua, dan itu memang yang diminta: sebaris KALAU BISA, bukan dipaksa
+   sebaris sampai hurufnya tidak terbaca.
+
+   Nomor dadanya tetap ditulis walaupun kotak navigasi di atasnya sudah
+   memuatnya besar-besar: yang satu apa yang DIKETIK, yang satu apa yang
+   DITEMUKAN, dan seluruh guna kartu ini membandingkan keduanya. */
+.card-identity.identitas-sebaris { padding: .45rem .6rem; line-height: 1.3; }
+.identitas-sebaris .nama    { font-size: 1rem; font-weight: 800; }
+.identitas-sebaris .detail  { font-size: .85rem; margin-top: 0; }
 /* SATU BARIS: kotak isian, lambang simpan, lambang gembok — berurutan sesuai
    cara dipakainya (baca angkanya, betulkan, simpan, gembok).
 
@@ -5460,7 +5505,7 @@ button.pill-number:hover { filter: brightness(.95); }
      atas memakan ~170px; sebaris ~90px, dan selisihnya jatuh ke foto. */
   .isi.cek .baris-pilih { margin: 0; }
   .isi.cek .cek-navigasi { margin: 0; }
-  .isi.cek .cek-posisi { margin: 0; }
+  .isi.cek .cek-kendali .baris-pilih .field { margin-bottom: 0; }
   /* `.isi.cek > .card`, BUKAN `:first-of-type`. Saudara pertama di dalam
      .isi adalah <div id="pita-antrean">, dan `div:first-of-type` menunjuk
      DIA — bukan kartu ini — jadi aturannya tidak pernah mengenai apa pun dan


### PR DESCRIPTION
## What

**The arrow no longer throws the page back to the top.** Moving to the next
nomor dada now leaves the scroll offset exactly where it was, so a run of
regu can be checked without re-scrolling to the photo every time.

**The head of the screen is smaller**, all of it as requested:

- the "Pos" label above the dropdown is gone; the dropdown already reads
  "Pos 5 — Yel-Yel"
- the "7 / 181" counter is gone
- the regu identity is one line — `007 · RANCAKA · MA PUI Cijantung ·
  Penegak PA` — instead of two plus a badge
- the "1 lomba dikunci" badge is gone from this screen, which already draws
  a padlock beside every lomba's value

**The bottom nav is 50px instead of 64px**, and the space reserved under the
page follows it down from 6rem to 5rem. That is 30px back on every phone
screen, not just this one.

Measured on Pos 5 in a 393×700 iframe: head 288px → 155px, page 1050px →
861px, bottom nav 65px → 51px.

## Why

The skeleton for the next regu is drawn with empty photo boxes, so for the
60 ms until the signed photo links arrive the document is shorter than the
current scroll offset — and the browser clamps the scroll to 0. The photos
then land and the page is tall again, but the scroll has already been lost.
Measured: page 1016px, scrolled to 300, clamped to 0.

The page is held at its old height across the redraw rather than scrolled
back afterwards, because a restore would blink — in the field a signed photo
URL can take half a second, and half a second of jumping up and back reads
like a screen drawing the wrong thing. Two steps are needed and each one
alone was measured to miss: pinning `#cek-isi` to its previous height is 16px
short (the last card's bottom margin stops collapsing out of it once
`min-height` applies), and measuring the shortfall from the document alone is
300px short (`scrollHeight` bottoms out at the viewport height when the
skeleton is shorter than the screen).

Everything the head lost was a repeat of something already on the screen —
section 9.3.

## Notes

- The pin is skipped when the page is not scrolled, so the one-screen layout
  at ≥ 1000px is untouched: there `#cek-isi` is a flex child that must stay
  free to shrink. In that range the lomba card is the scroller and it is
  `replaceChildren` that discards it, so its `scrollTop` is carried over
  instead. Verified at 1440×820, 1024×560 and 1000×330.
- Input Nilai Pos v2 keeps the old identity card. There the badge is the only
  lock indicator on the screen, because only one lomba is open at a time.
- Opened on a laptop against a local `hrcd_dev` with 12 numbered regu and
  photos: three consecutive arrow presses hold the scroll, so do two presses
  in the same frame, and so does a pos with no photos at all.
- 389 tests pass. The eleven new ones were each checked in both directions —
  five injected regressions, five failures.
