### PR TITLE
fix: the contact boxes line up, and the regu button moves below them

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=53">
+  <link rel="stylesheet" href="style.css?v=54">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -2342,8 +2342,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-peserta { table-layout: fixed; min-width: 858px; }
 
   .table-peserta > thead > tr > th:nth-child(1) { width: 16%; }
-  .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }
-  .table-peserta > thead > tr > th:nth-child(3) { width: 25%; }
+  /* 15%, bukan 13%: pada lebar tersempit tabel ini (min-width 858px) 13%
+     memberi sel 111px, isinya 95px, sementara kode pembayaran menuntut 106px
+     — jadi ia patah di tanda hubungnya sendiri dan "HRCD37-" berdiri sendiri
+     di baris pertama. Dua persen itu diambil dari Asal Sekolah, satu-satunya
+     kolom yang isinya memang boleh membungkus. */
+  .table-peserta > thead > tr > th:nth-child(2) { width: 15%; }
+  .table-peserta > thead > tr > th:nth-child(3) { width: 23%; }
   .table-peserta > thead > tr > th:nth-child(4) { width:  6%; }
   .table-peserta > thead > tr > th:nth-child(5) { width: 21%; }
   .table-peserta > thead > tr > th:nth-child(6) { width: 19%; }
@@ -3542,13 +3547,18 @@ button.pill-number:hover { filter: brightness(.95); }
   .data-table.table-peserta tbody tr[data-baris] > td[data-label]::before { content: none; }
   .table-peserta tbody tr[data-baris] {
     display: grid;
-    /* Kolom pertama DIPATOK, tidak `max-content` seperti Meja Pembayaran.
-       Bedanya karena kartu ini memuat KOTAK ISIAN, dan lebar bawaan sebuah
-       <input> ikut menentukan `max-content` kolomnya: terukur di 430px
-       kolomnya melar jadi 252px dan sisa kartunya tinggal 69px — nama sekolah,
-       tanggal, dan nomor WA semuanya terjepit. 9rem cukup untuk kode
-       pembayaran (terukur 118px) dan tidak bergantung pada isi sel mana pun. */
-    grid-template-columns: minmax(0, 9rem) minmax(0, 1fr);
+    /* DUA KOLOM SAMA LEBAR, dan yang menentukan itu BARIS KEDUA: dua kotak
+       isian bersebelahan yang lebarnya berbeda 8px terbaca sebagai dua kotak
+       yang tidak lurus, bukan sebagai sepasang. Terukur sebelum diperbaiki di
+       393px: 144px lawan 136px.
+
+       Kolom pertama sempat dipatok 9rem demi kode pembayaran, dan `1fr` tidak
+       mengambil apa pun darinya — separuh kartu di 393px adalah 156px,
+       sedangkan kode pembayaran terukur 118px. Yang TIDAK boleh kembali
+       `max-content`: lebar bawaan sebuah <input> ikut menentukannya, dan
+       terukur di 430px kolomnya melar jadi 252px sampai sisa kartunya tinggal
+       69px. */
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: .25rem .7rem;
     align-items: center;
   }
@@ -3566,9 +3576,52 @@ button.pill-number:hover { filter: brightness(.95); }
   .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { display: none; }
   .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
