### PR TITLE
fix: one size for every value box in Cek Nilai, and arrows at the card edge

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=47">
+  <link rel="stylesheet" href="style.css?v=48">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3235,8 +3235,23 @@ button.pill-number:hover { filter: brightness(.95); }
        kedua yang tidak akan pernah ada. 1.5 bawaan menyisakan 5px kosong di
        atas dan di bawah "Home". */
     line-height: 1.15;
+    /* TANPA KOTAK HITAM SAAT DISENTUH. Bawaan browser HP menyiram SELURUH
+       tombol dengan rgba(0,0,0,.18) begitu jari menyentuhnya — di tombol
+       berlatar sendiri itu nyaris tidak terlihat, tapi item bar ini tidak
+       punya latar, jadi yang muncul kotak abu 95x50 di sekeliling ikon 35x26.
+       Dilaporkan begitu: "malah muncul block kotak besar". */
+    -webkit-tap-highlight-color: transparent;
     cursor: pointer;
   }
+  /* Yang menggantikannya: pil ikonnya menua selagi ditekan, sebesar pil
+     penanda halaman yang sedang dibuka — jadi umpan baliknya memakai bentuk
+     yang sudah ada di bar ini, bukan bentuk baru.
+
+     `:active`, BUKAN `:hover`. Safari iOS menempelkan `:hover` pada elemen
+     yang terakhir disentuh dan menahannya sampai sesuatu yang lain disentuh
+     (alasan lengkapnya di `.button-secondary`), jadi hover di sini akan
+     meninggalkan pil yang menyala di menu yang barusan ditekan. */
+  .bottom-nav-item:active .bottom-nav-icon { background: var(--garis); }
   .bottom-nav-icon {
     font-size: 1rem; line-height: 1;
     display: inline-flex; align-items: center; justify-content: center;
@@ -5116,8 +5131,15 @@ button.pill-number:hover { filter: brightness(.95); }
   flex: 0 0 auto; width: auto; min-width: 3.4rem;
   font-size: 1.5rem; line-height: 1; padding: .2rem .6rem;
 }
+/* TANPA PATOKAN LEBAR DI HP, jadi kotaknya melebar sampai kedua panah duduk
+   tepat di tepi kartunya — sejajar dengan dropdown pos di atasnya dan dengan
+   kotak nilai di kartu bawahnya. Patokan 11rem membuat keduanya berhenti 13px
+   sebelum tepi, dan dari layar itu terbaca seperti baris yang salah lebar.
+   Sasaran sentuh panahnya ikut melebar sekalian, dan panah yang ditekan
+   ratusan kali sepagi memang tempatnya di tepi tempat jempol berada.
+   Di laptop patokannya kembali — lihat blok satu-layar. */
 .cek-dada {
-  flex: 1 1 auto; min-width: 0; max-width: 11rem; min-height: 46px;
+  flex: 1 1 auto; min-width: 0; min-height: 46px;
   text-align: center; font-size: 1.45rem; font-weight: 700;
   letter-spacing: .05em; font-variant-numeric: tabular-nums;
 }
@@ -5161,6 +5183,20 @@ button.pill-number:hover { filter: brightness(.95); }
 .card-identity.identitas-sebaris { padding: .45rem .6rem; line-height: 1.3; }
 .identitas-sebaris .nama    { font-size: 1rem; font-weight: 800; }
 .identitas-sebaris .detail  { font-size: .85rem; margin-top: 0; }
