### PR TITLE
feat: print the champions list

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=57">
+  <link rel="stylesheet" href="style.css?v=58">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -1232,6 +1232,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .receipt-signature { margin-top: 10mm; width: 60mm; margin-left: auto; text-align: center; }
   .receipt-line { margin-top: 14mm; border-top: 1pt solid #000; padding-top: 2mm; }
 
+  /* ---- Daftar juara ----
+
+     Satu dokumen mengalir, bukan satu lembar per bagian: sebelas bagian
+     berarti sebelas lembar yang dibolak-balik di podium, padahal seluruhnya
+     muat di dua. Yang dijaga cuma satu bagian tidak terbelah dua halaman —
+     gelar "Juara 1" yang tertinggal sendirian di kaki halaman, dengan
+     namanya di halaman berikutnya, adalah persis kesalahan yang mahal saat
+     dibacakan. */
+  .printout h2 { font-size: 12pt; margin: 5mm 0 1mm; }
+  .juara-bagian { break-inside: avoid; page-break-inside: avoid; }
+  /* Nama sekolah dan keterangan poin: kecil dan HITAM PEKAT, bukan abu.
+     Bagian 8.4 — yang harus mundur dibuat kecil, bukan pucat, karena raster
+     abu keluar belang dari mesin fotokopi. */
+  .juara-sekolah { font-size: 9pt; }
+  /* Gelar yang belum ada juaranya TIDAK diredupkan. Pembawa acara yang
+     menemukannya di atas panggung tidak punya jalan keluar; yang menemukannya
+     di kertas sebelum naik masih punya. Bedanya dari yang sudah terisi cukup
+     dari tebalnya: nama juara tebal, ini biasa. */
+  .juara-kosong { font-size: 11pt; }
+  .print-table .juara-gelar { width: 34mm; font-weight: 700; }
+  .print-table th.juara-gelar { font-weight: 700; }
+  .print-table .juara-skor { width: 20mm; text-align: right; font-weight: 700; }
+
   .print-note { font-size: 9pt; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
 

--- a/tests/cetak_daftar_juara.test.mjs
+++ b/tests/cetak_daftar_juara.test.mjs
@@ -1,0 +1,102 @@
+// ============================================================================
+// hrcd-rekap : tests/cetak_daftar_juara.test.mjs
+// Daftar juara di atas kertas.
+//
+// Dua pemakaian, dan keduanya menuntut kertas: dibacakan di panggung saat
+// pengumuman, lalu jadi dasar menulis sertifikat. Sampai 2 September 2026
+// layar Kejuaraan satu-satunya layar berisi hasil yang TIDAK punya tombol
+// cetak — sembilan layar lain punya — jadi satu-satunya cara mengeluarkannya
+// adalah tangkapan layar HP.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const app = await readFile(new URL("../web/js/app.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../web/style.css", import.meta.url), "utf8");
+
+const pembuat = app.slice(app.indexOf("function siapkanCetakJuara("),
+                          app.indexOf("async function layarKejuaraan()"));
+const layar = app.slice(app.indexOf("async function layarKejuaraan()"),
+                        app.indexOf("async function layarPengaturanKloter()") > 0
+                          ? app.indexOf("const RUTE = {") : undefined);
+
+test("bagian dan urutannya DIPINJAM dari layarnya, bukan ditulis ulang", () => {
+  // Dua daftar penghargaan yang harus ikut benar setiap kali satu gelar
+  // ditambah adalah dua daftar yang suatu hari berselisih — dan yang
+  // berselisih di sini terbaca di panggung.
+  assert.match(pembuat, /function siapkanCetakJuara\(hasil, bagian\) \{/,
+    "pembuat cetakan tidak menerima daftar bagian dari layarnya");
+  assert.match(layar, /siapkanCetakJuara\(hasil, bagian\);/,
+    "layar tidak mengoper daftar bagiannya sendiri ke pembuat cetakan");
+  assert.equal((pembuat.match(/Juara Umum Penegak/g) || []).length, 0,
+    "nama bagian ditulis ulang di pembuat cetakan");
+});
+
+test("window.print() tetap di dalam giliran ketukan", () => {
+  // Safari iPhone memblokirnya begitu ada satu `await` lebih dulu: sesudah itu
+  // panggilannya tidak lagi dianggap datang dari pengguna. Aturan yang sama
+  // dengan kedua tombol cetak Live Score dan tombol cetak Daftar Kloter.
+  const awal = layar.indexOf('getElementById("cetak-juara")');
+  assert.ok(awal > 0, "tombol Cetak Daftar Juara tidak dipasangi pendengar");
+  const pendengar = layar.slice(awal, layar.indexOf("});", awal) + 3);
+  assert.doesNotMatch(pendengar, /await/,
+    "ada await sebelum window.print() — Safari iPhone memblokirnya");
+  assert.match(pendengar, /siapkanCetakJuara\(hasil, bagian\);\s*\n\s*window\.print\(\);/,
+    "cetakan tidak dibangun tepat sebelum print()");
+});
+
+test("gelar yang belum ada juaranya IKUT dicetak", () => {
+  // Pembawa acara yang menemukan gelar kosong di atas panggung tidak punya
+  // jalan keluar; yang menemukannya di kertas, sebelum naik, masih punya.
+  assert.match(pembuat, /Belum ditentukan/,
+    "gelar tanpa juara tidak punya tulisan apa pun di kertas");
+  assert.doesNotMatch(pembuat, /\.filter\(x => x\.nama_regu\)/,
+    "gelar tanpa juara disaring keluar dari cetakan");
+  // Dan tidak diredupkan: bedanya dari yang terisi cukup dari tebalnya.
+  assert.match(css, /\.juara-kosong \{ font-size: 11pt; \}/,
+    "tulisan 'Belum ditentukan' diberi gaya yang meredupkannya");
+});
+
+test("kolom kanan berarti SATU hal: total skor regu", () => {
+  // Diisi juga untuk penghargaan sekolah, hasilnya angka yang sama tercetak
+  // dua kali bersebelahan — "42" di kolom kanan dan "42 poin juara" tepat di
+  // sebelahnya (bagian 9.3).
+  assert.match(pembuat,
+    /const angka = \(x\) => \(x\.nama_regu && x\.total != null\) \? angkaRapi\(x\.total\) : "";/,
+    "kolom skor kembali diisi angka yang satuannya berbeda-beda");
+});
+
+test("tanpa baris kepala yang diulang sebelas kali", () => {
+  // Terukur: sebelas baris kepala memakan 88mm — sepertiga halaman A4 — untuk
+  // mengulang tiga kata yang sudah terbaca dari bentuk kolomnya sendiri.
+  // Dokumennya turun dari 4 halaman jadi 3.
+  assert.doesNotMatch(pembuat, /<thead>/,
+    "baris kepala kembali di tabel daftar juara");
+});
+
+test("satu bagian tidak boleh terbelah dua halaman", () => {
+  // Gelar "Juara 1" yang tertinggal sendirian di kaki halaman, dengan namanya
+  // di halaman berikutnya, adalah kesalahan yang mahal saat dibacakan.
+  assert.match(css, /\.juara-bagian \{ break-inside: avoid; page-break-inside: avoid; \}/,
+    "bagian daftar juara boleh terbelah antar halaman");
+  // Satu dokumen mengalir, BUKAN satu lembar per bagian: sebelas bagian
+  // berarti sebelas lembar yang dibolak-balik di podium.
+  assert.equal((pembuat.match(/class="print-page"/g) || []).length, 1,
+    "daftar juara dipecah jadi lebih dari satu lembar paksa");
+});
+
+test("kertasnya menuruti aturan fotokopi", () => {
+  // Bagian 8: tanpa raster abu, tanpa blok hitam, tanpa teks terbalik; yang
+  // harus mundur dibuat KECIL dan hitam pekat, bukan pucat.
+  const blok = css.slice(css.indexOf("/* ---- Daftar juara ----"),
+                         css.indexOf(".print-note { font-size: 9pt;"));
+  assert.ok(blok.length > 0, "blok CSS daftar juara tidak ditemukan");
+  assert.doesNotMatch(blok, /background|color:\s*#(?!000)/,
+    "ada latar atau warna selain hitam di cetakan daftar juara");
+  // Huruf terkecil di kertas ini 9pt — batas bawahnya 7pt (bagian 8.6).
+  for (const m of blok.matchAll(/font-size: ([\d.]+)pt/g)) {
+    assert.ok(Number(m[1]) >= 7, `ada huruf ${m[1]}pt di kertas, di bawah batas 7pt`);
+  }
+});

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 57, sidik: "6b8ba7ee653e" },
+  "style.css": { versi: 58, sidik: "58d415542ad8" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=55">
+  <link rel="stylesheet" href="style.css?v=56">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6845,6 +6845,92 @@ async function layarLiveScore() {
 
 /* ============================ KEJUARAAN ================================= */
 
+/** DAFTAR JUARA DI ATAS KERTAS.
+ *
+ *  Dua pemakaian, dan keduanya menuntut kertas: dibacakan di panggung saat
+ *  pengumuman, lalu jadi dasar menulis sertifikat. Sebelum ini satu-satunya
+ *  cara mengeluarkannya dari layar adalah tangkapan layar HP.
+ *
+ *  BAGIAN DAN URUTANNYA DIPINJAM DARI LAYARNYA — `bagian` yang sama persis
+ *  dioper ke sini, tidak ditulis ulang. Dua daftar penghargaan yang harus
+ *  ikut benar setiap kali satu gelar ditambah adalah dua daftar yang suatu
+ *  hari berselisih, dan yang berselisih di sini terbaca di panggung.
+ *
+ *  YANG BELUM DITENTUKAN IKUT DICETAK, dan tidak diredupkan. Pembawa acara
+ *  yang menemukan gelar kosong di atas panggung tidak punya jalan keluar;
+ *  yang menemukannya di kertas, sebelum naik, masih punya. Karena itu ia
+ *  tertulis biasa — bukan miring, bukan abu — sementara yang sudah ada
+ *  namanya ditebalkan: bedanya terbaca dari kejauhan tanpa dieja.
+ *
+ *  SATU DOKUMEN MENGALIR, bukan satu lembar per bagian. Sebelas bagian
+ *  berarti sebelas lembar yang harus dibolak-balik di podium, padahal
+ *  seluruhnya muat di dua. Yang dijaga cuma satu bagian tidak terbelah dua
+ *  halaman, lewat `break-inside: avoid`.
+ *
+ *  Tanpa raster, tanpa abu, garis 1pt, huruf terkecil 9pt — kertas ini ikut
+ *  digandakan di mesin fotokopi bersama yang lain (CLAUDE.md bagian 8). */
+function siapkanCetakJuara(hasil, bagian) {
+  document.getElementById("cetakan")?.remove();
+  const dicetak = tanggalJam(new Date().toISOString());
+
+  /* KOLOM KANAN BERARTI SATU HAL: total skor regu. Penghargaan yang menunjuk
+     SEKOLAH — Juara Umum, Pangkalan Terjauh, Peserta Terbanyak — dibiarkan
+     kosong di sana, karena angkanya bukan skor dan satuannya berbeda-beda:
+     poin juara, jumlah regu. Angka itu tetap tertulis, di baris keterangan di
+     bawah namanya, lengkap dengan satuannya.
+
+     Sempat diisi juga, dan hasilnya angka yang sama tercetak dua kali
+     bersebelahan — "42" di kolom kanan dan "42 poin juara" tepat di
+     sebelahnya (bagian 9.3). Kolom yang isinya satu jenis angka bisa dibaca
+     lurus ke bawah; kolom yang isinya tiga jenis menuntut tiap barisnya
+     diartikan sendiri-sendiri. */
+  const angka = (x) => (x.nama_regu && x.total != null) ? angkaRapi(x.total) : "";
+
+  const isiJuara = (x) => {
+    if (x.nama_regu) {
+      return `<strong>${esc(dada3(x.nomor_dada))} · ${esc(x.nama_regu)}</strong>`
+        + `<br><span class="juara-sekolah">${esc(x.nama_sekolah || "")}</span>`;
+    }
+    if (x.nama_sekolah) {
+      const ket = x.kode.startsWith("juara_umum")
+        ? `${angkaRapi(x.poin_juara)} poin juara · ${angkaRapi(x.jumlah_skor)} total skor (6 besar)`
+        : x.kode === "peserta_terbanyak" ? `${angkaRapi(x.total)} regu bernomor dada` : "";
+      return `<strong>${esc(x.nama_sekolah)}</strong>`
+        + (ket ? `<br><span class="juara-sekolah">${esc(ket)}</span>` : "");
+    }
+    return `<span class="juara-kosong">Belum ditentukan</span>`;
+  };
+
+  const isi = bagian.map(([judul, masuk, label]) => {
+    const punya = hasil.filter(masuk);
+    if (!punya.length) return "";
+    return `
+      <section class="juara-bagian">
+        <h2>${esc(judul)}</h2>
+        <!-- TANPA BARIS KEPALA. "GELAR | JUARA | SKOR" akan tercetak
+             SEBELAS KALI di dokumen yang cuma punya tiga kolom, dan
+             ketiganya sudah terbaca dari bentuknya sendiri: gelar tebal di
+             kiri, nama juara di tengah, angka rata kanan. Terukur: sebelas
+             baris kepala memakan 88mm — sepertiga halaman, untuk mengulang
+             sesuatu yang tidak pernah ditanyakan. -->
+        <table class="print-table">
+          <tbody>${punya.map(x => `
+            <tr><td class="juara-gelar">${esc(label(x))}</td>
+                <td>${isiJuara(x)}</td>
+                <td class="juara-skor">${esc(angka(x))}</td></tr>`).join("")}</tbody>
+        </table>
+      </section>`;
+  }).join("");
+
+  document.body.appendChild(h(`<div id="cetakan" class="printout">
+    <section class="print-page">
+      <h1>DAFTAR JUARA — ${esc(EDISI ? EDISI.name : "")}</h1>
+      ${isi}
+      <p class="print-note">Dicetak ${esc(dicetak)}.</p>
+    </section>
+  </div>`));
+}
+
 async function layarKejuaraan() {
   pasangKepala("Kejuaraan", true);
   if (!bolehLihat("live_score")) {
@@ -6957,6 +7043,13 @@ async function layarKejuaraan() {
   ];
 
   LAYAR.replaceChildren(h(`
+    <div class="card">
+      <div class="option-row">
+        <button class="button button-primary" id="cetak-juara" type="button">
+          ${ikon("printer")} Cetak Daftar Juara
+        </button>
+      </div>
+    </div>
     <div class="kejuaraan-bagian">
       ${bagian.map(([judul, masuk, label, kelas]) => `
         <section class="card ${kelas}"><h2>${esc(judul)}</h2>
@@ -6965,6 +7058,17 @@ async function layarKejuaraan() {
           </tbody></table>
         </section>`).join("")}
     </div>`));
+
+  /* TIDAK async, dan itu keputusan yang sama dengan kedua tombol cetak di
+     Live Score: `window.print()` harus tetap berada di dalam giliran ketukan
+     jarinya. Safari iPhone memblokirnya begitu ada satu `await` lebih dulu,
+     karena sesudah itu panggilannya tidak lagi dianggap datang dari pengguna.
+     Seluruh daftarnya sudah di tangan sejak layar ini digambar, jadi memang
+     tidak ada yang perlu ditunggu. */
+  document.getElementById("cetak-juara")?.addEventListener("click", () => {
+    siapkanCetakJuara(hasil, bagian);
+    window.print();
+  });
 
   LAYAR.querySelectorAll(".kejuaraan-pilih").forEach(pilih => {
     const saran = pilih.nextElementSibling;

--- a/web/style.css
+++ b/web/style.css
@@ -1232,6 +1232,29 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .receipt-signature { margin-top: 10mm; width: 60mm; margin-left: auto; text-align: center; }
   .receipt-line { margin-top: 14mm; border-top: 1pt solid #000; padding-top: 2mm; }
 
+  /* ---- Daftar juara ----
+
+     Satu dokumen mengalir, bukan satu lembar per bagian: sebelas bagian
+     berarti sebelas lembar yang dibolak-balik di podium, padahal seluruhnya
+     muat di dua. Yang dijaga cuma satu bagian tidak terbelah dua halaman —
+     gelar "Juara 1" yang tertinggal sendirian di kaki halaman, dengan
+     namanya di halaman berikutnya, adalah persis kesalahan yang mahal saat
+     dibacakan. */
+  .printout h2 { font-size: 12pt; margin: 5mm 0 1mm; }
+  .juara-bagian { break-inside: avoid; page-break-inside: avoid; }
+  /* Nama sekolah dan keterangan poin: kecil dan HITAM PEKAT, bukan abu.
+     Bagian 8.4 — yang harus mundur dibuat kecil, bukan pucat, karena raster
+     abu keluar belang dari mesin fotokopi. */
+  .juara-sekolah { font-size: 9pt; }
+  /* Gelar yang belum ada juaranya TIDAK diredupkan. Pembawa acara yang
+     menemukannya di atas panggung tidak punya jalan keluar; yang menemukannya
+     di kertas sebelum naik masih punya. Bedanya dari yang sudah terisi cukup
+     dari tebalnya: nama juara tebal, ini biasa. */
+  .juara-kosong { font-size: 11pt; }
+  .print-table .juara-gelar { width: 34mm; font-weight: 700; }
+  .print-table th.juara-gelar { font-weight: 700; }
+  .print-table .juara-skor { width: 20mm; text-align: right; font-weight: 700; }
+
   .print-note { font-size: 9pt; margin-top: .5rem; }
   .insert-note { font-size: 9pt; font-weight: 700; margin-top: .4rem; }
 


### PR DESCRIPTION
## What

One button on `#/kejuaraan` — **Cetak Daftar Juara** — producing an A4 sheet:

```
DAFTAR JUARA — HRCD XXXVII

Juara Umum
  HRCD XXXVII  │ MA PUI Cijantung                                   │
               │ 42 poin juara · 17400 total skor (6 besar)         │

Penegak PA
  Juara I      │ 007 · RANCAKA                                      │ 1673
               │ MA PUI Cijantung                                   │
  Juara II     │ 005 · RANCAKA5                                     │ 1656
  …
Penghargaan Khusus
  Pangkalan Terjauh │ Belum ditentukan                              │
```

All eleven sections, in the screen's own order.

## Why

Kejuaraan was the only screen holding results with **no print button** —
nine others have one — so the only way to get the list off the screen was a
phone screenshot. It has two uses that both need paper: it is read out from
the stage at the announcement, and it is what the certificates are written
from.

## Notes

- **The sections and their order are borrowed from the screen**: the same
  `bagian` array is passed in rather than written out again. Two award lists
  that must both be right every time a title is added are two lists that will
  disagree one day, and the one that disagrees here is read aloud on stage.
- **Titles with no winner yet are printed, and not dimmed.** An MC who finds
  an empty title on stage has no way out; one who finds it on paper, before
  going up, still does. It reads as plain text while decided winners are bold.
- **The right-hand column means one thing**: a regu's total score. Awards that
  name a *school* leave it empty — their number is not a score and the unit
  differs each time (poin juara, jumlah regu), and it is spelled out with its
  unit on the line under the name instead. Filling the column too printed the
  same number twice side by side: `42` and `42 poin juara` right next to it.
- **No repeated table head.** "GELAR | JUARA | SKOR" eleven times over a
  three-column document repeats what the shape of the columns already says,
  and it measured 88mm — a third of an A4 page. Dropping it took the document
  from 4 pages to 3.
- `window.print()` stays inside the tap turn, no `await` before it — Safari
  iPhone blocks it otherwise, the same rule the Live Score and Daftar Kloter
  print buttons follow.
- **Measured** by dropping the sections onto 276.7mm pages (A4 minus Chrome's
  default margins): **3 pages, 665mm total, largest section 101mm** — so
  `break-inside: avoid` never has to force an awkward break. Black on white,
  1pt rules, smallest type 9pt (section 8).
- Rendered against a local database with real champion rows and checked by
  eye at both ends of the document. 416 tests pass.