+  /* KONTAK DI BARIS KEDUA, TOMBOL REGU DI BAWAHNYA. Sebelumnya terbalik, dan
+     tombol yang duduk di antara nama sekolah dan kotak kontaknya memisahkan
+     dua keterangan yang dibaca bersama — nama CP dan nomornya milik
+     pendaftaran yang sama, dan keduanya milik sekolah tepat di atasnya.
+     Tombol regu MEMBUKA sesuatu, jadi tempatnya di kaki kartu, tepat di atas
+     rincian yang keluar dari sana. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 2 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 3 / 1; }
+  /* Kedua kotak kontak DILURUSKAN DI ATAS, bukan ditengahkan sendiri-sendiri.
+     `align-items: center` pada kartunya benar untuk baris pertama — kode dan
+     nama sekolah beda tinggi barisnya — tetapi pada sepasang kotak isian ia
+     menurunkan yang lebih pendek beberapa piksel. Terukur 4px, cukup untuk
+     terlihat sebagai dua kotak yang tidak sejajar. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"],
+  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"] {
+    align-self: start;
+    /* `td:last-child { margin-top: .5rem }` di aturan kartu umum mengenai
+       kotak WhatsApp — ia memang anak terakhir barisnya — dan itulah 8px yang
+       menurunkannya dari kotak nama CP di sebelahnya. Aturan itu ada untuk
+       kartu yang tombolnya di sel terakhir; di sini sel terakhir justru
+       separuh dari sepasang kotak yang harus lurus. */
+    margin-top: 0;
+  }
+  /* DI BAWAH 360px KARTUNYA JADI SATU KOLOM, dan ambang itu diukur bukan
+     dipilih: separuh kartu di 360px adalah 123px, dan kode pembayaran
+     terukur 118px — pas. Di 320px separuhnya tinggal 103px dan kodenya patah
+     di tanda hubungnya sendiri, jadi "HRCD37-" berdiri di satu baris dan
+     "93E49F" di baris berikutnya. Dari layar itu terbaca seperti dua kode,
+     kesalahan yang sama dengan judul dialog Riwayat.
+
+     Yang mengalah SUSUNANNYA, bukan ukuran hurufnya: kode pembayaran dibaca
+     dari seberang meja dan dieja lewat telepon.
+
+     Urutannya tetap sama dari atas ke bawah — kode, sekolah, kontak, tombol
+     regu — jadi yang berpindah antara HP kecil dan HP besar tidak menemukan
+     dua susunan yang berbeda, cuma satu yang lebih tinggi. */
+  @media (max-width: 359px) {
+    .table-peserta tbody tr[data-baris] { grid-template-columns: minmax(0, 1fr); }
+    .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]     { grid-area: 1 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]   { grid-area: 2 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]       { grid-area: 4 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="Regu"]           { grid-area: 5 / 1; }
+  }
+
   /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
      lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
      sejajar dengan apa pun di atas maupun di bawahnya. */

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 53, sidik: "57d4d276541b" },
+  "style.css": { versi: 54, sidik: "dafdebbff474" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=51">
+  <link rel="stylesheet" href="style.css?v=52">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -2342,8 +2342,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .table-peserta { table-layout: fixed; min-width: 858px; }
 
   .table-peserta > thead > tr > th:nth-child(1) { width: 16%; }
-  .table-peserta > thead > tr > th:nth-child(2) { width: 13%; }
-  .table-peserta > thead > tr > th:nth-child(3) { width: 25%; }
+  /* 15%, bukan 13%: pada lebar tersempit tabel ini (min-width 858px) 13%
+     memberi sel 111px, isinya 95px, sementara kode pembayaran menuntut 106px
+     — jadi ia patah di tanda hubungnya sendiri dan "HRCD37-" berdiri sendiri
+     di baris pertama. Dua persen itu diambil dari Asal Sekolah, satu-satunya
+     kolom yang isinya memang boleh membungkus. */
+  .table-peserta > thead > tr > th:nth-child(2) { width: 15%; }
+  .table-peserta > thead > tr > th:nth-child(3) { width: 23%; }
   .table-peserta > thead > tr > th:nth-child(4) { width:  6%; }
   .table-peserta > thead > tr > th:nth-child(5) { width: 21%; }
   .table-peserta > thead > tr > th:nth-child(6) { width: 19%; }
@@ -3542,13 +3547,18 @@ button.pill-number:hover { filter: brightness(.95); }
   .data-table.table-peserta tbody tr[data-baris] > td[data-label]::before { content: none; }
   .table-peserta tbody tr[data-baris] {
     display: grid;
-    /* Kolom pertama DIPATOK, tidak `max-content` seperti Meja Pembayaran.
-       Bedanya karena kartu ini memuat KOTAK ISIAN, dan lebar bawaan sebuah
-       <input> ikut menentukan `max-content` kolomnya: terukur di 430px
-       kolomnya melar jadi 252px dan sisa kartunya tinggal 69px — nama sekolah,
-       tanggal, dan nomor WA semuanya terjepit. 9rem cukup untuk kode
-       pembayaran (terukur 118px) dan tidak bergantung pada isi sel mana pun. */
-    grid-template-columns: minmax(0, 9rem) minmax(0, 1fr);
+    /* DUA KOLOM SAMA LEBAR, dan yang menentukan itu BARIS KEDUA: dua kotak
+       isian bersebelahan yang lebarnya berbeda 8px terbaca sebagai dua kotak
+       yang tidak lurus, bukan sebagai sepasang. Terukur sebelum diperbaiki di
+       393px: 144px lawan 136px.
+
+       Kolom pertama sempat dipatok 9rem demi kode pembayaran, dan `1fr` tidak
+       mengambil apa pun darinya — separuh kartu di 393px adalah 156px,
+       sedangkan kode pembayaran terukur 118px. Yang TIDAK boleh kembali
+       `max-content`: lebar bawaan sebuah <input> ikut menentukannya, dan
+       terukur di 430px kolomnya melar jadi 252px sampai sisa kartunya tinggal
+       69px. */
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: .25rem .7rem;
     align-items: center;
   }
@@ -3566,9 +3576,52 @@ button.pill-number:hover { filter: brightness(.95); }
   .table-peserta tbody tr[data-baris] > td[data-label="Tanggal"]       { display: none; }
   .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]    { grid-area: 1 / 1; }
   .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]  { grid-area: 1 / 2; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 2 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
-  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 3 / 2; }
+  /* KONTAK DI BARIS KEDUA, TOMBOL REGU DI BAWAHNYA. Sebelumnya terbalik, dan
+     tombol yang duduk di antara nama sekolah dan kotak kontaknya memisahkan
+     dua keterangan yang dibaca bersama — nama CP dan nomornya milik
+     pendaftaran yang sama, dan keduanya milik sekolah tepat di atasnya.
+     Tombol regu MEMBUKA sesuatu, jadi tempatnya di kaki kartu, tepat di atas
+     rincian yang keluar dari sana. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 2 / 1; }
+  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]      { grid-area: 2 / 2; }
+  .table-peserta tbody tr[data-baris] > td[data-label="Regu"]          { grid-area: 3 / 1; }
+  /* Kedua kotak kontak DILURUSKAN DI ATAS, bukan ditengahkan sendiri-sendiri.
+     `align-items: center` pada kartunya benar untuk baris pertama — kode dan
+     nama sekolah beda tinggi barisnya — tetapi pada sepasang kotak isian ia
+     menurunkan yang lebih pendek beberapa piksel. Terukur 4px, cukup untuk
+     terlihat sebagai dua kotak yang tidak sejajar. */
+  .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"],
+  .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"] {
+    align-self: start;
+    /* `td:last-child { margin-top: .5rem }` di aturan kartu umum mengenai
+       kotak WhatsApp — ia memang anak terakhir barisnya — dan itulah 8px yang
+       menurunkannya dari kotak nama CP di sebelahnya. Aturan itu ada untuk
+       kartu yang tombolnya di sel terakhir; di sini sel terakhir justru
+       separuh dari sepasang kotak yang harus lurus. */
+    margin-top: 0;
+  }
+  /* DI BAWAH 360px KARTUNYA JADI SATU KOLOM, dan ambang itu diukur bukan
+     dipilih: separuh kartu di 360px adalah 123px, dan kode pembayaran
+     terukur 118px — pas. Di 320px separuhnya tinggal 103px dan kodenya patah
+     di tanda hubungnya sendiri, jadi "HRCD37-" berdiri di satu baris dan
+     "93E49F" di baris berikutnya. Dari layar itu terbaca seperti dua kode,
+     kesalahan yang sama dengan judul dialog Riwayat.
+
+     Yang mengalah SUSUNANNYA, bukan ukuran hurufnya: kode pembayaran dibaca
+     dari seberang meja dan dieja lewat telepon.
+
+     Urutannya tetap sama dari atas ke bawah — kode, sekolah, kontak, tombol
+     regu — jadi yang berpindah antara HP kecil dan HP besar tidak menemukan
+     dua susunan yang berbeda, cuma satu yang lebih tinggi. */
+  @media (max-width: 359px) {
+    .table-peserta tbody tr[data-baris] { grid-template-columns: minmax(0, 1fr); }
+    .table-peserta tbody tr[data-baris] > td[data-label="Kode Bayar"]     { grid-area: 1 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="Asal Sekolah"]   { grid-area: 2 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="Contact Person"] { grid-area: 3 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="WhatsApp"]       { grid-area: 4 / 1; }
+    .table-peserta tbody tr[data-baris] > td[data-label="Regu"]           { grid-area: 5 / 1; }
+  }
+
   /* Tombol regu rata KIRI di kolomnya, bukan di tengah: kolom pertama dipatok
      lebar kode pembayaran, dan tombol yang mengambang di tengahnya tidak
      sejajar dengan apa pun di atas maupun di bawahnya. */