+/* DI HP GOLONGANNYA DIBUANG, dan ia yang dibuang karena ia yang paling sedikit
+   menjawab: kartu ini ada untuk satu pertanyaan — "nomor yang barusan saya
+   ketik ini benar regu yang berdiri di depan saya?" — dan nomor dada, nama
+   regu, serta nama sekolah sudah menjawabnya. Golongan sendiri sudah terbaca
+   dari nomor dadanya.
+
+   Yang dibeli 82px, dan itu selisih antara sebaris dan dua baris untuk
+   sebagian besar sekolah: dengan golongan, isi 333px cukup untuk nama sekolah
+   sampai ~17 huruf (median daftar kurasi); tanpa golongan sampai ~28, yang
+   mencakup sembilan dari sepuluh. Di laptop ruangnya tidak pernah kurang,
+   jadi di sana golongannya tetap. */
+@media (max-width: 560px) {
+  .identitas-sebaris .identitas-golongan { display: none; }
+}
 /* SATU BARIS: kotak isian, lambang simpan, lambang gembok — berurutan sesuai
    cara dipakainya (baca angkanya, betulkan, simpan, gembok).
 
@@ -5291,9 +5327,27 @@ button.pill-number:hover { filter: brightness(.95); }
   align-items: flex-end; gap: .3rem;
   flex: 0 1 auto; min-width: 0;
 }
+/* SATU UKURAN KOTAK NILAI, SEMUA POS — dan patokannya lomba soal, "Kesehatan"
+   di Pos 2 (keputusan pemilik acara, 1 September 2026: "tidak terlalu besar /
+   kecil"). Terukur di HP 393px: 114 x 60.
+
+   Sebelumnya tiap lomba dapat ukuran sendiri karena tidak ada satu pun yang
+   MENYEBUT lebarnya — yang dipakai lebar bawaan kotaknya, dan browser
+   menurunkan itu dari isinya. Hasilnya lima ukuran berbeda dalam satu layar:
+   Bakiak 168 (kotak mm:ss punya aturan sendiri), Menaksir 152 (mentok
+   max-width), Kesehatan 114, Semaphore 99 — `input[type=number]` melebar
+   mengikuti jumlah digit `max`, dan Semaphore maksimal 5 sedangkan Kesehatan
+   10 — dan PBB 456 di laptop, karena satu lomba mendapat seluruh lebar kartu.
+
+   Jadi lebarnya disebut SEKALI di sini dan dipakai di ketiga tempat yang
+   membutuhkannya. Kotak yang tidak muat tetap mengalah: lima kriteria
+   Pembidaian tidak akan pernah muat 114px berjajar di layar 393px — itu
+   aritmetika, bukan pilihan — jadi `flex-shrink` mengecilkannya, dan
+   `max-width: 100%` menahan kotaknya ikut menyusut bersama barisnya. */
+.cek-isian { --kotak-nilai: 7.1rem; }
 .cek-isian .isian-baris {
   border: 0; padding: 0; gap: .15rem;
-  flex: 1 1 0; min-width: 0;
+  flex: 0 1 var(--kotak-nilai); min-width: 0;
 }
 /* Nama kriteria mengecil dan boleh membungkus: ia yang paling panjang
    ("Diagnosis dan Penanganan Awal") dan paling jarang dibaca ulang — yang
@@ -5306,37 +5360,40 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: .62rem; line-height: 1.1;
   overflow-wrap: anywhere; hyphens: auto;
 }
-/* SATU KRITERIA DAPAT KOTAK LEBIH LEBAR. Tidak ada yang berebut tempat di
-   barisnya, dan angka yang dibaca ratusan kali sepagi lebih murah dibaca di
-   kotak besar. Lomba berkriteria banyak mengecil di aturan berikutnya, karena
-   di sana lima kotak harus muat berjajar. */
 .cek-isian .small-input {
   font-size: 1.6rem; min-height: 58px;
-  width: 100%; min-width: 0; max-width: 9.5rem;
+  width: var(--kotak-nilai); min-width: 0; max-width: 100%;
 }
