### PR TITLE
fix: the riwayat link opens, and the departure window sits on one row

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=49">
+  <link rel="stylesheet" href="style.css?v=50">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -394,6 +394,14 @@ input.jam-ketik {
    Hanya di sini. Kotak jam lain — Keberangkatan, Kedatangan, dialog koreksi —
    berdiri di sebelah teks yang rata kiri, dan menengahkan yang di sana justru
    melepasnya dari barisnya. */
+/* DUA KOLOM DI LEBAR BERAPA PUN, termasuk HP. `.two-column` biasa runtuh jadi
+   satu kolom di bawah 640px, dan untuk sepasang isian yang tidak berhubungan
+   itu benar. Kedua kotak ini berhubungan: mereka dua ujung dari SATU jendela
+   keberangkatan, dan bertumpuk mereka terbaca seperti dua setelan terpisah —
+   sekaligus memakan dua kali tingginya di layar yang isinya justru daftar
+   kloter di bawahnya. Kekhususan 0,2,0 mengalahkan aturan 640px yang 0,1,0,
+   jadi urutannya di berkas ini tidak menentukan apa pun. */
+.two-column.planning-jam { grid-template-columns: 1fr 1fr; gap: .5rem; }
 .planning-jam { text-align: center; }
 .planning-jam .field label { text-align: center; }
 
@@ -933,7 +941,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   max-height: 90vh; overflow-y: auto;
   box-shadow: 0 10px 40px rgba(0,0,0,.3);
 }
