### PR TITLE
feat: Buku Sakti, a handbook and a sprint board inside the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ capnya menyebut sampai migrasi berapa ia berlaku. Kalau cap itu tertinggal jauh
 dari `supabase/migrations/`, angkanya jangan dipercaya sebelum dihitung ulang —
 itulah gunanya cap itu ada.
 
+**Buku Sakti tidak ada di tabel ini, dan itu bukan kelalaian.** Ia dokumen
+untuk PANITIA, bukan untuk pengelola repo, jadi ia tinggal di dalam sistemnya
+sendiri — layar `#/buku-sakti`, isinya `web/js/buku-sakti.mjs`. Di situ ia bisa
+dibuka dari HP di tengah acara, mencetak dirinya sendiri untuk difotokopi, dan
+menautkan tiap langkah ke layar yang mengerjakannya. Menyuntingnya berarti
+menyunting daftar blok di berkas itu; tidak ada satu pun tag HTML yang perlu
+disentuh, dan `tests/buku_sakti.test.mjs` menolak bentuk yang salah.
+
 `desain-sistem.md` dan `rancangan-b.md` merekam **keputusan pada saat itu**,
 bukan keadaan hari ini. Keduanya sengaja dipertahankan apa adanya karena 61
 komentar di kode — tersebar di 32 berkas: migrasi, tes, SPA, workflow,
@@ -41,9 +49,10 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 ├── docs/                     # spesifikasi, catatan keputusan, arsitektur
 ├── web/                      # SPA statis — layar panitia (panitia-hrcd37)
 │   ├── index.html            # layar panitia (butuh login)
-│   ├── js/                   # api.js, app.js, util.js, dan dua modul murni
-│   │                         # hitung: departure-calculator.mjs dan
-│   │                         # nomor-dada-series.mjs
+│   ├── js/                   # api.js, app.js, util.js, dua modul murni hitung
+│   │                         # (departure-calculator.mjs dan
+│   │                         # nomor-dada-series.mjs), dan buku-sakti.mjs —
+│   │                         # ISI Buku Sakti sebagai data, bukan kode
 │   ├── style.css             # seluruh gaya, termasuk aturan cetak
 │   ├── config.js             # URL Supabase + gateway (bukan rahasia)
 │   ├── _headers              # aturan cache Cloudflare
@@ -87,7 +96,7 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 │   ├── dev_server.py         # tiruan Supabase untuk mencoba layar
 │   ├── static_server.py      # penyaji web/ tanpa cache
 │   ├── concurrency_test.py   # uji daftar ulang serentak dari banyak meja
-│   ├── *.test.mjs            # 85 berkas tes layar + modul (node --test)
+│   ├── *.test.mjs            # 91 berkas tes layar + modul (node --test)
 │   └── status_migrasi_check.sh
 │                             # menguji jejak status_migrasi.sql dua arah;
 │                             # lambat, sengaja di luar run.sh

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ menautkan tiap langkah ke layar yang mengerjakannya. Menyuntingnya berarti
 menyunting daftar blok di berkas itu; tidak ada satu pun tag HTML yang perlu
 disentuh, dan `tests/buku_sakti.test.mjs` menolak bentuk yang salah.
 
+Bab terakhirnya papan sprint: tiga belas sprint dua mingguan dari Serah Terima
+Jabatan sampai hari-H, dan **tiap tugasnya bisa dicentang**. Centangnya duduk
+di database (`centang_sprint`, migrasi `0170`) dan terlihat oleh seluruh
+panitia beserta siapa yang mencentang dan kapan — papan rencana yang jawabannya
+berbeda-beda per HP bukan papan koordinasi. Kunci centangnya kode tugas di
+`buku-sakti.mjs`, jadi **kode yang sudah dipakai tidak pernah diubah**;
+menambah dan menghapus tugas aman, mengganti nama kodenya tidak.
+
 `desain-sistem.md` dan `rancangan-b.md` merekam **keputusan pada saat itu**,
 bukan keadaan hari ini. Keduanya sengaja dipertahankan apa adanya karena 61
 komentar di kode — tersebar di 32 berkas: migrasi, tes, SPA, workflow,
@@ -52,7 +60,9 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 │   ├── js/                   # api.js, app.js, util.js, dua modul murni hitung
 │   │                         # (departure-calculator.mjs dan
 │   │                         # nomor-dada-series.mjs), dan buku-sakti.mjs —
-│   │                         # ISI Buku Sakti sebagai data, bukan kode
+│   │                         # ISI Buku Sakti sebagai data, bukan kode:
+│   │                         # empat bab bacaan + papan 13 sprint yang
+│   │                         # tugasnya dicentang (migrasi 0170)
 │   ├── style.css             # seluruh gaya, termasuk aturan cetak
 │   ├── config.js             # URL Supabase + gateway (bukan rahasia)
 │   ├── _headers              # aturan cache Cloudflare
@@ -72,7 +82,7 @@ berbeda dari sistem sekarang, `docs/final-architecture.md` yang benar.
 │                             # shared-files.yml gagal kalau menyimpang
 ├── workers/gateway/          # satu-satunya kode "server": penerima form daftar
 ├── supabase/
-│   ├── migrations/           # skema database, urut 0001..0169
+│   ├── migrations/           # skema database, urut 0001..0170
 │   ├── checks/               # 30 SQL manual, dan 12 di antaranya MENGUBAH
 │   │                         # data (flow_test, cleanup_data_uji,
 │   │                         # cleanup_smoke, seed_data_uji, kloter_dari_stok,

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -7,7 +7,8 @@ sebelum sistemnya dibangun.
 
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
 sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0164`, lalu
-2 September 2026 sampai migrasi `0169`.
+2 September 2026 sampai migrasi `0169`, lalu 5 September 2026
+sampai migrasi `0170`.
 
 Dokumen ini sengaja TIDAK memuat jumlah view, RPC, policy, check, atau pemicu.
 Angka-angka itu berubah tiap beberapa migrasi, tidak ada satu tes pun yang
@@ -35,7 +36,11 @@ dihormati layar Cek Nilai, Input Nilai Pos, dan Input Nilai Pos v2; `0168`
 membetulkan judul dan petunjuk `menaksir` ("Hasil Taksir", "(meter)"),
 menyusul `0085` yang membalik arti angka yang diketik tetapi meninggalkan
 judulnya; `0169` mengosongkan `judul_isian` kelima lomba soal supaya layar
-menurunkan "Jumlah benar" sendiri, sama seperti Semaphore.
+menurunkan "Jumlah benar" sendiri, sama seperti Semaphore; `0170` memberi
+papan sprint Buku Sakti tabel centangnya (`centang_sprint`,
+`set_centang_sprint()`, `v_centang_sprint`) — satu-satunya tabel yang boleh
+ditulis SETIAP panitia tanpa centang fitur, dan alasannya ada di kepala
+berkas migrasinya.
 
 Bersamaan dengan `0169`, bentuk pengisian "soal" DIBUANG dari Input Nilai Pos
 v2 — `jenisLomba()` di `web/js/util.js` tinggal "waktu" dan "nilai", dan
@@ -111,7 +116,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-169 migrasi, `0001` sampai `0169`, dijalankan berurutan tanpa lubang penomoran.
+170 migrasi, `0001` sampai `0170`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -286,6 +286,7 @@ supaya tombol Back HP mengembalikan pemilih lomba, bukan melompat ke Home.
 | `#/pengaturan-kloter` | Pengaturan Kloter | simulasi dan perbaikan jadwal keberangkatan; pemegang `pengaturan` |
 | `#/ganti-password` | Ganti Password | — |
 | `#/account` | Akun | buat/nonaktifkan akun dan atur matriks hak; pemegang `akun` |
+| `#/buku-sakti` | Buku Sakti | buku pegangan yang diserahkan antar kepanitiaan: cara menjalankan HRCD, tugas pokok tiap seksi, alasan sistem ini berbentuk begini, dan timeline satu edisi dari Serah Terima Jabatan sampai pelaksanaan. Alamatnya berbuntut kode bab — `#/buku-sakti/seksi`. Isinya data statis di `web/js/buku-sakti.mjs`, bukan baris database, jadi ia tetap terbaca saat Supabase tidak bisa dihubungi. **Satu-satunya layar tanpa pagar hak akses**, dan itu disengaja: yang paling butuh membacanya justru yang haknya paling sempit. Tautan ke layar lain di dalamnya tetap ikut hak |
 
 Lima peran akun: `admin`, `registrasi`, `gerbang`, `juri_pos`, dan
 `koordinator_pos`. Peran hanya memilih centang awal lewat `paket_peran()`;

--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=61">
+  <link rel="stylesheet" href="style.css?v=62">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=62">
+  <link rel="stylesheet" href="style.css?v=63">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -777,6 +777,31 @@ export const bukaKunciNilaiPos = (nomorDada, pos, lomba, alasan) =>
   rpc("buka_kunci_nilai_pos",
       { p_nomor_dada: nomorDada, p_pos: pos, p_lomba: lomba, p_alasan: alasan });
 
+/* ---------- papan sprint Buku Sakti (migrasi 0170) ---------- */
+
+/** Centang tugas papan sprint edisi aktif, beserta siapa dan kapan.
+ *
+ *  Dibaca sekali saat layar Buku Sakti dibuka, bukan per tugas: seratusan
+ *  tugas berarti seratusan permintaan, dan seluruhnya muat dalam satu
+ *  jawaban berukuran beberapa kilobyte.
+ *
+ *  Gagalnya BUKAN alasan menutup layar. Buku Sakti sengaja tetap terbaca
+ *  tanpa database sama sekali (lihat pagar edisi di app.js), jadi yang
+ *  memanggil ini harus menangani gagalnya sebagai "centangnya belum
+ *  terbaca", bukan sebagai "bukunya tidak bisa dibuka". */
+export async function daftarCentangSprint() {
+  if (K.mode === "dev") return baca("/centang-sprint");
+  return baca(null, "v_centang_sprint?select=kode,dicentang_pada,dicentang_oleh");
+}
+
+/** Centang satu tugas, atau batalkan centangnya.
+ *
+ *  Satu fungsi dua arah, sama dengan RPC-nya: kotak centang selalu tahu
+ *  keadaan barunya, dan dua fungsi terpisah berarti dua tempat yang harus
+ *  sepakat soal edisi aktif dan jejaknya. */
+export const setCentangSprint = (kode, selesai) =>
+  rpc("set_centang_sprint", { p_kode: kode, p_selesai: !!selesai });
+
 /** Riwayat perubahan nilai satu regu di satu pos — siapa mengubah apa, kapan.
  *
  *  Dibaca saat penanda simpan diketuk, bukan ikut dimuat bersama lembarnya:

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -1022,7 +1022,12 @@ const IKON = {
     '<path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" /> <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" /> <path d="M7 3v4a1 1 0 0 0 1 1h7" />',
   // Panah memutar searah jarum jam: foto diputar 90 derajat tiap ketukan.
   "rotate-cw":
-    '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /> <path d="M21 3v5h-5" />'
+    '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /> <path d="M21 3v5h-5" />',
+  // Buku terbuka, dipakai ubin Buku Sakti. Sengaja BUKAN "file-text": ubin
+  // itu sudah dipakai layar lain, dan dua ubin bergambar sama di satu papan
+  // menghapus seluruh guna gambarnya.
+  "book-open":
+    '<path d="M12 7v14" /> <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />'
 };
 
 /** Satu ikon garis, siap ditempel ke template. Nama yang tidak dikenal

--- a/live/style.css
+++ b/live/style.css
@@ -292,7 +292,13 @@ button { font: inherit; cursor: pointer; }
   margin-top: .2rem;
 }
 
-input[type=text], input[type=number], input[type=password], input[type=time], input[type=tel] {
+/* `search` ikut daftar ini, bukan dibiarkan bawaan browser: kotak cari yang
+   tepinya setipis rambut dan tingginya 24px berdiri di antara kotak-kotak
+   setinggi 46px terbaca seperti kotak yang rusak, dan di HP ia terlalu
+   kecil untuk disentuh. Tombol silang bawaannya sengaja DIBIARKAN — ia
+   satu-satunya jalan mengosongkan kotaknya dengan satu ketukan. */
+input[type=text], input[type=number], input[type=password], input[type=time],
+input[type=tel], input[type=search] {
   width: 100%;
   font: inherit;
   font-size: 1.0625rem;
@@ -5976,4 +5982,360 @@ button.pill-number:hover { filter: brightness(.95); }
   .isi.cek .cek-foto { flex: 1; min-height: 150px; margin-top: .3rem; }
   .isi.cek .cek-foto .fg-petak { height: 100%; }
   .isi.cek .cek-lomba .foto-navigasi { margin-top: .25rem; flex: 0 0 auto; }
+}
+
+/* Pita Buku Sakti di kaki papan Home.
+
+   Sengaja BUKAN ubin. Empat belas ubin di atasnya masing-masing punya rona
+   sendiri, dan itu batasnya — rona kelima belas yang cukup berjauhan dari
+   keempat belas lainnya sudah tidak ada. Pita ini keluar dari kode warna itu
+   sama sekali: bentuknya yang membedakannya, bukan warnanya, jadi ia tidak
+   pernah bisa tertukar dengan meja mana pun.
+
+   Garis putus-putus, bukan bayangan kartu: ubin di atasnya benda yang bisa
+   ditekan sepanjang hari lomba, pita ini pintu yang dibuka sesekali. */
+.bs-pintu {
+  display: flex; align-items: center; gap: .8rem;
+  margin-top: 1rem; padding: .9rem 1.1rem;
+  border: 1.5px dashed var(--garis); border-radius: var(--radius);
+  background: var(--kartu);
+  text-decoration: none; color: inherit;
+  min-height: 46px;
+}
+.bs-pintu:hover { border-color: var(--utama); background: var(--utama-muda); }
+.bs-pintu:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.bs-pintu-ikon { width: 1.6rem; height: 1.6rem; color: var(--utama); flex: 0 0 auto; }
+.bs-pintu-nama { display: block; font-weight: 700; }
+.bs-pintu-ket {
+  display: block; font-size: .88rem; color: var(--tinta-lembut);
+  line-height: 1.45; margin-top: .1rem;
+}
+
+/* ============================================================================
+   BUKU SAKTI
+
+   Satu-satunya layar di sistem ini yang isinya BACAAN, bukan data. Aturan
+   yang membuat layar meja terbaca cepat — baris padat, angka besar, satu
+   aksi utama — justru melawan di sini: yang dibaca panitia baru di layar ini
+   paragraf demi paragraf, sekali, dengan sungguh-sungguh.
+
+   Jadi dua hal dilonggarkan, dan cuma dua:
+
+   1. LEBAR BARIS DIBATASI. Kartu bacaan berhenti di 68 huruf. Layar 1080px
+      memberi baris sepanjang 150 huruf, dan mata kehilangan awal baris
+      berikutnya setiap kali ia kembali ke kiri. Tabel dan timeline TIDAK ikut
+      dibatasi — keduanya dibaca melintang, bukan mengalir.
+   2. JARAK ANTAR BARIS DINAIKKAN ke 1.65. Tubuh 16px yang rapat nyaman untuk
+      satu baris nama regu dan melelahkan untuk sepuluh baris paragraf.
+
+   Selebihnya memakai kartu, tabel, dan pil yang sama persis dengan layar
+   lain. Buku yang tampilannya asing dari sistem yang ia jelaskan adalah buku
+   yang terbaca seperti tempelan.
+   ========================================================================== */
+
+.bs-kepala .description { margin-bottom: .8rem; }
+
+/* Kotak cari dan dua tombol cetak dalam satu baris; di HP tombolnya turun ke
+   baris kedua dan kotak carinya tetap selebar kartunya. `min-width: 0` wajib
+   ada di kotak carinya: tanpa itu ia menolak menyusut di bawah lebar bawaan
+   input dan mendorong tombol cetak keluar kartu. */
+.bs-alat {
+  display: flex; flex-wrap: wrap; gap: .6rem; align-items: center;
+}
+.bs-alat input[type="search"] {
+  flex: 1 1 14rem; min-width: 0;
+}
+.bs-cetak { display: flex; gap: .5rem; flex-wrap: wrap; }
+
+/* Tab bab memakai .tab-golongan/.tab-gol apa adanya. Yang berbeda cuma satu:
+   di sana tab-nya <button>, di sini <a> — karena bab boleh disebut sebagai
+   alamat. Anchor tidak mewarisi reset tombol, jadi garis bawah dan warna
+   tautannya dibuang di sini. */
+.bs-tab .tab-gol { text-decoration: none; }
+/* Bab yang terbuka ditandai `aria-current="page"`, bukan `aria-selected` —
+   ini tautan, bukan tab. Aturan warnanya ditulis lengkap di sini karena
+   .tab-gol[aria-selected="true"] di atas tidak mengenainya sama sekali. */
+.bs-tab .tab-gol[aria-current="page"] {
+  background: var(--utama); border-color: var(--utama); color: #fff;
+}
+.bs-tab .tab-gol[aria-current="page"] .tab-hitung {
+  background: rgba(255, 255, 255, .24); color: #fff;
+}
+
+/* ---- Kepala bab ---- */
+.bs-bab-kepala { display: flex; gap: .7rem; align-items: flex-start; }
+.bs-bab-kepala h2 { margin-bottom: .15rem; }
+
+/* Daftar isi bab. Bernomor, karena bagiannya memang berurutan waktu di bab
+   Menjalankan HRCD dan urutan itu bagian dari isinya. */
+.bs-isi { margin-top: .9rem; border-top: 1px solid var(--garis); padding-top: .8rem; }
+.bs-isi ol { margin: 0; padding-left: 1.4rem; }
+.bs-isi li { margin: .1rem 0; }
+/* `display: block`, dan itu bukan selera.
+
+   Tombol bawaannya inline-block, dan inline-block yang isinya membungkus dua
+   baris menyejajarkan BARIS TERAKHIRNYA dengan nomor daftar. Di HP, judul
+   bagian seperti "Seksi Kesekretariatan dan Pendaftaran" memang membungkus —
+   dan yang tergambar nomornya "5." berdiri di sebelah baris KEDUA, dengan
+   baris pertamanya menggantung di atasnya tanpa nomor.
+
+   Sebagai blok ia juga jadi sasaran sentuh selebar kartunya, yang memang
+   yang diinginkan dari daftar isi di HP. */
+.bs-ke {
+  display: block; width: 100%;
+  background: none; border: 0; padding: .25rem 0; font: inherit; cursor: pointer;
+  color: var(--utama); text-align: left; line-height: 1.4;
+}
+.bs-ke:hover { text-decoration: underline; }
+.bs-ke:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+
+/* ---- Satu bagian bacaan ---- */
+.bs-bagian {
+  /* TANPA max-width sendiri. Lebar kolomnya diputuskan wadahnya — layar ini
+     memakai `.isi` biasa 760px, bukan `.isi.wide` — supaya kepala, deret tab,
+     kartu bab, dan kartu bagian punya tepi yang sama. Terukur di browser:
+     satu baris paragraf jatuh di sekitar 68 huruf. */
+  line-height: 1.65;
+  /* Kepala halaman ikut menggulir (tidak sticky), jadi yang perlu
+     disisakan cuma satu jarak napas, bukan setinggi kepalanya. */
+  scroll-margin-top: .8rem;
+}
+.bs-bagian h3 {
+  font-size: 1.05rem; letter-spacing: -.01em; margin-bottom: .5rem;
+}
+.bs-bagian p { margin: .55rem 0; }
+
+/* Sorotan sesudah melompat dari daftar isi atau hasil cari. Dua detik, lalu
+   hilang sendiri — penanda yang menetap jadi bagian dari tampilan kartunya
+   dan berhenti berarti "yang ini". */
+.bs-sorot {
+  box-shadow: var(--bayang-naik), 0 0 0 2px var(--utama);
+  transition: box-shadow .25s ease;
+}
+
+.bs-poin, .bs-langkah { margin: .55rem 0; padding-left: 1.35rem; }
+.bs-poin li, .bs-langkah li { margin: .3rem 0; }
+/* Angka langkah ditebalkan supaya urutan kerja terbaca sebagai urutan, bukan
+   sebagai daftar yang kebetulan bernomor. */
+.bs-langkah li::marker { font-weight: 700; color: var(--utama); }
+
+/* Kotak "kenapa": alasan di balik satu aturan, dan satu-satunya blok yang
+   memang harus MENAHAN mata sebentar. Garis tebal di kiri, bukan latar
+   berwarna — kartu yang penuh kotak bertint terbaca seperti peringatan
+   beruntun, dan yang kesepuluh tidak dibaca siapa pun. */
+.bs-kenapa {
+  border-left: 3px solid var(--utama);
+  padding: .1rem 0 .1rem .8rem;
+  color: var(--tinta-lembut);
+}
+
+/* ---- Blok "layar" ---- */
+.bs-layar {
+  display: block; margin: .6rem 0;
+  border: 1px solid var(--garis); border-left: 3px solid var(--utama);
+  border-radius: var(--radius-kecil);
+  padding: .55rem .75rem;
+  text-decoration: none; color: inherit;
+  background: var(--kartu);
+}
+a.bs-layar:hover { border-color: var(--utama); background: var(--utama-muda); }
+a.bs-layar:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.bs-layar-nama { display: block; font-weight: 700; color: var(--utama); }
+/* Panah HANYA pada yang bisa diketuk. Pada kotak yang mati ia menjanjikan
+   perpindahan yang tidak akan terjadi. */
+a.bs-layar .bs-layar-nama::after { content: " \2192"; }
+.bs-layar-teks {
+  display: block; font-size: .92rem; color: var(--tinta-lembut);
+  margin-top: .1rem; line-height: 1.5;
+}
+/* Kotak layar yang di luar hak akun ini. Diredupkan, TIDAK dihilangkan: buku
+   ini menjelaskan pekerjaan seluruh panitia, dan seorang bendahara yang
+   membaca bab juri pos tetap perlu tahu layar itu ada. */
+.bs-layar-mati { border-left-color: var(--garis); background: var(--kertas); }
+.bs-layar-mati .bs-layar-nama { color: var(--tinta-lembut); }
+.bs-layar-hak {
+  display: block; margin-top: .25rem;
+  font-size: .82rem; color: var(--tinta-lembut);
+}
+
+/* Tabel di dalam bacaan. Digulir sendiri di wadahnya — CLAUDE.md bagian 15
+   berlaku di sini juga: yang boleh menggulir mendatar wadah tabelnya, tidak
+   pernah badan halaman. Di bawah 900px .data-table sudah berubah jadi kartu
+   sendiri, jadi wadah ini tinggal diam. */
+.bs-tabel-bungkus { overflow-x: auto; margin: .7rem 0; }
+.bs-tabel { line-height: 1.45; }
+
+/* ---- Hasil cari ---- */
+.bs-hasil-daftar { list-style: none; margin: .6rem 0 0; padding: 0; }
+.bs-hasil-daftar li + li { margin-top: .35rem; }
+.bs-hasil-butir {
+  display: block; width: 100%; text-align: left; cursor: pointer; font: inherit;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kartu); padding: .55rem .75rem; min-height: 44px;
+}
+.bs-hasil-butir:hover { border-color: var(--utama); background: var(--utama-muda); }
+.bs-hasil-butir:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.bs-hasil-bab {
+  display: block; font-size: .78rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .02em; color: var(--tinta-lembut);
+}
+.bs-hasil-judul { display: block; font-weight: 600; margin-top: .1rem; }
+
+/* ---- Timeline ---- */
+.bs-bulan { scroll-margin-top: .8rem; }
+.bs-bulan-kepala {
+  display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap;
+}
+/* Nomor urut bulan, bukan tanggal. Bulan kalendernya bergeser tiap edisi —
+   yang tidak bergeser urutannya: bulan pertama sesudah serah terima, bulan
+   keenam adalah pelaksanaan. */
+.bs-bulan-urut {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.7rem; height: 1.7rem; border-radius: 999px;
+  background: var(--utama-muda); color: var(--utama);
+  font-weight: 800; font-size: .85rem; flex: 0 0 auto;
+  align-self: center;
+}
+.bs-bulan-nama { font-size: 1.15rem; font-weight: 800; letter-spacing: -.01em; }
+.bs-bulan-tajuk { color: var(--tinta-lembut); font-weight: 600; }
+.bs-bulan-fokus { margin: .45rem 0 .2rem; line-height: 1.6; }
+
+/* Dua kolom di layar lebar, satu di HP. Tonggak dan langkah sistem memang dua
+   daftar yang dibaca berdampingan: yang satu dicentang panitia, yang satu
+   dikerjakan di layar. */
+.bs-bulan-kolom {
+  display: grid; gap: .3rem 1.4rem; margin-top: .5rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 700px) {
+  .bs-bulan-kolom { grid-template-columns: 1fr 1fr; }
+}
+.bs-bulan-kolom h4 {
+  font-size: .78rem; text-transform: uppercase; letter-spacing: .03em;
+  color: var(--tinta-lembut); margin-top: .5rem;
+}
+
+.bs-bulan-seksi {
+  display: flex; flex-wrap: wrap; gap: .3rem; margin: .7rem 0 .5rem;
+}
+.bs-pil {
+  font-size: .82rem; font-weight: 600;
+  background: var(--kertas); color: var(--tinta-lembut);
+  border-radius: 999px; padding: .15rem .6rem;
+}
+/* "Jangan sampai" memakai kotak kenapa yang sama, tapi merah: ia satu-satunya
+   kalimat di kartu bulan yang menyebut kerugian, dan warnanya yang membuatnya
+   ditemukan waktu kartunya cuma dipindai sekilas. */
+.bs-jangan { border-left-color: var(--bahaya); }
+
+/* ============================================================================
+   BUKU SAKTI DI KERTAS
+
+   Buku ini digandakan di mesin fotokopi seperti seluruh kertas acara ini,
+   jadi CLAUDE.md bagian 8 berlaku penuh: tidak ada blok hitam, tidak ada teks
+   terbalik, tidak ada abu maupun raster, garis paling tipis 0,75pt, huruf
+   paling kecil 7pt.
+
+   Yang di layar memakai warna dan tint di sini memakai GARIS. Kotak "kenapa"
+   tetap bergaris kiri, kotak layar jadi baris bernama tebal, dan pil seksi
+   jadi teks berpemisah titik tengah. Ketiganya tetap terbaca sesudah kertas
+   ini disalin empat kali; latar berwarna tidak.
+   ========================================================================== */
+@media print {
+  .buku-cetak { font-size: 11pt; line-height: 1.45; }
+  .buku-cetak h1 { font-size: 15pt; margin-bottom: .3rem; }
+  .buku-cetak h2 { font-size: 11.5pt; margin: 4mm 0 1mm; }
+  .buku-cetak p { margin: .35rem 0; }
+
+  /* Satu bagian tidak boleh terbelah dua halaman. Judul yang tertinggal
+     sendirian di kaki halaman dengan isinya di halaman berikutnya adalah
+     kegagalan yang paling terasa waktu buku ini dibaca sambil berdiri. */
+  .buku-cetak .bs-cetak-bagian {
+    break-inside: avoid; page-break-inside: avoid;
+    margin-bottom: 3mm;
+  }
+
+  .buku-cetak .bs-cetak-ringkas { font-size: 10pt; margin-bottom: 3mm; }
+  .buku-cetak .bs-cetak-isi-bab { font-weight: 700; margin: 3mm 0 0; }
+  .buku-cetak .bs-cetak-isi { margin: .5mm 0 0; padding-left: 6mm; }
+  .buku-cetak .bs-cetak-isi li { margin: .3mm 0; }
+  .buku-cetak .bs-cetak-label {
+    font-size: 8.5pt; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .02em; margin: 2mm 0 0;
+  }
+
+  .buku-cetak .bs-poin, .buku-cetak .bs-langkah {
+    margin: .3rem 0; padding-left: 6mm;
+  }
+  .buku-cetak .bs-poin li, .buku-cetak .bs-langkah li { margin: .8mm 0; }
+
+  /* Garis 1pt, bukan 3px: bagian 8.5 menuntut minimal 0,75pt supaya garisnya
+     selamat dari fotokopi. Warnanya hitam — hijau HRCD keluar sebagai abu
+     muda di mesin hitam-putih, dan abu justru yang paling buruk (bagian 8.4). */
+  .buku-cetak .bs-kenapa {
+    border-left: 1pt solid #000; padding-left: 3mm; color: #000;
+  }
+
+  /* Kotak layar kehilangan kotaknya di kertas. Yang tersisa nama layarnya
+     tebal diikuti keterangannya — persis yang berguna waktu tidak ada yang
+     bisa diketuk. */
+  .buku-cetak .bs-cetak-layar { margin: .3rem 0; }
+
+  /* ---- Tabel: TETAP TABEL di kertas ----
+
+     Ini bukan kerapian, ini perbaikan. Halaman cetak A4 dikurangi margin
+     12mm terhitung sekitar 720px CSS, dan itu DI BAWAH 900px — jadi aturan
+     kartu HP (`.data-table:not(.table-tetap) … { display: block }`) ikut
+     berlaku saat mencetak. Yang keluar dari printer: tiap sel jatuh ke
+     barisnya sendiri, tanpa kepala kolom, sehingga tabel lima peran akun
+     tercetak sebagai lima belas baris berdiri sendiri yang tidak
+     mengatakan baris mana milik peran mana.
+
+     Terlihat di PDF Chrome headless, bukan diduga: halaman 4 keluar begitu.
+
+     Kekhususannya SAMA PERSIS dengan aturan kartu itu (0,2,3), jadi yang
+     memutuskan urutan — dan blok ini memang paling belakang di berkas.
+     Menambah `!important` di sini akan menyembunyikan ketergantungan itu,
+     bukan menghapusnya. */
+  .buku-cetak .bs-tabel { display: table; }
+  .buku-cetak .bs-tabel > thead { display: table-header-group; }
+  .buku-cetak .bs-tabel > tbody { display: table-row-group; }
+  .buku-cetak .bs-tabel > tbody > tr { display: table-row; }
+  .buku-cetak .bs-tabel > tbody > tr > td { display: table-cell; }
+  /* Rupa kartu HP ikut dilucuti: kotak, jarak, dan awalan nama kolom hanya
+     berarti waktu barisnya bertumpuk. Di kertas kepala kolomnya sudah
+     tergambar sekali di atas, dan mengulangnya di tiap sel menggandakan
+     tabelnya. */
+  .buku-cetak .bs-tabel > tbody > tr[data-baris] {
+    border: 0; border-radius: 0; padding: 0; margin: 0;
+  }
+  .buku-cetak .bs-tabel > tbody > tr[data-baris] > td {
+    border: 1px solid #000; padding: 4pt 5pt; margin: 0;
+  }
+  .buku-cetak .bs-tabel > tbody > tr[data-baris] > td[data-label]::before {
+    content: none;
+  }
+  /* Kepala tabel DIPUTIHKAN dan dilepas dari patokannya.
+
+     `.data-table thead th` di aturan layar memberinya `background:
+     var(--kertas)` — abu #f0f1f4 — beserta `box-shadow` abu dan `position:
+     sticky`. Ketiganya benar di layar dan salah di kertas: bagian 8.4
+     melarang raster abu (mesin fotokopi mengubahnya jadi belang atau
+     kotoran), dan `position: sticky` di media cetak adalah cara yang sama
+     dengan `.bottom-nav` merusak setiap halaman.
+
+     Yang memisahkan kepala dari isinya tetap ada, dan tetap selamat
+     difotokopi: huruf tebal, HURUF BESAR, dan garis bawah 1,5pt. */
+  .buku-cetak .bs-tabel > thead > tr > th {
+    background: none; box-shadow: none; position: static;
+    border: 1px solid #000; padding: 4pt 5pt; text-align: left;
+    font-size: 8.5pt; text-transform: uppercase; font-weight: 700;
+    border-bottom-width: 1.5pt;
+  }
+
+  /* Nomor langkah HITAM, bukan hijau HRCD. Hijau tua keluar sebagai abu
+     sedang dari mesin fotokopi hitam-putih, dan abu justru yang paling
+     buruk (CLAUDE.md 8.4). Yang membedakan nomor dari isinya tetap ada:
+     ia tebal. */
+  .buku-cetak .bs-langkah li::marker { color: #000; }
 }

--- a/live/style.css
+++ b/live/style.css
@@ -3432,6 +3432,8 @@ button.pill-number:hover { filter: brightness(.95); }
   #nav-home[aria-current="page"]    .bottom-nav-icon { background: var(--utama-muda); }
   #nav-setting[aria-current="page"] .bottom-nav-icon { background: #f0eafe; }
   #nav-akun[aria-current="page"]    .bottom-nav-icon { background: #eef0f3; }
+  /* Hijau HRCD yang sama dengan Home: keduanya "tempat", bukan setelan. */
+  #nav-buku[aria-current="page"]    .bottom-nav-icon { background: var(--utama-muda); }
 
   /* Ruang supaya baris terakhir isi halaman tidak tertutup bar.
 
@@ -6181,50 +6183,77 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
 }
 .bs-hasil-judul { display: block; font-weight: 600; margin-top: .1rem; }
 
-/* ---- Timeline ---- */
-.bs-bulan { scroll-margin-top: .8rem; }
-.bs-bulan-kepala {
-  display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap;
-}
-/* Nomor urut bulan, bukan tanggal. Bulan kalendernya bergeser tiap edisi —
-   yang tidak bergeser urutannya: bulan pertama sesudah serah terima, bulan
-   keenam adalah pelaksanaan. */
-.bs-bulan-urut {
+/* ---- Papan sprint ---- */
+#bs-sprint-ringkas { margin-bottom: .8rem; }
+/* Centang belum terbaca: satu baris kecil, bukan kartu merah. Membuka buku
+   panduan waktu sinyal mati adalah hal yang wajar, dan peringatan yang muncul
+   tiap kali bukunya dibuka mengajari orang menutupnya tanpa membaca. */
+.bs-sprint-putus { color: var(--kuning); }
+
+.bs-sprint { scroll-margin-top: .8rem; }
+.bs-sprint-kepala { display: flex; gap: .6rem; align-items: flex-start; }
+/* Nomor sprint, bukan tanggal. Bulan kalendernya bergeser tiap edisi; yang
+   tidak bergeser urutannya dan hitungan mundurnya dari hari-H. */
+.bs-sprint-urut {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 1.7rem; height: 1.7rem; border-radius: 999px;
+  width: 1.9rem; height: 1.9rem; border-radius: 999px;
   background: var(--utama-muda); color: var(--utama);
-  font-weight: 800; font-size: .85rem; flex: 0 0 auto;
-  align-self: center;
+  font-weight: 800; font-size: .9rem; flex: 0 0 auto;
 }
-.bs-bulan-nama { font-size: 1.15rem; font-weight: 800; letter-spacing: -.01em; }
-.bs-bulan-tajuk { color: var(--tinta-lembut); font-weight: 600; }
-.bs-bulan-fokus { margin: .45rem 0 .2rem; line-height: 1.6; }
+.bs-sprint-judul { min-width: 0; flex: 1; }
+.bs-sprint-baris {
+  display: flex; align-items: baseline; gap: .5rem; flex-wrap: wrap;
+}
+.bs-sprint-tajuk { font-size: 1.1rem; font-weight: 800; letter-spacing: -.01em; }
+.bs-sprint-waktu {
+  font-size: .82rem; color: var(--tinta-lembut); margin-top: .1rem;
+}
+.bs-sprint-fokus { margin: .55rem 0 .2rem; line-height: 1.6; }
+.bs-sprint-hasil { margin: .6rem 0 .5rem; line-height: 1.55; }
 
-/* Dua kolom di layar lebar, satu di HP. Tonggak dan langkah sistem memang dua
-   daftar yang dibaca berdampingan: yang satu dicentang panitia, yang satu
-   dikerjakan di layar. */
-.bs-bulan-kolom {
-  display: grid; gap: .3rem 1.4rem; margin-top: .5rem;
-  grid-template-columns: 1fr;
+/* ---- Daftar tugas yang dicentang ---- */
+.bs-todo { list-style: none; margin: .7rem 0 0; padding: 0; }
+.bs-todo-item {
+  border-top: 1px solid var(--garis); padding: .5rem 0;
 }
-@media (min-width: 700px) {
-  .bs-bulan-kolom { grid-template-columns: 1fr 1fr; }
-}
-.bs-bulan-kolom h4 {
-  font-size: .78rem; text-transform: uppercase; letter-spacing: .03em;
-  color: var(--tinta-lembut); margin-top: .5rem;
-}
+.bs-todo-item:first-child { border-top: 0; }
 
-.bs-bulan-seksi {
-  display: flex; flex-wrap: wrap; gap: .3rem; margin: .7rem 0 .5rem;
+/* Kotak DAN kalimatnya satu sasaran ketukan. Kotak 20px yang berdiri sendiri
+   di antara seratus baris adalah sasaran yang meleset di HP, dan tugas yang
+   tercentang gara-gara meleset lebih buruk daripada tugas yang belum
+   tercentang: yang satu diam, yang lain berbohong. */
+.bs-todo-baris {
+  display: flex; gap: .6rem; align-items: flex-start; cursor: pointer;
+  line-height: 1.55;
 }
+.bs-todo-kotak { flex: 0 0 auto; margin-top: .2rem; }
+.bs-todo-teks { min-width: 0; }
+/* Yang sudah selesai DIREDUPKAN, tidak dicoret. Teks tercoret berhenti bisa
+   dibaca ulang, dan tugas yang sudah selesai masih sering dibaca ulang —
+   "kemarin kita mengirim surat ke berapa desa?" */
+.bs-todo-selesai .bs-todo-teks { color: var(--tinta-lembut); }
+
+.bs-todo-kaki {
+  display: flex; flex-wrap: wrap; gap: .3rem .5rem; align-items: center;
+  /* Sejajar dengan teksnya, bukan dengan kotaknya: lebar kotak + jaraknya. */
+  margin: .25rem 0 0 1.6rem;
+  font-size: .8rem; color: var(--tinta-lembut);
+}
+.bs-todo-layar {
+  color: var(--utama); text-decoration: none; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.bs-todo-layar:hover { text-decoration: underline; }
+.bs-todo-layar::after { content: " \2192"; }
+.bs-todo-jejak { font-variant-numeric: tabular-nums; }
+
 .bs-pil {
-  font-size: .82rem; font-weight: 600;
+  font-size: .78rem; font-weight: 600;
   background: var(--kertas); color: var(--tinta-lembut);
-  border-radius: 999px; padding: .15rem .6rem;
+  border-radius: 999px; padding: .1rem .55rem;
 }
 /* "Jangan sampai" memakai kotak kenapa yang sama, tapi merah: ia satu-satunya
-   kalimat di kartu bulan yang menyebut kerugian, dan warnanya yang membuatnya
+   kalimat di kartu sprint yang menyebut kerugian, dan warnanya yang membuatnya
    ditemukan waktu kartunya cuma dipindai sekilas. */
 .bs-jangan { border-left-color: var(--bahaya); }
 
@@ -6310,7 +6339,7 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
     border: 0; border-radius: 0; padding: 0; margin: 0;
   }
   .buku-cetak .bs-tabel > tbody > tr[data-baris] > td {
-    border: 1px solid #000; padding: 4pt 5pt; margin: 0;
+    border: 0.4px solid #000; padding: 4pt 5pt; margin: 0;
   }
   .buku-cetak .bs-tabel > tbody > tr[data-baris] > td[data-label]::before {
     content: none;
@@ -6328,7 +6357,7 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
      difotokopi: huruf tebal, HURUF BESAR, dan garis bawah 1,5pt. */
   .buku-cetak .bs-tabel > thead > tr > th {
     background: none; box-shadow: none; position: static;
-    border: 1px solid #000; padding: 4pt 5pt; text-align: left;
+    border: 0.4px solid #000; padding: 4pt 5pt; text-align: left;
     font-size: 8.5pt; text-transform: uppercase; font-weight: 700;
     border-bottom-width: 1.5pt;
   }
@@ -6338,4 +6367,30 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
      buruk (CLAUDE.md 8.4). Yang membedakan nomor dari isinya tetap ada:
      ia tebal. */
   .buku-cetak .bs-langkah li::marker { color: #000; }
+
+  /* ---- Papan sprint di kertas ----
+
+     Kertas ini ditempel di dinding sekretariat dan dicentang pakai pulpen
+     sepanjang enam bulan, jadi bentuknya daftar berkotak, bukan salinan
+     layar. */
+  .buku-cetak .bs-cetak-waktu {
+    font-size: 9pt; font-weight: 700; margin: 0 0 1mm;
+  }
+  .buku-cetak .bs-cetak-todo { list-style: none; margin: .3rem 0; padding: 0; }
+  .buku-cetak .bs-cetak-todo li {
+    display: flex; gap: 2.5mm; align-items: flex-start; margin: 1.2mm 0;
+    break-inside: avoid; page-break-inside: avoid;
+  }
+  /* Kotak centang tulis tangan: PUTIH, kosong, dan cukup besar untuk dicentang
+     pulpen (CLAUDE.md 8.7 — tidak ada apa pun di belakang area yang ditulisi).
+     Garisnya 1pt supaya selamat difotokopi (8.5). */
+  .buku-cetak .bs-cetak-kotak {
+    flex: 0 0 auto; width: 3.5mm; height: 3.5mm; margin-top: .6mm;
+    border: 1pt solid #000; background: none;
+  }
+  .buku-cetak .bs-cetak-todo-teks { min-width: 0; }
+  /* Nama seksi di belakang tugasnya, miring dan kecil — tetap 8pt, di atas
+     batas 7pt bagian 8.6. Tidak diredupkan: bagian 8.4 melarang abu, jadi
+     yang membuatnya mundur ukurannya, bukan warnanya. */
+  .buku-cetak .bs-cetak-todo-teks em { font-size: 8pt; white-space: nowrap; }
 }

--- a/supabase/checks/status_migrasi.sql
+++ b/supabase/checks/status_migrasi.sql
@@ -26,8 +26,8 @@
 -- daripada masalahnya lebih berbahaya daripada tidak ada pemeriksaan, karena ia
 -- menutup pertanyaannya.
 --
--- Sekarang keduanya disebutkan: 116 migrasi punya jejak yang diperiksa
--- (bagian 1), dan 53 tidak punya (bagian 2). 116 + 53 = 169, yaitu SELURUH
+-- Sekarang keduanya disebutkan: 117 migrasi punya jejak yang diperiksa
+-- (bagian 1), dan 53 tidak punya (bagian 2). 117 + 53 = 170, yaitu SELURUH
 -- migrasi yang ada — dan angka itu yang harus dijaga tiap kali berkas migrasi
 -- baru mendarat. Yang di bagian 2 bukan berarti belum diterapkan — berarti
 -- tidak ada yang tersisa untuk diperiksa.
@@ -339,7 +339,9 @@ begin
   ('0166', 'constraint nilai_terkunci.nilai_terkunci_pkey: PRIMARY KEY (regu_id, pos, kode_lomba)',
    $c$select exists (select 1 from pg_constraint where conrelid = 'nilai_terkunci'::regclass and conname = 'nilai_terkunci_pkey' and position('PRIMARY KEY (regu_id, pos, kode_lomba)' in pg_get_constraintdef(oid)) > 0)$c$),
   ('0167', 'constraint foto_lembar.foto_lembar_putaran_check: CHECK ((putaran = ANY (ARRAY[0, 90, 180, 270])))',
-   $c$select exists (select 1 from pg_constraint where conrelid = 'foto_lembar'::regclass and conname = 'foto_lembar_putaran_check' and position('CHECK ((putaran = ANY (ARRAY[0, 90, 180, 270])))' in pg_get_constraintdef(oid)) > 0)$c$)
+   $c$select exists (select 1 from pg_constraint where conrelid = 'foto_lembar'::regclass and conname = 'foto_lembar_putaran_check' and position('CHECK ((putaran = ANY (ARRAY[0, 90, 180, 270])))' in pg_get_constraintdef(oid)) > 0)$c$),
+  ('0170', 'function set_centang_sprint ada',
+   $c$select exists (select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace where n.nspname = 'public' and p.proname = 'set_centang_sprint')$c$)
 ) as t(nomor, jejak, cek)
   loop
     begin

--- a/supabase/migrations/0170_centang_sprint.sql
+++ b/supabase/migrations/0170_centang_sprint.sql
@@ -1,0 +1,163 @@
+-- ============================================================================
+-- hrcd-rekap : 0170_centang_sprint.sql
+-- Papan sprint Buku Sakti bisa dicentang, dan centangnya dilihat semua panitia.
+--
+-- KENAPA DI DATABASE, BUKAN DI HP MASING-MASING
+--
+-- Timeline persiapan adalah alat KOORDINASI. Pertanyaannya selalu berbunyi
+-- "surat ke desa sudah dikirim belum?", dan jawabannya harus sama untuk
+-- Ketua, Sekretaris, dan orang yang baru masuk rapat. Centang yang tinggal di
+-- localStorage HP masing-masing menjawab pertanyaan itu berbeda-beda per
+-- peranti: Sekretaris melihat papan penuh, Ketua melihat papan kosong, dan
+-- keduanya yakin papannya yang benar.
+--
+-- Daftar tugas yang berbohong lebih buruk daripada tidak ada daftar tugas.
+--
+-- BARIS ADA = SELESAI. Tidak ada kolom `selesai boolean`.
+--
+-- Alasannya sama dengan `akun_hak` di 0057: baris yang ada tapi bernilai
+-- false adalah dua cara menuliskan hal yang sama, dan dua cara berarti suatu
+-- hari keduanya tidak sepakat. Membatalkan centang = menghapus barisnya.
+--
+-- KUNCINYA (edisi, kode), DAN `kode` ITU MILIK BERKAS, BUKAN MILIK DATABASE
+--
+-- `kode` adalah kode tugas di `web/js/buku-sakti.mjs` — "s6-desa",
+-- "s9-tutup-sponsor". Database tidak menyimpan daftar tugasnya dan tidak bisa
+-- memvalidasinya: yang menulis timeline panitia lewat berkas, bukan lewat
+-- layar. Konsekuensinya satu, dan ia ditulis besar-besar di berkas itu juga:
+-- SEKALI SEBUAH KODE DIPAKAI, JANGAN PERNAH DIUBAH. Mengubahnya membuat
+-- centangnya menggantung — tugasnya kembali kosong dan tidak ada yang tahu
+-- kenapa.
+--
+-- Kode yang menggantung sengaja TIDAK dihapus otomatis. Timeline yang
+-- disunting lalu dikembalikan lagi akan menemukan centangnya masih ada, dan
+-- itu jauh lebih sering terjadi daripada kode yang benar-benar pensiun.
+--
+-- SIAPA BOLEH MENCENTANG: SETIAP PANITIA, DAN ITU DISENGAJA
+--
+-- Tidak ada fitur baru di layar Akun untuk ini. Papan sprint dipakai di
+-- rapat, dan yang memegang spidol bukan selalu yang memegang centang
+-- `pengaturan` — Sekretaris yang mencatat, koordinator seksi yang melapor.
+-- Mengikatnya ke satu centang berarti seluruh rapat menunggu satu orang.
+--
+-- Yang menggantikan pagar itu JEJAK: tiap baris menyimpan siapa dan kapan,
+-- dan layar menuliskannya di sebelah tugasnya. Salah centang bisa dilihat
+-- siapa yang melakukannya dan dibatalkan dalam satu ketukan. Untuk papan
+-- rencana — bukan nilai, bukan uang, bukan nomor dada — jejak yang terbuka
+-- lebih berguna daripada pintu yang terkunci.
+--
+-- Membacanya ikut aturan yang sama dengan `regu` dan `kloter` (CLAUDE.md
+-- 13.5): membaca data operasional = jadi panitia.
+-- ============================================================================
+
+create table if not exists centang_sprint (
+  edisi          int  not null references edisi(nomor) on delete cascade,
+  kode           text not null,
+  dicentang_pada timestamptz not null default now(),
+  dicentang_oleh uuid references akun_panitia(user_id) on delete set null,
+  primary key (edisi, kode)
+);
+
+-- Kode tugas dipakai jadi id elemen di layar dan jadi kunci di sini. Pagarnya
+-- dipasang di database juga, bukan cuma di tes berkasnya: yang menulis lewat
+-- RPC boleh saja suatu hari bukan layar ini.
+alter table centang_sprint drop constraint if exists centang_sprint_kode_check;
+alter table centang_sprint add constraint centang_sprint_kode_check
+  check (kode ~ '^[a-z0-9]+(-[a-z0-9]+)*$' and length(kode) between 2 and 60);
+
+comment on table centang_sprint is
+  'Centang tugas papan sprint Buku Sakti. Baris ada = selesai. '
+  'kode = kode tugas di web/js/buku-sakti.mjs, dan tidak pernah diubah.';
+comment on column centang_sprint.dicentang_oleh is
+  'Yang mencentang. NULL kalau akunnya dihapus — centangnya tetap berlaku, '
+  'yang hilang cuma namanya.';
+
+alter table centang_sprint enable row level security;
+
+-- Membaca: setiap panitia. Papan yang cuma terlihat sebagian orang bukan
+-- papan koordinasi.
+drop policy if exists sel_centang_sprint on centang_sprint;
+create policy sel_centang_sprint on centang_sprint
+  for select using (peran() is not null);
+
+-- Menulis lewat RPC saja. Tidak ada policy insert/delete langsung: RPC-nya
+-- yang mengunci edisinya ke edisi aktif dan mengisi kolom jejaknya, dan
+-- policy terbuka akan membuat keduanya bisa dilewati dari luar layar.
+drop policy if exists adm_centang_sprint on centang_sprint;
+
+-- ---------------------------------------------------------------------------
+-- RPC: satu fungsi untuk dua arah.
+--
+-- Dua fungsi terpisah (centang / batal) berarti dua tempat yang harus
+-- sepakat soal edisi aktif, jejak, dan pagar peran. Satu fungsi dengan satu
+-- boolean tidak punya masalah itu, dan layar memang selalu tahu ia sedang
+-- mau ke arah mana — kotak centang membawa keadaan barunya.
+-- ---------------------------------------------------------------------------
+create or replace function set_centang_sprint(p_kode text, p_selesai boolean)
+returns void
+language plpgsql security definer
+set search_path = public
+as $$
+declare
+  v_edisi int;
+begin
+  if peran() is null then
+    raise exception 'Hanya panitia yang bisa mencentang papan sprint.'
+      using errcode = '42501';
+  end if;
+
+  v_edisi := edisi_aktif();
+  if v_edisi is null then
+    raise exception 'Belum ada edisi aktif.' using errcode = '22023';
+  end if;
+
+  if p_selesai then
+    -- ON CONFLICT DO NOTHING, bukan DO UPDATE: centang yang diketuk dua kali
+    -- oleh dua orang harus tetap menyimpan yang PERTAMA. Yang menarik dari
+    -- kolom jejak bukan siapa yang terakhir menyentuhnya melainkan siapa
+    -- yang menyelesaikannya.
+    insert into centang_sprint (edisi, kode, dicentang_oleh)
+    values (v_edisi, p_kode, auth.uid())
+    on conflict (edisi, kode) do nothing;
+  else
+    -- WHERE yang memang berarti. `delete` tanpa WHERE ditolak ekstensi
+    -- safeupdate di produksi, dan ekstensi itu TIDAK ada di database uji
+    -- (CLAUDE.md 14.6) — jadi yang menahannya di sini cuma penulisnya.
+    delete from centang_sprint
+     where edisi = v_edisi and kode = p_kode;
+  end if;
+end;
+$$;
+
+revoke all on function set_centang_sprint(text, boolean) from public, anon;
+grant execute on function set_centang_sprint(text, boolean)
+  to authenticated, service_role;
+
+grant select on centang_sprint to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- View: centang edisi aktif beserta nama pencentangnya.
+--
+-- Layar butuh NAMA, bukan uuid, dan menggabungkannya di browser berarti
+-- menarik seluruh daftar akun ke setiap peranti yang membuka Buku Sakti —
+-- termasuk juri pos yang tidak berhak membaca daftar akun sama sekali.
+-- ---------------------------------------------------------------------------
+create or replace view v_centang_sprint
+with (security_invoker = true) as
+select c.kode,
+       c.dicentang_pada,
+       a.username as dicentang_oleh
+  from centang_sprint c
+  left join akun_panitia a on a.user_id = c.dicentang_oleh
+ where c.edisi = edisi_aktif();
+
+grant select on v_centang_sprint to authenticated, service_role;
+
+comment on view v_centang_sprint is
+  'Centang papan sprint edisi aktif, uuid sudah ditukar jadi username.';
+
+do $$
+begin
+  raise notice '0170: papan sprint bisa dicentang, % baris centang tersimpan',
+    (select count(*) from centang_sprint);
+end $$;

--- a/tests/buku_sakti.test.mjs
+++ b/tests/buku_sakti.test.mjs
@@ -1,0 +1,541 @@
+// ============================================================================
+// hrcd-rekap : tests/buku_sakti.test.mjs — bentuk dan kejujuran Buku Sakti.
+//
+// Buku Sakti tidak punya server yang menolaknya. Isinya data statis yang
+// langsung digambar, jadi satu salah ketik di dalamnya tidak menghasilkan
+// galat apa pun — ia menghasilkan tautan yang mendarat di Home, kolom tabel
+// yang bergeser satu, atau kalimat yang berhenti di tengah karena ada tanda
+// kurang-dari di dalamnya. Ketiganya terlihat seperti buku yang memang
+// begitu, dan yang menemukannya panitia yang berhenti mempercayainya.
+//
+// Jadi yang dijaga di sini bukan gaya penulisan melainkan hal-hal yang
+// membuat buku ini masih benar tahun depan:
+//
+//   1. Bentuk data — enam jenis blok, tidak ada yang ketujuh; baris tabel
+//      selebar kepalanya; kode bagian unik.
+//   2. Tautan — tiap rute yang disebut buku benar-benar ada di RUTE app.js,
+//      dan daftar rute di modulnya tidak ketinggalan dari yang sebenarnya.
+//   3. Nama centang — FITUR_NAMA harus sama persis dengan `insert into fitur`
+//      di migrasi 0057. Ini salinan, dan salinan yang diam adalah salinan
+//      yang suatu hari salah.
+//   4. Ikon dan warna — yang disebut bab harus benar-benar ada di util.js dan
+//      style.css, bukan nama yang terdengar masuk akal.
+//   5. Aturan kertas — CLAUDE.md bagian 8 berlaku penuh, karena buku ini ikut
+//      digandakan di mesin fotokopi.
+// ============================================================================
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  BUKU_SAKTI, TIMELINE, FITUR_NAMA, FITUR_SAH, RUTE_SAH,
+  bagianBuku, teksBagian, teksBulan, cariBagian, cariBulan,
+} from "../web/js/buku-sakti.mjs";
+
+const baca = (p) => readFile(new URL(p, import.meta.url), "utf8");
+const app = await baca("../web/js/app.js");
+const util = await baca("../web/js/util.js");
+const css = await baca("../web/style.css");
+const html = await baca("../web/index.html");
+const migrasi0057 = await baca("../supabase/migrations/0057_hak_akses.sql");
+
+const JENIS_SAH = ["p", "poin", "langkah", "tabel", "kenapa", "layar"];
+
+/** Tiap bagian dari tiap bab, membawa nama babnya untuk pesan galat. */
+const semuaBagian = () => bagianBuku().map(({ bab, bagian }) => ({
+  di: `${bab.kode}/${bagian.kode}`, bab, bagian,
+}));
+
+/** Kode tanpa komentarnya.
+ *
+ *  Beberapa tes di bawah melarang sebuah tulisan MUNCUL di dalam badan
+ *  fungsi. Tanpa pemotong ini, komentar yang MENJELASKAN larangan itu
+ *  menggagalkan tesnya sendiri — persis yang terjadi sekali, dan lapor palsu
+ *  adalah cara tercepat membuat orang berhenti mempercayai sebuah tes. */
+const tanpaKomentar = (kode) =>
+  kode.replace(/\/\*[\s\S]*?\*\//g, " ")
+      .split("\n").map(b => b.split("//")[0]).join("\n");
+
+/** Tiap blok dari tiap bagian. */
+const semuaBlok = () => semuaBagian().flatMap(({ di, bagian }) =>
+  bagian.isi.map((blok, i) => ({ di: `${di}[${i}]`, blok })));
+
+// ---------------------------------------------------------------------------
+// 1. Bentuk data
+// ---------------------------------------------------------------------------
+
+test("tiap bab punya kode, judul, ikon, warna, ringkas, dan bagian", () => {
+  assert.ok(BUKU_SAKTI.length >= 4, "buku harus punya minimal empat bab");
+  for (const bab of BUKU_SAKTI) {
+    for (const kunci of ["kode", "judul", "tab", "ikon", "warna", "ringkas"]) {
+      assert.equal(typeof bab[kunci], "string", `${bab.kode}: ${kunci} bukan string`);
+      assert.ok(bab[kunci].trim(), `${bab.kode}: ${kunci} kosong`);
+    }
+    assert.ok(Array.isArray(bab.bagian), `${bab.kode}: bagian bukan daftar`);
+  }
+});
+
+test("bab timeline ada, kosong bagiannya, dan berdiri paling akhir", () => {
+  const timeline = BUKU_SAKTI.find(b => b.kode === "timeline");
+  assert.ok(timeline, "bab timeline hilang");
+  // `bagian`-nya memang kosong: yang digambar TIMELINE, lewat percabangan di
+  // layarBukuSakti(). Kalau suatu hari ia diisi, isinya tidak akan tergambar
+  // sama sekali dan tidak ada yang mengeluh.
+  assert.equal(timeline.bagian.length, 0,
+    "bab timeline tidak digambar dari `bagian` — isinya tidak akan terlihat");
+  assert.equal(BUKU_SAKTI[BUKU_SAKTI.length - 1], timeline,
+    "timeline harus tab terakhir: ia kalender, dan kalender menutup buku");
+});
+
+test("label tab pendek, supaya empat tab muat tanpa penggulir", () => {
+  // Terukur di browser: kolom bacaannya 734px, dan empat JUDUL penuh
+  // berjejer memakan sekitar 844px — tab keempat terpotong dan .tab-golongan
+  // memunculkan penggulir mendatar, di layar selebar apa pun. Batas 14 huruf
+  // memberi kelonggaran yang cukup terhadap lebar huruf yang berbeda-beda.
+  for (const bab of BUKU_SAKTI) {
+    assert.ok(bab.tab.length <= 14,
+      `${bab.kode}: label tab "${bab.tab}" ${bab.tab.length} huruf, batasnya 14`);
+  }
+  const total = BUKU_SAKTI.reduce((n, b) => n + b.tab.length, 0);
+  assert.ok(total <= 40, `total huruf label tab ${total}, batasnya 40`);
+});
+
+test("tab yang tergambar label pendeknya, bukan judul penuhnya", () => {
+  const awal = app.indexOf('<nav class="tab-golongan bs-tab"');
+  const akhir = app.indexOf("</nav>", awal);
+  assert.ok(awal >= 0 && akhir > awal, "deret tab tidak ditemukan di app.js");
+  const deret = app.slice(awal, akhir);
+  assert.ok(deret.includes("esc(b.tab)"),
+    "deret tab tidak memakai label pendek");
+  assert.ok(!deret.includes("esc(b.judul)"),
+    "judul penuh kembali dipakai di tab — penggulir mendatarnya ikut kembali");
+});
+
+test("kode bab unik", () => {
+  const kode = BUKU_SAKTI.map(b => b.kode);
+  assert.equal(new Set(kode).size, kode.length, `kode bab kembar: ${kode}`);
+});
+
+test("kode bagian unik DI SELURUH BUKU, bukan cuma di dalam babnya", () => {
+  // Kode bagian jadi id elemen (`bs-<kode>`), dan seluruh bab digambar
+  // sekaligus ke satu halaman. Dua bagian sekode berarti dua elemen ber-id
+  // sama, dan getElementById() selalu mengembalikan yang pertama — jadi
+  // daftar isi bab ketiga melompat ke bagian di bab pertama.
+  const kode = semuaBagian().map(({ bagian }) => bagian.kode);
+  const kembar = kode.filter((k, i) => kode.indexOf(k) !== i);
+  assert.deepEqual(kembar, [], `kode bagian kembar: ${kembar}`);
+});
+
+test("kode bagian aman dipakai jadi id elemen", () => {
+  for (const { di, bagian } of semuaBagian()) {
+    assert.match(bagian.kode, /^[a-z0-9-]+$/,
+      `${di}: kode bagian harus huruf kecil, angka, dan tanda hubung`);
+  }
+});
+
+test("tiap bagian punya judul dan isi yang tidak kosong", () => {
+  for (const { di, bagian } of semuaBagian()) {
+    assert.ok(String(bagian.judul || "").trim(), `${di}: judul kosong`);
+    assert.ok(Array.isArray(bagian.isi) && bagian.isi.length,
+      `${di}: isi kosong`);
+  }
+});
+
+test("tidak ada jenis blok ketujuh", () => {
+  for (const { di, blok } of semuaBlok()) {
+    assert.ok(JENIS_SAH.includes(blok.jenis),
+      `${di}: jenis "${blok.jenis}" tidak dikenal perakit layar`);
+  }
+});
+
+test("blok p dan kenapa membawa teks; poin dan langkah membawa butir", () => {
+  for (const { di, blok } of semuaBlok()) {
+    if (blok.jenis === "p" || blok.jenis === "kenapa") {
+      assert.ok(String(blok.teks || "").trim(), `${di}: teks kosong`);
+    }
+    if (blok.jenis === "poin" || blok.jenis === "langkah") {
+      assert.ok(Array.isArray(blok.butir) && blok.butir.length,
+        `${di}: butir kosong`);
+      for (const butir of blok.butir) {
+        assert.ok(String(butir || "").trim(), `${di}: ada butir kosong`);
+      }
+    }
+  }
+});
+
+test("baris tabel selebar kepalanya", () => {
+  // Satu sel kurang menggeser SELURUH sisa barisnya satu kolom ke kiri, dan
+  // tabel yang bergeser tetap tergambar rapi — tidak ada satu pun tanda
+  // bahwa yang terbaca di kolom "Kapan" sebenarnya isi kolom sebelumnya.
+  for (const { di, blok } of semuaBlok()) {
+    if (blok.jenis !== "tabel") continue;
+    assert.ok(Array.isArray(blok.kepala) && blok.kepala.length,
+      `${di}: tabel tanpa kepala`);
+    assert.ok(Array.isArray(blok.baris) && blok.baris.length,
+      `${di}: tabel tanpa baris`);
+    for (const [i, baris] of blok.baris.entries()) {
+      assert.equal(baris.length, blok.kepala.length,
+        `${di}: baris ${i} punya ${baris.length} sel, kepalanya ${blok.kepala.length}`);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. Tautan
+// ---------------------------------------------------------------------------
+
+/** Rute yang benar-benar terdaftar di app.js. */
+const ruteApp = (() => {
+  const awal = app.indexOf("const RUTE = {");
+  const akhir = app.indexOf("};", awal);
+  assert.ok(awal >= 0 && akhir > awal, "tabel RUTE tidak ditemukan di app.js");
+  return [...app.slice(awal, akhir).matchAll(/"(#\/[a-z0-9-]+)":/g)].map(m => m[1]);
+})();
+
+test("RUTE_SAH menyebut persis rute yang ada di app.js", () => {
+  // Dua arah, dan yang kedua yang biasanya hilang: daftar yang kelebihan
+  // rute meloloskan tautan mati, daftar yang kekurangan menolak tautan yang
+  // sebenarnya benar — dan yang menulis buku lalu menyimpulkan tesnya rusak.
+  assert.deepEqual([...RUTE_SAH].sort(), [...ruteApp].sort());
+});
+
+test("tiap blok layar menunjuk rute yang ada", () => {
+  for (const { di, blok } of semuaBlok()) {
+    if (blok.jenis !== "layar") continue;
+    assert.ok(String(blok.nama || "").trim(), `${di}: blok layar tanpa nama`);
+    assert.ok(RUTE_SAH.includes(blok.hash),
+      `${di}: rute "${blok.hash}" tidak ada — tautannya akan jatuh ke Home`);
+  }
+});
+
+test("tiap blok layar menyebut fitur yang ada, atau null", () => {
+  for (const { di, blok } of semuaBlok()) {
+    if (blok.jenis !== "layar") continue;
+    assert.ok(blok.fitur === null || FITUR_SAH.includes(blok.fitur),
+      `${di}: fitur "${blok.fitur}" bukan salah satu centang di layar Akun`);
+  }
+});
+
+test("layar yang tidak berpagar hak ditulis fitur null, bukan dihilangkan", () => {
+  // `undefined` dan `null` berperilaku sama di perakitnya, tapi hanya `null`
+  // yang mengatakan "sudah dipikirkan dan memang terbuka". Field yang hilang
+  // sama saja dengan lupa mengisinya.
+  for (const { di, blok } of semuaBlok()) {
+    if (blok.jenis !== "layar") continue;
+    assert.ok("fitur" in blok, `${di}: blok layar tanpa field fitur`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Nama centang
+// ---------------------------------------------------------------------------
+
+test("FITUR_NAMA sama persis dengan `insert into fitur` di migrasi 0057", () => {
+  const awal = migrasi0057.indexOf("insert into fitur");
+  assert.ok(awal >= 0, "insert into fitur tidak ditemukan di 0057");
+  const potong = migrasi0057.slice(awal, migrasi0057.indexOf(";", awal));
+  const dariMigrasi = Object.fromEntries(
+    [...potong.matchAll(/\('([a-z_]+)',\s*'([^']+)',\s*\d+\)/g)]
+      .map(m => [m[1], m[2].trim()]));
+  assert.deepEqual(FITUR_NAMA, dariMigrasi);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Ikon dan warna
+// ---------------------------------------------------------------------------
+
+test("ikon tiap bab benar-benar ada di util.js", () => {
+  // ikon() mengembalikan string kosong untuk nama yang tidak dikenal, jadi
+  // salah ketik di sini menghasilkan kotak warna kosong tanpa gambar —
+  // tergambar rapi, dan tidak ada satu pun galat.
+  for (const bab of BUKU_SAKTI) {
+    assert.ok(util.includes(`"${bab.ikon}":`),
+      `${bab.kode}: ikon "${bab.ikon}" tidak ada di IKON util.js`);
+  }
+});
+
+test("warna tiap bab benar-benar ada di style.css", () => {
+  for (const bab of BUKU_SAKTI) {
+    assert.ok(new RegExp(`\\.i-${bab.warna}\\s`).test(css),
+      `${bab.kode}: kelas .i-${bab.warna} tidak ada di style.css`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. Teks yang aman digambar
+// ---------------------------------------------------------------------------
+
+/** Semua string teks yang benar-benar dicetak ke layar. */
+const semuaTeks = () => {
+  const keluar = [];
+  for (const { di, blok } of semuaBlok()) {
+    for (const [kunci, nilai] of Object.entries(blok)) {
+      if (kunci === "jenis" || kunci === "hash" || kunci === "fitur") continue;
+      if (typeof nilai === "string") keluar.push([`${di}.${kunci}`, nilai]);
+      if (Array.isArray(nilai)) {
+        for (const x of nilai.flat()) {
+          if (typeof x === "string") keluar.push([`${di}.${kunci}`, x]);
+        }
+      }
+    }
+  }
+  for (const bulan of TIMELINE) {
+    for (const [kunci, nilai] of Object.entries(bulan)) {
+      if (typeof nilai === "string") keluar.push([`timeline/${bulan.kode}.${kunci}`, nilai]);
+      if (Array.isArray(nilai)) {
+        for (const x of nilai) keluar.push([`timeline/${bulan.kode}.${kunci}`, x]);
+      }
+    }
+  }
+  return keluar;
+};
+
+test("teks buku string biasa: tanpa HTML, Markdown, atau backtick", () => {
+  // Perakitnya meng-escape semuanya, jadi <b> tidak akan menebalkan apa pun
+  // — ia akan TERCETAK sebagai "<b>". Yang menulisnya mengira ia menebalkan,
+  // dan yang membacanya melihat kode di tengah kalimat.
+  for (const [di, teks] of semuaTeks()) {
+    assert.ok(!/<[a-z/!]/i.test(teks), `${di}: ada tag HTML — "${teks.slice(0, 60)}"`);
+    assert.ok(!teks.includes("`"), `${di}: ada backtick — "${teks.slice(0, 60)}"`);
+    assert.ok(!/\*\*|__/.test(teks), `${di}: ada penebalan Markdown — "${teks.slice(0, 60)}"`);
+  }
+});
+
+test("buku tidak menyebut alat yang menulisnya", () => {
+  // CLAUDE.md bagian 2.3 dan 2.4. Buku ini dibaca panitia berikutnya sebagai
+  // dokumen ambalan, dan satu penyebutan begitu mengubah nadanya seluruhnya.
+  const terlarang = /\b(ai|claude|chatgpt|gpt|copilot|llm)\b/i;
+  for (const [di, teks] of semuaTeks()) {
+    assert.ok(!terlarang.test(teks), `${di}: menyebut alat penulis — "${teks.slice(0, 60)}"`);
+  }
+});
+
+test("perakit blok meng-escape setiap sisipan datanya", () => {
+  // Yang dijaga di sini pemakaian esc(), bukan hasilnya: satu `${blok.teks}`
+  // telanjang cukup membuang sisa paragraf begitu ada tanda kurang-dari di
+  // dalamnya, dan tesnya baru gagal kalau kebetulan ada teks yang memuatnya.
+  const awal = app.indexOf("function blokBuku(blok) {");
+  const akhir = app.indexOf("function bagianBukuHtml(", awal);
+  assert.ok(awal >= 0 && akhir > awal, "blokBuku tidak ditemukan di app.js");
+  const badan = app.slice(awal, akhir);
+  const telanjang = [...badan.matchAll(/\$\{\s*(blok|sel|baris|x|k)\b[^}]*\}/g)]
+    .map(m => m[0])
+    .filter(s => !s.includes("esc(") && !s.includes(".map(") && !s.includes(".jenis"));
+  assert.deepEqual(telanjang, [], `sisipan tanpa esc(): ${telanjang.join(", ")}`);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Timeline
+// ---------------------------------------------------------------------------
+
+const BULAN_URUT = ["September", "Oktober", "November", "Desember",
+                    "Januari", "Februari"];
+
+test("timeline enam bulan, berurutan dari serah terima sampai pelaksanaan", () => {
+  assert.deepEqual(TIMELINE.map(b => b.bulan), BULAN_URUT);
+});
+
+test("tiap bulan timeline lengkap", () => {
+  for (const bulan of TIMELINE) {
+    for (const kunci of ["kode", "bulan", "tajuk", "fokus", "jangan"]) {
+      assert.equal(typeof bulan[kunci], "string", `${bulan.kode}: ${kunci} bukan string`);
+      assert.ok(bulan[kunci].trim(), `${bulan.kode}: ${kunci} kosong`);
+    }
+    for (const kunci of ["tonggak", "seksi", "sistem"]) {
+      assert.ok(Array.isArray(bulan[kunci]) && bulan[kunci].length,
+        `${bulan.kode}: ${kunci} kosong`);
+    }
+  }
+});
+
+test("kode bulan aman dipakai jadi id elemen dan tidak kembar", () => {
+  const kode = TIMELINE.map(b => b.kode);
+  assert.equal(new Set(kode).size, kode.length, `kode bulan kembar: ${kode}`);
+  for (const k of kode) assert.match(k, /^[a-z0-9-]+$/);
+});
+
+test("seksi yang disebut timeline juga dijelaskan di bab Seksi", () => {
+  // Kalender yang menyebut "Seksi Barak" sementara babnya tidak pernah
+  // menjelaskan seksi itu meninggalkan pembaca dengan nama tanpa tugas —
+  // dan nama tanpa tugas adalah pekerjaan yang tidak dikerjakan siapa pun.
+  const bab = BUKU_SAKTI.find(b => b.kode === "seksi");
+  assert.ok(bab, "bab seksi hilang");
+  const teks = bab.bagian.map(teksBagian).join(" ");
+  for (const bulan of TIMELINE) {
+    for (const seksi of bulan.seksi) {
+      assert.ok(teks.includes(seksi.toLowerCase()),
+        `${bulan.kode}: "${seksi}" tidak dijelaskan di bab Seksi`);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. Pencarian
+// ---------------------------------------------------------------------------
+
+test("cari menuntut SEMUA kata, bukan salah satunya", () => {
+  const contoh = semuaBagian()[0];
+  const kata = teksBagian(contoh.bagian).split(/\s+/).filter(w => w.length > 4)[0];
+  assert.ok(kata, "bagian pertama tidak punya kata yang cukup panjang");
+  assert.ok(cariBagian(kata).length >= 1, "kata sendiri harus ketemu");
+  assert.equal(cariBagian(`${kata} zzzznonsensezzzz`).length, 0,
+    "satu kata yang tidak ada harus menggugurkan hasilnya");
+});
+
+test("cari yang kosong tidak mengembalikan apa pun", () => {
+  // Layar memakai ini sebagai penanda "tidak sedang mencari" dan
+  // mengembalikan seluruh panel. Kalau string kosong justru mengembalikan
+  // seluruh buku sebagai HASIL, panelnya tidak pernah muncul lagi.
+  assert.deepEqual(cariBagian(""), []);
+  assert.deepEqual(cariBagian("   "), []);
+  assert.deepEqual(cariBulan(""), []);
+});
+
+test("cari menyapu seluruh bab, bukan bab pertama saja", () => {
+  const babLain = BUKU_SAKTI.filter(b => b.bagian.length).at(-1);
+  assert.ok(babLain, "tidak ada bab berisi");
+  const bagian = babLain.bagian[0];
+  const ketemu = cariBagian(bagian.judul);
+  assert.ok(ketemu.some(x => x.bagian.kode === bagian.kode),
+    `judul "${bagian.judul}" tidak ketemu lewat cariBagian`);
+});
+
+test("teksBulan memuat seluruh kolom bulan", () => {
+  for (const bulan of TIMELINE) {
+    const teks = teksBulan(bulan);
+    for (const potong of [bulan.tajuk, bulan.fokus, bulan.jangan,
+                          ...bulan.tonggak, ...bulan.sistem]) {
+      assert.ok(teks.includes(potong.toLowerCase()),
+        `${bulan.kode}: "${potong.slice(0, 30)}" tidak ikut terindeks`);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 8. Layar dan jalan menujunya
+// ---------------------------------------------------------------------------
+
+test("rute #/buku-sakti terdaftar dan menunjuk layarnya", () => {
+  assert.match(app, /"#\/buku-sakti":\s*layarBukuSakti,/);
+});
+
+test("Buku Sakti punya jalan dari kepala halaman DAN dari menu bawah", () => {
+  // Dua tempat, dan keduanya wajib: tombol kepala disembunyikan di bawah
+  // 560px, jadi tanpa item menu bawah layar ini tidak punya jalan sama
+  // sekali di HP — peranti yang paling banyak dipakai panitia.
+  assert.ok(html.includes('id="btn-buku"'), "tombol kepala hilang di index.html");
+  assert.ok(html.includes('id="nav-buku"'), "item menu bawah hilang di index.html");
+  assert.match(app, /getElementById\("btn-buku"\)\.addEventListener\("click", keBuku\)/);
+  assert.match(app, /getElementById\("nav-buku"\)\.addEventListener\("click", keBuku\)/);
+});
+
+test("layar Buku Sakti meminta sinyal BARU, bukan yang sudah dibatalkan", () => {
+  // arahkan() memanggil pengendaliLayar.abort() lalu TIDAK membuat pengendali
+  // baru; hanya sinyalLayarBaru() yang membuatnya. Memakai
+  // `pengendaliLayar.signal` langsung berarti seluruh addEventListener di
+  // layar ini diam-diam tidak terpasang — kotak cari dan daftar isi mati,
+  // tanpa satu pun galat, dan layarnya tergambar lengkap seperti biasa.
+  // Persis itu yang terjadi sekali sebelum tes ini ditulis.
+  const awal = app.indexOf("function layarBukuSakti() {");
+  const akhir = app.indexOf("function blokBukuCetak(", awal);
+  assert.ok(awal >= 0 && akhir > awal, "layarBukuSakti tidak ditemukan");
+  const badan = tanpaKomentar(app.slice(awal, akhir));
+  assert.match(badan, /const sinyal = sinyalLayarBaru\(\);/);
+  assert.ok(!badan.includes("pengendaliLayar.signal"),
+    "sinyal yang sudah dibatalkan membuat setiap pendengar di layar ini diam");
+});
+
+test("tidak ada backtick di komentar HTML milik layar ini", () => {
+  // Komentar HTML di dalam layar ini hidup DI DALAM template literal, dan
+  // satu backtick di dalamnya menutup template itu di tengah jalan. Yang
+  // didapat SyntaxError saat berkasnya dimuat — seluruh app.js mati, bukan
+  // cuma layar ini. Sudah terjadi sekali di sini, dan CLAUDE.md sudah
+  // menuliskannya sebagai jebakan sebelum itu.
+  const awal = app.indexOf("function layarBukuSakti() {");
+  const akhir = app.indexOf("function blokBukuCetak(", awal);
+  assert.ok(awal >= 0 && akhir > awal, "layarBukuSakti tidak ditemukan");
+  for (const m of app.slice(awal, akhir).matchAll(/<!--[\s\S]*?-->/g)) {
+    assert.ok(!m[0].includes("`"),
+      `backtick di komentar HTML: ${m[0].slice(0, 70)}`);
+  }
+});
+
+test("layar Buku Sakti tidak dipagari hak akses", () => {
+  // Sengaja, dan didokumentasikan di kepala bagiannya: yang paling butuh
+  // membaca buku ini justru yang haknya paling sempit. Tes ini menahan
+  // "kerapian" yang suatu hari menambahkan pagar seperti layar lain.
+  const awal = app.indexOf("function layarBukuSakti() {");
+  const akhir = app.indexOf("function blokBukuCetak(", awal);
+  assert.ok(awal >= 0 && akhir > awal, "layarBukuSakti tidak ditemukan");
+  const badan = app.slice(awal, akhir);
+  assert.ok(!/kartuGalat\(\s*["'`]Akun ini tidak berhak/.test(badan),
+    "Buku Sakti tidak boleh dipagari hak akses — lihat komentar di atasnya");
+});
+
+// ---------------------------------------------------------------------------
+// 9. Aturan kertas (CLAUDE.md bagian 8)
+// ---------------------------------------------------------------------------
+
+/** Blok @media print terakhir di style.css — yang mengatur .buku-cetak.
+ *
+ *  KOMENTARNYA DIBUANG. Tes di bawah melarang tulisan tertentu muncul di
+ *  aturannya, dan komentar yang menjelaskan larangan itu harus menyebut
+ *  tulisannya — "aturan layar memberi `background: var(--kertas)`" gagal pada
+ *  tes yang melarang latar terisi, padahal aturannya sendiri bersih. */
+const cetakBuku = (() => {
+  const awal = css.indexOf(".buku-cetak { font-size:");
+  assert.ok(awal >= 0, "aturan cetak .buku-cetak tidak ditemukan di style.css");
+  return tanpaKomentar(css.slice(awal));
+})();
+
+test("cetak buku tanpa raster abu dan tanpa latar berwarna", () => {
+  // Bagian 8.2 dan 8.4: blok terisi keluar belang dari mesin fotokopi, dan
+  // abu adalah yang paling buruk — ia jadi raster titik yang menghilang di
+  // mesin lelah atau menghitam jadi kotoran.
+  // `background: none` justru yang DIMINTA — ia membatalkan latar abu milik
+  // aturan layar. Yang dilarang latar yang benar-benar mengisi sesuatu.
+  const terisi = [...cetakBuku.matchAll(/background:\s*([^;}]+)/g)]
+    .map(m => m[1].trim())
+    .filter(v => v !== "none");
+  assert.deepEqual(terisi, [], `ada latar terisi di aturan cetak buku: ${terisi}`);
+});
+
+test("kepala tabel cetak melepas abu, bayangan, dan sticky dari aturan layar", () => {
+  // `.data-table thead th` memberi latar `var(--kertas)` (abu #f0f1f4),
+  // `box-shadow` abu, dan `position: sticky` — ketiganya benar di layar.
+  // Di kertas yang digandakan fotokopi ketiganya salah: bagian 8.4 melarang
+  // raster abu, dan sticky di media cetak merusak tiap halaman persis seperti
+  // `.bottom-nav` pernah merusaknya. Aturan cetak WAJIB membatalkan ketiganya
+  // secara eksplisit — mewarisi diam-diam adalah yang membuatnya lolos sampai
+  // PDF pertama.
+  const th = cetakBuku.slice(cetakBuku.indexOf(".bs-tabel > thead > tr > th"));
+  const badan = th.slice(0, th.indexOf("}"));
+  for (const aturan of ["background: none", "box-shadow: none", "position: static"]) {
+    assert.ok(badan.includes(aturan),
+      `aturan kepala tabel cetak tidak memuat "${aturan}"`);
+  }
+});
+
+test("huruf cetak buku minimal 7pt dan garisnya minimal 0,75pt", () => {
+  for (const [, angka] of cetakBuku.matchAll(/font-size:\s*([\d.]+)pt/g)) {
+    assert.ok(Number(angka) >= 7, `huruf ${angka}pt di bawah batas 7pt`);
+  }
+  for (const [, angka] of cetakBuku.matchAll(/border[a-z-]*:\s*([\d.]+)pt/g)) {
+    assert.ok(Number(angka) >= 0.75, `garis ${angka}pt di bawah batas 0,75pt`);
+  }
+});
+
+test("satu bagian tidak terbelah dua halaman", () => {
+  assert.match(cetakBuku, /\.bs-cetak-bagian\s*\{[^}]*break-inside:\s*avoid/);
+  assert.match(cetakBuku, /\.bs-cetak-bagian\s*\{[^}]*page-break-inside:\s*avoid/);
+});
+
+test("cetak buku membuang tautan yang tidak bisa diketuk di kertas", () => {
+  const awal = app.indexOf("function blokBukuCetak(blok) {");
+  const akhir = app.indexOf("function siapkanCetakBuku(", awal);
+  assert.ok(awal >= 0 && akhir > awal, "blokBukuCetak tidak ditemukan");
+  const badan = app.slice(awal, akhir);
+  assert.ok(!badan.includes("href="),
+    "alamat hash tidak berarti apa-apa di atas kertas");
+});

--- a/tests/buku_sakti.test.mjs
+++ b/tests/buku_sakti.test.mjs
@@ -29,8 +29,8 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
-  BUKU_SAKTI, TIMELINE, FITUR_NAMA, FITUR_SAH, RUTE_SAH,
-  bagianBuku, teksBagian, teksBulan, cariBagian, cariBulan,
+  BUKU_SAKTI, SPRINT, FITUR_NAMA, FITUR_SAH, FITUR_LAYAR, NAMA_LAYAR, RUTE_SAH,
+  bagianBuku, teksBagian, teksSprint, cariBagian, cariSprint, tugasSprint,
 } from "../web/js/buku-sakti.mjs";
 
 const baca = (p) => readFile(new URL(p, import.meta.url), "utf8");
@@ -280,11 +280,13 @@ const semuaTeks = () => {
       }
     }
   }
-  for (const bulan of TIMELINE) {
-    for (const [kunci, nilai] of Object.entries(bulan)) {
-      if (typeof nilai === "string") keluar.push([`timeline/${bulan.kode}.${kunci}`, nilai]);
-      if (Array.isArray(nilai)) {
-        for (const x of nilai) keluar.push([`timeline/${bulan.kode}.${kunci}`, x]);
+  for (const sp of SPRINT) {
+    for (const [kunci, nilai] of Object.entries(sp)) {
+      if (typeof nilai === "string") keluar.push([`${sp.kode}.${kunci}`, nilai]);
+    }
+    for (const t of sp.tugas) {
+      for (const kunci of ["teks", "seksi"]) {
+        keluar.push([`${t.kode}.${kunci}`, t[kunci]]);
       }
     }
   }
@@ -326,48 +328,159 @@ test("perakit blok meng-escape setiap sisipan datanya", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Timeline
+// 6. Papan sprint
 // ---------------------------------------------------------------------------
 
-const BULAN_URUT = ["September", "Oktober", "November", "Desember",
-                    "Januari", "Februari"];
+/** Tiap string papan sprint SENDIRI-SENDIRI, tidak digabung.
+ *
+ *  Hanya papan sprint: larangan tanggal berlaku di sini saja. Bab bacaan
+ *  justru WAJIB boleh menyebut tanggal — "29 Agustus 2026" di bab Seksi
+ *  adalah fakta sejarah edisi lalu, dan memaksanya hilang membuat angka
+ *  acuannya menggantung tanpa tahun. */
+const teksPapan = () => SPRINT.flatMap(sp => [
+  ...Object.entries(sp)
+    .filter(([, v]) => typeof v === "string")
+    .map(([k, v]) => [`${sp.kode}.${k}`, v]),
+  ...sp.tugas.flatMap(t => [[`${t.kode}.teks`, t.teks],
+                            [`${t.kode}.seksi`, t.seksi]]),
+]);
 
-test("timeline enam bulan, berurutan dari serah terima sampai pelaksanaan", () => {
-  assert.deepEqual(TIMELINE.map(b => b.bulan), BULAN_URUT);
+const BULAN_URUT = ["September", "September", "Oktober", "Oktober",
+                    "November", "November", "Desember", "Desember",
+                    "Januari", "Januari", "Februari", "Februari",
+                    "Sesudah acara"];
+
+test("tiga belas sprint, dua per bulan, ditutup sprint evaluasi", () => {
+  assert.equal(SPRINT.length, 13);
+  assert.deepEqual(SPRINT.map(s => s.bulan), BULAN_URUT);
+  assert.deepEqual(SPRINT.map(s => s.nomor), [...Array(13)].map((_, i) => i + 1));
+  assert.deepEqual(SPRINT.map(s => s.kode),
+    [...Array(13)].map((_, i) => `s${i + 1}`));
 });
 
-test("tiap bulan timeline lengkap", () => {
-  for (const bulan of TIMELINE) {
-    for (const kunci of ["kode", "bulan", "tajuk", "fokus", "jangan"]) {
-      assert.equal(typeof bulan[kunci], "string", `${bulan.kode}: ${kunci} bukan string`);
-      assert.ok(bulan[kunci].trim(), `${bulan.kode}: ${kunci} kosong`);
+test("tiap sprint lengkap kolomnya", () => {
+  for (const sp of SPRINT) {
+    for (const kunci of ["kode", "bulan", "rentang", "mundur", "tajuk",
+                         "fokus", "hasil", "jangan"]) {
+      assert.equal(typeof sp[kunci], "string", `${sp.kode}: ${kunci} bukan string`);
+      assert.ok(sp[kunci].trim(), `${sp.kode}: ${kunci} kosong`);
     }
-    for (const kunci of ["tonggak", "seksi", "sistem"]) {
-      assert.ok(Array.isArray(bulan[kunci]) && bulan[kunci].length,
-        `${bulan.kode}: ${kunci} kosong`);
-    }
+    assert.equal(typeof sp.nomor, "number", `${sp.kode}: nomor bukan angka`);
+    assert.ok(Array.isArray(sp.tugas) && sp.tugas.length,
+      `${sp.kode}: tidak punya tugas`);
   }
 });
 
-test("kode bulan aman dipakai jadi id elemen dan tidak kembar", () => {
-  const kode = TIMELINE.map(b => b.kode);
-  assert.equal(new Set(kode).size, kode.length, `kode bulan kembar: ${kode}`);
-  for (const k of kode) assert.match(k, /^[a-z0-9-]+$/);
+test("papan sprint tidak menyebut satu pun tanggal kalender", () => {
+  // Tanggal lomba baru DITETAPKAN di Sprint 2 — ia salah satu tugas di papan
+  // ini. Papan yang menyebut tanggal berbohong tepat sampai tugas itu
+  // selesai, dan tahun berikutnya berbohong sepanjang enam bulan.
+  //
+  // Diperiksa PER KOLOM, bukan atas teks gabungan teksSprint(). Yang
+  // digabung memuat `nomor` tepat sebelum `bulan`, jadi sprint pertama
+  // berbunyi "s1 1 september ..." dan pemeriksa tanggal menuduhnya menyebut
+  // "1 September". Lapor palsu adalah cara tercepat membuat orang berhenti
+  // mempercayai sebuah tes.
+  const tahun = /\b(19|20)\d{2}\b/;
+  const tanggal = /\b\d{1,2}\s+(Januari|Februari|Maret|April|Mei|Juni|Juli|Agustus|September|Oktober|November|Desember)\b/i;
+  for (const [di, teks] of teksPapan()) {
+    assert.ok(!tahun.test(teks), `${di}: menyebut tahun — "${teks.slice(0, 60)}"`);
+    assert.ok(!tanggal.test(teks),
+      `${di}: menyebut tanggal kalender — "${teks.slice(0, 60)}"`);
+  }
 });
 
-test("seksi yang disebut timeline juga dijelaskan di bab Seksi", () => {
-  // Kalender yang menyebut "Seksi Barak" sementara babnya tidak pernah
-  // menjelaskan seksi itu meninggalkan pembaca dengan nama tanpa tugas —
-  // dan nama tanpa tugas adalah pekerjaan yang tidak dikerjakan siapa pun.
+test("kode tugas unik DI SELURUH PAPAN dan diawali kode sprintnya", () => {
+  // Kode tugas adalah KUNCI CENTANG di database (migrasi 0170). Dua tugas
+  // sekode berarti satu centang menyalakan dua kotak, tanpa satu pun galat.
+  const kode = tugasSprint().map(x => x.tugas.kode);
+  const kembar = kode.filter((k, i) => kode.indexOf(k) !== i);
+  assert.deepEqual(kembar, [], `kode tugas kembar: ${kembar}`);
+  for (const { sprint, tugas } of tugasSprint()) {
+    assert.match(tugas.kode, /^[a-z0-9]+(-[a-z0-9]+)*$/,
+      `${tugas.kode}: bentuknya ditolak constraint centang_sprint_kode_check`);
+    assert.ok(tugas.kode.startsWith(`${sprint.kode}-`),
+      `${tugas.kode}: tidak diawali "${sprint.kode}-"`);
+    assert.ok(tugas.kode.length <= 60,
+      `${tugas.kode}: lebih dari 60 huruf, ditolak constraint`);
+  }
+});
+
+test("tiap tugas punya teks, seksi, dan field layar", () => {
+  for (const { tugas } of tugasSprint()) {
+    assert.ok(String(tugas.teks || "").trim(), `${tugas.kode}: teks kosong`);
+    assert.ok(String(tugas.seksi || "").trim(), `${tugas.kode}: seksi kosong`);
+    // `undefined` dan `null` berperilaku sama di perakitnya, tapi hanya null
+    // yang mengatakan "sudah dipikirkan dan memang di luar sistem".
+    assert.ok("layar" in tugas, `${tugas.kode}: tanpa field layar`);
+  }
+});
+
+test("layar tiap tugas adalah rute yang ada", () => {
+  for (const { tugas } of tugasSprint()) {
+    if (tugas.layar === null) continue;
+    assert.ok(RUTE_SAH.includes(tugas.layar),
+      `${tugas.kode}: rute "${tugas.layar}" tidak ada`);
+  }
+});
+
+test("tiap seksi yang memegang tugas dijelaskan di bab Seksi", () => {
+  // Nama seksi tanpa bagian yang menjelaskannya adalah pekerjaan yang tidak
+  // dikerjakan siapa pun: papan menyuruh "Seksi Barak", dan tidak ada satu
+  // baris pun yang mengatakan siapa itu.
   const bab = BUKU_SAKTI.find(b => b.kode === "seksi");
   assert.ok(bab, "bab seksi hilang");
-  const teks = bab.bagian.map(teksBagian).join(" ");
-  for (const bulan of TIMELINE) {
-    for (const seksi of bulan.seksi) {
-      assert.ok(teks.includes(seksi.toLowerCase()),
-        `${bulan.kode}: "${seksi}" tidak dijelaskan di bab Seksi`);
-    }
+  const judul = bab.bagian.map(g => g.judul);
+  for (const { tugas } of tugasSprint()) {
+    assert.ok(judul.includes(tugas.seksi),
+      `${tugas.kode}: seksi "${tugas.seksi}" bukan judul bagian mana pun di bab Seksi`);
   }
+});
+
+test("tiap seksi di bab Seksi kebagian minimal satu tugas", () => {
+  // Arah sebaliknya, dan ia yang menangkap seksi yang dijelaskan panjang
+  // lebar lalu tidak pernah muncul di papan — pembacanya tahu tugas pokoknya
+  // tetapi tidak pernah tahu kapan mengerjakannya.
+  const bab = BUKU_SAKTI.find(b => b.kode === "seksi");
+  const dipakai = new Set(tugasSprint().map(x => x.tugas.seksi));
+  const menganggur = bab.bagian
+    .map(g => g.judul)
+    .filter(j => j !== "Cara membaca bab ini" && !dipakai.has(j));
+  assert.deepEqual(menganggur, [],
+    `seksi tanpa satu pun tugas di papan sprint: ${menganggur}`);
+});
+
+test("NAMA_LAYAR menutup tiap rute, dan sepakat dengan pasangKepala()", () => {
+  // Nama layar yang basi lebih buruk daripada alamat mentah: panitia mencari
+  // ubin bernama "Rekapitulasi" yang sudah tidak ada, dan menyimpulkan
+  // bukunya yang benar.
+  assert.deepEqual(Object.keys(NAMA_LAYAR).sort(), [...RUTE_SAH].sort());
+  const dipakai = new Set(
+    [...app.matchAll(/pasangKepala\("([^"]+)"/g)].map(m => m[1]));
+  for (const [rute, nama] of Object.entries(NAMA_LAYAR)) {
+    assert.ok(dipakai.has(nama),
+      `NAMA_LAYAR["${rute}"] = "${nama}", tapi tidak ada pasangKepala() dengan nama itu`);
+  }
+});
+
+test("FITUR_LAYAR menutup tiap rute, dan sepakat dengan ubin Home", () => {
+  // SALINAN YANG BERISIK. Yang memutuskan hak tetap boleh() di database;
+  // peta ini cuma menjawab "centang mana yang memunculkan ubinnya di Home",
+  // dan jawabannya harus sama dengan syarat ubin yang benar-benar digambar.
+  assert.deepEqual(Object.keys(FITUR_LAYAR).sort(), [...RUTE_SAH].sort());
+
+  const awal = app.indexOf("async function layarHome()");
+  const akhir = app.indexOf("/* ============================ PENGATURAN KLOTER", awal);
+  assert.ok(awal >= 0 && akhir > awal, "layarHome tidak ditemukan");
+  const home = app.slice(awal, akhir);
+  let cocok = 0;
+  for (const m of home.matchAll(/bolehLihat\("([a-z_]+)"\) \? `\s*<a href="(#\/[a-z0-9-]+)"/g)) {
+    cocok += 1;
+    assert.equal(FITUR_LAYAR[m[2]], m[1],
+      `FITUR_LAYAR["${m[2]}"] = ${FITUR_LAYAR[m[2]]}, tapi ubin Home menuntut ${m[1]}`);
+  }
+  assert.ok(cocok >= 8,
+    `cuma ${cocok} ubin Home terbaca — polanya berubah dan tes ini jadi diam`);
 });
 
 // ---------------------------------------------------------------------------
@@ -387,9 +500,30 @@ test("cari yang kosong tidak mengembalikan apa pun", () => {
   // Layar memakai ini sebagai penanda "tidak sedang mencari" dan
   // mengembalikan seluruh panel. Kalau string kosong justru mengembalikan
   // seluruh buku sebagai HASIL, panelnya tidak pernah muncul lagi.
-  assert.deepEqual(cariBagian(""), []);
-  assert.deepEqual(cariBagian("   "), []);
-  assert.deepEqual(cariBulan(""), []);
+  for (const cari of [cariBagian, cariSprint]) {
+    assert.deepEqual(cari(""), []);
+    assert.deepEqual(cari("   "), []);
+  }
+});
+
+test("cariSprint juga menuntut SEMUA kata, bukan salah satunya", () => {
+  // Diuji terpisah dari cariBagian: keduanya dipakai kotak cari yang SAMA,
+  // dan dua fungsi yang berperilaku beda di satu kotak berarti separuh
+  // hasilnya mengejutkan. Sebelum tes ini hanya cariBagian yang dijaga.
+  const kata = SPRINT[0].tajuk.split(/\s+/)[0];
+  assert.ok(cariSprint(kata).length >= 1, "kata sendiri harus ketemu");
+  assert.equal(cariSprint(`${kata} zzzznonsensezzzz`).length, 0,
+    "satu kata yang tidak ada harus menggugurkan hasilnya");
+});
+
+test("cariSprint menemukan lewat kode tugas dan nama seksi", () => {
+  // Keduanya jalan masuk yang nyata: kode tugas disalin dari notulen rapat,
+  // dan nama seksi dipakai koordinator untuk menyapu tugasnya sendiri.
+  const { sprint, tugas } = tugasSprint()[0];
+  assert.ok(cariSprint(tugas.kode).some(s => s.kode === sprint.kode),
+    `kode tugas ${tugas.kode} tidak ketemu`);
+  assert.ok(cariSprint(tugas.seksi).length >= 1,
+    `seksi ${tugas.seksi} tidak ketemu`);
 });
 
 test("cari menyapu seluruh bab, bukan bab pertama saja", () => {
@@ -401,13 +535,24 @@ test("cari menyapu seluruh bab, bukan bab pertama saja", () => {
     `judul "${bagian.judul}" tidak ketemu lewat cariBagian`);
 });
 
-test("teksBulan memuat seluruh kolom bulan", () => {
-  for (const bulan of TIMELINE) {
-    const teks = teksBulan(bulan);
-    for (const potong of [bulan.tajuk, bulan.fokus, bulan.jangan,
-                          ...bulan.tonggak, ...bulan.sistem]) {
-      assert.ok(teks.includes(potong.toLowerCase()),
-        `${bulan.kode}: "${potong.slice(0, 30)}" tidak ikut terindeks`);
+test("teksSprint memuat SETIAP kolom, tanpa kecuali", () => {
+  // Ditulis sebagai "tiap kolom yang berupa string", bukan daftar tangan:
+  // daftar tangan itulah yang dulu melewatkan dua kolom sambil nama tesnya
+  // berbunyi "seluruh kolom".
+  for (const sp of SPRINT) {
+    const teks = teksSprint(sp);
+    for (const [kunci, nilai] of Object.entries(sp)) {
+      if (typeof nilai !== "string") continue;
+      assert.ok(teks.includes(nilai.toLowerCase()),
+        `${sp.kode}: kolom ${kunci} tidak ikut terindeks`);
+    }
+    assert.ok(teks.includes(String(sp.nomor)),
+      `${sp.kode}: nomor sprint tidak ikut terindeks`);
+    for (const t of sp.tugas) {
+      for (const potong of [t.kode, t.teks, t.seksi]) {
+        assert.ok(teks.includes(potong.toLowerCase()),
+          `${sp.kode}: "${potong.slice(0, 30)}" tidak ikut terindeks`);
+      }
     }
   }
 });
@@ -468,9 +613,16 @@ test("layar Buku Sakti tidak dipagari hak akses", () => {
   const awal = app.indexOf("function layarBukuSakti() {");
   const akhir = app.indexOf("function blokBukuCetak(", awal);
   assert.ok(awal >= 0 && akhir > awal, "layarBukuSakti tidak ditemukan");
-  const badan = app.slice(awal, akhir);
-  assert.ok(!/kartuGalat\(\s*["'`]Akun ini tidak berhak/.test(badan),
-    "Buku Sakti tidak boleh dipagari hak akses — lihat komentar di atasnya");
+  const badan = tanpaKomentar(app.slice(awal, akhir));
+  /* Yang dicari BENTUK pagarnya, bukan satu kalimat tertentu. Layar lain
+     memakai kalimat yang berbeda-beda ("Akun ini tidak berhak membuka X"),
+     jadi tes yang mencocokkan satu kalimat akan diam terhadap pagar yang
+     ditulis dengan kalimat kedua. Yang menandai pagar dengan pasti dua hal:
+     kartu galat, dan bolehLihat() yang mengembalikan lebih awal. */
+  assert.ok(!badan.includes("kartuGalat("),
+    "Buku Sakti tidak boleh punya kartu galat hak akses — lihat komentar di atasnya");
+  assert.ok(!/if\s*\(!\s*bolehLihat\(/.test(badan),
+    "Buku Sakti tidak boleh menolak lewat bolehLihat() — lihat komentar di atasnya");
 });
 
 // ---------------------------------------------------------------------------
@@ -486,7 +638,29 @@ test("layar Buku Sakti tidak dipagari hak akses", () => {
 const cetakBuku = (() => {
   const awal = css.indexOf(".buku-cetak { font-size:");
   assert.ok(awal >= 0, "aturan cetak .buku-cetak tidak ditemukan di style.css");
-  return tanpaKomentar(css.slice(awal));
+  /* Berhenti di penutup `@media print` YANG MEMUATNYA, tidak di akhir berkas.
+     Versi pertama membaca sampai habis, jadi aturan LAYAR mana pun yang
+     ditambahkan sesudah blok ini ikut dinilai sebagai aturan kertas — satu
+     `background` biasa di sana menggagalkan tes fotokopi yang tidak ada
+     hubungannya dengannya, dan yang membacanya menyimpulkan tesnya rusak.
+
+     Dihitung dari `@media print {`, BUKAN dari `.buku-cetak {`: yang kedua
+     berhenti di kurung tutup aturan pertama, dan potongannya cuma satu
+     baris — tes kertas berikutnya lalu memeriksa nyaris tidak ada apa-apa
+     sambil tetap berbunyi hijau. */
+  const mulai = css.lastIndexOf("@media print", awal);
+  assert.ok(mulai >= 0, "@media print yang memuat .buku-cetak tidak ditemukan");
+  let dalam = 0;
+  let tutup = -1;
+  for (let j = css.indexOf("{", mulai); j < css.length; j++) {
+    if (css[j] === "{") dalam++;
+    else if (css[j] === "}") {
+      dalam--;
+      if (dalam === 0) { tutup = j; break; }
+    }
+  }
+  assert.ok(tutup > awal, "blok @media print tidak pernah ditutup");
+  return tanpaKomentar(css.slice(awal, tutup));
 })();
 
 test("cetak buku tanpa raster abu dan tanpa latar berwarna", () => {
@@ -495,7 +669,10 @@ test("cetak buku tanpa raster abu dan tanpa latar berwarna", () => {
   // mesin lelah atau menghitam jadi kotoran.
   // `background: none` justru yang DIMINTA — ia membatalkan latar abu milik
   // aturan layar. Yang dilarang latar yang benar-benar mengisi sesuatu.
-  const terisi = [...cetakBuku.matchAll(/background:\s*([^;}]+)/g)]
+  // `background-color`, `background-image`, dan `background` sekaligus:
+  // ketiganya menuangkan tinta, dan pemeriksa yang cuma tahu satu di
+  // antaranya melewatkan dua cara menulis hal yang sama.
+  const terisi = [...cetakBuku.matchAll(/background(?:-color|-image)?:\s*([^;}]+)/g)]
     .map(m => m[1].trim())
     .filter(v => v !== "none");
   assert.deepEqual(terisi, [], `ada latar terisi di aturan cetak buku: ${terisi}`);
@@ -538,4 +715,12 @@ test("cetak buku membuang tautan yang tidak bisa diketuk di kertas", () => {
   const badan = app.slice(awal, akhir);
   assert.ok(!badan.includes("href="),
     "alamat hash tidak berarti apa-apa di atas kertas");
+
+  /* Dan perakit cetaknya memang MEMANGGILNYA. Tanpa baris ini fungsinya
+     boleh saja benar sambil tidak pernah dipakai — siapkanCetakBuku()
+     kembali memanggil blokBuku() dan tautannya kembali tercetak, sementara
+     tes di atas tetap hijau karena ia cuma membaca fungsi yang menganggur. */
+  const perakit = app.slice(app.indexOf("function siapkanCetakBuku("));
+  assert.ok(perakit.slice(0, perakit.indexOf("\n}\n")).includes("blokBukuCetak"),
+    "siapkanCetakBuku tidak memanggil blokBukuCetak — tautannya ikut tercetak");
 });

--- a/tests/cek_nilai_satu_layar.test.mjs
+++ b/tests/cek_nilai_satu_layar.test.mjs
@@ -43,7 +43,15 @@ test("pengamat header memakai sinyal layar yang SUDAH ADA", () => {
   // "Memuat…" selamanya, tanpa satu pun galat. Itu benar-benar terjadi saat
   // tata letak ini dibangun.
   const awal = app.indexOf("async function layarCekNilai()");
-  const akhir = app.indexOf("const RUTE = {", awal);
+  /* Batas bawahnya SPANDUK BAGIAN BERIKUTNYA, bukan tabel RUTE.
+     Dulu ia `app.indexOf("const RUTE = {")`, dan itu benar hanya selama Cek
+     Nilai kebetulan bagian TERAKHIR sebelum tabel rute. Begitu satu layar
+     baru disisipkan di antaranya, potongan ini ikut memuat layar itu — dan
+     `sinyalLayarBaru()` miliknya terhitung sebagai panggilan kedua milik Cek
+     Nilai. Tesnya gagal, padahal layar yang dijaganya tidak berubah
+     sebarispun. */
+  const spanduk = app.indexOf("\n/* ==", awal);
+  const akhir = spanduk >= 0 ? spanduk : app.indexOf("const RUTE = {", awal);
   // Komentar dibuang dulu: alasan aturan ini justru dijelaskan di komentar
   // tepat di atas kodenya, dan nama fungsinya disebut di sana.
   const layar = app.slice(awal, akhir)

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -148,6 +148,7 @@ RPC = {
     "batal_ceklis_berangkat":["p_nomor_dada"],
     "koreksi_jam_berangkat": ["p_kloter", "p_jam", "p_alasan"],
     "minta_segarkan_live_score": [],
+    "set_centang_sprint":    ["p_kode", "p_selesai"],
     "putar_foto_lembar":     ["p_id", "p_putaran"],
     "simpan_nilai_massal":   ["p_baris", "p_sumber", "p_pos"],
     "hapus_nilai_pos":       ["p_nomor_dada", "p_kode", "p_pos"],
@@ -254,6 +255,18 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q(
                     "select id, name, address from sekolah order by name",
                     role="anon"))
+            elif u.path == "/centang-sprint":
+                # Papan sprint Buku Sakti (migrasi 0170). Layarnya sengaja
+                # tetap terbuka walau ini gagal, jadi yang penting di sini
+                # cuma bentuk jawabannya sama dengan v_centang_sprint di
+                # produksi: kode, dicentang_pada, dicentang_oleh.
+                # uid WAJIB diteruskan: v_centang_sprint security_invoker, dan
+                # RLS-nya menuntut peran() — tanpa uid yang kembali daftar
+                # KOSONG, bukan galat, dan papan sprint tergambar seolah belum
+                # ada satu tugas pun yang selesai.
+                self._kirim(200, q(
+                    "select kode, dicentang_pada, dicentang_oleh "
+                    "from v_centang_sprint order by kode", uid=p.get("uid")))
             elif u.path == "/edisi":
                 self._kirim(200, q(
                     "select * from v_edisi_publik", role="anon", fetch="one"))

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 61, sidik: "1a586323c25c" },
+  "style.css": { versi: 62, sidik: "886f4b534f8a" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 19, sidik: "3a694d058cbc" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 62, sidik: "886f4b534f8a" },
+  "style.css": { versi: 63, sidik: "8f7d4da28bb8" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/navigation_icons.test.mjs
+++ b/tests/navigation_icons.test.mjs
@@ -12,9 +12,16 @@ const util = await readFile(new URL("../web/js/util.js", import.meta.url), "utf8
 
 test("header dan bottom-nav memakai satu sumber ikon", () => {
   const nama = [...index.matchAll(/data-ikon="([^"]+)"/g)].map(m => m[1]);
+  // Lima nama, sembilan pemakaian: empat aksi ada DI DUA TEMPAT — tombol
+  // kepala untuk layar lebar dan item menu bawah untuk HP, tempat tombol
+  // kepala disembunyikan di bawah 560px. Yang muncul sekali cuma `log-out`:
+  // di kepala, Keluar adalah tombol BERTULISAN, bukan ikon.
+  // Angka ini sengaja dipatok: ikon baru di navigasi adalah keputusan,
+  // bukan kerapian, dan tes yang tidak menghitungnya membiarkan navigasi
+  // tumbuh diam-diam sampai menu bawah kehabisan lebar di HP sempit.
   assert.deepEqual([...new Set(nama)].sort(),
-    ["house", "log-out", "settings", "user-cog"]);
-  assert.equal(nama.length, 7);
+    ["book-open", "house", "log-out", "settings", "user-cog"]);
+  assert.equal(nama.length, 9);
   assert.doesNotMatch(index, /<svg\b/);
   assert.match(app,
     /querySelectorAll\("\[data-ikon\]"\)[\s\S]+ikon\(tempat\.dataset\.ikon\)/);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -739,6 +739,11 @@ run supabase/migrations/0168_judul_isian_menaksir.sql
 # sini: 0076 dijalankan lebih dulu, jadi kesepuluh baris soal ada dan angkanya
 # dilaporkan lewat notice.
 run supabase/migrations/0169_judul_isian_soal.sql
+# 0170 memberi papan sprint Buku Sakti tabel centangnya. Ia tidak menyentuh
+# satu pun data lomba, jadi urutannya bebas — yang penting ia ada di sini
+# sama sekali (CLAUDE.md 7.5).
+run supabase/migrations/0170_centang_sprint.sql
+run tests/sql/120_centang_sprint.sql
 
 # tests/sql/bentuk_lomba_produksi.sql SENGAJA TIDAK DIJALANKAN DI SINI, dan itu
 # perlu disebut karena CLAUDE.md 7.5 melatih pembaca mengharapkan sebaliknya.

--- a/tests/sql/120_centang_sprint.sql
+++ b/tests/sql/120_centang_sprint.sql
@@ -1,0 +1,119 @@
+\echo '--- 120. centang sprint: dua arah, satu jejak, berpagar panitia'
+
+do $$
+declare
+  v_jumlah int;
+  v_oleh   text;
+  v_pada   timestamptz;
+  v_ditolak boolean := false;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  -- 120.1 Mencentang menyimpan satu baris untuk edisi AKTIF, bukan edisi lain.
+  perform set_centang_sprint('s6-desa', true);
+  select count(*) into v_jumlah
+    from centang_sprint where kode = 's6-desa' and edisi = edisi_aktif();
+  assert v_jumlah = 1,
+    format('120.1 GAGAL: %s baris centang, bukan 1', v_jumlah);
+
+  -- 120.2 Jejaknya ikut terisi. Ini yang menggantikan pagar hak akses
+  --       (lihat kepala 0170), jadi kalau ia kosong pagarnya hilang tanpa
+  --       ada yang mengeluh.
+  select dicentang_oleh, dicentang_pada into v_oleh, v_pada
+    from v_centang_sprint where kode = 's6-desa';
+  assert v_oleh is not null, '120.2 GAGAL: nama pencentang tidak tercatat';
+  assert v_pada is not null, '120.2 GAGAL: waktu centang tidak tercatat';
+
+  -- 120.3 Mencentang DUA KALI tidak menggandakan barisnya, dan tidak
+  --       memindahkan jejaknya ke orang kedua. Yang berguna dari kolom itu
+  --       siapa yang MENYELESAIKAN, bukan siapa yang terakhir mengetuk.
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000b1', true);
+  perform set_centang_sprint('s6-desa', true);
+  select count(*) into v_jumlah
+    from centang_sprint where kode = 's6-desa' and edisi = edisi_aktif();
+  assert v_jumlah = 1,
+    format('120.3 GAGAL: centang kedua menggandakan baris (%s)', v_jumlah);
+  assert (select dicentang_oleh from v_centang_sprint where kode = 's6-desa')
+         = v_oleh,
+    '120.3 GAGAL: jejak berpindah ke pencentang kedua';
+
+  -- 120.4 Membatalkan menghapus barisnya, bukan menyetel kolom jadi false.
+  --       Kalau suatu hari ada kolom `selesai`, tes ini yang menangkapnya.
+  perform set_centang_sprint('s6-desa', false);
+  select count(*) into v_jumlah
+    from centang_sprint where kode = 's6-desa' and edisi = edisi_aktif();
+  assert v_jumlah = 0,
+    format('120.4 GAGAL: %s baris tersisa sesudah dibatalkan', v_jumlah);
+
+  -- 120.5 Membatalkan yang memang belum dicentang bukan galat. Dua orang
+  --       yang membatalkan tugas yang sama beruntun adalah kejadian rapat
+  --       yang biasa, bukan kesalahan yang perlu diteriakkan.
+  perform set_centang_sprint('s6-desa', false);
+
+  -- 120.6 Kode yang tidak sesuai bentuk ditolak. Kode dipakai jadi id elemen
+  --       di layar, dan yang tidak berbentuk begitu tidak akan pernah cocok
+  --       dengan tugas mana pun — ia cuma jadi baris yatim.
+  begin
+    perform set_centang_sprint('S6 Desa!', true);
+  exception when others then v_ditolak := true;
+  end;
+  assert v_ditolak, '120.6 GAGAL: kode berbentuk salah diterima';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 120.7 Pagarnya menempati kursi, bukan memindai nama (CLAUDE.md 13.8).
+--       Panggilan yang sama dijalankan dua kali; yang berubah di antaranya
+--       satu hal saja — apakah pemanggilnya panitia.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_ditolak boolean := false;
+begin
+  -- `lama_hrcd36` ADA di akun_panitia tetapi is_active false, dan peran()
+  -- menyaringnya. Sengaja memakai akun yang ada, bukan uuid karangan: yang
+  -- ingin dijaga bukan "uuid asing ditolak" melainkan "akun yang sudah
+  -- dinonaktifkan berhenti bisa menulis".
+  perform set_config('app.uid', '00000000-0000-0000-0000-0000000000ff', true);
+  begin
+    perform set_centang_sprint('s1-inti', true);
+  exception when others then v_ditolak := true;
+  end;
+  assert v_ditolak, '120.7 GAGAL: bukan panitia bisa mencentang';
+
+  -- uid yang sama persis dipakai lagi, kali ini milik panitia.
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+  perform set_centang_sprint('s1-inti', true);
+  assert (select count(*) from centang_sprint where kode = 's1-inti') = 1,
+    '120.7 GAGAL: panitia justru tidak bisa mencentang';
+  perform set_centang_sprint('s1-inti', false);
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 120.8 View-nya hanya membuka edisi AKTIF. Centang edisi lalu yang ikut
+--       terbaca akan membuat papan sprint tahun ini terbuka setengah penuh
+--       di hari pertama kepanitiaan baru — dan tidak ada satu pun tanda
+--       bahwa yang tercentang itu pekerjaan orang lain, tahun lalu.
+-- ---------------------------------------------------------------------------
+do $$
+declare v_edisi_lain int;
+begin
+  perform set_config('app.uid', '00000000-0000-0000-0000-00000000000a', true);
+
+  select nomor into v_edisi_lain from edisi where nomor <> edisi_aktif() limit 1;
+  if v_edisi_lain is null then
+    insert into edisi (nomor, name, tahun, tanggal_lomba, biaya_per_regu,
+                       is_active)
+    values (999, 'HRCD UJI 120', 2099, date '2099-01-01', 1000, false)
+    returning nomor into v_edisi_lain;
+  end if;
+
+  insert into centang_sprint (edisi, kode) values (v_edisi_lain, 's1-akses')
+    on conflict do nothing;
+
+  assert not exists (select 1 from v_centang_sprint where kode = 's1-akses'),
+    '120.8 GAGAL: centang edisi lain ikut terbaca di edisi aktif';
+
+  delete from centang_sprint where edisi = v_edisi_lain;
+  delete from edisi where nomor = 999;
+end $$;
+
+\echo '    120 OK'

--- a/tools/periksa_impor.py
+++ b/tools/periksa_impor.py
@@ -68,6 +68,7 @@ if __name__ == "__main__":
         ("web/js/app.js", "web/js/api.js", "./api.js"),
         ("web/js/app.js", "web/js/util.js", "./util.js"),
         ("web/js/app.js", "web/js/nomor-dada-series.mjs", "./nomor-dada-series.mjs"),
+        ("web/js/app.js", "web/js/buku-sakti.mjs", "./buku-sakti.mjs"),
         ("live/js/daftar.js", "live/js/api.js", "./api.js"),
         ("live/js/daftar.js", "live/js/util.js", "./util.js"),
         ("live/js/daftar.js", "live/js/school-search.mjs", "./school-search.mjs"),

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=59">
+  <link rel="stylesheet" href="style.css?v=60">
 </head>
 <body>
   <header class="header" id="kepala" hidden>
@@ -23,6 +23,19 @@
          dibuka sekali di awal edisi tidak boleh ikut bersaing di sana. -->
     <button class="icon-button" id="btn-akun" type="button" hidden
             aria-label="Akun" title="Akun"><span data-ikon="user-cog"></span></button>
+    <!-- Buku Sakti ada DI SINI, bukan sebagai ubin di Home, dan alasannya dua.
+         Yang pertama sama dengan alasan tombol Akun di sebelah kiri: papan
+         Home dipakai sepanjang hari lomba dan sudah memuat empat belas ubin.
+         Yang kedua warna — tiap ubin Home punya rona sendiri supaya jempol
+         bisa menuju "yang jingga" tanpa mengeja, dan keempat belas rona yang
+         cukup berjauhan sudah habis terpakai. Ubin kelima belas berarti dua
+         ubin serona, yang menghapus guna warnanya sendiri.
+
+         Di kepala halaman ia justru lebih mudah dicapai: ada di SETIAP layar,
+         termasuk papan juri pos yang isinya terpisah dari papan meja dan
+         karena itu sering ketinggalan waktu ubin baru ditambahkan. -->
+    <button class="icon-button" id="btn-buku" type="button"
+            aria-label="Buku Sakti" title="Buku Sakti"><span data-ikon="book-open"></span></button>
     <button class="icon-button" id="ganti-password" type="button" aria-label="Ganti Password" title="Ganti Password"><span data-ikon="settings"></span></button>
     <button class="button button-small button-secondary" id="btn-keluar" type="button">Keluar</button>
   </header>
@@ -38,6 +51,13 @@
   <nav class="bottom-nav" id="bottom-nav" hidden aria-label="Menu utama">
     <button class="bottom-nav-item" id="nav-home" type="button">
       <span class="bottom-nav-icon" data-ikon="house"></span><span>Home</span>
+    </button>
+    <!-- Di HP tombol kepala disembunyikan (style.css, 560px), jadi tanpa item
+         ini Buku Sakti tidak punya jalan sama sekali di peranti yang paling
+         banyak dipakai panitia. Alasannya sama persis dengan item Akun di
+         bawah, hanya saja yang ini untuk semua orang. -->
+    <button class="bottom-nav-item" id="nav-buku" type="button">
+      <span class="bottom-nav-icon" data-ikon="book-open"></span><span>Buku</span>
     </button>
     <button class="bottom-nav-item" id="nav-setting" type="button">
       <span class="bottom-nav-icon" data-ikon="settings"></span><span>Setelan</span>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -777,6 +777,31 @@ export const bukaKunciNilaiPos = (nomorDada, pos, lomba, alasan) =>
   rpc("buka_kunci_nilai_pos",
       { p_nomor_dada: nomorDada, p_pos: pos, p_lomba: lomba, p_alasan: alasan });
 
+/* ---------- papan sprint Buku Sakti (migrasi 0170) ---------- */
+
+/** Centang tugas papan sprint edisi aktif, beserta siapa dan kapan.
+ *
+ *  Dibaca sekali saat layar Buku Sakti dibuka, bukan per tugas: seratusan
+ *  tugas berarti seratusan permintaan, dan seluruhnya muat dalam satu
+ *  jawaban berukuran beberapa kilobyte.
+ *
+ *  Gagalnya BUKAN alasan menutup layar. Buku Sakti sengaja tetap terbaca
+ *  tanpa database sama sekali (lihat pagar edisi di app.js), jadi yang
+ *  memanggil ini harus menangani gagalnya sebagai "centangnya belum
+ *  terbaca", bukan sebagai "bukunya tidak bisa dibuka". */
+export async function daftarCentangSprint() {
+  if (K.mode === "dev") return baca("/centang-sprint");
+  return baca(null, "v_centang_sprint?select=kode,dicentang_pada,dicentang_oleh");
+}
+
+/** Centang satu tugas, atau batalkan centangnya.
+ *
+ *  Satu fungsi dua arah, sama dengan RPC-nya: kotak centang selalu tahu
+ *  keadaan barunya, dan dua fungsi terpisah berarti dua tempat yang harus
+ *  sepakat soal edisi aktif dan jejaknya. */
+export const setCentangSprint = (kode, selesai) =>
+  rpc("set_centang_sprint", { p_kode: kode, p_selesai: !!selesai });
+
 /** Riwayat perubahan nilai satu regu di satu pos — siapa mengubah apa, kapan.
  *
  *  Dibaca saat penanda simpan diketuk, bukan ikut dimuat bersama lembarnya:

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,6 +27,7 @@ import {
   hasilKejuaraan, simpanKejuaraanManual, simpanKejuaraanTerjauh, daftarSekolah,
   unggahFotoMasuk, daftarFotoBelumTaut, tautkanFoto, kuotaFoto,
   statusAcara, bolehLihat, lengkapiHakSesi,
+  daftarCentangSprint, setCentangSprint,
   aturFaseLive, segarkanLiveScore,
   daftarAkun, ubahPeranAkun, setAktifAkun, buatAkun, resetPasswordAkun, daftarPanitia,
   ubahUsernameAkun, daftarFitur, daftarHak, setHak, tautanFotoBanyak,
@@ -46,8 +47,8 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
 import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
 import { deretCocok, deretIntern, nomorStok, pesanDeret }
   from "./nomor-dada-series.mjs";
-import { BUKU_SAKTI, TIMELINE, FITUR_NAMA, cariBagian, cariBulan }
-  from "./buku-sakti.mjs";
+import { BUKU_SAKTI, SPRINT, FITUR_NAMA, FITUR_LAYAR, NAMA_LAYAR,
+         cariBagian, cariSprint, tugasSprint } from "./buku-sakti.mjs";
 
 const LAYAR = document.getElementById("layar");
 
@@ -194,6 +195,13 @@ function pasangKepala(judul, lebar = false) {
       .setAttribute("aria-current", location.hash === "#/ganti-password" ? "page" : "false");
     document.getElementById("nav-akun")
       .setAttribute("aria-current", location.hash === "#/account" ? "page" : "false");
+    /* pangkalRute(), bukan perbandingan hash utuh: alamat Buku Sakti
+       berbuntut kode bab, jadi `#/buku-sakti/seksi` juga sedang di layar ini.
+       Tanpa itu penandanya menyala di bab pertama lalu padam begitu pembaca
+       pindah tab — satu-satunya item menu yang berkedip. */
+    document.getElementById("nav-buku")
+      .setAttribute("aria-current",
+        pangkalRute(location.hash) === "#/buku-sakti" ? "page" : "false");
   }
   // Akun hanya untuk admin. Disembunyikan, BUKAN dinonaktifkan: tombol mati di
   // pojok header tidak memberi tahu apa pun selain bahwa ada sesuatu yang
@@ -10734,33 +10742,156 @@ function bagianBukuHtml(bagian) {
   </section>`;
 }
 
-/** Satu bulan timeline. Bentuknya sengaja berbeda dari bagian bacaan: yang
- *  dicari orang di kalender bukan paragraf melainkan tonggak yang bisa
- *  dicentang dan langkah sistem yang harus dikerjakan bulan itu. */
-function bulanBukuHtml(bulan, indeks) {
-  return `<section class="card bs-bulan" id="bs-bulan-${esc(bulan.kode)}">
-    <div class="bs-bulan-kepala">
-      <span class="bs-bulan-urut">${esc(String(indeks + 1))}</span>
-      <span class="bs-bulan-nama">${esc(bulan.bulan)}</span>
-      <span class="bs-bulan-tajuk">${esc(bulan.tajuk)}</span>
+/* ------------------------------ PAPAN SPRINT -----------------------------
+
+   Tiga belas sprint dua mingguan, dan tiap tugasnya bisa dicentang. Centangnya
+   duduk di database (migrasi 0170) dan terlihat oleh seluruh panitia — papan
+   rencana yang jawabannya berbeda-beda per HP bukan papan koordinasi.
+
+   DIGAMBAR DULU, CENTANGNYA MENYUSUL.
+
+   Layar ini tidak menunggu jaringan sebelum menggambar apa pun. Isinya berkas
+   statis yang sudah ikut termuat bersama app.js, jadi papannya muncul seketika
+   dengan seluruh kotak dalam keadaan kosong, lalu satu permintaan mengisinya.
+   Urutan itu yang membuat janji di kepala buku-sakti.mjs tetap benar: bukunya
+   terbaca walau Supabase tidak terjangkau, dan yang hilang cuma centangnya.
+
+   Karena itu gagalnya BUKAN kartu galat. Yang tergambar sebaris kecil di
+   kepala papan, dan seluruh isi bukunya tetap bisa dibaca. */
+
+/** Centang yang sedang berlaku: kode tugas -> { dicentang_oleh, dicentang_pada }.
+ *
+ *  Di luar fungsi layarnya supaya kembali dari layar lain tidak mengosongkan
+ *  papan sampai permintaannya selesai — papan yang berkedip kosong tiap kali
+ *  pembaca menekan Back terbaca seperti centang yang hilang. */
+let centangSprint = new Map();
+
+/** Sudah pernah dibaca dari server sekali? Membedakan "belum tahu" dari
+ *  "sudah tahu, dan memang kosong" — yang pertama tidak boleh dilaporkan
+ *  sebagai papan yang belum dikerjakan siapa pun. */
+let centangSprintTerbaca = false;
+
+/** Tautan kecil di kaki sebuah tugas, ikut hak akun.
+ *
+ *  Yang tidak berhak TIDAK diberi tautan mati: tugasnya tetap terbaca lengkap,
+ *  cuma tanpa jalan pintas. Menuliskan "butuh centang X" di sini seperti pada
+ *  blok layar akan menambah satu baris di bawah SERATUS TUJUH tugas, dan papan
+ *  yang gunanya untuk disapu cepat berhenti bisa disapu. */
+function tautanTugasSprint(tugas) {
+  if (!tugas.layar) return "";
+  const fitur = FITUR_LAYAR[tugas.layar];
+  if (fitur && !bolehLihat(fitur)) return "";
+  return `<a class="bs-todo-layar" href="${esc(tugas.layar)}">${
+    esc(NAMA_LAYAR[tugas.layar] || tugas.layar)}</a>`;
+}
+
+/** Satu tugas: kotak centang, teksnya, seksinya, dan jejak siapa mencentang.
+ *
+ *  Kotak centang DI DALAM <label> bersama teksnya, jadi seluruh kalimat jadi
+ *  sasaran ketukan. Di HP, kotak 20px yang berdiri sendiri di antara seratus
+ *  baris adalah sasaran yang meleset. */
+function tugasSprintHtml(tugas) {
+  return `<li class="bs-todo-item" data-tugas="${esc(tugas.kode)}">
+    <label class="bs-todo-baris">
+      <input type="checkbox" class="checkbox bs-todo-kotak"
+             data-tugas="${esc(tugas.kode)}">
+      <span class="bs-todo-teks">${esc(tugas.teks)}</span>
+    </label>
+    <div class="bs-todo-kaki">
+      <span class="bs-pil">${esc(tugas.seksi)}</span>
+      ${tautanTugasSprint(tugas)}
+      <span class="bs-todo-jejak" data-jejak="${esc(tugas.kode)}"></span>
     </div>
-    <p class="bs-bulan-fokus">${esc(bulan.fokus)}</p>
-    <div class="bs-bulan-kolom">
-      <div>
-        <h4>Tonggak</h4>
-        <ul class="bs-poin">${bulan.tonggak.map(x =>
-          `<li>${esc(x)}</li>`).join("")}</ul>
-      </div>
-      <div>
-        <h4>Di sistem</h4>
-        <ul class="bs-poin">${bulan.sistem.map(x =>
-          `<li>${esc(x)}</li>`).join("")}</ul>
+  </li>`;
+}
+
+/** Satu sprint. */
+function sprintHtml(sprint) {
+  return `<section class="card bs-sprint" id="bs-sprint-${esc(sprint.kode)}">
+    <div class="bs-sprint-kepala">
+      <span class="bs-sprint-urut">${esc(String(sprint.nomor))}</span>
+      <div class="bs-sprint-judul">
+        <div class="bs-sprint-baris">
+          <span class="bs-sprint-tajuk">${esc(sprint.tajuk)}</span>
+          <span class="bs-sprint-kemajuan"
+                data-kemajuan="${esc(sprint.kode)}"></span>
+        </div>
+        <!-- Tiga patokan waktu, dan yang ketiga yang membuat papan ini masih
+             berguna tahun depan: bulan boleh bergeser, hitungan mundur dari
+             hari-H tidak. -->
+        <div class="bs-sprint-waktu">${esc(sprint.bulan)} · ${
+          esc(sprint.rentang)} · ${esc(sprint.mundur)}</div>
       </div>
     </div>
-    <p class="bs-bulan-seksi">${bulan.seksi.map(x =>
-      `<span class="bs-pil">${esc(x)}</span>`).join("")}</p>
-    <p class="bs-kenapa bs-jangan">${esc(bulan.jangan)}</p>
+    <p class="bs-sprint-fokus">${esc(sprint.fokus)}</p>
+    <ul class="bs-todo">${sprint.tugas.map(tugasSprintHtml).join("")}</ul>
+    <p class="bs-sprint-hasil"><strong>Selesai kalau:</strong> ${
+      esc(sprint.hasil)}</p>
+    <p class="bs-kenapa bs-jangan">${esc(sprint.jangan)}</p>
   </section>`;
+}
+
+/** Gambar ulang kotak centang, jejak, dan lencana kemajuan dari `centangSprint`.
+ *
+ *  MENYENTUH SEL YANG SUDAH ADA, tidak membangun ulang papannya. Membangun
+ *  ulang akan memindahkan kotak tepat sebelum jempol turun, dan melempar
+ *  gulirannya ke atas di tengah rapat — persis alasan layar lain berhenti
+ *  menggambar ulang pada `visibilitychange`. */
+function segarkanPapanSprint() {
+  const papan = document.getElementById("bs-panel-sprint");
+  if (!papan) return;
+
+  for (const kotak of papan.querySelectorAll("[data-tugas].bs-todo-kotak")) {
+    const c = centangSprint.get(kotak.dataset.tugas);
+    kotak.checked = !!c;
+    kotak.closest(".bs-todo-item")?.classList.toggle("bs-todo-selesai", !!c);
+  }
+  for (const jejak of papan.querySelectorAll("[data-jejak]")) {
+    const c = centangSprint.get(jejak.dataset.jejak);
+    /* Jejak dibiarkan KOSONG kalau belum dicentang, bukan diisi "belum".
+       Seratus tujuh baris "belum" adalah seratus tujuh baris yang tidak
+       mengatakan apa-apa, dan yang dicari mata justru yang sudah selesai. */
+    jejak.textContent = c
+      ? `${c.dicentang_oleh || "panitia"} · ${berapaLalu(c.dicentang_pada)}`
+      : "";
+  }
+  for (const lencana of papan.querySelectorAll("[data-kemajuan]")) {
+    const sprint = SPRINT.find(s => s.kode === lencana.dataset.kemajuan);
+    if (!sprint) continue;
+    const selesai = sprint.tugas.filter(t => centangSprint.has(t.kode)).length;
+    const penuh = selesai === sprint.tugas.length;
+    lencana.className = `badge bs-sprint-kemajuan ${
+      penuh ? "badge-green" : "badge-kemajuan"}`;
+    lencana.textContent = `${selesai}/${sprint.tugas.length}`;
+  }
+
+  const ringkas = document.getElementById("bs-sprint-ringkas");
+  if (ringkas) {
+    const semua = tugasSprint();
+    const selesai = semua.filter(x => centangSprint.has(x.tugas.kode)).length;
+    ringkas.textContent = centangSprintTerbaca
+      ? `${selesai} dari ${semua.length} tugas selesai.`
+      : "Centang belum terbaca — papan ini tetap bisa dibaca, tetapi yang "
+        + "tercentang belum tentu tergambar.";
+    ringkas.classList.toggle("bs-sprint-putus", !centangSprintTerbaca);
+  }
+}
+
+/** Ambil centang dari server lalu gambar ulang. Gagalnya ditelan.
+ *
+ *  Sengaja TIDAK melempar dan tidak memanggil notif(): membuka buku panduan
+ *  saat sinyal mati adalah hal yang wajar dilakukan orang, dan kotak merah
+ *  yang muncul tiap kali bukunya dibuka mengajari orang menutupnya tanpa
+ *  membaca. Yang memberitahukannya satu baris kecil di kepala papan. */
+async function muatCentangSprint() {
+  try {
+    const baris = await daftarCentangSprint();
+    centangSprint = new Map((baris || []).map(x => [x.kode, x]));
+    centangSprintTerbaca = true;
+  } catch {
+    centangSprintTerbaca = false;
+  }
+  segarkanPapanSprint();
 }
 
 function layarBukuSakti() {
@@ -10808,7 +10939,10 @@ function layarBukuSakti() {
         </nav>`}
       </div>
       ${b.kode === "timeline"
-        ? `<div class="bs-timeline">${TIMELINE.map(bulanBukuHtml).join("")}</div>`
+        ? `<div class="bs-timeline" id="bs-panel-sprint">
+             <p class="description" id="bs-sprint-ringkas"></p>
+             ${SPRINT.map(sprintHtml).join("")}
+           </div>`
         : b.bagian.map(bagianBukuHtml).join("")}
     </div>`).join("");
 
@@ -10849,7 +10983,7 @@ function layarBukuSakti() {
           b === bab ? ' aria-current="page"' : ""}>
           ${esc(b.tab)}
           <span class="tab-hitung">${esc(String(
-            b.kode === "timeline" ? TIMELINE.length : b.bagian.length))}</span>
+            b.kode === "timeline" ? SPRINT.length : b.bagian.length))}</span>
         </a>`).join("")}
     </nav>
 
@@ -10897,19 +11031,6 @@ function layarBukuSakti() {
     setTimeout(() => gulirKe(tujuan), 0);
   }
 
-  LAYAR.addEventListener("click", (ev) => {
-    const ke = ev.target.closest(".bs-ke");
-    if (ke) { gulirKe(ke.dataset.ke); return; }
-    const hasil = ev.target.closest(".bs-hasil-butir");
-    if (!hasil) return;
-    /* Hasil cari boleh menunjuk bab lain, dan berpindah bab mengganti hash.
-       Kalau bab-nya SAMA, hash-nya tidak berubah dan hashchange tidak pernah
-       datang — jadi gulirnya dikerjakan langsung di sini. */
-    if (hasil.dataset.bab === bab.kode) { gulirKe(hasil.dataset.ke); return; }
-    bagianDitujuBuku = hasil.dataset.ke;
-    location.hash = `#/buku-sakti/${hasil.dataset.bab}`;
-  }, { signal: sinyal });
-
   /* KOTAK CARI MENYAPU SELURUH BUKU, bukan bab yang sedang terbuka.
 
      Yang mengetik "gembok" tidak tahu — dan tidak perlu tahu — bahwa gembok
@@ -10924,8 +11045,8 @@ function layarBukuSakti() {
       return;
     }
     const bagian = cariBagian(kata);
-    const bulan = cariBulan(kata);
-    const jumlah = bagian.length + bulan.length;
+    const sprint = cariSprint(kata);
+    const jumlah = bagian.length + sprint.length;
     elSemua.hidden = true;
     elHasil.hidden = false;
     elHasil.replaceChildren(h(`<div>
@@ -10940,28 +11061,108 @@ function layarBukuSakti() {
               esc(b.judul)}</span>
             <span class="bs-hasil-judul">${esc(g.judul)}</span>
           </button></li>`).join("")}
-        ${bulan.map(bl => `
+        ${sprint.map(sp => `
           <li><button type="button" class="bs-hasil-butir"
-                      data-bab="timeline" data-ke="bs-bulan-${esc(bl.kode)}">
-            <span class="bs-hasil-bab">Timeline</span>
-            <span class="bs-hasil-judul">${esc(bl.bulan)} — ${esc(bl.tajuk)}</span>
+                      data-bab="timeline" data-ke="bs-sprint-${esc(sp.kode)}">
+            <span class="bs-hasil-bab">Sprint ${esc(String(sp.nomor))} · ${
+              esc(sp.bulan)} ${esc(sp.rentang)}</span>
+            <span class="bs-hasil-judul">${esc(sp.tajuk)}</span>
           </button></li>`).join("")}
       </ul>
     </div>`));
   };
   elCari.addEventListener("input", saring, { signal: sinyal });
 
-  /* Cetak Bab Ini pada tab Timeline mencetak TIMELINE-nya, bukan halaman
-     kosong: bab itu memang tidak punya `bagian`, dan tombol yang berbunyi
-     "Cetak Bab Ini" lalu mengeluarkan satu lembar sampul adalah tombol yang
-     berbohong. */
+  /* KOTAK CENTANG PAPAN SPRINT.
+
+     Bentuknya sama persis dengan matriks hak di layar Akun, dan itu disengaja
+     — panitia yang sudah pernah mencentang di sana tidak perlu belajar apa
+     pun yang baru:
+
+       diredupkan selagi disimpan, BUKAN di-disable (.checkbox.saving);
+       ketukan beruntun DIANTREKAN, bukan diblokir, supaya salah centang bisa
+         langsung dibatalkan;
+       ditolak server = kotaknya DIKEMBALIKAN, karena kotak yang tetap
+         tercentang padahal servernya menolak adalah kebohongan yang baru
+         ketahuan besok.
+
+     Satu antrean untuk SELURUH papan: dua ketukan pada tugas yang sama harus
+     mendarat urut, dan urutan itulah yang menentukan keadaan akhirnya. */
+  let antreCentang = Promise.resolve();
+  LAYAR.addEventListener("change", (ev) => {
+    const kotak = ev.target.closest(".bs-todo-kotak");
+    if (!kotak) return;
+    const kode = kotak.dataset.tugas;
+    const mau = kotak.checked;
+    kotak.classList.add("saving");
+    kotak.closest(".bs-todo-item")?.classList.toggle("bs-todo-selesai", mau);
+    antreCentang = antreCentang.then(async () => {
+      try {
+        await setCentangSprint(kode, mau);
+        /* Jejaknya dibaca ULANG dari server, tidak ditebak di sini. Yang
+           tercatat siapa yang MENYELESAIKAN — dan kalau orang lain sudah
+           mencentangnya lebih dulu, yang benar namanya, bukan nama kita. */
+        await muatCentangSprint();
+      } catch (e) {
+        kotak.checked = !mau;
+        kotak.closest(".bs-todo-item")?.classList.toggle("bs-todo-selesai", !mau);
+        notif(e instanceof ErrorApi ? e.message : "Centang gagal disimpan.", true);
+      } finally {
+        kotak.classList.remove("saving");
+      }
+    });
+  }, { signal: sinyal });
+
+  /* Dimuat SESUDAH layarnya tergambar, dan tanpa await: papan sprint muncul
+     seketika dengan kotak kosong, lalu terisi. Membalik urutannya berarti
+     seluruh buku menunggu satu permintaan jaringan yang boleh saja tidak
+     pernah dijawab. */
+  segarkanPapanSprint();
+  muatCentangSprint();
+
+  LAYAR.addEventListener("click", (ev) => {
+    const ke = ev.target.closest(".bs-ke");
+    if (ke) { gulirKe(ke.dataset.ke); return; }
+    const hasil = ev.target.closest(".bs-hasil-butir");
+    if (!hasil) return;
+
+    /* KOTAK CARI DIKOSONGKAN LEBIH DULU, dan itu bukan kerapian.
+
+       Selama mencari, `#bs-panel-semua` disembunyikan — seluruh isi buku ada
+       di dalamnya. `scrollIntoView()` pada elemen di dalam `display: none`
+       tidak melakukan apa pun dan tidak melempar apa pun, jadi mengetuk hasil
+       cari yang bagiannya ada di bab yang SEDANG terbuka terasa seperti
+       tombol mati. Persis itu yang terjadi sebelum baris ini ada.
+
+       saring() dipanggil, bukan `hidden` yang disetel tangan: yang memutuskan
+       panel mana terlihat cuma satu fungsi, dan dua tempat yang memutuskan
+       hal yang sama adalah dua tempat yang suatu hari tidak sepakat. */
+    elCari.value = "";
+    saring();
+
+    /* Berpindah bab mengganti hash, dan penggambaran ulanglah yang menggulir
+       — lewat bagianDitujuBuku. Kalau babnya SAMA, hash-nya tidak berubah,
+       hashchange tidak pernah datang, dan tidak ada penggambaran ulang: di
+       situ gulirnya harus dikerjakan langsung. */
+    if (hasil.dataset.bab === bab.kode) { gulirKe(hasil.dataset.ke); return; }
+    bagianDitujuBuku = hasil.dataset.ke;
+    location.hash = `#/buku-sakti/${hasil.dataset.bab}`;
+  }, { signal: sinyal });
+
+  /* SATU PARAMETER, SATU ARTI: bab yang dicetak, atau null untuk seluruhnya.
+
+     Sebelumnya dua — `(babSatu, ikutTimeline)` — dan `babSatu === null` sudah
+     dipakai untuk arti "semua bab". Akibatnya papan sprint tidak punya cara
+     diungkapkan sama sekali: "Cetak Bab Ini" di tab Sprint memanggil
+     `(null, true)`, argumen yang SAMA PERSIS dengan tombol di sebelahnya,
+     dan yang keluar seluruh buku. Tombolnya melakukan kebalikan dari
+     namanya, tanpa satu pun galat. */
   document.getElementById("bs-cetak-bab").addEventListener("click", () => {
-    const sendiri = bab.kode === "timeline";
-    siapkanCetakBuku(sendiri ? null : bab, sendiri);
+    siapkanCetakBuku(bab);
     window.print();
   }, { signal: sinyal });
   document.getElementById("bs-cetak-semua").addEventListener("click", () => {
-    siapkanCetakBuku(null, true);
+    siapkanCetakBuku(null);
     window.print();
   }, { signal: sinyal });
 }
@@ -10996,26 +11197,33 @@ function blokBukuCetak(blok) {
     blok.teks ? ` — ${esc(blok.teks)}` : ""}</p>`;
 }
 
-function siapkanCetakBuku(babSatu, ikutTimeline) {
+function siapkanCetakBuku(babSatu) {
   document.getElementById("cetakan")?.remove();
   const dicetak = tanggalJam(new Date().toISOString());
   const judulEdisi = EDISI ? EDISI.name : "HRCD";
-  const babCetak = babSatu ? [babSatu] : BUKU_SAKTI.filter(b => b.bagian.length);
-  const timeline = !!(ikutTimeline && TIMELINE.length);
+
+  /* SATU DAFTAR BAB, dan papan sprint ikut di dalamnya sebagai bab biasa.
+     `babSatu` null berarti seluruh buku; selain itu tepat satu bab — termasuk
+     kalau yang dipilih papan sprint. Tidak ada sentinel yang memikul dua arti
+     di sini (lihat komentar di tombolnya). */
+  const babCetak = babSatu ? [babSatu] : BUKU_SAKTI;
+  const babBacaan = babCetak.filter(b => b.bagian.length);
+  const adaSprint = babCetak.some(b => b.kode === "timeline") && SPRINT.length > 0;
 
   const daftarIsi = `
     <h2>Daftar Isi</h2>
-    ${babCetak.map(b => `
+    ${babBacaan.map(b => `
       <p class="bs-cetak-isi-bab">Bab ${esc(String(nomorBabBuku(b)))} — ${
         esc(b.judul)}</p>
       <ul class="bs-cetak-isi">${b.bagian.map(g =>
         `<li>${esc(g.judul)}</li>`).join("")}</ul>`).join("")}
-    ${timeline ? `
-      <p class="bs-cetak-isi-bab">Timeline Satu Edisi</p>
-      <ul class="bs-cetak-isi">${TIMELINE.map(bl =>
-        `<li>${esc(bl.bulan)} — ${esc(bl.tajuk)}</li>`).join("")}</ul>` : ""}`;
+    ${adaSprint ? `
+      <p class="bs-cetak-isi-bab">Papan Sprint Satu Edisi</p>
+      <ul class="bs-cetak-isi">${SPRINT.map(sp =>
+        `<li>Sprint ${esc(String(sp.nomor))} · ${esc(sp.bulan)} ${
+          esc(sp.rentang)} — ${esc(sp.tajuk)}</li>`).join("")}</ul>` : ""}`;
 
-  const halamanBab = babCetak.map(b => `
+  const halamanBab = babBacaan.map(b => `
     <section class="print-page">
       <h1>Bab ${esc(String(nomorBabBuku(b)))} — ${esc(b.judul)}</h1>
       <p class="bs-cetak-ringkas">${esc(b.ringkas)}</p>
@@ -11026,32 +11234,45 @@ function siapkanCetakBuku(babSatu, ikutTimeline) {
         </section>`).join("")}
     </section>`).join("");
 
-  /* RINGKASAN ENAM BULAN DALAM SATU TABEL, lalu rinciannya.
-     Tabel itu yang ditempel di dinding sekretariat; rinciannya yang dibaca
-     saat bulannya tiba. Keduanya dicetak karena keduanya dipakai berbeda. */
-  const halamanTimeline = !timeline ? "" : `
+  /* KOTAK CENTANG DICETAK KOSONG, SELALU — tidak peduli apa yang tercentang
+     di layar.
+
+     Kertas ini ditempel di dinding sekretariat dan dicentang pakai pulpen
+     sepanjang enam bulan. Mencetak keadaan hari ini membuatnya jadi POTRET,
+     dan potret yang ditempel di dinding berhenti benar keesokan harinya
+     sementara kotak-kotak yang sudah tercetak hitam tidak bisa dibatalkan
+     lagi oleh siapa pun.
+
+     Kotaknya juga tetap PUTIH dan kosong — CLAUDE.md 8.7 melarang apa pun di
+     belakang area yang ditulisi tangan. */
+  const halamanSprint = !adaSprint ? "" : `
     <section class="print-page">
-      <h1>Timeline Satu Edisi</h1>
+      <h1>Papan Sprint Satu Edisi</h1>
+      <p class="bs-cetak-ringkas">Tiga belas sprint dua mingguan. Tanggalnya
+        dihitung mundur dari hari-H, jadi papan ini tetap berlaku pada edisi
+        yang bulannya bergeser. Kotaknya sengaja tercetak kosong: yang di
+        layar berubah tiap hari, yang di dinding dicentang pakai pulpen.</p>
       <table class="print-table">
-        <thead><tr><th>Bulan</th><th>Tajuk</th><th>Fokus</th></tr></thead>
-        <tbody>${TIMELINE.map(bl => `<tr>
-          <td>${esc(bl.bulan)}</td>
-          <td>${esc(bl.tajuk)}</td>
-          <td>${esc(bl.fokus)}</td></tr>`).join("")}</tbody>
+        <thead><tr><th>Sprint</th><th>Waktu</th><th>Tajuk</th><th>Tugas</th></tr></thead>
+        <tbody>${SPRINT.map(sp => `<tr>
+          <td class="text-center">${esc(String(sp.nomor))}</td>
+          <td>${esc(sp.bulan)} ${esc(sp.rentang)}<br>${esc(sp.mundur)}</td>
+          <td>${esc(sp.tajuk)}</td>
+          <td class="text-center">${esc(String(sp.tugas.length))}</td></tr>`).join("")}</tbody>
       </table>
-      ${TIMELINE.map(bl => `
+      ${SPRINT.map(sp => `
         <section class="bs-cetak-bagian">
-          <h2>${esc(bl.bulan)} — ${esc(bl.tajuk)}</h2>
-          <p>${esc(bl.fokus)}</p>
-          <p class="bs-cetak-label">Tonggak</p>
-          <ul class="bs-poin">${bl.tonggak.map(x =>
-            `<li>${esc(x)}</li>`).join("")}</ul>
-          <p class="bs-cetak-label">Di sistem</p>
-          <ul class="bs-poin">${bl.sistem.map(x =>
-            `<li>${esc(x)}</li>`).join("")}</ul>
-          <p class="bs-cetak-label">Seksi yang paling sibuk</p>
-          <p>${esc(bl.seksi.join(" · "))}</p>
-          <p class="bs-kenapa">${esc(bl.jangan)}</p>
+          <h2>Sprint ${esc(String(sp.nomor))} — ${esc(sp.tajuk)}</h2>
+          <p class="bs-cetak-waktu">${esc(sp.bulan)} ${esc(sp.rentang)} · ${
+            esc(sp.mundur)}</p>
+          <p>${esc(sp.fokus)}</p>
+          <ul class="bs-cetak-todo">${sp.tugas.map(t => `
+            <li><span class="bs-cetak-kotak"></span>
+              <span class="bs-cetak-todo-teks">${esc(t.teks)}
+                <em>${esc(t.seksi)}</em></span></li>`).join("")}</ul>
+          <p class="bs-cetak-label">Selesai kalau</p>
+          <p>${esc(sp.hasil)}</p>
+          <p class="bs-kenapa">${esc(sp.jangan)}</p>
         </section>`).join("")}
     </section>`;
 
@@ -11064,7 +11285,7 @@ function siapkanCetakBuku(babSatu, ikutTimeline) {
       <p class="print-note">Dicetak ${esc(dicetak)}.</p>
     </section>
     ${halamanBab}
-    ${halamanTimeline}
+    ${halamanSprint}
   </div>`));
 }
 
@@ -11137,7 +11358,24 @@ async function arahkan() {
   await lengkapiHakSesi();
   if (!EDISI) {
     try { EDISI = await infoEdisi(); }
-    catch (e) { layarButuhEdisi("Sistem Panitia"); return; }
+    catch (e) {
+      /* BUKU SAKTI LEWAT, layar lain tidak.
+
+         Setiap layar lain menggambar data edisi — biaya, jam berangkat, nama
+         edisi di kepala tabel — jadi tanpa baris edisi yang tergambar cuma
+         angka yang salah. Buku Sakti tidak membaca satu baris data pun:
+         isinya berkas statis yang sudah ikut termuat bersama app.js.
+
+         Dan justru di sinilah ia paling dibutuhkan. Sinyal mati di pos,
+         Supabase tidak terjangkau, dan yang dicari orang adalah halaman yang
+         mengatakan apa yang harus dikerjakan. Menahannya di balik pagar ini
+         membuat buku panduan menghilang tepat pada keadaan yang paling
+         membutuhkannya — dan janji itu tertulis di kepala buku-sakti.mjs,
+         jadi tanpa baris ini janjinya bohong. */
+      if (pangkalRute(location.hash) !== "#/buku-sakti") {
+        layarButuhEdisi("Sistem Panitia"); return;
+      }
+    }
   }
   // Alamat lamanya `#/akun`, dan itu masih duduk di riwayat browser dan
   // bookmark panitia. Dialihkan, bukan didiamkan: rute yang tidak dikenal
@@ -11150,7 +11388,7 @@ async function arahkan() {
   (RUTE[pangkalRute(location.hash)] || layarHome)();
 }
 
-// Tiga aksi yang sama dipasang di DUA tempat: tombol header (layar lebar)
+// EMPAT aksi yang sama dipasang di DUA tempat: tombol header (layar lebar)
 // dan menu bawah (HP). Dideklarasikan lebih dulu supaya tidak ada listener
 // yang menunjuk const yang belum terisi.
 const keHome = () => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -46,6 +46,8 @@ import { esc, h, html, rupiah, jamMenit, tanggalPanjang, tanggalJam, notif, kapi
 import { hitungRekomendasiKloter, jadwalPlanning } from "./departure-calculator.mjs";
 import { deretCocok, deretIntern, nomorStok, pesanDeret }
   from "./nomor-dada-series.mjs";
+import { BUKU_SAKTI, TIMELINE, FITUR_NAMA, cariBagian, cariBulan }
+  from "./buku-sakti.mjs";
 
 const LAYAR = document.getElementById("layar");
 
@@ -529,6 +531,20 @@ async function layarHome() {
           <div class="function-name">${ikonKotak("trophy", "jingga")} Kejuaraan</div>
         </a>` : ""}
       </div>
+      <a class="bs-pintu" href="#/buku-sakti">
+        ${ikon("book-open", "ikon bs-pintu-ikon")}
+        <span class="bs-pintu-teks">
+          <span class="bs-pintu-nama">Buku Sakti</span>
+          <!-- Glosnya DIPERTAHANKAN, dan itu bukan pelanggaran bagian 9.9.
+               Aturan itu melarang menjelaskan nama yang sudah mengatakan
+               dirinya sendiri — "Pendaftaran", "Keberangkatan". "Buku Sakti"
+               adalah NAMA, bukan keterangan: ia tidak menyebut satu pun dari
+               tiga hal yang ada di dalamnya, dan yang baru pertama melihatnya
+               tidak punya cara menduga. -->
+          <span class="bs-pintu-ket">Cara menjalankan HRCD, tugas pokok tiap
+            seksi, dan timeline satu edisi.</span>
+        </span>
+      </a>
 `));
     return;
   }
@@ -642,6 +658,33 @@ async function layarHome() {
         <div class="function-name">${ikonKotak("settings", "abu")} Kalkulator Keberangkatan</div>
       </a>` : ""}
     </div>
+
+    <!-- BUKAN UBIN KELIMA BELAS, dan itu keputusan warna sebelum keputusan
+         tata letak. Tiap ubin di papan ini punya rona sendiri supaya jempol
+         bisa menuju "yang jingga" tanpa mengeja namanya, dan keempat belas
+         rona yang jaraknya cukup jauh sudah habis terpakai. Ubin kelima belas
+         berarti dua ubin serona — dan sejak itu warnanya berhenti menandai
+         apa pun, untuk keempat belas ubin sekaligus, bukan cuma yang baru.
+
+         Jadi ia berdiri DI BAWAH grid sebagai pita selebar papan: terlihat
+         tanpa dicari, tidak ikut kode warna, dan tidak menggeser satu pun
+         ubin yang tangan panitia sudah hafal letaknya. Hak aksesnya sengaja
+         tidak diperiksa — alasannya di kepala bagian BUKU SAKTI. -->
+
+      <a class="bs-pintu" href="#/buku-sakti">
+        ${ikon("book-open", "ikon bs-pintu-ikon")}
+        <span class="bs-pintu-teks">
+          <span class="bs-pintu-nama">Buku Sakti</span>
+          <!-- Glosnya DIPERTAHANKAN, dan itu bukan pelanggaran bagian 9.9.
+               Aturan itu melarang menjelaskan nama yang sudah mengatakan
+               dirinya sendiri — "Pendaftaran", "Keberangkatan". "Buku Sakti"
+               adalah NAMA, bukan keterangan: ia tidak menyebut satu pun dari
+               tiga hal yang ada di dalamnya, dan yang baru pertama melihatnya
+               tidak punya cara menduga. -->
+          <span class="bs-pintu-ket">Cara menjalankan HRCD, tugas pokok tiap
+            seksi, dan timeline satu edisi.</span>
+        </span>
+      </a>
   `));
 }
 
@@ -10579,6 +10622,452 @@ async function layarCekNilai() {
   await muatPos();
 }
 
+/* ============================== BUKU SAKTI ===============================
+
+   Buku pegangan yang diserahkan ke kepanitiaan berikutnya. Isinya tinggal di
+   buku-sakti.mjs sebagai data; layar ini cuma menggambarnya dan menyiapkan
+   versi cetaknya.
+
+   TIDAK ADA PAGAR HAK AKSES DI PINTUNYA, dan itu keputusan, bukan kelalaian.
+   Buku ini menjelaskan pekerjaan SELURUH panitia, dan yang paling butuh
+   membacanya justru yang haknya paling sempit: juri pos yang baru pertama
+   memegang lembar nilai, petugas meja yang dipindah pagi itu juga. Mengikat
+   buku ke satu centang berarti orang-orang itu yang tidak bisa membukanya.
+
+   Yang dijaga hak akses adalah DATA. Buku ini tidak memuat satu baris data
+   pun — tidak ada nama regu, tidak ada nilai, tidak ada nomor WA pembina.
+
+   TAUTAN DI DALAMNYA TETAP IKUT HAK. Blok "layar" menyebut fitur yang
+   dibutuhkan, dan yang tidak memegangnya melihat kotak yang sama tanpa
+   tautan, lengkap dengan nama centang yang harus diminta ke admin. Tautan
+   yang berujung pada kartu "tidak berhak" mengajari orang bahwa buku ini
+   tidak bisa dipercaya, dan buku panduan yang tidak dipercaya sama saja
+   dengan tidak ada.
+   ========================================================================= */
+
+/** Bagian yang harus digulir ke tempatnya SESUDAH layar digambar ulang.
+ *
+ *  Daftar isi dan hasil cari sama-sama bisa menunjuk bagian di bab LAIN, dan
+ *  berpindah bab berarti hash berganti, arahkan() jalan, dan seluruh DOM
+ *  dibangun ulang. Elemen tujuannya belum ada saat tombolnya diketuk, jadi
+ *  yang bisa dititipkan lintas penggambaran cuma kodenya. */
+let bagianDitujuBuku = null;
+
+/** Nomor bab untuk dibaca manusia: "Bab 2". Diambil dari urutannya di
+ *  BUKU_SAKTI, bukan disimpan di datanya — dua tempat yang menyimpan urutan
+ *  yang sama adalah dua tempat yang suatu hari tidak sepakat. */
+const nomorBabBuku = (bab) => BUKU_SAKTI.indexOf(bab) + 1;
+
+/** Satu blok isi jadi markup layar.
+ *
+ *  esc() di SETIAP sisipan. Teks buku ini memang ditulis panitia sendiri,
+ *  tapi "ditulis orang yang kita percaya" bukan alasan yang bertahan: satu
+ *  tanda kurang-dari di tengah kalimat sudah cukup membuang sisa paragrafnya,
+ *  tanpa satu pun galat, dan yang menemukannya pembaca yang kehilangan
+ *  separuh halaman. */
+function blokBuku(blok) {
+  switch (blok.jenis) {
+    case "p":
+      return `<p>${esc(blok.teks)}</p>`;
+    case "poin":
+      return `<ul class="bs-poin">${
+        blok.butir.map(x => `<li>${esc(x)}</li>`).join("")}</ul>`;
+    case "langkah":
+      return `<ol class="bs-langkah">${
+        blok.butir.map(x => `<li>${esc(x)}</li>`).join("")}</ol>`;
+    case "tabel":
+      /* DUA hal yang membuat tabel ini terbaca di HP, dan keduanya wajib.
+
+         `data-label` membawa nama kolomnya, karena di bawah 900px `<thead>`
+         disembunyikan dan sel tanpa label kehilangan artinya sama sekali —
+         isi yang berdiri sendiri tanpa nama kolomnya.
+
+         `data-baris` yang MENYALAKAN rupa kartunya. Tanpa atribut itu barisnya
+         tetap dipecah jadi blok bertumpuk (aturan `.data-table:not(
+         .table-tetap)`), tetapi tidak mendapat kotak, jarak, maupun awalan
+         nama kolom — yang tergambar deretan potongan teks telanjang, dan
+         labelnya justru tidak ikut. Nilainya cuma nomor urut: seluruh aturan
+         di style.css memakainya sebagai penanda ADA, bukan membaca isinya. */
+      return `<div class="bs-tabel-bungkus">
+        <table class="table data-table bs-tabel">
+          <thead><tr>${blok.kepala.map(k => `<th>${esc(k)}</th>`).join("")}</tr></thead>
+          <tbody>${blok.baris.map((baris, n) => `<tr data-baris="${n}">${
+            baris.map((sel, i) => `<td data-label="${esc(blok.kepala[i] || "")}">${
+              esc(sel)}</td>`).join("")}</tr>`).join("")}</tbody>
+        </table></div>`;
+    case "kenapa":
+      return `<p class="bs-kenapa">${esc(blok.teks)}</p>`;
+    case "layar":
+      return blokLayarBuku(blok);
+    default:
+      /* Jenis yang tidak dikenal DIAM, tidak melempar. Buku yang salah ketik
+         satu jenis blok tetap terbuka dan kehilangan satu blok; kalau ia
+         melempar, seluruh layar jadi kartu galat dan yang hilang seluruh
+         buku. Yang menangkap salah ketiknya tes bentuk, jauh sebelum sini. */
+      return "";
+  }
+}
+
+/** Blok "layar": kotak yang menunjuk layar sungguhan, ikut hak akun. */
+function blokLayarBuku(blok) {
+  const isi = `<span class="bs-layar-nama">${esc(blok.nama)}</span>`
+    + (blok.teks ? `<span class="bs-layar-teks">${esc(blok.teks)}</span>` : "");
+  if (!blok.fitur || bolehLihat(blok.fitur)) {
+    return `<a class="bs-layar" href="${esc(blok.hash)}">${isi}</a>`;
+  }
+  return `<div class="bs-layar bs-layar-mati">${isi}
+    <span class="bs-layar-hak">Butuh centang ${
+      esc(FITUR_NAMA[blok.fitur] || blok.fitur)} di layar Akun.</span></div>`;
+}
+
+/** Satu bagian bacaan.
+ *
+ *  TIDAK ada atribut pencarian di sini, dan itu disengaja: kotak cari
+ *  membaca DATA-nya lewat cariBagian(), bukan DOM. Menaruh salinan teksnya di
+ *  atribut akan membuat dua sumber untuk satu pertanyaan — dan yang di DOM
+ *  itu yang basi begitu bukunya disunting sementara halamannya tidak dimuat
+ *  ulang. */
+function bagianBukuHtml(bagian) {
+  return `<section class="card bs-bagian" id="bs-${esc(bagian.kode)}">
+    <h3>${esc(bagian.judul)}</h3>
+    ${bagian.isi.map(blokBuku).join("")}
+  </section>`;
+}
+
+/** Satu bulan timeline. Bentuknya sengaja berbeda dari bagian bacaan: yang
+ *  dicari orang di kalender bukan paragraf melainkan tonggak yang bisa
+ *  dicentang dan langkah sistem yang harus dikerjakan bulan itu. */
+function bulanBukuHtml(bulan, indeks) {
+  return `<section class="card bs-bulan" id="bs-bulan-${esc(bulan.kode)}">
+    <div class="bs-bulan-kepala">
+      <span class="bs-bulan-urut">${esc(String(indeks + 1))}</span>
+      <span class="bs-bulan-nama">${esc(bulan.bulan)}</span>
+      <span class="bs-bulan-tajuk">${esc(bulan.tajuk)}</span>
+    </div>
+    <p class="bs-bulan-fokus">${esc(bulan.fokus)}</p>
+    <div class="bs-bulan-kolom">
+      <div>
+        <h4>Tonggak</h4>
+        <ul class="bs-poin">${bulan.tonggak.map(x =>
+          `<li>${esc(x)}</li>`).join("")}</ul>
+      </div>
+      <div>
+        <h4>Di sistem</h4>
+        <ul class="bs-poin">${bulan.sistem.map(x =>
+          `<li>${esc(x)}</li>`).join("")}</ul>
+      </div>
+    </div>
+    <p class="bs-bulan-seksi">${bulan.seksi.map(x =>
+      `<span class="bs-pil">${esc(x)}</span>`).join("")}</p>
+    <p class="bs-kenapa bs-jangan">${esc(bulan.jangan)}</p>
+  </section>`;
+}
+
+function layarBukuSakti() {
+  /* LEBAR BIASA (760px), bukan `wide`.
+
+     Layar meja memakai 1080px supaya tabelnya muat; layar ini bacaan, dan
+     baris sepanjang 1054px membuat mata kehilangan awal baris berikutnya tiap
+     kali ia kembali ke kiri. Diukur di browser: pada lebar biasa satu baris
+     paragraf jatuh di sekitar 68 huruf — persis rentang yang nyaman dibaca
+     panjang-panjang.
+
+     Wadahnya yang dibatasi, bukan paragrafnya. Kalau `max-width` ditaruh di
+     kartu bagian saja, kartu bacaan jadi 686px sementara kepala, deret tab,
+     dan kartu bab tetap 1054px — empat tepi kiri-kanan yang tidak sejajar di
+     satu halaman, dan itu terbaca seperti tata letak yang rusak, bukan
+     seperti kolom bacaan. */
+  pasangKepala("Buku Sakti");
+  const diminta = ekorRute(location.hash);
+  const bab = BUKU_SAKTI.find(b => b.kode === diminta) || BUKU_SAKTI[0];
+
+  /* SELURUH BAB DIGAMBAR SEKALIGUS, yang tidak terpilih disembunyikan.
+
+     Isinya statis dan tidak menyentuh jaringan sama sekali, jadi harganya
+     cuma DOM — dan yang dibeli dengan itu kotak cari yang menyapu seluruh
+     buku tanpa satu pun penggambaran ulang, termasuk bab yang sedang tidak
+     terbuka. Menggambar per bab akan menuntut kotak cari punya salinan
+     teksnya sendiri, dan salinan itu yang suatu hari tidak sepakat dengan
+     yang tergambar. */
+  const panel = BUKU_SAKTI.map(b => `
+    <div class="bs-panel" data-bab="${esc(b.kode)}"${b === bab ? "" : " hidden"}>
+      <div class="card bs-bab">
+        <div class="bs-bab-kepala">
+          ${ikonKotak(b.ikon, b.warna)}
+          <div>
+            <h2>Bab ${esc(String(nomorBabBuku(b)))} — ${esc(b.judul)}</h2>
+            <p class="description">${esc(b.ringkas)}</p>
+          </div>
+        </div>
+        ${b.kode === "timeline" ? "" : `
+        <nav class="bs-isi" aria-label="Daftar isi ${esc(b.judul)}">
+          <ol>${b.bagian.map(bagian =>
+            `<li><button type="button" class="bs-ke"
+                         data-ke="bs-${esc(bagian.kode)}">${
+              esc(bagian.judul)}</button></li>`).join("")}</ol>
+        </nav>`}
+      </div>
+      ${b.kode === "timeline"
+        ? `<div class="bs-timeline">${TIMELINE.map(bulanBukuHtml).join("")}</div>`
+        : b.bagian.map(bagianBukuHtml).join("")}
+    </div>`).join("");
+
+  LAYAR.replaceChildren(h(`
+    <div class="card bs-kepala">
+      <h2>Buku Sakti — ${esc(EDISI ? EDISI.name : "HRCD")}</h2>
+      <!-- Satu kalimat, dan ia membawa fakta yang tidak ada di judulnya:
+           siapa yang menulis buku ini dan kapan ia ditulis ulang. Tanpa itu
+           pembaca tidak tahu bahwa isinya boleh — dan harus — diubah. -->
+      <p class="description">Ditulis ulang tiap serah terima jabatan oleh
+        panitia yang turun, untuk panitia yang naik.</p>
+      <div class="bs-alat">
+        <label class="visually-hidden" for="bs-cari">Cari isi buku</label>
+        <input type="search" id="bs-cari" autocomplete="off"
+               placeholder="Cari isi buku…">
+        <div class="bs-cetak">
+          <button class="button button-secondary button-small" id="bs-cetak-bab"
+                  type="button">${ikon("printer")} Cetak Bab Ini</button>
+          <button class="button button-primary button-small" id="bs-cetak-semua"
+                  type="button">${ikon("printer")} Cetak Semua</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- NAV BERISI TAUTAN, bukan role="tablist" berisi role="tab".
+         Bentuknya memang meminjam pil tab Live Score, tapi yang di sini
+         benar-benar TAUTAN: mengetuknya mengganti alamat dan menambah entri
+         Back, sementara sebuah tab tidak pindah halaman. Pembaca layar yang
+         diberi tahu "tab" lalu mendapat perpindahan halaman kehilangan
+         tempatnya. Yang menandai bab terbuka aria-current="page" — penanda
+         yang memang untuk satu tautan di antara sekelompok tautan.
+
+         (Tanpa backtick di komentar ini: ia berada DI DALAM template
+         literal, dan satu backtick menutupnya di tengah jalan.) -->
+    <nav class="tab-golongan bs-tab" aria-label="Bab">
+      ${BUKU_SAKTI.map(b => `
+        <a class="tab-gol" href="#/buku-sakti/${esc(b.kode)}"${
+          b === bab ? ' aria-current="page"' : ""}>
+          ${esc(b.tab)}
+          <span class="tab-hitung">${esc(String(
+            b.kode === "timeline" ? TIMELINE.length : b.bagian.length))}</span>
+        </a>`).join("")}
+    </nav>
+
+    <div class="card bs-hasil" id="bs-hasil" hidden></div>
+    <div id="bs-panel-semua">${panel}</div>
+  `));
+
+  /* sinyalLayarBaru(), BUKAN `pengendaliLayar.signal`.
+
+     arahkan() memanggil `pengendaliLayar.abort()` sebelum menggambar layar
+     berikutnya dan TIDAK membuat pengendali baru — yang membuatnya cuma
+     fungsi ini. Jadi sinyal yang dibaca langsung dari `pengendaliLayar` di
+     sini sudah dalam keadaan aborted, dan `addEventListener` dengan sinyal
+     seperti itu diam saja: tidak melempar, tidak memperingatkan, tidak
+     memasang apa pun.
+
+     Ditulis sepanjang ini karena gagalnya tidak terlihat. Layarnya tergambar
+     lengkap, tab-nya berpindah (itu tautan, bukan pendengar), dan yang mati
+     cuma kotak cari serta daftar isinya — dua hal yang baru dicoba orang
+     sesudah beberapa menit membaca. */
+  const sinyal = sinyalLayarBaru();
+  const elCari = document.getElementById("bs-cari");
+  const elHasil = document.getElementById("bs-hasil");
+  const elSemua = document.getElementById("bs-panel-semua");
+
+  /** Gulir ke satu bagian dan tandai sebentar supaya mata menemukannya.
+   *
+   *  Tanpa penandaan, melompat ke bagian kesebelas dari daftar isi mendarat
+   *  di tengah tembok teks yang semuanya berupa kartu putih seukuran sama,
+   *  dan yang melompat harus membaca judulnya untuk memastikan ia sampai di
+   *  tempat yang benar. */
+  const gulirKe = (id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.scrollIntoView({ block: "start", behavior: "smooth" });
+    el.classList.add("bs-sorot");
+    setTimeout(() => el.classList.remove("bs-sorot"), 1600);
+  };
+
+  if (bagianDitujuBuku) {
+    const tujuan = bagianDitujuBuku;
+    bagianDitujuBuku = null;
+    // Satu putaran ditunggu: elemennya baru saja masuk DOM dan belum punya
+    // posisi, jadi scrollIntoView() yang dipanggil sekarang mendarat di 0.
+    setTimeout(() => gulirKe(tujuan), 0);
+  }
+
+  LAYAR.addEventListener("click", (ev) => {
+    const ke = ev.target.closest(".bs-ke");
+    if (ke) { gulirKe(ke.dataset.ke); return; }
+    const hasil = ev.target.closest(".bs-hasil-butir");
+    if (!hasil) return;
+    /* Hasil cari boleh menunjuk bab lain, dan berpindah bab mengganti hash.
+       Kalau bab-nya SAMA, hash-nya tidak berubah dan hashchange tidak pernah
+       datang — jadi gulirnya dikerjakan langsung di sini. */
+    if (hasil.dataset.bab === bab.kode) { gulirKe(hasil.dataset.ke); return; }
+    bagianDitujuBuku = hasil.dataset.ke;
+    location.hash = `#/buku-sakti/${hasil.dataset.bab}`;
+  }, { signal: sinyal });
+
+  /* KOTAK CARI MENYAPU SELURUH BUKU, bukan bab yang sedang terbuka.
+
+     Yang mengetik "gembok" tidak tahu — dan tidak perlu tahu — bahwa gembok
+     dijelaskan di bab Menjalankan HRCD dan disinggung lagi di bab Seksi.
+     Kotak yang cuma menyaring bab yang kebetulan terbuka menjawab "tidak
+     ketemu" untuk kata yang jelas-jelas ada di bukunya. */
+  const saring = () => {
+    const kata = elCari.value.trim();
+    if (!kata) {
+      elHasil.hidden = true;
+      elSemua.hidden = false;
+      return;
+    }
+    const bagian = cariBagian(kata);
+    const bulan = cariBulan(kata);
+    const jumlah = bagian.length + bulan.length;
+    elSemua.hidden = true;
+    elHasil.hidden = false;
+    elHasil.replaceChildren(h(`<div>
+      <p class="description">${jumlah === 0
+        ? "Tidak ada bagian yang memuat semua kata itu."
+        : `${esc(String(jumlah))} bagian memuat semua kata itu.`}</p>
+      <ul class="bs-hasil-daftar">
+        ${bagian.map(({ bab: b, bagian: g }) => `
+          <li><button type="button" class="bs-hasil-butir"
+                      data-bab="${esc(b.kode)}" data-ke="bs-${esc(g.kode)}">
+            <span class="bs-hasil-bab">Bab ${esc(String(nomorBabBuku(b)))} · ${
+              esc(b.judul)}</span>
+            <span class="bs-hasil-judul">${esc(g.judul)}</span>
+          </button></li>`).join("")}
+        ${bulan.map(bl => `
+          <li><button type="button" class="bs-hasil-butir"
+                      data-bab="timeline" data-ke="bs-bulan-${esc(bl.kode)}">
+            <span class="bs-hasil-bab">Timeline</span>
+            <span class="bs-hasil-judul">${esc(bl.bulan)} — ${esc(bl.tajuk)}</span>
+          </button></li>`).join("")}
+      </ul>
+    </div>`));
+  };
+  elCari.addEventListener("input", saring, { signal: sinyal });
+
+  /* Cetak Bab Ini pada tab Timeline mencetak TIMELINE-nya, bukan halaman
+     kosong: bab itu memang tidak punya `bagian`, dan tombol yang berbunyi
+     "Cetak Bab Ini" lalu mengeluarkan satu lembar sampul adalah tombol yang
+     berbohong. */
+  document.getElementById("bs-cetak-bab").addEventListener("click", () => {
+    const sendiri = bab.kode === "timeline";
+    siapkanCetakBuku(sendiri ? null : bab, sendiri);
+    window.print();
+  }, { signal: sinyal });
+  document.getElementById("bs-cetak-semua").addEventListener("click", () => {
+    siapkanCetakBuku(null, true);
+    window.print();
+  }, { signal: sinyal });
+}
+
+/* ---------------------------------------------------------------------------
+   CETAK BUKU SAKTI
+
+   Buku ini digandakan di mesin fotokopi seperti seluruh kertas acara ini,
+   jadi aturan CLAUDE.md bagian 8 berlaku penuh: tidak ada blok hitam, tidak
+   ada teks terbalik, tidak ada abu dan raster, garis paling tipis 0,75pt,
+   huruf paling kecil 7pt.
+
+   SATU DOKUMEN MENGALIR PER BAB, bukan satu lembar per bagian. Empat puluh
+   bagian berarti empat puluh lembar untuk isi yang muat di belasan, dan
+   tumpukan setebal itu tidak dibaca siapa pun. Yang dijaga cuma satu bagian
+   tidak terbelah dua halaman, lewat `break-inside: avoid`.
+
+   Daftar isinya TANPA nomor halaman. Nomor halaman hanya bisa benar kalau
+   dihitung dari hasil paginasi browser, dan itu berbeda antar peranti dan
+   antar ukuran kertas — daftar isi yang menyebut halaman 12 sementara
+   bagiannya di halaman 14 lebih buruk daripada daftar isi tanpa angka sama
+   sekali.
+   --------------------------------------------------------------------------- */
+
+/** Blok isi jadi markup KERTAS. Bedanya dari blokBuku() cuma satu, dan itu
+ *  yang membuat fungsi ini ada: blok "layar" kehilangan tautannya. Alamat
+ *  `#/pembayaran` di atas kertas tidak bisa diketuk dan tidak memberi tahu
+ *  apa pun kepada yang membacanya — yang berguna tinggal nama layarnya. */
+function blokBukuCetak(blok) {
+  if (blok.jenis !== "layar") return blokBuku(blok);
+  return `<p class="bs-cetak-layar"><strong>${esc(blok.nama)}</strong>${
+    blok.teks ? ` — ${esc(blok.teks)}` : ""}</p>`;
+}
+
+function siapkanCetakBuku(babSatu, ikutTimeline) {
+  document.getElementById("cetakan")?.remove();
+  const dicetak = tanggalJam(new Date().toISOString());
+  const judulEdisi = EDISI ? EDISI.name : "HRCD";
+  const babCetak = babSatu ? [babSatu] : BUKU_SAKTI.filter(b => b.bagian.length);
+  const timeline = !!(ikutTimeline && TIMELINE.length);
+
+  const daftarIsi = `
+    <h2>Daftar Isi</h2>
+    ${babCetak.map(b => `
+      <p class="bs-cetak-isi-bab">Bab ${esc(String(nomorBabBuku(b)))} — ${
+        esc(b.judul)}</p>
+      <ul class="bs-cetak-isi">${b.bagian.map(g =>
+        `<li>${esc(g.judul)}</li>`).join("")}</ul>`).join("")}
+    ${timeline ? `
+      <p class="bs-cetak-isi-bab">Timeline Satu Edisi</p>
+      <ul class="bs-cetak-isi">${TIMELINE.map(bl =>
+        `<li>${esc(bl.bulan)} — ${esc(bl.tajuk)}</li>`).join("")}</ul>` : ""}`;
+
+  const halamanBab = babCetak.map(b => `
+    <section class="print-page">
+      <h1>Bab ${esc(String(nomorBabBuku(b)))} — ${esc(b.judul)}</h1>
+      <p class="bs-cetak-ringkas">${esc(b.ringkas)}</p>
+      ${b.bagian.map(g => `
+        <section class="bs-cetak-bagian">
+          <h2>${esc(g.judul)}</h2>
+          ${g.isi.map(blokBukuCetak).join("")}
+        </section>`).join("")}
+    </section>`).join("");
+
+  /* RINGKASAN ENAM BULAN DALAM SATU TABEL, lalu rinciannya.
+     Tabel itu yang ditempel di dinding sekretariat; rinciannya yang dibaca
+     saat bulannya tiba. Keduanya dicetak karena keduanya dipakai berbeda. */
+  const halamanTimeline = !timeline ? "" : `
+    <section class="print-page">
+      <h1>Timeline Satu Edisi</h1>
+      <table class="print-table">
+        <thead><tr><th>Bulan</th><th>Tajuk</th><th>Fokus</th></tr></thead>
+        <tbody>${TIMELINE.map(bl => `<tr>
+          <td>${esc(bl.bulan)}</td>
+          <td>${esc(bl.tajuk)}</td>
+          <td>${esc(bl.fokus)}</td></tr>`).join("")}</tbody>
+      </table>
+      ${TIMELINE.map(bl => `
+        <section class="bs-cetak-bagian">
+          <h2>${esc(bl.bulan)} — ${esc(bl.tajuk)}</h2>
+          <p>${esc(bl.fokus)}</p>
+          <p class="bs-cetak-label">Tonggak</p>
+          <ul class="bs-poin">${bl.tonggak.map(x =>
+            `<li>${esc(x)}</li>`).join("")}</ul>
+          <p class="bs-cetak-label">Di sistem</p>
+          <ul class="bs-poin">${bl.sistem.map(x =>
+            `<li>${esc(x)}</li>`).join("")}</ul>
+          <p class="bs-cetak-label">Seksi yang paling sibuk</p>
+          <p>${esc(bl.seksi.join(" · "))}</p>
+          <p class="bs-kenapa">${esc(bl.jangan)}</p>
+        </section>`).join("")}
+    </section>`;
+
+  document.body.appendChild(h(`<div id="cetakan" class="printout buku-cetak">
+    <section class="print-page">
+      <h1>BUKU SAKTI — ${esc(judulEdisi)}</h1>
+      <p class="bs-cetak-ringkas">Buku pegangan panitia. Ditulis ulang tiap
+        serah terima jabatan oleh panitia yang turun, untuk panitia yang naik.</p>
+      ${daftarIsi}
+      <p class="print-note">Dicetak ${esc(dicetak)}.</p>
+    </section>
+    ${halamanBab}
+    ${halamanTimeline}
+  </div>`));
+}
+
 /* ALAMAT BOLEH BERBUNTUT: `#/pos2/2:bakiak`.
 
    Satu-satunya yang memakainya hari ini Input Nilai Pos v2, dan alasannya
@@ -10615,6 +11104,10 @@ const RUTE = {
   "#/pengaturan-kloter": layarPengaturanKloter,
   "#/ganti-password": layarGantiPassword,
   "#/account": layarAkun,
+  // Berbuntut kode bab: `#/buku-sakti/seksi`. Itu yang membuat satu bab
+  // bisa disebut di grup panitia sebagai alamat, bukan sebagai
+  // "buka Buku Sakti lalu ketuk tab ketiga".
+  "#/buku-sakti": layarBukuSakti,
 };
 
 // Hash yang benar-benar sedang tergambar. `location.hash` sudah berisi tujuan
@@ -10670,6 +11163,14 @@ const keSetelan = () => {
 const keAkun = () => {
   if (location.hash === "#/account") arahkan(); else location.hash = "#/account";
 };
+/* Menuju Buku Sakti dari mana pun. `pangkalRute()` dipakai, bukan hash utuh:
+   alamatnya berbuntut kode bab, jadi `#/buku-sakti/seksi` juga sudah "sedang
+   di Buku Sakti" — dan tombolnya harus menggambar ulang di tempat, bukan
+   melempar pembaca kembali ke bab pertama. */
+const keBuku = () => {
+  if (pangkalRute(location.hash) === "#/buku-sakti") arahkan();
+  else location.hash = "#/buku-sakti";
+};
 const keluarSekarang = () => {
   if (!bolehMeninggalkanNilai()) return;
   // Peringatan sudah dijawab di atas; samakan penanda agar arahkan() tidak
@@ -10684,6 +11185,8 @@ document.getElementById("nav-home").addEventListener("click", keHome);
 document.getElementById("nav-setting").addEventListener("click", keSetelan);
 document.getElementById("btn-akun").addEventListener("click", keAkun);
 document.getElementById("nav-akun").addEventListener("click", keAkun);
+document.getElementById("btn-buku").addEventListener("click", keBuku);
+document.getElementById("nav-buku").addEventListener("click", keBuku);
 document.getElementById("nav-keluar").addEventListener("click", keluarSekarang);
 document.getElementById("ganti-password").addEventListener("click", keSetelan);
 window.addEventListener("hashchange", arahkan);

--- a/web/js/buku-sakti.mjs
+++ b/web/js/buku-sakti.mjs
@@ -92,6 +92,75 @@ export const FITUR_NAMA = {
 /** Kode fitur yang boleh disebut blok "layar". */
 export const FITUR_SAH = Object.keys(FITUR_NAMA);
 
+/** Centang yang membuat sebuah layar TERJANGKAU dari papan Home.
+ *
+ *  Ini pertanyaan yang BERBEDA dari `fitur` di blok "layar", dan keduanya
+ *  memang boleh berbeda untuk rute yang sama. Blok layar menjawab "apa yang
+ *  dibutuhkan untuk MELAKUKAN hal yang sedang dijelaskan paragraf ini" —
+ *  karena itu satu blok tentang saklar fase menyebut `pengaturan` sementara
+ *  blok lain tentang papan klasemen di layar yang sama menyebut `live_score`,
+ *  dan keduanya benar. Peta ini menjawab yang lebih kasar: centang mana yang
+ *  memunculkan ubinnya di Home sama sekali.
+ *
+ *  Dipakai tautan kecil di tiap tugas papan sprint, yang tidak punya ruang
+ *  untuk membedakan sehalus itu.
+ *
+ *  SALINAN YANG BERISIK, sama seperti FITUR_NAMA: tes membandingkannya
+ *  dengan syarat ubin di layarHome(). Kalau suatu edisi memindahkan sebuah
+ *  layar ke centang lain, tesnya yang memberi tahu.
+ *
+ *  `null` berarti terbuka untuk setiap panitia. */
+export const FITUR_LAYAR = {
+  "#/home":              null,
+  "#/ganti-password":    null,
+  "#/buku-sakti":        null,
+  "#/data-peserta":      "pendaftaran",
+  "#/pembayaran":        "pembayaran",
+  "#/daftar-ulang":      "daftar_ulang",
+  "#/cetak-kloter":      "cetak_kloter",
+  "#/keberangkatan":     "keberangkatan",
+  "#/finish":            "kedatangan",
+  "#/pos":               "pos",
+  "#/pos2":              "pos",
+  "#/foto":              "pos",
+  "#/cek-nilai":         "pengaturan",
+  "#/pengaturan-kloter": "pengaturan",
+  "#/live-score":        "live_score",
+  "#/kejuaraan":         "live_score",
+  "#/account":           "akun",
+};
+
+/** Nama layar seperti tertulis di kepala halamannya.
+ *
+ *  Tautan kecil di tiap tugas papan sprint memakai ini, bukan alamatnya
+ *  sendiri: "#/cetak-kloter" adalah alamat, dan yang dicari panitia yang
+ *  membaca papan adalah NAMA layar yang harus dibuka. Alamat cuma berarti
+ *  bagi yang sudah tahu isinya.
+ *
+ *  SALINAN YANG BERISIK, seperti FITUR_NAMA dan FITUR_LAYAR: tes
+ *  membandingkannya dengan pasangKepala() di app.js, jadi layar yang berganti
+ *  nama membuat tesnya gagal, bukan membuat papan sprint memanggil nama yang
+ *  sudah tidak dipakai siapa pun. */
+export const NAMA_LAYAR = {
+  "#/home":              "Home",
+  "#/ganti-password":    "Ganti Password",
+  "#/buku-sakti":        "Buku Sakti",
+  "#/data-peserta":      "Data Peserta",
+  "#/pembayaran":        "Meja Pembayaran",
+  "#/daftar-ulang":      "Meja Daftar Ulang",
+  "#/cetak-kloter":      "Daftar Kloter",
+  "#/keberangkatan":     "Keberangkatan",
+  "#/finish":            "Kedatangan",
+  "#/pos":               "Input Nilai Tabel",
+  "#/pos2":              "Input Nilai Per Lomba",
+  "#/foto":              "Foto Jawaban Sekaligus",
+  "#/cek-nilai":         "Cek Nilai",
+  "#/pengaturan-kloter": "Kalkulator Keberangkatan",
+  "#/live-score":        "Live Score",
+  "#/kejuaraan":         "Kejuaraan",
+  "#/account":           "Akun",
+};
+
 /** Rute yang boleh disebut blok "layar". Sama alasannya dengan FITUR_SAH:
  *  tautan yang salah ketik di dalam buku jatuh ke Home tanpa satu pun galat,
  *  dan yang membacanya menyimpulkan bukunya yang bohong. */
@@ -151,7 +220,7 @@ const BAB_TUTORIAL = {
           butir: [
             "Aturan penilaian adalah data, bukan kode. Tiap tahun angkanya berubah tanpa satu baris kode disentuh.",
             "Memindahkan satu lomba dari satu pos ke pos lain mengubah bobot KEDUA pos itu tanpa satu angka pun diedit.",
-            "Status migrasi sendiri baru mencakup sampai berkas 0163. Berkas yang lebih muda belum ikut diperiksa, jadi jangan membaca laporan hijau sebagai jaminan penuh.",
+            "Status migrasi memeriksa SELURUH migrasi yang ada: 116 punya sidik jari yang dicari di database, 53 sisanya tidak punya karena migrasi yang lebih muda sudah menimpa objeknya. Jumlah keduanya harus selalu sama dengan jumlah berkas migrasi — begitu ada berkas baru, angka itu yang harus ikut naik.",
           ],
         },
       ],
@@ -1090,7 +1159,7 @@ const BAB_SEKSI = {
             "Menyebarkan link form pendaftaran ke pangkalan bersama humas, dan menjawab pertanyaan pembina yang tersangkut di tengah form.",
             "Menjaga nama regu unik di seluruh acara: dua regu dari sekolah yang sama ditulis NAMA 1 dan NAMA 2, tabrakan antar sekolah dibedakan dengan ekor nama sekolah.",
             "Menjaga satu sekolah satu baris. Pembeda dua sekolah senama ditulis di dalam namanya sendiri, misalnya MAN 3 Ciamis dan MAN 3 Tasikmalaya; kalau tidak ada tabrakan, jangan tambahkan ekor apa pun.",
-            "Membetulkan salah ketik lewat Data Peserta. Yang bisa diubah di sana cuma tulisan: nama regu, nama kontak, dan nomor WA pembina. Golongan, sekolah, nomor dada, dan status bayar punya jalurnya sendiri.",
+            "Membetulkan salah ketik lewat Data Peserta: nama regu, nama ketua, keempat nama anggota, Kelas atau Organisasi, nama kontak, dan nomor WA pembina. Golongan, sekolah, nomor dada, dan status bayar TIDAK bisa diubah di sana — ketiganya punya jalurnya sendiri.",
             "Menyerahkan hitungan regu terakhir ke perlengkapan dan konsumsi begitu pendaftaran ditutup.",
             "Menyiapkan meja offline: 2 sampai 3 meja, tiap meja 1 sampai 2 orang, dengan satu laptop yang sudah login sebelum peserta datang.",
           ],
@@ -2175,7 +2244,7 @@ const BAB_KENAPA = {
       isi: [
         {
           jenis: "p",
-          teks: "Sejak pendaftaran dibuka sampai juara diumumkan, sistem ini dipakai orang sungguhan sambil kita menyuntingnya. Layar yang mati bukan bug yang dilaporkan besok, melainkan pekerjaan yang berhenti sekarang, di meja dengan antrean di depannya. Karena itu sebelum merge, buka layar yang disentuh dan HITUNG BARISNYA.",
+          teks: "Sejak pendaftaran dibuka sampai juara diumumkan, sistem ini dipakai orang sungguhan sambil kita edit. Layar yang mati bukan bug yang dilaporkan besok, melainkan pekerjaan yang berhenti sekarang, di meja dengan antrean di depannya. Karena itu sebelum merge, buka layar yang disentuh dan HITUNG BARISNYA.",
         },
         {
           jenis: "poin",
@@ -2198,207 +2267,442 @@ const BAB_KENAPA = {
     },
   ],
 };
-/* Bulan-bulan timeline. Bentuknya BERBEDA dari bab di atas, dan itu disengaja
-   — sebuah bulan bukan sebuah bagian bacaan: ia punya tonggak yang dicentang,
-   seksi yang sedang sibuk, dan satu kesalahan khas yang mahal. Memaksanya
-   masuk ke daftar blok akan mengubur keempat hal itu di dalam paragraf.
+/* PAPAN SPRINT — tiga belas sprint dua mingguan, September sampai hari-H,
+   ditutup satu sprint evaluasi.
 
-   Harganya satu percabangan di perakit layar, dan itu batas yang jelas:
-   bab dengan `bagian` digambar sebagai bacaan, bab timeline digambar sebagai
-   kalender. */
-export const TIMELINE = [
+   Bentuknya BERBEDA dari bab bacaan di atas, dan itu disengaja. Sebuah sprint
+   bukan bagian yang dibaca: ia daftar tugas yang DICENTANG, dan tiap tugas
+   punya seksi yang memegangnya. Memaksanya masuk ke daftar blok akan
+   mengubur keduanya di dalam paragraf.
+
+   TANPA SATU PUN TANGGAL KALENDER, dan itu bukan kemalasan. Tanggal lomba
+   ditetapkan di Sprint 2 — ia salah satu tugas di papan ini — jadi papan yang
+   menyebut tanggal akan berbohong tepat sampai tugas itu selesai. Yang dipakai
+   dua patokan yang tidak pernah basi: bulan beserta nomor minggunya, dan
+   hitungan mundur dari hari-H. Edisi yang jatuh di bulan lain memakai kolom
+   `mundur` dan membiarkan `bulan` sebagai contoh.
+
+   KODE TUGAS ADALAH KUNCI CENTANG DI DATABASE (migrasi 0170).
+
+   SEKALI SEBUAH KODE DIPAKAI, JANGAN PERNAH DIUBAH. Database tidak menyimpan
+   daftar tugasnya dan tidak bisa memvalidasi kodenya — ia cuma menyimpan
+   pasangan (edisi, kode). Mengganti "s6-desa" jadi "s6-surat-desa" membuat
+   centangnya menggantung: tugasnya kembali kosong, centang lamanya tetap
+   duduk di database, dan tidak ada satu pun galat yang menjelaskan kenapa.
+
+   Menambah tugas baru aman. Menghapus tugas aman. Yang tidak aman cuma
+   MENGGANTI NAMA. Kalau sebuah tugas berubah isinya, ubah `teks`-nya dan
+   biarkan kodenya — kode itu identitas, bukan judul. */
+export const SPRINT = [
   {
-    kode: "september",
+    kode: "s1",
+    nomor: 1,
     bulan: "September",
+    rentang: "Minggu 1-2",
+    mundur: "H-167 sampai H-154",
     tajuk: "Serah Terima Jabatan",
-    fokus:
-      "Kepengurusan berpindah ke angkatan berikutnya, dan panitia inti edisi baru terbentuk sebelum satu rapat besar pun digelar.",
-    tonggak: [
-      "Serah terima jabatan pengurus ambalan selesai, penanggung jawab acara ditetapkan namanya",
-      "Ketua Pelaksana, Sekretaris, dan Bendahara edisi baru ditunjuk",
-      "Evaluasi edisi sebelumnya dibaca ulang bersama, bukan disimpan",
-      "Akses diserahkan: siapa yang memegang akun admin, akun GitHub organisasi, dan password Supabase",
-      "Tanggal lomba diusulkan ke pembina dan sekolah untuk dikunci di rapat Oktober",
+    fokus: "Kepengurusan berpindah, panitia inti terbentuk, dan akses ke seluruh akun organisasi berpindah tangan sebelum satu rapat besar pun digelar.",
+    hasil: "Ketua Pelaksana, Sekretaris, dan Bendahara sudah ada namanya, dan minimal dua orang memegang password tiap akun organisasi.",
+    tugas: [
+      { kode: "s1-serah-terima", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Selesaikan serah terima jabatan pengurus ambalan dan tetapkan siapa penanggung jawab HRCD edisi ini." },
+      { kode: "s1-inti", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Tunjuk Ketua Pelaksana, Wakil, Sekretaris, dan Bendahara. Seksi selebihnya menyusul di rapat besar." },
+      { kode: "s1-akses", seksi: "Administrator Sistem", layar: null,
+        teks: "Serahkan password akun organisasi (Supabase, Cloudflare, GitHub, email ambalan) ke minimal DUA orang, dan catat siapa memegang apa di luar sistem." },
+      { kode: "s1-password", seksi: "Administrator Sistem", layar: "#/account",
+        teks: "Ganti password akun admin yang diwariskan, jangan dipakai apa adanya." },
+      { kode: "s1-evaluasi", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Baca ulang catatan evaluasi edisi lalu bersama-sama. Tiap keluhan yang berulang jadi calon tugas di sprint berikutnya." },
+      { kode: "s1-arsip", seksi: "Seksi Rekap dan Skor", layar: "#/live-score",
+        teks: "Cetak arsip edisi lalu selagi datanya masih utuh: Rekap Nilai Semua dari Live Score, dan Daftar Juara dari Kejuaraan." },
+      { kode: "s1-nonaktif", seksi: "Administrator Sistem", layar: "#/account",
+        teks: "Nonaktifkan akun panitia edisi lalu yang orangnya sudah lulus. Jangan hapus barisnya, riwayat nilai menunjuk ke sana." },
+      { kode: "s1-buku", seksi: "Ketua Pelaksana dan Wakil", layar: "#/buku-sakti",
+        teks: "Minta seluruh panitia inti membaca Buku Sakti ini sampai habis sebelum rapat besar." },
     ],
-    seksi: [
-      "Ketua Pelaksana dan Wakil",
-      "Sekretaris",
-      "Bendahara — Meja Pembayaran",
-      "Administrator Sistem",
-    ],
-    sistem: [
-      "Serahkan akun admin lama ke pengurus baru lewat workflow \"Ganti password akun panitia\" — satu akun sekali jalan, password dibuat server, diambil dari Artifact sebelum hilang tiga hari",
-      "Buka layar Akun di #/account dan nonaktifkan akun panitia edisi lalu yang orangnya sudah lulus; jangan hapus barisnya, riwayat nilai menunjuk ke sana",
-      "Buka Live Score selagi datanya masih ada, cetak lewat tombol \"Rekap Nilai Semua\", dan salin daftar juara dari layar Kejuaraan sebagai arsip kertas",
-      "Pastikan minimal dua orang tahu password akun organisasi (Supabase, Cloudflare, GitHub) — bukan satu orang, bukan akun pribadi",
-    ],
-    jangan:
-      "Jangan membersihkan data edisi lalu bulan ini — begitu dihapus, tidak ada lagi bahan evaluasi dan tidak ada contoh layar terisi untuk melatih panitia baru.",
+    jangan: "Jangan membersihkan data edisi lalu bulan ini. Begitu dihapus, tidak ada lagi bahan evaluasi dan tidak ada satu pun layar terisi untuk melatih panitia baru.",
   },
+
   {
-    kode: "oktober",
+    kode: "s2",
+    nomor: 2,
+    bulan: "September",
+    rentang: "Minggu 3-4",
+    mundur: "H-153 sampai H-140",
+    tajuk: "Tanggal dan Anggaran Dikunci",
+    fokus: "Tanggal acara ditetapkan bersama kepala sekolah dan pembina, dan dari tanggal itulah seluruh tenggat berikutnya dihitung mundur.",
+    hasil: "Tanggal lomba terkunci hitam di atas putih, dan anggaran kasar sudah punya titik impas dari uang pendaftaran saja.",
+    tugas: [
+      { kode: "s2-tanggal", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "TETAPKAN TANGGAL LOMBA bersama kepala sekolah dan pembina, lalu tulis di notulen. Seluruh tenggat di sprint berikutnya dihitung mundur dari tanggal ini." },
+      { kode: "s2-tema", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Tetapkan tema, kuota regu, dan biaya pendaftaran per regu, termasuk biaya regu Intern yang memang berbeda." },
+      { kode: "s2-rab", seksi: "Bendahara — Meja Pembayaran", layar: null,
+        teks: "Susun anggaran kasar dan hitung titik impasnya dari uang pendaftaran SAJA. Acara harus tetap jalan kalau sponsor nol." },
+      { kode: "s2-izin-prinsip", seksi: "Sekretaris", layar: null,
+        teks: "Ajukan izin prinsip kegiatan ke Kepala Sekolah selaku Ka Mabigus. Ini induk semua surat; tanpa nomornya tidak ada surat lain yang sah." },
+      { kode: "s2-proposal", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Susun proposal umum dan proposal sponsor berjenjang: sponsor utama, pendukung, dan partisipan." },
+      { kode: "s2-target-sponsor", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Susun daftar calon sponsor beserta NAMA ORANG yang akan didatangi. Alumni dan orang tua siswa yang paling sering berhasil." },
+      { kode: "s2-kalender", seksi: "Sekretaris", layar: "#/buku-sakti",
+        teks: "Salin timeline ini jadi kalender panitia dengan tanggal sungguhan, lalu tempel di sekretariat." },
+    ],
+    jangan: "Jangan menunda penetapan tanggal ke bulan depan. Setiap minggu tanggal belum pasti adalah satu minggu yang hilang dari antrean izin keramaian, dan antrean itu tidak bisa dipercepat dengan cara apa pun.",
+  },
+
+  {
+    kode: "s3",
+    nomor: 3,
     bulan: "Oktober",
-    tajuk: "Rapat Besar dan Anggaran",
-    fokus:
-      "Tema, tanggal, biaya, dan seluruh seksi dikunci dalam satu rapat besar, lalu edisi baru dibuat di database.",
-    tonggak: [
-      "Rapat besar: tema, tanggal lomba, dan biaya pendaftaran diputuskan dan dicatat notulennya",
-      "Seluruh seksi terisi namanya, lengkap dengan koordinator tiap seksi",
-      "Anggaran kasar disusun: pemasukan dari perkiraan jumlah regu, pengeluaran per seksi",
-      "Rute dan lokasi lima pos disurvei ulang, termasuk titik pos bayangan sebelum tiap pos",
-      "Kebutuhan barak dihitung dari perkiraan regu luar kota",
+    rentang: "Minggu 1-2",
+    mundur: "H-139 sampai H-126",
+    tajuk: "Rapat Besar dan Seksi Lengkap",
+    fokus: "Seluruh seksi terisi namanya, dan proposal mulai berjalan ke calon sponsor.",
+    hasil: "Tidak ada seksi tanpa koordinator, dan proposal sudah ada di tangan sepuluh calon sponsor pertama.",
+    tugas: [
+      { kode: "s3-rapat-besar", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Gelar rapat besar: tema, tanggal, biaya, dan susunan seluruh seksi diputuskan dan dinotulenkan." },
+      { kode: "s3-koordinator", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Tunjuk koordinator tiap seksi dan serahkan daftarnya ke Administrator Sistem sebelum akun dibuat." },
+      { kode: "s3-sk", seksi: "Sekretaris", layar: null,
+        teks: "Ajukan SK Panitia atau Surat Tugas ke Kepala Sekolah. Hampir semua permohonan berikutnya melampirkannya." },
+      { kode: "s3-sebar-proposal", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Datangi sepuluh calon sponsor pertama dan serahkan proposalnya LANGSUNG, jangan hanya kirim pesan." },
+      { kode: "s3-survei-1", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Jalani survei rute pertama dengan berjalan kaki penuh. Catat titik rawan: jalan raya yang harus diseberangi, jembatan, tanjakan, dan tepi sungai." },
+      { kode: "s3-foto-rute", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Rekam titik dan foto tiap calon lokasi pos untuk lampiran surat izin desa dan surat izin lahan nanti." },
+      { kode: "s3-akun-panitia", seksi: "Administrator Sistem", layar: "#/account",
+        teks: "Buat akun untuk koordinator tiap seksi di layar Akun. Pilih PERANNYA dulu, centangnya sesudahnya." },
+      { kode: "s3-buku-seksi", seksi: "Sekretaris", layar: "#/buku-sakti",
+        teks: "Minta tiap koordinator membaca bab Tugas Pokok Seksi bagian seksinya sendiri, lalu membantahnya kalau tidak cocok." },
     ],
-    seksi: [
-      "Ketua Pelaksana dan Wakil",
-      "Sekretaris",
-      "Bendahara — Meja Pembayaran",
-      "Seksi Lomba dan Juri Pos",
-      "Seksi Perlengkapan",
-    ],
-    sistem: [
-      "Susun migration edisi baru dan isi kolomnya apa adanya: nomor, nama, tahun, tanggal_lomba, biaya_per_regu, jam_mulai_berangkat, dan interval_berangkat_menit",
-      "Jalankan migration itu lewat workflow \"Apply migration to Supabase\" — merge saja tidak pernah menerapkannya",
-      "Jalankan supabase/checks/status_migrasi.sql lewat workflow yang sama, lalu baca hasilnya: yang berbunyi BELUM belum pernah hidup, dan yang tidak disebut sama sekali belum pernah diperiksa",
-      "Samakan stok nomor dada dengan kain yang benar-benar dipesan lewat supabase/checks/stok_nomor_dada.sql — dua deret, Eksternal dan Intern, dan pagar nomor dada membaca angkanya dari sana",
-      "Buka Kalkulator Keberangkatan di #/pengaturan-kloter dan lihat perkiraan jam berangkat kloter terakhir — kalau lewat 10:00, jumlah kloter atau interval_berangkat_menit yang salah, bukan jam upacaranya",
-    ],
-    jangan:
-      "Jangan menulis tanggal lomba di kode atau di skrip mana pun — seluruh perkiraan jam berangkat dihitung dari satu kolom tanggal di tabel edisi, dan tanggal yang ditulis di dua tempat akan berbeda persis saat tidak ada waktu memperbaikinya.",
+    jangan: "Jangan membuat akun panitia sebelum perannya diputuskan. Mengganti peran akan MENGHAPUS seluruh centang tangan lalu mengisinya ulang dari paket peran, tanpa peringatan.",
   },
+
   {
-    kode: "november",
+    kode: "s4",
+    nomor: 4,
+    bulan: "Oktober",
+    rentang: "Minggu 3-4",
+    mundur: "H-125 sampai H-112",
+    tajuk: "Surat Pertama Keluar",
+    fokus: "Izin prinsip dan SK panitia terbit, lalu permohonan rekomendasi Kwartir Ranting berangkat.",
+    hasil: "Ada surat sah bernomor untuk dilampirkan ke seluruh permohonan berikutnya.",
+    tugas: [
+      { kode: "s4-izin-prinsip-terbit", seksi: "Sekretaris", layar: null,
+        teks: "Pastikan izin prinsip Kepala Sekolah dan SK Panitia sudah TERBIT, bukan sekadar diajukan." },
+      { kode: "s4-kwarran", seksi: "Sekretaris", layar: null,
+        teks: "Ajukan permohonan rekomendasi ke Kwartir Ranting, lampirkan proposal dan SK Panitia. Prosesnya satu sampai dua minggu." },
+      { kode: "s4-izin-gedung", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Ajukan izin pemakaian ruang kelas untuk barak, lapangan upacara, aula, dapur, dan kamar mandi lewat Wakasek Sarpras. Sebutkan ruang mana saja dan tanggal berapa dikosongkan dari KBM." },
+      { kode: "s4-survei-2", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Jalani survei rute kedua bersama perangkat desa untuk menetapkan lima titik pos, titik air, titik ambulans, dan jalur evakuasi." },
+      { kode: "s4-poster", seksi: "Seksi Dokumentasi dan Publikasi", layar: null,
+        teks: "Susun draf poster, logo kegiatan, dan desain kaos. Logo sponsor menyusul di versi kedua." },
+      { kode: "s4-juklak", seksi: "Sekretaris", layar: null,
+        teks: "Susun petunjuk pelaksanaan dan petunjuk teknis. Ini dokumen yang benar-benar dibaca pembina, jauh lebih menentukan daripada poster." },
+      { kode: "s4-follow-up", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Follow-up calon sponsor tiap tujuh sampai sepuluh hari, dan catat siapa menelepon siapa." },
+      { kode: "s4-format-soal", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Tetapkan jumlah soal, bobot, dan format jawaban tiap mata lomba, samakan dengan yang dipakai sistem penilaian." },
+    ],
+    jangan: "Jangan mengirim surat ke desa atau kepolisian sebelum rutenya final. Surat yang dilampiri peta yang kemudian berubah harus diulang dari nol, dan antreannya tidak bisa dipotong.",
+  },
+
+  {
+    kode: "s5",
+    nomor: 5,
     bulan: "November",
-    tajuk: "Soal, Kriteria, Bobot",
-    fokus:
-      "Isi lombanya disusun: soal ditulis, kriteria penilaian ditetapkan, dan bobot tiap pos dikunci sebelum blangko dirancang.",
-    tonggak: [
-      "Soal lima lomba tulis selesai beserta kunci jawabannya, disimpan tertutup",
-      "Kriteria tiap lomba dan rentang nilainya disepakati juri, bukan diputuskan sendiri oleh seksi lomba",
-      "Kontrak waktu yang ditawarkan ditetapkan, beserta penalti per menit terlalu cepat maupun terlambat",
-      "Surat izin sekolah, surat ke kepolisian dan puskesmas, serta surat undangan pangkalan dikirim",
-      "Proposal sponsor disebar dan yang sudah menyatakan iya dicatat nominalnya",
+    rentang: "Minggu 1-2",
+    mundur: "H-111 sampai H-98",
+    tajuk: "Rute Final dan Kisi-Kisi",
+    fokus: "Rute dikunci supaya surat desa, surat lahan, dan titik pos bisa berangkat; kisi-kisi soal disusun.",
+    hasil: "Peta rute final tercetak, dan kisi-kisi tiap mata lomba sudah ada.",
+    tugas: [
+      { kode: "s5-rute-final", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "KUNCI RUTE FINAL dan cetak petanya. Surat desa dan surat lahan menunggu ini, jadi rutenya tidak boleh bergerak lagi sesudah sprint ini." },
+      { kode: "s5-kwarran-terbit", seksi: "Sekretaris", layar: null,
+        teks: "Pastikan rekomendasi Kwartir Ranting sudah terbit, lalu ajukan rekomendasi ke Kwartir Cabang. Prosesnya dua sampai tiga minggu." },
+      { kode: "s5-kisi", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Susun kisi-kisi tiap mata lomba: cakupan materi, tingkat kesulitan, dan pembagian Penggalang dan Penegak." },
+      { kode: "s5-rubrik", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Tulis rubrik penilaian tiap lomba praktik dan angkakan. Rubrik yang tidak eksplisit membuat dua juri berselisih tiga puluh poin untuk penampilan yang sama." },
+      { kode: "s5-poster-final", seksi: "Seksi Dokumentasi dan Publikasi", layar: null,
+        teks: "Finalkan poster dan juklak-juknis supaya siap disebar begitu rekomendasi Kwarcab keluar." },
+      { kode: "s5-edaran", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Minta Kwartir Cabang menerbitkan surat edaran ke gudep SMP dan SMA se-kabupaten. Ini alat publikasi paling ampuh dan tidak berbiaya." },
+      { kode: "s5-migrasi-edisi", seksi: "Administrator Sistem", layar: null,
+        teks: "Susun migration edisi baru: nomor, nama, tahun, tanggal lomba, biaya per regu Eksternal dan Intern, jam mulai dan batas berangkat, serta jeda maksimal antar kloter." },
+      { kode: "s5-kalkulator", seksi: "Administrator Sistem", layar: "#/pengaturan-kloter",
+        teks: "Buka Kalkulator Keberangkatan dan pastikan kloter terakhir masih berangkat sebelum jam sepuluh dengan perkiraan jumlah regu tahun ini." },
     ],
-    seksi: [
-      "Seksi Lomba dan Juri Pos",
-      "Ketua Pelaksana dan Wakil",
-      "Sekretaris",
-      "Seksi Humas dan Sponsor",
-      "Seksi Keamanan dan P3K",
-    ],
-    sistem: [
-      "Susun migration pos, lomba, dan penilaian edisi baru: tiap penilaian dengan poin_maks-nya, lomba berupa soal dengan total_soal-nya, dan pengelompokan lomba lewat kolom wahana.lomba",
-      "Ingat bobot pos tidak pernah ditulis sebagai angka — ia jumlah poin_maks seluruh wahana di pos itu; memindah satu lomba antar pos mengubah bobot keduanya sekaligus",
-      "Kunci rentang nilai mentah sama dengan jumlah soal, supaya petugas tidak bisa mengetik 12 dari 10",
-      "Jalankan migration lewat \"Apply migration to Supabase\", lalu baca hasilnya lewat supabase/checks/lomba_per_pos.sql — pengelompokan lomba itu data, tidak bisa dibaca dari kode",
-      "Buka Input Nilai Tabel di #/pos, hitung kolomnya per pos, lalu tekan cetak blangko dan bawa kertasnya ke rapat juri; pos yang seluruhnya lomba soal memang menolak mencetak dan menyebutkan alasannya di layar",
-    ],
-    jangan:
-      "Jangan menggabungkan dua lomba yang lembar jawabannya terpisah menjadi satu baris — kolom foto ikut kode lomba, jadi satu kode untuk dua lomba berarti satu kolom memegang dua lembar jawaban berbeda, dan itu baru ketahuan saat ada nilai yang disengketakan.",
+    jangan: "Jangan menulis tanggal lomba di dalam kode atau di skrip mana pun. Ia baris konfigurasi di database, dan panitia tahun depan mengubahnya tanpa menyentuh satu baris kode.",
   },
+
   {
-    kode: "desember",
+    kode: "s6",
+    nomor: 6,
+    bulan: "November",
+    rentang: "Minggu 3-4",
+    mundur: "H-97 sampai H-84",
+    tajuk: "Pendaftaran Dibuka",
+    fokus: "Publikasi berangkat dan form pendaftaran dibuka, bersamaan dengan surat ke setiap desa yang dilewati rute.",
+    hasil: "Sekolah peserta sudah menerima undangan dan bisa mendaftar, dan tiap desa rute sudah menerima suratnya.",
+    tugas: [
+      { kode: "s6-migrasi-terap", seksi: "Administrator Sistem", layar: null,
+        teks: "Jalankan migration edisi baru lewat workflow \"Apply migration to Supabase\", satu berkas sekali jalan, lalu baca notice-nya. Merge saja tidak pernah menerapkannya." },
+      { kode: "s6-status-migrasi", seksi: "Administrator Sistem", layar: null,
+        teks: "Jalankan supabase/checks/status_migrasi.sql lewat workflow yang sama untuk membuktikan migration-nya benar-benar hidup di produksi." },
+      { kode: "s6-bobot", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Isi daftar pos, lomba, dan penilaian beserta poin maksimalnya. Bobot sebuah pos tidak ditulis di mana pun: ia jumlah poin maksimal seluruh wahana di pos itu." },
+      { kode: "s6-buka-daftar", seksi: "Seksi Kesekretariatan dan Pendaftaran", layar: null,
+        teks: "BUKA FORM PENDAFTARAN di situs peserta dan umumkan alamatnya ke grup pembina." },
+      { kode: "s6-undangan", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Kirim surat undangan beserta juklak-juknis ke sekolah peserta, dan buat grup pembina." },
+      { kode: "s6-desa", seksi: "Sekretaris", layar: null,
+        teks: "Antarkan surat izin ke SETIAP kepala desa yang dilewati rute atau ditempati pos, satu surat per desa, sambil membawa peta. Yang paling sering terjadi adalah kurang satu desa." },
+      { kode: "s6-kisi-umum", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Umumkan kisi-kisi ke sekolah peserta. Ini bagian dari keadilan lomba, dan ia memangkas protes di hari-H." },
+      { kode: "s6-pantau-daftar", seksi: "Seksi Kesekretariatan dan Pendaftaran", layar: "#/data-peserta",
+        teks: "Pantau Data Peserta tiap hari sejak pendaftaran dibuka. Salah ketik pembina jauh lebih murah dibetulkan hari ini daripada di meja daftar ulang." },
+    ],
+    jangan: "Jangan membuka pendaftaran sebelum data uji dibersihkan. Kloter yang masih menyandang tanda cetak atau jam berangkat dari percobaan membuat pembagian berikutnya mulai dari tengah, dan panitia mencari kloter yang tidak pernah ada.",
+  },
+
+  {
+    kode: "s7",
+    nomor: 7,
     bulan: "Desember",
-    tajuk: "Publikasi dan Pendaftaran Dibuka",
-    fokus:
-      "Acara diumumkan ke pangkalan, form pendaftaran dibuka, dan akun panitia dibuat jauh sebelum dipakai.",
-    tonggak: [
-      "Pamflet dan link pendaftaran disebar ke pangkalan SMP dan SMA se-wilayah",
-      "Form pendaftaran dibuka pada tanggal yang diumumkan, dan pendaftar pertama masuk",
-      "Nomor kontak panitia untuk pertanyaan pembina diumumkan, satu nomor saja",
-      "Rekening penerimaan pembayaran dipastikan hidup dan nama pemiliknya diumumkan apa adanya",
-      "Meja pendaftaran offline dijadwalkan: hari, jam, dan siapa yang menjaga",
+    rentang: "Minggu 1-2",
+    mundur: "H-83 sampai H-70",
+    tajuk: "Izin Lahan dan Penulisan Soal",
+    fokus: "Pemilik lahan ditemui satu per satu, dan soal mulai ditulis.",
+    hasil: "Tiap titik yang dilintasi punya nama dan nomor HP pemiliknya, dan draf soal tiap mata lomba sudah ada.",
+    tugas: [
+      { kode: "s7-lahan", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Temui pemilik lahan yang dilintasi bersama perangkat desa; catat nama, nomor HP, dan titiknya. Sebagian minta ganti tanaman yang terinjak, jadi anggarkan." },
+      { kode: "s7-lahan-pos", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Urus izin lahan kelima pos secara TERPISAH dari lahan yang cuma dilewati. Pos butuh tempat teduh, air, dan ruang untuk satu regu bergerak." },
+      { kode: "s7-camat", seksi: "Sekretaris", layar: null,
+        teks: "Ajukan rekomendasi Camat. Syaratnya surat desa sudah terbit lebih dulu." },
+      { kode: "s7-tulis-soal", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Tulis soal beserta kunci jawabannya, satu penulis per mata lomba, dikerjakan offline dan tidak dibagikan di grup umum." },
+      { kode: "s7-uji-jalan", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Uji jalan kaki rute penuh dengan stopwatch minimal dua kali, di hari dan jam yang sama dengan hari-H: satu tim berkecepatan Penggalang SMP, satu tim Penegak SMA." },
+      { kode: "s7-materi-praktik", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Siapkan materi lomba praktik dan rahasiakan: sepuluh objek KIM Lihat, daftar simpul, kata semaphore, objek menaksir beserta ukuran benarnya, dan skenario cedera pembidaian." },
+      { kode: "s7-juri-undangan", seksi: "Sekretaris", layar: null,
+        teks: "Kirim permohonan juri undangan untuk PBB, yel-yel, keagamaan, dan kesehatan. Orangnya sibuk, jadi kirim awal dan konfirmasi ulang." },
+      { kode: "s7-alat-praktik", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Hitung kebutuhan alat praktik PER POS, bukan total: mitela, bidai, tongkat, tali, bakiak, bendera semaphore, stopwatch, dan meteran." },
     ],
-    seksi: [
-      "Seksi Humas dan Sponsor",
-      "Seksi Dokumentasi dan Publikasi",
-      "Seksi Kesekretariatan dan Pendaftaran",
-      "Bendahara — Meja Pembayaran",
-      "Administrator Sistem",
-    ],
-    sistem: [
-      "Bersihkan data uji SEKARANG lewat supabase/checks/cleanup_data_uji.sql di workflow \"Apply migration to Supabase\" — termasuk mengembalikan penomoran kloter ke 1, kalau tidak pembagian kloter nanti mulai dari tengah",
-      "Bakukan daftar sekolah kurasi lebih dulu, lalu sapu sisanya lewat supabase/checks/sekolah_kembar.sql; dua sekolah senama dibedakan di dalam namanya sendiri, bukan lewat alamat",
-      "Jalankan workflow \"Provision akun panitia\" per batch: tempel CSV berisi username, email, peran, dan pos; ambil passwordnya dari Artifact sebelum terhapus tiga hari lagi",
-      "Buka layar Akun dan cocokkan centang tiap akun dengan pekerjaan orangnya, dengan urutan yang benar: pilih perannya DULU, sesuaikan centangnya SESUDAHNYA — mengganti peran menghapus seluruh centang tangan",
-      "Buka form pendaftaran di situs peserta dari HP sungguhan, daftarkan satu regu percobaan sampai selesai, lalu hapus regu itu — di fase Internal peserta hanya melihat jumlah pendaftar dan jalan ke formulir",
-    ],
-    jangan:
-      "Jangan membuka pendaftaran sebelum data uji dibersihkan: regu percobaan yang tertinggal ikut terhitung di jumlah pendaftar yang dilihat publik, dan cleanup_data_uji.sql tidak membedakan data uji dari data asli — sesudah ada pendaftar sungguhan, berkas itu tidak boleh dijalankan lagi.",
+    jangan: "Jangan mengukur kontrak waktu memakai panitia yang paling bugar. Regu yang terlambat karena patokannya salah adalah kesalahan panitia, tetapi penaltinya tetap jatuh ke peserta.",
   },
+
   {
-    kode: "januari",
+    kode: "s8",
+    nomor: 8,
+    bulan: "Desember",
+    rentang: "Minggu 3-4",
+    mundur: "H-69 sampai H-56",
+    tajuk: "Izin Keramaian Masuk",
+    fokus: "Berkas izin keramaian masuk ke kepolisian, dan kontrak waktu dihitung dari hasil uji jalan.",
+    hasil: "Berkas izin keramaian sudah diterima, dan pilihan kontrak waktu sudah punya angka yang bisa dipertanggungjawabkan.",
+    tugas: [
+      { kode: "s8-keramaian", seksi: "Sekretaris", layar: null,
+        teks: "Masukkan berkas izin keramaian lewat Polsek: surat permohonan, proposal, susunan panitia, jadwal, peta rute, rekomendasi desa dan camat, surat sekolah, fotokopi KTP penanggung jawab, dan perkiraan jumlah peserta." },
+      { kode: "s8-polsek", seksi: "Seksi Keamanan dan P3K", layar: null,
+        teks: "Datangi Kapolsek atau Kanit Binmas untuk membicarakan pengamanan titik start, penyeberangan, dan keramaian malam. Datang, jangan hanya berkirim surat." },
+      { kode: "s8-kontrak-waktu", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Hitung pilihan kontrak waktu dari total waktu jalan ditambah waktu di lima pos ditambah istirahat wajar, lalu masukkan sebagai konfigurasi edisi." },
+      { kode: "s8-satlantas", seksi: "Seksi Keamanan dan P3K", layar: null,
+        teks: "Bicarakan penyeberangan jalan raya dengan Satlantas secara terpisah dari izin keramaian, dan Dinas Perhubungan kalau ada pengalihan jalan atau parkir bus." },
+      { kode: "s8-koramil", seksi: "Sekretaris", layar: null,
+        teks: "Kirim surat pemberitahuan ke Koramil dan temui Danramil. Babinsa tiap desa rute sering ikut membantu di lapangan." },
+      { kode: "s8-piala", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Pesan piala, medali, dan plakat dengan plat KOSONG. Grafir butuh empat sampai enam minggu, dan nama juara memang belum ada sebelum acara." },
+      { kode: "s8-uji-lomba", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Uji coba tiap lomba praktik dengan satu regu contoh dan ukur waktunya. Dari sinilah lama satu regu berada di satu pos diketahui." },
+      { kode: "s8-sponsor-nego", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "Tutup negosiasi sponsor dan siapkan kesepakatan tertulisnya: nominal atau barang, hak tampil logo, jumlah spanduk, dan tenggat pembayaran." },
+    ],
+    jangan: "Jangan mengajukan izin keramaian kurang dari tiga minggu sebelum hari-H. Prosesnya sendiri satu sampai dua minggu kerja, dan hampir selalu ada berkas yang harus dilengkapi lebih dulu.",
+  },
+
+  {
+    kode: "s9",
+    nomor: 9,
     bulan: "Januari",
-    tajuk: "Penutupan, Daftar Ulang, Gladi",
-    fokus:
-      "Pendaftaran ditutup, uang masuk dicocokkan, nomor dada dibagikan, dan seluruh alur dicoba dari ujung ke ujung sebelum hari-H.",
-    tonggak: [
-      "Pendaftaran ditutup pada tanggal yang diumumkan, jumlah regu final diketahui",
-      "Seluruh pembayaran dicocokkan dan ditandai lunas",
-      "Technical meeting dengan pembina: rute, kontrak waktu, aturan penalti, dan jam kumpul",
-      "Daftar ulang berjalan 1-2 hari sebelum lomba, nomor dada kain berpindah ke tangan regu",
-      "Gladi lapangan: seluruh panitia berdiri di posnya masing-masing, memakai laptop dan HP yang akan dipakai hari-H",
+    rentang: "Minggu 1-2",
+    mundur: "H-55 sampai H-42",
+    tajuk: "Sponsor Ditutup, Soal Divalidasi",
+    fokus: "Kontrak sponsor ditutup supaya logo masih sempat masuk cetakan, dan seluruh soal diperiksa orang lain.",
+    hasil: "Tidak ada logo baru sesudah sprint ini, dan tiap kunci jawaban sudah divalidasi pembina.",
+    tugas: [
+      { kode: "s9-tutup-sponsor", seksi: "Seksi Humas dan Sponsor", layar: null,
+        teks: "TUTUP KONTRAK SPONSOR. Sesudah ini tidak ada logo baru, karena spanduk, backdrop, kaos, sertifikat, dan ID card semuanya menunggu file logo." },
+      { kode: "s9-logo", seksi: "Seksi Dokumentasi dan Publikasi", layar: null,
+        teks: "Kumpulkan file logo sponsor dalam resolusi cetak, lalu kunci desain spanduk dan backdrop." },
+      { kode: "s9-cadangan", seksi: "Bendahara — Meja Pembayaran", layar: null,
+        teks: "Periksa pemasukan sponsor. Kalau kurang dari separuh target, jalankan rencana cadangan SEKARANG: danus, potong biaya yang bisa dipotong, dan ganti sewa dengan pinjaman barang." },
+      { kode: "s9-validasi-soal", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Serahkan seluruh soal ke pembina dan guru mata pelajaran untuk divalidasi: kunci benar, tidak ada soal berkunci ganda, bahasa tidak ambigu, dan sesuai jenjang SMP dan SMA." },
+      { kode: "s9-medis", seksi: "Seksi Keamanan dan P3K", layar: null,
+        teks: "Ajukan permohonan tenaga medis dan ambulans ke Puskesmas kecamatan dan PMI, lalu sepakati rumah sakit rujukan beserta nomor IGD-nya." },
+      { kode: "s9-nomor-dada", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Pesan kain nomor dada beserta cadangan sepuluh persen. Sablon butuh dua minggu kerja. Kalau pendaftaran belum ditutup, pesan sejumlah KUOTA, bukan sejumlah pendaftar." },
+      { kode: "s9-pinjam", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Kirim surat peminjaman tenda, terpal, meja-kursi, sound system, HT, genset, dan lampu sorot." },
+      { kode: "s9-stok-dada", seksi: "Administrator Sistem", layar: null,
+        teks: "Samakan stok nomor dada di sistem dengan kain yang benar-benar dipesan: dua deret, Eksternal dan Intern. Pagar nomor dada membaca angkanya dari sana." },
     ],
-    seksi: [
-      "Seksi Kesekretariatan dan Pendaftaran",
-      "Bendahara — Meja Pembayaran",
-      "Seksi Daftar Ulang",
-      "Seksi Perlengkapan",
-      "Seksi Konsumsi",
-    ],
-    sistem: [
-      "Kosongkan antrean Meja Pembayaran di #/pembayaran — regu yang belum lunas tidak bisa daftar ulang — lalu betulkan salah ketik pembina di Data Peserta sebelum nomor dada keluar, karena sesudahnya nama regu ikut membeku",
-      "Cetak blangko master tiap lomba dari Input Nilai Tabel: yang keluar dari printer SATU master A5 melintang per lomba, dan penggandaannya pekerjaan mesin fotokopi 2-up di sekretariat",
-      "Jalankan daftar ulang di Meja Daftar Ulang di #/daftar-ulang dengan 2-3 meja paralel; nomor dada diketik dari kain di tangan, kloter jatuh sendiri secara FIFO",
-      "Cetak dua bentuk dari Daftar Kloter: \"Cetak Kloter untuk Petugas\" untuk meja staging, dan \"Cetak Kloter untuk Peserta\" untuk papan pengumuman",
-      "Isi database uji lewat supabase/checks/simulasi_end_to_end.sql sampai papan Live Score terisi, dan jelang gladi jalankan workflow \"Setel password bersama semua akun\" supaya sepuluh orang bisa login tanpa sepuluh serah terima — kembalikan ke acak sesudahnya",
-    ],
-    jangan:
-      "Jangan salah mengetik nomor dada saat daftar ulang: blangko penilaian hanya memuat nomor dada tanpa nama regu, jadi satu angka keliru memindahkan seluruh nilai satu regu ke regu lain, dan tidak ada apa pun di kertas yang memperlihatkannya.",
+    jangan: "Jangan menerima sponsor yang logonya datang belakangan. Satu logo yang menyusul memaksa seluruh cetakan diulang, dan biaya cetak ulangnya lebih besar daripada sponsornya.",
   },
+
   {
-    kode: "februari",
+    kode: "s10",
+    nomor: 10,
+    bulan: "Januari",
+    rentang: "Minggu 3-4",
+    mundur: "H-41 sampai H-28",
+    tajuk: "Soal Selesai dan Meja Diuji",
+    fokus: "Soal dikunci total, dan alur meja dicoba dengan data contoh sebelum peserta sungguhan datang.",
+    hasil: "Soal siap digandakan, dan panitia tahu berapa lama satu regu dilayani di meja.",
+    tugas: [
+      { kode: "s10-revisi-soal", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Perbaiki soal dari hasil validasi, lalu ujicobakan ke lima sampai sepuluh anggota ambalan yang TIDAK ikut menyusun, untuk mengukur waktu pengerjaan yang sebenarnya." },
+      { kode: "s10-soal-kunci", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "KUNCI SOAL DAN LAYOUT FINALNYA. Sesudah ini tidak ada perubahan isi, hanya penggandaan." },
+      { kode: "s10-simulasi-meja", seksi: "Seksi Daftar Ulang", layar: "#/daftar-ulang",
+        teks: "Jalankan simulasi meja pembayaran dan daftar ulang dengan data contoh. Ukur berapa lama satu regu dilayani, lalu kalikan dengan jumlah regu tahun ini." },
+      { kode: "s10-bersih-uji", seksi: "Administrator Sistem", layar: null,
+        teks: "Bersihkan data uji sesudah simulasi, termasuk mengembalikan penomoran kloter ke satu." },
+      { kode: "s10-sertifikat", seksi: "Seksi Dokumentasi dan Publikasi", layar: null,
+        teks: "Siapkan template sertifikat, ID card panitia dan juri, serta rompi atau slayer pembeda." },
+      { kode: "s10-konsumsi", seksi: "Seksi Konsumsi", layar: null,
+        teks: "Kunci kontrak konsumsi panitia, juri, tamu, dan aparat. Jumlah pastinya dikonfirmasi ulang tiga hari sebelum hari-H." },
+      { kode: "s10-bpbd", seksi: "Seksi Keamanan dan P3K", layar: null,
+        teks: "Kirim pemberitahuan ke BPBD dan minta pembacaan risiko rute, lalu kumpulkan izin orang tua panitia yang menginap." },
+      { kode: "s10-rambu", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Buat penunjuk arah, rambu bahaya, dan papan nama pos dari bahan tahan hujan, huruf besar, dua sisi." },
+    ],
+    jangan: "Jangan membiarkan soal selesai mepet. Soal yang jadi tiga hari sebelum acara tidak sempat divalidasi, dan kunci yang salah baru ketahuan sesudah tiga ratus regu menjawab — satu mata lomba dianulir dan seluruh klasemen goyah.",
+  },
+
+  {
+    kode: "s11",
+    nomor: 11,
     bulan: "Februari",
-    tajuk: "Pelaksanaan dan Evaluasi",
-    fokus:
-      "Hari lomba: upacara, keberangkatan bertahap, penilaian di lima pos, kedatangan, pengumuman juara, lalu arsip.",
-    tonggak: [
-      "Upacara dan pemberangkatan kloter pertama oleh pejabat, seluruh keberangkatan selesai pukul 10:00",
-      "Lima pos berjalan dan nilai mentah masuk sistem sepanjang siang",
-      "Seluruh regu tercatat sampai di finish dan kelengkapan anggota diperiksa fisik",
-      "Juara diumumkan di lapangan, baru sesudah itu ditampilkan di layar peserta",
-      "Rapat evaluasi digelar selagi ingatan masih segar, dan arsipnya diserahkan ke pengurus berikutnya",
+    rentang: "Minggu 1-2",
+    mundur: "H-27 sampai H-14",
+    tajuk: "Pendaftaran Ditutup",
+    fokus: "Jumlah regu terkunci, nomor dada dibagikan, kloter terbentuk, dan technical meeting digelar.",
+    hasil: "Daftar Kloter tercetak, dan tiap pembina sudah tahu kira-kira jam berapa regunya berangkat.",
+    tugas: [
+      { kode: "s11-tutup-daftar", seksi: "Seksi Kesekretariatan dan Pendaftaran", layar: null,
+        teks: "TUTUP PENDAFTARAN. Sejak titik ini jumlah regu terkunci, dan konsumsi, nomor dada, serta blangko baru bisa dipesan dengan angka pasti." },
+      { kode: "s11-sapu-bayar", seksi: "Bendahara — Meja Pembayaran", layar: "#/pembayaran",
+        teks: "Sapu Meja Pembayaran sampai antrean menunggu pembayaran habis. Hubungi pembina yang belum lunas lewat kontak di Data Peserta, jangan dibiarkan sampai pagi hari-H." },
+      { kode: "s11-gandakan-soal", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Gandakan soal lima mata lomba beserta cadangan sepuluh persen, ditunggui panitia, lalu paketkan per pos, disegel, diberi label, dan disimpan terkunci." },
+      { kode: "s11-blangko", seksi: "Seksi Lomba dan Juri Pos", layar: "#/pos",
+        teks: "Cetak MASTER blangko dari layar Input Nilai Tabel lalu gandakan di mesin fotokopi. Yang dicetak dari layar satu master per lomba, bukan setumpuk." },
+      { kode: "s11-daftar-ulang", seksi: "Seksi Daftar Ulang", layar: "#/daftar-ulang",
+        teks: "Jalankan daftar ulang: cari batch lewat kode pembayaran, isi nomor dada seluruh regu sekolah itu sekaligus, dan tukar nomor yang kainnya rusak." },
+      { kode: "s11-cetak-kloter", seksi: "Seksi Keberangkatan", layar: "#/cetak-kloter",
+        teks: "Cetak Daftar Kloter untuk Petugas dan untuk Peserta sesudah seluruh regu bernomor dada." },
+      { kode: "s11-tm", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Gelar technical meeting dengan pembina peserta: rute, kontrak waktu, sistem penilaian, barang bawaan, aturan barak, sanksi, jam kloter, dan tata cara protes. Buat berita acara dan bagikan notulennya — yang tidak hadir tetap terikat." },
+      { kode: "s11-latih-juri", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Latih juri pos dengan kalibrasi: dua juri menilai penampilan yang sama, lalu selisihnya dibahas sampai rubriknya dibaca serupa. Wajib untuk PBB, yel-yel, dan pembidaian." },
+      { kode: "s11-akun-juri", seksi: "Administrator Sistem", layar: "#/account",
+        teks: "Buat akun juri pos beserta kolom posnya, dan satu akun koordinator pos yang kolom posnya DIKOSONGKAN supaya kelima pos terbuka untuknya." },
+      { kode: "s11-izin-terbit", seksi: "Sekretaris", layar: null,
+        teks: "Pastikan izin keramaian sudah TERBIT, lalu ajukan permohonan pengamanan menyusul sekalian menanyakan jumlah personel dan konsumsinya." },
     ],
-    seksi: [
-      "Seksi Keberangkatan",
-      "Seksi Kedatangan — Finish",
-      "Seksi Lomba dan Juri Pos",
-      "Seksi Rekap dan Skor",
-      "Administrator Sistem",
+    jangan: "Jangan menomori kloter sendiri. Urutan FIFO dan kuota lima Eksternal serta tiga Intern dijaga di dalam sistem, bukan oleh urutan nomor dada. Kalau kloter perlu disusun ulang, bersihkan lalu jalankan ulang alurnya.",
+  },
+
+  {
+    kode: "s12",
+    nomor: 12,
+    bulan: "Februari",
+    rentang: "Minggu 3-4",
+    mundur: "H-13 sampai hari-H",
+    tajuk: "Gladi dan Hari-H",
+    fokus: "Gladi kotor, gladi bersih, lalu hari lomba itu sendiri dari upacara sampai pengumuman juara.",
+    hasil: "Juara diumumkan, rekap terbit, dan seluruh nilai terkunci.",
+    tugas: [
+      { kode: "s12-survei-ulang", seksi: "Seksi Lomba dan Juri Pos", layar: null,
+        teks: "Susuri ulang rute mencari perubahan: panen, penutupan jalan, longsor, pagar baru, kandang baru." },
+      { kode: "s12-simulasi-penuh", seksi: "Administrator Sistem", layar: null,
+        teks: "Jalankan simulasi end-to-end penuh dengan data uji, dari pendaftaran sampai klasemen, lalu bersihkan datanya sampai kloter kembali ke nomor satu." },
+      { kode: "s12-gladi-kotor", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Gelar gladi kotor: seluruh panitia, seluruh alur, pos dijalankan dengan regu boneka dari anggota ambalan. Uji HT dan cari titik tanpa sinyal sekalian." },
+      { kode: "s12-gladi-bersih", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Gelar gladi bersih untuk upacara, pemberangkatan kloter, dan penutupan. Fokusnya urutan dan waktu, bukan seluruh pos." },
+      { kode: "s12-barak", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Siapkan barak: pembagian ruang, pemisahan putra dan putri, denah tertempel, penjaga malam per lantai, penerangan, dan aturan jam malam." },
+      { kode: "s12-pasang-rambu", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Pasang penunjuk arah sehari sebelum acara, sore hari, jangan lebih awal. Rambu yang dipasang seminggu sebelumnya hilang, dicabut, atau berpindah arah." },
+      { kode: "s12-berangkat", seksi: "Seksi Keberangkatan", layar: "#/keberangkatan",
+        teks: "Hari-H pagi: upacara, lalu berangkatkan kloter dari jam tujuh sampai jam sepuluh, dengan tiga kloter selalu siap — satu di Pemberangkatan, dua di staging." },
+      { kode: "s12-nilai", seksi: "Seksi Lomba dan Juri Pos", layar: "#/pos2",
+        teks: "Sepanjang siang: juri mengisi nilai per lomba dan memotret lembar jawabannya, lalu koordinator pos memantau kelengkapan kelima pos." },
+      { kode: "s12-datang", seksi: "Seksi Kedatangan — Finish", layar: "#/finish",
+        teks: "Catat kedatangan tiap regu dengan tombol SAMPAI DI FINISH pada jam sungguhan, lalu hitung anggotanya secara fisik." },
+      { kode: "s12-fase", seksi: "Seksi Rekap dan Skor", layar: "#/live-score",
+        teks: "Naikkan fase live bertahap lalu terbitkan rekapnya. Urutannya selalu nyalakan fasenya dulu, terbitkan sesudahnya, dan itu berlaku ke dua arah." },
     ],
-    sistem: [
-      "Pagi: naikkan fase live ke Progress lewat saklar di Live Score, lalu jalankan workflow \"Publish rekap live\" — fasenya dulu, penerbitan sesudahnya, dan urutan itu berlaku ke dua arah",
-      "Keberangkatan di #/keberangkatan: kertas yang jadi pencatat utama dan laptop memverifikasi, jam berangkat diketik dari jam sungguhan; di Kedatangan di #/finish justru terbalik, laptop pencatat utamanya, dan regu yang lupa dicatat tiba hilang dari klasemen tanpa satu galat pun",
-      "Pantau Live Score sepanjang siang: angka hilang berarti regu sudah closing tapi nilainya belum lengkap, dan pos yang berhenti menyetor lebih dari setengah jam berarti laptop atau sinyalnya rusak",
-      "Sisir Cek Nilai di #/cek-nilai lewat ketiga saringannya — Belum Input, Belum Foto, Belum Kunci — sampai angkanya nol: adu foto lembar jawaban dengan angka yang diketik, betulkan kalau beda, lalu pasang gembok per lomba",
-      "Sesudah juara dibacakan di lapangan: isi pilihan manual di Kejuaraan, naikkan fase ke Juara, jalankan \"Publish rekap live\" lagi, lalu cetak \"Rekap Nilai Semua\" dari Live Score dan Daftar Kloter final sebagai arsip",
+    jangan: "Jangan mengumumkan juara sebelum Cek Nilai bersih. Angka yang dibetulkan sesudah papan juara dibacakan tidak bisa ditarik kembali dari ingatan orang yang sudah bertepuk tangan.",
+  },
+
+  {
+    kode: "s13",
+    nomor: 13,
+    bulan: "Sesudah acara",
+    rentang: "Dua minggu setelah hari-H",
+    mundur: "H+1 sampai H+14",
+    tajuk: "Evaluasi dan Serah Terima",
+    fokus: "Ucapan terima kasih, laporan, arsip, dan buku yang ditulis ulang untuk kepanitiaan berikutnya.",
+    hasil: "Izin tahun depan jadi mudah, dan panitia berikutnya menerima buku yang sudah diperbarui.",
+    tugas: [
+      { kode: "s13-terima-kasih", seksi: "Sekretaris", layar: null,
+        teks: "Kirim surat ucapan terima kasih ke seluruh instansi, sponsor, pemilik lahan, dan pemberi pinjaman barang. Inilah yang menentukan izin tahun depan mudah atau susah." },
+      { kode: "s13-kembalikan", seksi: "Seksi Perlengkapan", layar: null,
+        teks: "Kembalikan seluruh barang pinjaman dengan berita acara, dan bereskan sampah di sekolah maupun sepanjang rute sesuai kesepakatan dengan desa." },
+      { kode: "s13-evaluasi", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Gelar rapat evaluasi selagi ingatan masih segar, dan TULIS notulennya. Yang tidak ditulis minggu ini hilang." },
+      { kode: "s13-lpj", seksi: "Bendahara — Meja Pembayaran", layar: null,
+        teks: "Tutup laporan keuangan dan susun LPJ ke Kepala Sekolah, Kwartir Ranting, dan tiap sponsor beserta foto pemasangan logonya." },
+      { kode: "s13-arsip", seksi: "Seksi Rekap dan Skor", layar: "#/kejuaraan",
+        teks: "Cetak arsip: Rekap Nilai Semua, Daftar Kloter final, dan Daftar Juara. Simpan bersama notulen dan seluruh berkas izin." },
+      { kode: "s13-sertifikat-juara", seksi: "Seksi Dokumentasi dan Publikasi", layar: null,
+        teks: "Cetak dan bagikan sertifikat juara sesudah hasilnya pasti." },
+      { kode: "s13-tulis-buku", seksi: "Sekretaris", layar: "#/buku-sakti",
+        teks: "TULIS ULANG BUKU SAKTI ini dari hasil evaluasi: yang berubah tahun ini, yang ternyata salah, dan yang baru kalian pelajari. Buku yang tidak diperbarui pelan-pelan jadi buku yang menyesatkan." },
+      { kode: "s13-serah-terima", seksi: "Ketua Pelaksana dan Wakil", layar: null,
+        teks: "Serahkan akses akun organisasi, arsip, dan buku ini ke kepengurusan berikutnya, lalu mulai lagi dari Sprint 1." },
     ],
-    jangan:
-      "Jangan menaikkan fase ke Juara sebelum juara dibacakan di lapangan, dan jangan menurunkannya kembali sesudahnya berharap papan kembali — berkas fase juara tidak memuat satu baris klasemen pun, jadi papannya kosong sampai rekap diterbitkan ulang.",
+    jangan: "Jangan membersihkan data acara sebelum arsipnya tercetak dan LPJ selesai. Sekali dibersihkan, klasemen, nilai mentah, dan daftar juara tidak bisa dikembalikan.",
   },
 ];
-/** Timeline ikut jadi tab supaya seluruh buku punya satu deretan tab, bukan
- *  tiga tab ditambah satu tombol yang letaknya lain sendiri. `bagian`-nya
- *  sengaja kosong: yang digambar TIMELINE di atas. */
-const BAB_TIMELINE = {
-  kode: "timeline", judul: "Timeline Satu Edisi",
-  tab: "Timeline", ikon: "clock", warna: "toska",
-  ringkas: "Enam bulan dari Serah Terima Jabatan sampai hari pelaksanaan: "
-    + "tonggak yang dicentang, langkah yang dikerjakan di sistem, dan satu "
-    + "kesalahan khas tiap bulan.",
+/** Papan sprint ikut jadi tab supaya seluruh buku punya satu deretan tab,
+ *  bukan tiga tab ditambah satu tombol yang letaknya lain sendiri.
+ *  `bagian`-nya sengaja kosong: yang digambar SPRINT di atas. */
+const BAB_SPRINT = {
+  kode: "timeline", judul: "Papan Sprint Satu Edisi",
+  tab: "Sprint", ikon: "list-checks", warna: "toska",
+  ringkas: "Tiga belas sprint dua mingguan dari Serah Terima Jabatan sampai "
+    + "hari-H, ditutup satu sprint evaluasi. Tiap tugas bisa dicentang, dan "
+    + "centangnya dilihat seluruh panitia.",
   bagian: [],
 };
 
-export const BUKU_SAKTI = [BAB_TUTORIAL, BAB_SEKSI, BAB_KENAPA, BAB_TIMELINE];
+export const BUKU_SAKTI = [BAB_TUTORIAL, BAB_SEKSI, BAB_KENAPA, BAB_SPRINT];
 
 /** Seluruh bagian buku, rata, masing-masing membawa bab asalnya. Dipakai
  *  kotak cari dan daftar isi cetak. */
@@ -2425,10 +2729,18 @@ export function teksBagian(bagian) {
   return potong.join(" ").toLowerCase();
 }
 
-/** Semua teks satu bulan timeline, sebentuk dengan teksBagian(). */
-export function teksBulan(bulan) {
-  return [bulan.bulan, bulan.tajuk, bulan.fokus, bulan.jangan,
-          ...bulan.tonggak, ...bulan.seksi, ...bulan.sistem]
+/** Semua teks satu sprint, sebentuk dengan teksBagian().
+ *
+ *  SELURUH kolom ikut, termasuk nomor sprint dan nama seksi. Yang mencari
+ *  "perizinan" mau menemukan sprintnya; yang mencari "Bendahara" mau
+ *  menemukan semua tugas bendahara; dan yang mengetik "s9" sedang menyalin
+ *  kode tugas dari notulen rapat. Kolom yang tertinggal dari daftar ini jadi
+ *  kata yang ada di layar tetapi tidak pernah ketemu. */
+export function teksSprint(sprint) {
+  return [sprint.kode, String(sprint.nomor), sprint.bulan, sprint.rentang,
+          sprint.mundur, sprint.tajuk, sprint.fokus, sprint.hasil,
+          sprint.jangan,
+          ...sprint.tugas.flatMap(t => [t.kode, t.teks, t.seksi])]
     .join(" ").toLowerCase();
 }
 
@@ -2446,12 +2758,21 @@ export function cariBagian(kata) {
   });
 }
 
-/** Bulan timeline yang cocok, aturan sama dengan cariBagian(). */
-export function cariBulan(kata) {
+/** Sprint yang cocok. Aturannya SAMA dengan cariBagian() — semua kata, bukan
+ *  salah satunya — dan kesamaan itu diuji, bukan diandaikan: dua kotak cari
+ *  yang berperilaku berbeda di satu layar adalah kotak cari yang salah satunya
+ *  pasti mengejutkan. */
+export function cariSprint(kata) {
   const potong = String(kata || "").toLowerCase().split(/\s+/).filter(Boolean);
   if (!potong.length) return [];
-  return TIMELINE.filter(bulan => {
-    const teks = teksBulan(bulan);
+  return SPRINT.filter(sprint => {
+    const teks = teksSprint(sprint);
     return potong.every(k => teks.includes(k));
   });
+}
+
+/** Seluruh tugas papan sprint, rata, masing-masing membawa sprint asalnya.
+ *  Dipakai menghitung kemajuan dan mencetak papannya. */
+export function tugasSprint() {
+  return SPRINT.flatMap(sprint => sprint.tugas.map(tugas => ({ sprint, tugas })));
 }

--- a/web/js/buku-sakti.mjs
+++ b/web/js/buku-sakti.mjs
@@ -1,0 +1,2457 @@
+/* ============================================================================
+   hrcd-rekap : buku-sakti.mjs — isi Buku Sakti.
+
+   Buku pegangan yang diserahkan dari kepanitiaan satu ke kepanitiaan
+   berikutnya: cara menjalankan HRCD, tugas pokok tiap seksi, alasan sistem
+   ini berbentuk seperti sekarang, dan timeline satu edisi penuh dari Serah
+   Terima Jabatan sampai hari pelaksanaan.
+
+   KENAPA ISINYA DI SINI DAN BUKAN DI DATABASE
+
+   Buku ini ditulis ulang sekali setahun oleh panitia yang mau turun, bukan
+   diketik di lapangan. Menaruhnya di database berarti satu tabel, satu set
+   policy RLS, satu layar penyunting, dan satu backup lagi yang harus diingat
+   orang — empat konsep baru untuk teks yang berubah dua belas kali lebih
+   jarang daripada tabel mana pun di sistem ini (CLAUDE.md bagian 6.4).
+
+   Di sini ia ikut git: siapa mengubah apa dan kapan sudah tercatat sendiri,
+   dan bukunya tetap terbaca walau Supabase sedang tidak bisa dihubungi —
+   keadaan yang justru paling mungkin bikin orang membuka buku panduan.
+
+   KENAPA ISINYA DATA, BUKAN HTML
+
+   Yang menyunting buku ini panitia SMA, bukan programmer. Daftar blok
+   berjenis bisa disunting tanpa tahu satu tag pun, tidak bisa merusak tata
+   letak layar, dan tidak bisa menyelundupkan markup — layar yang
+   menggambarnya meng-escape semuanya. Itu juga yang membuat isinya bisa
+   diuji di Node tanpa membuka browser.
+
+   ENAM JENIS BLOK, DAN TIDAK ADA YANG KETUJUH
+
+     { jenis: "p",       teks: "satu paragraf" }
+     { jenis: "poin",    butir: ["...", "..."] }          daftar bertitik
+     { jenis: "langkah", butir: ["...", "..."] }          daftar bernomor
+     { jenis: "tabel",   kepala: ["A", "B"],
+                         baris: [["a1", "b1"]] }          panjang baris = kepala
+     { jenis: "kenapa",  teks: "..." }                    kotak beraksen
+     { jenis: "layar",   nama: "Meja Pembayaran",
+                         hash: "#/pembayaran",
+                         fitur: "pembayaran",             null = terbuka untuk
+                         teks: "..." }                    semua panitia
+
+   Menambah jenis ketujuh menuntut tiga tempat berubah sekaligus: perakit di
+   app.js, perakit cetaknya, dan tes bentuk di tests/buku_sakti.test.mjs.
+   Sebelum menambahnya, periksa dulu apakah salah satu dari enam yang ada
+   sudah cukup — hampir selalu cukup.
+
+   SATU BAB PUNYA DUA NAMA, dan keduanya wajib.
+
+     judul  "Kenapa Sistemnya Begini"   dipakai di kepala bab dan di kertas
+     tab    "Kenapa"                    dipakai di pil tab
+
+   Bukan kerapian: empat judul penuh berjejer sepanjang 844px di kolom
+   selebar 734px, jadi tab keempat terpotong dan muncul penggulir mendatar di
+   layar selebar apa pun. Terukur di browser, bukan dikira-kira. Label pendek
+   memilih kata yang paling membedakan babnya — di bawah judul lengkap yang
+   tergambar sebaris di bawahnya, satu kata sudah cukup.
+
+   TEKSNYA STRING BIASA. Tidak ada HTML, tidak ada Markdown, tidak ada
+   backtick. Layar yang menata; penulis yang bercerita.
+   ========================================================================== */
+
+/** Nama centang seperti tertulis di layar Akun.
+ *
+ *  Blok "layar" menyebut fitur yang dibutuhkan, dan layar Buku Sakti memakai
+ *  itu untuk dua hal: menyembunyikan tautan yang akan berujung pada kartu
+ *  "tidak berhak", dan menyebutkan centang mana yang harus diminta ke admin.
+ *  Yang kedua itu yang menuntut namanya, bukan cuma kodenya — "butuh centang
+ *  daftar_ulang" menyuruh orang mencari kotak yang tidak pernah tertulis
+ *  begitu di layar mana pun.
+ *
+ *  INI SALINAN, dan salinannya disengaja BERISIK. Yang memutuskan hak tetap
+ *  `boleh()` di database (CLAUDE.md 13.1); daftar ini tidak memutuskan apa
+ *  pun, ia cuma memberi nama. Supaya ia tidak diam-diam basi,
+ *  tests/buku_sakti.test.mjs membandingkannya baris demi baris dengan
+ *  `insert into fitur` di migrasi 0057 — kalau edisi berikutnya menambah
+ *  fitur ke-dua belas, tesnya yang memberi tahu, bukan panitia yang membaca
+ *  nama kode mentah di tengah buku. */
+export const FITUR_NAMA = {
+  pendaftaran:   "Pendaftaran",
+  pembayaran:    "Pembayaran",
+  daftar_ulang:  "Daftar Ulang",
+  cetak_kloter:  "Daftar Kloter",
+  keberangkatan: "Keberangkatan",
+  kedatangan:    "Kedatangan",
+  pos:           "Input Nilai Pos",
+  live_score:    "Live Score",
+  rekap:         "Rekapitulasi",
+  akun:          "Akun",
+  pengaturan:    "Pengaturan",
+};
+
+/** Kode fitur yang boleh disebut blok "layar". */
+export const FITUR_SAH = Object.keys(FITUR_NAMA);
+
+/** Rute yang boleh disebut blok "layar". Sama alasannya dengan FITUR_SAH:
+ *  tautan yang salah ketik di dalam buku jatuh ke Home tanpa satu pun galat,
+ *  dan yang membacanya menyimpulkan bukunya yang bohong. */
+export const RUTE_SAH = [
+  "#/home", "#/foto", "#/data-peserta", "#/pembayaran", "#/daftar-ulang",
+  "#/cetak-kloter", "#/keberangkatan", "#/finish", "#/pos", "#/pos2",
+  "#/cek-nilai", "#/live-score", "#/kejuaraan", "#/pengaturan-kloter",
+  "#/ganti-password", "#/account", "#/buku-sakti",
+];
+
+const BAB_TUTORIAL = {
+  kode: "tutorial",
+  judul: "Menjalankan HRCD",
+  tab: "Menjalankan",
+  ikon: "list-ordered",
+  warna: "biru",
+  ringkas: "Urutan kerja satu edisi HRCD, dari menyiapkan edisi baru sampai papan juara dan pembersihan sesudah acara.",
+  bagian: [
+    {
+      kode: "tutorial-edisi-baru",
+      judul: "Menyiapkan edisi baru",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Sebelum satu pun pendaftar masuk, angka-angka edisi harus sudah benar: tanggal lomba, jendela keberangkatan, jarak antar kloter, daftar pos dan lomba, bobot tiap lomba, pilihan kontrak waktu, dan stok nomor dada. Semuanya adalah baris di database, bukan angka yang ditulis di dalam kode.",
+        },
+        {
+          jenis: "p",
+          teks: "Karena itu tidak ada layar untuk mengubahnya. Perubahan ditulis sebagai migration, di-merge, lalu dijalankan satu berkas per satu berkas lewat workflow Apply migration di GitHub Actions.",
+        },
+        {
+          jenis: "layar",
+          nama: "Kalkulator Keberangkatan",
+          hash: "#/pengaturan-kloter",
+          fitur: "pengaturan",
+          teks: "Isi Waktu Berangkat Pertama, Waktu Berangkat Terakhir, jumlah regu Eksternal dan Intern; layar ini menghitung rekomendasi berapa kloter yang terbentuk beserta jam berangkat tiap kloter. Dipakai untuk memastikan seluruh kloter masih masuk jendela sebelum angkanya dikunci.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Tetapkan tanggal lomba di baris edisi. Seluruh perkiraan jam berangkat dihitung dari tanggal ini, jadi jangan pernah menulis tanggal di dalam kode atau di skrip apa pun.",
+            "Tetapkan jendela keberangkatan 07:00 sampai 10:00 dan jeda MAKSIMAL antar keberangkatan 5 menit sebagai konfigurasi edisi, bukan sebagai angka tetap. Jeda itu batas atas: kalau kloternya sedikit, yang terakhir berangkat jauh sebelum ujung jendela.",
+            "Isi daftar pos, lomba, dan penilaian beserta poin maksimalnya. Bobot sebuah pos tidak pernah ditulis di mana pun: ia adalah jumlah poin maksimal seluruh wahana di pos itu.",
+            "Isi pilihan kontrak waktu (3 jam, 3,5 jam, 4 jam) dan konfigurasi penalti.",
+            "Isi stok nomor dada dua deret: Eksternal 1 sampai 500, Intern 1001 sampai 1250.",
+            "Buka Kalkulator Keberangkatan dan pastikan kloter terakhir masih berangkat sebelum 10:00.",
+            "Sesudah PR mendarat, jalankan workflow Apply migration to Supabase untuk tiap berkas migration, satu per satu, lalu baca notice yang keluar.",
+            "Jalankan supabase/checks/status_migrasi.sql lewat workflow yang sama untuk membuktikan migration-nya benar-benar hidup di database.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Migration tidak pernah ikut merge. Berkas yang di-merge tapi tidak pernah dijalankan tidak menimbulkan satu galat pun: CI tetap hijau dan layar tetap menyala. Sepuluh migration pernah menganggur enam hari seperti itu, dan yang menemukannya adalah seorang pembina yang ditolak saat mendaftarkan regu Intern.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Aturan penilaian adalah data, bukan kode. Tiap tahun angkanya berubah tanpa satu baris kode disentuh.",
+            "Memindahkan satu lomba dari satu pos ke pos lain mengubah bobot KEDUA pos itu tanpa satu angka pun diedit.",
+            "Status migrasi sendiri baru mencakup sampai berkas 0163. Berkas yang lebih muda belum ikut diperiksa, jadi jangan membaca laporan hijau sebagai jaminan penuh.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-akun",
+      judul: "Akun panitia dan hak akses",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Yang menentukan sebuah layar terbuka atau tidak adalah matriks centang di layar Akun, bukan nama peran. Peran hanya preset yang mengisi centang awal. Kalau seorang panitia butuh satu layar tambahan di luar paketnya, centang tambahan itulah jalannya.",
+        },
+        {
+          jenis: "layar",
+          nama: "Akun",
+          hash: "#/account",
+          fitur: "akun",
+          teks: "Membuat akun panitia, memilih peran, dan mencentang fitur per akun. Hanya pemegang fitur akun yang melihat tombolnya di header.",
+        },
+        {
+          jenis: "layar",
+          nama: "Ganti Password",
+          hash: "#/ganti-password",
+          fitur: null,
+          teks: "Terbuka untuk semua akun, tanpa centang apa pun. Selain password baru, layar ini meminta Kode Konfirmasi — tanyakan ke koordinator kalau lupa.",
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Peran", "Kolom pos", "Centang bawaan"],
+          baris: [
+            ["admin", "kosong", "sebelas fitur, termasuk akun dan pengaturan"],
+            ["registrasi", "kosong", "pendaftaran, pembayaran, daftar_ulang, cetak_kloter, live_score"],
+            ["gerbang", "kosong", "keberangkatan, kedatangan, live_score"],
+            ["juri_pos", "wajib diisi nomor posnya", "pos, live_score — terkunci ke posnya sendiri"],
+            ["koordinator_pos", "wajib kosong", "pos, live_score — terbuka untuk kelima pos"],
+          ],
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Buka layar Akun, buat akun, dan pilih perannya LEBIH DULU.",
+            "Baru sesudah peran tersimpan, tambahkan atau kurangi centang fiturnya.",
+            "Untuk juri_pos, isi kolom pos dengan nomor pos yang dipegangnya.",
+            "Untuk koordinator_pos, biarkan kolom pos kosong. Kekosongan itulah yang membuka kelima pos.",
+            "Bagikan password awal, lalu minta tiap orang menggantinya sendiri di Ganti Password sebelum hari-H.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Mengganti peran akan MENGHAPUS seluruh centang tangan lalu mengisinya ulang dari paket peran. Jadi urutannya wajib peran dulu, centang sesudahnya. Kalau dibalik, centang tambahan yang sudah susah payah dipasang lenyap tanpa peringatan.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Fitur rekap hanya ada di paket admin. Siapa pun di luar admin yang perlu membacanya harus dicentang manual.",
+            "Akun yang dinonaktifkan kehilangan seluruh haknya seketika, apa pun isi centangnya, tanpa menunggu dia logout.",
+            "Isolasi pos berlaku saat MENULIS nilai, tidak saat membaca. Juri Pos 3 memang bisa melihat angka Pos 1 sebelum diumumkan, dan itu keputusan pemilik acara.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-pendaftaran",
+      judul: "Pendaftaran dibuka",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Pendaftaran diisi sendiri oleh pembina lewat form di situs peserta, satu form per sekolah untuk beberapa regu sekaligus. Panitia TIDAK punya layar entri pendaftaran. Meja offline memakai link yang sama persis, cuma menyediakan HP atau laptop untuk pembina yang datang langsung.",
+        },
+        {
+          jenis: "layar",
+          nama: "Pendaftaran",
+          hash: "#/home",
+          fitur: "pendaftaran",
+          teks: "Ubin Pendaftaran di Home bukan form, melainkan link keluar ke halaman daftar di situs peserta. Buka lewat ubin ini supaya alamat yang dipakai panitia sama dengan yang dibagikan ke pembina.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Pastikan fase live masih pra. Di fase itu halaman peserta hanya menampilkan jumlah pendaftar dan jalan menuju formulir.",
+            "Sebarkan link form pendaftaran ke pembina.",
+            "Di meja offline, dampingi pembina mengisi form yang sama: jenis peserta, sekolah, konfirmasi alamat, kebutuhan barak, jumlah regu per golongan, lalu nama regu dan anggota tiap regu.",
+            "Satu batch pendaftaran menghasilkan satu kode pembayaran. Tuliskan kode itu untuk pembina dan tekankan bahwa kode itu yang dibawa saat daftar ulang.",
+            "Untuk metode transfer, pembina wajib upload bukti di form. Buktinya masuk ke penyimpanan privat, bukan ke folder umum.",
+          ],
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Kunci sekolah adalah NAMANYA. Alamat yang diketik pembina tidak melahirkan baris sekolah baru dan tidak menimpa alamat yang sudah dikurasi panitia.",
+            "Dua sekolah senama dibedakan DI DALAM namanya: MAN 3 Ciamis dan MAN 3 Tasikmalaya. Kalau tidak ada tabrakan, jangan tambahkan ekor apa pun.",
+            "Nama regu unik untuk seluruh acara. Dua regu dari satu sekolah dipisah dengan angka di belakang namanya.",
+            "Pertanyaan barak tidak muncul untuk peserta Internal.",
+            "Pembayaran sebagian tidak dilayani. Satu batch dibayar semuanya atau tidak sama sekali, dan tidak ada refund.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kunci sekolah pernah berupa pasangan nama dan alamat. Beda satu koma antara Jl. dan Jln. sudah cukup melahirkan sekolah baru: SMPN 1 Ciamis pernah muncul tiga kali di kotak pilihan, SMPN 2 Cipaku empat kali. Baris kembar memecah pencarian, rekap, dan identitas pendaftaran.",
+        },
+      ],
+    },
+    {
+      kode: "tutorial-data-peserta",
+      judul: "Memeriksa dan membetulkan data peserta",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Yang mengetik data peserta adalah pembina, bukan panitia, dan sebagian mengetiknya dari HP sambil berdiri. Jadi selalu ada nomor kontak yang kurang satu angka, nama ketua yang disingkat, atau nama regu yang salah huruf. Membetulkannya adalah pekerjaan meja yang sama dengan menerima pendaftaran, cuma terpisah waktu.",
+        },
+        {
+          jenis: "layar",
+          nama: "Data Peserta",
+          hash: "#/data-peserta",
+          fitur: "pendaftaran",
+          teks: "Membetulkan kontak, nama regu, ketua, anggota, kelas, dan organisasi. Semua perubahan tercatat di riwayat pendaftaran.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Sapu daftar pendaftar per sekolah, bukan per regu. Kesalahan ketik biasanya mengelompok di satu batch karena satu orang yang mengisinya.",
+            "Betulkan nomor kontak lebih dulu. Itu satu-satunya jalan menghubungi pembina kalau bukti transfernya bermasalah.",
+            "Periksa nama regu terhadap aturan unik: dua regu satu sekolah dengan nama yang sama dipisah dengan angka.",
+            "Pastikan ketua terisi. Empat anggota lain boleh kosong di form, tapi kelengkapan lima orang tetap diperiksa fisik di garis finish.",
+            "Selesaikan pembetulan SEBELUM regunya menerima nomor dada.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Sesudah nomor dada diberikan, identitas lapangan regu itu beku. Nama regu yang sudah bernomor dada tidak diganti lagi, sekalipun konvensi penamaan berubah kemudian, karena kertas dan papan sudah menyebut nama itu.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Membetulkan data peserta TIDAK BOLEH mengubah status pembayaran, nomor dada, kloter, atau apa pun hasil daftar ulang. Regu yang sudah lunas tetap lunas.",
+            "Daftar anggota di form bukan pengganti pemeriksaan fisik di finish, dan tidak dipakai menghitung penalti anggota.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-pembayaran",
+      judul: "Verifikasi pembayaran",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Satu kode pembayaran mencakup seluruh regu dalam satu batch. Menandai lunas membuat seluruh batch itu valid bersama-sama, lalu kwitansinya bisa dicetak.",
+        },
+        {
+          jenis: "layar",
+          nama: "Meja Pembayaran",
+          hash: "#/pembayaran",
+          fitur: "pembayaran",
+          teks: "Daftar seluruh batch pendaftaran, tombol Tandai Lunas, dan tombol Cetak Kwitansi yang muncul sesudahnya. Home membawa lencana jumlah batch yang masih menunggu pembayaran.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Buka lencana menunggu pembayaran di Home untuk melihat antreannya.",
+            "Untuk transfer: buka bukti yang di-upload pembina, cocokkan nominal dan nama pengirim dengan mutasi rekening.",
+            "Untuk tunai: hitung uangnya di meja, cocokkan dengan nominal batch.",
+            "Tandai lunas. Seluruh regu dalam batch itu berubah status bersamaan.",
+            "Cetak kwitansi dan serahkan ke pembina.",
+            "Kalau nominalnya kurang, JANGAN tandai lunas sebagian. Hubungi pembina lewat kontak di Data Peserta.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Regu yang belum lunas tidak bisa daftar ulang dan tidak masuk penyebut kelengkapan pos. Antrean yang tertahan di sini akan muncul kembali sebagai antrean panjang di meja daftar ulang, satu hari sebelum lomba, saat tidak ada lagi waktu mengurusnya.",
+        },
+      ],
+    },
+    {
+      kode: "tutorial-daftar-ulang",
+      judul: "Daftar ulang dan nomor dada",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Daftar ulang berjalan satu sampai dua hari sebelum lomba, biasanya dengan dua atau tiga meja paralel. Regu datang menyebut kode pembayaran, panitia mengonfirmasi nama regu dan sekolahnya, lalu MENGETIK nomor dada dari kain fisik yang sudah ada di tangan.",
+        },
+        {
+          jenis: "layar",
+          nama: "Meja Daftar Ulang",
+          hash: "#/daftar-ulang",
+          fitur: "daftar_ulang",
+          teks: "Cari batch dengan kode pembayaran, isi nomor dada untuk seluruh regu sekolah itu sekaligus lewat satu tombol Simpan, dan tukar nomor yang kainnya rusak.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Minta kode pembayaran, ketik di kotak cari.",
+            "Bacakan nama regu, asal sekolah, dan golongannya. Peserta mengonfirmasi datanya sendiri secara lisan.",
+            "Ambil kain nomor dada dari kotak, ketik angkanya persis seperti yang tertulis di kain.",
+            "Bacakan lagi nomor dada tiap regu sebelum menekan Simpan. Itu pintu terakhir yang masih murah.",
+            "Isi seluruh regu sekolah itu dalam satu kali simpan. Sepuluh regu berarti sepuluh nomor dada dalam satu transaksi.",
+            "Serahkan kain nomor dadanya.",
+            "Kalau kainnya rusak, pakai tombol Tukar nomor rusak. Nomor lama dipensiunkan permanen.",
+          ],
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Nomor dada DIKETIK petugas, tidak diterbitkan sistem. Sistem hanya memeriksa: ada di stok, belum dipensiunkan, belum dipakai, dan berada di deret yang benar.",
+            "Ada DUA deret. Eksternal 1 sampai 500. Intern 1001 sampai 1250.",
+            "Kain Intern bertulis 001 diketik 1001, dan angka 1001 itulah yang tampil di seluruh layar, kertas, dan papan peserta. Kain barunya diberi angka 1 di depan supaya tidak ada terjemahan di kepala siapa pun.",
+            "Kloter ditentukan SISTEM saat nomor dada tersimpan. Petugas tidak memilih kloter di layar ini.",
+            "Tidak ada tanda tangan dan tidak ada centang konfirmasi di sistem. Konsekuensinya tidak ada catatan siapa mengonfirmasi apa dan kapan, jadi konfirmasi lisannya harus benar-benar dilakukan.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Blangko penilaian per lomba hanya memuat NOMOR DADA tanpa nama regu. Nomor dada yang salah setelah lomba dimulai bukan sekadar salah tulis: ia memindahkan seluruh nilai satu regu ke regu lain, dan tidak ada apa pun di kertas yang memperlihatkannya. Sebelum kertasnya dicetak, pembetulan cuma satu ketukan.",
+        },
+      ],
+    },
+    {
+      kode: "tutorial-kloter",
+      judul: "Kloter dan daftar kloter",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Pembagian kloter bukan pekerjaan terpisah. Ia jatuh sendiri saat nomor dada tersimpan di meja daftar ulang. Yang perlu dikerjakan panitia hanyalah mencetak daftarnya, dan mencetaknya dalam dua bentuk berbeda untuk dua pembaca berbeda.",
+        },
+        {
+          jenis: "layar",
+          nama: "Daftar Kloter",
+          hash: "#/cetak-kloter",
+          fitur: "cetak_kloter",
+          teks: "Mencetak daftar isi tiap kloter, satu kloter per halaman, dan mengatur jendela Planning Keberangkatan yang jamnya ikut tercetak. Dua tombol cetak: Cetak Kloter untuk Petugas dan Cetak Kloter untuk Peserta.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Kuota otomatis per kloter: 5 Eksternal dan 3 Intern, dihitung TERPISAH.",
+            "Urutannya FIFO murni. Yang lebih dahulu menyelesaikan daftar ulang mendapat kloter lebih awal.",
+            "Sekolah tidak memengaruhi apa pun. Tidak ada pengacakan dan tidak ada lompatan kloter. Dua regu satu sekolah boleh sekloter kalau memang FIFO menempatkan mereka di sana.",
+            "Pengacakan otomatis MELEWATI kloter yang sudah berangkat. Tanda cetak tidak menutup kloter untuk penambahan regu.",
+            "Jangan pernah menomori kloter sendiri. Kalau perlu disusun ulang, bersihkan datanya lalu jalankan ulang alurnya.",
+          ],
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Tekan Cetak Kloter untuk Petugas: lembarnya memuat kolom Kontrak Waktu dan Hadir yang ditulisi berdampingan, plus tempat menulis tangan jam berangkat sebenarnya.",
+            "Tekan Cetak Kloter untuk Peserta untuk papan pengumuman dan barak: hanya perkiraan jam berangkat, tanpa kolom centang dan tanpa kotak jam, karena yang membacanya peserta.",
+            "Tempel lembar papan di barak dan di titik kumpul semalam sebelum hari-H.",
+            "Serahkan lembar staging ke petugas Pemberangkatan, Staging 1, dan Staging 2.",
+            "Cetak ulang tanpa ragu kalau ada regu masuk belakangan. Mencetak ulang selembar daftar itu murah.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Mencetak ulang selembar daftar itu murah; memberangkatkan kloter dengan empat tempat kosong tidak bisa diulang. Itu sebabnya tanda cetak sengaja TIDAK mengunci kloter.",
+        },
+        {
+          jenis: "p",
+          teks: "Bersihkan data harus mengembalikan penomoran kloter ke 1. Produksi pernah memulai pembagian dari kloter 17 karena 24 kloter pertama masih menyandang tanda cetak dari percobaan sebelumnya, dan panitia menghabiskan pagi mencari enam belas kloter yang tidak pernah ada.",
+        },
+      ],
+    },
+    {
+      kode: "tutorial-pagi-hari-h",
+      judul: "Pagi hari-H: upacara dan antrean start",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Jendela keberangkatan adalah 07:00 sampai 10:00. Tidak ada kloter yang berangkat sebelum jam tujuh dan yang terakhir sudah jalan sebelum jam sepuluh. Seluruh pagi disusun dari kenyataan bahwa itu tiga jam untuk berapa pun jumlah kloter tahun ini.",
+        },
+        {
+          jenis: "p",
+          teks: "Pagi dibuka dengan upacara, dan seorang pejabat memberangkatkan kloter pertama untuk difoto. Itu bukan penundaan yang harus dihilangkan; itu alasan acara ini punya garis start yang layak difoto. Susun jadwalnya mengelilingi upacara, bukan melawannya.",
+        },
+        {
+          jenis: "layar",
+          nama: "Daftar Kloter",
+          hash: "#/cetak-kloter",
+          fitur: "cetak_kloter",
+          teks: "Kartu tiap kloter membawa jam Rencana dan, sesudah kloter itu jalan, jam Real. Ini yang dibuka untuk menjawab pertanyaan pembina: kloter 9 kira-kira jam berapa.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Tempatkan TIGA kloter siap sejak sebelum upacara: kloter 1 di Pemberangkatan, kloter 2 di Staging 1, kloter 3 di Staging 2.",
+            "Sisanya tetap di formasi upacara.",
+            "Susun formasi upacara TERBALIK: kloter terakhir di depan, kloter 4, 5, dan 6 di belakang.",
+            "Verifikasi kehadiran regu DI TITIK TUNGGUNYA, bukan saat sudah sampai di garis start.",
+            "Konfirmasi kontrak waktu tiap regu TIGA kloter sebelum ia berangkat. Pilihannya 3 jam, 3,5 jam, atau 4 jam, dan ditentukan per REGU.",
+            "Selesaikan semua urusan administrasi regu pada momen konfirmasi itu juga.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kloter 4, 5, dan 6 berdiri di BELAKANG karena merekalah yang berikutnya dipanggil, dan barisan belakang adalah yang paling dekat jalan keluar. Formasi dengan kloter 4, 5, 6 di depan terlihat lebih rapi dan memakan beberapa menit tambahan per kloter sepanjang pagi.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Satu kloter boleh berisi regu dengan kontrak waktu berbeda-beda. Kontrak itu milik regu, bukan milik kloter.",
+            "Urusan administrasi yang tidak selesai tiga kloter di muka akan menahan garis start, dan seluruh sisa pagi bergeser.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-keberangkatan",
+      judul: "Keberangkatan",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Di garis start, KERTAS adalah pencatat utamanya dan laptop yang memverifikasi. Panitia kertas mencentang tiap regu yang berangkat, menulis tangan regu yang tidak sesuai kloter awalnya, dan mencatat jam berangkat tiap kloter. Kertas itu lalu diserahkan ke panitia laptop untuk dimasukkan.",
+        },
+        {
+          jenis: "layar",
+          nama: "Keberangkatan",
+          hash: "#/keberangkatan",
+          fitur: "keberangkatan",
+          teks: "Centang hadir per nomor dada, atur kontrak waktu, pindahkan regu antar kloter, dan ketik jam berangkat kloter. Home membawa lencana kemajuan berangkat dibanding siap.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Terima lembar staging dari petugas kertas sesudah kloternya jalan.",
+            "Centang tiap nomor dada yang hadir sesuai kertas.",
+            "Masukkan regu yang ditulis tangan sebagai sisipan ke kloter yang benar.",
+            "KETIK jam berangkat kloter dari angka yang tertulis di kertas, bukan dari jam saat kamu mengetik.",
+            "Berangkatkan kloter itu di sistem, lalu ambil lembar kloter berikutnya.",
+          ],
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Kotak jam menerima 745, 0745, 7:45, dan 7.45. Angka di luar rentang DITOLAK dengan pesan, tidak ditebak.",
+            "Kotak jam sengaja bukan pemilih waktu bawaan browser: laptop berbahasa Inggris menampilkan 07:15 AM, dan itu cara yang sangat murah untuk mencatat 07:15 sebagai 19:15.",
+            "Jam berangkat yang tercatat adalah dasar seluruh penalti waktu. Perkiraan jam berangkat hanya untuk merencanakan pagi, dan keduanya tidak pernah disimpan di kolom yang sama.",
+            "Jarak antar keberangkatan paling banyak 5 menit.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Regu yang terlambat masuk kloter terakhir. Tapi menyisipkan regu ke kloter yang SUDAH berangkat tetap boleh dan tidak dibatasi kuota, karena itu keputusan petugas yang melihat lapangan. Regu yang disisipkan sesudah kertas dicetak wajib ditandai, sebab nomornya tidak ada di lembar petugas staging.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Regu yang disisipkan ke kloter yang sudah berangkat dihitung berangkat pada JAM KLOTER ITU, bukan jam ia benar-benar jalan, karena penalti dihitung dari jam berangkat kloter. Kalau maksudnya regu itu berangkat sekarang, tempatnya di kloter yang belum jalan.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Salah satu menit di jam berangkat menggeser penalti SELURUH regu di kloter itu sekaligus.",
+            "Kloter yang tidak pernah dicatat berangkat membuat regunya tidak masuk klasemen resmi.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-di-pos",
+      judul: "Di pos: blangko, input nilai, foto jawaban",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Tiga level, bukan dua: satu pos memuat beberapa lomba, dan satu lomba memuat satu atau lebih penilaian. Pos 3 punya empat lomba, bukan tujuh: Pembidaian, Kim Lihat, Kim Cium, dan Logika. Kim Lihat dan Kim Cium adalah DUA lomba, bukan dua kriteria satu lomba, karena masing-masing punya lembar jawaban dan kolom fotonya sendiri.",
+        },
+        {
+          jenis: "layar",
+          nama: "Input Nilai Tabel",
+          hash: "#/pos",
+          fitur: "pos",
+          teks: "Satu tabel selebar pos, satu regu satu baris, meniru lembar yang biasa dipakai. Dipakai meja IT yang memasukkan tumpukan kertas berurutan. Ini SATU-SATUNYA tempat blangko bisa dicetak.",
+        },
+        {
+          jenis: "layar",
+          nama: "Input Nilai Per Lomba",
+          hash: "#/pos2",
+          fitur: "pos",
+          teks: "Pilih satu lomba, lalu satu regu satu layar dengan tombol simpan. Dipakai juri yang memegang satu lomba sepagian dari HP.",
+        },
+        {
+          jenis: "layar",
+          nama: "Foto Jawaban Sekaligus",
+          hash: "#/foto",
+          fitur: "pos",
+          teks: "Memotret setumpuk lembar jawaban di pos, per lomba, nomor dadanya ditautkan belakangan. Jumlah foto yang belum tertaut tampil sebagai angka di layar.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Sebelum hari-H, buka Input Nilai Tabel di tiap pos dan cetak SATU master blangko per lomba.",
+            "Bawa master itu ke tukang fotokopi. Pos dengan tiga lomba dan 500 regu berarti 1.500 lembar hasil fotokopi, bukan 1.500 halaman dari printer.",
+            "Di lapangan, juri menulis nilai mentah di blangko lomba yang dipegangnya, satu lembar per regu.",
+            "Masukkan lembar yang sudah terisi ke KOTAK PENILAIAN pos itu.",
+            "Jalur foto utamanya tombol kamera di meja IT: difoto saat nomor dadanya baru diketik, jadi gambarnya tertaut sendiri ke regu dan lomba yang tepat.",
+            "Foto Jawaban Sekaligus dipakai untuk yang tidak bisa dilakukan tombol itu: memotret setumpuk kertas DI POS sebelum ia berangkat ke meja IT. Nomor dadanya menganggur di antrean sampai ada yang menautkannya, jadi jangan biarkan antreannya menumpuk.",
+            "Urutkan kertasnya menurut nomor dada sebelum diinput — tabelnya juga berurut begitu, deret 1 sampai 500 dulu lalu 1001 ke atas — lalu masukkan berurutan lewat Input Nilai Tabel.",
+          ],
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Blangko dicetak SATU master lalu difotokopi. Mencetak tumpukannya dari browser menghabiskan satu toner kantor untuk pekerjaan yang diselesaikan mesin fotokopi dalam beberapa menit.",
+            "LOMBA SOAL TIDAK MENCETAK BLANGKO SAMA SEKALI. Peserta menjawab di lembar soalnya sendiri, jadi pos yang seluruh lombanya soal tidak mencetak master apa pun dan mengatakan alasannya di layar.",
+            "Kertasnya A5 melintang, satu halaman per lomba, difotokopi dua-up ke A4 lalu dipotong sekali lurus.",
+            "Petugas lapangan hanya mencatat data MENTAH dan tidak pernah menghitung poin. Kolom Nilai Pos sengaja tidak dicetak di bentuk kertas mana pun.",
+            "Tidak ada tombol simpan di Input Nilai Tabel. Baris tersimpan sendiri saat ditinggalkan, dan centang hijaunya baru muncul sesudah angka itu benar-benar ada di database — lencana kuning bertuliskan belum artinya masih di layar saja.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "FOTO ADALAH BUKTI, BUKAN SUMBER NILAI. Angka yang berlaku adalah yang diketik. Kalau isi foto berbeda dari yang terinput, penyelesaiannya manual dan diputuskan orang, bukan otomatis diambil dari gambar.",
+        },
+        {
+          jenis: "p",
+          teks: "Input Nilai Per Lomba menyimpan nilai yang gagal terkirim di HP petugas. Jaminannya adalah terkirim begitu halaman itu dibuka lagi dan ada sinyal, bukan pasti terkirim nanti. Selama pita kuning masih tampil, ada angka yang belum ada di mana pun selain HP itu — jangan tutup halamannya dan jangan pulang.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Yang ditolak server — nilai di luar rentang, regu tergembok, komponen bukan untuk golongan itu — dilaporkan merah saat itu juga selagi regunya masih di depan petugas, dan tidak masuk antrean.",
+            "Kotak penilaian yang tertinggal di pos adalah satu-satunya cara nilai lenyap tanpa jejak. Tunjuk satu orang penanggung jawabnya sejak pos tutup sampai isinya masuk sistem.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-kedatangan",
+      judul: "Kedatangan dan penalti waktu",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Di garis finish urutannya kebalikan dari garis start: LAPTOP pencatat utamanya, kertas hanya untuk verifikasi. Targetnya sekitar tiga detik per regu, karena mejanya cuma satu atau dua.",
+        },
+        {
+          jenis: "layar",
+          nama: "Kedatangan",
+          hash: "#/finish",
+          fitur: "kedatangan",
+          teks: "Ketik nomor dada, detail regu muncul sendiri untuk dipastikan — tidak ada tombol Cari — lalu satu tombol SAMPAI DI FINISH menandainya tiba. Home membawa lencana kemajuan datang dibanding berangkat.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Ketik nomor dada regu yang baru masuk.",
+            "Pastikan nama regu dan sekolah yang muncul cocok dengan yang berdiri di depan meja.",
+            "Hitung anggotanya secara FISIK. Lima orang atau tidak.",
+            "Tekan SAMPAI DI FINISH. Jam yang tercatat adalah jam saat tombol itu ditekan, jadi tekan dulu — jangan menunggu selesai menghitung.",
+            "Kalau anggotanya kurang dari lima, buka Perbaiki jam atau jumlah anggota dan turunkan angkanya. Kotak itu terisi 5 secara bawaan.",
+            "Kalau antrean menumpuk, catat di kertas dulu dan masukkan menyusul, lalu betulkan jam datangnya lewat kotak yang sama.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Penalti waktu menilai KETEPATAN, bukan kecepatan. Target tiba sebuah regu adalah jam berangkat kloternya ditambah kontrak waktunya. Berangkat 07:00 dengan kontrak 4 jam berarti target 11:00 tepat.",
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kejadian", "Akibat"],
+          baris: [
+            ["Tiba satu menit lebih cepat", "kurang 1 poin"],
+            ["Tiba satu menit lebih lambat", "kurang 1 poin"],
+            ["Tiba tepat waktu", "tidak ada pengurangan"],
+            ["Melewatkan satu pos", "nilai pos itu 0, tanpa pengurangan tambahan"],
+            ["Anggota kurang satu orang", "kurang 20 poin per orang"],
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Satu menit terlalu cepat dihukum sama persis dengan satu menit terlambat, dan tidak ada toleransi sama sekali. Aturan lama punya toleransi sembilan menit; jangan menghidupkannya kembali. Yang diuji adalah kemampuan regu memperkirakan perjalanannya sendiri, bukan kemampuan berlari.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Jam datang adalah jam saat tombol ditekan di laptop panitia, BUKAN timestamp server saat datanya sampai. Kalau server yang menandai waktunya sendiri, regu yang dicatat dua puluh menit setelah tiba dihukum atas keterlambatan yang tidak pernah terjadi.",
+            "Karena itu jam datang tetap boleh diubah manual untuk pencatatan susulan dari kertas.",
+            "Penalti pos terlewat dan penalti anggota TIDAK berlaku bagi regu Intern.",
+            "Regu yang belum tercatat tiba tetap tampil di Live Score tanpa peringkat, tidak bisa masuk enam besar, dan tidak dikenai pengurangan apa pun. Ia hilang dari klasemen resmi tanpa satu galat pun muncul.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-cek-nilai",
+      judul: "Cek nilai dan gembok",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Sesudah angka masuk, ada satu orang yang membuka foto slip di sebelah angka yang diketik darinya. Kalau cocok, ia mengetuk gembok. Yang memeriksa memang bukan yang mengetik, dan pemisahan itulah yang membuat layar pemeriksa boleh mengubah nilai.",
+        },
+        {
+          jenis: "layar",
+          nama: "Cek Nilai",
+          hash: "#/cek-nilai",
+          fitur: "pengaturan",
+          teks: "Satu regu satu layar, navigasi maju mundur per nomor dada. Angka boleh dibetulkan dan langsung dikunci di tempat. Dipegang admin server, bukan juri pos.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Buka Cek Nilai dan mulai dari nomor dada terkecil.",
+            "Untuk tiap lomba, buka fotonya di sebelah angka yang tercatat.",
+            "Kalau berbeda, betulkan angkanya di layar ini. Yang berlaku tetap keputusan orang, bukan isi gambar.",
+            "Kalau sudah cocok, ketuk gembok lomba itu.",
+            "Kalau ternyata masih ada koreksi sah, buka gembok itu — sekali ketuk, tanpa dialog alasan — lalu betulkan dan gembok lagi.",
+          ],
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Gembok berlaku PER LOMBA, bukan per pos. Pos 1 punya lima gembok terpisah.",
+            "Nilai yang tergembok DITOLAK oleh seluruh jalur tulis, termasuk layar juri.",
+            "Mengunci terlalu dini memblokir koreksi yang sah. Tidak mengunci sama sekali berarti tidak ada satu tanda pun bahwa sebuah lomba sudah diadu dengan fotonya.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Gembok per pos hanya bisa mengatakan seluruh pos ini sudah diperiksa, padahal yang diperiksa adalah satu lomba pada satu waktu. Kunci gembok memakai kunci yang sama persis dengan kolom foto, supaya gembok dan bukti selalu menunjuk hal yang sama.",
+        },
+      ],
+    },
+    {
+      kode: "tutorial-live-score",
+      judul: "Live Score dan fase live",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Live Score bukan cuma papan skor; sepanjang lomba ia adalah alat memantau kelengkapan. Di kartu Status ada satu cincin per pos: persennya di dalam cincin, dan di bawahnya berapa regu yang nilainya sudah LENGKAP dibanding berapa regu yang seharusnya dinilai di pos itu.",
+        },
+        {
+          jenis: "layar",
+          nama: "Live Score",
+          hash: "#/live-score",
+          fitur: "live_score",
+          teks: "Cincin kemajuan per pos, podium enam tempat per golongan, tabel rinci per golongan dengan penyaring sekolah, tombol Rekap Nilai per Sekolah dan Rekap Nilai Semua, dan tombol Refresh. Saklar fase hanya muncul untuk pemegang pengaturan.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Cincin yang belum penuh BUKAN berarti ada yang hilang. Regu yang memang belum sampai di pos itu ikut penyebutnya sejak pagi.",
+            "Yang dibaca dari cincin adalah GERAKANNYA, bukan angkanya. Empat pos merangkak naik dan satu diam saja berarti sambungan atau laptop pos itu yang perlu dilihat.",
+            "Cincin yang tidak penuh sampai lomba usai barulah kejaran: kertasnya masih di kotak penilaian pos, atau ada baris yang belum diinput di meja IT.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Nilai satu regu di satu pos terisi dalam DUA gelombang: angka lomba lebih dulu, angka soal menyusul karena lembar soal ditumpuk dan dinilai berkelompok. Cincin kelengkapan yang belum penuh di tengah lomba itu wajar, bukan tanda ada yang terlewat.",
+        },
+        {
+          jenis: "p",
+          teks: "Ada lima fase live, dan saklarnya ada di layar ini. Fase menentukan apa yang boleh dilihat peserta di HP mereka.",
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Tombol di saklar", "Fase di database", "Yang dilihat peserta"],
+          baris: [
+            ["Internal", "pra", "hanya jumlah pendaftar dan ajakan mendaftar"],
+            ["Progress", "progres", "centang per komponen, tanpa satu angka nilai, plus kloter, kontrak waktu, dan jam regunya sendiri"],
+            ["Live", "penuh", "sama persis dengan yang dilihat panitia"],
+            ["Top 10", "top10", "maksimal sepuluh regu berperingkat per golongan beserta totalnya, tanpa poin per pos"],
+            ["Juara", "juara", "papan diganti DAFTAR JUARA, dan tidak ada yang lain"],
+          ],
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Sapu cincin kelengkapan tiap pos setiap kali ada jeda di meja.",
+            "Bandingkan cincin-cincinnya satu sama lain, bukan dengan angka yang diingat-ingat. Cincin yang diam sendirian sementara yang lain naik itulah yang perlu ditelepon.",
+            "Tekan Refresh kalau angkanya terasa basi. Sejak migrasi 0165 tombol itu MENGHITUNG ULANG, bukan sekadar membaca ulang snapshot lama — dan di luar tanggal lomba penyegaran otomatis memang mati, jadi tombol inilah satu-satunya yang memperbaruinya.",
+            "Naikkan fase HANYA sesudah panitia inti setuju.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Angka di Live Score tidak pernah dihitung di layar. Ia selalu berasal dari database, karena menghitungnya di browser akan melahirkan mesin skor kedua yang cepat atau lambat tidak sepakat dengan yang pertama.",
+        },
+      ],
+    },
+    {
+      kode: "tutorial-terbitkan",
+      judul: "Menerbitkan rekap ke peserta",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Layar peserta tidak membaca database. Ia membaca satu berkas yang diterbitkan panitia. Karena itu ada satu urutan kerja yang harus dihafal: NYALAKAN FASENYA DULU, TERBITKAN SESUDAHNYA.",
+        },
+        {
+          jenis: "p",
+          teks: "Penerbitannya BUKAN tombol di layar panitia. Yang ada di layar cuma saklar fase; yang menulis berkasnya adalah workflow Publish rekap live di GitHub Actions, dijalankan dari tab Actions — dan itu bisa dari HP. Pesan yang muncul sesudah saklar digeser pun menyuruh hal yang sama.",
+        },
+        {
+          jenis: "layar",
+          nama: "Live Score",
+          hash: "#/live-score",
+          fitur: "pengaturan",
+          teks: "Saklar fase live duduk di kepala kartu klasemen dan hanya muncul untuk pemegang fitur pengaturan. Lima tombol: Internal, Progress, Live, Top 10, Juara.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Pastikan angka yang mau diterbitkan sudah dicek dan digembok.",
+            "Geser saklar fase di Live Score ke fase yang dituju.",
+            "Baru jalankan workflow Publish rekap live di GitHub Actions.",
+            "Buka situs peserta dari HP sendiri dan hitung barisnya. Jangan menilai dari judul halaman.",
+            "Kalau papannya kosong padahal seharusnya berisi, jalankan Publish rekap live sekali lagi. Berkas fase sebelumnya mungkin memang tidak memuat baris itu.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Berkas rekap duduk di CDN dan bisa diminta siapa pun yang tahu alamatnya. Satu-satunya jaminan bahwa nilai belum bocor adalah nilainya MEMANG TIDAK ADA di berkas itu, bukan ada tapi tidak digambar di layar. Penerbitan punya sembilan pagar bocor, dan tidak satu pun boleh dilonggarkan demi tampilan yang lebih enak.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "HP peserta membaca fase langsung tiap lima belas detik, tapi fase hanya boleh MEMPERKETAT. Ia tidak pernah bisa menampilkan lebih dari isi berkas yang sudah terbit.",
+            "Menurunkan saklar dari Juara kembali ke Live TIDAK mengembalikan papan sampai rekap diterbitkan ulang, karena berkas fase juara memang tidak memuat satu baris klasemen pun. Itu bukan kerusakan.",
+            "Centang komponen boleh terbit sejak fase progres; angka nilai hanya boleh terbit di fase penuh.",
+            "Berkas rekap sengaja TIDAK tersambung otomatis ke repository. Kalau disambungkan, tiap perubahan kode akan menimpanya dengan berkas contoh fase pra dan rekap peserta mendadak kosong tanpa ada yang gagal.",
+            "Penerbitan otomatis hanya hidup pada tanggal lomba, tiap lima belas menit, dan hanya pada jam lomba. Di luar itu rekap cuma terbit kalau workflow-nya dijalankan tangan.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-juara",
+      judul: "Pengumuman juara",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Sebagian penghargaan dihitung sistem dari skor, sebagian lagi keputusan panitia yang harus dimasukkan tangan sebelum diumumkan. Yang manual harus sudah terisi SEBELUM naik ke fase juara.",
+        },
+        {
+          jenis: "layar",
+          nama: "Kejuaraan",
+          hash: "#/kejuaraan",
+          fitur: "live_score",
+          teks: "Daftar seluruh penghargaan beserta angkanya. Mengubah pilihan manual butuh fitur pengaturan.",
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Penghargaan", "Dari mana"],
+          baris: [
+            ["Juara 1 sampai 3 dan Harapan 1 sampai 3", "enam besar skor tiap golongan"],
+            ["Juara Umum, Juara Umum Penegak, Juara Umum Penggalang", "poin gelar tiap sekolah — Juara 1 bernilai 6 sampai Harapan 3 bernilai 1"],
+            ["Juara Yel Yel", "poin Pos 5 tertinggi, per golongan"],
+            ["Peserta Terbanyak", "jumlah nomor dada Eksternal per sekolah, satu untuk seluruh acara"],
+            ["Juara Kostum dan Peserta Terfavorit", "pilihan manual panitia, per golongan"],
+            ["Pangkalan Terjauh", "pilihan manual panitia, SEKOLAH bukan regu, satu untuk seluruh acara"],
+          ],
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Pastikan semua regu sudah tercatat tiba. Regu yang belum closing tidak bisa masuk enam besar.",
+            "Isi pilihan manual: Juara Kostum dan Peserta Terfavorit per golongan, lalu Pangkalan Terjauh yang diisi nama SEKOLAH.",
+            "Periksa daftar juara di layar Kejuaraan bersama panitia inti.",
+            "UMUMKAN DI LAPANGAN lebih dulu.",
+            "Baru geser saklar fase ke Juara.",
+            "Baru jalankan Publish rekap live sekali lagi.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Podium tidak memakai angka peringkat. Peringkat membuat dua regu berskor sama berbagi angka lalu melompati angka berikutnya — benar untuk peringkat, salah untuk GELAR, karena piala Juara 2 hanya ada satu. Pemecah serinya ketepatan waktu lebih dulu, lalu nomor dada terkecil.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Daftar juara terbit BESERTA angkanya, karena angka itu baru saja dibacakan di lapangan.",
+            "Yang menahan angka sebelum pengumuman bukan ketiadaan kolom, melainkan pagar fase: di luar fase juara tidak ada satu baris pun untuk dibaca siapa pun.",
+            "Tidak ada mekanisme sanggahan. Nilai yang sudah direkap bersifat final.",
+          ],
+        },
+      ],
+    },
+    {
+      kode: "tutorial-sesudah-acara",
+      judul: "Sesudah acara",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Pekerjaan belum selesai saat piala dibagikan. Ada barang fisik yang harus kembali, dan ada data yang harus dibiarkan utuh sampai kepanitiaan berikutnya siap membersihkannya.",
+        },
+        {
+          jenis: "layar",
+          nama: "Live Score",
+          hash: "#/live-score",
+          fitur: "live_score",
+          teks: "Tekan Rekap Nilai Semua dari sini untuk arsip kertas kepanitiaan, sesudah seluruh gembok terpasang. Rekap Nilai per Sekolah memecahnya per sekolah.",
+        },
+        {
+          jenis: "layar",
+          nama: "Akun",
+          hash: "#/account",
+          fitur: "akun",
+          teks: "Nonaktifkan akun panitia yang sudah selesai tugasnya. Akun nonaktif kehilangan seluruh haknya seketika tanpa perlu dihapus.",
+        },
+        {
+          jenis: "langkah",
+          butir: [
+            "Kumpulkan seluruh kotak penilaian dari kelima pos dan pastikan tidak ada satu pun tertinggal.",
+            "Pastikan tidak ada lagi pita kuning tersisa di HP petugas Input Nilai Per Lomba sebelum mereka pulang.",
+            "Cetak Rekap Nilai Semua untuk arsip kertas.",
+            "Kumpulkan kembali kain nomor dada, pisahkan yang rusak dan catat nomornya sebagai dipensiunkan.",
+            "Nonaktifkan akun panitia yang sudah selesai tugasnya.",
+            "Serahkan Buku Sakti ini beserta catatan apa yang berubah tahun ini kepada kepanitiaan berikutnya.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "JANGAN membersihkan data atas inisiatif sendiri. Bersihkan data menghapus regu, nilai, DAN mengembalikan penomoran kloter ke 1 — dan itu adalah satu-satunya salinan hasil lomba tahun ini sampai arsipnya benar-benar dipegang orang. Tunggu sampai pemilik acara memintanya.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Catat hal-hal yang belum ada layarnya supaya kepanitiaan berikutnya tidak mencarinya di hari-H: penempatan barak belum punya layar di aplikasi panitia, upload nilai massal belum dibangun sama sekali, dan foto borongan masih ditautkan ke nomor dada dengan tangan.",
+            "Catat juga apa yang tahun ini berubah angkanya — bobot lomba, kontrak waktu, stok nomor dada — supaya edisi berikutnya tahu apa yang harus ditinjau ulang.",
+          ],
+        },
+      ],
+    },
+  ],
+};
+const BAB_SEKSI = {
+  kode: "seksi",
+  judul: "Tugas Pokok Seksi",
+  tab: "Seksi",
+  ikon: "users",
+  warna: "magenta",
+  ringkas: "Usulan pembagian seksi kepanitiaan HRCD, dipetakan ke layar dan akun yang benar-benar ada di sistem.",
+  bagian: [
+    {
+      kode: "seksi-cara-membaca",
+      judul: "Cara membaca bab ini",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Daftar seksi di bawah ini adalah USULAN, bukan aturan. Nama seksi tidak tersimpan di database mana pun, tidak dipakai satu baris kode pun, dan tidak pernah ditulis di dokumen edisi sebelumnya — waktu bab ini disusun, satu-satunya pembagian kerja yang benar-benar tertulis di sistem adalah lima peran akun dan sebelas centang fitur. Jadi susun ulang seksinya sesuka kepanitiaan tahun ini; yang harus tetap cocok cuma pemetaan ke lima peran itu.",
+        },
+        {
+          jenis: "p",
+          teks: "Angka yang dipakai sebagai acuan di seluruh bab ini diambil dari HRCD XXXVII, 29 Agustus 2026: sekitar 300 regu, kurang lebih 2.500 peserta, lima pos penilaian, dan jendela keberangkatan 07:00 sampai 10:00. Edisi biasanya jatuh di Februari atau Maret, jadi jangan menyalin tanggalnya — salin ukurannya.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Tiap seksi dibuka satu paragraf tugas pokok, lalu daftar tugas konkret, lalu tabel kapan pekerjaan itu jatuh.",
+            "Blok layar menyebut nama layar, alamatnya, dan centang fitur yang harus ada di akun supaya layar itu terbuka.",
+            "Blok kenapa di akhir tiap seksi berisi alasan pembagiannya, atau satu kesalahan yang seksi itu paling sering buat.",
+            "Seksi tanpa blok layar memang tidak memegang layar apa pun; angka yang dibutuhkannya diminta ke seksi yang memegangnya.",
+            "Jam di kolom Kapan adalah usulan susunan hari, bukan angka yang tersimpan di sistem. Yang benar-benar terkunci cuma jendela keberangkatan 07:00 sampai 10:00 dan jarak antar kloter paling lama 5 menit — dan bahkan keduanya duduk di konfigurasi edisi, jadi tahun depan bisa berbeda.",
+            "Sistem tidak menyimpan nama panitia. Satu akun cuma punya username, peran, kolom pos, dan status aktif, jadi daftar siapa memegang akun mana harus ditulis di luar sistem.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Peran akun", "Centang bawaan dan kolom pos"],
+          baris: [
+            ["admin", "Sebelas centang, semuanya: pendaftaran, pembayaran, daftar ulang, cetak kloter, keberangkatan, kedatangan, pos, live score, rekap, akun, pengaturan. Kolom pos wajib kosong."],
+            ["registrasi", "Lima: pendaftaran, pembayaran, daftar ulang, cetak kloter, live score. Kolom pos wajib kosong."],
+            ["gerbang", "Tiga: keberangkatan, kedatangan, live score. Kolom pos wajib kosong."],
+            ["juri_pos", "Dua: pos, live score. Kolom pos WAJIB diisi 1 sampai 5, dan isian itulah yang mengunci barisnya ke posnya sendiri."],
+            ["koordinator_pos", "Dua yang sama persis: pos, live score. Kolom pos wajib KOSONG, dan kekosongan itu yang membuka kelima pos sekaligus."],
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Satu peran sering tidak cukup. Seksi yang memegang dua pekerjaan sekaligus tetap dibuat dengan peran terdekat, lalu centangnya ditambah tangan di layar Akun — memang itu gunanya matriks centang. Dua hal yang harus diingat waktu menambah: fitur rekap hanya ada di paket admin, jadi siapa pun di luar admin yang perlu membaca rekap penuh harus dicentangkan manual; dan mengganti peran sesudahnya akan menghapus seluruh centang tangan itu lalu mengisinya ulang dari paket.",
+        },
+        {
+          jenis: "layar",
+          nama: "Akun",
+          hash: "#/account",
+          fitur: "akun",
+          teks: "Tempat peran dan centang tiap akun diatur. Urutannya selalu: pilih perannya dulu, sesuaikan centangnya sesudahnya. Kotak Pos hanya bisa diisi untuk peran juri_pos.",
+        },
+        {
+          jenis: "layar",
+          nama: "Buku Sakti",
+          hash: "#/buku-sakti",
+          fitur: null,
+          teks: "Bab ini sendiri, terbuka untuk semua akun panitia. Dua tombol di atasnya, Cetak Bab Ini dan Cetak Semua. Yang dicetak adalah pegangan, bukan pengganti orang yang menjelaskan.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Seksi adalah cara membagi orang; peran akun adalah cara membagi hak. Keduanya tidak wajib satu lawan satu — satu orang bisa memegang dua meja, dan satu seksi bisa berisi tiga akun dengan peran berbeda.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-ketua",
+      judul: "Ketua Pelaksana dan Wakil",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Ketua memegang keputusan yang tidak bisa diambil di meja: tanggal, biaya, susunan pos, siapa memegang akun apa, dan kapan nilai boleh diumumkan. Di dalam sistem jabatan ini tidak punya nama — beberapa layar hanya menulis hubungi koordinator kepada panitia yang kehilangan akses, dan koordinator itu ketua atau orang yang ditunjuknya. Wakil bukan cadangan yang menunggu: bagi wilayahnya sejak awal, satu memegang jalur administrasi (pendaftaran sampai daftar ulang), satu memegang jalur lapangan (keberangkatan sampai kedatangan).",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menetapkan tanggal lomba dan biaya pendaftaran per regu — DUA angka, satu untuk Eksternal dan satu untuk Intern — lalu memastikan ketiganya benar-benar masuk ke sistem lewat pemegang fitur pengaturan.",
+            "Menunjuk koordinator tiap seksi dan menyerahkan daftarnya ke administrator sistem sebelum akun dibuat.",
+            "Memutuskan hal yang tidak boleh diputuskan sendiri oleh petugas meja: pembatalan keberangkatan, penyisipan regu terlambat ke kloter, dan sanksi.",
+            "Memutuskan kapan fase live dinaikkan — Internal, Progress, Live, Top 10, Juara — dan mengumumkannya ke seksi rekap, bukan sebaliknya.",
+            "Menjadi orang yang berdiri di titik paling mungkin macet pagi itu, bukan di ruang panitia.",
+            "Menyerahkan Buku Sakti, daftar akun, dan catatan keputusan ke kepanitiaan berikutnya.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Tiga bulan sebelum", "Menyusun seksi, menunjuk koordinatornya, menetapkan tanggal dan kedua biaya pendaftaran."],
+            ["Satu bulan sebelum", "Memimpin technical meeting pembina; mengunci susunan pos, lomba, dan bobot nilai supaya angkanya tidak berubah lagi sesudah blangko dicetak."],
+            ["H-7", "Gladi: seluruh alur dijalankan memakai data uji, dari pendaftaran sampai daftar juara, dengan orang yang sungguhan akan memegangnya."],
+            ["Hari lomba", "Berdiri di upacara, garis start, lalu meja daftar ulang. Memutuskan di tempat dan memberitahukan keputusannya ke seksi yang terkena."],
+            ["Sesudah acara", "Menurunkan fase live, memerintahkan password bersama dikembalikan ke acak, memimpin evaluasi dan serah terima."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Home",
+          hash: "#/home",
+          fitur: null,
+          teks: "Ubin yang muncul di Home adalah cerminan centang akun, bukan daftar menu tetap. Akun admin melihat empat belas ubin; kalau seorang panitia melapor ubinnya tidak ada, yang salah hampir selalu centangnya, bukan layarnya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Sistem tidak mengenal jabatan, ia hanya mengenal centang — jadi wewenang ketua tidak otomatis jadi hak di layar: membatalkan keberangkatan ada di balik fitur pengaturan, dan kalau akun ketua tidak dicentang itu, keputusannya harus dititipkan ke orang lain di tengah antrean.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-sekretaris",
+      judul: "Sekretaris",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Sekretaris memegang semua yang berbentuk surat dan catatan: proposal, undangan pangkalan, surat izin tempat, notulen rapat, daftar hadir, sertifikat, dan laporan akhir. Sekretaris tidak memasukkan satu angka pun ke sistem, tapi dialah yang menyimpan alasan di balik angka-angka itu — database mencatat apa yang berubah dan siapa yang mengubahnya, tidak pernah kenapa.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyiapkan surat undangan pangkalan, surat izin tempat dan jalur, serta surat tugas juri.",
+            "Menulis notulen tiap rapat, terutama keputusan yang mengubah angka di sistem: biaya pendaftaran, bobot pos, kontrak waktu, aturan penalti.",
+            "Mencatat siapa memegang username apa, karena sistem hanya menyimpan username — tidak ada kolom nama orang di mana pun.",
+            "Menyusun sertifikat dan piagam dari daftar juara sesudah pengumuman, memakai nama regu persis seperti yang tersimpan.",
+            "Mengarsipkan satu salinan blangko tiap lomba, satu salinan daftar kloter, dan satu salinan rekap akhir sebagai bukti fisik.",
+            "Menyusun laporan pertanggungjawaban bersama bendahara sesudah acara.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Tiga bulan sebelum", "Proposal, surat izin tempat, dan surat ke pangkalan; nomor surat dibuka dan dicatat urut sejak baris pertama."],
+            ["Tiap rapat", "Notulen ditulis di hari yang sama. Keputusan yang menyangkut angka disalin terpisah supaya mudah dicari tahun depan."],
+            ["H-3", "Menyiapkan daftar hadir pembina dan tamu, serta blanko sertifikat yang tinggal diisi nama."],
+            ["Sesudah pengumuman", "Mengambil daftar juara dari layar Kejuaraan, mencetak sertifikat, dan menyerahkan arsip lengkap ke ketua."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Data Peserta",
+          hash: "#/data-peserta",
+          fitur: "pendaftaran",
+          teks: "Sumber tunggal nama regu, sekolah, ketua, dan anggota untuk daftar hadir dan sertifikat. Salin dari sini, jangan dari file rekap edisi lalu yang ejaan sekolahnya sudah dibetulkan sesudahnya.",
+        },
+        {
+          jenis: "layar",
+          nama: "Kejuaraan",
+          hash: "#/kejuaraan",
+          fitur: "live_score",
+          teks: "Daftar juara beserta skornya. Nama regu di layar ini adalah nama yang akan tercetak di sertifikat — kalau ada salah tulis, perbaiki lewat pemegang fitur pendaftaran sebelum mencetak, bukan sesudahnya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Riwayat di database mencatat apa yang berubah dan oleh siapa, tetapi tidak pernah alasannya; notulen sekretaris adalah satu-satunya tempat alasan itu tersimpan, dan justru alasan itu yang dicari kepanitiaan tahun depan.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-bendahara",
+      judul: "Bendahara — Meja Pembayaran",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Bendahara memegang uang masuk dan uang keluar, dan di hari lomba ia duduk di Meja Pembayaran: memeriksa bukti transfer yang di-upload pembina, menerima pembayaran tunai, lalu menandai regu lunas. Tanda lunas itu bukan catatan pasif — ia yang membuka daftar ulang, jadi regu yang belum ditandai tidak akan pernah mendapat nomor dada.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyusun anggaran dan menetapkan biaya pendaftaran per regu bersama ketua, sebelum form pendaftaran dibuka.",
+            "Membuka bukti transfer yang di-upload pembina di form pendaftaran, mencocokkan nominal dan jamnya dengan mutasi rekening, baru menandai lunas.",
+            "Menerima pembayaran tunai di meja lalu memilih metode tunai waktu menekan Tandai Lunas. Metode yang dipilih pembina saat mendaftar cuma niat — yang masuk laporan keuangan adalah yang dicatat di meja ini.",
+            "Mengingat satu pendaftaran bisa memuat beberapa regu sekaligus — satu bukti bayar bisa melunasi tiga regu, dan tiga regu itu semuanya harus ikut tertandai.",
+            "Membuka meja pembayaran 2 sampai 3 buah pada hari lomba, tiap meja dijaga 1 sampai 2 orang.",
+            "Menyusun laporan keuangan bersama sekretaris sesudah acara.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Dua bulan sebelum", "Anggaran disusun, biaya per regu ditetapkan, nomor rekening penerima disiapkan dan diuji dengan satu transfer kecil."],
+            ["Sejak pendaftaran dibuka", "Memeriksa bukti transfer tiap hari, jangan menumpuk. Regu yang lunas lebih awal berhak antre daftar ulang lebih awal."],
+            ["H-1", "Menyapu sisa pendaftaran yang bayarnya belum jelas dan menghubunginya lewat humas, bukan dibiarkan sampai pagi."],
+            ["Hari lomba 05:30 sampai 09:00", "Melayani pembayaran tunai dan bukti transfer yang baru masuk; meja ini berdiri sebelum meja daftar ulang."],
+            ["Sesudah acara", "Menutup buku, mencocokkan total penerimaan dengan jumlah regu lunas di sistem."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Meja Pembayaran",
+          hash: "#/pembayaran",
+          fitur: "pembayaran",
+          teks: "Daftar pendaftaran beserta bukti bayarnya dan tombol tandai lunas. Akun yang dipakai berperan registrasi, yang sudah membawa centang pembayaran; hitungan di kepala layar dihitung dari data yang diterima, jadi jangan menilai dari angka itu — hitung barisnya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kesalahan khas seksi ini: menandai lunas dulu supaya antrean jalan, dengan niat mencocokkan uangnya nanti. Tanda lunas langsung membuka daftar ulang, regu itu berangkat membawa nomor dada, dan yang tersisa untuk menagih cuma nomor WA pembina yang sedang berjalan di rute.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-kesekretariatan",
+      judul: "Seksi Kesekretariatan dan Pendaftaran",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini adalah pintu masuk acara. Sebagian besar regu mendaftar sendiri lewat form online yang diisi pembina, tetapi meja pendaftaran offline tetap dibuka 2 sampai 3 buah untuk pembina yang datang langsung. Pekerjaan terberatnya bukan menerima, melainkan menjaga data tetap bersih: nama regu unik, satu sekolah satu baris, dan nomor kontak yang benar-benar bisa dihubungi.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyebarkan link form pendaftaran ke pangkalan bersama humas, dan menjawab pertanyaan pembina yang tersangkut di tengah form.",
+            "Menjaga nama regu unik di seluruh acara: dua regu dari sekolah yang sama ditulis NAMA 1 dan NAMA 2, tabrakan antar sekolah dibedakan dengan ekor nama sekolah.",
+            "Menjaga satu sekolah satu baris. Pembeda dua sekolah senama ditulis di dalam namanya sendiri, misalnya MAN 3 Ciamis dan MAN 3 Tasikmalaya; kalau tidak ada tabrakan, jangan tambahkan ekor apa pun.",
+            "Membetulkan salah ketik lewat Data Peserta. Yang bisa diubah di sana cuma tulisan: nama regu, nama kontak, dan nomor WA pembina. Golongan, sekolah, nomor dada, dan status bayar punya jalurnya sendiri.",
+            "Menyerahkan hitungan regu terakhir ke perlengkapan dan konsumsi begitu pendaftaran ditutup.",
+            "Menyiapkan meja offline: 2 sampai 3 meja, tiap meja 1 sampai 2 orang, dengan satu laptop yang sudah login sebelum peserta datang.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Dua bulan sebelum", "Form pendaftaran dibuka; link disebar ke pangkalan lewat surat dan media sosial."],
+            ["Sepanjang pendaftaran", "Memantau regu masuk tiap hari; menyapu nama regu kembar dan sekolah kembar selagi jumlahnya masih puluhan, bukan ratusan."],
+            ["H-3", "Menutup pendaftaran online, mengunci daftar regu, menyerahkan hitungan akhir ke perlengkapan dan konsumsi."],
+            ["Hari lomba pagi", "Melayani pendaftaran susulan di meja kalau ketua mengizinkan, lalu mengarahkannya ke meja pembayaran."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Pendaftaran",
+          hash: "#/home",
+          fitur: "pendaftaran",
+          teks: "Ubin Pendaftaran di Home membuka form pendaftaran di situs peserta — form yang sama persis dengan yang diisi pembina di rumah. Meja offline mengisi form itu untuk pembina yang datang, bukan mengetik langsung ke database.",
+        },
+        {
+          jenis: "layar",
+          nama: "Data Peserta",
+          hash: "#/data-peserta",
+          fitur: "pendaftaran",
+          teks: "Seluruh regu, sekolahnya, ketua, anggota, dan nomor kontak pembina. Di sinilah nama regu dan nomor kontak dibetulkan, dan tiap perubahan masuk riwayat sendiri: siapa mengubah, kapan, dan dari apa ke apa.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Sekolah kembar terlihat sepele sampai daftar sekolah dibuka pembina berikutnya: satu sekolah pernah muncul tiga kali di kotak pilihan pendaftaran, dan tiap salinannya membawa regunya sendiri ke rekap yang berbeda.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-daftar-ulang",
+      judul: "Seksi Daftar Ulang",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini mengubah regu yang terdaftar jadi regu yang ada di lapangan: mencocokkan jumlah anggota, menyerahkan nomor dada, dan menempatkan regu ke kloter. Penempatan kloter dikerjakan sistem, bukan orang — pengacakan otomatis mengisi kloter paling awal yang belum berangkat secara FIFO, maksimal 5 regu Eksternal dan 3 regu Intern per kloter, dan sekolah tidak berpengaruh sama sekali.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Memanggil regu yang sudah lunas, mencocokkan jumlah anggota yang hadir dengan daftar, lalu memberi nomor dada.",
+            "Menyerahkan nomor dari deret yang benar. Stok XXXVII: Eksternal 1 sampai 500, Intern 1001 sampai 1250 — angka itu isi stok kain, bukan aturan di kode, jadi panitia berikutnya mengubah stoknya. Golongan regu yang menentukan deretnya, dan golongan yang sama itu juga yang menentukan kuota kloternya.",
+            "Menukar nomor dada yang rusak lewat tombol tukar di layar, bukan dengan menyerahkan nomor cadangan diam-diam — nomor yang tidak tercatat tidak akan ketemu lagi di rekap.",
+            "Membiarkan sistem menomori kloter. Jangan menulis nomor kloter sendiri; kalau susunannya kacau, bersihkan lalu jalankan ulang alurnya.",
+            "Mencetak daftar kloter dan menempelnya di papan pengumuman utama dan di barak, supaya pembina berhenti bertanya di meja.",
+            "Menyisipkan regu terlambat ke kloter secara manual hanya atas keputusan ketua, dan menyebutkan konsekuensinya waktu meminta keputusan itu.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["H-1", "Kain nomor dada diurutkan dan dipisah per deret; daftar regu lunas dicetak sebagai cadangan kalau jaringan mati."],
+            ["Hari lomba 05:30", "Meja dibuka sebelum peserta datang: 2 sampai 3 meja, tiap meja 1 sampai 2 orang, laptop sudah login."],
+            ["05:30 sampai 09:30", "Daftar ulang berjalan bersamaan dengan keberangkatan — kloter berikutnya terisi sementara kloter sebelumnya sudah jalan."],
+            ["Tiap kloter penuh", "Mencetak daftar kloter dan menempelnya; satu orang khusus mengurus tempel-menempel supaya meja tidak berhenti."],
+            ["Sesudah kloter terakhir", "Mencetak daftar kloter final dan menyerahkan salinannya ke seksi kedatangan."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Meja Daftar Ulang",
+          hash: "#/daftar-ulang",
+          fitur: "daftar_ulang",
+          teks: "Pemberian nomor dada, penukaran nomor rusak, dan pengacakan otomatis ke kloter. Akun yang dipakai berperan registrasi.",
+        },
+        {
+          jenis: "layar",
+          nama: "Daftar Kloter",
+          hash: "#/cetak-kloter",
+          fitur: "cetak_kloter",
+          teks: "Lembar daftar isi tiap kloter untuk ditempel dan dibawa ke garis start. Tanda sudah tercetak tidak menutup kloter — regu masih boleh ditambahkan, dan mencetak ulang selembar itu murah.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Penalti waktu dihitung dari jam berangkat KLOTER, bukan dari jam regu benar-benar jalan; menyisipkan regu terlambat ke kloter yang sudah berangkat berarti regu itu dianggap berangkat sejam yang lalu, dan kontrak waktunya habis sebelum ia sampai pos pertama.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-keberangkatan",
+      judul: "Seksi Keberangkatan",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini memegang garis start — bernomor 0 di daftar pos, bernama Keberangkatan, dan peserta menyebutnya Pos 0 — beserta upacara pembukaan dan dua titik tunggu di belakangnya. Tidak ada nilai yang dicatat di sana, cuma waktu. Seluruh kloter harus jalan antara 07:00 dan 10:00 dengan jarak antar kloter paling lama 5 menit, jadi pekerjaannya adalah menjaga irama: selalu ada kloter berikutnya yang sudah berdiri rapi waktu kloter sekarang dilepas.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menjalankan upacara pembukaan, lalu mempersilakan pejabat undangan memberangkatkan kloter 1 untuk foto. Ini bukan keterlambatan yang harus dihemat — ini alasan acara punya garis start yang layak difoto.",
+            "Menahan tiga kloter siap sekaligus: kloter 1 di Pemberangkatan, kloter 2 di Staging 1, kloter 3 di Staging 2.",
+            "Menyusun formasi upacara terbalik — kloter terakhir di depan, kloter 4, 5, dan 6 di belakang dekat jalan keluar, karena merekalah yang berikutnya dipanggil.",
+            "Mencatat jam berangkat tiap kloter dari jam sungguhan di kertas, lalu memasukkannya ke sistem. Di meja ini KERTAS yang jadi pencatat utama dan laptop yang memverifikasi — kebalikan dari meja finish. Satu orang mencatat, satu orang mengetik, duduk bersebelahan.",
+            "Mengonfirmasi kontrak waktu tiap regu — 3 jam, 3,5 jam, atau 4 jam — tiga kloter sebelum ia berangkat, dan memastikan pembina tahu jam berapa regunya ditunggu di finish.",
+            "Menyerahkan orang dan meja ke seksi kedatangan begitu kloter terakhir jalan.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["H-1", "Menandai titik Pemberangkatan, Staging 1, dan Staging 2; menyepakati satu jam acuan — semua pencatatan memakai jam itu, bukan jam masing-masing HP."],
+            ["06:00", "Formasi upacara disusun terbalik; tiga kloter pertama ditarik ke titiknya sebelum barisan rapat."],
+            ["07:00", "Upacara, lalu kloter 1 diberangkatkan pejabat undangan."],
+            ["07:00 sampai 10:00", "Kloter dilepas berurutan dengan jarak paling lama 5 menit; jamnya dicatat di kertas lalu diketik ke sistem."],
+            ["10:00", "Kloter terakhir jalan. Titik staging dibongkar dan orangnya pindah ke garis finish."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Keberangkatan",
+          hash: "#/keberangkatan",
+          fitur: "keberangkatan",
+          teks: "Ceklis kehadiran per nomor dada, kontrak waktu per regu, pemindahan regu antar kloter, dan kotak jam berangkat per kloter yang memang DIKETIK — bukan tombol, karena angkanya disalin dari kertas. Akun yang dipakai berperan gerbang, yang membawa centang keberangkatan, kedatangan, dan live score.",
+        },
+        {
+          jenis: "layar",
+          nama: "Kalkulator Keberangkatan",
+          hash: "#/pengaturan-kloter",
+          fitur: "pengaturan",
+          teks: "Perkiraan jam berangkat tiap kloter, dipakai untuk menjawab pertanyaan pembina di lapangan. Perkiraan, bukan catatan — dan layar ini ada di balik fitur pengaturan, jadi akun gerbang biasa tidak membukanya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Perkiraan dan catatan tidak pernah boleh masuk ke kolom yang sama. Kesalahan khas seksi ini adalah mengetik jam perkiraan supaya layar cepat penuh lalu lupa membetulkannya — dan seluruh penalti waktu regu di kloter itu jadi salah tanpa satu pun galat muncul.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-kedatangan",
+      judul: "Seksi Kedatangan — Finish",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Garis finish dan garis start adalah tempat yang sama dengan dua nama menurut arah lari — peserta menyebutnya Pos 6 saat kembali — tetapi orangnya bekerja terbalik: di keberangkatan kertas yang jadi pencatat utama dan laptop yang memverifikasi, di finish laptop yang mencatat langsung dan kertas yang jadi cek silang. Meja closing sengaja dibuat SATU, paling banyak dua, supaya urutan kedatangan tidak pecah.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Mengetik nomor dada, memastikan detail regunya benar, lalu menekan SAMPAI DI FINISH begitu regu tiba. Jam yang tersimpan adalah jam saat tombol ditekan, jadi menundanya berarti menambah penalti yang tidak terjadi.",
+            "Menjaga satu jalur antrean masuk. Regu yang menumpuk diminta berbaris, bukan dilayani meja tambahan — kalau tetap menumpuk, catat jam datangnya di kertas dulu lalu ketik menyusul, karena kotak jamnya memang bisa diubah tangan.",
+            "Mencocokkan jumlah regu datang dengan jumlah regu berangkat per kloter, bukan hanya totalnya.",
+            "Menerima kembali barang pinjaman dan mengarahkan regu ke barak supaya lapangan finish tidak penuh.",
+            "Melaporkan regu yang jauh melewati kontrak waktunya ke seksi keamanan, jangan menunggu ditanya.",
+            "Menyerahkan daftar kedatangan lengkap ke seksi rekap sebelum penilaian ditutup.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["H-1", "Menyiapkan meja closing, jalur antrean, papan urutan kedatangan, dan salinan kertas daftar kloter."],
+            ["10:00", "Meja dibuka begitu kloter terakhir jalan; orang dari titik staging pindah kemari."],
+            ["10:00 sampai 14:00", "Jendela kedatangan, dihitung dari berangkat 07:00 sampai 10:00 ditambah kontrak 3 sampai 4 jam. Ini jam tersibuk seluruh acara dan jamnya bertabrakan dengan makan siang."],
+            ["Sesudah regu terakhir", "Mencocokkan daftar berangkat dan daftar datang; regu yang belum datang diserahkan ke keamanan untuk disusuri."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Kedatangan",
+          hash: "#/finish",
+          fitur: "kedatangan",
+          teks: "Kotak nomor dada, kartu regu untuk dipastikan, dan satu tombol besar SAMPAI DI FINISH. Jam datang dan anggota hadir sengaja tidak sejajar dengan tombol itu — keduanya dipakai waktu membetulkan, bukan tiap regu. Akun yang dipakai berperan gerbang, sama persis dengan akun garis start, karena orangnya memang pindah dari sana.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kesalahan khas seksi ini adalah menambah meja kedua dan ketiga waktu antrean menumpuk: dua meja tidak pernah mencatat dari jam yang sama, urutan kedatangan langsung pecah, dan di sini selisih satu menit bernilai satu poin — ke dua arah, karena datang terlalu cepat dihukum sama beratnya dengan terlambat.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-lomba",
+      judul: "Seksi Lomba dan Juri Pos",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini yang membuat acara punya isi: lima pos, masing-masing berisi beberapa lomba, dan tiap lomba berisi satu atau beberapa penilaian. Susunan edisi XXXVII adalah Pos 1 Kepramukaan, Pos 2 Halang Rintang, Pos 3 P3K, Pos 4 PBB, dan Pos 5 Yel-Yel. Tiap pos dijaga minimal 5 orang tim lapangan ditambah 2 operator IT dengan laptop, dan tiap pos wajib punya sinyal, internet, dan sumber pengisian daya.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyusun lomba, kriteria penilaian, dan soal tiap pos, lalu menyerahkan angka bobotnya ke pemegang fitur pengaturan untuk dimasukkan sebelum blangko dicetak.",
+            "Mencetak blangko: layar mencetak SATU master per lomba, dan mesin fotokopi di sekretariat yang menggandakannya. Pos 3 mencetak tiga master — Pembidaian, Kim Lihat, Kim Cium.",
+            "Mengingat lomba soal tidak mencetak blangko sama sekali: peserta menjawab di lembar soalnya sendiri, jadi pos yang isinya soal semua tidak mencetak master apa pun.",
+            "Menjalankan dua jalur di tiap pos yang menerima soal: jalur lomba yang dikerjakan di pos itu, dan jalur soal yang kertasnya diambil regu SEBELUM pos ini lalu diserahkan di sini. Nilainya masuk ke pos tempat kertas itu DISERAHKAN, bukan tempat ia diambil, jadi tidak ada angka yang harus dititipkan ke operator pos lain.",
+            "Memfoto lembar jawaban per lomba lalu memasukkan nilainya per kloter, jangan menumpuk sampai sore.",
+            "Menempatkan juri: juri satu pos memakai peran juri_pos dengan kolom pos diisi nomornya; juri keliling memakai peran koordinator_pos dengan kolom pos dikosongkan.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Dua bulan sebelum", "Menyusun daftar lomba dan kriterianya; menetapkan berapa poin tiap lomba dan berapa soal tiap kuis."],
+            ["H-14", "Soal ditulis dan digandakan; blangko master dicetak dari layar lalu difotokopi sesuai perkiraan jumlah regu."],
+            ["H-1", "Menata pos di lapangan dan menguji login akun pos DI LOKASI — sinyal di pos tidak sama dengan sinyal di sekolah."],
+            ["08:00 sampai 15:00", "Menilai, memfoto lembar, memasukkan nilai. Kloter yang sudah lewat diselesaikan sebelum kloter berikutnya datang."],
+            ["Sesudah regu terakhir", "Memastikan tidak ada kolom kosong di posnya sendiri sebelum melapor ke seksi rekap."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Input Nilai Per Lomba",
+          hash: "#/pos2",
+          fitur: "pos",
+          teks: "Memasukkan nilai satu lomba untuk banyak regu sekaligus. Akun juri_pos hanya melihat barisan posnya sendiri; akun koordinator_pos melihat kelima pos karena kolom posnya kosong.",
+        },
+        {
+          jenis: "layar",
+          nama: "Input Nilai Tabel",
+          hash: "#/pos",
+          fitur: "pos",
+          teks: "Bentuk tabel: satu kolom per penilaian, satu baris per regu. Lomba dengan lima kriteria muncul sebagai lima kolom di sini, sementara di kertas ia tetap satu blangko.",
+        },
+        {
+          jenis: "layar",
+          nama: "Foto Jawaban Sekaligus",
+          hash: "#/foto",
+          fitur: "pos",
+          teks: "Upload foto lembar jawaban banyak regu sekaligus, dipasangkan ke nomor dada. Foto adalah bukti, bukan sumber nilai — kalau angkanya berselisih, yang memutuskan tetap orang.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Isolasi pos berlaku waktu MENULIS, tidak lagi waktu membaca: juri Pos 3 bisa melihat angka Pos 1 di Live Score sebelum diumumkan, dan itu keputusan pemilik acara, bukan celah — jadi jangan menutupnya diam-diam, dan jangan pula membacakannya kepada peserta.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-rekap",
+      judul: "Seksi Rekap dan Skor",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini mengubah ribuan angka jadi satu peringkat yang dibacakan di lapangan. Pekerjaannya tiga: memeriksa nilai yang janggal sebelum jadi peringkat, menaikkan fase live sesuai keputusan ketua, dan menerbitkan rekap ke situs peserta. Nomor tiga inilah yang membuat angka benar-benar terlihat di HP penonton — 1.500 sampai 3.000 HP pada hari lomba.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyisir tiap pos lewat Cek Nilai dengan saringannya: Belum Input, Belum Foto, Belum Kunci. Angka di sebelah tiap saringan adalah sisa pekerjaannya, dan yang dikejar sampai nol.",
+            "Menaikkan fase live sesuai perintah ketua. Lima fase, dan tombolnya di layar memakai nama akibatnya: Internal (peserta tidak melihat apa pun), Progress (centang per komponen tanpa angka), Live (sama dengan yang dilihat panitia), Top 10 (sepuluh besar per golongan beserta totalnya), Juara (papan diganti daftar juara).",
+            "Menjaga urutan kerja: naikkan fasenya dulu, jalankan penerbitan sesudahnya. Berlaku ke dua arah, termasuk waktu menurunkan fase kembali.",
+            "Menjalankan workflow Publish rekap live tiap kali ada perbaikan nilai — halaman peserta tidak pernah menampilkan lebih dari isi berkas yang sudah terbit.",
+            "Menyusun daftar juara di layar Kejuaraan sebelum dibacakan, lalu menerbitkannya sesudah dibacakan, bukan sebelum.",
+            "Meminta centang rekap ke administrator sistem kalau perlu membaca rekap penuh, karena centang itu hanya ada di paket admin dan akan hilang kalau perannya diganti kemudian.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["H-1", "Menguji seluruh rantai memakai data uji: masukkan nilai, cek, terbitkan, lalu buka situs peserta di HP sungguhan."],
+            ["Pagi hari lomba", "Fase Internal. Peserta belum melihat apa pun selain ajakan mendaftar."],
+            ["Sesudah pos pertama terisi", "Fase Progress. Peserta melihat centang per komponen, jadi pembina tahu regunya sudah dinilai tanpa satu angka pun bocor."],
+            ["Sore, sesudah nilai lengkap", "Fase Live atau Top 10 menurut keputusan ketua; terbitkan ulang tiap kali ada perbaikan."],
+            ["Sesudah juara dibacakan", "Fase Juara, lalu terbitkan. Papan klasemen hilang dengan sendirinya dan daftar juara beserta skornya yang muncul."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Cek Nilai",
+          hash: "#/cek-nilai",
+          fitur: "pengaturan",
+          teks: "Satu pos, satu regu, semua lombanya sekaligus: pindah regu lewat panah atau ketik nomor dadanya. Boleh membetulkan angka, memasang gembok, dan membuka gembok yang sudah terpasang. Layar ini di balik fitur pengaturan, bukan pos — supaya juri tidak bisa mengunci nilai lomba yang bukan pegangannya.",
+        },
+        {
+          jenis: "layar",
+          nama: "Live Score",
+          hash: "#/live-score",
+          fitur: "live_score",
+          teks: "Papan klasemen panitia beserta saklar fasenya. TIDAK ADA tombol terbit di sini — menekan saklar cuma mengubah fase, dan layarnya sendiri yang mengingatkan supaya workflow Publish rekap live dijalankan sesudahnya. Melihat papannya cukup dengan centang live score; saklar fasenya cuma muncul untuk pemegang centang pengaturan.",
+        },
+        {
+          jenis: "layar",
+          nama: "Kejuaraan",
+          hash: "#/kejuaraan",
+          fitur: "live_score",
+          teks: "Daftar juara per golongan, Juara Umum, dan Peserta Terbanyak, beserta angkanya. Tombol ubah di layar ini menuntut centang pengaturan.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Yang menahan nilai sebelum diumumkan adalah nilainya MEMANG TIDAK ADA di berkas yang terbit, bukan layar yang memilih tidak menggambarnya — berkas rekap duduk di CDN dan bisa diminta siapa pun yang tahu alamatnya, jadi menerbitkan terlalu cepat tidak bisa ditebus dengan menyembunyikan tampilan.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-perlengkapan",
+      judul: "Seksi Perlengkapan",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini tidak memegang satu layar pun, tetapi hampir semua hitungannya diambil dari sistem: berapa regu, berapa kloter, berapa nomor dada, berapa lembar blangko. Kesalahan hitung di sini tidak bisa diperbaiki hari itu juga, jadi mintalah angkanya dari kesekretariatan secara tertulis, bukan dari perkiraan rapat.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyiapkan alat tiap lomba sesuai daftar dari seksi lomba: tongkat, tali, tandu dan bidai, bendera semaphore, dan alat halang rintang.",
+            "Menyiapkan kain nomor dada sesuai deretnya. Stok XXXVII: Eksternal 1 sampai 500, Intern 1001 sampai 1250, ditambah cadangan untuk yang rusak di lapangan. Berapa pun stok yang dibawa, angkanya harus dimasukkan ke sistem — pagar nomor dada membacanya dari sana.",
+            "Mengurus fotokopi blangko di sekretariat: yang keluar dari printer cuma satu master per lomba, sisanya pekerjaan mesin fotokopi.",
+            "Menyiapkan papan pengumuman utama dan papan barak tempat daftar kloter ditempel.",
+            "Menyediakan listrik, meja, dan tempat teduh untuk dua laptop di tiap pos, serta sound system untuk upacara dan pengumuman juara.",
+            "Menugaskan satu orang berkeliling pos membawa cadangan sepanjang hari, karena yang hilang selalu ketahuan waktu lomba sedang berjalan.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Satu bulan sebelum", "Mendata alat yang ada, yang rusak, dan yang harus dipinjam; mengurus surat pinjam lewat sekretaris."],
+            ["H-7", "Meminta hitungan regu terakhir dari kesekretariatan. Jumlah nomor dada dan blangko ditentukan dari angka itu, bukan dari perkiraan."],
+            ["H-1", "Memasang tenda pos, meja, papan, dan listrik; menguji sound system sampai bunyi, bukan sampai tersambung."],
+            ["Hari lomba", "Menambal kekurangan di tempat; satu orang keliling membawa cadangan alat tulis, tali, dan blangko."],
+            ["Sesudah acara", "Membongkar, menghitung ulang, dan mengembalikan pinjaman di hari yang sama selagi orangnya masih lengkap."],
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kesalahan khas seksi ini adalah mencetak blangko satu lembar per regu langsung dari browser: blangko dikalikan di mesin fotokopi, bukan di printer, dan pos dengan tiga lomba memang hanya mencetak tiga halaman master — bukan seribu lima ratus.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-konsumsi",
+      judul: "Seksi Konsumsi",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Konsumsi mengurus makan dan minum peserta, panitia, juri, dan tamu undangan sepanjang hari yang dimulai jam lima pagi dan baru selesai sore. Jumlahnya besar — pada 300 regu jumlah peserta sekitar 2.500 orang — jadi angkanya harus diambil dari hitungan regu terakhir, dan jadwalnya harus menghindari jam tersibuk.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menghitung porsi dari jumlah regu terakhir dan jumlah panitia, lalu menambahkan cadangan untuk pendaftaran susulan.",
+            "Menyiapkan air minum di lima pos, ditambah garis start dan garis finish. Pos yang jauh dari jalan diisi lebih dulu, bukan terakhir.",
+            "Menjadwalkan makan panitia BERGILIR supaya tidak ada meja yang kosong; puncak kerja sistem jatuh sekitar jam dua belas siang.",
+            "Menyediakan konsumsi tamu undangan dan pembina di tempat tersendiri, jauh dari antrean peserta.",
+            "Mengatur pengiriman ke pos: kotak dihitung dan diserahterimakan per pos, bukan ditumpuk di satu titik lalu diambil siapa saja.",
+            "Mengurus sisa makanan dan sampah sebelum tempat dikembalikan.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Satu bulan sebelum", "Memilih penyedia, mencicipi, dan menetapkan harga per porsi bersama bendahara."],
+            ["H-7", "Mengunci jumlah porsi dari hitungan regu terakhir; menambah cadangan sepuluh persen untuk panitia yang bertambah di menit akhir."],
+            ["Hari lomba 05:00", "Konsumsi panitia pagi sudah siap sebelum meja pembayaran dan meja daftar ulang dibuka."],
+            ["10:00", "Mengirim air dan konsumsi ke lima pos selagi jalur belum penuh peserta yang pulang."],
+            ["10:00 sampai 14:00", "Jendela kedatangan dan makan siang bertabrakan; siapkan dua jalur dan giliran makan panitia yang tidak bersamaan."],
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kesalahan khas seksi ini bukan kurang porsi, melainkan menjadwalkan semua orang makan bersamaan — meja daftar ulang dan meja finish jadi kosong justru pada jam antreannya paling panjang.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-dokumentasi",
+      judul: "Seksi Dokumentasi dan Publikasi",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini memegang foto, video, poster, dan media sosial acara. Satu hal harus dipisah tegas sejak hari pertama: foto dokumentasi dan foto lembar jawaban adalah dua benda berbeda. Yang kedua bukan pekerjaan seksi ini — itu bukti nilai, diambil juri lewat akun pos, dan tersimpan berkunci kode lomba, satu kolom foto untuk tiap lomba.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Membuat poster dan materi pengumuman pendaftaran, lalu menyebarnya bersama humas.",
+            "Menyusun daftar momen wajib sebelum hari-H: upacara, pemberangkatan kloter 1, tiap pos, garis finish, dan pengumuman juara.",
+            "Menempatkan satu orang tetap di garis start sampai kloter terakhir jalan, karena momen itu tidak bisa diulang.",
+            "Mengumumkan hasil ke media sosial HANYA sesudah dibacakan di lapangan, dan mengambil angkanya dari layar Kejuaraan, bukan dari bisik-bisik panitia pos.",
+            "Menyiapkan penamaan file dan tempat penyimpanan foto sejak awal, supaya laporan tidak berhenti karena file tersebar di tujuh HP.",
+            "Tidak menyentuh foto lembar jawaban sama sekali.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Dua bulan sebelum", "Poster dan pengumuman pendaftaran; link form disebar bersama humas dan kesekretariatan."],
+            ["H-1", "Menyusun daftar momen wajib dan membagi orang per titik; mengisi baterai dan menyiapkan penyimpanan kosong."],
+            ["Hari lomba", "Memotret dan merekam sesuai daftar; menyerahkan file ke satu tempat penyimpanan di akhir tiap sesi, bukan di akhir hari."],
+            ["Sesudah pengumuman", "Upload hasil dan foto juara; menyerahkan laporan dokumentasi ke sekretaris."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Kejuaraan",
+          hash: "#/kejuaraan",
+          fitur: "live_score",
+          teks: "Sumber resmi nama juara dan angkanya untuk pengumuman media sosial. Kalau seksi ini butuh akun, mintalah akun dengan centang live score saja — jangan meminjam akun pos, karena akun pos bisa menulis nilai.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Dua hal berbeda sama-sama disebut foto di acara ini, dan yang kedua adalah bukti: kalau lembar jawaban tercampur ke folder dokumentasi, yang hilang bukan kenangan melainkan dasar satu nilai yang sedang disengketakan.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-keamanan",
+      judul: "Seksi Keamanan dan P3K",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seksi ini menjaga jalur, orang, dan barang dari sebelum peserta datang sampai sesudah regu terakhir pulang. Perhatikan satu tabrakan nama: P3K di acara ini juga nama Pos 3, yang menilai lomba pembidaian. Pos 3 adalah tempat lomba, bukan tempat berobat.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyusuri rute sebelum hari-H, menandai penyeberangan jalan, tikungan, dan bagian yang jauh dari pos mana pun.",
+            "Menyiapkan tim P3K berjalan yang bergerak di antara pos, ditambah satu titik tetap dekat garis finish.",
+            "Memegang nomor puskesmas dan rumah sakit terdekat, serta menyepakati siapa yang mengantar kalau ada yang harus dibawa.",
+            "Meminta daftar regu yang belum datang dari seksi kedatangan, lalu menyusurinya dari arah berlawanan.",
+            "Mengatur parkir bus dan kendaraan pembina, serta menjaga barak — ruang kelas yang mejanya dikesampingkan jadi tempat menginap, diusahakan satu ruangan untuk satu sekolah.",
+            "Mencatat tiap kejadian beserta jamnya dan menyerahkannya ke sekretaris, sekecil apa pun.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["H-14", "Menyusuri rute, menandai titik rawan, mengurus izin lewat dan koordinasi dengan aparat setempat."],
+            ["H-1", "Menyiapkan kotak P3K tiap pos, tandu, dan pembagian tim penyusur; memeriksa penerangan jalur pagi."],
+            ["07:00 sampai 10:00", "Menjaga penyeberangan di jalur awal — di jam ini lalu lintas peserta paling padat."],
+            ["11:00 sampai 15:00", "Menyusuri jalur dari belakang mengikuti regu terakhir tiap kloter."],
+            ["Sesudah regu terakhir datang", "Menyatakan jalur bersih ke ketua sebelum pos dibongkar, dan menyerahkan catatan kejadian."],
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kesalahan khas seksi ini adalah menumpuk tim medis di Pos 3 karena namanya P3K — padahal yang paling sering butuh pertolongan adalah jalur di antara pos, tempat yang justru tidak dijaga siapa-siapa.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-humas",
+      judul: "Seksi Humas dan Sponsor",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Humas menghubungkan kepanitiaan dengan orang di luarnya: pangkalan yang diundang, pembina yang bertanya, sponsor, tamu undangan, dan pejabat yang memberangkatkan kloter 1. Di hari lomba tugasnya berubah jadi satu hal yang sangat konkret — menahan pertanyaan supaya tidak sampai ke meja yang sedang melayani antrean.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Menyusun daftar pangkalan SMP dan SMA yang diundang, lalu mengirim undangan bersama sekretaris.",
+            "Membuka SATU nomor kontak resmi yang dijaga bergilir, dan memastikan nomor itu benar-benar dijawab sampai malam.",
+            "Mencari sponsor dan menyusun paket timbal baliknya bersama bendahara.",
+            "Mengurus tamu undangan dan pejabat pemberangkat: kepastian hadir, penjemputan, tempat duduk, dan urutan acara upacara.",
+            "Menjadi penghubung tunggal ke pembina selama hari lomba, termasuk menjelaskan perkiraan jam berangkat kloter.",
+            "Menjaga nomor WA pembina tidak keluar dari sistem — nomor itu tidak boleh disalin ke daftar sponsor, ke grup mana pun, atau ke file yang beredar.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["Tiga bulan sebelum", "Menyusun daftar pangkalan dan daftar calon sponsor; menyiapkan proposal bersama sekretaris."],
+            ["Dua bulan sebelum", "Mengirim undangan dan membuka nomor kontak resmi bersamaan dengan dibukanya form pendaftaran."],
+            ["H-7", "Memastikan tamu undangan dan pejabat pemberangkat sudah menyatakan hadir; menyusun urutan acara upacara."],
+            ["Hari lomba", "Mendampingi tamu, menjawab pembina, dan mengalihkan pertanyaan yang biasanya menghantam meja daftar ulang."],
+            ["Sesudah acara", "Mengirim ucapan terima kasih ke pangkalan dan sponsor, beserta foto dan hasil lomba."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Data Peserta",
+          hash: "#/data-peserta",
+          fitur: "pendaftaran",
+          teks: "Tempat nomor kontak pembina tersimpan. Kalau seksi ini perlu membukanya, akunnya berperan registrasi — dan yang boleh keluar dari layar ini cuma satu nomor yang sedang dihubungi, bukan daftarnya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Data pribadi yang dipegang sistem ini cuma tiga: nomor WA pembina, nama ketua, dan nama anggota regu. Pagar penerbitan menolak mengirim nomor WA itu ke situs peserta — tapi pagar itu tidak berlaku untuk salinan yang dibuat orang dengan tangan.",
+        },
+      ],
+    },
+
+    {
+      kode: "seksi-admin-sistem",
+      judul: "Administrator Sistem",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Bukan seksi lapangan, dan tidak perlu banyak orang — satu sampai dua cukup, dan keduanya harus tahu password akun organisasi, bukan hanya satu. Tugasnya membuat akun, mengatur centangnya, menjalankan penerbitan dan deploy, serta menjadi orang yang dicari waktu ada yang tidak bisa login. Akunnya berperan admin: sebelas centang, kolom pos wajib kosong.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Membuat akun panitia sekaligus banyak lewat workflow Provision akun panitia. Password dibuat server, diambil dari Artifact, dan hilang otomatis tiga hari — jadi ambil dan bagikan segera.",
+            "Mengganti password satu akun lewat Ganti password akun panitia, lalu membagikannya lewat WA japri, tidak pernah lewat grup.",
+            "Menyetel password bersama untuk pagi simulasi atau hari lomba lewat Setel password bersama semua akun, dan WAJIB mengembalikannya ke acak sesudah acara selesai.",
+            "Mengatur peran dan centang di layar Akun dengan urutan yang benar: pilih perannya DULU, sesuaikan centangnya SESUDAHNYA — mengganti peran menghapus seluruh centang tangan lalu mengisinya ulang dari paket peran.",
+            "Membuat satu akun per ORANG, bukan satu akun per meja, supaya riwayat perubahan bisa ditelusuri ke orangnya.",
+            "Menonaktifkan akun yang selesai dipakai: akun yang dinonaktifkan kehilangan seluruh haknya apa pun isi centangnya.",
+            "Menjalankan penerbitan dan deploy dari tab Actions, termasuk dari HP kalau build otomatis menggantung.",
+          ],
+        },
+        {
+          jenis: "tabel",
+          kepala: ["Kapan", "Yang dikerjakan"],
+          baris: [
+            ["H-14", "Membuat akun sesuai daftar dari ketua, satu akun per orang, lengkap dengan peran dan nomor pos untuk juri."],
+            ["H-7", "Gladi. Tiap orang login dengan akunnya sendiri dan membuka layarnya sendiri; ubin yang kurang dibetulkan centangnya di tempat, saat itu juga."],
+            ["Pagi hari lomba", "Memasang password bersama kalau ketua memutuskan begitu, dan mencatat jam pemasangannya."],
+            ["Hari lomba", "Menjaga penerbitan berjalan dan menjadi orang yang dihubungi panitia yang tidak bisa masuk."],
+            ["Sesudah acara", "Mengembalikan password ke acak, menonaktifkan akun yang selesai, menyerahkan daftar akun ke kepanitiaan berikutnya."],
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Akun",
+          hash: "#/account",
+          fitur: "akun",
+          teks: "Daftar akun panitia, perannya, kolom posnya, dan matriks centang per fitur. Hak yang dicabut di sini langsung berlaku pada DATA, karena yang memutuskan ada di database — tetapi ubin di layar petugas baru menyesuaikan sesudah halamannya dibuka ulang, jadi minta ia me-refresh kalau ubinnya masih terlihat.",
+        },
+        {
+          jenis: "layar",
+          nama: "Ganti Password",
+          hash: "#/ganti-password",
+          fitur: null,
+          teks: "Terbuka untuk semua akun, termasuk juri pos. Selain password baru ia minta satu kode konfirmasi, dan kode itu datang dari koordinator, bukan dari layarnya. Ajari tiap panitia mengganti passwordnya sendiri sesudah menerima password bersama — itu memindahkan pekerjaan dari satu orang ke sepuluh orang.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Yang menjaga pintu adalah centang fitur, bukan nama peran; peran cuma mengisi centang awal — jadi jangan pernah menambahkan pengecualian yang berdasar nama peran, karena centang bisa diubah panitia dari layar Akun sedangkan nama peran tidak.",
+        },
+      ],
+    },
+  ],
+};
+const BAB_KENAPA = {
+  kode: "kenapa",
+  judul: "Kenapa Sistemnya Begini",
+  tab: "Kenapa",
+  ikon: "file-text",
+  warna: "ungu",
+  ringkas: "Dua puluh dua keputusan yang membentuk sistem ini, alternatif yang ditolak, dan apa yang rusak kalau dibalik.",
+  bagian: [
+    {
+      kode: "kenapa-biaya-nol",
+      judul: "Biaya Rp 0 mutlak, tanpa kartu kredit di mana pun",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seluruh sistem ini harus berjalan tanpa satu rupiah pun tagihan dan tanpa nomor kartu tersimpan di layanan mana pun. Ini bukan penghematan, ini syarat kelangsungan: kepanitiaan berganti tiap tahun dan tidak ada seorang pun yang bisa jadi pemegang tagihan lintas generasi. Hampir semua keputusan lain di bab ini adalah akibat dari batas ini.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak free trial dan tier berbayar-kecil. Trial bukan gratis, ia cuma menunda tanggal tagihannya sampai sesudah kepanitiaan bubar.",
+            "Ditolak layanan apa pun yang minta kartu hanya untuk verifikasi. Kartu yang terpasang adalah kartu pribadi seseorang, dan orang itu lulus sekolah.",
+            "Inilah yang menggugurkan Firebase: Cloud Storage-nya menuntut paket Blaze sejak Oktober 2025, bahkan untuk project lama, jadi foto bukti transfer tidak akan pernah bisa disimpan di sana.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau batas ini dilonggarkan, tagihan kejutan jatuh ke rekening pribadi pengurus lama, dan kuota yang habis mematikan SEMUA workflow — termasuk apply-migration dan tombol ganti password yang dipakai panitia dari HP.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-supabase",
+      judul: "Supabase, bukan Sheets, Firebase, atau laptop panitia",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Empat kandidat dibandingkan sebelum satu dipilih. Yang menang Supabase karena tiga hal yang paling berbahaya kalau salah — nomor dada ganda, isolasi pos, dan riwayat perubahan — dijamin oleh platformnya sendiri lewat transaksi, RLS, dan trigger. Bukan oleh kehati-hatian orang yang sedang berdiri di meja dengan antrean di depannya.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak Google Sheets plus Apps Script: batas 30 eksekusi bersamaan dibagi ke SEMUA perangkat, dan tiap aksi berjeda 1 sampai 4 detik. Sepuluh meja bekerja bersamaan sudah menghabiskannya.",
+            "Ditolak Firebase paket Spark: kuota 50.000 baca per hari tersentuh oleh belasan penonton yang refresh, dan kalau habis, database mati baca sampai jam 15:00 WIB — persis di tengah penilaian.",
+            "Ditolak PocketBase di laptop panitia lewat Tunnel: memindahkan seluruh risiko ke satu hardware pelajar di hari paling sibuk. Laptop ditutup, acara berhenti.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau dibalik, kebenaran data kembali bergantung pada disiplin manusia, dan hari-H punya tebing kuota atau tutup-laptop sebagai mode gagalnya.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-cloudflare",
+      judul: "Cloudflare tanpa server aplikasi, dan dua situs terpisah",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Halaman peserta dan layar panitia dua-duanya file statis yang disajikan Cloudflare, dari DUA situs yang berbeda: alamat pendek untuk peserta, alamat berawalan panitia- untuk panitia. Tidak ada backend dan tidak ada lapisan API buatan sendiri; yang bicara ke database adalah browser, langsung, dijaga RLS dan RPC. Satu-satunya kode server di seluruh sistem adalah Worker kecil untuk form pendaftaran publik.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak Vercel paket Hobby dengan 100 GB per bulan. Ratusan HP peserta yang refresh rekap adalah lalu lintas yang tidak bisa diramalkan, dan hanya Cloudflare menjawabnya dengan tak terbatas alih-alih angka bulanan.",
+            "Ditolak backend sendiri: tiap pagar hak akses harus ditulis dua kali, sekali di server dan sekali di database, lalu keduanya dijaga tetap sama selamanya.",
+            "Ditolak satu situs berisi halaman peserta dan layar panitia berdampingan. Yang disebar ke ratusan orang lewat grup WA sekolah adalah alamat peserta, dan alamat itu tidak boleh sekaligus membawa pintu masuk panitia.",
+            "Bebannya juga terpisah: ratusan HP yang refresh papan tidak menyentuh Worker yang sedang dipakai meja bekerja, dan halaman peserta tidak memuat kunci apa pun selain anon key.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau digabung, alamat yang diteruskan ke ratusan orang sekaligus menyebarkan pintu masuk panitia — dan beban ratusan HP yang refresh papan jatuh ke Worker yang sama dengan yang sedang dipakai meja bekerja.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-berkas-statis",
+      judul: "Peserta membaca file statis, dan situsnya sengaja tidak tersambung Git",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Seluruh data peserta dan nilai datang dari dua file yang diterbitkan workflow: live.json berukuran sekitar 1 KB yang di-poll tiap 60 detik, dan rekap.json berukuran puluhan KB yang diambil sekali per versi, itu pun baru setelah peserta mengetik nama sekolahnya. Versi itu sidik jari ISI, jadi menerbitkan sepuluh kali tanpa nilai baru tidak membuat satu HP pun download ulang. Satu-satunya permintaan langsung dari HP peserta ke database adalah membaca saklar fase, v_fase_live, tiap 15 detik selama halamannya terlihat — satu nilai, bukan satu baris rekap pun.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak halaman peserta yang menarik seluruh rekap langsung dari Supabase: pesertanya 1.500 sampai 3.000 orang dan mereka membuka alamat yang sama berkali-kali dalam jendela waktu yang sama persis.",
+            "Ditolak Realtime: koneksi terbuka per HP untuk data yang sebagian besar waktu tidak berubah sama sekali. Polling yang ada pun berhenti begitu tab tidak terlihat, dan jalan lagi begitu HP dibuka.",
+            "Ditolak menyambungkan situs peserta ke Git seperti layar panitia. Yang di-deploy ke sana bukan isi repository melainkan live.json yang baru ditulis workflow dari database beberapa detik sebelumnya.",
+            "Kalau tersambung Git, tiap push ke main menimpanya dengan file contoh fase pra yang memang ada di repository — rekap peserta mendadak kosong tanpa satu langkah pun yang gagal.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau dibalik, tiga ribu HP menarik file gemuk tiap menit langsung dari database, dan papan peserta bisa dikosongkan di tengah acara oleh perbaikan warna tombol yang sama sekali tidak berhubungan.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-fase-live",
+      judul: "Kejutan dijaga database, bukan tampilan",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Ada lima fase live: pra, progres, penuh, top10, dan juara. Yang menahan nilai sebelum diumumkan bukan JavaScript yang menyembunyikan angka, melainkan view yang mengembalikan NOL BARIS. Selama fasenya masih progres, v_klasemen_publik mengembalikan nol baris dan v_progres_publik tidak punya satu pun kolom berisi angka nilai — jadi file yang terbit memang tidak memuatnya.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menerbitkan semua nilai lalu menyembunyikannya dengan CSS atau JS: rekap.json duduk di CDN dan bisa diminta siapa pun yang tahu alamatnya, tanpa membuka halamannya.",
+            "Ditolak daftar larangan kolom di penerbitan. Yang dipakai DAFTAR IZIN: kolom yang tidak dikenal menghentikan penerbitan, karena hasil_kejuaraan duduk di atas tabel pendaftaran yang memuat nomor WA pembina.",
+            "publish-live.yml memegang sembilan pagar BOCOR, dan tidak satu pun boleh dilonggarkan demi kenyamanan tampilan.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Satu akibat yang harus diketahui panitia: menurunkan saklar dari Juara kembali ke Live tidak mengembalikan papan. File fase juara memang tidak memuat satu baris klasemen pun, dan halaman peserta dilarang menampilkan lebih banyak daripada isi filenya. Urutan kerjanya nyalakan fasenya dulu, terbitkan sesudahnya, dan itu berlaku ke dua arah.",
+        },
+        {
+          jenis: "layar",
+          nama: "Live Score",
+          hash: "#/live-score",
+          fitur: "live_score",
+          teks: "Saklar fase live ada di sini, dan hanya pemegang pengaturan yang bisa menggesernya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau kejutan dijaga tampilan, juara bocor lewat alamat file sebelum dibacakan di lapangan, dan tidak ada satu galat pun yang muncul untuk memberi tahu.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-tanpa-build",
+      judul: "Tanpa build step; HTML dan JS polos",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Tidak ada React, tidak ada bundler, tidak ada npm install sebelum apa pun bisa dijalankan. File di web/ disajikan apa adanya, dan merge sama dengan deploy. Alasannya satu dan tidak bisa ditawar: pemeliharanya pelajar SMA yang belajar sambil jalan, dan sebagian baru pertama kali membuka editor.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak framework plus bundler: seorang pelajar harus paham toolchain sebelum bisa membetulkan satu label yang salah ketik.",
+            "Ditolak juga karena waktu. Perbaikan mendadak jam enam pagi hari-H tidak boleh menunggu proses build yang bisa gagal karena hal yang tidak berhubungan.",
+            "Harganya dibayar sadar: file bersama seperti api.js, util.js, style.css, dan config.js harus DISALIN ke situs peserta, dan shared-files.yml yang menjaga salinannya tidak membusuk. web/ selalu acuannya.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau dibalik, pemelihara berikutnya berhenti di langkah nol, dan sistem ini mati bukan karena rusak melainkan karena tidak ada yang bisa membukanya.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-skor-mentah",
+      judul: "Skor tidak pernah disimpan, dan yang dicatat nilai mentah",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Tidak ada kolom total di mana pun. Klasemen adalah rantai view: v_poin_wahana menghitung poin tiap penilaian, v_poin_pos menjumlahkannya per pos, v_total_skor menjumlahkan seluruh pos, v_klasemen mengurutkannya. Dan yang masuk ke rantai itu adalah apa yang dilihat juri — berapa detik, berapa jawaban benar, berapa angka kriteria — bukan poin yang sudah dihitung orang.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak kolom total tersimpan plus tombol hitung ulang: koreksi yang datang di menit terakhir menuntut seseorang ingat menekan tombolnya, dan papan mengumumkan juara dari angka lama.",
+            "Ditolak juri menghitung poin di kepala atau di kertas. Blangko cetak sengaja TIDAK punya kolom Nilai Pos: juri hanya menulis data mentah, dan skornya tetap dihitung database.",
+            "Ditolak layar menghitung poin di browser. Layar Input Nilai Tabel selalu membaca ulang angkanya dari v_lembar_pos tiap kali satu baris tersimpan, karena menghitung di browser melahirkan mesin skor kedua yang suatu hari berbeda pendapat dengan v_poin_pos.",
+            "cache_live_score dari migration 0146 murni soal kecepatan. Menghapusnya tidak menghilangkan satu nilai pun, karena ia bukan sumber angkanya.",
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Input Nilai Tabel",
+          hash: "#/pos",
+          fitur: "pos",
+          teks: "Lembar satu pos, satu baris per regu. Nama dan urutan kolomnya dibangun dari baris wahana, bukan ditulis di kode.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau skor disimpan atau dihitung di dua tempat, akan ada dua angka untuk satu regu, dan suatu hari keduanya berbeda pendapat — biasanya di panggung, saat juara dibacakan.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-aturan-data",
+      judul: "Aturan penilaian adalah data, bukan kode",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Aturan skor berganti hampir tiap tahun. Karena itu tiap kolom penilaian adalah satu baris di tabel wahana, dengan enam bentuk konversi yang bisa dipilih. Layar Input Nilai Tabel membangun kolomnya dari baris-baris itu — nama dan urutannya dari wahana, bentuk kotaknya dari wahana, rentang yang boleh diketik dari wahana — jadi mengganti penilaian tahun depan tidak menyentuh satu baris kode pun.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak rumus dan bobot ditulis di kode aplikasi: panitia tahun depan harus mencari programmer untuk mengganti bobot satu lomba.",
+            "Ditolak menghitung bobot pos dari CACAH lomba. Bobot pos adalah jumlah poin_maks seluruh wahana-nya. Memecah KIM jadi Kim Lihat dan Kim Cium di migration 0087 tidak mengubah satu poin pun, sedangkan memindah satu lomba antar pos mengubah bobot dua pos tanpa satu angka diedit.",
+            "Salah baca yang paling sering: angka 0 sampai 10 di KIM itu RENTANG MENTAH, bukan bobot. Dibaca sebagai bobot, Pos 3 terlihat 220 padahal 400, dan KIM mulai terlihat seperti lomba yang perlu dinaikkan.",
+            "Lomba berbentuk soal cukup satu angka: berapa jawaban benar. Rentang mentahnya harus sama dengan jumlah soalnya, karena rentang yang lebih longgar membiarkan petugas mengetik 12 dari 10.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau aturan dipindah ke kode, panitia kehilangan kendali atas acaranya sendiri dan harus menunggu orang yang bisa menyentuh kode.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-nomor-dada",
+      judul: "Nomor dada diketik petugas, bukan diterbitkan sistem",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Sistem tidak memberi nomor. Petugas mengetik nomor yang ADA DI TANGANNYA, karena nomor dada itu benda fisik berupa kain di atas meja, dan tumpukan kain tidak selalu urut. Migration 0011 yang memutuskan ini sesudah versi awal memaksa nomor terkecil yang tersedia.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak sistem memberi nomor terkecil yang tersedia: petugas jadi harus mencari kain nomor tertentu di tumpukan, sementara antrean berdiri di depannya.",
+            "Sejak migration 0116 ada dua deret dari satu kunci yang sama: Eksternal 1 sampai 500, Intern 1001 sampai 1250.",
+            "Deret Intern itu keputusan pemilik acara, 27 Agustus 2026, dan ia menutup jalur sistemnya saja. Jalur kertasnya ikut menuntut: kain Intern harus ditandai supaya yang ditulis juri di blangko juga 1xxx, karena juri menyalin nomor dari kain di dada regu — kain polos bertulis 001 menghasilkan blangko ambigu yang tidak bisa dipulihkan satu baris SQL pun.",
+            "Efek sampingnya menjatuhkan satu bug tidur: pemformat tiga digit memotong 1001 jadi 100. Diperbaiki di migration 0117.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau sistem dan kain menyebut angka yang berbeda, tiap juri melakukan terjemahan di kepala sepanjang hari, dan satu kali salah terjemah tidak bisa ditemukan lagi.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-advisory-lock",
+      judul: "Satu gerbang untuk seluruh daftar ulang",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Pemberian nomor dada dan penempatan kloter dilewatkan lewat SATU advisory lock yang dipegang selama seluruh urusan itu berlangsung. Terdengar kasar dibanding pola kunci-baris yang pintar, dan justru itu yang membuatnya benar.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak pola kunci baris yang dipakai migration 0004. Versi itu mengunci baris di nomor_dada_stok sambil memutuskan sebuah nomor sudah terpakai atau belum dari tabel LAIN, regu.nomor_dada — mengunci tabel A untuk memutuskan tabel B, dan pada 30 meja serentak dua transaksi bisa sama-sama menganggap nomor yang sama masih kosong.",
+            "Perbaikannya menyederhanakan, bukan menambah kepintaran. Dengan satu gerbang di awal, pola SKIP LOCKED tidak diperlukan lagi sama sekali — dan penerus tidak perlu menalar kunci lintas tabel untuk membaca fungsinya.",
+            "Terukur, bukan diyakini. Diuji dengan 30 koneksi serentak memperebutkan 300 nomor dada: versi lama gagal di 1 sampai 3 meja tiap putaran, 290 dari 300 regu berhasil. Sesudah migration 0007 memakai satu gerbang, lima putaran berturut-turut memberi 300 dari 300 regu bernomor, nol error, nol duplikat, selesai dalam 1,65 detik.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kunci UNIQUE pada nomor dada memang menahan datanya, tapi yang ditahan cuma datanya — di meja yang terlihat adalah satu sekolah gagal daftar ulang dengan pesan error teknis, di depan antrean.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-kloter",
+      judul: "Kloter FIFO berkuota, dan sisipan manual yang berteriak",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Pembagian kloter otomatis mengisi kloter paling awal yang belum berangkat, urut siapa yang lebih dulu menyelesaikan daftar ulang, paling banyak 5 Eksternal dan 3 Intern per kloter dengan kuota dihitung terpisah. Sekolah tidak berpengaruh sama sekali. Tapi kloter yang kertasnya sudah dicetak TETAP boleh ditambah regu secara manual.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak penyebaran per sekolah dan lompatan dua kloter — aturan lama yang dibuang migration 0092 karena tidak ada yang bisa menjelaskannya di lapangan. Aturan sekarang muat dalam satu kalimat ke pembina.",
+            "Ditolak membekukan kloter begitu kertasnya dicetak. Pagar itu pernah ada di migration 0008, dikembalikan di 0040, lalu dibuang seluruhnya di 0066: mencetak ulang selembar daftar itu murah, memberangkatkan kloter dengan empat tempat kosong tidak bisa diulang.",
+            "Kejadian nyatanya: satu sekolah datang terlambat, daftar ulang sesudah kertas dibagikan, regunya diselipkan. Di garis start kloter memanggil sepuluh nama padahal kertas memuat sembilan. Karena itu sisipan ditandai waktunya dan tampil sebagai kartu merah yang MENETAP.",
+            "Pengacakan OTOMATIS tetap melewati kloter yang sudah berangkat, dikembalikan migration 0088. Yang dibuka cuma jalur manual, dan itu keputusan petugas yang sadar.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Satu akibat yang wajib diketahui petugas yang menyisipkan: penalti waktu dihitung dari jam berangkat kloter, jadi regu yang dimasukkan ke kloter yang sudah jalan dihitung berangkat pada jam kloter itu, bukan jam ia benar-benar jalan. Kalau maksudnya regu itu berangkat sekarang, tempatnya di kloter yang belum jalan. Dan jangan menomori kloter sendiri secara manual: penomoran menyimpan aturan yang tidak kelihatan dari nomornya.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau kloter dibekukan, regu ada di database tapi tidak pernah dipanggil di garis start; kalau sekolah dijadikan faktor lagi, pertanyaan kenapa regu kami di kloter 30 tidak bisa dijawab siapa pun di lapangan.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-jam-diketik",
+      judul: "Jam selalu diketik, tidak ada jam server tersembunyi",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Fungsi berangkatkan_kloter menerima jamnya sebagai argumen dan kolomnya tidak punya default now(). Jam berangkat adalah angka yang dibaca petugas dari jam sungguhan lalu diketik, karena penalti sepuluh regu sekaligus lahir dari angka itu. Kotak isiannya juga bukan pemilih jam bawaan browser, melainkan sepasang kotak teks dengan pemeriksa sendiri.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak timestamp server saat data sampai: jaringan lambat menggeser jam berangkat beberapa menit, dan penalti dihitung dari jam yang tidak pernah terjadi.",
+            "Ditolak pemilih jam bawaan browser: ia dirender menurut locale BROWSER, bukan bahasa halamannya. Laptop panitia berbahasa Inggris menampilkan 07:15 AM, dan satu meja ber-AM/PM di antara kertas 24 jam adalah cara sangat murah mencatat 07:15 sebagai 19:15.",
+            "Yang diterima sengaja longgar, karena pencatat menyalin dari kertas dan mengetik cepat: 745, 0745, 7:45, 7.45, dan 07 45 semuanya jadi 07:45. Yang di luar 00:00 sampai 23:59 ditolak, bukan dibetulkan diam-diam.",
+          ],
+        },
+        {
+          jenis: "layar",
+          nama: "Keberangkatan",
+          hash: "#/keberangkatan",
+          fitur: "keberangkatan",
+          teks: "Tempat jam berangkat kloter diketik. Perkiraan jam yang tampil di layar lain bukan angka ini, dan keduanya tidak pernah disimpan di kolom yang sama.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau jam diambil server, penalti seluruh kloter dihitung dari momen paket data tiba, bukan momen regu benar-benar melangkah.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-penalti-simetris",
+      judul: "Penalti waktu menilai ketepatan, bukan kecepatan",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Tiap regu memilih sendiri kontrak waktunya. Targetnya jam berangkat kloter ditambah kontrak itu: berangkat 07:00 dengan kontrak empat jam berarti harus tiba tepat 11:00. Satu menit terlalu cepat dan satu menit terlambat sama-sama mengurangi satu poin.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menilai kecepatan: regu akan berlomba pulang secepat mungkin dan kontrak waktu kehilangan seluruh artinya.",
+            "Ditolak toleransi 0 sampai 9 menit dari aturan lama. Sejak migration 0089 konfigurasinya blok 1 menit dan penalti 1 poin per blok — jangan hidupkan lagi toleransinya.",
+            "Selisihnya dipotong pada menit mentah: 9 menit 30 detik dihitung 9 menit, bukan dibulatkan dulu jadi 10.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau penalti jadi tidak simetris, yang diuji berubah dari kemampuan regu menepati janjinya sendiri menjadi siapa yang paling kuat berlari.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-hak-akses",
+      judul: "Hak akses lewat centang, bukan lewat nama peran",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Yang menjaga pintu adalah fungsi boleh(fitur), yang membaca matriks centang di layar Akun. Peran cuma mengisi centang awal saat akun dibuat. Jadi panitia bisa menggeser tugas seseorang tengah hari tanpa migration dan tanpa siapa pun menyentuh kode.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak policy yang membandingkan nama peran. Menambahkan satu perbandingan seperti itu berarti ada dua mekanisme untuk satu pertanyaan, dan yang satu tidak bisa diubah panitia.",
+            "Pemeriksaan yang cakupannya lebih sempit daripada masalahnya sudah terbukti berbahaya DUA KALI. Migration 0064 memindai policy dan function lalu melapor bersih — enam VIEW lolos karena view bukan keduanya. Migration 0065 menambahkan view lalu melapor bersih lagi — v_klasemen_live_score lolos karena ia menyaring dengan nama peran admin, yang tidak mengandung nama peran lama yang sedang dicari. Dua laporan hijau, dua layar kosong di lapangan.",
+            "Isolasi pos sengaja tinggal pada MENULIS. Sejak migration 0069 rincian Live Score dibuka untuk semua pemegang centang live_score — keputusan pemilik acara, dan konsekuensinya diterima: juri Pos 3 bisa melihat angka Pos 1 sebelum diumumkan.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Satu peran yang mudah dirusak tanpa sengaja: koordinator_pos adalah juri pos yang kolom pos-nya KOSONG, dan seluruh gunanya bertumpu pada itu. Pos kosong berarti pagar per-pos membuka kelimanya. Memberinya pos utama mengubahnya diam-diam jadi juri pos biasa dengan nama lain.",
+        },
+        {
+          jenis: "layar",
+          nama: "Akun",
+          hash: "#/account",
+          fitur: "akun",
+          teks: "Matriks centang per fitur. Ini satu-satunya sumber hak akses di seluruh sistem.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau hak akses kembali diikat ke nama peran, tiap pergeseran tugas di lapangan butuh migration, dan pemeriksaan yang melapor bersih tidak lagi berarti apa-apa.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-blangko",
+      judul: "Blangko A5 landscape, satu master per lomba, difotokopi",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Yang dicetak dari browser adalah MASTER, bukan tumpukannya. Satu pos dengan tiga lomba mencetak tiga halaman, bukan 1.500. Blangko itu kosong, jadi menggandakannya di fotokopi lebih cepat dan jauh lebih murah — mencetak tumpukannya dari browser menghabiskan satu toner kantor untuk pekerjaan yang selesai dalam hitungan menit di mesin fotokopi.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak A5 portrait: nomor dada dan nilai mentah harus besar dan berdampingan; di portrait keduanya berdesakan turun sampai kotak nilainya tinggal separuh. A5 landscape adalah separuh A4 dipotong lurus, jadi fotokopi bisa menggandakannya dua-up.",
+            "Ditolak satu lembar per kriteria: satu regu di Pembidaian akan menerima lima kertas sekaligus di satu lomba. Satu lomba, satu lembar, dan juri menulis semua kriterianya di situ.",
+            "Lomba berbentuk soal tidak mendapat blangko sama sekali. Peserta menulis di lembar soalnya sendiri, jadi pos yang seluruh lombanya berbentuk soal tidak mencetak apa pun dan mengatakan alasannya.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Karena masternya difotokopi berulang — sering kali fotokopi dari fotokopi — aturan cetaknya keras dan tidak satu pun kosmetik: tanpa blok hitam pekat, tanpa abu-abu atau raster, tanpa tulisan putih di atas gelap, garis minimal 0,75pt, huruf minimal 7pt, dan tidak ada apa pun di belakang area yang ditulisi. Blok hitam keluar belang dan berbercak dari mesin fotokopi, abu-abu jadi kotor atau hilang sama sekali, dan huruf di bawah 7pt tertutup toner sampai lubang huruf a dan e menutup.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau aturan cetak dilonggarkan, salinan keempat jadi bercak yang tidak terbaca — dan yang memegangnya juri di pos, bukan orang yang menyetujui desainnya di layar.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-bahasa",
+      judul: "Istilah domain tetap Indonesia, istilah teknis tetap Inggris",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Pembagiannya menurut siapa yang membaca, bukan menurut jenis filenya. Kata yang diucapkan panitia tetap Indonesia sampai ke dalam nama kolom database. Kata yang diucapkan pemelihara kode tetap Inggris.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menerjemahkan semuanya ke Inggris. Menulis chestNumber untuk nomor dada memasang pajak terjemahan di tiap percakapan lapangan, dan pada akhirnya jadi bug.",
+            "Ditolak menerjemahkan semuanya ke Indonesia. Menulis pengendali untuk controller memutus pemelihara pelajar dari tiap tutorial, dokumentasi library, dan pesan error yang akan mereka cari.",
+            "Ditolak juga bentuk formal seperti daring, unggah, dan kata sandi. Panitia tersandung membacanya, dan dokumen yang harus dipecahkan dulu tidak akan dibaca sama sekali.",
+            "Nama file ikut aturan yang sama: apply-migration.yml karena migration itu urusan teknis, tapi 0011_nomor_dada_manual.sql karena nomor dada itu yang diucapkan orang.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau pembagiannya dibalik, tiap nama harus diterjemahkan dua arah setiap kali dibicarakan antara meja dan kode.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-teks-secukupnya",
+      judul: "Teks layar secukupnya, panitia tidak digurui",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Panitia membaca layar yang sama ratusan kali dalam satu shift. Kalimat yang mengajarkan sesuatu yang dipelajari sekali tetap dibaca ulang di tiap kalinya, dan mendorong tombol yang penting turun ke bawah lipatan layar HP. Karena itu judul yang jelas plus label field plus nama tombol biasanya sudah seluruh antarmukanya.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak paragraf penjelas di atas tiap fitur. Contoh yang dipakai dulu dialog gembok: judulnya di atas satu field beralasan sudah mengatakan seluruh isi paragrafnya, dalam seperempat tingginya, di HP tempat paragraf itu justru mendorong field-nya keluar layar. Dialog itu sendiri sudah tidak ada sejak migration 0166 — Cek Nilai membuka gembok langsung dengan alasan tetap Dibuka dari Cek Nilai — jadi yang tersisa pelajarannya, bukan layarnya.",
+            "Ditolak glosarium istilah di layar. Menjelaskan Penggalang PA sebagai SMP atau MTs putra dibuang, karena ia menjelaskan istilah kepada orang yang mengucapkannya tiap hari.",
+            "Yang DIPERTAHANKAN: fakta yang tidak bisa dibaca dari layar itu sendiri — angka yang berlaku sekarang, akibat yang tidak bisa dibatalkan, peringatan bahwa sesuatu sudah tercetak atau sudah berangkat.",
+            "Satu pengecualian yang sengaja: form pendaftaran. Pembina mengisinya sekali seumur acara, tanpa pelatihan, dan tanpa siapa pun untuk ditanya.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau layar ditambahi penjelasan, ia bertambah tinggi, tombol utamanya turun di bawah lipatan HP, dan kalimat yang benar-benar penting ikut tidak dibaca.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-hp",
+      judul: "Semua layar wajib jalan di HP, termasuk layar panitia",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Tidak ada satu pun layar yang boleh menganggap panitianya duduk di depan laptop. Diperiksa terukur pada lebar 390px: tidak ada elemen yang meluber, halaman tidak pernah bisa digeser ke samping, dan tidak ada sasaran sentuh di bawah 36px.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak ukuran huruf seragam untuk semua layar. Versi pertama memakai tubuh 18px dan isian 23px, dan form pendaftaran jadi setinggi 4,1 layar HP — panitia mengeluh kebanyakan menggulir.",
+            "Sesudah diturunkan ke 16 dan 17px, form lima regu turun dari 3.429px ke 2.242px, atau 35 persen lebih pendek.",
+            "Satu batas keras yang tidak boleh diturunkan: huruf di kotak isian minimal 16px. Di bawah itu iOS Safari memaksa zoom tiap kali isian disentuh, dan halamannya melompat.",
+            "Aturan CSS baru WAJIB diukur di browser, bukan dibaca. Lima kali dalam satu hari aturannya ada, terbaca benar, dan tidak mengenai apa pun karena kalah khusus atau kalah urutan.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau layar dianggap milik laptop, meja yang bekerja dari HP dan pembina yang mendaftar dari HP mendapat halaman yang melompat-lompat tiap kali disentuh.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-migration-manual",
+      judul: "Migration diterapkan manual, satu file per jalan",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Merge tidak menerapkan apa pun ke database. Perubahan skema dijalankan lewat workflow apply-migration, satu file, dijalankan sengaja oleh seseorang yang membaca log-nya. File-nya dijalankan dalam satu transaksi dan berhenti di error pertama, jadi tidak ada migration setengah jadi.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menerapkan migration otomatis saat merge ke main: satu perbaikan CSS yang kebetulan satu branch dengan migration akan mengubah skema produksi di tengah antrean pendaftaran.",
+            "Harga yang dibayar nyata dan wajib diketahui: TIDAK ADA yang mencatat migration mana yang sudah jalan. Sepuluh file — 0091 dan 0098 sampai 0106 — tidak pernah sampai produksi, dan CI tetap hijau selama itu.",
+            "Yang menemukannya enam hari kemudian bukan tes, melainkan pembina yang mendaftarkan regu Internal dan ditolak karena constraint golongan masih versi migration 0001. Migration 0119 memasang ulang isinya.",
+            "Karena itu ada supabase/checks/status_migrasi.sql: ia mencari SIDIK JARI sebuah migration di database — sebuah constraint, sebuah kolom, potongan definisi function, sebaris konfigurasi — dan tidak mengubah apa pun. Nama file tidak bisa diperiksa, karena tidak ada yang menyimpannya.",
+            "Cakupannya disebutkan, bukan didiamkan: 116 migration punya jejak yang diperiksa dan 53 tidak menyisakan jejak apa pun, dan 116 tambah 53 adalah seluruh 169 migration yang ada. Angka itu yang harus dijaga tiap kali file migration baru mendarat — nomor yang tidak ada di kedua daftar tidak muncul sebagai BELUM, ia tidak muncul sama sekali.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Satu jebakan waktu memperbaiki migration yang terlewat: menjalankan ulang file lama TIDAK otomatis aman. Periksa dulu apakah ada migration yang lebih muda sudah mengganti objek yang sama — menjalankan file lamanya sekarang akan mengembalikan objek itu ke versi lama. Itu sebabnya 0119 sengaja tidak memuat beberapa bagian dari sepuluh file yang dipasangnya ulang.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau migration ikut merge, skema produksi berubah tanpa satu orang pun membaca notice-nya, di tengah hari yang tidak bisa diulang.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-ci-manual",
+      judul: "Check CI dijalankan sengaja, tesnya di laptop",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Dua workflow pemeriksa — sql-tests dan shared-files — hanya bisa dijalankan lewat tombol, tidak otomatis saat push maupun pull request. Semua yang mereka periksa selesai di laptop dalam hitungan detik, dan aturan pertamanya memang menjalankannya di sana.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menjalankannya otomatis tiap push. GitHub membulatkan tiap JOB ke menit penuh, jadi yang mahal JUMLAH run, bukan lamanya: check 7 detik dan check 50 detik ditagih sama persis.",
+            "Satu hari yang terukur: 24 dari 60 run adalah salinan kedua dari check yang sudah lulus — sekali di pull request, sekali waktu merge-nya mendarat di main, atas tree yang sama persis.",
+            "Cron pun ditakar. Jadwal tiap lima menit sama dengan 288 menit terbilang per hari, dan itu menghabiskan jatah bulanan dalam sepekan. Dua cron yang ada dikunci ke tanggal lombanya dengan penjaga tahun di langkah pertama, karena cron tidak punya kolom tahun.",
+            "Dispatch CI kalau salah itu mahal: ada migration baru, perubahannya tidak bisa dijalankan lokal, laptopnya tidak punya PostgreSQL, atau acaranya kurang dari sepekan lagi.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau jatah gratis habis, yang ikut mati bukan cuma pemeriksa — apply-migration dan tombol ganti password yang dipakai panitia dari HP berhenti juga. Dan karena tidak ada yang memeriksa sendiri, menjalankan tes di laptop bukan saran.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-antrean-nilai",
+      judul: "Nilai yang gagal terkirim mengantre di HP, yang ditolak server tidak",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Di pos, internet putus adalah kejadian biasa, dan angka yang cuma ada di layar sama dengan angka yang tidak pernah dicatat. Karena itu kegagalan JARINGAN duduk di localStorage HP petugas dan dikirim ulang sendiri tiap 15 detik, juga seketika saat internet kembali. Tapi yang DITOLAK server tidak diantre sama sekali.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menolak simpanan waktu jaringan putus: angkanya hilang, dan regunya sudah pergi ke pos berikutnya.",
+            "Ditolak mengantre semua kegagalan tanpa pandang bulu. Nilai di luar rentang, regu yang tergembok, atau komponen yang bukan untuk golongan itu tidak akan berubah jawabannya karena ditunggu — dan satu baris rusak menyumbat seluruh antrean di belakangnya.",
+            "Yang ditolak server dilaporkan merah SELAGI regunya masih berdiri di depan petugas, saat masih bisa dibetulkan.",
+            "Janjinya ditulis jujur: terkirim begitu halaman ini terbuka dan ada sinyal, bukan pasti terkirim nanti. Tidak ada service worker, dan Background Sync tidak ada di Safari iOS.",
+          ],
+        },
+        {
+          jenis: "kenapa",
+          teks: "Kalau dibalik, nilai hilang diam-diam di pos, atau satu baris salah membekukan seluruh antrean satu HP sampai petugasnya menyadari sendiri.",
+        },
+      ],
+    },
+    {
+      kode: "kenapa-buka-layarnya",
+      judul: "Selama acara berjalan, buka layarnya sebelum merge",
+      isi: [
+        {
+          jenis: "p",
+          teks: "Sejak pendaftaran dibuka sampai juara diumumkan, sistem ini dipakai orang sungguhan sambil kita menyuntingnya. Layar yang mati bukan bug yang dilaporkan besok, melainkan pekerjaan yang berhenti sekarang, di meja dengan antrean di depannya. Karena itu sebelum merge, buka layar yang disentuh dan HITUNG BARISNYA.",
+        },
+        {
+          jenis: "poin",
+          butir: [
+            "Ditolak menganggap parse check, tes SQL, dan halaman contoh sebagai bukti sebuah layar hidup. 28 Agustus 2026 Meja Pembayaran KOSONG di produksi selama acara berjalan; satu deklarasi berakhir di bawah pemakainya dan melempar error untuk SETIAP baris.",
+            "Parse check lulus, seluruh tes lulus, pengukuran tata letak dikerjakan di halaman contoh berisi markup statis. Tidak satu langkah pun membuka layarnya. Yang menemukannya petugas di lapangan.",
+            "Layar yang rusak sering terbaca seperti layar yang kosong. Waktu itu tulisan 39 invoice dan 40 regu di atas tabel tetap benar, karena angkanya dihitung dari data yang sudah diterima, bukan dari barisnya. Jangan menilai dari kepala layar.",
+            "Kalau alat untuk membuka layarnya sendiri rusak, itu bug prioritas tinggi, bukan gangguan kecil. Skrip tests/dev_database.sh pernah berhenti di migration 0118 sejak file itu mendarat, dan selama itu tidak ada cara membuka layar mana pun di laptop — jadi aturan di atas mustahil dipatuhi tanpa disadari siapa pun.",
+          ],
+        },
+        {
+          jenis: "p",
+          teks: "Konsekuensinya tegas: perubahan yang layarnya tidak bisa dibuka, JANGAN di-merge selama acara berjalan. Tunda sampai bisa. Risiko menahan satu perbaikan tampilan jauh lebih kecil daripada risiko satu layar mati di tengah antrean. Dan kalau kamu tetap mau membalik salah satu keputusan di bab ini, baca dulu kotak penutupnya: isinya bukan ancaman, itu daftar hal yang sudah pernah terjadi.",
+        },
+        {
+          jenis: "kenapa",
+          teks: "Yang paling sering merusak sistem ini bukan orang yang tidak peduli, melainkan orang yang peduli dan tidak tahu alasannya. Kalau kamu mengubah sesuatu di sini, tulis alasannya di sini juga — bab yang tidak diperbarui menyesatkan lebih parah daripada bab yang kosong.",
+        },
+      ],
+    },
+  ],
+};
+/* Bulan-bulan timeline. Bentuknya BERBEDA dari bab di atas, dan itu disengaja
+   — sebuah bulan bukan sebuah bagian bacaan: ia punya tonggak yang dicentang,
+   seksi yang sedang sibuk, dan satu kesalahan khas yang mahal. Memaksanya
+   masuk ke daftar blok akan mengubur keempat hal itu di dalam paragraf.
+
+   Harganya satu percabangan di perakit layar, dan itu batas yang jelas:
+   bab dengan `bagian` digambar sebagai bacaan, bab timeline digambar sebagai
+   kalender. */
+export const TIMELINE = [
+  {
+    kode: "september",
+    bulan: "September",
+    tajuk: "Serah Terima Jabatan",
+    fokus:
+      "Kepengurusan berpindah ke angkatan berikutnya, dan panitia inti edisi baru terbentuk sebelum satu rapat besar pun digelar.",
+    tonggak: [
+      "Serah terima jabatan pengurus ambalan selesai, penanggung jawab acara ditetapkan namanya",
+      "Ketua Pelaksana, Sekretaris, dan Bendahara edisi baru ditunjuk",
+      "Evaluasi edisi sebelumnya dibaca ulang bersama, bukan disimpan",
+      "Akses diserahkan: siapa yang memegang akun admin, akun GitHub organisasi, dan password Supabase",
+      "Tanggal lomba diusulkan ke pembina dan sekolah untuk dikunci di rapat Oktober",
+    ],
+    seksi: [
+      "Ketua Pelaksana dan Wakil",
+      "Sekretaris",
+      "Bendahara — Meja Pembayaran",
+      "Administrator Sistem",
+    ],
+    sistem: [
+      "Serahkan akun admin lama ke pengurus baru lewat workflow \"Ganti password akun panitia\" — satu akun sekali jalan, password dibuat server, diambil dari Artifact sebelum hilang tiga hari",
+      "Buka layar Akun di #/account dan nonaktifkan akun panitia edisi lalu yang orangnya sudah lulus; jangan hapus barisnya, riwayat nilai menunjuk ke sana",
+      "Buka Live Score selagi datanya masih ada, cetak lewat tombol \"Rekap Nilai Semua\", dan salin daftar juara dari layar Kejuaraan sebagai arsip kertas",
+      "Pastikan minimal dua orang tahu password akun organisasi (Supabase, Cloudflare, GitHub) — bukan satu orang, bukan akun pribadi",
+    ],
+    jangan:
+      "Jangan membersihkan data edisi lalu bulan ini — begitu dihapus, tidak ada lagi bahan evaluasi dan tidak ada contoh layar terisi untuk melatih panitia baru.",
+  },
+  {
+    kode: "oktober",
+    bulan: "Oktober",
+    tajuk: "Rapat Besar dan Anggaran",
+    fokus:
+      "Tema, tanggal, biaya, dan seluruh seksi dikunci dalam satu rapat besar, lalu edisi baru dibuat di database.",
+    tonggak: [
+      "Rapat besar: tema, tanggal lomba, dan biaya pendaftaran diputuskan dan dicatat notulennya",
+      "Seluruh seksi terisi namanya, lengkap dengan koordinator tiap seksi",
+      "Anggaran kasar disusun: pemasukan dari perkiraan jumlah regu, pengeluaran per seksi",
+      "Rute dan lokasi lima pos disurvei ulang, termasuk titik pos bayangan sebelum tiap pos",
+      "Kebutuhan barak dihitung dari perkiraan regu luar kota",
+    ],
+    seksi: [
+      "Ketua Pelaksana dan Wakil",
+      "Sekretaris",
+      "Bendahara — Meja Pembayaran",
+      "Seksi Lomba dan Juri Pos",
+      "Seksi Perlengkapan",
+    ],
+    sistem: [
+      "Susun migration edisi baru dan isi kolomnya apa adanya: nomor, nama, tahun, tanggal_lomba, biaya_per_regu, jam_mulai_berangkat, dan interval_berangkat_menit",
+      "Jalankan migration itu lewat workflow \"Apply migration to Supabase\" — merge saja tidak pernah menerapkannya",
+      "Jalankan supabase/checks/status_migrasi.sql lewat workflow yang sama, lalu baca hasilnya: yang berbunyi BELUM belum pernah hidup, dan yang tidak disebut sama sekali belum pernah diperiksa",
+      "Samakan stok nomor dada dengan kain yang benar-benar dipesan lewat supabase/checks/stok_nomor_dada.sql — dua deret, Eksternal dan Intern, dan pagar nomor dada membaca angkanya dari sana",
+      "Buka Kalkulator Keberangkatan di #/pengaturan-kloter dan lihat perkiraan jam berangkat kloter terakhir — kalau lewat 10:00, jumlah kloter atau interval_berangkat_menit yang salah, bukan jam upacaranya",
+    ],
+    jangan:
+      "Jangan menulis tanggal lomba di kode atau di skrip mana pun — seluruh perkiraan jam berangkat dihitung dari satu kolom tanggal di tabel edisi, dan tanggal yang ditulis di dua tempat akan berbeda persis saat tidak ada waktu memperbaikinya.",
+  },
+  {
+    kode: "november",
+    bulan: "November",
+    tajuk: "Soal, Kriteria, Bobot",
+    fokus:
+      "Isi lombanya disusun: soal ditulis, kriteria penilaian ditetapkan, dan bobot tiap pos dikunci sebelum blangko dirancang.",
+    tonggak: [
+      "Soal lima lomba tulis selesai beserta kunci jawabannya, disimpan tertutup",
+      "Kriteria tiap lomba dan rentang nilainya disepakati juri, bukan diputuskan sendiri oleh seksi lomba",
+      "Kontrak waktu yang ditawarkan ditetapkan, beserta penalti per menit terlalu cepat maupun terlambat",
+      "Surat izin sekolah, surat ke kepolisian dan puskesmas, serta surat undangan pangkalan dikirim",
+      "Proposal sponsor disebar dan yang sudah menyatakan iya dicatat nominalnya",
+    ],
+    seksi: [
+      "Seksi Lomba dan Juri Pos",
+      "Ketua Pelaksana dan Wakil",
+      "Sekretaris",
+      "Seksi Humas dan Sponsor",
+      "Seksi Keamanan dan P3K",
+    ],
+    sistem: [
+      "Susun migration pos, lomba, dan penilaian edisi baru: tiap penilaian dengan poin_maks-nya, lomba berupa soal dengan total_soal-nya, dan pengelompokan lomba lewat kolom wahana.lomba",
+      "Ingat bobot pos tidak pernah ditulis sebagai angka — ia jumlah poin_maks seluruh wahana di pos itu; memindah satu lomba antar pos mengubah bobot keduanya sekaligus",
+      "Kunci rentang nilai mentah sama dengan jumlah soal, supaya petugas tidak bisa mengetik 12 dari 10",
+      "Jalankan migration lewat \"Apply migration to Supabase\", lalu baca hasilnya lewat supabase/checks/lomba_per_pos.sql — pengelompokan lomba itu data, tidak bisa dibaca dari kode",
+      "Buka Input Nilai Tabel di #/pos, hitung kolomnya per pos, lalu tekan cetak blangko dan bawa kertasnya ke rapat juri; pos yang seluruhnya lomba soal memang menolak mencetak dan menyebutkan alasannya di layar",
+    ],
+    jangan:
+      "Jangan menggabungkan dua lomba yang lembar jawabannya terpisah menjadi satu baris — kolom foto ikut kode lomba, jadi satu kode untuk dua lomba berarti satu kolom memegang dua lembar jawaban berbeda, dan itu baru ketahuan saat ada nilai yang disengketakan.",
+  },
+  {
+    kode: "desember",
+    bulan: "Desember",
+    tajuk: "Publikasi dan Pendaftaran Dibuka",
+    fokus:
+      "Acara diumumkan ke pangkalan, form pendaftaran dibuka, dan akun panitia dibuat jauh sebelum dipakai.",
+    tonggak: [
+      "Pamflet dan link pendaftaran disebar ke pangkalan SMP dan SMA se-wilayah",
+      "Form pendaftaran dibuka pada tanggal yang diumumkan, dan pendaftar pertama masuk",
+      "Nomor kontak panitia untuk pertanyaan pembina diumumkan, satu nomor saja",
+      "Rekening penerimaan pembayaran dipastikan hidup dan nama pemiliknya diumumkan apa adanya",
+      "Meja pendaftaran offline dijadwalkan: hari, jam, dan siapa yang menjaga",
+    ],
+    seksi: [
+      "Seksi Humas dan Sponsor",
+      "Seksi Dokumentasi dan Publikasi",
+      "Seksi Kesekretariatan dan Pendaftaran",
+      "Bendahara — Meja Pembayaran",
+      "Administrator Sistem",
+    ],
+    sistem: [
+      "Bersihkan data uji SEKARANG lewat supabase/checks/cleanup_data_uji.sql di workflow \"Apply migration to Supabase\" — termasuk mengembalikan penomoran kloter ke 1, kalau tidak pembagian kloter nanti mulai dari tengah",
+      "Bakukan daftar sekolah kurasi lebih dulu, lalu sapu sisanya lewat supabase/checks/sekolah_kembar.sql; dua sekolah senama dibedakan di dalam namanya sendiri, bukan lewat alamat",
+      "Jalankan workflow \"Provision akun panitia\" per batch: tempel CSV berisi username, email, peran, dan pos; ambil passwordnya dari Artifact sebelum terhapus tiga hari lagi",
+      "Buka layar Akun dan cocokkan centang tiap akun dengan pekerjaan orangnya, dengan urutan yang benar: pilih perannya DULU, sesuaikan centangnya SESUDAHNYA — mengganti peran menghapus seluruh centang tangan",
+      "Buka form pendaftaran di situs peserta dari HP sungguhan, daftarkan satu regu percobaan sampai selesai, lalu hapus regu itu — di fase Internal peserta hanya melihat jumlah pendaftar dan jalan ke formulir",
+    ],
+    jangan:
+      "Jangan membuka pendaftaran sebelum data uji dibersihkan: regu percobaan yang tertinggal ikut terhitung di jumlah pendaftar yang dilihat publik, dan cleanup_data_uji.sql tidak membedakan data uji dari data asli — sesudah ada pendaftar sungguhan, berkas itu tidak boleh dijalankan lagi.",
+  },
+  {
+    kode: "januari",
+    bulan: "Januari",
+    tajuk: "Penutupan, Daftar Ulang, Gladi",
+    fokus:
+      "Pendaftaran ditutup, uang masuk dicocokkan, nomor dada dibagikan, dan seluruh alur dicoba dari ujung ke ujung sebelum hari-H.",
+    tonggak: [
+      "Pendaftaran ditutup pada tanggal yang diumumkan, jumlah regu final diketahui",
+      "Seluruh pembayaran dicocokkan dan ditandai lunas",
+      "Technical meeting dengan pembina: rute, kontrak waktu, aturan penalti, dan jam kumpul",
+      "Daftar ulang berjalan 1-2 hari sebelum lomba, nomor dada kain berpindah ke tangan regu",
+      "Gladi lapangan: seluruh panitia berdiri di posnya masing-masing, memakai laptop dan HP yang akan dipakai hari-H",
+    ],
+    seksi: [
+      "Seksi Kesekretariatan dan Pendaftaran",
+      "Bendahara — Meja Pembayaran",
+      "Seksi Daftar Ulang",
+      "Seksi Perlengkapan",
+      "Seksi Konsumsi",
+    ],
+    sistem: [
+      "Kosongkan antrean Meja Pembayaran di #/pembayaran — regu yang belum lunas tidak bisa daftar ulang — lalu betulkan salah ketik pembina di Data Peserta sebelum nomor dada keluar, karena sesudahnya nama regu ikut membeku",
+      "Cetak blangko master tiap lomba dari Input Nilai Tabel: yang keluar dari printer SATU master A5 melintang per lomba, dan penggandaannya pekerjaan mesin fotokopi 2-up di sekretariat",
+      "Jalankan daftar ulang di Meja Daftar Ulang di #/daftar-ulang dengan 2-3 meja paralel; nomor dada diketik dari kain di tangan, kloter jatuh sendiri secara FIFO",
+      "Cetak dua bentuk dari Daftar Kloter: \"Cetak Kloter untuk Petugas\" untuk meja staging, dan \"Cetak Kloter untuk Peserta\" untuk papan pengumuman",
+      "Isi database uji lewat supabase/checks/simulasi_end_to_end.sql sampai papan Live Score terisi, dan jelang gladi jalankan workflow \"Setel password bersama semua akun\" supaya sepuluh orang bisa login tanpa sepuluh serah terima — kembalikan ke acak sesudahnya",
+    ],
+    jangan:
+      "Jangan salah mengetik nomor dada saat daftar ulang: blangko penilaian hanya memuat nomor dada tanpa nama regu, jadi satu angka keliru memindahkan seluruh nilai satu regu ke regu lain, dan tidak ada apa pun di kertas yang memperlihatkannya.",
+  },
+  {
+    kode: "februari",
+    bulan: "Februari",
+    tajuk: "Pelaksanaan dan Evaluasi",
+    fokus:
+      "Hari lomba: upacara, keberangkatan bertahap, penilaian di lima pos, kedatangan, pengumuman juara, lalu arsip.",
+    tonggak: [
+      "Upacara dan pemberangkatan kloter pertama oleh pejabat, seluruh keberangkatan selesai pukul 10:00",
+      "Lima pos berjalan dan nilai mentah masuk sistem sepanjang siang",
+      "Seluruh regu tercatat sampai di finish dan kelengkapan anggota diperiksa fisik",
+      "Juara diumumkan di lapangan, baru sesudah itu ditampilkan di layar peserta",
+      "Rapat evaluasi digelar selagi ingatan masih segar, dan arsipnya diserahkan ke pengurus berikutnya",
+    ],
+    seksi: [
+      "Seksi Keberangkatan",
+      "Seksi Kedatangan — Finish",
+      "Seksi Lomba dan Juri Pos",
+      "Seksi Rekap dan Skor",
+      "Administrator Sistem",
+    ],
+    sistem: [
+      "Pagi: naikkan fase live ke Progress lewat saklar di Live Score, lalu jalankan workflow \"Publish rekap live\" — fasenya dulu, penerbitan sesudahnya, dan urutan itu berlaku ke dua arah",
+      "Keberangkatan di #/keberangkatan: kertas yang jadi pencatat utama dan laptop memverifikasi, jam berangkat diketik dari jam sungguhan; di Kedatangan di #/finish justru terbalik, laptop pencatat utamanya, dan regu yang lupa dicatat tiba hilang dari klasemen tanpa satu galat pun",
+      "Pantau Live Score sepanjang siang: angka hilang berarti regu sudah closing tapi nilainya belum lengkap, dan pos yang berhenti menyetor lebih dari setengah jam berarti laptop atau sinyalnya rusak",
+      "Sisir Cek Nilai di #/cek-nilai lewat ketiga saringannya — Belum Input, Belum Foto, Belum Kunci — sampai angkanya nol: adu foto lembar jawaban dengan angka yang diketik, betulkan kalau beda, lalu pasang gembok per lomba",
+      "Sesudah juara dibacakan di lapangan: isi pilihan manual di Kejuaraan, naikkan fase ke Juara, jalankan \"Publish rekap live\" lagi, lalu cetak \"Rekap Nilai Semua\" dari Live Score dan Daftar Kloter final sebagai arsip",
+    ],
+    jangan:
+      "Jangan menaikkan fase ke Juara sebelum juara dibacakan di lapangan, dan jangan menurunkannya kembali sesudahnya berharap papan kembali — berkas fase juara tidak memuat satu baris klasemen pun, jadi papannya kosong sampai rekap diterbitkan ulang.",
+  },
+];
+/** Timeline ikut jadi tab supaya seluruh buku punya satu deretan tab, bukan
+ *  tiga tab ditambah satu tombol yang letaknya lain sendiri. `bagian`-nya
+ *  sengaja kosong: yang digambar TIMELINE di atas. */
+const BAB_TIMELINE = {
+  kode: "timeline", judul: "Timeline Satu Edisi",
+  tab: "Timeline", ikon: "clock", warna: "toska",
+  ringkas: "Enam bulan dari Serah Terima Jabatan sampai hari pelaksanaan: "
+    + "tonggak yang dicentang, langkah yang dikerjakan di sistem, dan satu "
+    + "kesalahan khas tiap bulan.",
+  bagian: [],
+};
+
+export const BUKU_SAKTI = [BAB_TUTORIAL, BAB_SEKSI, BAB_KENAPA, BAB_TIMELINE];
+
+/** Seluruh bagian buku, rata, masing-masing membawa bab asalnya. Dipakai
+ *  kotak cari dan daftar isi cetak. */
+export function bagianBuku() {
+  return BUKU_SAKTI.flatMap(bab =>
+    bab.bagian.map(bagian => ({ bab, bagian })));
+}
+
+/** Semua teks satu bagian, digabung jadi satu baris huruf kecil.
+ *
+ *  Kotak cari mencari DI SINI, bukan di DOM. Mencari di DOM berarti judul
+ *  bagian yang cocok tetapi isinya tidak akan hilang begitu satu blok
+ *  disembunyikan, dan sebaliknya — dan yang mencari kata "gembok" tidak
+ *  peduli kata itu ada di paragraf, di butir, atau di sel tabel. */
+export function teksBagian(bagian) {
+  const potong = [bagian.judul];
+  for (const blok of bagian.isi) {
+    if (blok.teks) potong.push(blok.teks);
+    if (blok.nama) potong.push(blok.nama);
+    if (blok.butir) potong.push(...blok.butir);
+    if (blok.kepala) potong.push(...blok.kepala);
+    if (blok.baris) for (const baris of blok.baris) potong.push(...baris);
+  }
+  return potong.join(" ").toLowerCase();
+}
+
+/** Semua teks satu bulan timeline, sebentuk dengan teksBagian(). */
+export function teksBulan(bulan) {
+  return [bulan.bulan, bulan.tajuk, bulan.fokus, bulan.jangan,
+          ...bulan.tonggak, ...bulan.seksi, ...bulan.sistem]
+    .join(" ").toLowerCase();
+}
+
+/** Bagian yang memuat SELURUH kata yang diketik, bukan salah satunya.
+ *
+ *  Panitia mengetik "cetak kloter" untuk mencari satu hal, bukan dua. Dengan
+ *  "salah satu", kata "cetak" sendirian sudah mengembalikan setengah buku dan
+ *  kotak carinya berhenti menyaring apa pun. */
+export function cariBagian(kata) {
+  const potong = String(kata || "").toLowerCase().split(/\s+/).filter(Boolean);
+  if (!potong.length) return [];
+  return bagianBuku().filter(({ bagian }) => {
+    const teks = teksBagian(bagian);
+    return potong.every(k => teks.includes(k));
+  });
+}
+
+/** Bulan timeline yang cocok, aturan sama dengan cariBagian(). */
+export function cariBulan(kata) {
+  const potong = String(kata || "").toLowerCase().split(/\s+/).filter(Boolean);
+  if (!potong.length) return [];
+  return TIMELINE.filter(bulan => {
+    const teks = teksBulan(bulan);
+    return potong.every(k => teks.includes(k));
+  });
+}

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -1022,7 +1022,12 @@ const IKON = {
     '<path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" /> <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" /> <path d="M7 3v4a1 1 0 0 0 1 1h7" />',
   // Panah memutar searah jarum jam: foto diputar 90 derajat tiap ketukan.
   "rotate-cw":
-    '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /> <path d="M21 3v5h-5" />'
+    '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /> <path d="M21 3v5h-5" />',
+  // Buku terbuka, dipakai ubin Buku Sakti. Sengaja BUKAN "file-text": ubin
+  // itu sudah dipakai layar lain, dan dua ubin bergambar sama di satu papan
+  // menghapus seluruh guna gambarnya.
+  "book-open":
+    '<path d="M12 7v14" /> <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />'
 };
 
 /** Satu ikon garis, siap ditempel ke template. Nama yang tidak dikenal

--- a/web/style.css
+++ b/web/style.css
@@ -292,7 +292,13 @@ button { font: inherit; cursor: pointer; }
   margin-top: .2rem;
 }
 
-input[type=text], input[type=number], input[type=password], input[type=time], input[type=tel] {
+/* `search` ikut daftar ini, bukan dibiarkan bawaan browser: kotak cari yang
+   tepinya setipis rambut dan tingginya 24px berdiri di antara kotak-kotak
+   setinggi 46px terbaca seperti kotak yang rusak, dan di HP ia terlalu
+   kecil untuk disentuh. Tombol silang bawaannya sengaja DIBIARKAN — ia
+   satu-satunya jalan mengosongkan kotaknya dengan satu ketukan. */
+input[type=text], input[type=number], input[type=password], input[type=time],
+input[type=tel], input[type=search] {
   width: 100%;
   font: inherit;
   font-size: 1.0625rem;
@@ -5976,4 +5982,360 @@ button.pill-number:hover { filter: brightness(.95); }
   .isi.cek .cek-foto { flex: 1; min-height: 150px; margin-top: .3rem; }
   .isi.cek .cek-foto .fg-petak { height: 100%; }
   .isi.cek .cek-lomba .foto-navigasi { margin-top: .25rem; flex: 0 0 auto; }
+}
+
+/* Pita Buku Sakti di kaki papan Home.
+
+   Sengaja BUKAN ubin. Empat belas ubin di atasnya masing-masing punya rona
+   sendiri, dan itu batasnya — rona kelima belas yang cukup berjauhan dari
+   keempat belas lainnya sudah tidak ada. Pita ini keluar dari kode warna itu
+   sama sekali: bentuknya yang membedakannya, bukan warnanya, jadi ia tidak
+   pernah bisa tertukar dengan meja mana pun.
+
+   Garis putus-putus, bukan bayangan kartu: ubin di atasnya benda yang bisa
+   ditekan sepanjang hari lomba, pita ini pintu yang dibuka sesekali. */
+.bs-pintu {
+  display: flex; align-items: center; gap: .8rem;
+  margin-top: 1rem; padding: .9rem 1.1rem;
+  border: 1.5px dashed var(--garis); border-radius: var(--radius);
+  background: var(--kartu);
+  text-decoration: none; color: inherit;
+  min-height: 46px;
+}
+.bs-pintu:hover { border-color: var(--utama); background: var(--utama-muda); }
+.bs-pintu:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.bs-pintu-ikon { width: 1.6rem; height: 1.6rem; color: var(--utama); flex: 0 0 auto; }
+.bs-pintu-nama { display: block; font-weight: 700; }
+.bs-pintu-ket {
+  display: block; font-size: .88rem; color: var(--tinta-lembut);
+  line-height: 1.45; margin-top: .1rem;
+}
+
+/* ============================================================================
+   BUKU SAKTI
+
+   Satu-satunya layar di sistem ini yang isinya BACAAN, bukan data. Aturan
+   yang membuat layar meja terbaca cepat — baris padat, angka besar, satu
+   aksi utama — justru melawan di sini: yang dibaca panitia baru di layar ini
+   paragraf demi paragraf, sekali, dengan sungguh-sungguh.
+
+   Jadi dua hal dilonggarkan, dan cuma dua:
+
+   1. LEBAR BARIS DIBATASI. Kartu bacaan berhenti di 68 huruf. Layar 1080px
+      memberi baris sepanjang 150 huruf, dan mata kehilangan awal baris
+      berikutnya setiap kali ia kembali ke kiri. Tabel dan timeline TIDAK ikut
+      dibatasi — keduanya dibaca melintang, bukan mengalir.
+   2. JARAK ANTAR BARIS DINAIKKAN ke 1.65. Tubuh 16px yang rapat nyaman untuk
+      satu baris nama regu dan melelahkan untuk sepuluh baris paragraf.
+
+   Selebihnya memakai kartu, tabel, dan pil yang sama persis dengan layar
+   lain. Buku yang tampilannya asing dari sistem yang ia jelaskan adalah buku
+   yang terbaca seperti tempelan.
+   ========================================================================== */
+
+.bs-kepala .description { margin-bottom: .8rem; }
+
+/* Kotak cari dan dua tombol cetak dalam satu baris; di HP tombolnya turun ke
+   baris kedua dan kotak carinya tetap selebar kartunya. `min-width: 0` wajib
+   ada di kotak carinya: tanpa itu ia menolak menyusut di bawah lebar bawaan
+   input dan mendorong tombol cetak keluar kartu. */
+.bs-alat {
+  display: flex; flex-wrap: wrap; gap: .6rem; align-items: center;
+}
+.bs-alat input[type="search"] {
+  flex: 1 1 14rem; min-width: 0;
+}
+.bs-cetak { display: flex; gap: .5rem; flex-wrap: wrap; }
+
+/* Tab bab memakai .tab-golongan/.tab-gol apa adanya. Yang berbeda cuma satu:
+   di sana tab-nya <button>, di sini <a> — karena bab boleh disebut sebagai
+   alamat. Anchor tidak mewarisi reset tombol, jadi garis bawah dan warna
+   tautannya dibuang di sini. */
+.bs-tab .tab-gol { text-decoration: none; }
+/* Bab yang terbuka ditandai `aria-current="page"`, bukan `aria-selected` —
+   ini tautan, bukan tab. Aturan warnanya ditulis lengkap di sini karena
+   .tab-gol[aria-selected="true"] di atas tidak mengenainya sama sekali. */
+.bs-tab .tab-gol[aria-current="page"] {
+  background: var(--utama); border-color: var(--utama); color: #fff;
+}
+.bs-tab .tab-gol[aria-current="page"] .tab-hitung {
+  background: rgba(255, 255, 255, .24); color: #fff;
+}
+
+/* ---- Kepala bab ---- */
+.bs-bab-kepala { display: flex; gap: .7rem; align-items: flex-start; }
+.bs-bab-kepala h2 { margin-bottom: .15rem; }
+
+/* Daftar isi bab. Bernomor, karena bagiannya memang berurutan waktu di bab
+   Menjalankan HRCD dan urutan itu bagian dari isinya. */
+.bs-isi { margin-top: .9rem; border-top: 1px solid var(--garis); padding-top: .8rem; }
+.bs-isi ol { margin: 0; padding-left: 1.4rem; }
+.bs-isi li { margin: .1rem 0; }
+/* `display: block`, dan itu bukan selera.
+
+   Tombol bawaannya inline-block, dan inline-block yang isinya membungkus dua
+   baris menyejajarkan BARIS TERAKHIRNYA dengan nomor daftar. Di HP, judul
+   bagian seperti "Seksi Kesekretariatan dan Pendaftaran" memang membungkus —
+   dan yang tergambar nomornya "5." berdiri di sebelah baris KEDUA, dengan
+   baris pertamanya menggantung di atasnya tanpa nomor.
+
+   Sebagai blok ia juga jadi sasaran sentuh selebar kartunya, yang memang
+   yang diinginkan dari daftar isi di HP. */
+.bs-ke {
+  display: block; width: 100%;
+  background: none; border: 0; padding: .25rem 0; font: inherit; cursor: pointer;
+  color: var(--utama); text-align: left; line-height: 1.4;
+}
+.bs-ke:hover { text-decoration: underline; }
+.bs-ke:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+
+/* ---- Satu bagian bacaan ---- */
+.bs-bagian {
+  /* TANPA max-width sendiri. Lebar kolomnya diputuskan wadahnya — layar ini
+     memakai `.isi` biasa 760px, bukan `.isi.wide` — supaya kepala, deret tab,
+     kartu bab, dan kartu bagian punya tepi yang sama. Terukur di browser:
+     satu baris paragraf jatuh di sekitar 68 huruf. */
+  line-height: 1.65;
+  /* Kepala halaman ikut menggulir (tidak sticky), jadi yang perlu
+     disisakan cuma satu jarak napas, bukan setinggi kepalanya. */
+  scroll-margin-top: .8rem;
+}
+.bs-bagian h3 {
+  font-size: 1.05rem; letter-spacing: -.01em; margin-bottom: .5rem;
+}
+.bs-bagian p { margin: .55rem 0; }
+
+/* Sorotan sesudah melompat dari daftar isi atau hasil cari. Dua detik, lalu
+   hilang sendiri — penanda yang menetap jadi bagian dari tampilan kartunya
+   dan berhenti berarti "yang ini". */
+.bs-sorot {
+  box-shadow: var(--bayang-naik), 0 0 0 2px var(--utama);
+  transition: box-shadow .25s ease;
+}
+
+.bs-poin, .bs-langkah { margin: .55rem 0; padding-left: 1.35rem; }
+.bs-poin li, .bs-langkah li { margin: .3rem 0; }
+/* Angka langkah ditebalkan supaya urutan kerja terbaca sebagai urutan, bukan
+   sebagai daftar yang kebetulan bernomor. */
+.bs-langkah li::marker { font-weight: 700; color: var(--utama); }
+
+/* Kotak "kenapa": alasan di balik satu aturan, dan satu-satunya blok yang
+   memang harus MENAHAN mata sebentar. Garis tebal di kiri, bukan latar
+   berwarna — kartu yang penuh kotak bertint terbaca seperti peringatan
+   beruntun, dan yang kesepuluh tidak dibaca siapa pun. */
+.bs-kenapa {
+  border-left: 3px solid var(--utama);
+  padding: .1rem 0 .1rem .8rem;
+  color: var(--tinta-lembut);
+}
+
+/* ---- Blok "layar" ---- */
+.bs-layar {
+  display: block; margin: .6rem 0;
+  border: 1px solid var(--garis); border-left: 3px solid var(--utama);
+  border-radius: var(--radius-kecil);
+  padding: .55rem .75rem;
+  text-decoration: none; color: inherit;
+  background: var(--kartu);
+}
+a.bs-layar:hover { border-color: var(--utama); background: var(--utama-muda); }
+a.bs-layar:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.bs-layar-nama { display: block; font-weight: 700; color: var(--utama); }
+/* Panah HANYA pada yang bisa diketuk. Pada kotak yang mati ia menjanjikan
+   perpindahan yang tidak akan terjadi. */
+a.bs-layar .bs-layar-nama::after { content: " \2192"; }
+.bs-layar-teks {
+  display: block; font-size: .92rem; color: var(--tinta-lembut);
+  margin-top: .1rem; line-height: 1.5;
+}
+/* Kotak layar yang di luar hak akun ini. Diredupkan, TIDAK dihilangkan: buku
+   ini menjelaskan pekerjaan seluruh panitia, dan seorang bendahara yang
+   membaca bab juri pos tetap perlu tahu layar itu ada. */
+.bs-layar-mati { border-left-color: var(--garis); background: var(--kertas); }
+.bs-layar-mati .bs-layar-nama { color: var(--tinta-lembut); }
+.bs-layar-hak {
+  display: block; margin-top: .25rem;
+  font-size: .82rem; color: var(--tinta-lembut);
+}
+
+/* Tabel di dalam bacaan. Digulir sendiri di wadahnya — CLAUDE.md bagian 15
+   berlaku di sini juga: yang boleh menggulir mendatar wadah tabelnya, tidak
+   pernah badan halaman. Di bawah 900px .data-table sudah berubah jadi kartu
+   sendiri, jadi wadah ini tinggal diam. */
+.bs-tabel-bungkus { overflow-x: auto; margin: .7rem 0; }
+.bs-tabel { line-height: 1.45; }
+
+/* ---- Hasil cari ---- */
+.bs-hasil-daftar { list-style: none; margin: .6rem 0 0; padding: 0; }
+.bs-hasil-daftar li + li { margin-top: .35rem; }
+.bs-hasil-butir {
+  display: block; width: 100%; text-align: left; cursor: pointer; font: inherit;
+  border: 1px solid var(--garis); border-radius: var(--radius-kecil);
+  background: var(--kartu); padding: .55rem .75rem; min-height: 44px;
+}
+.bs-hasil-butir:hover { border-color: var(--utama); background: var(--utama-muda); }
+.bs-hasil-butir:focus-visible { outline: 2px solid var(--utama); outline-offset: 2px; }
+.bs-hasil-bab {
+  display: block; font-size: .78rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .02em; color: var(--tinta-lembut);
+}
+.bs-hasil-judul { display: block; font-weight: 600; margin-top: .1rem; }
+
+/* ---- Timeline ---- */
+.bs-bulan { scroll-margin-top: .8rem; }
+.bs-bulan-kepala {
+  display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap;
+}
+/* Nomor urut bulan, bukan tanggal. Bulan kalendernya bergeser tiap edisi —
+   yang tidak bergeser urutannya: bulan pertama sesudah serah terima, bulan
+   keenam adalah pelaksanaan. */
+.bs-bulan-urut {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.7rem; height: 1.7rem; border-radius: 999px;
+  background: var(--utama-muda); color: var(--utama);
+  font-weight: 800; font-size: .85rem; flex: 0 0 auto;
+  align-self: center;
+}
+.bs-bulan-nama { font-size: 1.15rem; font-weight: 800; letter-spacing: -.01em; }
+.bs-bulan-tajuk { color: var(--tinta-lembut); font-weight: 600; }
+.bs-bulan-fokus { margin: .45rem 0 .2rem; line-height: 1.6; }
+
+/* Dua kolom di layar lebar, satu di HP. Tonggak dan langkah sistem memang dua
+   daftar yang dibaca berdampingan: yang satu dicentang panitia, yang satu
+   dikerjakan di layar. */
+.bs-bulan-kolom {
+  display: grid; gap: .3rem 1.4rem; margin-top: .5rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 700px) {
+  .bs-bulan-kolom { grid-template-columns: 1fr 1fr; }
+}
+.bs-bulan-kolom h4 {
+  font-size: .78rem; text-transform: uppercase; letter-spacing: .03em;
+  color: var(--tinta-lembut); margin-top: .5rem;
+}
+
+.bs-bulan-seksi {
+  display: flex; flex-wrap: wrap; gap: .3rem; margin: .7rem 0 .5rem;
+}
+.bs-pil {
+  font-size: .82rem; font-weight: 600;
+  background: var(--kertas); color: var(--tinta-lembut);
+  border-radius: 999px; padding: .15rem .6rem;
+}
+/* "Jangan sampai" memakai kotak kenapa yang sama, tapi merah: ia satu-satunya
+   kalimat di kartu bulan yang menyebut kerugian, dan warnanya yang membuatnya
+   ditemukan waktu kartunya cuma dipindai sekilas. */
+.bs-jangan { border-left-color: var(--bahaya); }
+
+/* ============================================================================
+   BUKU SAKTI DI KERTAS
+
+   Buku ini digandakan di mesin fotokopi seperti seluruh kertas acara ini,
+   jadi CLAUDE.md bagian 8 berlaku penuh: tidak ada blok hitam, tidak ada teks
+   terbalik, tidak ada abu maupun raster, garis paling tipis 0,75pt, huruf
+   paling kecil 7pt.
+
+   Yang di layar memakai warna dan tint di sini memakai GARIS. Kotak "kenapa"
+   tetap bergaris kiri, kotak layar jadi baris bernama tebal, dan pil seksi
+   jadi teks berpemisah titik tengah. Ketiganya tetap terbaca sesudah kertas
+   ini disalin empat kali; latar berwarna tidak.
+   ========================================================================== */
+@media print {
+  .buku-cetak { font-size: 11pt; line-height: 1.45; }
+  .buku-cetak h1 { font-size: 15pt; margin-bottom: .3rem; }
+  .buku-cetak h2 { font-size: 11.5pt; margin: 4mm 0 1mm; }
+  .buku-cetak p { margin: .35rem 0; }
+
+  /* Satu bagian tidak boleh terbelah dua halaman. Judul yang tertinggal
+     sendirian di kaki halaman dengan isinya di halaman berikutnya adalah
+     kegagalan yang paling terasa waktu buku ini dibaca sambil berdiri. */
+  .buku-cetak .bs-cetak-bagian {
+    break-inside: avoid; page-break-inside: avoid;
+    margin-bottom: 3mm;
+  }
+
+  .buku-cetak .bs-cetak-ringkas { font-size: 10pt; margin-bottom: 3mm; }
+  .buku-cetak .bs-cetak-isi-bab { font-weight: 700; margin: 3mm 0 0; }
+  .buku-cetak .bs-cetak-isi { margin: .5mm 0 0; padding-left: 6mm; }
+  .buku-cetak .bs-cetak-isi li { margin: .3mm 0; }
+  .buku-cetak .bs-cetak-label {
+    font-size: 8.5pt; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .02em; margin: 2mm 0 0;
+  }
+
+  .buku-cetak .bs-poin, .buku-cetak .bs-langkah {
+    margin: .3rem 0; padding-left: 6mm;
+  }
+  .buku-cetak .bs-poin li, .buku-cetak .bs-langkah li { margin: .8mm 0; }
+
+  /* Garis 1pt, bukan 3px: bagian 8.5 menuntut minimal 0,75pt supaya garisnya
+     selamat dari fotokopi. Warnanya hitam — hijau HRCD keluar sebagai abu
+     muda di mesin hitam-putih, dan abu justru yang paling buruk (bagian 8.4). */
+  .buku-cetak .bs-kenapa {
+    border-left: 1pt solid #000; padding-left: 3mm; color: #000;
+  }
+
+  /* Kotak layar kehilangan kotaknya di kertas. Yang tersisa nama layarnya
+     tebal diikuti keterangannya — persis yang berguna waktu tidak ada yang
+     bisa diketuk. */
+  .buku-cetak .bs-cetak-layar { margin: .3rem 0; }
+
+  /* ---- Tabel: TETAP TABEL di kertas ----
+
+     Ini bukan kerapian, ini perbaikan. Halaman cetak A4 dikurangi margin
+     12mm terhitung sekitar 720px CSS, dan itu DI BAWAH 900px — jadi aturan
+     kartu HP (`.data-table:not(.table-tetap) … { display: block }`) ikut
+     berlaku saat mencetak. Yang keluar dari printer: tiap sel jatuh ke
+     barisnya sendiri, tanpa kepala kolom, sehingga tabel lima peran akun
+     tercetak sebagai lima belas baris berdiri sendiri yang tidak
+     mengatakan baris mana milik peran mana.
+
+     Terlihat di PDF Chrome headless, bukan diduga: halaman 4 keluar begitu.
+
+     Kekhususannya SAMA PERSIS dengan aturan kartu itu (0,2,3), jadi yang
+     memutuskan urutan — dan blok ini memang paling belakang di berkas.
+     Menambah `!important` di sini akan menyembunyikan ketergantungan itu,
+     bukan menghapusnya. */
+  .buku-cetak .bs-tabel { display: table; }
+  .buku-cetak .bs-tabel > thead { display: table-header-group; }
+  .buku-cetak .bs-tabel > tbody { display: table-row-group; }
+  .buku-cetak .bs-tabel > tbody > tr { display: table-row; }
+  .buku-cetak .bs-tabel > tbody > tr > td { display: table-cell; }
+  /* Rupa kartu HP ikut dilucuti: kotak, jarak, dan awalan nama kolom hanya
+     berarti waktu barisnya bertumpuk. Di kertas kepala kolomnya sudah
+     tergambar sekali di atas, dan mengulangnya di tiap sel menggandakan
+     tabelnya. */
+  .buku-cetak .bs-tabel > tbody > tr[data-baris] {
+    border: 0; border-radius: 0; padding: 0; margin: 0;
+  }
+  .buku-cetak .bs-tabel > tbody > tr[data-baris] > td {
+    border: 1px solid #000; padding: 4pt 5pt; margin: 0;
+  }
+  .buku-cetak .bs-tabel > tbody > tr[data-baris] > td[data-label]::before {
+    content: none;
+  }
+  /* Kepala tabel DIPUTIHKAN dan dilepas dari patokannya.
+
+     `.data-table thead th` di aturan layar memberinya `background:
+     var(--kertas)` — abu #f0f1f4 — beserta `box-shadow` abu dan `position:
+     sticky`. Ketiganya benar di layar dan salah di kertas: bagian 8.4
+     melarang raster abu (mesin fotokopi mengubahnya jadi belang atau
+     kotoran), dan `position: sticky` di media cetak adalah cara yang sama
+     dengan `.bottom-nav` merusak setiap halaman.
+
+     Yang memisahkan kepala dari isinya tetap ada, dan tetap selamat
+     difotokopi: huruf tebal, HURUF BESAR, dan garis bawah 1,5pt. */
+  .buku-cetak .bs-tabel > thead > tr > th {
+    background: none; box-shadow: none; position: static;
+    border: 1px solid #000; padding: 4pt 5pt; text-align: left;
+    font-size: 8.5pt; text-transform: uppercase; font-weight: 700;
+    border-bottom-width: 1.5pt;
+  }
+
+  /* Nomor langkah HITAM, bukan hijau HRCD. Hijau tua keluar sebagai abu
+     sedang dari mesin fotokopi hitam-putih, dan abu justru yang paling
+     buruk (CLAUDE.md 8.4). Yang membedakan nomor dari isinya tetap ada:
+     ia tebal. */
+  .buku-cetak .bs-langkah li::marker { color: #000; }
 }

--- a/web/style.css
+++ b/web/style.css
@@ -3432,6 +3432,8 @@ button.pill-number:hover { filter: brightness(.95); }
   #nav-home[aria-current="page"]    .bottom-nav-icon { background: var(--utama-muda); }
   #nav-setting[aria-current="page"] .bottom-nav-icon { background: #f0eafe; }
   #nav-akun[aria-current="page"]    .bottom-nav-icon { background: #eef0f3; }
+  /* Hijau HRCD yang sama dengan Home: keduanya "tempat", bukan setelan. */
+  #nav-buku[aria-current="page"]    .bottom-nav-icon { background: var(--utama-muda); }
 
   /* Ruang supaya baris terakhir isi halaman tidak tertutup bar.
 
@@ -6181,50 +6183,77 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
 }
 .bs-hasil-judul { display: block; font-weight: 600; margin-top: .1rem; }
 
-/* ---- Timeline ---- */
-.bs-bulan { scroll-margin-top: .8rem; }
-.bs-bulan-kepala {
-  display: flex; align-items: baseline; gap: .55rem; flex-wrap: wrap;
-}
-/* Nomor urut bulan, bukan tanggal. Bulan kalendernya bergeser tiap edisi —
-   yang tidak bergeser urutannya: bulan pertama sesudah serah terima, bulan
-   keenam adalah pelaksanaan. */
-.bs-bulan-urut {
+/* ---- Papan sprint ---- */
+#bs-sprint-ringkas { margin-bottom: .8rem; }
+/* Centang belum terbaca: satu baris kecil, bukan kartu merah. Membuka buku
+   panduan waktu sinyal mati adalah hal yang wajar, dan peringatan yang muncul
+   tiap kali bukunya dibuka mengajari orang menutupnya tanpa membaca. */
+.bs-sprint-putus { color: var(--kuning); }
+
+.bs-sprint { scroll-margin-top: .8rem; }
+.bs-sprint-kepala { display: flex; gap: .6rem; align-items: flex-start; }
+/* Nomor sprint, bukan tanggal. Bulan kalendernya bergeser tiap edisi; yang
+   tidak bergeser urutannya dan hitungan mundurnya dari hari-H. */
+.bs-sprint-urut {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 1.7rem; height: 1.7rem; border-radius: 999px;
+  width: 1.9rem; height: 1.9rem; border-radius: 999px;
   background: var(--utama-muda); color: var(--utama);
-  font-weight: 800; font-size: .85rem; flex: 0 0 auto;
-  align-self: center;
+  font-weight: 800; font-size: .9rem; flex: 0 0 auto;
 }
-.bs-bulan-nama { font-size: 1.15rem; font-weight: 800; letter-spacing: -.01em; }
-.bs-bulan-tajuk { color: var(--tinta-lembut); font-weight: 600; }
-.bs-bulan-fokus { margin: .45rem 0 .2rem; line-height: 1.6; }
+.bs-sprint-judul { min-width: 0; flex: 1; }
+.bs-sprint-baris {
+  display: flex; align-items: baseline; gap: .5rem; flex-wrap: wrap;
+}
+.bs-sprint-tajuk { font-size: 1.1rem; font-weight: 800; letter-spacing: -.01em; }
+.bs-sprint-waktu {
+  font-size: .82rem; color: var(--tinta-lembut); margin-top: .1rem;
+}
+.bs-sprint-fokus { margin: .55rem 0 .2rem; line-height: 1.6; }
+.bs-sprint-hasil { margin: .6rem 0 .5rem; line-height: 1.55; }
 
-/* Dua kolom di layar lebar, satu di HP. Tonggak dan langkah sistem memang dua
-   daftar yang dibaca berdampingan: yang satu dicentang panitia, yang satu
-   dikerjakan di layar. */
-.bs-bulan-kolom {
-  display: grid; gap: .3rem 1.4rem; margin-top: .5rem;
-  grid-template-columns: 1fr;
+/* ---- Daftar tugas yang dicentang ---- */
+.bs-todo { list-style: none; margin: .7rem 0 0; padding: 0; }
+.bs-todo-item {
+  border-top: 1px solid var(--garis); padding: .5rem 0;
 }
-@media (min-width: 700px) {
-  .bs-bulan-kolom { grid-template-columns: 1fr 1fr; }
-}
-.bs-bulan-kolom h4 {
-  font-size: .78rem; text-transform: uppercase; letter-spacing: .03em;
-  color: var(--tinta-lembut); margin-top: .5rem;
-}
+.bs-todo-item:first-child { border-top: 0; }
 
-.bs-bulan-seksi {
-  display: flex; flex-wrap: wrap; gap: .3rem; margin: .7rem 0 .5rem;
+/* Kotak DAN kalimatnya satu sasaran ketukan. Kotak 20px yang berdiri sendiri
+   di antara seratus baris adalah sasaran yang meleset di HP, dan tugas yang
+   tercentang gara-gara meleset lebih buruk daripada tugas yang belum
+   tercentang: yang satu diam, yang lain berbohong. */
+.bs-todo-baris {
+  display: flex; gap: .6rem; align-items: flex-start; cursor: pointer;
+  line-height: 1.55;
 }
+.bs-todo-kotak { flex: 0 0 auto; margin-top: .2rem; }
+.bs-todo-teks { min-width: 0; }
+/* Yang sudah selesai DIREDUPKAN, tidak dicoret. Teks tercoret berhenti bisa
+   dibaca ulang, dan tugas yang sudah selesai masih sering dibaca ulang —
+   "kemarin kita mengirim surat ke berapa desa?" */
+.bs-todo-selesai .bs-todo-teks { color: var(--tinta-lembut); }
+
+.bs-todo-kaki {
+  display: flex; flex-wrap: wrap; gap: .3rem .5rem; align-items: center;
+  /* Sejajar dengan teksnya, bukan dengan kotaknya: lebar kotak + jaraknya. */
+  margin: .25rem 0 0 1.6rem;
+  font-size: .8rem; color: var(--tinta-lembut);
+}
+.bs-todo-layar {
+  color: var(--utama); text-decoration: none; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.bs-todo-layar:hover { text-decoration: underline; }
+.bs-todo-layar::after { content: " \2192"; }
+.bs-todo-jejak { font-variant-numeric: tabular-nums; }
+
 .bs-pil {
-  font-size: .82rem; font-weight: 600;
+  font-size: .78rem; font-weight: 600;
   background: var(--kertas); color: var(--tinta-lembut);
-  border-radius: 999px; padding: .15rem .6rem;
+  border-radius: 999px; padding: .1rem .55rem;
 }
 /* "Jangan sampai" memakai kotak kenapa yang sama, tapi merah: ia satu-satunya
-   kalimat di kartu bulan yang menyebut kerugian, dan warnanya yang membuatnya
+   kalimat di kartu sprint yang menyebut kerugian, dan warnanya yang membuatnya
    ditemukan waktu kartunya cuma dipindai sekilas. */
 .bs-jangan { border-left-color: var(--bahaya); }
 
@@ -6310,7 +6339,7 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
     border: 0; border-radius: 0; padding: 0; margin: 0;
   }
   .buku-cetak .bs-tabel > tbody > tr[data-baris] > td {
-    border: 1px solid #000; padding: 4pt 5pt; margin: 0;
+    border: 0.4px solid #000; padding: 4pt 5pt; margin: 0;
   }
   .buku-cetak .bs-tabel > tbody > tr[data-baris] > td[data-label]::before {
     content: none;
@@ -6328,7 +6357,7 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
      difotokopi: huruf tebal, HURUF BESAR, dan garis bawah 1,5pt. */
   .buku-cetak .bs-tabel > thead > tr > th {
     background: none; box-shadow: none; position: static;
-    border: 1px solid #000; padding: 4pt 5pt; text-align: left;
+    border: 0.4px solid #000; padding: 4pt 5pt; text-align: left;
     font-size: 8.5pt; text-transform: uppercase; font-weight: 700;
     border-bottom-width: 1.5pt;
   }
@@ -6338,4 +6367,30 @@ a.bs-layar .bs-layar-nama::after { content: " \2192"; }
      buruk (CLAUDE.md 8.4). Yang membedakan nomor dari isinya tetap ada:
      ia tebal. */
   .buku-cetak .bs-langkah li::marker { color: #000; }
+
+  /* ---- Papan sprint di kertas ----
+
+     Kertas ini ditempel di dinding sekretariat dan dicentang pakai pulpen
+     sepanjang enam bulan, jadi bentuknya daftar berkotak, bukan salinan
+     layar. */
+  .buku-cetak .bs-cetak-waktu {
+    font-size: 9pt; font-weight: 700; margin: 0 0 1mm;
+  }
+  .buku-cetak .bs-cetak-todo { list-style: none; margin: .3rem 0; padding: 0; }
+  .buku-cetak .bs-cetak-todo li {
+    display: flex; gap: 2.5mm; align-items: flex-start; margin: 1.2mm 0;
+    break-inside: avoid; page-break-inside: avoid;
+  }
+  /* Kotak centang tulis tangan: PUTIH, kosong, dan cukup besar untuk dicentang
+     pulpen (CLAUDE.md 8.7 — tidak ada apa pun di belakang area yang ditulisi).
+     Garisnya 1pt supaya selamat difotokopi (8.5). */
+  .buku-cetak .bs-cetak-kotak {
+    flex: 0 0 auto; width: 3.5mm; height: 3.5mm; margin-top: .6mm;
+    border: 1pt solid #000; background: none;
+  }
+  .buku-cetak .bs-cetak-todo-teks { min-width: 0; }
+  /* Nama seksi di belakang tugasnya, miring dan kecil — tetap 8pt, di atas
+     batas 7pt bagian 8.6. Tidak diredupkan: bagian 8.4 melarang abu, jadi
+     yang membuatnya mundur ukurannya, bukan warnanya. */
+  .buku-cetak .bs-cetak-todo-teks em { font-size: 8pt; white-space: nowrap; }
 }


### PR DESCRIPTION
## What

A new screen at `#/buku-sakti` — the handbook the outgoing panitia hand to the
next one. Four chapters, addressable one by one (`#/buku-sakti/seksi` opens a
chapter directly):

| Bab | Isi |
| --- | --- |
| Menjalankan HRCD | 16 bagian, urut waktu: siapkan edisi → akun → pendaftaran → pembayaran → daftar ulang → kloter → pagi hari-H → pos → kedatangan → cek nilai → fase live → terbitkan → juara → sesudah acara |
| Tugas Pokok Seksi | 16 seksi; tiap satu: tugas pokok, tugas konkret, tabel *kapan → yang dikerjakan*, layar yang dipegang beserta centang yang dibutuhkan, dan satu kesalahan khas |
| Kenapa Sistemnya Begini | 22 keputusan desain, alternatif yang ditolak, dan apa yang rusak kalau dibalik |
| Papan Sprint | 13 sprint dua mingguan, 107 tugas yang **bisa dicentang** |

Isinya data di `web/js/buku-sakti.mjs`, bukan markup: enam jenis blok, semuanya
objek biasa berisi string biasa. Yang menyuntingnya tidak perlu tahu satu tag
pun, tidak bisa merusak tata letak, dan tidak bisa menyelundupkan markup.

**Papan sprint punya centang bersama.** Mencentang menulis ke database
(`centang_sprint`, migrasi `0170`) dan seluruh panitia melihatnya beserta siapa
yang mencentang dan kapan. Tiap tugas membawa seksi pemiliknya dan — kalau
pekerjaannya di layar — tautan ke layar itu, ikut centang yang sama dengan
ubinnya di Home.

Papan ini memuat pekerjaan yang menentukan acaranya jadi atau tidak: izin
keramaian masuk kepolisian di H-60, surat desa dan rekomendasi camat yang jadi
syaratnya, izin lahan warga, Kwarran dan Kwarcab, puskesmas dan PMI, kontrak
sponsor yang ditutup H-45 karena seluruh cetakan menunggu logonya, dan soal
yang ditulis, divalidasi, diujicobakan, lalu dikunci sebelum digandakan.

Tanggalnya bulan + nomor minggu + hitungan mundur dari hari-H, tidak pernah
tanggal kalender — tanggal lombanya justru ditetapkan DI DALAM papan ini
(Sprint 2), jadi papan yang menyebut tanggal berbohong sampai tugas itu
selesai. Ada tes yang menjaganya.

Mencetak memberi seluruh buku sebagai satu dokumen A4 mengalir, dan papan
sprintnya sebagai wall chart berkotak KOSONG — kertasnya dicentang pakai
pulpen sepanjang enam bulan, dan potret keadaan hari ini berhenti benar
keesokan harinya.

## Why

Sistem ini diserahkan tiap tahun ke angkatan berikutnya, dan yang selama ini
ikut berpindah cuma kodenya. Alasan di balik bentuknya — kenapa penalti
simetris, kenapa kloter FIFO, kenapa migrasi dijalankan manual, kenapa blangko
satu master — tersebar di komentar kode dan CLAUDE.md, dua tempat yang tidak
pernah dibuka panitia. Buku ini menaruhnya di tempat yang memang mereka buka,
lengkap dengan urutan kerja satu edisi dan papan yang bisa dicentang bersama.

Isinya tidak di database karena ia ditulis ulang sekali setahun, bukan diketik
di lapangan: satu tabel, satu set policy, satu layar penyunting, dan satu
backup lagi untuk teks sesejarang itu tidak sepadan — dan yang di database
ikut mati persis saat Supabase tidak terjangkau, keadaan yang paling mungkin
membuat orang mencari buku panduan.

Layarnya sendiri **tidak berpagar hak akses**, dan itu keputusan: yang paling
butuh membacanya justru yang haknya paling sempit — juri pos yang baru pertama
memegang lembar nilai. Ia tidak memuat satu baris data pun. Tautan di dalamnya
tetap ikut matriks centang, jadi yang tidak berhak melihat layarnya dijelaskan
dan diredupkan, bukan tautan yang mendarat di kartu "tidak berhak".

Centang papan sprint juga tidak diikat ke satu fitur. Papan ini dipakai di
rapat, dan yang memegang spidol bukan selalu yang memegang centang
`pengaturan`. Yang menggantikan pagar itu jejak: tiap baris menyimpan siapa
dan kapan, dan layar menuliskannya di sebelah tugasnya.

Jalan masuknya lewat kepala halaman, menu bawah, dan satu pita di kaki papan
Home — **bukan ubin kelima belas**. #808 sudah memutuskan empat belas ubin
dapat empat belas rona, dan yang kelima belas membuat dua ubin serona; yang
hilang bukan cuma penanda ubin baru itu, melainkan seluruh kode warna papannya.

## Notes

- **Migrasi `0170` tidak ikut merge.** Sesudah PR ini mendarat, jalankan
  `Apply migration to Supabase` dengan
  `supabase/migrations/0170_centang_sprint.sql`. Sampai itu dijalankan,
  papannya tampil lengkap tetapi centangnya gagal disimpan — layarnya sudah
  menanganinya sebagai "centang belum terbaca", bukan sebagai buku yang rusak.
- **Kode tugas adalah kunci centang.** Menambah dan menghapus tugas aman;
  MENGGANTI NAMA kodenya membuat centangnya menggantung tanpa satu pun galat.
  Ditulis besar-besar di kepala `buku-sakti.mjs` dan di kepala migrasinya.
- `tests/run.sh` dan `supabase/checks/status_migrasi.sql` sudah memuat `0170`.
- Dijalankan lokal: 468/468 tes JS, `SEMUA TES LULUS` untuk tes SQL, ketiga
  pemeriksa sumber, dan salinan `live/` sama dengan `web/`.
- Layarnya dibuka sungguhan di browser (CLAUDE.md 17.2): centang bertahan
  lintas muat ulang di kedua arah, jejaknya benar, dan paginasi cetaknya
  diukur dari PDF Chrome headless — 63 halaman, bukan dibagi tinggi.
