### PR TITLE
fix: the champions sheet is laid out like the screen it comes from

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=59">
+  <link rel="stylesheet" href="style.css?v=60">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -895,7 +895,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kejuaraan-bagian .card { overflow: visible; }
 .kejuaraan-terkunci { display: flex; align-items: center; gap: .45rem; }
 .kejuaraan-nilai { flex: 1; min-width: 0; }
-@media (min-width: 900px) {
+/* `, print` DI SINI, dan itu yang membuat kertas Daftar Juara jadi salinan
+   layar ini alih-alih tata letak kedua yang harus dijaga sejalan. Kertasnya
+   memakai kelas yang sama persis — `kejuaraan-umum`, `kejuaraan-penegak-pa`,
+   dan seterusnya — jadi menggeser satu kartu di sini menggesernya di
+   dua-duanya. Yang TIDAK ikut cuma warnanya; blok cetak di bawah
+   mengembalikannya ke hitam-putih (bagian 8). */
+@media (min-width: 900px), print {
   .kejuaraan-bagian { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .kejuaraan-umum {
     grid-column: 1 / -1; grid-row: 1;
@@ -1243,19 +1249,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .printout h2 { font-size: 12pt; margin: 5mm 0 1mm; }
   .juara-bagian { break-inside: avoid; page-break-inside: avoid; }
 
-  /* DUA KOLOM DI SATU LEMBAR. Sebelas bagian yang mengalir satu kolom penuh
-     memakan tiga halaman; dibagi dua, keduanya muat lebih rapat tanpa satu
-     baris pun mengecil.
+  /* TATA LETAKNYA MILIK LAYARNYA. Kertas ini memakai kelas yang sama dan
+     ditempatkan blok grid `@media (min-width: 900px), print` di atas: Juara
+     Umum melintang di puncak, sisanya berpasangan dua kolom. Yang tersisa di
+     sini cuma melepas hiasannya.
 
-     `column-fill: auto` dan bukan `balance`: yang dibacakan di panggung harus
-     punya urutan yang tidak bisa salah dibaca — kolom kiri sampai habis, baru
-     kolom kanan. `balance` membagi rata dan membuat bagian terakhir kolom
-     kiri berpindah-pindah mengikuti panjang isinya.
-
-     Judul dan cap cetak MELINTANG penuh, di luar kolomnya: judul dokumen yang
-     duduk di kolom kiri saja terbaca seperti judul kolom itu. */
-  .juara-cetak .print-page { columns: 2; column-gap: 7mm; column-fill: auto; }
-  .juara-cetak h1, .juara-cetak .print-note { column-span: all; }
+     Latar tint dari `.kejuaraan-umum` dan kawan-kawan DIBUANG: bagian 8.4
+     melarang raster abu di kertas yang digandakan fotokopi — yang halus
+     keluar belang, yang pekat menghitami tulisannya. Kekhususan 0,2,0 di sini
+     mengalahkan 0,1,0 milik warnanya. */
+  .printout .kejuaraan-bagian { display: grid; gap: 4mm; }
+  .printout .juara-bagian { background: none; }
   /* Kolom selebar ~91mm, jadi patokan yang dipakai satu kolom terlalu longgar
      di sini: yang dipersempit gelar dan angkanya, karena keduanya isinya
      pendek dan tetap — "Harapan III" dan empat digit. Sisanya jatuh ke nama

--- a/tests/cetak_daftar_juara.test.mjs
+++ b/tests/cetak_daftar_juara.test.mjs
@@ -84,20 +84,23 @@ test("judul hanya untuk kolom kanan, dua kolom pertama dibiarkan", () => {
     "dua kolom pertama ikut diberi judul");
 });
 
-test("kertasnya dua kolom kiri-kanan", () => {
-  // Sebelas bagian mengalir satu kolom penuh memakan tiga lembar; dibagi dua,
-  // dua lembar — tanpa satu baris pun mengecil. Terukur di lebar kolom 91mm:
-  // tiga kolom terpakai, jadi dua lembar A4.
-  assert.match(css, /\.juara-cetak \.print-page \{ columns: 2; column-gap: 7mm; column-fill: auto; \}/,
-    "daftar juara tidak lagi dicetak dua kolom");
-  // `auto`, bukan `balance`: yang dibacakan di panggung harus punya urutan
-  // yang tidak bisa salah dibaca — kolom kiri sampai habis, baru kolom kanan.
-  assert.ok(!css.includes("column-fill: balance"),
-    "kolomnya diseimbangkan, jadi urutan bacanya berpindah-pindah");
-  assert.match(css, /\.juara-cetak h1, \.juara-cetak \.print-note \{ column-span: all; \}/,
-    "judul dokumen duduk di satu kolom saja");
-  assert.ok(kodePembuat.includes('class="printout juara-cetak"'),
-    "cetakan daftar juara tidak lagi ditandai untuk tata letak dua kolom");
+test("tata letak kertasnya MILIK layarnya, satu blok untuk keduanya", () => {
+  // Kertasnya salinan layar Kejuaraan: Juara Umum melintang di puncak,
+  // sisanya berpasangan dua kolom. Satu blok grid melayani dua-duanya, jadi
+  // menggeser satu kartu di layar menggesernya di kertas juga — tanpa ada
+  // tata letak kedua yang harus diingat.
+  assert.match(css, /@media \(min-width: 900px\), print \{/,
+    "blok grid Kejuaraan tidak lagi ikut berlaku saat mencetak");
+  assert.ok(kodePembuat.includes('<section class="juara-bagian ${esc(kelas)}">'),
+    "bagian cetakan tidak lagi membawa kelas letak dari layarnya");
+  assert.ok(kodePembuat.includes('<div class="kejuaraan-bagian">${isi}</div>'),
+    "cetakan tidak dibungkus wadah grid yang sama dengan layarnya");
+  assert.match(css, /\.printout \.kejuaraan-bagian \{ display: grid; gap: 4mm; \}/,
+    "wadah grid cetakan tidak dipasang");
+  // Yang TIDAK ikut cuma warnanya: bagian 8.4 melarang raster abu di kertas
+  // yang digandakan fotokopi.
+  assert.match(css, /\.printout \.juara-bagian \{ background: none; \}/,
+    "latar tint kartu ikut tercetak");
 });
 
 test("satu bagian tidak boleh terbelah dua halaman", () => {
@@ -117,8 +120,16 @@ test("kertasnya menuruti aturan fotokopi", () => {
   const blok = css.slice(css.indexOf("/* ---- Daftar juara ----"),
                          css.indexOf(".print-note { font-size: 9pt;"));
   assert.ok(blok.length > 0, "blok CSS daftar juara tidak ditemukan");
-  assert.doesNotMatch(blok, /background|color:\s*#(?!000)/,
-    "ada latar atau warna selain hitam di cetakan daftar juara");
+  // `background: none` justru yang MEMBUANG tint, jadi yang dilarang cuma
+  // latar yang punya warna.
+  for (const m of blok.matchAll(/background:\s*([^;]+);/g)) {
+    assert.equal(m[1].trim(), "none",
+      `ada latar berwarna di cetakan daftar juara: ${m[0]}`);
+  }
+  for (const m of blok.matchAll(/#[0-9a-fA-F]{3,6}/g)) {
+    assert.match(m[0], /^#0{3,6}$/,
+      `ada warna selain hitam di cetakan daftar juara: ${m[0]}`);
+  }
   // Huruf terkecil di kertas ini 9pt — batas bawahnya 7pt (bagian 8.6).
   for (const m of blok.matchAll(/font-size: ([\d.]+)pt/g)) {
     assert.ok(Number(m[1]) >= 7, `ada huruf ${m[1]}pt di kertas, di bawah batas 7pt`);
@@ -132,35 +143,23 @@ const tanpaKomentar = (t) => t.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/
 const kodePembuat = tanpaKomentar(pembuat);
 const kodeLayar = tanpaKomentar(layar);
 
-test("urutan bacanya menempel di bagian layarnya, bukan jadi daftar kedua", () => {
-  // Daftar penghargaan yang ditulis dua kali adalah daftar yang suatu hari
-  // berselisih, dan yang berselisih di sini dibacakan di depan orang banyak.
-  // Angka urutnya jadi unsur kelima tiap bagian; pembuat cetakan cuma
-  // mengurutkannya.
-  assert.ok(kodePembuat.includes("[...bagian].sort((a, b) => a[4] - b[4])"),
-    "pembuat cetakan tidak mengurutkan bagian menurut angka urut bacanya");
-
-  // Urutan panggung yang diminta pemilik acara, 2 September 2026: penghargaan
-  // pilihan dulu, juara per golongan (Penggalang sebelum Penegak, putri
-  // sebelum putra), lalu Juara Umum sebagai puncaknya.
+test("bagian dicetak dalam urutan layarnya, tanpa daftar kedua", () => {
+  // Kertasnya salinan layarnya, jadi tidak ada urutan cetak tersendiri untuk
+  // dijaga sejalan. Daftar penghargaan yang ditulis dua kali adalah daftar
+  // yang suatu hari berselisih.
+  assert.ok(kodePembuat.includes("const isi = bagian.map(([judul, masuk, label, kelas]) => {"),
+    "pembuat cetakan tidak lagi memakai urutan bagian milik layarnya");
+  assert.ok(!kodePembuat.includes("].sort((a, b) => a[4] - b[4])"),
+    "urutan cetak tersendiri kembali — kertasnya bukan lagi salinan layarnya");
   const awal = kodeLayar.indexOf("const bagian = [");
   assert.ok(awal > 0, "daftar bagian tidak ditemukan di layar Kejuaraan");
   const daftar = kodeLayar.slice(awal, kodeLayar.indexOf("];", awal));
-  for (const [tanda, urut] of [
-    ['"kejuaraan-terfavorit kejuaraan-pilihan", 1', "Peserta Terfavorit ke-1"],
-    ['"kejuaraan-kostum kejuaraan-pilihan", 2', "Juara Kostum ke-2"],
-    ['"kejuaraan-yel-yel", 3', "Juara Yel Yel ke-3"],
-    ['"kejuaraan-khusus kejuaraan-pilihan", 4', "Penghargaan Khusus ke-4"],
-    ['gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi", 5)', "Penggalang PI ke-5"],
-    ['gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa", 6)', "Penggalang PA ke-6"],
-    ['gelarGolongan("penegak_pi", "kejuaraan-penegak-pi", 7)', "Penegak PI ke-7"],
-    ['gelarGolongan("penegak_pa", "kejuaraan-penegak-pa", 8)', "Penegak PA ke-8"],
-    ['"kejuaraan-umum-penggalang", 9', "Juara Umum Penggalang ke-9"],
-    ['"kejuaraan-umum-penegak", 10', "Juara Umum Penegak ke-10"],
-    ['"kejuaraan-umum", 11', "Juara Umum ke-11"],
-  ]) {
-    assert.ok(daftar.includes(tanda), `urutan baca berubah: ${urut}`);
-  }
+  // Juara Umum tetap yang pertama, dan kelas letaknya yang menempatkannya.
+  assert.ok(daftar.indexOf('"kejuaraan-umum"') < daftar.indexOf('"kejuaraan-umum-penegak"'),
+    "Juara Umum bukan bagian pertama");
+  const umum = css.slice(css.indexOf(".kejuaraan-umum {"));
+  assert.ok(umum.slice(0, umum.indexOf("}")).includes("grid-column: 1 / -1; grid-row: 1;"),
+    "Juara Umum tidak lagi melintang di baris pertama");
 });
 
 test("satu aturan mengurutkan baris di ketiga bentuk bagian", () => {

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 59, sidik: "51af280792a9" },
+  "style.css": { versi: 60, sidik: "f5e96710365c" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=57">
+  <link rel="stylesheet" href="style.css?v=58">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6939,14 +6939,19 @@ function siapkanCetakJuara(hasil, bagian) {
     return [g < 0 ? URUT_BACA_GOLONGAN.length : g, p ? -Number(p[1]) : 0];
   };
 
-  const isi = [...bagian].sort((a, b) => a[4] - b[4]).map(([judul, masuk, label]) => {
+  const isi = bagian.map(([judul, masuk, label, kelas]) => {
     const punya = hasil.filter(masuk).sort((a, b) => {
       const ka = kunciBaca(a), kb = kunciBaca(b);
       return ka[0] - kb[0] || ka[1] - kb[1];
     });
     if (!punya.length) return "";
+    /* Kelas letaknya DIBAWA APA ADANYA dari layarnya, dan itu yang membuat
+       kertas ini benar-benar salinan layarnya: satu blok aturan grid di
+       style.css menempatkan kedua-duanya — Juara Umum di atas melintang,
+       sisanya berpasangan dua kolom — jadi menggeser satu kartu di layar
+       menggeser kartu yang sama di kertas, tanpa ada yang perlu diingat. */
     return `
-      <section class="juara-bagian">
+      <section class="juara-bagian ${esc(kelas)}">
         <h2>${esc(judul)}</h2>
         <!-- JUDUL HANYA UNTUK KOLOM KANAN. Dua kolom pertama sudah terbaca
              dari bentuknya sendiri — gelar tebal di kiri, nama juara di
@@ -6969,7 +6974,7 @@ function siapkanCetakJuara(hasil, bagian) {
   document.body.appendChild(h(`<div id="cetakan" class="printout juara-cetak">
     <section class="print-page">
       <h1>DAFTAR JUARA — ${esc(EDISI ? EDISI.name : "")}</h1>
-      ${isi}
+      <div class="kejuaraan-bagian">${isi}</div>
       <p class="print-note">Dicetak ${esc(dicetak)}.</p>
     </section>
   </div>`));
@@ -7058,44 +7063,36 @@ async function layarKejuaraan() {
   /* Label golongan diambil dari GOLONGAN_LABEL, tidak ditulis ulang di sini:
      satu-satunya tempatnya `util.js`, dan `periksa_urutan_golongan.py` yang
      menjaganya tetap satu. */
-  /* Angka kelima tiap bagian adalah URUTAN BACANYA DI PANGGUNG, dan ia
-     sengaja berbeda dari urutan di layar ini.
-
-     Layar dipakai MEMERIKSA: yang dicari mata Juara I, jadi ia di atas.
-     Panggung dibacakan MENAIK: penghargaan pilihan lebih dulu, lalu juara per
-     golongan dari Harapan III sampai Juara I, dan Juara Umum paling akhir
-     sebagai puncaknya. Urutan ini keputusan pemilik acara, 2 September 2026.
-
-     Ditaruh sebagai angka DI SINI, bukan sebagai daftar kedua di pembuat
-     cetakannya: daftar penghargaan yang ditulis dua kali adalah daftar yang
-     suatu hari berselisih, dan yang berselisih di sini dibacakan di depan
-     orang banyak. */
-  const gelarGolongan = (kode, kelas, urut) => [
+  /* SATU DAFTAR untuk layar dan kertas, termasuk urutannya. Kertasnya salinan
+     layarnya — Juara Umum di atas, sisanya berpasangan — keputusan pemilik
+     acara, 2 September 2026. Yang berbeda cuma urutan BARIS di dalam tiap
+     kartu; lihat kunciBaca() di pembuat cetakannya. */
+  const gelarGolongan = (kode, kelas) => [
     GOLONGAN_LABEL[kode], x => x.kode.startsWith(kode + "_"),
-    x => x.nama_penghargaan.replace(GOLONGAN_LABEL[kode] + " ", ""), kelas, urut];
+    x => x.nama_penghargaan.replace(GOLONGAN_LABEL[kode] + " ", ""), kelas];
 
   const bagian = [
     ["Juara Umum", x => x.kode === "juara_umum",
-      x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum", 11],
+      x => x.nama_penghargaan.replace(/^Juara Umum /, ""), "kejuaraan-umum"],
     ["Juara Umum Penegak", x => x.kode === "juara_umum_penegak",
-      () => "PENEGAK", "kejuaraan-umum-penegak", 10],
-    gelarGolongan("penegak_pa", "kejuaraan-penegak-pa", 8),
-    gelarGolongan("penegak_pi", "kejuaraan-penegak-pi", 7),
+      () => "PENEGAK", "kejuaraan-umum-penegak"],
+    gelarGolongan("penegak_pa", "kejuaraan-penegak-pa"),
+    gelarGolongan("penegak_pi", "kejuaraan-penegak-pi"),
     ["Juara Umum Penggalang", x => x.kode === "juara_umum_penggalang",
-      () => "PENGGALANG", "kejuaraan-umum-penggalang", 9],
-    gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa", 6),
-    gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi", 5),
+      () => "PENGGALANG", "kejuaraan-umum-penggalang"],
+    gelarGolongan("penggalang_pa", "kejuaraan-penggalang-pa"),
+    gelarGolongan("penggalang_pi", "kejuaraan-penggalang-pi"),
     ["Juara Kostum", x => x.kode.startsWith("kostum_"),
       x => x.nama_penghargaan.replace(/^Juara Kostum /, ""),
-      "kejuaraan-kostum kejuaraan-pilihan", 2],
+      "kejuaraan-kostum kejuaraan-pilihan"],
     ["Juara Yel Yel", x => x.kode.startsWith("yel_yel_"),
-      x => x.nama_penghargaan.replace(/^Juara Yel Yel /, ""), "kejuaraan-yel-yel", 3],
+      x => x.nama_penghargaan.replace(/^Juara Yel Yel /, ""), "kejuaraan-yel-yel"],
     ["Peserta Terfavorit", x => x.kode.startsWith("terfavorit_"),
       x => x.nama_penghargaan.replace(/^Peserta Terfavorit /, ""),
-      "kejuaraan-terfavorit kejuaraan-pilihan", 1],
+      "kejuaraan-terfavorit kejuaraan-pilihan"],
     ["Penghargaan Khusus",
       x => x.kode === "terjauh" || x.kode === "peserta_terbanyak",
-      x => x.nama_penghargaan, "kejuaraan-khusus kejuaraan-pilihan", 4],
+      x => x.nama_penghargaan, "kejuaraan-khusus kejuaraan-pilihan"],
   ];
 
   LAYAR.replaceChildren(h(`

--- a/web/style.css
+++ b/web/style.css
@@ -895,7 +895,13 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
 .kejuaraan-bagian .card { overflow: visible; }
 .kejuaraan-terkunci { display: flex; align-items: center; gap: .45rem; }
 .kejuaraan-nilai { flex: 1; min-width: 0; }
-@media (min-width: 900px) {
+/* `, print` DI SINI, dan itu yang membuat kertas Daftar Juara jadi salinan
+   layar ini alih-alih tata letak kedua yang harus dijaga sejalan. Kertasnya
+   memakai kelas yang sama persis — `kejuaraan-umum`, `kejuaraan-penegak-pa`,
+   dan seterusnya — jadi menggeser satu kartu di sini menggesernya di
+   dua-duanya. Yang TIDAK ikut cuma warnanya; blok cetak di bawah
+   mengembalikannya ke hitam-putih (bagian 8). */
+@media (min-width: 900px), print {
   .kejuaraan-bagian { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .kejuaraan-umum {
     grid-column: 1 / -1; grid-row: 1;
@@ -1243,19 +1249,17 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
   .printout h2 { font-size: 12pt; margin: 5mm 0 1mm; }
   .juara-bagian { break-inside: avoid; page-break-inside: avoid; }
 
-  /* DUA KOLOM DI SATU LEMBAR. Sebelas bagian yang mengalir satu kolom penuh
-     memakan tiga halaman; dibagi dua, keduanya muat lebih rapat tanpa satu
-     baris pun mengecil.
+  /* TATA LETAKNYA MILIK LAYARNYA. Kertas ini memakai kelas yang sama dan
+     ditempatkan blok grid `@media (min-width: 900px), print` di atas: Juara
+     Umum melintang di puncak, sisanya berpasangan dua kolom. Yang tersisa di
+     sini cuma melepas hiasannya.
 
-     `column-fill: auto` dan bukan `balance`: yang dibacakan di panggung harus
-     punya urutan yang tidak bisa salah dibaca — kolom kiri sampai habis, baru
-     kolom kanan. `balance` membagi rata dan membuat bagian terakhir kolom
-     kiri berpindah-pindah mengikuti panjang isinya.
-
-     Judul dan cap cetak MELINTANG penuh, di luar kolomnya: judul dokumen yang
-     duduk di kolom kiri saja terbaca seperti judul kolom itu. */
-  .juara-cetak .print-page { columns: 2; column-gap: 7mm; column-fill: auto; }
-  .juara-cetak h1, .juara-cetak .print-note { column-span: all; }
+     Latar tint dari `.kejuaraan-umum` dan kawan-kawan DIBUANG: bagian 8.4
+     melarang raster abu di kertas yang digandakan fotokopi — yang halus
+     keluar belang, yang pekat menghitami tulisannya. Kekhususan 0,2,0 di sini
+     mengalahkan 0,1,0 milik warnanya. */
+  .printout .kejuaraan-bagian { display: grid; gap: 4mm; }
+  .printout .juara-bagian { background: none; }
   /* Kolom selebar ~91mm, jadi patokan yang dipakai satu kolom terlalu longgar
      di sini: yang dipersempit gelar dan angkanya, karena keduanya isinya
      pendek dan tetap — "Harapan III" dan empat digit. Sisanya jatuh ke nama


### PR DESCRIPTION
## What

The printed sheet is now a copy of the Kejuaraan screen:

```
            [ Juara Umum ]
Juara Umum Penegak    │ Juara Umum Penggalang
Penegak PA            │ Penggalang PA
Penegak PI            │ Penggalang PI
Juara Kostum          │ Juara Yel Yel
Peserta Terfavorit    │ Penghargaan Khusus
```

## Why

It really is **one layout, not two that happen to match**: the print sections
carry the same classes as the screen cards, and the grid block that places
them became `@media (min-width: 900px), print`. Moving a card on screen moves
it on paper, with nothing to remember.

What print does not take is the colour — the tint behind Juara Umum and its
neighbours is cleared, because section 8.4 rules out grey rasters on paper
that gets photocopied.

The section order goes back to the screen's own, so the print-order numbers
added two commits ago are **gone** rather than left sitting there unused.

## Notes

- **Kept from the announcement order: the order inside each card** — Harapan
  III, Harapan II, Harapan I, Juara III, Juara II, Juara I, and putri before
  putra where a card lists golongan. That was asked for on its own terms — it
  is how the awards are read out — and nothing since retracted it. Say the
  word if you want Juara I back at the top of each card too, and it is one
  line.
- The `Skor / Poin Juara` heading and the two-line-max column width are
  unchanged from the previous commit.
- Measured: 469mm tall, so two A4 sheets, with every card placed exactly where
  its screen counterpart sits. 421 tests pass.