-.dialog h2 { margin-bottom: .8rem; }
+/* UKURANNYA DISEBUT, tidak dibiarkan bawaan browser. `h2` bawaan 1.5em =
+   24px tebal, dan pada lebar HP judul "Riwayat HRCD37-2B8582" menuntut lebih
+   dari 284px yang tersedia di dalam dialog — jadi ia patah dua baris, tepat di
+   tanda hubung kode bayarnya. 1.2rem membuatnya 223px dan muat sebaris,
+   sekaligus sejajar dengan `.card h2` yang 1.1rem: judul di dalam dialog tidak
+   punya alasan lebih besar daripada judul kartu di layar di belakangnya. */
+.dialog h2 { font-size: 1.2rem; margin-bottom: .8rem; }
 /* Tanpa <h2>, isi pertama dialog naik ke tepi atas dan bertemu silang tutup
    yang duduk di pojok kanan. Padding ini yang memberinya jalan. */
 .dialog-tanpa-judul { padding-top: 2.6rem; }

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 49, sidik: "ebed55ffa3f3" },
+  "style.css": { versi: 50, sidik: "cd7598d8c2aa" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/time_input_labels.test.mjs
+++ b/tests/time_input_labels.test.mjs
@@ -12,8 +12,8 @@ test("semua label kotak jam manual menunjuk input HH", () => {
   const pasangan = [
     ["kloter-pertama", "Waktu Berangkat Pertama"],
     ["kloter-terakhir", "Waktu Berangkat Terakhir"],
-    ["planning-pertama", "Rencana Berangkat Pertama"],
-    ["planning-terakhir", "Rencana Berangkat Terakhir"],
+    ["planning-pertama", "Jam Berangkat Pertama"],
+    ["planning-terakhir", "Jam Berangkat Terakhir"],
     ["jam-berangkat", "Jam berangkat"],
     ["jam", "Jam datang"],
   ];

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=47">
+  <link rel="stylesheet" href="style.css?v=48">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -997,18 +997,33 @@ const TABEL_RIWAYAT = {
 };
 
 /** JSON apa adanya tidak dibaca orang: null jadi "—", daftar anggota jadi
- *  kalimat, dan boolean jadi kata. */
+ *  kalimat, dan boolean jadi kata.
+ *
+ *  MENGEMBALIKAN HTML, BUKAN TEKS, jadi ia yang meng-escape isinya sendiri —
+ *  seluruh jalur keluar di bawah lewat esc(). Nama anggota diketik orang luar
+ *  (lihat kepala util.js), dan satu jalur yang lupa di-escape di sini adalah
+ *  XSS tersimpan di layar panitia. */
 function nilaiRiwayat(v) {
   if (v === null || v === undefined) return "—";
-  if (Array.isArray(v)) return v.length ? v.join(", ") : "—";
+  if (Array.isArray(v)) return v.length ? esc(v.join(", ")) : "—";
   if (typeof v === "boolean") return v ? "ya" : "tidak";
   const t = String(v);
   if (t === "") return "—";
-  // Tautan bukti transfer ditulis "(tautan)", bukan alamatnya. Alamat Drive
-  // panjangnya 60 huruf dan tidak satu pun di antaranya menjawab pertanyaan
-  // yang sedang ditanyakan — sedangkan tombol yang MEMBUKA tautan itu ada di
-  // baris yang riwayatnya sedang dibaca.
-  return /^https?:\/\//.test(t) ? "(tautan)" : t;
+  /* Link bukti transfer ditulis "(link)", bukan alamatnya: alamat Drive
+     panjangnya 60 huruf dan tidak satu pun di antaranya menjawab pertanyaan
+     yang sedang ditanyakan.
+
+     TAPI SEKARANG BISA DIKETUK. Sebelumnya ia tulisan mati, dan tombol yang
+     membuka bukti itu memang ada di baris tabelnya — tetapi baris riwayat
+     yang sedang dibaca justru menyebut bukti yang DULU dipasang, yang bisa
+     berbeda dari yang berlaku sekarang. Satu-satunya cara melihat yang
+     disebut riwayat adalah membukanya dari riwayat.
+
+     "link", bukan "tautan": kata yang memang diucapkan panitia
+     (CLAUDE.md 5.7). */
+  return /^https?:\/\//.test(t)
+    ? `<a href="${esc(t)}" target="_blank" rel="noopener">(link)</a>`
+    : esc(t);
 }
 
 /** Satu baris riwayat jadi satu atau beberapa <li>.
@@ -1032,12 +1047,15 @@ function liRiwayat(b) {
     </li>`;
   }
 
+  /* Template BIASA, bukan html`` — nilaiRiwayat() sudah mengembalikan HTML
+     (link bukti transfer bisa diketuk), dan tag html`` akan meng-escape-nya
+     jadi tulisan `<a href=...>`. Yang lain tetap lewat esc() satu per satu. */
   const ubah = b.perubahan || {};
-  return Object.keys(ubah).map(k => html`<li>
-    <span class="r-lomba">${LABEL_RIWAYAT[k] || k}</span>
+  return Object.keys(ubah).map(k => `<li>
+    <span class="r-lomba">${esc(LABEL_RIWAYAT[k] || k)}</span>
     <span class="r-nilai">${nilaiRiwayat(ubah[k].lama)} →
       <strong>${nilaiRiwayat(ubah[k].baru)}</strong></span>
-    <span class="r-oleh">${oleh}</span>
+    <span class="r-oleh">${esc(oleh)}</span>
   </li>`).join("");
 }
 
@@ -1081,7 +1099,13 @@ async function bukaRiwayatPendaftaran(kode) {
 
   const isi = baris.map(liRiwayat).join("");
   await dialog({
-    judul: `Riwayat ${kode}`,
+    /* TANDA HUBUNG YANG TIDAK BOLEH DIPATAH (U+2011). Kode bayar berbentuk
+       "HRCD37-2B8582", dan tanda hubung biasa adalah tempat pemenggalan baris
+       yang sah — jadi judulnya patah jadi "Riwayat HRCD37-" di baris pertama
+       dan "2B8582" di baris kedua, dan dari layar itu terbaca seperti dua
+       kode. Rupanya sama persis; yang berbeda cuma ia tidak bisa dijadikan
+       tempat patah. */
+    judul: `Riwayat ${kode.replace(/-/g, "‑")}`,
     kartuHtml: isi
       ? `<ul class="riwayat riwayat-pendaftaran">${isi}</ul>`
       : `<p class="description">Belum pernah diubah.</p>`,
@@ -2726,20 +2750,25 @@ async function layarCetakKloter() {
            di bawah membuat petugas menekan Cetak lebih dulu, lalu menemukan
            kotak jamnya sesudah kertasnya keluar.
 
+           SEBARIS BERDUA, kiri dan kanan, di lebar berapa pun. Keduanya dua
+           ujung dari SATU jendela — yang diatur bukan dua jam melainkan
+           rentangnya — dan bertumpuk mereka terbaca seperti dua setelan yang
+           tidak berhubungan, sekaligus memakan dua kali tingginya di HP.
+
            TANPA judul dan TANPA paragraf penjelas. Labelnya sendiri sudah
-           menyebut "Rencana Berangkat", jadi judul di atasnya cuma mengulang
+           menyebut jamnya, jadi judul di atasnya cuma mengulang
            label yang ada di bawahnya (pasal 9.3),
            dan kalimat "jam ini dibagi rata lalu tercetak untuk peserta"
            menjelaskan sesuatu yang terlihat sendiri begitu jamnya diubah
            sekali (pasal 9.1 dan 9.6). -->
       <div class="two-column planning-jam" style="margin-top:1rem">
         <div class="field">
-          <label for="planning-pertama-hh">Rencana Berangkat Pertama</label>
+          <label for="planning-pertama-hh">Jam Berangkat Pertama</label>
           ${kotakJamHtml("planning-pertama", jamPendek(
             cfg.planning_berangkat_pertama || cfg.jam_mulai_berangkat))}
         </div>
         <div class="field">
-          <label for="planning-terakhir-hh">Rencana Berangkat Terakhir</label>
+          <label for="planning-terakhir-hh">Jam Berangkat Terakhir</label>
           ${kotakJamHtml("planning-terakhir", jamPendek(
             cfg.planning_berangkat_terakhir || cfg.jam_batas_berangkat))}
         </div>
@@ -4692,7 +4721,7 @@ async function layarInputPos() {
               ? `<a class="fg-petak" href="${esc(url)}" target="_blank" rel="noopener"
                     title="${esc(judul)}">
                    <img src="${esc(url)}" alt="${esc(judul)}" loading="lazy"></a>`
-              : `<span class="fg-petak fg-kosong">tautan gagal</span>`}
+              : `<span class="fg-petak fg-kosong">link gagal</span>`}
             <button type="button" class="fg-hapus" data-hapus
                     title="Hapus foto ${esc(String(ke))}"
                     aria-label="Hapus foto ${esc(String(ke))} ${esc(namaLomba)}"
@@ -8605,7 +8634,7 @@ async function gambarLombaNilai(l) {
           ? `<a class="foto-tautan" href="${esc(url)}" target="_blank" rel="noopener"
                 title="${esc(judul)}"><img src="${esc(url)}" alt="${esc(judul)}"
                 loading="lazy"></a>`
-          : `<span class="foto-tautan foto-lembar-kosong">tautan gagal</span>`}
+          : `<span class="foto-tautan foto-lembar-kosong">link gagal</span>`}
         ${silang}
       </div>`;
     }).join("")));
