### PR TITLE
feat: the champions sheet gets a column heading and prints two-up

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=58">
+  <link rel="stylesheet" href="style.css?v=59">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -1242,6 +1242,39 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dibacakan. */
   .printout h2 { font-size: 12pt; margin: 5mm 0 1mm; }
   .juara-bagian { break-inside: avoid; page-break-inside: avoid; }
+
+  /* DUA KOLOM DI SATU LEMBAR. Sebelas bagian yang mengalir satu kolom penuh
+     memakan tiga halaman; dibagi dua, keduanya muat lebih rapat tanpa satu
+     baris pun mengecil.
+
+     `column-fill: auto` dan bukan `balance`: yang dibacakan di panggung harus
+     punya urutan yang tidak bisa salah dibaca — kolom kiri sampai habis, baru
+     kolom kanan. `balance` membagi rata dan membuat bagian terakhir kolom
+     kiri berpindah-pindah mengikuti panjang isinya.
+
+     Judul dan cap cetak MELINTANG penuh, di luar kolomnya: judul dokumen yang
+     duduk di kolom kiri saja terbaca seperti judul kolom itu. */
+  .juara-cetak .print-page { columns: 2; column-gap: 7mm; column-fill: auto; }
+  .juara-cetak h1, .juara-cetak .print-note { column-span: all; }
+  /* Kolom selebar ~91mm, jadi patokan yang dipakai satu kolom terlalu longgar
+     di sini: yang dipersempit gelar dan angkanya, karena keduanya isinya
+     pendek dan tetap — "Harapan III" dan empat digit. Sisanya jatuh ke nama
+     regu dan sekolahnya, satu-satunya yang panjangnya tidak bisa ditebak. */
+  .juara-cetak .print-table .juara-gelar { width: 21mm; font-size: 9pt; }
+  .juara-cetak .print-table .juara-skor { width: 21mm; }
+  .juara-cetak .print-table th, .juara-cetak .print-table td { padding: 3pt 4pt; }
+  /* Judul kolomnya HURUF BIASA dan 8pt, bukan kapital 9pt seperti kepala
+     tabel lain di berkas ini. "SKOR / POIN JUARA" berkapital menuntut tiga
+     baris di kolom 21mm — kepala kosong setinggi tiga baris, sebelas kali.
+     Huruf biasa 8pt memuatnya dalam dua, dan 8pt masih di atas batas 7pt
+     (bagian 8.6). */
+  .juara-cetak .print-table th { text-transform: none; font-size: 8pt; }
+  /* Jarak antar bagian dirapatkan, dan itu yang menentukan satu lembar atau
+     dua: sebelas judul bagian dengan jarak atas 5mm adalah 55mm — seperlima
+     halaman untuk ruang kosong. Terukur, seluruh daftar jatuh dari 284mm ke
+     bawah 277mm, jadi muat satu lembar A4 bolak-balik-tidak-perlu. */
+  .juara-cetak h2 { margin: 2.5mm 0 0; }
+  .juara-cetak .print-table { margin-top: 1mm; }
   /* Nama sekolah dan keterangan poin: kecil dan HITAM PEKAT, bukan abu.
      Bagian 8.4 — yang harus mundur dibuat kecil, bukan pucat, karena raster
      abu keluar belang dari mesin fotokopi. */

--- a/tests/cetak_daftar_juara.test.mjs
+++ b/tests/cetak_daftar_juara.test.mjs
@@ -59,21 +59,45 @@ test("gelar yang belum ada juaranya IKUT dicetak", () => {
     "tulisan 'Belum ditentukan' diberi gaya yang meredupkannya");
 });
 
