### PR TITLE
feat: one colour per pos on the lomba picker

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=52">
+  <link rel="stylesheet" href="style.css?v=53">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4837,10 +4837,42 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* auto-fill, bukan jumlah kolom yang dipatok: pos berisi satu lomba (Pos 4,
    Pos 5) dan pos berisi lima (Pos 1) memakai petak yang sama. */
+/* ---------- pemilih lomba: satu warna per pos ----------
+
+   Bentuknya dipinjam dari layar Kejuaraan, dan alasannya sama persis: kartu
+   yang seragam memaksa judulnya dibaca sebelum isinya, sementara yang membuka
+   layar ini berdiri di SATU pos sepanjang pagi dan mencari blok yang itu-itu
+   saja. Tepi kiri tebal, judul sewarna, latar tint pucat.
+
+   Warna TIDAK PERNAH jadi satu-satunya pembeda — judul tiap kartu tetap
+   tertulis penuh beserta nomor posnya, aturan yang sama dengan kotak ikon di
+   papan Home.
+
+   Kelima rona diambil dari palet yang sudah ada di berkas ini supaya layar
+   panitia tidak punya dua daftar warna yang harus dijaga sejalan. Pos di luar
+   1-5 (pos bayangan) memakai warna bawaan di `.pos-blok`. */
+.pos-blok { --aksen: #00695c; --tint: #f4faf9; }
+.pos-warna-1 { --aksen: #1a56db; --tint: #f5f8fe; }
+.pos-warna-2 { --aksen: #b54708; --tint: #fefaf5; }
+.pos-warna-3 { --aksen: #c01048; --tint: #fef6f8; }
+.pos-warna-4 { --aksen: #6941c6; --tint: #faf8fe; }
+.pos-warna-5 { --aksen: #067647; --tint: #f3faf6; }
+.card.pos-blok {
+  border-left: 5px solid var(--aksen);
+  background: var(--tint);
+}
+.card.pos-blok > h2 { color: var(--aksen); }
+
 .pilih-lomba {
   display: grid; gap: .6rem;
   grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
 }
+/* Kotak lombanya tetap PUTIH di atas tint kartunya, dan itu yang membuatnya
+   terbaca sebagai tombol: benda yang bisa ditekan berdiri di atas alasnya,
+   bukan sewarna dengannya. */
+.pos-blok .lomba-kotak:hover { border-color: var(--aksen); color: var(--aksen); }
+.pos-blok .lomba-kotak:active { background: var(--tint); }
+.pos-blok .lomba-kotak:focus-visible { outline-color: var(--aksen); }
 /* Isinya tinggal nama lombanya, jadi diletakkan di TENGAH kotak — nama
    pendek yang rata kiri di petak selebar 11rem meninggalkan lahan kosong di
    kanan yang terbaca seperti ada sesuatu yang hilang di sana. */

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 52, sidik: "2a2f68eade29" },
+  "style.css": { versi: 53, sidik: "57d4d276541b" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=50">
+  <link rel="stylesheet" href="style.css?v=51">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -8331,8 +8331,21 @@ function gambarPemilihLomba(katalog) {
     blok.isi.push(l);
   }
 
+  /* SATU WARNA PER POS, bentuk yang sama dengan layar Kejuaraan: tepi kiri
+     tebal dan judul sewarna, di atas latar tint pucat. Lima kartu seragam
+     memaksa juri membaca judul tiap kartu untuk tahu ia sedang melihat pos
+     mana — dan yang membuka layar ini berdiri di SATU pos, sepanjang pagi,
+     mencari blok yang sama berulang kali.
+
+     Warnanya tidak pernah jadi satu-satunya pembeda: judul tiap kartu tetap
+     tertulis penuh, dan nomor posnya ada di dalam judul itu.
+
+     Nomor posnya dibawa kelas, bukan gaya sebaris: warna adalah keputusan
+     style.css, dan menuliskannya di sini berarti dua tempat harus ikut benar
+     setiap kali paletnya berubah. Pos di luar 1-5 — pos bayangan — jatuh ke
+     warna bawaan `.pos-blok`, bukan ke kartu tanpa warna. */
   LAYAR.replaceChildren(h(`<div id="pita-antrean"></div>` + perPos.map(b => `
-    <div class="card">
+    <div class="card pos-blok pos-warna-${esc(String(b.pos))}">
       <h2>${esc(b.judul)}</h2>
       <div class="pilih-lomba">
         ${b.isi.map(l => `

--- a/web/style.css
+++ b/web/style.css
@@ -4837,10 +4837,42 @@ button.pill-number:hover { filter: brightness(.95); }
 
 /* auto-fill, bukan jumlah kolom yang dipatok: pos berisi satu lomba (Pos 4,
    Pos 5) dan pos berisi lima (Pos 1) memakai petak yang sama. */
+/* ---------- pemilih lomba: satu warna per pos ----------
+
+   Bentuknya dipinjam dari layar Kejuaraan, dan alasannya sama persis: kartu
+   yang seragam memaksa judulnya dibaca sebelum isinya, sementara yang membuka
+   layar ini berdiri di SATU pos sepanjang pagi dan mencari blok yang itu-itu
+   saja. Tepi kiri tebal, judul sewarna, latar tint pucat.
+
+   Warna TIDAK PERNAH jadi satu-satunya pembeda — judul tiap kartu tetap
+   tertulis penuh beserta nomor posnya, aturan yang sama dengan kotak ikon di
+   papan Home.
+
+   Kelima rona diambil dari palet yang sudah ada di berkas ini supaya layar
+   panitia tidak punya dua daftar warna yang harus dijaga sejalan. Pos di luar
+   1-5 (pos bayangan) memakai warna bawaan di `.pos-blok`. */
+.pos-blok { --aksen: #00695c; --tint: #f4faf9; }
+.pos-warna-1 { --aksen: #1a56db; --tint: #f5f8fe; }
+.pos-warna-2 { --aksen: #b54708; --tint: #fefaf5; }
+.pos-warna-3 { --aksen: #c01048; --tint: #fef6f8; }
+.pos-warna-4 { --aksen: #6941c6; --tint: #faf8fe; }
+.pos-warna-5 { --aksen: #067647; --tint: #f3faf6; }
+.card.pos-blok {
+  border-left: 5px solid var(--aksen);
+  background: var(--tint);
+}
+.card.pos-blok > h2 { color: var(--aksen); }
+
 .pilih-lomba {
   display: grid; gap: .6rem;
   grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
 }
+/* Kotak lombanya tetap PUTIH di atas tint kartunya, dan itu yang membuatnya
+   terbaca sebagai tombol: benda yang bisa ditekan berdiri di atas alasnya,
+   bukan sewarna dengannya. */
+.pos-blok .lomba-kotak:hover { border-color: var(--aksen); color: var(--aksen); }
+.pos-blok .lomba-kotak:active { background: var(--tint); }
+.pos-blok .lomba-kotak:focus-visible { outline-color: var(--aksen); }
 /* Isinya tinggal nama lombanya, jadi diletakkan di TENGAH kotak — nama
    pendek yang rata kiri di petak selebar 11rem meninggalkan lahan kosong di
    kanan yang terbaca seperti ada sesuatu yang hilang di sana. */


### PR DESCRIPTION
## What

Each pos block on Input Nilai Pos v2 now carries its own colour, in the shape
Kejuaraan already uses: a thick accent border down the left, the heading in
that accent, and a pale tint behind the card.

| Pos | accent |
| --- | --- |
| Pos 1 — Kepramukaan | biru `#1a56db` |
| Pos 2 — Halang Rintang | jingga `#b54708` |
| Pos 3 — P3K | mawar `#c01048` |
| Pos 4 — PBB | ungu `#6941c6` |
| Pos 5 — Yel-Yel | hijau `#067647` |

The lomba boxes stay white on top of the tint and take the accent on hover,
press and keyboard focus.

## Why

Five identical cards made a juri read the heading of each one to find out
which pos they were looking at — and whoever opens this screen stands at
**one** pos all morning, hunting the same block over and over. Kejuaraan
solved the same complaint the same way, so this screen borrows its shape
rather than inventing a second one.

## Notes

- The five hues come from the palette already in style.css, so the panitia
  screens do not grow a second list of colours to keep in step.
- A pos outside 1–5 — a shadow pos — falls back to the default accent on
  `.pos-blok`, not to a card with no colour at all.
- Colour is never the only difference: every card still writes its heading in
  full, pos number included.
- White boxes on a tinted card is not decoration — it is what makes them read
  as things you press rather than part of the ground they sit on.
- Rendered at 393px and measured: five blocks, five distinct accents, every
  lomba button present. 395 tests pass.
