### PR TITLE
fix: three small corrections asked for on three screens

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=48">
+  <link rel="stylesheet" href="style.css?v=49">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3151,16 +3151,29 @@ button.pill-number:hover { filter: brightness(.95); }
   .table-toolbar { flex-direction: column; align-items: stretch; }
   .table-count { text-align: right; }
 
-  /* KETIGA CHIP SATU BARIS. Dengan label panjang mereka membungkus jadi dua
-     baris — dan baris kedua yang cuma berisi "Semua" terbaca seperti tombol
-     yang berdiri sendiri, bukan seperti pilihan ketiga dari tiga.
+  /* CHIP TETAP SATU BARIS. Baris kedua yang cuma berisi "Semua" terbaca
+     seperti tombol yang berdiri sendiri, bukan seperti pilihan terakhir dari
+     empat — itu yang dihindari `nowrap` sejak awal, dan itu masih benar.
 
-     `nowrap` saja tidak cukup: chipnya akan meluap keluar kartu. Yang
-     memuatkannya label pendek — "Belum lengkap" jadi "Belum". Kata yang
-     dibuang bisa ditebak dari kolom yang sedang disaring, dan chip yang
-     menyala tetap menyebut keadaannya. */
+     YANG BERUBAH cuma batas bawah perasannya. `min-width: 0` membiarkan chip
+     diperas sampai kotak isinya NOL, dan tulisan yang tidak muat tidak ikut
+     mengecil — ia tercetak menembus padding kanannya. Terlihat di lembar
+     Input Pos, yang punya EMPAT chip tanpa label pendek: "Lengkap" dan
+     "Semua" menabrak tepi chipnya sendiri. Dilaporkan begitu, 1 September
+     2026.
+
+     `min-content` = selebar KATA TERPANJANG di dalamnya, jadi label dua kata
+     boleh membungkus di dalam chipnya ("Belum" di atas "Input") sementara
+     kata tunggal tidak pernah dipaksa lebih sempit daripada dirinya sendiri.
+     Terukur di 393px: keempat chip berjumlah 286px dari 345px yang ada, jadi
+     barisnya tetap satu. Meja Pembayaran dan Meja Daftar Ulang tidak berubah
+     sama sekali — label pendeknya sudah jauh lebih sempit daripada batas
+     ini. */
   .filter-row { flex-wrap: nowrap; }
-  .filter-row .option-small { flex: 1 1 auto; min-width: 0; padding-left: .5rem; padding-right: .5rem; }
+  .filter-row .option-small {
+    flex: 1 1 auto; min-width: min-content;
+    padding-left: .5rem; padding-right: .5rem;
+  }
   .saring-panjang { display: none; }
   .saring-pendek  { display: inline; }
 
@@ -5180,7 +5193,13 @@ button.pill-number:hover { filter: brightness(.95); }
    Nomor dadanya tetap ditulis walaupun kotak navigasi di atasnya sudah
    memuatnya besar-besar: yang satu apa yang DIKETIK, yang satu apa yang
    DITEMUKAN, dan seluruh guna kartu ini membandingkan keduanya. */
