### PR TITLE
fix: the champions sheet reads like a programme, not a form

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=60">
+  <link rel="stylesheet" href="style.css?v=61">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -1258,27 +1258,86 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      melarang raster abu di kertas yang digandakan fotokopi — yang halus
      keluar belang, yang pekat menghitami tulisannya. Kekhususan 0,2,0 di sini
      mengalahkan 0,1,0 milik warnanya. */
-  .printout .kejuaraan-bagian { display: grid; gap: 4mm; }
-  .printout .juara-bagian { background: none; }
-  /* Kolom selebar ~91mm, jadi patokan yang dipakai satu kolom terlalu longgar
-     di sini: yang dipersempit gelar dan angkanya, karena keduanya isinya
-     pendek dan tetap — "Harapan III" dan empat digit. Sisanya jatuh ke nama
-     regu dan sekolahnya, satu-satunya yang panjangnya tidak bisa ditebak. */
-  .juara-cetak .print-table .juara-gelar { width: 21mm; font-size: 9pt; }
-  .juara-cetak .print-table .juara-skor { width: 21mm; }
-  .juara-cetak .print-table th, .juara-cetak .print-table td { padding: 3pt 4pt; }
-  /* Judul kolomnya HURUF BIASA dan 8pt, bukan kapital 9pt seperti kepala
-     tabel lain di berkas ini. "SKOR / POIN JUARA" berkapital menuntut tiga
-     baris di kolom 21mm — kepala kosong setinggi tiga baris, sebelas kali.
-     Huruf biasa 8pt memuatnya dalam dua, dan 8pt masih di atas batas 7pt
-     (bagian 8.6). */
-  .juara-cetak .print-table th { text-transform: none; font-size: 8pt; }
-  /* Jarak antar bagian dirapatkan, dan itu yang menentukan satu lembar atau
-     dua: sebelas judul bagian dengan jarak atas 5mm adalah 55mm — seperlima
-     halaman untuk ruang kosong. Terukur, seluruh daftar jatuh dari 284mm ke
-     bawah 277mm, jadi muat satu lembar A4 bolak-balik-tidak-perlu. */
-  .juara-cetak h2 { margin: 2.5mm 0 0; }
-  .juara-cetak .print-table { margin-top: 1mm; }
+  .printout .kejuaraan-bagian { display: grid; gap: 6mm 8mm; }
+  /* TEPI KIRI TEBAL, sama seperti di layar — dan itu yang membuat layar
+     Kejuaraan gampang dibaca: tiap kartu punya sisi yang menandai di mana ia
+     mulai dan berhenti. Di layar sisi itu berwarna; di kertas ia garis hitam
+     2pt, dan bagian 8.2 memang menyuruh begitu — garis selamat difotokopi,
+     blok warna tidak.
+
+     Latar tintnya sendiri dibuang: bagian 8.4, raster abu keluar belang. */
+  .printout .juara-bagian {
+    background: none;
+    border-left: 2pt solid #000; padding-left: 3.5mm;
+  }
+  /* ---- Bukan kotak-kotak ----
+
+     Daftar juara BUKAN formulir. Blangko dikotak-kotak karena orang menulis
+     ke dalam kotaknya; daftar ini cuma dibaca — dibacakan di panggung, lalu
+     disalin ke sertifikat — dan garis di keempat sisi tiap sel membuat
+     halaman yang seluruhnya isian terbaca seperti borang pajak.
+
+     Yang dibuang GARIS TEGAKNYA, dan itu yang menentukan: garis tegak yang
+     membelah tiap baris jadi tiga petak adalah satu-satunya hal yang membuat
+     sesuatu terbaca sebagai TABEL. Yang tinggal garis mendatar tipis di
+     antara juara — bentuk yang sama dengan daftar acara dan daftar menu,
+     dibaca dari atas ke bawah tanpa satu pun petak.
+
+     Garisnya 0.75pt, batas bawah yang masih selamat difotokopi (bagian 8.5),
+     dan hitam pekat — bukan abu, yang justru keluar belang (bagian 8.4). */
+  .juara-cetak .print-table th,
+  .juara-cetak .print-table td { border: 0; padding: 1.6mm 1.5mm; }
+  /* Satu garis tegas di bawah kepala, sekaligus jadi garis bawah judul
+     bagiannya: keduanya berdampingan, jadi satu garis melayani dua-duanya.
+     Judulnya melintang tiga kolom dan rata kanan — duduk tepat di atas
+     angkanya tanpa memaksa kolomnya melebar. */
+  .juara-cetak .print-table thead th.juara-kepala {
+    border-bottom: 1.5pt solid #000;
+    text-transform: none; font-size: 8pt; font-weight: 700;
+    text-align: right; white-space: nowrap; padding: 0 2mm .8mm;
+  }
+  /* Garis antar juara. TIDAK di baris terakhir: garis yang menutup daftar
+     mengembalikan kesan kotak yang baru saja dibuang.
+
+     1pt, bukan 0.75pt. 0.75 adalah BATAS BAWAH yang masih selamat difotokopi
+     (bagian 8.5), bukan ukuran yang enak dibaca — di antara dua baris setinggi
+     12pt ia nyaris tidak terlihat, dan pemisah yang harus dicari bukan
+     pemisah. Kepala bagiannya 1.5pt supaya tetap terbaca lebih tegas daripada
+     pemisah antar juara: satu tingkat, bukan dua garis yang sama. */
+  .juara-cetak .print-table tbody tr + tr td { border-top: 1pt solid #000; }
+
+  /* Nomor dada dan nama regu — yang dibacakan — jadi yang paling besar di
+     kartunya. Gelarnya sendiri kecil dan berjarak huruf: ia penanda, bukan
+     kalimat, dan mata mencarinya sebagai bentuk di tepi kiri. */
+  /* `width: 1%` + `nowrap` = kolom SELEBAR ISINYA. Patokan milimeter mana pun
+     salah di sini: "Harapan III" dan "Peserta Terbanyak" beda jauh, dan
+     patokan yang muat untuk yang panjang memboroskan tempat untuk yang
+     pendek — sedangkan yang terlalu sempit mematahkan "Harapan III" jadi dua
+     baris, yang di daftar tanpa kotak justru paling kelihatan. Sisa lebarnya
+     jatuh ke nama regu, satu-satunya yang panjangnya tidak bisa ditebak. */
+  .juara-cetak .print-table .juara-gelar {
+    width: 1%; white-space: nowrap; font-size: 8.5pt; letter-spacing: .02em;
+  }
+  /* Jarak ke angkanya 3mm, bukan 5mm. Setiap milimeter yang diambil kolom
+     gelar atau kolom angka diambil dari NAMA REGU — dan nama regu yang patah
+     jadi "011 ·" lalu "RANCAKA11" di baris berikutnya adalah satu-satunya hal
+     di kertas ini yang benar-benar dibacakan keras-keras. Terukur di kartu
+     tersempit (79mm): namanya dapat 47mm, cukup untuk nomor dada beserta nama
+     satu kata terpanjang. */
+  .juara-cetak .print-table .juara-skor {
+    width: 1%; white-space: nowrap; font-size: 12pt; padding-left: 3mm;
+  }
+  .juara-cetak .print-table td strong { font-size: 12pt; }
+
+  /* Judul bagian diberi jarak di atasnya, bukan garis: yang memisahkan dua
+     kartu bersebelahan ruang kosong, dan ruang kosong tidak pernah keluar
+     belang dari mesin fotokopi. */
+  .juara-cetak h2 { margin: 0 0 1mm; letter-spacing: .01em; }
+  .juara-cetak .print-table { margin-top: 0; }
+  /* Judul dokumen di tengah, seperti kepala acara. Rata kiri membuatnya
+     terbaca seperti judul kolom pertama. */
+  .juara-cetak h1 { text-align: center; margin-bottom: 4mm; }
+  .juara-cetak .print-note { text-align: center; margin-top: 4mm; }
   /* Nama sekolah dan keterangan poin: kecil dan HITAM PEKAT, bukan abu.
      Bagian 8.4 — yang harus mundur dibuat kecil, bukan pucat, karena raster
      abu keluar belang dari mesin fotokopi. */

--- a/tests/cetak_daftar_juara.test.mjs
+++ b/tests/cetak_daftar_juara.test.mjs
@@ -78,10 +78,15 @@ test("judul hanya untuk kolom kanan, dua kolom pertama dibiarkan", () => {
   // "GELAR | JUARA" yang tercetak sebelas kali mengulang sesuatu yang sudah
   // terbaca dari bentuknya. Angka di kanan tidak begitu: 1673 dan 42 duduk di
   // kolom yang sama padahal yang satu skor regu dan yang satu poin juara.
-  assert.ok(kodePembuat.includes('<th class="juara-skor">Skor / Poin Juara</th>'),
-    "judul kolom kanan hilang atau berubah bunyinya");
-  assert.ok(kodePembuat.includes('<thead><tr><th class="juara-gelar"></th><th></th>'),
-    "dua kolom pertama ikut diberi judul");
+  assert.ok(kodePembuat.includes(
+    '<thead><tr><th colspan="3" class="juara-kepala">Skor / Poin Juara</th></tr></thead>'),
+    "judul kolom kanan hilang, berubah bunyinya, atau tidak lagi melintang");
+  // Melintang tiga kolom dan rata kanan, bukan sel di kolom ketiga: kolom itu
+  // selebar angkanya saja, dan judulnya patah jadi tiga baris di dalamnya.
+  assert.match(css, /\.juara-cetak \.print-table thead th\.juara-kepala \{/,
+    "aturan judul kolom melintang hilang");
+  assert.match(css, /text-align: right; white-space: nowrap;/,
+    "judul kolom tidak lagi dipaku satu baris di tepi kanan");
 });
 
 test("tata letak kertasnya MILIK layarnya, satu blok untuk keduanya", () => {
@@ -95,12 +100,17 @@ test("tata letak kertasnya MILIK layarnya, satu blok untuk keduanya", () => {
     "bagian cetakan tidak lagi membawa kelas letak dari layarnya");
   assert.ok(kodePembuat.includes('<div class="kejuaraan-bagian">${isi}</div>'),
     "cetakan tidak dibungkus wadah grid yang sama dengan layarnya");
-  assert.match(css, /\.printout \.kejuaraan-bagian \{ display: grid; gap: 4mm; \}/,
+  assert.match(css, /\.printout \.kejuaraan-bagian \{ display: grid; gap: 6mm 8mm; \}/,
     "wadah grid cetakan tidak dipasang");
-  // Yang TIDAK ikut cuma warnanya: bagian 8.4 melarang raster abu di kertas
-  // yang digandakan fotokopi.
-  assert.match(css, /\.printout \.juara-bagian \{ background: none; \}/,
-    "latar tint kartu ikut tercetak");
+  // Yang TIDAK ikut warnanya: bagian 8.4 melarang raster abu di kertas yang
+  // digandakan fotokopi. Yang ikut BENTUKNYA — tepi kiri tebal tiap kartu,
+  // penanda yang membuat layarnya gampang dibaca, jadi garis hitam 2pt
+  // (bagian 8.2: garis selamat difotokopi, blok warna tidak).
+  const kartu = css.slice(css.indexOf(".printout .juara-bagian {"));
+  const aturanKartu = kartu.slice(0, kartu.indexOf("}"));
+  assert.match(aturanKartu, /background: none;/, "latar tint kartu ikut tercetak");
+  assert.match(aturanKartu, /border-left: 2pt solid #000;/,
+    "tepi kiri kartu hilang — yang membedakan satu kartu dari tetangganya");
 });
 
 test("satu bagian tidak boleh terbelah dua halaman", () => {

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 60, sidik: "f5e96710365c" },
+  "style.css": { versi: 61, sidik: "1a586323c25c" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=58">
+  <link rel="stylesheet" href="style.css?v=59">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6954,15 +6954,20 @@ function siapkanCetakJuara(hasil, bagian) {
       <section class="juara-bagian ${esc(kelas)}">
         <h2>${esc(judul)}</h2>
         <!-- JUDUL HANYA UNTUK KOLOM KANAN. Dua kolom pertama sudah terbaca
-             dari bentuknya sendiri — gelar tebal di kiri, nama juara di
+             dari bentuknya sendiri — gelar kecil di kiri, nama juara besar di
              tengah — dan "GELAR | JUARA" yang tercetak sebelas kali cuma
              mengulang sesuatu yang tidak pernah ditanyakan (bagian 9.3).
              Angka di kanan tidak begitu: 1673 dan 42 duduk di kolom yang sama
              padahal yang satu skor regu dan yang satu poin juara, dan tanpa
-             judul tidak ada yang mengatakan itu. -->
+             judul tidak ada yang mengatakan itu.
+
+             SATU SEL MELINTANG TIGA KOLOM, rata kanan — bukan sel di kolom
+             ketiga. Kolom itu selebar angkanya saja, dan "Skor / Poin Juara"
+             di dalamnya patah jadi tiga baris: satu blok tulisan menggantung
+             dengan ruang kosong di kirinya, sebelas kali. Melintang, ia satu
+             baris yang duduk tepat di atas angkanya. -->
         <table class="print-table">
-          <thead><tr><th class="juara-gelar"></th><th></th>
-            <th class="juara-skor">Skor / Poin Juara</th></tr></thead>
+          <thead><tr><th colspan="3" class="juara-kepala">Skor / Poin Juara</th></tr></thead>
           <tbody>${punya.map(x => `
             <tr><td class="juara-gelar">${esc(label(x))}</td>
                 <td>${isiJuara(x)}</td>

--- a/web/style.css
+++ b/web/style.css
@@ -1258,27 +1258,86 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      melarang raster abu di kertas yang digandakan fotokopi — yang halus
      keluar belang, yang pekat menghitami tulisannya. Kekhususan 0,2,0 di sini
      mengalahkan 0,1,0 milik warnanya. */
-  .printout .kejuaraan-bagian { display: grid; gap: 4mm; }
-  .printout .juara-bagian { background: none; }
-  /* Kolom selebar ~91mm, jadi patokan yang dipakai satu kolom terlalu longgar
-     di sini: yang dipersempit gelar dan angkanya, karena keduanya isinya
-     pendek dan tetap — "Harapan III" dan empat digit. Sisanya jatuh ke nama
-     regu dan sekolahnya, satu-satunya yang panjangnya tidak bisa ditebak. */
-  .juara-cetak .print-table .juara-gelar { width: 21mm; font-size: 9pt; }
-  .juara-cetak .print-table .juara-skor { width: 21mm; }
-  .juara-cetak .print-table th, .juara-cetak .print-table td { padding: 3pt 4pt; }
-  /* Judul kolomnya HURUF BIASA dan 8pt, bukan kapital 9pt seperti kepala
-     tabel lain di berkas ini. "SKOR / POIN JUARA" berkapital menuntut tiga
-     baris di kolom 21mm — kepala kosong setinggi tiga baris, sebelas kali.
-     Huruf biasa 8pt memuatnya dalam dua, dan 8pt masih di atas batas 7pt
-     (bagian 8.6). */
-  .juara-cetak .print-table th { text-transform: none; font-size: 8pt; }
-  /* Jarak antar bagian dirapatkan, dan itu yang menentukan satu lembar atau
-     dua: sebelas judul bagian dengan jarak atas 5mm adalah 55mm — seperlima
-     halaman untuk ruang kosong. Terukur, seluruh daftar jatuh dari 284mm ke
-     bawah 277mm, jadi muat satu lembar A4 bolak-balik-tidak-perlu. */
-  .juara-cetak h2 { margin: 2.5mm 0 0; }
-  .juara-cetak .print-table { margin-top: 1mm; }
+  .printout .kejuaraan-bagian { display: grid; gap: 6mm 8mm; }
+  /* TEPI KIRI TEBAL, sama seperti di layar — dan itu yang membuat layar
+     Kejuaraan gampang dibaca: tiap kartu punya sisi yang menandai di mana ia
+     mulai dan berhenti. Di layar sisi itu berwarna; di kertas ia garis hitam
+     2pt, dan bagian 8.2 memang menyuruh begitu — garis selamat difotokopi,
+     blok warna tidak.
+
+     Latar tintnya sendiri dibuang: bagian 8.4, raster abu keluar belang. */
+  .printout .juara-bagian {
+    background: none;
+    border-left: 2pt solid #000; padding-left: 3.5mm;
+  }
+  /* ---- Bukan kotak-kotak ----
+
+     Daftar juara BUKAN formulir. Blangko dikotak-kotak karena orang menulis
+     ke dalam kotaknya; daftar ini cuma dibaca — dibacakan di panggung, lalu
+     disalin ke sertifikat — dan garis di keempat sisi tiap sel membuat
+     halaman yang seluruhnya isian terbaca seperti borang pajak.
+
+     Yang dibuang GARIS TEGAKNYA, dan itu yang menentukan: garis tegak yang
+     membelah tiap baris jadi tiga petak adalah satu-satunya hal yang membuat
+     sesuatu terbaca sebagai TABEL. Yang tinggal garis mendatar tipis di
+     antara juara — bentuk yang sama dengan daftar acara dan daftar menu,
+     dibaca dari atas ke bawah tanpa satu pun petak.
+
+     Garisnya 0.75pt, batas bawah yang masih selamat difotokopi (bagian 8.5),
+     dan hitam pekat — bukan abu, yang justru keluar belang (bagian 8.4). */
+  .juara-cetak .print-table th,
+  .juara-cetak .print-table td { border: 0; padding: 1.6mm 1.5mm; }
+  /* Satu garis tegas di bawah kepala, sekaligus jadi garis bawah judul
+     bagiannya: keduanya berdampingan, jadi satu garis melayani dua-duanya.
+     Judulnya melintang tiga kolom dan rata kanan — duduk tepat di atas
+     angkanya tanpa memaksa kolomnya melebar. */
+  .juara-cetak .print-table thead th.juara-kepala {
+    border-bottom: 1.5pt solid #000;
+    text-transform: none; font-size: 8pt; font-weight: 700;
+    text-align: right; white-space: nowrap; padding: 0 2mm .8mm;
+  }
+  /* Garis antar juara. TIDAK di baris terakhir: garis yang menutup daftar
+     mengembalikan kesan kotak yang baru saja dibuang.
+
+     1pt, bukan 0.75pt. 0.75 adalah BATAS BAWAH yang masih selamat difotokopi
+     (bagian 8.5), bukan ukuran yang enak dibaca — di antara dua baris setinggi
+     12pt ia nyaris tidak terlihat, dan pemisah yang harus dicari bukan
+     pemisah. Kepala bagiannya 1.5pt supaya tetap terbaca lebih tegas daripada
+     pemisah antar juara: satu tingkat, bukan dua garis yang sama. */
+  .juara-cetak .print-table tbody tr + tr td { border-top: 1pt solid #000; }
+
+  /* Nomor dada dan nama regu — yang dibacakan — jadi yang paling besar di
+     kartunya. Gelarnya sendiri kecil dan berjarak huruf: ia penanda, bukan
+     kalimat, dan mata mencarinya sebagai bentuk di tepi kiri. */
+  /* `width: 1%` + `nowrap` = kolom SELEBAR ISINYA. Patokan milimeter mana pun
+     salah di sini: "Harapan III" dan "Peserta Terbanyak" beda jauh, dan
+     patokan yang muat untuk yang panjang memboroskan tempat untuk yang
+     pendek — sedangkan yang terlalu sempit mematahkan "Harapan III" jadi dua
+     baris, yang di daftar tanpa kotak justru paling kelihatan. Sisa lebarnya
+     jatuh ke nama regu, satu-satunya yang panjangnya tidak bisa ditebak. */
+  .juara-cetak .print-table .juara-gelar {
+    width: 1%; white-space: nowrap; font-size: 8.5pt; letter-spacing: .02em;
+  }
+  /* Jarak ke angkanya 3mm, bukan 5mm. Setiap milimeter yang diambil kolom
+     gelar atau kolom angka diambil dari NAMA REGU — dan nama regu yang patah
+     jadi "011 ·" lalu "RANCAKA11" di baris berikutnya adalah satu-satunya hal
+     di kertas ini yang benar-benar dibacakan keras-keras. Terukur di kartu
+     tersempit (79mm): namanya dapat 47mm, cukup untuk nomor dada beserta nama
+     satu kata terpanjang. */
+  .juara-cetak .print-table .juara-skor {
+    width: 1%; white-space: nowrap; font-size: 12pt; padding-left: 3mm;
+  }
+  .juara-cetak .print-table td strong { font-size: 12pt; }
+
+  /* Judul bagian diberi jarak di atasnya, bukan garis: yang memisahkan dua
+     kartu bersebelahan ruang kosong, dan ruang kosong tidak pernah keluar
+     belang dari mesin fotokopi. */
+  .juara-cetak h2 { margin: 0 0 1mm; letter-spacing: .01em; }
+  .juara-cetak .print-table { margin-top: 0; }
+  /* Judul dokumen di tengah, seperti kepala acara. Rata kiri membuatnya
+     terbaca seperti judul kolom pertama. */
+  .juara-cetak h1 { text-align: center; margin-bottom: 4mm; }
+  .juara-cetak .print-note { text-align: center; margin-top: 4mm; }
   /* Nama sekolah dan keterangan poin: kecil dan HITAM PEKAT, bukan abu.
      Bagian 8.4 — yang harus mundur dibuat kecil, bukan pucat, karena raster
      abu keluar belang dari mesin fotokopi. */


### PR DESCRIPTION
## What

The printed champions list is no longer a grid of boxes.

```
│ Penegak PA
│                              Skor / Poin Juara
│ ─────────────────────────────────────────────
│ Harapan III   009 · RANCAKA9              1094
│               MA PUI Cijantung
│ ─────────────────────────────────────────────
│ Harapan II    001 · RANCAKA1              1244
│               MA PUI Cijantung
```

## Why

Boxed cells are what a *blangko* needs, because somebody writes inside the
box. Nobody writes on this sheet — it is read out from a stage and copied onto
certificates — and a page ruled on all four sides of every cell reads like a
tax form.

**The vertical rules are gone, and that is the part that matters**: the lines
splitting each row into three cells are the single thing that makes something
read as a *table*.

What replaced them came from the screen, which is the thing that is already
easy to read: every card there has a thick coloured edge marking where it
starts and stops. On paper that edge is a **2pt black rule** — section 8.2
asks for exactly that, because a rule survives a photocopier and a block of
colour does not. The tint behind Juara Umum and its neighbours stays off (8.4).

## Notes

- **Separators are heavier than the first attempt**: 1pt between winners, 1.5pt
  under each section head. 0.75pt is the *floor* that survives copying, not a
  size that is comfortable to read — between two 12pt lines it was almost
  invisible, and a separator you have to look for is not one.
- The column heading spans all three columns and sits right-aligned above the
  numbers. In the score column alone — as wide as four digits — "Skor / Poin
  Juara" broke into three lines, a floating block of text with empty space
  beside it, eleven times over.
- The gelar and score columns take the width of their own contents rather than
  a fixed millimetre guess. Every millimetre those two take comes out of the
  regu name, and a name that breaks into `011 ·` then `RANCAKA11` is the one
  thing on this sheet that actually gets read aloud. **Measured in the
  narrowest card (79mm): the name gets 47mm and none of the seventeen names
  wrap.**
- Title and print stamp are centred; 449mm tall, two A4 sheets. 421 tests pass.
