### PR TITLE
fix: changing lomba no longer balloons the photo card

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=54">
+  <link rel="stylesheet" href="style.css?v=55">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -181,8 +181,13 @@ export function tanggalJam(t) {
  *
  *  `role="status"` + satu baris tersembunyi menjaga pembaca layar tetap
  *  mendapat kabar — bagi mereka perputaran tidak berarti apa-apa. */
-export function pemuat(teks = "Memuat…") {
-  return `<div class="pemuat" role="status" aria-live="polite">
+/** Penanda muat. `kecil` untuk yang duduk DI DALAM kartu, bukan menggantikan
+ *  seluruh layar: yang biasa memesan hampir setinggi layar supaya cincinnya
+ *  jatuh di tengah dan halaman tidak menyusut selagi isinya datang, dan di
+ *  dalam kartu setinggi 99px pesanan itu justru menggelembungkannya jadi
+ *  675px sekejap sebelum menciut lagi. */
+export function pemuat(teks = "Memuat…", { kecil = false } = {}) {
+  return `<div class="pemuat${kecil ? " pemuat-kecil" : ""}" role="status" aria-live="polite">
     <span class="pemuat-cincin" aria-hidden="true"></span>
     <span class="visually-hidden">${esc(teks)}</span>
   </div>`;

--- a/live/style.css
+++ b/live/style.css
@@ -4130,6 +4130,14 @@ button.pill-number:hover { filter: brightness(.95); }
      akibatnya layar terlihat kosong dulu sebelum apa pun terjadi — diam yang
      justru terbaca sebagai macet. */
 }
+/* Penanda muat DI DALAM kartu: tanpa pesanan setinggi layar.
+   `min-height: calc(100vh - 10rem)` di atas benar untuk layar yang seluruh
+   isinya belum ada — di layar 760px ia 600px. Dijatuhkan ke dalam petak foto
+   layar Foto Jawaban Sekaligus, angka itu membuat kartunya melonjak dari 99px
+   ke 675px lalu balik lagi setiap kali lombanya diganti. Terukur begitu, dan
+   dilaporkan sebagai "langsung membesar dan mengecil". */
+.pemuat.pemuat-kecil { min-height: 0; padding: .9rem; }
+
 .pemuat-cincin {
   width: 36px; height: 36px; border-radius: 50%;
   border: 3px solid var(--garis);

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 54, sidik: "dafdebbff474" },
+  "style.css": { versi: 55, sidik: "937a8f4c2145" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=52">
+  <link rel="stylesheet" href="style.css?v=53">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7551,7 +7551,7 @@ async function layarFoto() {
        bawahnya, tempat isinya memang sedang berubah. */
     elLomba.disabled = true;
     elPos.disabled = true;
-    elGrid.replaceChildren(h(pemuat()));
+    elGrid.replaceChildren(h(pemuat("Memuat…", { kecil: true })));
     let komponen;
     try { komponen = await komponenPos(EDISI.nomor, nomorPos); }
     catch (e) {
@@ -7586,7 +7586,7 @@ async function layarFoto() {
       // Pemutar, bukan tulisan. Yang sedang terjadi selalu sama — sedang
       // dimuat — jadi kata yang mengatakannya tidak menambah apa pun, dan di
       // layar yang dipakai ratusan kali per shift ia terbaca berulang-ulang.
-      elGrid.replaceChildren(h(pemuat()));
+      elGrid.replaceChildren(h(pemuat("Memuat…", { kecil: true })));
     }
     let daftar;
     try { daftar = await daftarFotoBelumTaut(nomorPos, kodeLomba); }

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -181,8 +181,13 @@ export function tanggalJam(t) {
  *
  *  `role="status"` + satu baris tersembunyi menjaga pembaca layar tetap
  *  mendapat kabar — bagi mereka perputaran tidak berarti apa-apa. */
-export function pemuat(teks = "Memuat…") {
-  return `<div class="pemuat" role="status" aria-live="polite">
+/** Penanda muat. `kecil` untuk yang duduk DI DALAM kartu, bukan menggantikan
+ *  seluruh layar: yang biasa memesan hampir setinggi layar supaya cincinnya
+ *  jatuh di tengah dan halaman tidak menyusut selagi isinya datang, dan di
+ *  dalam kartu setinggi 99px pesanan itu justru menggelembungkannya jadi
+ *  675px sekejap sebelum menciut lagi. */
+export function pemuat(teks = "Memuat…", { kecil = false } = {}) {
+  return `<div class="pemuat${kecil ? " pemuat-kecil" : ""}" role="status" aria-live="polite">
     <span class="pemuat-cincin" aria-hidden="true"></span>
     <span class="visually-hidden">${esc(teks)}</span>
   </div>`;

--- a/web/style.css
+++ b/web/style.css
@@ -4130,6 +4130,14 @@ button.pill-number:hover { filter: brightness(.95); }
      akibatnya layar terlihat kosong dulu sebelum apa pun terjadi — diam yang
      justru terbaca sebagai macet. */
 }
+/* Penanda muat DI DALAM kartu: tanpa pesanan setinggi layar.
+   `min-height: calc(100vh - 10rem)` di atas benar untuk layar yang seluruh
+   isinya belum ada — di layar 760px ia 600px. Dijatuhkan ke dalam petak foto
+   layar Foto Jawaban Sekaligus, angka itu membuat kartunya melonjak dari 99px
+   ke 675px lalu balik lagi setiap kali lombanya diganti. Terukur begitu, dan
+   dilaporkan sebagai "langsung membesar dan mengecil". */
+.pemuat.pemuat-kecil { min-height: 0; padding: .9rem; }
+
 .pemuat-cincin {
   width: 36px; height: 36px; border-radius: 50%;
   border: 3px solid var(--garis);


### PR DESCRIPTION
## What

Changing pos or lomba on **Foto Jawaban Sekaligus** no longer makes the card
grow to 675px and drop back.

Measured at 393×760, switching between a lomba with seven photos and an empty
one:

| | before | after |
| --- | --- | --- |
| 7 foto → kosong | 1512 → **600** → 99 | 1512 → **140** → 99 |
| kosong → 7 foto | 99 → **600** → 1512 | 99 → **140** → 1512 |

## Why

The loader dropped into the photo grid is the same one that stands in for a
whole screen, and that one asks for `min-height: calc(100vh - 10rem)` on
purpose — it keeps the ring in the middle of the screen and stops the page
shrinking while its contents arrive. Inside a card 99px tall, the same request
is a 576px balloon that exists for one frame.

## Notes

- `pemuat()` takes a `kecil` option now; the two loaders inside that grid use
  it, and nothing else in the app does — every other call replaces a whole
  screen, where the tall reservation is what you want.
- The card still changes size, because the contents genuinely did. What is
  gone is growing before shrinking.
- 395 tests pass.