### PR DESCRIPTION
## What

On the Data Peserta card:

- the **Nama CP** and **nomor HP** boxes are now the same width and on the same
  line
- the **"▸ N regu" button moves under them**, at the foot of the card
- below 360px the card stacks into one column so the payment code never breaks
- in the wide table the payment code no longer wraps either

## Why

The two boxes were 144px against 136px, and the WhatsApp box sat 8px lower
than the name beside it. The width came from a card grid whose first column
was pinned at 9rem for the payment code; the 8px came from
`td:last-child { margin-top: .5rem }` in the shared card rules, which happens
to catch the WhatsApp cell because it **is** the last child — a rule written
for cards whose last cell is a button.

The regu button used to sit between the school name and the contact boxes,
splitting two things that are read together: the CP name and their number
belong to the same pendaftaran, and both belong to the school directly above.
A button that *opens* something belongs at the foot of the card, right above
what comes out of it.

## Notes

- Both columns are `1fr` now, so the pair is equal by construction, and
  nothing is lost to the code: half a card at 393px is 156px and the code
  measures 118px.
- Measured: half a card at 360px is 123px, so 360 still fits side by side; at
  320px the half is 103px and the code breaks at its own hyphen, leaving
  `HRCD37-` on one line and `93E49F` on the next — the same "reads as two
  codes" fault just fixed in the Riwayat dialog. What gives way is the
  arrangement, not the type size: a payment code is read across a table and
  spelled out over the phone.
- The wide table had the same fault from a different rule: 13% of the table's
  narrowest width leaves 95px for 106px of text. It is 15% now, the two points
  taken from Asal Sekolah, the one column whose contents may wrap. Verified at
  960px and 1440px: one line, no sideways scroll, no school name overflowing.
- 395 tests pass.