-/* KOTAK mm:ss LEBIH LEBAR DARI KOTAK ANGKA, bukan lebih sempit.
+/* KOTAK mm:ss SELEBAR KOTAK ANGKA, tidak lebih dan tidak kurang.
    `input.small-input.input-waktu { width: 5.6rem }` di bagian tabel menang
-   atas `.cek-isian .small-input { width: 100% }` — kekhususan 0,2,1 lawan
-   0,2,0 — jadi "00:13" berdiri di kotak 90px sementara angka satu digit di
-   lomba sebelahnya dapat 152px. Terbalik: yang isinya lima huruf justru yang
-   paling sempit, dan di HP isinya terpotong.
+   atas `.cek-isian .small-input` — kekhususan 0,2,1 lawan 0,2,0 — jadi tanpa
+   baris ini "00:13" mendapat lebar yang bukan lebar siapa pun di layar ini.
 
    Yang dilakukan MENGALAHKAN aturan itu di sini, bukan menambah aturan untuk
    membatalkannya di tempat lain (CLAUDE.md 15.12) — 5.6rem tetap benar untuk
-   lembar pos, tempat satu baris memuat belasan kolom. */
-.cek-isian input.small-input.input-waktu { width: 100%; max-width: 10.5rem; }
-/* Lomba berkriteria BANYAK: yang mengalah LEBAR kotaknya, bukan besar
-   angkanya. Lima kotak tidak akan pernah muat selebar kotak tunggal di layar
-   430px — itu aritmetika, bukan pilihan — tapi angka DI DALAMNYA tidak punya
-   alasan ikut mengecil, dan angka itulah yang dicocokkan dengan tulisan
-   tangan di foto.
+   lembar pos, tempat satu baris memuat belasan kolom.
 
-   Jadi hurufnya hampir sebesar kotak tunggal dan paddingnya yang dirampingkan:
-   12px kiri-kanan pada kotak selebar 52px berarti separuh kotaknya kosong.
-   Nilai kriteria selalu dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang
-   dibebaskan padding memang jatuh ke angkanya. */
+   Sempat 10.5rem, karena 5.6rem memang terlalu sempit untuk lima huruf. Itu
+   mengayun terlalu jauh ke arah sebaliknya: 168px di sebelah 114px, dan yang
+   isinya paling sedikit berubah justru yang paling besar. "00:13" pada
+   1.6rem butuh ~99px, jadi 7.1rem cukup. */
+.cek-isian input.small-input.input-waktu {
+  width: var(--kotak-nilai); max-width: 100%;
+}
+/* Lomba berkriteria BANYAK: yang mengalah PADDING-nya, bukan ukuran kotaknya
+   maupun besar angkanya. Lima kotak tidak akan pernah muat 114px berjajar di
+   layar 393px, jadi `flex-shrink` membawanya turun ke 58px — dan 12px kiri
+   kanan pada kotak 58px berarti separuh kotaknya kosong. Nilai kriteria selalu
+   dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang dibebaskan padding
+   memang jatuh ke angkanya.
+
+   TIDAK ADA `max-width: none` di sini lagi, dan itu bukan kerapian: aturan ini
+   berkekhususan 0,4,0 — `:has()` mewarisi kekhususan argumennya, dan
+   `.isian-baris + .isian-baris` sendiri sudah 0,2,0 — jadi ia mengalahkan
+   `.cek-isian .small-input { max-width: 100% }`. Dengan `none` kelima kotak
+   Pembidaian bertahan di 114px, meluap keluar barisnya dan saling menimpa,
+   tanpa satu pun penggulir yang menandainya. Terukur begitu. */
 .cek-angka:has(.isian-baris + .isian-baris) .small-input {
-  font-size: 1.5rem; min-height: 56px; max-width: none;
   padding-left: .25rem; padding-right: .25rem;
 }
 /* Jarak antar kotak dirapatkan di baris berkriteria banyak: .3rem x 4 celah
@@ -5506,6 +5563,11 @@ button.pill-number:hover { filter: brightness(.95); }
   .isi.cek .baris-pilih { margin: 0; }
   .isi.cek .cek-navigasi { margin: 0; }
   .isi.cek .cek-kendali .baris-pilih .field { margin-bottom: 0; }
+  /* Patokan lebar nomor dada, yang di HP sengaja tidak ada supaya panahnya
+     duduk di tepi kartu. Di sini kartunya sebaris — pemilih pos, panah, nomor
+     dada, identitas regu — dan kotak yang melebar sebebasnya akan mendorong
+     identitas regunya keluar baris. */
+  .isi.cek .cek-dada { max-width: 11rem; }
   /* `.isi.cek > .card`, BUKAN `:first-of-type`. Saudara pertama di dalam
      .isi adalah <div id="pita-antrean">, dan `div:first-of-type` menunjuk
      DIA — bukan kartu ini — jadi aturannya tidak pernah mengenai apa pun dan

--- a/tests/cek_nilai_kompak.test.mjs
+++ b/tests/cek_nilai_kompak.test.mjs
@@ -81,6 +81,78 @@ test("kartu ringkas satu baris, tanpa penanda gembok", () => {
     "ukuran detail di kartu ringkas berubah — lihat catatan yang sama");
 });
 
+test("golongan dibuang dari kartu identitas di HP, bukan di laptop", () => {
+  // Yang paling sedikit menjawab "apakah ini regu yang berdiri di depan saya"
+  // — dan sudah terbaca dari nomor dadanya. 82px yang dibelinya adalah selisih
+  // antara sebaris dan dua baris untuk sembilan dari sepuluh sekolah.
+  assert.match(app, /<span class="identitas-golongan">/,
+    "golongan tidak lagi dibungkus span sendiri, jadi tidak bisa disembunyikan");
+  const hp = css.slice(css.indexOf(".identitas-sebaris .detail"));
+  assert.match(hp,
+    /@media \(max-width: 560px\) \{\s*\.identitas-sebaris \.identitas-golongan \{ display: none; \}/,
+    "golongan tidak disembunyikan di rentang HP");
+});
+
+test("satu ukuran kotak nilai, dipakai ketiga tempat yang membutuhkannya", () => {
+  // Tanpa lebar yang DISEBUT, browser menurunkannya dari isi tiap kotak dan
+  // satu layar berisi lima ukuran berbeda: Bakiak 168, Menaksir 152,
+  // Kesehatan 114, Semaphore 99, PBB 456 di laptop.
+  assert.match(css, /\.cek-isian \{ --kotak-nilai: 7\.1rem; \}/,
+    "lebar kotak nilai tidak lagi disebut sekali di satu tempat");
+  const perlu = [
+    [/\.cek-isian \.isian-baris \{[\s\S]{0,120}flex: 0 1 var\(--kotak-nilai\)/,
+      "baris isian"],
+    [/\.cek-isian \.small-input \{[\s\S]{0,120}width: var\(--kotak-nilai\)/,
+      "kotak angka"],
+    [/\.cek-isian input\.small-input\.input-waktu \{[\s\S]{0,80}width: var\(--kotak-nilai\)/,
+      "kotak mm:ss"],
+  ];
+  for (const [pola, apa] of perlu) {
+    assert.match(css, pola, `${apa} tidak memakai --kotak-nilai`);
+  }
+});
+
+test("kotak berkriteria banyak boleh menyusut, tidak dilepas dari batasnya", () => {
+  // `max-width: none` di sini berkekhususan 0,4,0 — `:has()` mewarisi
+  // kekhususan argumennya — jadi ia mengalahkan
+  // `.cek-isian .small-input { max-width: 100% }`, dan kelima kotak Pembidaian
+  // bertahan di 114px lalu saling menimpa tanpa satu pun penggulir yang
+  // menandainya. Terukur begitu.
+  const awal = css.indexOf(".cek-angka:has(.isian-baris + .isian-baris) .small-input {");
+  assert.ok(awal > 0, "aturan kotak berkriteria banyak hilang");
+  const aturan = css.slice(awal, css.indexOf("}", awal));
+  assert.doesNotMatch(aturan, /max-width: none/,
+    "max-width: none kembali di kotak berkriteria banyak");
+  assert.doesNotMatch(aturan, /font-size|min-height/,
+    "kotak berkriteria banyak kembali punya ukuran hurufnya sendiri — yang "
+    + "diminta satu ukuran untuk semua pos");
+});
+
+test("panah nomor dada duduk di tepi kartu di HP, dipatok lagi di laptop", () => {
+  const dasar = css.slice(css.indexOf(".cek-dada {"), css.indexOf("}", css.indexOf(".cek-dada {")));
+  assert.doesNotMatch(dasar, /max-width/,
+    "patokan lebar kembali di .cek-dada, dan panahnya berhenti 13px sebelum "
+    + "tepi kartu");
+  const satuLayar = css.slice(css.indexOf("@media (min-width: 1000px)"));
+  assert.match(satuLayar, /\.isi\.cek \.cek-dada \{ max-width: 11rem; \}/,
+    "patokan lebar hilang di tata letak satu-layar, tempat kartunya sebaris "
+    + "dan kotak yang melebar mendorong identitas regu keluar baris");
+});
+
+test("menu bawah tidak dihitami browser saat disentuh", () => {
+  // Bawaan HP menyiram SELURUH tombol dengan rgba(0,0,0,.18); item bar ini
+  // tidak punya latar sendiri, jadi yang muncul kotak abu 95x50 di sekeliling
+  // ikon 35x26. Dilaporkan begitu.
+  const nav = css.slice(css.indexOf(".bottom-nav-item {"));
+  assert.match(nav.slice(0, nav.indexOf("}")), /-webkit-tap-highlight-color: transparent;/,
+    "menu bawah kembali memakai kotak sentuh bawaan browser");
+  assert.match(css, /\.bottom-nav-item:active \.bottom-nav-icon \{/,
+    "tidak ada umpan balik sentuh yang menggantikannya");
+  assert.doesNotMatch(css, /\.bottom-nav-item:hover/,
+    "umpan balik memakai :hover, yang menempel di Safari iOS sampai sesuatu "
+    + "yang lain disentuh");
+});
+
 test("menu bawah tetap sasaran sentuh yang sah sesudah dirampingkan", () => {
   // 48px masih di atas 44px, batas yang dipakai iOS maupun Android. Di bawah
   // itu perampingan berhenti jadi perampingan.

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 47, sidik: "cfd574db2e17" },
+  "style.css": { versi: 48, sidik: "a12045e9bbdb" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=45">
+  <link rel="stylesheet" href="style.css?v=46">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -8120,8 +8120,8 @@ const posUntukAkun = (s, semuaPos) => {
 const kartuReguNilai = (r, { ringkas = false } = {}) => (ringkas ? `
   <div class="card card-identity identitas-sebaris" style="margin:0">
     ${html`<span class="nama">${dada3(r.nomor_dada)} · ${r.nama_regu}</span><span
-      class="detail"> · ${r.nama_sekolah} · ${
-      GOLONGAN_LABEL[r.golongan] || r.golongan}</span>`}
+      class="detail"> · ${r.nama_sekolah}<span class="identitas-golongan"> · ${
+      GOLONGAN_LABEL[r.golongan] || r.golongan}</span></span>`}
   </div>` : `
   <div class="card card-identity" style="margin:0">
     ${html`<div class="nama">${dada3(r.nomor_dada)} · ${r.nama_regu}</div>

--- a/web/style.css
+++ b/web/style.css
@@ -3235,8 +3235,23 @@ button.pill-number:hover { filter: brightness(.95); }
        kedua yang tidak akan pernah ada. 1.5 bawaan menyisakan 5px kosong di
        atas dan di bawah "Home". */
     line-height: 1.15;
