### PR TITLE
fix: the printed champions list runs in announcement order

### DIFF
--- a/tests/cetak_daftar_juara.test.mjs
+++ b/tests/cetak_daftar_juara.test.mjs
@@ -22,7 +22,7 @@ const layar = app.slice(app.indexOf("async function layarKejuaraan()"),
                         app.indexOf("async function layarPengaturanKloter()") > 0
                           ? app.indexOf("const RUTE = {") : undefined);
 
-test("bagian dan urutannya DIPINJAM dari layarnya, bukan ditulis ulang", () => {
+test("bagian DIPINJAM dari layarnya, bukan ditulis ulang", () => {
   // Dua daftar penghargaan yang harus ikut benar setiap kali satu gelar
   // ditambah adalah dua daftar yang suatu hari berselisih — dan yang
   // berselisih di sini terbaca di panggung.
@@ -99,4 +99,73 @@ test("kertasnya menuruti aturan fotokopi", () => {
   for (const m of blok.matchAll(/font-size: ([\d.]+)pt/g)) {
     assert.ok(Number(m[1]) >= 7, `ada huruf ${m[1]}pt di kertas, di bawah batas 7pt`);
   }
+});
+
+/** Kode tanpa komentar. Alasan tiap aturan di bawah justru ditulis sebagai
+ *  komentar tepat di atas kodenya, lengkap dengan nama yang dicari — dan
+ *  penjaga yang menemukannya di komentar tidak menjaga apa pun. */
+const tanpaKomentar = (t) => t.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+const kodePembuat = tanpaKomentar(pembuat);
+const kodeLayar = tanpaKomentar(layar);
+
+test("urutan bacanya menempel di bagian layarnya, bukan jadi daftar kedua", () => {
+  // Daftar penghargaan yang ditulis dua kali adalah daftar yang suatu hari
+  // berselisih, dan yang berselisih di sini dibacakan di depan orang banyak.
+  // Angka urutnya jadi unsur kelima tiap bagian; pembuat cetakan cuma
+  // mengurutkannya.
+  assert.ok(kodePembuat.includes("[...bagian].sort((a, b) => a[4] - b[4])"),
+    "pembuat cetakan tidak mengurutkan bagian menurut angka urut bacanya");
+
+  // Urutan panggung yang diminta pemilik acara, 2 September 2026: penghargaan
+  // pilihan dulu, juara per golongan (Penggalang sebelum Penegak, putri
+  // sebelum putra), lalu Juara Umum sebagai puncaknya.
+  const awal = kodeLayar.indexOf("const bagian = [");
+  assert.ok(awal > 0, "daftar bagian tidak ditemukan di layar Kejuaraan");
+  const daftar = kodeLayar.slice(awal, kodeLayar.indexOf("];", awal));
+  for (const [tanda, urut] of [
+    ['"kejuaraan-terfavorit kejuaraan-pilihan", 1', "Peserta Terfavorit ke-1"],
+    ['"kejuaraan-kostum kejuaraan-pilihan", 2', "Juara Kostum ke-2"],
+    ['"kejuaraan-yel-yel", 3', "Juara Yel Yel ke-3"],
+    ['"kejuaraan-khusus kejuaraan-pilihan", 4', "Penghargaan Khusus ke-4"],
+    ['gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi", 5)', "Penggalang PI ke-5"],
+    ['gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa", 6)', "Penggalang PA ke-6"],
+    ['gelarGolongan("penegak_pi", "kejuaraan-penegak-pi", 7)', "Penegak PI ke-7"],
+    ['gelarGolongan("penegak_pa", "kejuaraan-penegak-pa", 8)', "Penegak PA ke-8"],
+    ['"kejuaraan-umum-penggalang", 9', "Juara Umum Penggalang ke-9"],
+    ['"kejuaraan-umum-penegak", 10', "Juara Umum Penegak ke-10"],
+    ['"kejuaraan-umum", 11', "Juara Umum ke-11"],
+  ]) {
+    assert.ok(daftar.includes(tanda), `urutan baca berubah: ${urut}`);
+  }
+});
+
+test("satu aturan mengurutkan baris di ketiga bentuk bagian", () => {
+  // penggalang_pi_6       golongan + peringkat -> Harapan III dulu
+  // kostum_penggalang_pi  golongan saja        -> urut golongan
+  // terjauh               keduanya tidak ada   -> biarkan apa adanya
+  assert.ok(kodePembuat.includes("x.kode.match(/_(\\d+)$/)"),
+    "peringkat tidak dibaca dari ekor kode penghargaan");
+  assert.ok(kodePembuat.includes("p ? -Number(p[1]) : 0"),
+    "peringkat tidak dibalik — Juara I akan dibacakan lebih dulu, bukan terakhir");
+  assert.ok(kodePembuat.includes("const ka = kunciBaca(a), kb = kunciBaca(b);"),
+    "baris di dalam bagian tidak diurutkan ulang untuk dibacakan");
+});
+
+test("urutan BACA bukan salinan urutan TAMPIL", () => {
+  // util.js memegang urutan tampil (tab Live Score, kolom rekap). Yang di sini
+  // urutan dibacakan: putri lebih dulu di tiap tingkat, Penggalang sebelum
+  // Penegak. Dua fakta berbeda yang kebetulan sama bentuknya — dan mengganti
+  // yang ini dengan URUT_GOLONGAN akan membalik urutan pengumuman.
+  assert.ok(kodePembuat.includes(
+    '["penggalang_pi", "penggalang_pa", "penegak_pi", "penegak_pa"]'),
+    "urutan baca golongan berubah");
+  assert.ok(!kodePembuat.includes("URUT_GOLONGAN"),
+    "urutan baca diganti dengan urutan tampil dari util.js");
+});
+
+test("layarnya TIDAK ikut dibalik", () => {
+  // Layar dipakai memeriksa: yang dicari mata Juara I, jadi ia tetap di atas.
+  // Yang dibalik cuma kertasnya.
+  assert.ok(kodeLayar.includes("${bagian.map(([judul, masuk, label, kelas]) => `"),
+    "layar Kejuaraan tidak lagi menggambar bagiannya apa adanya");
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6851,10 +6851,16 @@ async function layarLiveScore() {
  *  pengumuman, lalu jadi dasar menulis sertifikat. Sebelum ini satu-satunya
  *  cara mengeluarkannya dari layar adalah tangkapan layar HP.
  *
- *  BAGIAN DAN URUTANNYA DIPINJAM DARI LAYARNYA — `bagian` yang sama persis
- *  dioper ke sini, tidak ditulis ulang. Dua daftar penghargaan yang harus
- *  ikut benar setiap kali satu gelar ditambah adalah dua daftar yang suatu
- *  hari berselisih, dan yang berselisih di sini terbaca di panggung.
+ *  BAGIANNYA DIPINJAM DARI LAYARNYA — `bagian` yang sama persis dioper ke
+ *  sini, tidak ditulis ulang. Dua daftar penghargaan yang harus ikut benar
+ *  setiap kali satu gelar ditambah adalah dua daftar yang suatu hari
+ *  berselisih, dan yang berselisih di sini terbaca di panggung.
+ *
+ *  URUTANNYA BERBEDA DARI LAYARNYA, dan itu disengaja. Layar dipakai
+ *  memeriksa — yang dicari mata Juara I, jadi ia di atas. Panggung dibacakan
+ *  menaik: penghargaan pilihan dulu, lalu juara per golongan dari Harapan III
+ *  sampai Juara I, dan Juara Umum penutupnya. Angka urutnya ikut menempel di
+ *  tiap bagian di layarnya, jadi tetap satu daftar.
  *
  *  YANG BELUM DITENTUKAN IKUT DICETAK, dan tidak diredupkan. Pembawa acara
  *  yang menemukan gelar kosong di atas panggung tidak punya jalan keluar;
@@ -6901,8 +6907,34 @@ function siapkanCetakJuara(hasil, bagian) {
     return `<span class="juara-kosong">Belum ditentukan</span>`;
   };
 
-  const isi = bagian.map(([judul, masuk, label]) => {
-    const punya = hasil.filter(masuk);
+  /* URUTAN BACA DI DALAM SATU BAGIAN, dan satu aturan melayani ketiga
+     bentuknya karena kode penghargaannya sendiri yang membawanya:
+
+       penggalang_pi_6        golongan + peringkat  -> Harapan III dulu
+       kostum_penggalang_pi   golongan saja         -> urut golongan
+       terjauh                keduanya tidak ada    -> biarkan apa adanya
+
+     Peringkatnya dibalik (6 dulu, 1 terakhir) karena panggung dibacakan
+     menaik: Harapan III lebih dulu, Juara I penutupnya.
+
+     DAFTAR GOLONGAN DI SINI BUKAN SALINAN `URUT_GOLONGAN`, dan tidak boleh
+     diganti dengan itu. Yang di util.js urutan TAMPIL — dipakai tab Live
+     Score dan kolom rekap; yang ini urutan DIBACAKAN, diminta pemilik acara:
+     putri lebih dulu di tiap tingkat, dan Penggalang sebelum Penegak. Dua
+     fakta berbeda yang kebetulan sama bentuknya. */
+  const URUT_BACA_GOLONGAN =
+    ["penggalang_pi", "penggalang_pa", "penegak_pi", "penegak_pa"];
+  const kunciBaca = (x) => {
+    const g = URUT_BACA_GOLONGAN.findIndex(k => x.kode.includes(k));
+    const p = x.kode.match(/_(\d+)$/);
+    return [g < 0 ? URUT_BACA_GOLONGAN.length : g, p ? -Number(p[1]) : 0];
+  };
+
+  const isi = [...bagian].sort((a, b) => a[4] - b[4]).map(([judul, masuk, label]) => {
+    const punya = hasil.filter(masuk).sort((a, b) => {
+      const ka = kunciBaca(a), kb = kunciBaca(b);
+      return ka[0] - kb[0] || ka[1] - kb[1];
+    });
     if (!punya.length) return "";
     return `
       <section class="juara-bagian">
@@ -7014,32 +7046,44 @@ async function layarKejuaraan() {
   /* Label golongan diambil dari GOLONGAN_LABEL, tidak ditulis ulang di sini:
      satu-satunya tempatnya `util.js`, dan `periksa_urutan_golongan.py` yang
      menjaganya tetap satu. */
-  const gelarGolongan = (kode, kelas) => [
+  /* Angka kelima tiap bagian adalah URUTAN BACANYA DI PANGGUNG, dan ia
+     sengaja berbeda dari urutan di layar ini.
+
+     Layar dipakai MEMERIKSA: yang dicari mata Juara I, jadi ia di atas.
+     Panggung dibacakan MENAIK: penghargaan pilihan lebih dulu, lalu juara per
+     golongan dari Harapan III sampai Juara I, dan Juara Umum paling akhir
+     sebagai puncaknya. Urutan ini keputusan pemilik acara, 2 September 2026.
+
+     Ditaruh sebagai angka DI SINI, bukan sebagai daftar kedua di pembuat
+     cetakannya: daftar penghargaan yang ditulis dua kali adalah daftar yang
+     suatu hari berselisih, dan yang berselisih di sini dibacakan di depan
+     orang banyak. */
+  const gelarGolongan = (kode, kelas, urut) => [
     GOLONGAN_LABEL[kode], x => x.kode.startsWith(kode + "_"),
-    x => x.nama_penghargaan.replace(GOLONGAN_LABEL[kode] + " ", ""), kelas];
+    x => x.nama_penghargaan.replace(GOLONGAN_LABEL[kode] + " ", ""), kelas, urut];
 
   const bagian = [
     ["Juara Umum", x => x.kode === "juara_umum",
-      x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum"],
+      x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum", 11],
     ["Juara Umum Penegak", x => x.kode === "juara_umum_penegak",
-      () => "PENEGAK", "kejuaraan-umum-penegak"],
-    gelarGolongan("penegak_pa", "kejuaraan-penegak-pa"),
-    gelarGolongan("penegak_pi", "kejuaraan-penegak-pi"),
+      () => "PENEGAK", "kejuaraan-umum-penegak", 10],
+    gelarGolongan("penegak_pa", "kejuaraan-penegak-pa", 8),
+    gelarGolongan("penegak_pi", "kejuaraan-penegak-pi", 7),
     ["Juara Umum Penggalang", x => x.kode === "juara_umum_penggalang",
-      () => "PENGGALANG", "kejuaraan-umum-penggalang"],
-    gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa"),
-    gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi"),
+      () => "PENGGALANG", "kejuaraan-umum-penggalang", 9],
+    gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa", 6),
+    gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi", 5),
     ["Juara Kostum", x => x.kode.startsWith("kostum_"),
       x => x.nama_penghargaan.replace(/^Juara Kostum /, ""),
-      "kejuaraan-kostum kejuaraan-pilihan"],
+      "kejuaraan-kostum kejuaraan-pilihan", 2],
     ["Juara Yel Yel", x => x.kode.startsWith("yel_yel_"),
-      x => x.nama_penghargaan.replace(/^Juara Yel Yel /, ""), "kejuaraan-yel-yel"],
+      x => x.nama_penghargaan.replace(/^Juara Yel Yel /, ""), "kejuaraan-yel-yel", 3],
     ["Peserta Terfavorit", x => x.kode.startsWith("terfavorit_"),
       x => x.nama_penghargaan.replace(/^Peserta Terfavorit /, ""),
-      "kejuaraan-terfavorit kejuaraan-pilihan"],
+      "kejuaraan-terfavorit kejuaraan-pilihan", 1],
     ["Penghargaan Khusus",
       x => x.kode === "terjauh" || x.kode === "peserta_terbanyak",
-      x => x.nama_penghargaan, "kejuaraan-khusus kejuaraan-pilihan"],
+      x => x.nama_penghargaan, "kejuaraan-khusus kejuaraan-pilihan", 4],
   ];
 
   LAYAR.replaceChildren(h(`


### PR DESCRIPTION
## What

The printed sheet now runs in the order it is read out from the stage:

| | | |
| --- | --- | --- |
| 1 Peserta Terfavorit | 5 Penggalang PI | 9 Juara Umum Penggalang |
| 2 Juara Kostum | 6 Penggalang PA | 10 Juara Umum Penegak |
| 3 Juara Yel Yel | 7 Penegak PI | 11 Juara Umum |
| 4 Penghargaan Khusus | 8 Penegak PA | |

Inside each ranked section: **Harapan III → Harapan II → Harapan I → Juara III
→ Juara II → Juara I**. Inside every section that lists golongan (Terfavorit,
Kostum, Yel Yel): **Penggalang PI → Penggalang PA → Penegak PI → Penegak PA**.

## Why

A stage is read the other way round from a screen. The screen is for
**checking** — the eye goes looking for Juara I, so it stays at the top. The
stage builds **up**: the chosen awards first, then each golongan from Harapan
III to Juara I, and Juara Umum last as the peak.

**The screen itself is untouched.**

## Notes

- The order is a **fifth element on each section of the screen's own list**,
  not a second list in the print builder. An award list written down twice is
  an award list that will disagree one day, and the one that disagrees here is
  read out in front of a crowd.
- **One rule sorts the rows in all three shapes of section**, because the
  award code already carries what it needs: `penggalang_pi_6` is golongan plus
  rank, `kostum_penggalang_pi` is golongan alone, `terjauh` is neither. The
  rank sorts descending, which is what puts Harapan III first and Juara I
  last. Penghargaan Khusus keeps its own order because neither key applies and
  the sort is stable.
- **The golongan list in the print builder is not a copy of `URUT_GOLONGAN`
  and must not be replaced with it.** util.js holds the order things are
  *shown* in — Live Score tabs, rekap columns — while this is the order they
  are *read out*. Two different facts that happen to have the same shape;
  a test guards against the swap.
- Verified against a local database: sections come out in exactly the eleven
  positions above, ranked sections read `Harapan III … Juara I`, and the
  golongan sections read `Penggalang PI, Penggalang PA, Penegak PI, Penegak
  PA`. 420 tests pass.
