### PR TITLE
feat: Cek Nilai filters the arrows, and the two input screens are renamed

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=56">
+  <link rel="stylesheet" href="style.css?v=57">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -5310,6 +5310,13 @@ button.pill-number:hover { filter: brightness(.95); }
    menyusut karenanya. */
 .cek-kendali { padding: .6rem .8rem; }
 .cek-kendali .baris-pilih .field { margin-bottom: .5rem; }
+/* KEDUA DROPDOWN SEBARIS, termasuk di HP. Patokan bawaan `.baris-pilih .field`
+   adalah `flex: 1 1 12rem` — 192px, jadi dua kotak menumpuk di layar 393px
+   yang isinya cuma 330px, dan kartu kendalinya naik dari 116px jadi 177px.
+   Tinggi itu di layar ini diambil langsung dari foto slip.
+   `flex: 1 1 0` membagi barisnya rata: 160px per kotak, cukup untuk
+   "Pos 5 — Yel-Yel" maupun "Belum Kunci (12)". */
+.cek-kendali .baris-pilih .field { flex: 1 1 0; min-width: 0; }
 .cek-kendali .cek-navigasi { margin-top: 0; }
 
 /* Kartu identitas regu diberi jarak ke blok lomba pertama. Tanpa ini nama

--- a/tests/cek_nilai_saringan.test.mjs
+++ b/tests/cek_nilai_saringan.test.mjs
@@ -1,0 +1,116 @@
+// ============================================================================
+// hrcd-rekap : tests/cek_nilai_saringan.test.mjs
+// Saringan Cek Nilai: "mana yang masih perlu dikerjakan?"
+//
+// Layar ini berjalan SATU REGU pada satu waktu, jadi saringan di sini bukan
+// daftar melainkan jalur panah: yang tersaring keluar dilewati, dan yang
+// tersisa jadi antrean kerja. "Belum Kunci" dengan begitu berubah jadi
+// tumpukan yang tinggal dihabiskan.
+//
+// Diminta pemilik acara, 2 September 2026, beserta pertanyaan di mana
+// tempatnya. Jawabannya di SINI, karena di sinilah gembok dipasang (0166) dan
+// di sinilah regu ditelusuri satu per satu. Lembar Input Nilai Tabel sudah
+// punya "Belum Input" dan "Belum Foto" sendiri; ia TIDAK diberi "Belum Kunci"
+// karena penanda barisnya berarti "ADA lomba pos ini yang tergembok", bukan
+// "semuanya tergembok" — chip yang dibangun di atasnya akan berselisih dengan
+// layar ini tentang regu yang sama (CLAUDE.md 13.3).
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+const layarCek = (() => {
+  const awal = app.indexOf("async function layarCekNilai()");
+  return app.slice(awal, app.indexOf("const RUTE = {", awal));
+})();
+
+test("empat saringan, dan angkanya ikut di dalam pilihannya", () => {
+  assert.match(layarCek, /\["semua", "Semua", \(\) => true\]/, "saringan Semua hilang");
+  for (const [kode, label] of [
+    ["belum-input", "Belum Input"], ["belum-foto", "Belum Foto"],
+    ["belum-kunci", "Belum Kunci"],
+  ]) {
+    assert.ok(layarCek.includes(`["${kode}", "${label}",`), `saringan ${label} hilang`);
+  }
+  // Tanpa angkanya, petugas harus menekan panah sampai mentok untuk tahu
+  // berapa yang tersisa.
+  assert.match(layarCek, /\$\{esc\(label\)\} \(\$\{lembar\.filter\(uji\)\.length\}\)/,
+    "jumlah tiap saringan tidak ditulis di pilihannya");
+});
+
+test("saringan MELEWATI, tidak membuang barisnya", () => {
+  // Kotak nomor dada harus tetap bisa melompat ke regu mana pun, termasuk yang
+  // tersaring keluar: petugas yang mengetik 042 sedang memegang regu 042 di
+  // depannya.
+  assert.match(layarCek, /const tetangga = \(arah\) => \{/,
+    "panah tidak lagi mencari tetangga yang lolos saringan");
+  assert.match(layarCek, /if \(cocokSaring\(lembar\[i\]\)\) return i;/,
+    "pencarian tetangga tidak memeriksa saringan");
+  assert.match(layarCek, /elMundur\.addEventListener\("click", \(\) => geser\(-1\)/,
+    "panah mundur tidak lewat geser()");
+  assert.match(layarCek, /elMaju\.addEventListener\("click", \(\) => geser\(1\)/,
+    "panah maju tidak lewat geser()");
+  // Lompat lewat kotak nomor dada TIDAK boleh ikut disaring.
+  const lompat = layarCek.slice(layarCek.indexOf("const lompat = ("));
+  assert.match(lompat.slice(0, lompat.indexOf("};")), /ke\(i\);/,
+    "lompat ke nomor dada ikut tersaring");
+});
+
+test("panah mati mengikuti saringan, bukan ujung daftar", () => {
+  assert.match(layarCek, /elMundur\.disabled = tetangga\(-1\) < 0;/,
+    "panah mundur masih memakai ujung daftar penuh");
+  assert.match(layarCek, /elMaju\.disabled = tetangga\(1\) < 0;/,
+    "panah maju masih memakai ujung daftar penuh");
+});
+
+test("yang berlaku dibatasi golongan regunya", () => {
+  // Komponen dan lomba yang bukan urusan golongan itu tidak boleh dihitung
+  // sebagai pekerjaan yang belum selesai — aturan yang sama dengan
+  // gambarKunci() dan statusAwal().
+  assert.match(layarCek, /const lombaBerlaku = \(r\) => lombaPos\(\)\.filter\(l =>\s*\n\s*l\.kolom\.some\(kol => varianUntuk\(kol, r\.golongan\)\)\);/,
+    "lomba yang berlaku tidak disaring per golongan");
+  assert.match(layarCek, /\.map\(kol => varianUntuk\(kol, r\.golongan\)\)\.filter\(Boolean\)/,
+    "komponen yang berlaku tidak disaring per golongan");
+});
+
+test("daftar foto sepos diambil SEKALI, bukan per regu", () => {
+  // daftarFotoLembar() menjawab satu regu per permintaan; saringan ini
+  // menanyakannya untuk ratusan regu sekaligus.
+  assert.match(layarCek, /fotoLembarPos\(nomorPos\)\.catch\(\(\) => null\)/,
+    "daftar foto sepos tidak diambil sekali di muatPos");
+  assert.match(layarCek, /fotoAda = new Set\(\(foto \|\| \[\]\)\.map\(f => `\$\{f\.nomor_dada\}\|\$\{f\.kode_lomba\}`\)\);/,
+    "kunci foto bukan pasangan nomor dada + kode lomba");
+});
+
+test("saringan foto HILANG kalau daftar fotonya gagal dibaca", () => {
+  // Menyisakannya berarti menandai seluruh regu belum difoto — tuduhan
+  // terhadap pekerjaan yang mungkin sudah selesai, aturan yang sama dengan
+  // "foto tidak terbaca" di petak fotonya.
+  assert.match(layarCek, /fotoTerbaca = foto !== null;/,
+    "gagal baca daftar foto tidak dibedakan dari 'tidak ada foto'");
+  assert.match(layarCek,
+    /SARING\.filter\(\(\[kode\]\) => fotoTerbaca \|\| kode !== "belum-foto"\)/,
+    "saringan Belum Foto tetap ditawarkan walau daftarnya tidak terbaca");
+  assert.match(layarCek, /if \(!pakai\.some\(\(\[kode\]\) => kode === saring\)\) saring = "semua";/,
+    "saringan yang hilang tidak dikembalikan ke Semua");
+});
+
+test("katalog lomba disimpan, tidak disusun ulang per regu", () => {
+  // Saringan memanggilnya sekali untuk SETIAP regu dikali empat saringan.
+  assert.match(layarCek, /const lombaPos = \(\) => \(lombaCache \|\|= katalogLomba\(/,
+    "katalog lomba disusun ulang tiap panggilan");
+  assert.match(layarCek, /lombaCache = null;/,
+    "simpanan katalog tidak dikosongkan saat pos berganti");
+});
+
+test("kedua dropdown sebaris, supaya kepala layar tidak tumbuh", () => {
+  // Patokan bawaan `.baris-pilih .field` 12rem membuat keduanya menumpuk di
+  // 393px dan kartu kendalinya naik dari 116px jadi 177px — tinggi yang di
+  // layar ini diambil langsung dari foto slip.
+  assert.match(css, /\.cek-kendali \.baris-pilih \.field \{ flex: 1 1 0; min-width: 0; \}/,
+    "dua dropdown Cek Nilai tidak lagi dipaksa sebaris");
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 56, sidik: "78929f67b40f" },
+  "style.css": { versi: 57, sidik: "6b8ba7ee653e" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=54">
+  <link rel="stylesheet" href="style.css?v=55">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -511,10 +511,10 @@ async function layarHome() {
              tidak melihatnya sama sekali. Persis yang terjadi sampai baris
              ini ditulis. -->
         <a href="#/pos2">
-          <div class="function-name">${ikonKotak("clipboard-pen", "ungu")} Input Nilai Pos v2</div>
+          <div class="function-name">${ikonKotak("clipboard-pen", "ungu")} Input Nilai Per Lomba</div>
         </a>
         <a href="#/pos">
-          <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos${
+          <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Tabel${
             sesi().pos != null && sesi().pos !== "" ? ` ${esc(sesi().pos)}` : ""}</div>
         </a>
         <a href="#/foto">
@@ -614,7 +614,7 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/pos">
-        <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Pos</div>
+        <div class="function-name">${ikonKotak("square-pen", "nila")} Input Nilai Tabel</div>
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/foto">
@@ -622,7 +622,7 @@ async function layarHome() {
       </a>` : ""}
       ${bolehLihat("pos") ? `
       <a href="#/pos2">
-        <div class="function-name">${ikonKotak("clipboard-pen", "ungu")} Input Nilai Pos v2</div>
+        <div class="function-name">${ikonKotak("clipboard-pen", "ungu")} Input Nilai Per Lomba</div>
       </a>` : ""}
       ${bolehLihat("pengaturan") ? `
       <a href="#/cek-nilai">
@@ -4118,7 +4118,7 @@ function siapkanCetakBlangko(pos, kolomLayar) {
 async function layarInputPos() {
   const s = sesi();
   if (!bolehLihat("pos")) {
-    pasangKepala("Input Nilai Pos");
+    pasangKepala("Input Nilai Tabel");
     LAYAR.replaceChildren(h(html`
       <div class="card">
         <h2>Akun meja, bukan akun pos</h2>
@@ -4128,7 +4128,7 @@ async function layarInputPos() {
     return;
   }
 
-  pasangKepala("Input Nilai Pos", "lembar");
+  pasangKepala("Input Nilai Tabel", "lembar");
   LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
@@ -8317,7 +8317,7 @@ const kartuReguNilai = (r, { ringkas = false } = {}) => (ringkas ? `
 async function layarInputPos2() {
   const s = sesi();
   if (!bolehLihat("pos")) {
-    pasangKepala("Input Nilai Pos v2");
+    pasangKepala("Input Nilai Per Lomba");
     LAYAR.replaceChildren(h(html`
       <div class="card">
         <h2>Akun meja, bukan akun pos</h2>
@@ -8327,7 +8327,7 @@ async function layarInputPos2() {
     return;
   }
 
-  pasangKepala("Input Nilai Pos v2", true);
+  pasangKepala("Input Nilai Per Lomba", true);
   LAYAR.replaceChildren(h(pemuat()));
 
   const layarIni = location.hash;
@@ -9380,6 +9380,15 @@ async function layarCekNilai() {
   let nomorPos = Number(posBoleh[0].nomor);
   let lembar = [];      // seluruh regu bernomor dada di pos ini
   let indeks = 0;
+  /* SARINGAN: yang dipilih tidak membuang barisnya, ia cuma menentukan mana
+     yang DILEWATI panah. `lembar` tetap utuh — kotak nomor dada harus tetap
+     bisa melompat ke regu mana pun, termasuk yang tersaring keluar: petugas
+     yang mengetik 042 sedang memegang regu 042 di depannya, dan layar yang
+     menjawab "tidak ada" karena saringannya sedang menyala membantah kenyataan
+     di meja. */
+  let saring = "semua";
+  let fotoAda = new Set();   // "nomorDada|kodeLomba" yang sudah punya foto
+  let fotoTerbaca = false;   // false = daftarnya gagal dibaca, bukan "tidak ada foto"
 
   LAYAR.replaceChildren(h(`
     <!-- Pita antrean ada DI SINI JUGA, dan itu bukan kerapian: sejak layar ini
@@ -9401,6 +9410,20 @@ async function layarCekNilai() {
                   ${posBoleh.length < 2 ? "disabled" : ""}>
             ${posBoleh.map(p => `<option value="${esc(p.nomor)}"
               >${esc(judulPos(p))}</option>`).join("")}
+          </select>
+        </div>
+        <!-- SARINGAN SEBAGAI DROPDOWN, bukan deretan chip. Empat chip beserta
+             angkanya tidak muat sebaris di layar 393px, dan yang tidak muat
+             membungkus jadi baris kedua — tinggi yang di layar ini diambil
+             dari foto slip. Dropdown juga bentuk yang sudah berdiri di
+             sebelahnya, jadi tidak ada satu pun benda baru untuk dipelajari.
+
+             ANGKANYA IKUT DI DALAM PILIHANNYA. "Belum Kunci" tanpa angka
+             menyuruh petugas menekan panah sampai mentok untuk tahu berapa
+             yang tersisa; dengan angkanya, pertanyaan itu sudah terjawab
+             sebelum ditekan sekali pun. -->
+        <div class="field">
+          <select id="cek-saring" class="select-small" aria-label="Saringan">
           </select>
         </div>
       </div>
@@ -9466,26 +9489,111 @@ async function layarCekNilai() {
   const elDada = document.getElementById("cek-dada");
   pasangDada3(elDada, sinyal);
   const elIsi = document.getElementById("cek-isi");
+  const elSaring = document.getElementById("cek-saring");
   const elMundur = document.getElementById("cek-mundur");
   const elMaju = document.getElementById("cek-maju");
 
-  /** Lomba pos yang sedang dibuka, dari katalog yang sudah di tangan. */
-  const lombaPos = () => katalogLomba(
+  /** Lomba pos yang sedang dibuka, dari katalog yang sudah di tangan.
+   *
+   *  DISIMPAN, tidak dihitung ulang tiap panggilan: saringan di bawah
+   *  memanggilnya sekali untuk SETIAP regu di pos ini — 269 kali dikali empat
+   *  saringan — dan katalogLomba() menyusun ulang seluruh kolom pos tiap kali.
+   *  Dikosongkan saat posnya berganti, satu-satunya saat jawabannya berubah. */
+  let lombaCache = null;
+  const lombaPos = () => (lombaCache ||= katalogLomba(
     katalogMentah.pos.filter(p => Number(p.nomor) === nomorPos),
-    katalogMentah.komponen);
+    katalogMentah.komponen));
+
+  /* ------------------------------------------------------------------------
+     SARINGAN: "mana yang masih perlu dikerjakan?"
+
+     Layar ini berjalan satu regu pada satu waktu, jadi saringan di sini bukan
+     daftar melainkan JALUR PANAH: yang tersaring keluar dilewati, dan yang
+     tersisa jadi antrean kerja. "Belum Kunci" dengan begitu berubah jadi
+     tumpukan yang tinggal dihabiskan.
+
+     Yang berlaku untuk satu regu dibatasi golongannya — komponen dan lomba
+     yang bukan urusan golongan itu tidak boleh dihitung sebagai pekerjaan
+     yang belum selesai. Aturan yang sama dipakai gambarKunci() dan
+     statusAwal(), lewat varianUntuk().
+     --------------------------------------------------------------------- */
+  const lombaBerlaku = (r) => lombaPos().filter(l =>
+    l.kolom.some(kol => varianUntuk(kol, r.golongan)));
+
+  const belumInput = (r) => lombaPos().some(l => l.kolom
+    .map(kol => varianUntuk(kol, r.golongan)).filter(Boolean)
+    .some(k => (r.nilai || {})[k.kode] === undefined));
+
+  const belumFoto = (r) => lombaBerlaku(r)
+    .some(l => !fotoAda.has(`${r.nomor_dada}|${l.kode}`));
+
+  const belumKunci = (r) => {
+    const kunci = new Set(r.lomba_terkunci || []);
+    return lombaBerlaku(r).some(l => !kunci.has(l.kode));
+  };
+
+  const SARING = [
+    ["semua", "Semua", () => true],
+    ["belum-input", "Belum Input", belumInput],
+    ["belum-foto", "Belum Foto", belumFoto],
+    ["belum-kunci", "Belum Kunci", belumKunci],
+  ];
+  const cocokSaring = (r) =>
+    (SARING.find(x => x[0] === saring) || SARING[0])[2](r);
+
+  /** Isi ulang pilihan saringan BESERTA jumlahnya.
+   *
+   *  Angkanya berubah tiap kali satu nilai disimpan atau satu gembok dipasang,
+   *  jadi ia dibangun ulang di tiap penggambaran — bukan sekali saat posnya
+   *  dimuat. "Belum Kunci (34)" yang tetap 34 sesudah tiga digembok adalah
+   *  angka yang membohongi orang yang sedang menghitung sisanya.
+   *
+   *  "Belum Foto" HILANG dari daftar kalau daftar fotonya gagal dibaca.
+   *  Menyisakannya berarti menandai seluruh regu belum difoto — tuduhan
+   *  terhadap pekerjaan yang mungkin sudah selesai, aturan yang sama dengan
+   *  "foto tidak terbaca" di petak fotonya. */
+  function isiSaring() {
+    const pakai = SARING.filter(([kode]) => fotoTerbaca || kode !== "belum-foto");
+    if (!pakai.some(([kode]) => kode === saring)) saring = "semua";
+    elSaring.innerHTML = pakai.map(([kode, label, uji]) =>
+      `<option value="${esc(kode)}"${kode === saring ? " selected" : ""}
+        >${esc(label)} (${lembar.filter(uji).length})</option>`).join("");
+  }
 
   async function muatPos() {
     elIsi.replaceChildren(h(pemuat()));
-    try { lembar = await lembarPos(nomorPos); }
-    catch (e) { elIsi.replaceChildren(kartuGagalMuat(e.message, muatPos)); return; }
+    lombaCache = null;
+    /* Daftar foto SEPOS diambil sekali di sini, bukan per regu: saringan
+       "Belum Foto" menanyakannya untuk 269 regu sekaligus, dan
+       daftarFotoLembar() menjawab satu regu per permintaan. v_foto_lembar
+       mengembalikan pasangan nomor dada + kode lomba saja, jadi ia murah.
+
+       Kegagalannya TIDAK menjatuhkan layar: fotonya cuma menghidupkan satu
+       saringan, sedangkan angkanya — yang membuat layar ini ada — datang dari
+       lembar pos. */
+    let foto = null;
+    try {
+      [lembar, foto] = await Promise.all([
+        lembarPos(nomorPos),
+        fotoLembarPos(nomorPos).catch(() => null),
+      ]);
+    } catch (e) { elIsi.replaceChildren(kartuGagalMuat(e.message, muatPos)); return; }
     if (sinyal.aborted) return;
+    fotoTerbaca = foto !== null;
+    fotoAda = new Set((foto || []).map(f => `${f.nomor_dada}|${f.kode_lomba}`));
     indeks = 0;
+    /* Regu pertama yang LOLOS saringan, bukan regu pertama. Saringan yang
+       bertahan saat pos diganti tetapi selalu mendarat di regu yang tersaring
+       keluar akan terbaca seperti saringan yang tidak jalan. */
+    const awal = lembar.findIndex(cocokSaring);
+    if (awal >= 0) indeks = awal;
     await gambarRegu();
   }
 
   function perbaruiNavigasi() {
-    elMundur.disabled = indeks <= 0;
-    elMaju.disabled = indeks >= lembar.length - 1;
+    isiSaring();
+    elMundur.disabled = tetangga(-1) < 0;
+    elMaju.disabled = tetangga(1) < 0;
     /* Kotaknya JANGAN ditimpa selagi diketik: petugas yang sedang mengetik
        "04" untuk menuju 042 akan melihat ketikannya diganti nomor yang sedang
        terbuka, di tengah ketikan. */
@@ -10198,8 +10306,33 @@ async function layarCekNilai() {
     gambarRegu();
   };
 
-  elMundur.addEventListener("click", () => ke(indeks - 1), { signal: sinyal });
-  elMaju.addEventListener("click", () => ke(indeks + 1), { signal: sinyal });
+  /** Tetangga berikutnya yang LOLOS saringan, atau -1 kalau tidak ada lagi.
+   *
+   *  Inilah seluruh isi saringan di layar ini: barisnya tidak dibuang, cuma
+   *  dilewati panah. */
+  const tetangga = (arah) => {
+    for (let i = indeks + arah; i >= 0 && i < lembar.length; i += arah) {
+      if (cocokSaring(lembar[i])) return i;
+    }
+    return -1;
+  };
+  const geser = (arah) => { const i = tetangga(arah); if (i >= 0) ke(i); };
+
+  elMundur.addEventListener("click", () => geser(-1), { signal: sinyal });
+  elMaju.addEventListener("click", () => geser(1), { signal: sinyal });
+
+  elSaring.addEventListener("change", () => {
+    saring = elSaring.value;
+    /* Regu yang sedang terbuka TIDAK ditinggalkan kalau ia masih lolos. Kalau
+       tidak, layar pindah ke yang pertama lolos — dan kalau tidak ada satu
+       pun, ia tetap di tempatnya dengan kedua panah mati. Angka (0) di
+       pilihannya sudah mengatakan itu sebelum ditekan. */
+    if (lembar.length && !cocokSaring(lembar[indeks])) {
+      const i = lembar.findIndex(cocokSaring);
+      if (i >= 0) { ke(i); return; }
+    }
+    perbaruiNavigasi();
+  }, { signal: sinyal });
 
   /* Panah kiri-kanan menggerakkan halaman juga. Petugas yang membandingkan
      dua ratus regu menekan "Berikutnya" dua ratus kali, dan memindahkan
@@ -10209,8 +10342,8 @@ async function layarCekNilai() {
      membetulkan ketikannya lebih buruk daripada tidak ada pintasan. */
   const panahNavigasi = (e) => {
     if (e.target.matches("input, select, textarea")) return;
-    if (e.key === "ArrowLeft") ke(indeks - 1);
-    else if (e.key === "ArrowRight") ke(indeks + 1);
+    if (e.key === "ArrowLeft") geser(-1);
+    else if (e.key === "ArrowRight") geser(1);
   };
   // Satu baris dengan opsinya, bukan dipecah: tests/screen_listener_cleanup
   // memeriksa BARIS yang memuat window.addEventListener, dan pendengar layar

--- a/web/style.css
+++ b/web/style.css
@@ -5310,6 +5310,13 @@ button.pill-number:hover { filter: brightness(.95); }
    menyusut karenanya. */
 .cek-kendali { padding: .6rem .8rem; }
 .cek-kendali .baris-pilih .field { margin-bottom: .5rem; }
+/* KEDUA DROPDOWN SEBARIS, termasuk di HP. Patokan bawaan `.baris-pilih .field`
+   adalah `flex: 1 1 12rem` — 192px, jadi dua kotak menumpuk di layar 393px
+   yang isinya cuma 330px, dan kartu kendalinya naik dari 116px jadi 177px.
+   Tinggi itu di layar ini diambil langsung dari foto slip.
+   `flex: 1 1 0` membagi barisnya rata: 160px per kotak, cukup untuk
+   "Pos 5 — Yel-Yel" maupun "Belum Kunci (12)". */
+.cek-kendali .baris-pilih .field { flex: 1 1 0; min-width: 0; }
 .cek-kendali .cek-navigasi { margin-top: 0; }
 
 /* Kartu identitas regu diberi jarak ke blok lomba pertama. Tanpa ini nama


### PR DESCRIPTION
## Where the filter belongs — the answer

**Cek Nilai.** Locking happens on this screen and nowhere else (migration
`0166`), and this is the screen that walks regu one at a time. So a filter
here is not a list — it is **the route the arrows take**. "Belum Kunci" turns
the screen into a pile to work through: press next and it only stops where
there is something left to do.

**Input Nilai Tabel keeps its own Belum Input / Belum Foto chips and does NOT
get Belum Kunci.** Its row flag means *"some lomba of this pos is locked"*, not
*"all of them are"*, and a chip built on that would disagree with Cek Nilai
about the same regu — the exact shape of mistake section 13.3 describes.

## What

A dropdown beside the pos one, each choice carrying its own count:

```
[ Pos 5 — Yel-Yel ▾ ]  [ Belum Kunci (7) ▾ ]
        ‹      007      ›
```

- **Semua**, **Belum Input**, **Belum Foto**, **Belum Kunci**
- the arrows (and the ← → keys) move only between regu that match
- the count is inside the option, so "how many left" is answered before
  pressing anything

Renamed while there: **Input Nilai Pos → Input Nilai Tabel**, **Input Nilai
Pos v2 → Input Nilai Per Lomba**, on both Home boards and in each screen's own
header.

## Notes

- **A dropdown rather than chips**: four chips with their numbers do not fit
  one row at 393px, and a second row is height taken straight out of the slip
  photo. Both dropdowns share one row, so the control card stays **116px** —
  exactly what it measured before this feature existed.
- **The filter skips, it does not drop.** The nomor dada box still jumps to
  any regu, filtered out or not: somebody typing 042 is holding regu 042, and
  a screen that answers "not found" because a filter is on is arguing with the
  table.
- What counts as unfinished is bounded by the regu's golongan — the same rule
  `gambarKunci()` and `statusAwal()` use.
- The photo list is fetched **once per pos** (`v_foto_lembar` returns just
  nomor dada + kode lomba) rather than once per regu. When that request fails,
  the **Belum Foto choice is removed** rather than shown listing everyone:
  saying "not photographed" about work that may well be done is the accusation
  this codebase already refuses to make in the photo tiles.
- Verified live at 393×760 against seeded data — 5 regu locked, 2 with no
  score, 2 with no photo: counts read `Semua (12) · Belum Input (2) · Belum
  Foto (2) · Belum Kunci (7)`, and the arrows visited exactly `004 006 007 009
  010 011 012`, `004 009`, and `006 011`. At 1440×820 the one-screen layout is
  unchanged: control card 67px, photos still 491px, no scrolling.
- 409 tests pass.