@@ -9657,7 +9686,7 @@ async function layarCekNilai() {
       el.replaceChildren(h(milik.map((f, i) => {
         const url = peta[f.path];
         const judul = `Foto ${i + 1}${f.diunggah_pada ? ` · ${tanggalJam(f.diunggah_pada)}` : ""}`;
-        if (!url) return `<span class="fg-petak fg-kosong">tautan gagal</span>`;
+        if (!url) return `<span class="fg-petak fg-kosong">link gagal</span>`;
         /* Sudutnya dibawa `data-putar`, bukan gaya sebaris: yang memutar CSS,
            dan CSS perlu tahu 90/270 supaya bisa MENUKAR lebar dengan tinggi.
            Gambar yang cuma diputar tanpa ditukar ukurannya meluap keluar

--- a/web/style.css
+++ b/web/style.css
@@ -394,6 +394,14 @@ input.jam-ketik {
    Hanya di sini. Kotak jam lain — Keberangkatan, Kedatangan, dialog koreksi —
    berdiri di sebelah teks yang rata kiri, dan menengahkan yang di sana justru
    melepasnya dari barisnya. */
+/* DUA KOLOM DI LEBAR BERAPA PUN, termasuk HP. `.two-column` biasa runtuh jadi
+   satu kolom di bawah 640px, dan untuk sepasang isian yang tidak berhubungan
+   itu benar. Kedua kotak ini berhubungan: mereka dua ujung dari SATU jendela
+   keberangkatan, dan bertumpuk mereka terbaca seperti dua setelan terpisah —
+   sekaligus memakan dua kali tingginya di layar yang isinya justru daftar
+   kloter di bawahnya. Kekhususan 0,2,0 mengalahkan aturan 640px yang 0,1,0,
+   jadi urutannya di berkas ini tidak menentukan apa pun. */
+.two-column.planning-jam { grid-template-columns: 1fr 1fr; gap: .5rem; }
 .planning-jam { text-align: center; }
 .planning-jam .field label { text-align: center; }
 
@@ -933,7 +941,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   max-height: 90vh; overflow-y: auto;
   box-shadow: 0 10px 40px rgba(0,0,0,.3);
 }
-.dialog h2 { margin-bottom: .8rem; }
+/* UKURANNYA DISEBUT, tidak dibiarkan bawaan browser. `h2` bawaan 1.5em =
+   24px tebal, dan pada lebar HP judul "Riwayat HRCD37-2B8582" menuntut lebih
+   dari 284px yang tersedia di dalam dialog — jadi ia patah dua baris, tepat di
+   tanda hubung kode bayarnya. 1.2rem membuatnya 223px dan muat sebaris,
+   sekaligus sejajar dengan `.card h2` yang 1.1rem: judul di dalam dialog tidak
+   punya alasan lebih besar daripada judul kartu di layar di belakangnya. */
+.dialog h2 { font-size: 1.2rem; margin-bottom: .8rem; }
 /* Tanpa <h2>, isi pertama dialog naik ke tepi atas dan bertemu silang tutup
    yang duduk di pojok kanan. Padding ini yang memberinya jalan. */
 .dialog-tanpa-judul { padding-top: 2.6rem; }


### PR DESCRIPTION
## What

**Riwayat dialog**

- the proof-of-transfer entry is a real link now, and it says **(link)**
  instead of "(tautan)" — the word the panitia actually use (5.7). "tautan
  gagal" follows it to "link gagal" in the three photo grids.
- the title no longer breaks in half. `Riwayat HRCD37-2B8582` stays on one
  line, and the payment code can never be the break point.

**Daftar Kloter**

- the two departure-window boxes sit side by side at every width, and are
  called **Jam Berangkat Pertama** and **Jam Berangkat Terakhir**.

## Why

The button that opens the proof does live on the table row, but the history
line names the proof that was attached *then*, which can differ from the one
in force now — so the only way to see what the history is talking about is to
open it from the history.

`h2` at the browser default of 1.5em needs more than the 284px a phone dialog
has for that title, so it wrapped — and the place it chose was the hyphen
inside the payment code, which read as two codes.

The two departure boxes are the two ends of one window; stacked they read as
two unrelated settings and cost twice the height on the screen whose point is
the kloter list below them.

## Notes

- `nilaiRiwayat()` returns HTML rather than text now, so it escapes every one
  of its own exits — member names are typed by outsiders, and one unescaped
  path there is stored XSS on a panitia screen. Its caller drops the `html`
  tag for the same reason and escapes each field by hand.
- The title is 1.2rem (223px, one line, level with `.card h2` at 1.1rem) and
  the code carries a non-breaking hyphen, which is what holds it together on a
  320px phone where even 1.2rem does not fit on one line.
- **One caveat worth your call:** section 10.6 keeps the *plan* and the
  *record* apart on purpose, and "Rencana" was the word doing that here. The
  kloter cards below still say `Rencana 07:00 · Real 06:51`, so the
  distinction is still on the screen — but if you want the boxes to keep
  saying "Rencana", say so and I will put it back.
- Measured: the two boxes fit side by side down to 320px. 395 tests pass.