+    /* TANPA KOTAK HITAM SAAT DISENTUH. Bawaan browser HP menyiram SELURUH
+       tombol dengan rgba(0,0,0,.18) begitu jari menyentuhnya — di tombol
+       berlatar sendiri itu nyaris tidak terlihat, tapi item bar ini tidak
+       punya latar, jadi yang muncul kotak abu 95x50 di sekeliling ikon 35x26.
+       Dilaporkan begitu: "malah muncul block kotak besar". */
+    -webkit-tap-highlight-color: transparent;
     cursor: pointer;
   }
+  /* Yang menggantikannya: pil ikonnya menua selagi ditekan, sebesar pil
+     penanda halaman yang sedang dibuka — jadi umpan baliknya memakai bentuk
+     yang sudah ada di bar ini, bukan bentuk baru.
+
+     `:active`, BUKAN `:hover`. Safari iOS menempelkan `:hover` pada elemen
+     yang terakhir disentuh dan menahannya sampai sesuatu yang lain disentuh
+     (alasan lengkapnya di `.button-secondary`), jadi hover di sini akan
+     meninggalkan pil yang menyala di menu yang barusan ditekan. */
+  .bottom-nav-item:active .bottom-nav-icon { background: var(--garis); }
   .bottom-nav-icon {
     font-size: 1rem; line-height: 1;
     display: inline-flex; align-items: center; justify-content: center;
@@ -5116,8 +5131,15 @@ button.pill-number:hover { filter: brightness(.95); }
   flex: 0 0 auto; width: auto; min-width: 3.4rem;
   font-size: 1.5rem; line-height: 1; padding: .2rem .6rem;
 }