-.card-identity.identitas-sebaris { padding: .45rem .6rem; line-height: 1.3; }
+/* RATA TENGAH, sejajar dengan nomor dada besar di kotak navigasi tepat di
+   atasnya dan dengan judul lomba di kartu bawahnya — ketiganya menjawab
+   pertanyaan yang sama dan mata membacanya berurutan dari atas ke bawah di
+   satu garis. Rata kiri membuat yang tengah sendiri melompat ke tepi. */
+.card-identity.identitas-sebaris {
+  padding: .45rem .6rem; line-height: 1.3; text-align: center;
+}
 .identitas-sebaris .nama    { font-size: 1rem; font-weight: 800; }
 .identitas-sebaris .detail  { font-size: .85rem; margin-top: 0; }
 /* DI HP GOLONGANNYA DIBUANG, dan ia yang dibuang karena ia yang paling sedikit

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 48, sidik: "a12045e9bbdb" },
+  "style.css": { versi: 49, sidik: "ebed55ffa3f3" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=46">
+  <link rel="stylesheet" href="style.css?v=47">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -518,7 +518,7 @@ async function layarHome() {
             sesi().pos != null && sesi().pos !== "" ? ` ${esc(sesi().pos)}` : ""}</div>
         </a>
         <a href="#/foto">
-          <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban</div>
+          <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban Sekaligus</div>
         </a>
         ${bolehLihat("live_score") ? `
         <a href="#/live-score">
@@ -618,7 +618,7 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/foto">
-        <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban</div>
+        <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban Sekaligus</div>
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/pos2">
@@ -7293,8 +7293,8 @@ async function layarAkun() {
    yang tidak terlihat adalah antrean yang tidak pernah dikerjakan.
    ========================================================================= */
 async function layarFoto() {
-  if (!EDISI) { layarButuhEdisi("Foto Jawaban"); return; }
-  pasangKepala("Foto Jawaban", true);
+  if (!EDISI) { layarButuhEdisi("Foto Jawaban Sekaligus"); return; }
+  pasangKepala("Foto Jawaban Sekaligus", true);
   LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;

--- a/web/style.css
+++ b/web/style.css
@@ -3151,16 +3151,29 @@ button.pill-number:hover { filter: brightness(.95); }
   .table-toolbar { flex-direction: column; align-items: stretch; }
   .table-count { text-align: right; }
 
-  /* KETIGA CHIP SATU BARIS. Dengan label panjang mereka membungkus jadi dua
-     baris — dan baris kedua yang cuma berisi "Semua" terbaca seperti tombol
-     yang berdiri sendiri, bukan seperti pilihan ketiga dari tiga.
+  /* CHIP TETAP SATU BARIS. Baris kedua yang cuma berisi "Semua" terbaca
+     seperti tombol yang berdiri sendiri, bukan seperti pilihan terakhir dari
+     empat — itu yang dihindari `nowrap` sejak awal, dan itu masih benar.
 
-     `nowrap` saja tidak cukup: chipnya akan meluap keluar kartu. Yang
-     memuatkannya label pendek — "Belum lengkap" jadi "Belum". Kata yang
-     dibuang bisa ditebak dari kolom yang sedang disaring, dan chip yang
-     menyala tetap menyebut keadaannya. */
+     YANG BERUBAH cuma batas bawah perasannya. `min-width: 0` membiarkan chip
+     diperas sampai kotak isinya NOL, dan tulisan yang tidak muat tidak ikut
+     mengecil — ia tercetak menembus padding kanannya. Terlihat di lembar
+     Input Pos, yang punya EMPAT chip tanpa label pendek: "Lengkap" dan
+     "Semua" menabrak tepi chipnya sendiri. Dilaporkan begitu, 1 September
+     2026.
+
+     `min-content` = selebar KATA TERPANJANG di dalamnya, jadi label dua kata
+     boleh membungkus di dalam chipnya ("Belum" di atas "Input") sementara
+     kata tunggal tidak pernah dipaksa lebih sempit daripada dirinya sendiri.
+     Terukur di 393px: keempat chip berjumlah 286px dari 345px yang ada, jadi
+     barisnya tetap satu. Meja Pembayaran dan Meja Daftar Ulang tidak berubah
+     sama sekali — label pendeknya sudah jauh lebih sempit daripada batas
+     ini. */
   .filter-row { flex-wrap: nowrap; }
-  .filter-row .option-small { flex: 1 1 auto; min-width: 0; padding-left: .5rem; padding-right: .5rem; }
+  .filter-row .option-small {
+    flex: 1 1 auto; min-width: min-content;
+    padding-left: .5rem; padding-right: .5rem;
+  }
   .saring-panjang { display: none; }
   .saring-pendek  { display: inline; }
 
@@ -5180,7 +5193,13 @@ button.pill-number:hover { filter: brightness(.95); }
    Nomor dadanya tetap ditulis walaupun kotak navigasi di atasnya sudah
    memuatnya besar-besar: yang satu apa yang DIKETIK, yang satu apa yang
    DITEMUKAN, dan seluruh guna kartu ini membandingkan keduanya. */
-.card-identity.identitas-sebaris { padding: .45rem .6rem; line-height: 1.3; }
+/* RATA TENGAH, sejajar dengan nomor dada besar di kotak navigasi tepat di
+   atasnya dan dengan judul lomba di kartu bawahnya — ketiganya menjawab
+   pertanyaan yang sama dan mata membacanya berurutan dari atas ke bawah di
+   satu garis. Rata kiri membuat yang tengah sendiri melompat ke tepi. */
+.card-identity.identitas-sebaris {
+  padding: .45rem .6rem; line-height: 1.3; text-align: center;
+}
 .identitas-sebaris .nama    { font-size: 1rem; font-weight: 800; }
 .identitas-sebaris .detail  { font-size: .85rem; margin-top: 0; }
 /* DI HP GOLONGANNYA DIBUANG, dan ia yang dibuang karena ia yang paling sedikit


### PR DESCRIPTION
## What

**Cek Nilai** — the identity line is centred.

**Input Nilai Pos** — "Lengkap" and "Semua" no longer print through their own
right padding.

**Home** — the bulk photo screen is now called **Foto Jawaban Sekaligus**, on
the tile and in its own header.

## Why

The identity line sits between the big nomor dada in the navigation box above
it and the lomba title in the card below, both centred; left-aligned, the
middle one of the three jumped to the edge.

`min-width: 0` let a filter chip be squeezed until its content box was zero,
and text that does not fit does not shrink with it. Input Nilai Pos is the
sheet with **four** chips and no short labels, so it squeezed further than the
three-chip tables the rule was written for. `min-content` stops the squeeze at
the longest word inside the chip: two-word labels wrap inside their own chip,
single words are never forced narrower than themselves.

Input Nilai Pos v2 photographs one regu at a time and calls that "Foto
Jawaban" too. The extra word is what tells the two apart.

## Notes

- Measured at 393px: the four chips come to 286px of the 345px available, so
  the row is still one row — the second row holding only "Semua" is what
  `nowrap` was there to prevent, and it still does. Meja Pembayaran and Meja
  Daftar Ulang are unchanged down to 320px.
- 395 tests pass.
