### PR TITLE
fix: fourteen tiles, fourteen colours, and no icon used twice

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=50">
+  <link rel="stylesheet" href="style.css?v=51">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -980,6 +980,22 @@ const IKON = {
     '<path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /> <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />',
   "id-card":
     '<path d="M16 10h2" /> <path d="M16 14h2" /> <path d="M6.17 15a3 3 0 0 1 5.66 0" /> <circle cx="9" cy="11" r="2" /> <rect x="2" y="5" width="20" height="14" rx="2" />',
+  // Dua orang, dipakai ubin Data Peserta. Sebelumnya ubin itu memakai
+  // "id-card" — kartu yang SAMA PERSIS dengan ubin Daftar Ulang tepat di
+  // bawahnya, jadi dua ubin bersebelahan bergambar sama. Yang dibuka Data
+  // Peserta memang daftar ORANG, bukan satu kartu.
+  "users":
+    '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /> <circle cx="9" cy="7" r="4" /> <path d="M22 21v-2a4 4 0 0 0-3-3.87" /> <path d="M16 3.13a4 4 0 0 1 0 7.75" />',
+  // Papan jalan berpena, dipakai ubin Input Nilai Pos v2. Sebelumnya JAM —
+  // sisa dari masa layar itu memang stopwatch. Sekarang ia layar isian nilai
+  // per lomba, dan jam di ubinnya menjanjikan layar yang tidak ada.
+  "clipboard-pen":
+    '<rect width="8" height="4" x="8" y="2" rx="1" /> <path d="M10.4 12.6a2 2 0 0 1 3 3L8 21l-4 1 1-4Z" /> <path d="M16 4h2a2 2 0 0 1 2 2v4" /> <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h5.5" />',
+  // Daftar bercentang, dipakai ubin Cek Nilai. Sebelumnya "circle-check" —
+  // sama persis dengan ubin Kedatangan, dan dua ubin bergambar sama di satu
+  // papan menghapus seluruh guna gambarnya.
+  "list-checks":
+    '<path d="M11 6h9" /> <path d="M11 12h9" /> <path d="M11 18h9" /> <path d="m3 6 1.5 1.5L7 5" /> <path d="m3 12 1.5 1.5L7 11" /> <path d="m3 18 1.5 1.5L7 17" />',
   "list-ordered":
     '<path d="M11 5h10" /> <path d="M11 12h10" /> <path d="M11 19h10" /> <path d="M4 4h1v5" /> <path d="M4 9h2" /> <path d="M6.5 20H3.4c0-1 2.6-1.925 2.6-3.5a1.5 1.5 0 0 0-2.6-1.02" />',
   "log-out":

--- a/live/style.css
+++ b/live/style.css
@@ -4381,15 +4381,38 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .ikon-kotak .ikon { width: 1.2rem; height: 1.2rem; }
 
-.i-biru   { background: #e7f0fd; color: #1a56db; }
-.i-hijau  { background: #e4f6ec; color: #067647; }
-.i-ungu   { background: #f0eafe; color: #6941c6; }
-.i-toska  { background: #dff2f0; color: #00695c; }
-.i-jingga { background: #fdefe0; color: #b54708; }
-.i-zamrud { background: #e2f7f0; color: #047857; }
-.i-emas   { background: #fdf3dc; color: #a16207; }
-.i-nila   { background: #e9ecfc; color: #3538cd; }
-.i-mawar  { background: #fce9ee; color: #c01048; }
+/* EMPAT BELAS UBIN, EMPAT BELAS WARNA — dan itu batasnya, bukan kebetulan.
+   Papan Home admin memuat empat belas ubin sekaligus, jadi warna yang dipakai
+   dua kali menghapus gunanya sendiri: yang dituju jempol berhenti bisa
+   disebut "yang hijau".
+
+   Sebelum ini tujuh warna melayani empat belas ubin — dan tiga di antaranya
+   HIJAU yang nyaris sama (#067647, #047857, #00695c), jadi Data Peserta,
+   Pembayaran, Daftar Kloter, Kedatangan dan Cek Nilai terbaca sebagai satu
+   kelompok yang sama. Dilaporkan begitu, 1 September 2026.
+
+   Nadanya dijaga sama untuk semuanya — latar tint pucat, ikon versi pekat
+   dari warna yang sama — supaya kotaknya terbaca sebagai satu benda. Yang
+   berbeda hanya RONA-nya, dan jaraknya dipilih supaya dua ubin bertetangga di
+   papan tidak pernah berdekatan rona. */
+.i-biru    { background: #e7f0fd; color: #1a56db; }
+.i-sian    { background: #ddf2f7; color: #0e7490; }
+.i-hijau   { background: #e4f6ec; color: #067647; }
+.i-magenta { background: #fbe8fb; color: #a21caf; }
+.i-toska   { background: #dff2f0; color: #00695c; }
+.i-merah   { background: #fdeceb; color: #b42318; }
+.i-zamrud  { background: #e2f7f0; color: #047857; }
+.i-nila    { background: #e9ecfc; color: #3538cd; }
+.i-mawar   { background: #fce9ee; color: #c01048; }
+.i-ungu    { background: #f0eafe; color: #6941c6; }
+.i-lumut   { background: #eef6df; color: #4d7c0f; }
+.i-emas    { background: #fdf3dc; color: #a16207; }
+.i-jingga  { background: #fdefe0; color: #b54708; }
+/* Abu untuk ALAT, bukan untuk meja: Kalkulator Keberangkatan tidak menjaga
+   satu pun data, ia menghitung. Kelas ini sudah dipakai app.js sebelum
+   ditulis di sini, jadi selama itu ubinnya tergambar TANPA kotak sama sekali
+   — ikon telanjang di antara tiga belas ikon berkotak. */
+.i-abu     { background: #eef0f3; color: #475467; }
 
 /* Di kertas semua tint hilang — CLAUDE.md 8.4 melarang abu dan raster, dan
    latar berwarna yang difotokopi jadi kotoran. Ikonnya sendiri tidak dicetak

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 50, sidik: "cd7598d8c2aa" },
+  "style.css": { versi: 51, sidik: "dd59d5cdbd3f" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=48">
+  <link rel="stylesheet" href="style.css?v=49">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -511,14 +511,14 @@ async function layarHome() {
              tidak melihatnya sama sekali. Persis yang terjadi sampai baris
              ini ditulis. -->
         <a href="#/pos2">
-          <div class="function-name">${ikonKotak("clock", "mawar")} Input Nilai Pos v2</div>
+          <div class="function-name">${ikonKotak("clipboard-pen", "ungu")} Input Nilai Pos v2</div>
         </a>
         <a href="#/pos">
           <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos${
             sesi().pos != null && sesi().pos !== "" ? ` ${esc(sesi().pos)}` : ""}</div>
         </a>
         <a href="#/foto">
-          <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban Sekaligus</div>
+          <div class="function-name">${ikonKotak("camera", "mawar")} Foto Jawaban Sekaligus</div>
         </a>
         ${bolehLihat("live_score") ? `
         <a href="#/live-score">
@@ -586,7 +586,7 @@ async function layarHome() {
            berada DI DALAM template literal, dan satu backtick menutupnya.) -->
       ${bolehLihat("pendaftaran") ? `
       <a href="#/data-peserta">
-        <div class="function-name">${ikonKotak("id-card", "toska")} Data Peserta</div>
+        <div class="function-name">${ikonKotak("users", "sian")} Data Peserta</div>
       </a>` : ""}
       ${bolehLihat("pembayaran") ? `
       <a href="#/pembayaran">
@@ -594,7 +594,7 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("daftar_ulang") ? `
       <a href="#/daftar-ulang">
-        <div class="function-name">${ikonKotak("id-card", "ungu")} Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
+        <div class="function-name">${ikonKotak("id-card", "magenta")} Daftar Ulang ${lencana(r ? r.lunas_belum_nomor : null)}</div>
       </a>` : ""}
       ${bolehLihat("cetak_kloter") ? `
       <a href="#/cetak-kloter">
@@ -602,7 +602,7 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("keberangkatan") ? `
       <a href="#/keberangkatan">
-        <div class="function-name">${ikonKotak("flag", "jingga")} Keberangkatan ${
+        <div class="function-name">${ikonKotak("flag", "merah")} Keberangkatan ${
           kemajuan(r ? r.regu_berangkat : null, r ? r.regu_siap : null)}</div>
       </a>` : ""}
       ${bolehLihat("kedatangan") ? `
@@ -618,15 +618,15 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/foto">
-        <div class="function-name">${ikonKotak("camera", "biru")} Foto Jawaban Sekaligus</div>
+        <div class="function-name">${ikonKotak("camera", "mawar")} Foto Jawaban Sekaligus</div>
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/pos2">
-        <div class="function-name">${ikonKotak("clock", "mawar")} Input Nilai Pos v2</div>
+        <div class="function-name">${ikonKotak("clipboard-pen", "ungu")} Input Nilai Pos v2</div>
       </a>` : ""}
       ${bolehLihat("pengaturan") ? `
       <a href="#/cek-nilai">
-        <div class="function-name">${ikonKotak("circle-check", "zamrud")} Cek Nilai</div>
+        <div class="function-name">${ikonKotak("list-checks", "lumut")} Cek Nilai</div>
       </a>` : ""}
       ${bolehLihat("live_score") ? `
       <a href="#/live-score">

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -980,6 +980,22 @@ const IKON = {
     '<path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /> <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />',
   "id-card":
     '<path d="M16 10h2" /> <path d="M16 14h2" /> <path d="M6.17 15a3 3 0 0 1 5.66 0" /> <circle cx="9" cy="11" r="2" /> <rect x="2" y="5" width="20" height="14" rx="2" />',
+  // Dua orang, dipakai ubin Data Peserta. Sebelumnya ubin itu memakai
+  // "id-card" — kartu yang SAMA PERSIS dengan ubin Daftar Ulang tepat di
+  // bawahnya, jadi dua ubin bersebelahan bergambar sama. Yang dibuka Data
+  // Peserta memang daftar ORANG, bukan satu kartu.
+  "users":
+    '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /> <circle cx="9" cy="7" r="4" /> <path d="M22 21v-2a4 4 0 0 0-3-3.87" /> <path d="M16 3.13a4 4 0 0 1 0 7.75" />',
+  // Papan jalan berpena, dipakai ubin Input Nilai Pos v2. Sebelumnya JAM —
+  // sisa dari masa layar itu memang stopwatch. Sekarang ia layar isian nilai
+  // per lomba, dan jam di ubinnya menjanjikan layar yang tidak ada.
+  "clipboard-pen":
+    '<rect width="8" height="4" x="8" y="2" rx="1" /> <path d="M10.4 12.6a2 2 0 0 1 3 3L8 21l-4 1 1-4Z" /> <path d="M16 4h2a2 2 0 0 1 2 2v4" /> <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h5.5" />',
+  // Daftar bercentang, dipakai ubin Cek Nilai. Sebelumnya "circle-check" —
+  // sama persis dengan ubin Kedatangan, dan dua ubin bergambar sama di satu
+  // papan menghapus seluruh guna gambarnya.
+  "list-checks":
+    '<path d="M11 6h9" /> <path d="M11 12h9" /> <path d="M11 18h9" /> <path d="m3 6 1.5 1.5L7 5" /> <path d="m3 12 1.5 1.5L7 11" /> <path d="m3 18 1.5 1.5L7 17" />',
   "list-ordered":
     '<path d="M11 5h10" /> <path d="M11 12h10" /> <path d="M11 19h10" /> <path d="M4 4h1v5" /> <path d="M4 9h2" /> <path d="M6.5 20H3.4c0-1 2.6-1.925 2.6-3.5a1.5 1.5 0 0 0-2.6-1.02" />',
   "log-out":

--- a/web/style.css
+++ b/web/style.css
@@ -4381,15 +4381,38 @@ button.pill-number:hover { filter: brightness(.95); }
 }
 .ikon-kotak .ikon { width: 1.2rem; height: 1.2rem; }
 
-.i-biru   { background: #e7f0fd; color: #1a56db; }
-.i-hijau  { background: #e4f6ec; color: #067647; }
-.i-ungu   { background: #f0eafe; color: #6941c6; }
-.i-toska  { background: #dff2f0; color: #00695c; }
-.i-jingga { background: #fdefe0; color: #b54708; }
-.i-zamrud { background: #e2f7f0; color: #047857; }
-.i-emas   { background: #fdf3dc; color: #a16207; }
-.i-nila   { background: #e9ecfc; color: #3538cd; }
-.i-mawar  { background: #fce9ee; color: #c01048; }
+/* EMPAT BELAS UBIN, EMPAT BELAS WARNA — dan itu batasnya, bukan kebetulan.
+   Papan Home admin memuat empat belas ubin sekaligus, jadi warna yang dipakai
+   dua kali menghapus gunanya sendiri: yang dituju jempol berhenti bisa
+   disebut "yang hijau".
+
+   Sebelum ini tujuh warna melayani empat belas ubin — dan tiga di antaranya
+   HIJAU yang nyaris sama (#067647, #047857, #00695c), jadi Data Peserta,
+   Pembayaran, Daftar Kloter, Kedatangan dan Cek Nilai terbaca sebagai satu
+   kelompok yang sama. Dilaporkan begitu, 1 September 2026.
+
+   Nadanya dijaga sama untuk semuanya — latar tint pucat, ikon versi pekat
+   dari warna yang sama — supaya kotaknya terbaca sebagai satu benda. Yang
+   berbeda hanya RONA-nya, dan jaraknya dipilih supaya dua ubin bertetangga di
+   papan tidak pernah berdekatan rona. */
+.i-biru    { background: #e7f0fd; color: #1a56db; }
+.i-sian    { background: #ddf2f7; color: #0e7490; }
+.i-hijau   { background: #e4f6ec; color: #067647; }
+.i-magenta { background: #fbe8fb; color: #a21caf; }
+.i-toska   { background: #dff2f0; color: #00695c; }
+.i-merah   { background: #fdeceb; color: #b42318; }
+.i-zamrud  { background: #e2f7f0; color: #047857; }
+.i-nila    { background: #e9ecfc; color: #3538cd; }
+.i-mawar   { background: #fce9ee; color: #c01048; }
+.i-ungu    { background: #f0eafe; color: #6941c6; }
+.i-lumut   { background: #eef6df; color: #4d7c0f; }
+.i-emas    { background: #fdf3dc; color: #a16207; }
+.i-jingga  { background: #fdefe0; color: #b54708; }
+/* Abu untuk ALAT, bukan untuk meja: Kalkulator Keberangkatan tidak menjaga
+   satu pun data, ia menghitung. Kelas ini sudah dipakai app.js sebelum
+   ditulis di sini, jadi selama itu ubinnya tergambar TANPA kotak sama sekali
+   — ikon telanjang di antara tiga belas ikon berkotak. */
+.i-abu     { background: #eef0f3; color: #475467; }
 
 /* Di kertas semua tint hilang — CLAUDE.md 8.4 melarang abu dan raster, dan
    latar berwarna yang difotokopi jadi kotoran. Ikonnya sendiri tidak dicetak


### PR DESCRIPTION
## What

Every tile on Home now has its own colour, and no icon appears twice.

| Tile | icon | colour |
| --- | --- | --- |
| Pendaftaran | clipboard-list | biru |
| Data Peserta | **users** | **sian** |
| Pembayaran | credit-card | hijau |
| Daftar Ulang | id-card | **magenta** |
| Daftar Kloter | list-ordered | toska |
| Keberangkatan | flag | **merah** |
| Kedatangan | circle-check | zamrud |
| Input Nilai Pos | square-pen | nila |
| Foto Jawaban Sekaligus | camera | **mawar** |
| Input Nilai Pos v2 | **clipboard-pen** | **ungu** |
| Cek Nilai | **list-checks** | **lumut** |
| Live Score | medal | emas |
| Kejuaraan | trophy | jingga |
| Kalkulator Keberangkatan | settings | **abu** (the box existed only in the code) |

## Why

Seven colours were serving fourteen tiles, and three of the seven were
greens close enough to read as one — `#067647`, `#047857`, `#00695c`. That
put Data Peserta, Pembayaran, Daftar Kloter, Kedatangan and Cek Nilai in what
looked like the same family, which is exactly what the colour is there to
prevent: a tile you can aim at as "the green one" stops existing once five
tiles are green.

Three tiles were wrong beyond their colour:

- **Input Nilai Pos v2** carried a clock, left over from when that screen was
  the stopwatch. It has been the per-lomba score entry screen for a while, and
  a clock on its tile promises a screen that isn't there.
- **Data Peserta** and **Daftar Ulang** carried the same id-card, one directly
  under the other. What Data Peserta opens is a list of people.
- **Cek Nilai** and **Kedatangan** carried the same circle-check.

`i-abu` was referenced by the Kalkulator tile but had never been written in
style.css, so that tile drew a bare icon among thirteen boxed ones.

## Notes

- Every colour keeps the same recipe — pale tint behind a deep ink of the same
  hue — so only the hue moves, and adjacent tiles never land near each other
  on the wheel.
- Colour is still never the only difference: the name is always beside it and
  no two icons repeat, which is what keeps the board readable for the roughly
  one in twelve men who cannot separate red from green.
- Rendered at 393px and measured: 14 tiles, 14 distinct ink colours, every icon
  drawing. 395 tests pass.
