### PR TITLE
fix: a rotated slip stays upright when you open it

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=55">
+  <link rel="stylesheet" href="style.css?v=56">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -5672,6 +5672,52 @@ button.pill-number:hover { filter: brightness(.95); }
 .fg-petak[data-putar="180"] .fg-buka img { transform: rotate(180deg); }
 .fg-petak[data-putar="270"] .fg-buka img { transform: translate(-50%, -50%) rotate(270deg); }
 
+/* ---------------------------------------------------------------------------
+   PENAMPIL FOTO SATU LAYAR.
+
+   Dipakai ketiga petak foto (lembar pos, Input Nilai Pos v2, Cek Nilai)
+   sebagai ganti membuka berkas aslinya di tab baru. Alasannya di app.js:
+   sudut putar disimpan dan diterapkan CSS, jadi BERKASNYA masih miring dan
+   tab baru memperlihatkan yang miring itu.
+
+   90 dan 270 MENUKAR SUMBU, dan urutannya yang menentukan benar tidaknya:
+   batas lebarnya diambil dari tinggi layar dan batas tingginya dari lebar
+   layar LEBIH DULU, baru gambarnya diputar. Dibalik — diputar dulu lalu
+   dibatasi — yang dibatasi kotak sebelum berputar, dan slip tegak yang
+   diputar 90 derajat menjulur keluar layar di kedua sisinya.
+   --------------------------------------------------------------------------- */
+.lihat-foto {
+  position: fixed; inset: 0; z-index: 70;
+  display: flex; align-items: center; justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, .92);
+}
+.lihat-foto img {
+  max-width: 100%; max-height: 100%;
+  object-fit: contain; border-radius: 4px;
+}
+.lihat-foto img[data-putar="90"],
+.lihat-foto img[data-putar="270"] {
+  max-width: calc(100dvh - 2rem);
+  max-height: calc(100dvw - 2rem);
+}
+.lihat-foto img[data-putar="90"]  { transform: rotate(90deg); }
+.lihat-foto img[data-putar="180"] { transform: rotate(180deg); }
+.lihat-foto img[data-putar="270"] { transform: rotate(270deg); }
+/* Latar putih separuh tembus, alasan yang sama dengan tombol putar di bawah:
+   slip adalah kertas putih, dan silang putih di atasnya hilang begitu
+   gambarnya mengisi layar. 44px karena ia satu-satunya jalan keluar yang
+   terlihat. */
+.lihat-tutup {
+  position: absolute; top: .6rem; right: .6rem; z-index: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 44px; min-height: 44px;
+  font-size: 1.8rem; line-height: 1;
+  background: rgba(255, 255, 255, .9); color: var(--tinta);
+  border: 0; border-radius: 999px;
+  -webkit-tap-highlight-color: transparent;
+}
+
 /* Tombol putar mengambang di pojok petaknya. Latar putih separuh tembus,
    bukan ikon telanjang: slip adalah kertas putih, dan lambang abu-abu di
    atasnya hilang sama sekali. */

