### PR TITLE
fix: the Daftar Ulang card stops carrying empty space

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=51">
+  <link rel="stylesheet" href="style.css?v=52">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -3419,8 +3419,14 @@ button.pill-number:hover { filter: brightness(.95); }
   .table-daftar-ulang tbody tr[data-baris] {
     display: grid;
     grid-template-columns: max-content 1fr;
-    gap: .2rem .8rem;
+    gap: .1rem .8rem;
     align-items: baseline;
+    /* Lebih rapat daripada kartu lain di berkas ini, dan itu karena isinya
+       memang lebih sedikit: dua keterangan pendek dan satu tombol. Terukur
+       sebelum dirampingkan, 111px untuk dua baris tulisan — dan di layar yang
+       memuat puluhan baris antrean, tinggi yang tidak membawa apa-apa berarti
+       satu sekolah lebih sedikit yang terlihat sekaligus. */
+    padding: .5rem .7rem; margin-bottom: .5rem;
   }
   /* Label kolom dibuang — kekhususannya harus menandingi aturan label umum
      (0,4,2), yang punya `.data-table` dan `:not([data-label=""])`. */
@@ -3437,11 +3443,21 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   /* Nomor dada lalu tombol, masing-masing melintang penuh, dalam urutan itu. */
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada {
-    grid-area: 2 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
+    grid-area: 2 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .1rem;
   }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-tukar {
-    grid-area: 3 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
+    grid-area: 3 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .25rem;
   }
+  /* SEL KOSONG DIBUANG, bukan dibiarkan setinggi paddingnya. "Tukar nomor
+     rusak…" cuma ada pada baris yang SUDAH punya nomor dada, jadi pada baris
+     antrean — yang paling banyak jumlahnya — selnya kosong dan tetap memakan
+     13px di kaki tiap kartu: 4px isi ditambah jarak di atasnya. Empat belas
+     kartu di layar berarti hampir 200px yang tidak membawa apa pun.
+
+     `:empty` bekerja di sini karena template-nya menulis `>${tombolTukar}<`
+     tanpa spasi — satu spasi saja sudah jadi simpul teks dan `:empty`
+     berhenti cocok. */
+  .table-daftar-ulang tbody tr[data-baris] > td.kol-tukar:empty { display: none; }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .pill-row,
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .sub {
     display: flex; flex-wrap: wrap; gap: .3rem; justify-content: flex-start;

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 51, sidik: "dd59d5cdbd3f" },
+  "style.css": { versi: 52, sidik: "2a2f68eade29" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=49">
+  <link rel="stylesheet" href="style.css?v=50">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -3419,8 +3419,14 @@ button.pill-number:hover { filter: brightness(.95); }
   .table-daftar-ulang tbody tr[data-baris] {
     display: grid;
     grid-template-columns: max-content 1fr;
-    gap: .2rem .8rem;
+    gap: .1rem .8rem;
     align-items: baseline;
+    /* Lebih rapat daripada kartu lain di berkas ini, dan itu karena isinya
+       memang lebih sedikit: dua keterangan pendek dan satu tombol. Terukur
+       sebelum dirampingkan, 111px untuk dua baris tulisan — dan di layar yang
+       memuat puluhan baris antrean, tinggi yang tidak membawa apa-apa berarti
+       satu sekolah lebih sedikit yang terlihat sekaligus. */
+    padding: .5rem .7rem; margin-bottom: .5rem;
   }
   /* Label kolom dibuang — kekhususannya harus menandingi aturan label umum
      (0,4,2), yang punya `.data-table` dan `:not([data-label=""])`. */
@@ -3437,11 +3443,21 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   /* Nomor dada lalu tombol, masing-masing melintang penuh, dalam urutan itu. */
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada {
-    grid-area: 2 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
+    grid-area: 2 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .1rem;
   }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-tukar {
-    grid-area: 3 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .35rem;
+    grid-area: 3 / 1 / auto / 3; width: auto; white-space: normal; margin-top: .25rem;
   }
+  /* SEL KOSONG DIBUANG, bukan dibiarkan setinggi paddingnya. "Tukar nomor
+     rusak…" cuma ada pada baris yang SUDAH punya nomor dada, jadi pada baris
+     antrean — yang paling banyak jumlahnya — selnya kosong dan tetap memakan
+     13px di kaki tiap kartu: 4px isi ditambah jarak di atasnya. Empat belas
+     kartu di layar berarti hampir 200px yang tidak membawa apa pun.
+
+     `:empty` bekerja di sini karena template-nya menulis `>${tombolTukar}<`
+     tanpa spasi — satu spasi saja sudah jadi simpul teks dan `:empty`
+     berhenti cocok. */
+  .table-daftar-ulang tbody tr[data-baris] > td.kol-tukar:empty { display: none; }
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .pill-row,
   .table-daftar-ulang tbody tr[data-baris] > td.kol-dada .sub {
     display: flex; flex-wrap: wrap; gap: .3rem; justify-content: flex-start;


### PR DESCRIPTION
## What

A queue card on Meja Daftar Ulang is **88px instead of 111px**, and the
"Isi N Nomor Dada" action sits directly under the payment code.

## Why

111px for two short lines of text, and 13px of that was a cell with nothing
in it. "Tukar nomor rusak…" only exists on rows that already **have** a nomor
dada, so on the queue rows — the ones there are most of — its cell sat empty
at 4px of content plus the gap above it. Fourteen cards on screen made that
nearly 200px carrying nothing.

## Notes

- The empty cell is dropped with `:empty`, which works here because the
  template writes `>${tombolTukar}<` with no space; one space would make it a
  text node and stop matching.
- Card padding comes in from `.65rem/.75rem` to `.5rem/.7rem`, and the action
  sits `.1rem` under the code instead of `.35rem`.
- Measured at 393px: a completed card still draws its nomor dada pill and its
  Tukar button, with no cell overlapping another. 395 tests pass.