+/* TANPA PATOKAN LEBAR DI HP, jadi kotaknya melebar sampai kedua panah duduk
+   tepat di tepi kartunya — sejajar dengan dropdown pos di atasnya dan dengan
+   kotak nilai di kartu bawahnya. Patokan 11rem membuat keduanya berhenti 13px
+   sebelum tepi, dan dari layar itu terbaca seperti baris yang salah lebar.
+   Sasaran sentuh panahnya ikut melebar sekalian, dan panah yang ditekan
+   ratusan kali sepagi memang tempatnya di tepi tempat jempol berada.
+   Di laptop patokannya kembali — lihat blok satu-layar. */
 .cek-dada {
-  flex: 1 1 auto; min-width: 0; max-width: 11rem; min-height: 46px;
+  flex: 1 1 auto; min-width: 0; min-height: 46px;
   text-align: center; font-size: 1.45rem; font-weight: 700;
   letter-spacing: .05em; font-variant-numeric: tabular-nums;
 }
@@ -5161,6 +5183,20 @@ button.pill-number:hover { filter: brightness(.95); }
 .card-identity.identitas-sebaris { padding: .45rem .6rem; line-height: 1.3; }
 .identitas-sebaris .nama    { font-size: 1rem; font-weight: 800; }
 .identitas-sebaris .detail  { font-size: .85rem; margin-top: 0; }