-test("kolom kanan berarti SATU hal: total skor regu", () => {
-  // Diisi juga untuk penghargaan sekolah, hasilnya angka yang sama tercetak
-  // dua kali bersebelahan — "42" di kolom kanan dan "42 poin juara" tepat di
-  // sebelahnya (bagian 9.3).
-  assert.match(pembuat,
-    /const angka = \(x\) => \(x\.nama_regu && x\.total != null\) \? angkaRapi\(x\.total\) : "";/,
-    "kolom skor kembali diisi angka yang satuannya berbeda-beda");
+test("kolom kanan persis seperti judulnya: skor ATAU poin juara", () => {
+  // Tidak ada yang ketiga. Peserta Terbanyak menghitung REGU dan Pangkalan
+  // Terjauh tidak punya angka sama sekali, jadi keduanya kosong di kolom itu
+  // dan angkanya tetap tertulis lengkap dengan satuannya di baris bawah nama.
+  // Kolom berisi tiga jenis angka menuntut tiap barisnya diartikan
+  // sendiri-sendiri, dan kolom ini justru ada supaya dibaca lurus ke bawah.
+  assert.ok(kodePembuat.includes('if (x.kode.startsWith("juara_umum")) return angkaRapi(x.poin_juara);'),
+    "poin juara tidak masuk ke kolom yang judulnya menyebutnya");
+  assert.ok(!kodePembuat.includes('x.kode === "peserta_terbanyak" ? angkaRapi(x.total)'),
+    "jumlah regu ikut masuk ke kolom skor — satuannya bukan skor maupun poin juara");
+  // Dan poin juaranya tidak diulang di baris keterangan di bawah namanya.
+  assert.ok(kodePembuat.includes("`${angkaRapi(x.jumlah_skor)} total skor (6 besar)`"),
+    "keterangan Juara Umum masih mengulang poin juara yang sudah di kolom kanan");
 });
 
-test("tanpa baris kepala yang diulang sebelas kali", () => {
-  // Terukur: sebelas baris kepala memakan 88mm — sepertiga halaman A4 — untuk
-  // mengulang tiga kata yang sudah terbaca dari bentuk kolomnya sendiri.
-  // Dokumennya turun dari 4 halaman jadi 3.
-  assert.doesNotMatch(pembuat, /<thead>/,
-    "baris kepala kembali di tabel daftar juara");
+test("judul hanya untuk kolom kanan, dua kolom pertama dibiarkan", () => {
+  // "GELAR | JUARA" yang tercetak sebelas kali mengulang sesuatu yang sudah
+  // terbaca dari bentuknya. Angka di kanan tidak begitu: 1673 dan 42 duduk di
+  // kolom yang sama padahal yang satu skor regu dan yang satu poin juara.
+  assert.ok(kodePembuat.includes('<th class="juara-skor">Skor / Poin Juara</th>'),
+    "judul kolom kanan hilang atau berubah bunyinya");
+  assert.ok(kodePembuat.includes('<thead><tr><th class="juara-gelar"></th><th></th>'),
+    "dua kolom pertama ikut diberi judul");
+});
+
+test("kertasnya dua kolom kiri-kanan", () => {
+  // Sebelas bagian mengalir satu kolom penuh memakan tiga lembar; dibagi dua,
+  // dua lembar — tanpa satu baris pun mengecil. Terukur di lebar kolom 91mm:
+  // tiga kolom terpakai, jadi dua lembar A4.
+  assert.match(css, /\.juara-cetak \.print-page \{ columns: 2; column-gap: 7mm; column-fill: auto; \}/,
+    "daftar juara tidak lagi dicetak dua kolom");
+  // `auto`, bukan `balance`: yang dibacakan di panggung harus punya urutan
+  // yang tidak bisa salah dibaca — kolom kiri sampai habis, baru kolom kanan.
+  assert.ok(!css.includes("column-fill: balance"),
+    "kolomnya diseimbangkan, jadi urutan bacanya berpindah-pindah");
+  assert.match(css, /\.juara-cetak h1, \.juara-cetak \.print-note \{ column-span: all; \}/,
+    "judul dokumen duduk di satu kolom saja");
+  assert.ok(kodePembuat.includes('class="printout juara-cetak"'),
+    "cetakan daftar juara tidak lagi ditandai untuk tata letak dua kolom");
 });
 
 test("satu bagian tidak boleh terbelah dua halaman", () => {

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 58, sidik: "58d415542ad8" },
+  "style.css": { versi: 59, sidik: "51af280792a9" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=56">
+  <link rel="stylesheet" href="style.css?v=57">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6879,18 +6879,23 @@ function siapkanCetakJuara(hasil, bagian) {
   document.getElementById("cetakan")?.remove();
   const dicetak = tanggalJam(new Date().toISOString());
 
-  /* KOLOM KANAN BERARTI SATU HAL: total skor regu. Penghargaan yang menunjuk
-     SEKOLAH — Juara Umum, Pangkalan Terjauh, Peserta Terbanyak — dibiarkan
-     kosong di sana, karena angkanya bukan skor dan satuannya berbeda-beda:
-     poin juara, jumlah regu. Angka itu tetap tertulis, di baris keterangan di
-     bawah namanya, lengkap dengan satuannya.
+  /* KOLOM KANAN PERSIS SEPERTI JUDULNYA: skor regu, atau poin juara untuk
+     Juara Umum. Tidak ada yang ketiga — Peserta Terbanyak menghitung REGU dan
+     Pangkalan Terjauh tidak punya angka sama sekali, jadi keduanya dibiarkan
+     kosong di kolom itu dan angkanya tetap tertulis lengkap dengan satuannya
+     di baris di bawah namanya.
 
-     Sempat diisi juga, dan hasilnya angka yang sama tercetak dua kali
-     bersebelahan — "42" di kolom kanan dan "42 poin juara" tepat di
-     sebelahnya (bagian 9.3). Kolom yang isinya satu jenis angka bisa dibaca
-     lurus ke bawah; kolom yang isinya tiga jenis menuntut tiap barisnya
-     diartikan sendiri-sendiri. */
-  const angka = (x) => (x.nama_regu && x.total != null) ? angkaRapi(x.total) : "";
+     Kolomnya sempat tanpa judul dan hanya berisi skor regu; judulnya yang
+     membuat poin juara boleh ikut masuk, karena sekarang ada yang
+     mengatakan angka itu bisa dua macam. Yang tidak boleh masuk tetap yang
+     satuannya lain lagi (bagian 9.3): kolom berisi tiga jenis angka menuntut
+     tiap barisnya diartikan sendiri-sendiri, dan kolom ini justru ada supaya
+     bisa dibaca lurus ke bawah. */
+  const angka = (x) => {
+    if (x.nama_regu) return x.total == null ? "" : angkaRapi(x.total);
+    if (x.kode.startsWith("juara_umum")) return angkaRapi(x.poin_juara);
+    return "";
+  };
 
   const isiJuara = (x) => {
     if (x.nama_regu) {
@@ -6898,8 +6903,12 @@ function siapkanCetakJuara(hasil, bagian) {
         + `<br><span class="juara-sekolah">${esc(x.nama_sekolah || "")}</span>`;
     }
     if (x.nama_sekolah) {
+      /* Poin juaranya TIDAK diulang di sini — ia sudah berdiri di kolom
+         kanan. Yang tersisa di baris ini justru yang tidak muat di sana:
+         total skor enam besar, angka kedua yang menjelaskan dari mana poin
+         itu datang. */
       const ket = x.kode.startsWith("juara_umum")
-        ? `${angkaRapi(x.poin_juara)} poin juara · ${angkaRapi(x.jumlah_skor)} total skor (6 besar)`
+        ? `${angkaRapi(x.jumlah_skor)} total skor (6 besar)`
         : x.kode === "peserta_terbanyak" ? `${angkaRapi(x.total)} regu bernomor dada` : "";
       return `<strong>${esc(x.nama_sekolah)}</strong>`
         + (ket ? `<br><span class="juara-sekolah">${esc(ket)}</span>` : "");
@@ -6939,13 +6948,16 @@ function siapkanCetakJuara(hasil, bagian) {
     return `
       <section class="juara-bagian">
         <h2>${esc(judul)}</h2>
-        <!-- TANPA BARIS KEPALA. "GELAR | JUARA | SKOR" akan tercetak
-             SEBELAS KALI di dokumen yang cuma punya tiga kolom, dan
-             ketiganya sudah terbaca dari bentuknya sendiri: gelar tebal di
-             kiri, nama juara di tengah, angka rata kanan. Terukur: sebelas
-             baris kepala memakan 88mm — sepertiga halaman, untuk mengulang
-             sesuatu yang tidak pernah ditanyakan. -->
+        <!-- JUDUL HANYA UNTUK KOLOM KANAN. Dua kolom pertama sudah terbaca
+             dari bentuknya sendiri — gelar tebal di kiri, nama juara di
+             tengah — dan "GELAR | JUARA" yang tercetak sebelas kali cuma
+             mengulang sesuatu yang tidak pernah ditanyakan (bagian 9.3).
+             Angka di kanan tidak begitu: 1673 dan 42 duduk di kolom yang sama
+             padahal yang satu skor regu dan yang satu poin juara, dan tanpa
+             judul tidak ada yang mengatakan itu. -->
         <table class="print-table">
+          <thead><tr><th class="juara-gelar"></th><th></th>
+            <th class="juara-skor">Skor / Poin Juara</th></tr></thead>
           <tbody>${punya.map(x => `
             <tr><td class="juara-gelar">${esc(label(x))}</td>
                 <td>${isiJuara(x)}</td>
@@ -6954,7 +6966,7 @@ function siapkanCetakJuara(hasil, bagian) {
       </section>`;
   }).join("");
 
-  document.body.appendChild(h(`<div id="cetakan" class="printout">
+  document.body.appendChild(h(`<div id="cetakan" class="printout juara-cetak">
     <section class="print-page">
       <h1>DAFTAR JUARA — ${esc(EDISI ? EDISI.name : "")}</h1>
       ${isi}

--- a/web/style.css
+++ b/web/style.css
@@ -1242,6 +1242,39 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      dibacakan. */
   .printout h2 { font-size: 12pt; margin: 5mm 0 1mm; }
   .juara-bagian { break-inside: avoid; page-break-inside: avoid; }
+
+  /* DUA KOLOM DI SATU LEMBAR. Sebelas bagian yang mengalir satu kolom penuh
+     memakan tiga halaman; dibagi dua, keduanya muat lebih rapat tanpa satu
+     baris pun mengecil.
+
+     `column-fill: auto` dan bukan `balance`: yang dibacakan di panggung harus
+     punya urutan yang tidak bisa salah dibaca — kolom kiri sampai habis, baru
+     kolom kanan. `balance` membagi rata dan membuat bagian terakhir kolom
+     kiri berpindah-pindah mengikuti panjang isinya.
+
+     Judul dan cap cetak MELINTANG penuh, di luar kolomnya: judul dokumen yang
+     duduk di kolom kiri saja terbaca seperti judul kolom itu. */
+  .juara-cetak .print-page { columns: 2; column-gap: 7mm; column-fill: auto; }
+  .juara-cetak h1, .juara-cetak .print-note { column-span: all; }
+  /* Kolom selebar ~91mm, jadi patokan yang dipakai satu kolom terlalu longgar
+     di sini: yang dipersempit gelar dan angkanya, karena keduanya isinya
+     pendek dan tetap — "Harapan III" dan empat digit. Sisanya jatuh ke nama
+     regu dan sekolahnya, satu-satunya yang panjangnya tidak bisa ditebak. */
+  .juara-cetak .print-table .juara-gelar { width: 21mm; font-size: 9pt; }
+  .juara-cetak .print-table .juara-skor { width: 21mm; }
+  .juara-cetak .print-table th, .juara-cetak .print-table td { padding: 3pt 4pt; }
+  /* Judul kolomnya HURUF BIASA dan 8pt, bukan kapital 9pt seperti kepala
+     tabel lain di berkas ini. "SKOR / POIN JUARA" berkapital menuntut tiga
+     baris di kolom 21mm — kepala kosong setinggi tiga baris, sebelas kali.
+     Huruf biasa 8pt memuatnya dalam dua, dan 8pt masih di atas batas 7pt
+     (bagian 8.6). */
+  .juara-cetak .print-table th { text-transform: none; font-size: 8pt; }
+  /* Jarak antar bagian dirapatkan, dan itu yang menentukan satu lembar atau
+     dua: sebelas judul bagian dengan jarak atas 5mm adalah 55mm — seperlima
+     halaman untuk ruang kosong. Terukur, seluruh daftar jatuh dari 284mm ke
+     bawah 277mm, jadi muat satu lembar A4 bolak-balik-tidak-perlu. */
+  .juara-cetak h2 { margin: 2.5mm 0 0; }
+  .juara-cetak .print-table { margin-top: 1mm; }
   /* Nama sekolah dan keterangan poin: kecil dan HITAM PEKAT, bukan abu.
      Bagian 8.4 — yang harus mundur dibuat kecil, bukan pucat, karena raster
      abu keluar belang dari mesin fotokopi. */


### PR DESCRIPTION
## What

Order unchanged. Two things move.

**The right-hand column carries a heading: `Skor / Poin Juara`** — and the
heading is what lets poin juara back into that column.

**The sheet prints in two columns, left then right.** Three A4 sheets → **two**.

## Why

`1673` and `42` sit in the same column while one is a regu's total score and
the other a champion's points, and until now nothing said so. What still stays
out is anything measured in a third unit — **Peserta Terbanyak** counts *regu*
and **Pangkalan Terjauh** has no number at all, so both leave the column empty
and keep their figure, with its unit, on the line under the name. A column
holding three kinds of number has to be read a row at a time, and this column
exists to be read straight down.

Juara Umum's line drops the poin juara it used to repeat and keeps the one
thing the column cannot hold: the six-best total the points came from.

## Notes

- `column-fill: auto` rather than `balance` — something read from a stage must
  have an order that cannot be misread: left column to the bottom, then the
  right one. The title and the print stamp span both.
- **Measured at 91mm column width**: the eleven sections need three columns, so
  two A4 sheets, against three sheets one-up. The section gaps came in from 5mm
  to 2.5mm to get there.
- The column heading is **sentence case at 8pt** rather than 9pt capitals:
  "SKOR / POIN JUARA" needs three lines in a 21mm column, which is a three-line
  empty header eleven times over. 8pt is still above the 7pt floor (section
  8.6), and the rest of the sheet is unchanged — black on white, 1pt rules.
- The gelar column is 9pt so "Harapan III" and "Juara I" hold one line; the
  two-word labels ("Penggalang PA", "Peserta Terbanyak") wrap to two, which
  they already did at the wider setting.
- 421 tests pass.