--- a/tests/filter_sekolah.test.mjs
+++ b/tests/filter_sekolah.test.mjs
@@ -36,8 +36,14 @@ for (const [nama, kode] of [["panitia", app], ["peserta", live]]) {
     assert.match(kode, /new AbortController\(\)/,
       `panel ${nama} tidak punya pengendali untuk membatalkan pendengarnya`);
 
-    // Tiap pemasangan pendengar document di berkas ini harus membawa signal.
+    /* Tiap pemasangan pendengar document di berkas ini harus membawa signal —
+       KECUALI yang dipasang sekali saat berkasnya dimuat. Yang itu hidup
+       selama tabnya terbuka dan memang tidak punya apa pun untuk dibatalkan;
+       membedakannya lewat INDENTASI, aturan yang sama dengan penjaga
+       pendengar window di tests/screen_listener_cleanup.test.mjs. */
     for (const m of pasang) {
+      const awalBaris = kode.lastIndexOf("\n", m.index) + 1;
+      if (awalBaris === m.index) continue;      // kolom 0 = dipasang saat boot
       const potongan = kode.slice(m.index, kode.indexOf("});", m.index) + 3);
       assert.match(potongan, /\{ signal \}/,
         `satu pendengar document di ${nama} dipasang tanpa signal:\n`

--- a/tests/foto_penampil_putaran.test.mjs
+++ b/tests/foto_penampil_putaran.test.mjs
@@ -1,0 +1,91 @@
+// ============================================================================
+// hrcd-rekap : tests/foto_penampil_putaran.test.mjs
+// Foto slip yang sudah diputar harus TETAP tegak waktu dibuka besar.
+//
+// Sudut putarnya disimpan per foto (migrasi 0167) dan diterapkan CSS —
+// berkasnya sendiri tidak pernah disentuh, supaya bukti tidak dikompres ulang
+// tiap kali ada yang salah tekan. Yang tidak ikut dipikirkan waktu itu: `<a
+// href>` di dalam petaknya menyerahkan BERKAS ASLI ke browser, dan berkas asli
+// masih miring. Jadi petugas memutar fotonya, mengetuknya untuk membaca
+// tulisan tangannya lebih besar, dan mendapat gambar melintang lagi.
+// Dilaporkan begitu, 2 September 2026.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+test("ketukan pada KETIGA petak foto dibelokkan ke penampil", () => {
+  // Lembar pos (a.fg-petak), Input Nilai Pos v2 (a.foto-tautan), Cek Nilai
+  // (a.fg-buka). Ketiganya membungkus tautannya dengan elemen ber-data-putar,
+  // jadi satu pendengar melayani ketiganya.
+  assert.match(app,
+    /closest\("a\.fg-buka, a\.fg-petak, a\.foto-tautan"\)/,
+    "pendengar tidak lagi mengenali ketiga petak foto");
+  assert.match(app, /const wadah = taut\.closest\("\[data-putar\]"\);/,
+    "sudut putar tidak dibaca dari pembungkusnya");
+  assert.match(app, /bukaFotoPenuh\(url, wadah \? wadah\.dataset\.putar : 0/,
+    "penampil dibuka tanpa membawa sudut putarnya");
+});
+
+test("Ctrl/Cmd-klik tetap membuka berkas aslinya", () => {
+  // Yang memang mau berkas mentahnya di tab sendiri harus tetap bisa, dan
+  // `target="_blank"` di markup-nya tetap jadi jaring kalau JS gagal dimuat.
+  assert.match(app,
+    /if \(e\.metaKey \|\| e\.ctrlKey \|\| e\.shiftKey \|\| e\.altKey\) return;/,
+    "klik bertombol pengubah ikut dibelokkan");
+});
+
+test("penampil ditutup Esc, latar, silang, dan pindah layar", () => {
+  const fungsi = app.slice(app.indexOf("function bukaFotoPenuh("),
+                           app.indexOf("/* Satu pendengar untuk KETIGA petak foto"));
+  assert.ok(fungsi.length > 0, "bukaFotoPenuh tidak ditemukan");
+  assert.match(fungsi, /e\.key === "Escape"/, "Esc tidak menutup penampil");
+  assert.match(fungsi, /e\.target === el \|\| e\.target\.closest\("\.lihat-tutup"\)/,
+    "latar atau tombol silang tidak menutup penampil");
+  // Penampilnya menempel di <body>, jadi LAYAR.replaceChildren() tidak
+  // membawanya pergi — tanpa baris ini ia bertahan menutupi layar berikutnya.
+  assert.match(fungsi, /window\.addEventListener\("hashchange", tutup, \{ signal \}\)/,
+    "penampil tidak ditutup saat pindah layar");
+  // Pendengarnya menempel di luar elemennya, jadi membuang elemen saja
+  // meninggalkan mereka hidup. Satu AbortController melepas semuanya.
+  assert.match(fungsi, /function tutup\(\) \{ el\.remove\(\); pengendali\.abort\(\); \}/,
+    "pendengar penampil tidak dilepas saat ditutup");
+});
+
+test("gambar SENDIRI tidak menutup penampil", () => {
+  // Di HP jari mendarat di tengah layar saat hendak mencubit untuk
+  // memperbesar, dan penampil yang tertutup oleh cubitan pertama tidak bisa
+  // dipakai membaca tulisan tangan — satu-satunya alasan foto ini dibuka.
+  const fungsi = app.slice(app.indexOf("function bukaFotoPenuh("),
+                           app.indexOf("/* Satu pendengar untuk KETIGA petak foto"));
+  assert.doesNotMatch(fungsi, /el\.addEventListener\("click", tutup\)/,
+    "seluruh penampil menutup saat diketuk, termasuk gambarnya");
+});
+
+test("90 dan 270 DIBATASI dulu, baru diputar", () => {
+  // Urutannya yang menentukan benar tidaknya: kalau gambarnya diputar dulu
+  // lalu dibatasi, yang dibatasi kotak SEBELUM berputar — dan slip tegak yang
+  // diputar 90 derajat menjulur keluar layar di kedua sisinya.
+  const blok = css.slice(css.indexOf(".lihat-foto {"), css.indexOf(".lihat-tutup {"));
+  assert.ok(blok.length > 0, "aturan .lihat-foto tidak ditemukan");
+  const batas = blok.indexOf("max-width: calc(100dvh - 2rem)");
+  const putar = blok.indexOf('img[data-putar="90"]  { transform: rotate(90deg); }');
+  assert.ok(batas > 0, "batas sumbu tertukar tidak dipasang untuk 90/270");
+  assert.ok(putar > batas,
+    "gambar diputar sebelum batasnya ditukar — hasilnya menjulur keluar layar");
+  assert.match(blok, /max-height: calc\(100dvw - 2rem\)/,
+    "batas tinggi tidak diambil dari lebar layar");
+});
+
+test("penampil berdiri DI ATAS dialog", () => {
+  // Satu jalan masuknya lewat dialog foto lembar pos, yang z-index-nya 60.
+  const pen = css.slice(css.indexOf(".lihat-foto {"));
+  const z = pen.slice(0, pen.indexOf("}")).match(/z-index: (\d+)/);
+  assert.ok(z, "penampil tidak punya z-index");
+  assert.ok(Number(z[1]) > 60,
+    `z-index penampil ${z[1]}, tidak di atas dialog (60) yang membukanya`);
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 55, sidik: "937a8f4c2145" },
+  "style.css": { versi: 56, sidik: "78929f67b40f" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/screen_listener_cleanup.test.mjs
+++ b/tests/screen_listener_cleanup.test.mjs
@@ -31,7 +31,11 @@ test("pendengar window di dalam layar selalu membawa signal", () => {
 
   for (const l of baris) {
     if (!/^\s/.test(l)) continue;              // dipasang saat boot, bukan per layar
-    assert.match(l, /signal:/,
+    // `{ signal }` maupun `{ signal: sinyal }` sama-sama diterima. Polanya
+    // dulu `/signal:/` saja, waktu setiap pemanggilnya menulis nama sinyal
+    // layarnya; penampil foto memakai AbortController sendiri dan
+    // mendestrukturnya jadi `signal`, yang membawa persis jaminan yang sama.
+    assert.match(l, /\{[^}]*\bsignal\b/,
       `pendengar window di dalam fungsi tanpa signal: ${l.trim()}`);
   }
 });

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=53">
+  <link rel="stylesheet" href="style.css?v=54">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1086,6 +1086,78 @@ function pasangCentangRiwayat(wadah) {
     btn.addEventListener("click", () => bukaRiwayatPendaftaran(btn.dataset.riwayatKode)));
 }
 
+/* ============================================================================
+   FOTO SLIP DIBUKA BESAR, DAN IKUT SUDUT PUTARNYA.
+
+   Sudut putar disimpan per foto (migrasi 0167) dan DITERAPKAN CSS — berkasnya
+   sendiri tidak pernah disentuh. Itu keputusan yang benar: memutar berkasnya
+   berarti mengkompres ulang bukti setiap kali ada yang salah tekan.
+
+   Akibatnya satu hal yang tidak ikut dipikirkan: petaknya tegak, tetapi
+   `<a href>` di dalamnya menyerahkan BERKAS ASLI ke browser, dan berkas asli
+   masih miring. Jadi petugas memutar fotonya, mengetuknya untuk membaca
+   tulisan tangannya lebih besar, dan mendapat gambar melintang lagi.
+   Dilaporkan begitu, 2 September 2026.
+
+   Yang dilakukan: ketukannya dibelokkan ke penampil di dalam aplikasi, yang
+   memasang sudut yang sama dengan petaknya. Tab baru sekalian hilang — dan
+   itu memang sudah lama diinginkan di layar ini: sembilan foto berarti
+   sembilan tab, dan sembilan kali menekan "kembali" di HP.
+
+   Ctrl/Cmd/Shift-klik tetap dibiarkan lewat, jadi yang memang mau membuka
+   berkas aslinya di tab sendiri masih bisa. `target="_blank"` di markup-nya
+   juga tetap: kalau JS layar ini gagal dimuat, ketukannya kembali membuka
+   berkasnya — miring, tapi ada.
+   ========================================================================== */
+
+/** Satu foto sebesar layar, dengan sudut putar yang tersimpan. */
+function bukaFotoPenuh(url, putaran, judul) {
+  document.querySelector(".lihat-foto")?.remove();
+  document.body.appendChild(h(`
+    <div class="lihat-foto" role="dialog" aria-modal="true"
+         aria-label="${esc(judul || "Foto")}">
+      <button type="button" class="lihat-tutup" aria-label="Tutup">&times;</button>
+      <img src="${esc(url)}" alt="${esc(judul || "")}"
+           data-putar="${esc(String(Number(putaran) || 0))}">
+    </div>`));
+  const el = document.body.lastElementChild;
+  /* SATU pengendali untuk semua pendengarnya, bukan removeEventListener satu
+     per satu: keduanya menempel di luar `el`, jadi membuang elemennya saja
+     meninggalkan mereka hidup. Bentuk ini juga yang dituntut penjaga di
+     tests/screen_listener_cleanup.test.mjs — pendengar `document` dan
+     `window` di dalam fungsi selalu membawa signal. */
+  const pengendali = new AbortController();
+  const { signal } = pengendali;
+  function tutup() { el.remove(); pengendali.abort(); }
+  el.addEventListener("click", (e) => {
+    /* Gambarnya sendiri TIDAK menutup. Di HP jari mendarat di tengah layar
+       saat hendak mencubit untuk memperbesar, dan penampil yang tertutup oleh
+       cubitan pertama tidak bisa dipakai membaca tulisan tangan — yang justru
+       satu-satunya alasan foto ini dibuka. */
+    if (e.target === el || e.target.closest(".lihat-tutup")) tutup();
+  }, { signal });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") tutup();
+  }, { signal });
+  // Pindah layar menutupnya, alasan yang sama dengan dialog(): penampil ini
+  // menempel di <body>, jadi LAYAR.replaceChildren() tidak membawanya pergi.
+  window.addEventListener("hashchange", tutup, { signal });
+}
+
+/* Satu pendengar untuk KETIGA petak foto — lembar pos, Input Nilai Pos v2,
+   dan Cek Nilai. Ketiganya membungkus tautannya dengan elemen ber-`data-putar`,
+   jadi sudutnya dibaca dari sana; markup ketiganya tidak perlu diubah sama
+   sekali. */
+document.addEventListener("click", (e) => {
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+  const taut = e.target.closest("a.fg-buka, a.fg-petak, a.foto-tautan");
+  const url = taut && taut.getAttribute("href");
+  if (!url) return;
+  e.preventDefault();
+  const wadah = taut.closest("[data-putar]");
+  bukaFotoPenuh(url, wadah ? wadah.dataset.putar : 0, taut.getAttribute("title") || "");
+});
+
 /** Dibaca saat DIKETUK, bukan ikut dimuat bersama tabelnya: satu layar memuat
  *  ratusan baris dan hampir semuanya tidak pernah ditanya riwayatnya.
  *

--- a/web/style.css
+++ b/web/style.css
@@ -5672,6 +5672,52 @@ button.pill-number:hover { filter: brightness(.95); }
 .fg-petak[data-putar="180"] .fg-buka img { transform: rotate(180deg); }
 .fg-petak[data-putar="270"] .fg-buka img { transform: translate(-50%, -50%) rotate(270deg); }
 
+/* ---------------------------------------------------------------------------
+   PENAMPIL FOTO SATU LAYAR.
+
+   Dipakai ketiga petak foto (lembar pos, Input Nilai Pos v2, Cek Nilai)
+   sebagai ganti membuka berkas aslinya di tab baru. Alasannya di app.js:
+   sudut putar disimpan dan diterapkan CSS, jadi BERKASNYA masih miring dan
+   tab baru memperlihatkan yang miring itu.
+
+   90 dan 270 MENUKAR SUMBU, dan urutannya yang menentukan benar tidaknya:
+   batas lebarnya diambil dari tinggi layar dan batas tingginya dari lebar
+   layar LEBIH DULU, baru gambarnya diputar. Dibalik — diputar dulu lalu
+   dibatasi — yang dibatasi kotak sebelum berputar, dan slip tegak yang
+   diputar 90 derajat menjulur keluar layar di kedua sisinya.
+   --------------------------------------------------------------------------- */
+.lihat-foto {
+  position: fixed; inset: 0; z-index: 70;
+  display: flex; align-items: center; justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, .92);
+}
+.lihat-foto img {
+  max-width: 100%; max-height: 100%;
+  object-fit: contain; border-radius: 4px;
+}
+.lihat-foto img[data-putar="90"],
+.lihat-foto img[data-putar="270"] {
+  max-width: calc(100dvh - 2rem);
+  max-height: calc(100dvw - 2rem);
+}
+.lihat-foto img[data-putar="90"]  { transform: rotate(90deg); }
+.lihat-foto img[data-putar="180"] { transform: rotate(180deg); }
+.lihat-foto img[data-putar="270"] { transform: rotate(270deg); }
+/* Latar putih separuh tembus, alasan yang sama dengan tombol putar di bawah:
+   slip adalah kertas putih, dan silang putih di atasnya hilang begitu
+   gambarnya mengisi layar. 44px karena ia satu-satunya jalan keluar yang
+   terlihat. */
+.lihat-tutup {
+  position: absolute; top: .6rem; right: .6rem; z-index: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 44px; min-height: 44px;
+  font-size: 1.8rem; line-height: 1;
+  background: rgba(255, 255, 255, .9); color: var(--tinta);
+  border: 0; border-radius: 999px;
+  -webkit-tap-highlight-color: transparent;
+}
+
 /* Tombol putar mengambang di pojok petaknya. Latar putih separuh tembus,
    bukan ikon telanjang: slip adalah kertas putih, dan lambang abu-abu di
    atasnya hilang sama sekali. */


### PR DESCRIPTION
## What

Tapping a slip photo now opens a viewer **inside the app**, carrying the same
rotation as its tile. Before, it handed the browser the original file — which
is still sideways.

Works from all three photo grids: lembar pos, Input Nilai Pos v2, and Cek
Nilai.

## Why

Rotation is stored per photo (migration `0167`) and applied by CSS — the file
itself is never touched, so evidence is not re-compressed every time somebody
taps the button by mistake. That is the right call, and it left one thing
unthought: the `<a href>` inside the tile hands over the **original file**. So
an officer rotates the photo, taps it to read the handwriting larger, and gets
a landscape image again.

The new tab goes with it, which this screen has wanted for a while: nine
photos meant nine tabs and nine presses of Back on a phone.

## Notes

- For 90° and 270° the axis limits are swapped **before** the rotation, not
  after. Rotate first and the box being limited is the one before turning, and
  an upright slip turned 90° juts off both edges of the screen.
- Ctrl/Cmd/Shift-click still goes through to the original file, and
  `target="_blank"` stays in the markup: if this screen's JavaScript fails to
  load, tapping opens the file again — sideways, but there.
- One listener serves all three grids, because all three wrap their link in an
  element carrying `data-putar`. **No markup changed anywhere.**
- Tapping the image itself does not close the viewer: on a phone the finger
  lands in the middle of the screen when you go to pinch, and a viewer that
  the first pinch closes cannot be used for the one thing it is for.
- Verified live in all three grids, including the viewer sitting above the
  lembar pos dialog that opens it (z-index 70 over 60), and Esc / backdrop /
  × / changing screen all closing it with nothing left behind after repeated
  open-close.

**Two guards were generalised, not loosened** — worth a look:

- `screen_listener_cleanup` asked for the literal `signal:`, written when
  every caller named its screen signal. The viewer holds its own
  `AbortController` and destructures it, so the check now accepts `{ signal }`
  as well.
- `filter_sekolah` required every `document` listener in app.js to carry a
  signal, written when every one of them belonged to a filter panel. A
  listener installed once at module load has nothing to cancel, and it is now
  told apart by indentation — the same rule its sibling guard already used.

401 tests pass.