+/* DI HP GOLONGANNYA DIBUANG, dan ia yang dibuang karena ia yang paling sedikit
+   menjawab: kartu ini ada untuk satu pertanyaan — "nomor yang barusan saya
+   ketik ini benar regu yang berdiri di depan saya?" — dan nomor dada, nama
+   regu, serta nama sekolah sudah menjawabnya. Golongan sendiri sudah terbaca
+   dari nomor dadanya.
+
+   Yang dibeli 82px, dan itu selisih antara sebaris dan dua baris untuk
+   sebagian besar sekolah: dengan golongan, isi 333px cukup untuk nama sekolah
+   sampai ~17 huruf (median daftar kurasi); tanpa golongan sampai ~28, yang
+   mencakup sembilan dari sepuluh. Di laptop ruangnya tidak pernah kurang,
+   jadi di sana golongannya tetap. */
+@media (max-width: 560px) {
+  .identitas-sebaris .identitas-golongan { display: none; }
+}
 /* SATU BARIS: kotak isian, lambang simpan, lambang gembok — berurutan sesuai
    cara dipakainya (baca angkanya, betulkan, simpan, gembok).
 
@@ -5291,9 +5327,27 @@ button.pill-number:hover { filter: brightness(.95); }
   align-items: flex-end; gap: .3rem;
   flex: 0 1 auto; min-width: 0;
 }
+/* SATU UKURAN KOTAK NILAI, SEMUA POS — dan patokannya lomba soal, "Kesehatan"
+   di Pos 2 (keputusan pemilik acara, 1 September 2026: "tidak terlalu besar /
+   kecil"). Terukur di HP 393px: 114 x 60.
+
+   Sebelumnya tiap lomba dapat ukuran sendiri karena tidak ada satu pun yang
+   MENYEBUT lebarnya — yang dipakai lebar bawaan kotaknya, dan browser
+   menurunkan itu dari isinya. Hasilnya lima ukuran berbeda dalam satu layar:
+   Bakiak 168 (kotak mm:ss punya aturan sendiri), Menaksir 152 (mentok
+   max-width), Kesehatan 114, Semaphore 99 — `input[type=number]` melebar
+   mengikuti jumlah digit `max`, dan Semaphore maksimal 5 sedangkan Kesehatan
+   10 — dan PBB 456 di laptop, karena satu lomba mendapat seluruh lebar kartu.
+
+   Jadi lebarnya disebut SEKALI di sini dan dipakai di ketiga tempat yang
+   membutuhkannya. Kotak yang tidak muat tetap mengalah: lima kriteria
+   Pembidaian tidak akan pernah muat 114px berjajar di layar 393px — itu
+   aritmetika, bukan pilihan — jadi `flex-shrink` mengecilkannya, dan
+   `max-width: 100%` menahan kotaknya ikut menyusut bersama barisnya. */
+.cek-isian { --kotak-nilai: 7.1rem; }
 .cek-isian .isian-baris {
   border: 0; padding: 0; gap: .15rem;
-  flex: 1 1 0; min-width: 0;
+  flex: 0 1 var(--kotak-nilai); min-width: 0;
 }
 /* Nama kriteria mengecil dan boleh membungkus: ia yang paling panjang
    ("Diagnosis dan Penanganan Awal") dan paling jarang dibaca ulang — yang
@@ -5306,37 +5360,40 @@ button.pill-number:hover { filter: brightness(.95); }
   font-size: .62rem; line-height: 1.1;
   overflow-wrap: anywhere; hyphens: auto;
 }
-/* SATU KRITERIA DAPAT KOTAK LEBIH LEBAR. Tidak ada yang berebut tempat di
-   barisnya, dan angka yang dibaca ratusan kali sepagi lebih murah dibaca di
-   kotak besar. Lomba berkriteria banyak mengecil di aturan berikutnya, karena
-   di sana lima kotak harus muat berjajar. */
 .cek-isian .small-input {
   font-size: 1.6rem; min-height: 58px;
-  width: 100%; min-width: 0; max-width: 9.5rem;
+  width: var(--kotak-nilai); min-width: 0; max-width: 100%;
 }
-/* KOTAK mm:ss LEBIH LEBAR DARI KOTAK ANGKA, bukan lebih sempit.
+/* KOTAK mm:ss SELEBAR KOTAK ANGKA, tidak lebih dan tidak kurang.
    `input.small-input.input-waktu { width: 5.6rem }` di bagian tabel menang
-   atas `.cek-isian .small-input { width: 100% }` — kekhususan 0,2,1 lawan
-   0,2,0 — jadi "00:13" berdiri di kotak 90px sementara angka satu digit di
-   lomba sebelahnya dapat 152px. Terbalik: yang isinya lima huruf justru yang
-   paling sempit, dan di HP isinya terpotong.
+   atas `.cek-isian .small-input` — kekhususan 0,2,1 lawan 0,2,0 — jadi tanpa
+   baris ini "00:13" mendapat lebar yang bukan lebar siapa pun di layar ini.
 
    Yang dilakukan MENGALAHKAN aturan itu di sini, bukan menambah aturan untuk
    membatalkannya di tempat lain (CLAUDE.md 15.12) — 5.6rem tetap benar untuk
-   lembar pos, tempat satu baris memuat belasan kolom. */
-.cek-isian input.small-input.input-waktu { width: 100%; max-width: 10.5rem; }
-/* Lomba berkriteria BANYAK: yang mengalah LEBAR kotaknya, bukan besar
-   angkanya. Lima kotak tidak akan pernah muat selebar kotak tunggal di layar
-   430px — itu aritmetika, bukan pilihan — tapi angka DI DALAMNYA tidak punya
-   alasan ikut mengecil, dan angka itulah yang dicocokkan dengan tulisan
-   tangan di foto.
+   lembar pos, tempat satu baris memuat belasan kolom.
 
-   Jadi hurufnya hampir sebesar kotak tunggal dan paddingnya yang dirampingkan:
-   12px kiri-kanan pada kotak selebar 52px berarti separuh kotaknya kosong.
-   Nilai kriteria selalu dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang
-   dibebaskan padding memang jatuh ke angkanya. */
+   Sempat 10.5rem, karena 5.6rem memang terlalu sempit untuk lima huruf. Itu
+   mengayun terlalu jauh ke arah sebaliknya: 168px di sebelah 114px, dan yang
+   isinya paling sedikit berubah justru yang paling besar. "00:13" pada
+   1.6rem butuh ~99px, jadi 7.1rem cukup. */
+.cek-isian input.small-input.input-waktu {
+  width: var(--kotak-nilai); max-width: 100%;
+}
+/* Lomba berkriteria BANYAK: yang mengalah PADDING-nya, bukan ukuran kotaknya
+   maupun besar angkanya. Lima kotak tidak akan pernah muat 114px berjajar di
+   layar 393px, jadi `flex-shrink` membawanya turun ke 58px — dan 12px kiri
+   kanan pada kotak 58px berarti separuh kotaknya kosong. Nilai kriteria selalu
+   dua digit (Pembidaian 0-25, PBB 0-30), jadi ruang yang dibebaskan padding
+   memang jatuh ke angkanya.
+
+   TIDAK ADA `max-width: none` di sini lagi, dan itu bukan kerapian: aturan ini
+   berkekhususan 0,4,0 — `:has()` mewarisi kekhususan argumennya, dan
+   `.isian-baris + .isian-baris` sendiri sudah 0,2,0 — jadi ia mengalahkan
+   `.cek-isian .small-input { max-width: 100% }`. Dengan `none` kelima kotak
+   Pembidaian bertahan di 114px, meluap keluar barisnya dan saling menimpa,
+   tanpa satu pun penggulir yang menandainya. Terukur begitu. */
 .cek-angka:has(.isian-baris + .isian-baris) .small-input {
-  font-size: 1.5rem; min-height: 56px; max-width: none;
   padding-left: .25rem; padding-right: .25rem;
 }
 /* Jarak antar kotak dirapatkan di baris berkriteria banyak: .3rem x 4 celah
@@ -5506,6 +5563,11 @@ button.pill-number:hover { filter: brightness(.95); }
   .isi.cek .baris-pilih { margin: 0; }
   .isi.cek .cek-navigasi { margin: 0; }
   .isi.cek .cek-kendali .baris-pilih .field { margin-bottom: 0; }
+  /* Patokan lebar nomor dada, yang di HP sengaja tidak ada supaya panahnya
+     duduk di tepi kartu. Di sini kartunya sebaris — pemilih pos, panah, nomor
+     dada, identitas regu — dan kotak yang melebar sebebasnya akan mendorong
+     identitas regunya keluar baris. */
+  .isi.cek .cek-dada { max-width: 11rem; }
   /* `.isi.cek > .card`, BUKAN `:first-of-type`. Saudara pertama di dalam
      .isi adalah <div id="pita-antrean">, dan `div:first-of-type` menunjuk
      DIA — bukan kartu ini — jadi aturannya tidak pernah mengenai apa pun dan


### PR DESCRIPTION
## What

**Every value box is the same size**, and that size is Kesehatan at Pos 2 —
the one picked as neither too big nor too small. Measured on a 393px phone,
before → after:

| Lomba | before | after |
| --- | --- | --- |
| Bakiak / Lari Balok / Balap Karung (mm:ss) | 168 | 114 |
| Menaksir | 152 | 114 |
| Kesehatan / Pengetahuan Umum / Keagamaan / Kepramukaan / Kim / Logika | 114 | 114 |
| Semaphore / Tebak Simpul | 99 | 114 |
| PBB / Yel-Yel (4 kriteria) | 73 | 73 |
| Pembidaian (5 kriteria) | 58 | 58 |

On a laptop the same rule takes PBB and Yel-Yel down from **456px** to 114.

**On a phone both arrows now sit flush with the card edge**, level with the
pos dropdown above them and the value box below, instead of stopping 13px
short. The nomor dada box fills what is left.

**Tapping a bottom nav item no longer paints a grey block over it.**

**The golongan leaves the identity card below 561px**, so it reads
`007 · RANCAKA · MA PUI Cijantung`.

## Why

Nothing named a box width, so the browser derived each one from its own
content — five different widths on one screen, none of them chosen.
`input[type=number]` widens with the digit count of its `max` attribute,
which is why Semaphore (max 5) came out narrower than Kesehatan (max 10);
the mm:ss box had a rule of its own; and a pos with a single lomba handed
its whole card width to four boxes. The width is now named once,
`--kotak-nilai: 7.1rem`, and used in the three places that need it.

Bottom nav items have no background of their own, so the browser's default
tap highlight of `rgba(0,0,0,.18)` across the whole button showed up as a
95×50 slab around a 35×26 icon.

The golongan is the least informative of the four fields — the nomor dada
already implies it — and the 82px it frees is the difference between one line
and two for nine schools in ten (median curated name is 17 characters, p90 is
28).

## Notes

- Boxes that cannot fit still give way: five Pembidaian criteria will never
  sit at 114px across a 393px screen, so `flex-shrink` takes them to 58 and
  `max-width` keeps them inside their row. That is why `max-width: none` had
  to go from the many-criteria rule — `:has()` inherits its argument's
  specificity, so at 0,4,0 it beat the `100%` and the five boxes stayed 114px,
  overlapping each other with no scrollbar to show for it. Measured.
- The arrow cap comes back in the one-screen layout, where the card is a
  single row and a box free to grow would push the regu identity out of it.
- The press feedback uses `:active`, not `:hover`, which sticks on Safari iOS
  until something else is touched.
- Opened at 360, 393, 700 and 1440px against a local database seeded for all
  five pos: no horizontal overflow anywhere, no vertical scroll on the laptop
  layout, photos still 434–491px tall. 394 tests pass.
