### PR TITLE
docs: the word is Eksternal and Internal, not Ekstern and Intern

### DIFF
--- a/.github/workflows/publish-live.yml
+++ b/.github/workflows/publish-live.yml
@@ -155,7 +155,7 @@ jobs:
           # Live Score peserta hanya untuk Eksternal. Database dan layar
           # panitia tetap menyimpan Intern PA/PI sebagai klasemen tersendiri;
           # barisnya dibuang di batas penerbitan supaya bukan sekadar tab yang
-          # disembunyikan oleh JavaScript. Komponen khusus Intern juga tidak
+          # disembunyikan oleh JavaScript. Komponen khusus Internal juga tidak
           # perlu ikut memperbesar berkas publik.
           eksternal = lambda baris: not str(baris.get('golongan', '')).startswith('intern')
           d['progres'] = [baris for baris in d['progres'] if eksternal(baris)]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,7 +506,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 2. **Pengacakan otomatis selalu mengisi kloter paling awal yang BELUM
    BERANGKAT dulu secara FIFO.** Yang lebih dahulu menyelesaikan daftar ulang
    mendapat kloter lebih awal. Setiap kloter otomatis memuat paling banyak
-   **5 Eksternal dan 3 Intern**; kuota keduanya dihitung terpisah. Tidak ada
+   **5 Eksternal dan 3 Internal**; kuota keduanya dihitung terpisah. Tidak ada
    lagi pengacakan atau lompatan dua kloter berdasarkan sekolah.
 3. **Di lapangan semua dinamis, jadi penyisipan manual tetap diperlukan.**
    Peserta yang terlambat bisa memaksa berangkat, dan panitia dapat
@@ -534,7 +534,7 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    masih bertanda tercetak, dan papan seperti itu membuat panitia mencari
    keenam belas kloter yang tidak pernah ada.
 5. **Sekolah tidak memengaruhi penempatan kloter.** Urutan daftar ulang dan
-   kuota 5 Eksternal + 3 Intern adalah seluruh aturan otomatis. Dua regu dari
+   kuota 5 Eksternal + 3 Internal adalah seluruh aturan otomatis. Dua regu dari
    sekolah yang sama boleh berada dalam kloter yang sama bila FIFO menempatkan
    mereka di sana.
 6. **Jangan menomori kloter sendiri.** Penomoran menyimpan aturan yang tidak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,7 +504,7 @@ Guidance for Claude Code when working in this repository.
 2. **Pengacakan otomatis selalu mengisi kloter paling awal yang BELUM
    BERANGKAT dulu secara FIFO.** Yang lebih dahulu menyelesaikan daftar ulang
    mendapat kloter lebih awal. Setiap kloter otomatis memuat paling banyak
-   **5 Eksternal dan 3 Intern**; kuota keduanya dihitung terpisah. Tidak ada
+   **5 Eksternal dan 3 Internal**; kuota keduanya dihitung terpisah. Tidak ada
    lagi pengacakan atau lompatan dua kloter berdasarkan sekolah.
 3. **Di lapangan semua dinamis, jadi penyisipan manual tetap diperlukan.**
    Peserta yang terlambat bisa memaksa berangkat, dan panitia dapat
@@ -532,7 +532,7 @@ Guidance for Claude Code when working in this repository.
    masih bertanda tercetak, dan papan seperti itu membuat panitia mencari
    keenam belas kloter yang tidak pernah ada.
 5. **Sekolah tidak memengaruhi penempatan kloter.** Urutan daftar ulang dan
-   kuota 5 Eksternal + 3 Intern adalah seluruh aturan otomatis. Dua regu dari
+   kuota 5 Eksternal + 3 Internal adalah seluruh aturan otomatis. Dua regu dari
    sekolah yang sama boleh berada dalam kloter yang sama bila FIFO menempatkan
    mereka di sana.
 6. **Jangan menomori kloter sendiri.** Penomoran menyimpan aturan yang tidak

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ bash tests/dev_database.sh        # siapkan database hrcd_dev
 python tests/concurrency_test.py  # 30 meja serentak, 300 nomor diperebutkan
 ```
 
-Uji ini memakai 270 regu Eksternal dan 30 regu Intern supaya kedua kuota
+Uji ini memakai 270 regu Eksternal dan 30 regu Internal supaya kedua kuota
 kloter diuji bersamaan. Workflow **SQL Tests** juga menjalankannya terhadap
 database `hrcd_test` setelah seluruh migrasi dan tes SQL selesai.
 

--- a/docs/alur-hrcd.svg
+++ b/docs/alur-hrcd.svg
@@ -120,7 +120,7 @@
     <g>
       <line x1="1380" y1="333" x2="1380" y2="345" stroke="#2E7D32" stroke-width="2"/>
       <rect x="1220" y="345" width="320" height="34" rx="17" fill="#E8F5E9" stroke="#2E7D32" stroke-width="1.5"/>
-      <text x="1380" y="367" font-size="14.5" font-weight="600" fill="#2E7D32" text-anchor="middle">Kloter FIFO · 5 Eksternal + 3 Intern</text>
+      <text x="1380" y="367" font-size="14.5" font-weight="600" fill="#2E7D32" text-anchor="middle">Kloter FIFO · 5 Eksternal + 3 Internal</text>
     </g>
 
     <!-- ================= TAHAP 2 ================= -->

--- a/docs/alur-lomba.md
+++ b/docs/alur-lomba.md
@@ -47,7 +47,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - **Aplikasi panitia** — satu link yang sama untuk semua panitia, dengan
      akses yang dibedakan per akun (bagian 8.10).
    - **Tampilan live untuk peserta** — halaman publik tanpa login, berisi
-     **klasemen empat golongan Eksternal** (Intern tidak masuk papan), dibuka
+     **klasemen empat golongan Eksternal** (Internal tidak masuk papan), dibuka
      **bertahap** lewat lima fase: `pra`, `progres` (centang per pos tanpa
      satu angka nilai pun, ditambah kloter, kontrak waktu, jam berangkat, dan
      jam datang regu itu sendiri, supaya jamnya bisa dicocokkan sebelum
@@ -80,7 +80,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    - Intern PA (tuan rumah, putra)
    - Intern PI (tuan rumah, putri)
 
-   Keempat golongan Eksternal dinilai penuh. Regu **Intern** semuanya berasal
+   Keempat golongan Eksternal dinilai penuh. Regu **Internal** semuanya berasal
    dari satu sekolah — tuan rumah — dan hanya dinilai dari lima lomba soal
    tulis ditambah ketepatan waktu; lomba lapangan, penalti tanpa checkout,
    penalti anggota, dan nilai pos terlewat tidak berlaku bagi mereka. Papan
@@ -182,8 +182,8 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    dipensiunkan, belum dipakai regu lain, dan **berada di deret yang benar**.
    Nomor yang sudah dipakai ditolak dengan pesan, bukan diterima diam-diam.
 
-   **Ada DUA deret** (migrasi `0116`): Eksternal 1–500, Intern 1001–1250. Kain
-   kedua set sama-sama bertulis 001, jadi kain Intern bertulis 001 diketik
+   **Ada DUA deret** (migrasi `0116`): Eksternal 1–500, Internal 1001–1250. Kain
+   kedua set sama-sama bertulis 001, jadi kain Internal bertulis 001 diketik
    1001 — dan yang tampil di seluruh layar, kertas, dan papan peserta adalah
    1001, bukan terjemahan yang cuma hidup di satu layar.
 6. **Pengisian nomor dada dilakukan sekaligus per sekolah**, bukan satu regu
@@ -191,7 +191,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    transaksi di meja. Urutan selesainya transaksi itulah yang menentukan
    kloternya — lihat bagian 5.4. Sekolahnya sendiri tidak menentukan apa pun.
 7. **Kloternya tetap ditentukan sistem** (bagian 5.3). Yang manual hanya
-   nomor dadanya; urutan FIFO dan kuota 5 Eksternal + 3 Intern dijaga di dalam
+   nomor dadanya; urutan FIFO dan kuota 5 Eksternal + 3 Internal dijaga di dalam
    `daftar_ulang_batch`, bukan oleh petugas satu meja yang tidak bisa melihat
    apa yang baru saja terisi di meja sebelah.
 8. **Peserta wajib mengonfirmasi datanya sendiri, termasuk nomor dada,
@@ -229,9 +229,9 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
 
 ## 5. Kloter dan kontrak waktu
 
-1. Penempatan otomatis memakai kuota **5 regu Eksternal + 3 regu Intern** per
+1. Penempatan otomatis memakai kuota **5 regu Eksternal + 3 regu Internal** per
    kloter. Kedua kuota dihitung terpisah.
-2. Perkiraan 300 Eksternal + 50 Intern membutuhkan **60 kloter**, tetapi edisi
+2. Perkiraan 300 Eksternal + 50 Internal membutuhkan **60 kloter**, tetapi edisi
    menyediakan **75 kloter** agar tempat kosong pada kloter yang sudah
    berangkat tidak menggagalkan batch daftar ulang berikutnya.
 3. Kloter ditentukan otomatis begitu regu menerima nomor dada.
@@ -248,7 +248,7 @@ Sebaliknya, istilah lomba tetap apa adanya dan tidak diterjemahkan: **regu**,
    (5 menit, keputusan pemilik acara), supaya dua kloter tidak dijadwalkan
    berjarak tiga jam hanya karena kloternya sedikit.
 8. **Satu kloter boleh berisi golongan campuran.** Penggalang dan Penegak, putra
-   dan putri, dapat berangkat dalam kloter yang sama; hanya Intern dan Eksternal
+   dan putri, dapat berangkat dalam kloter yang sama; hanya Internal dan Eksternal
    yang mempunyai kuota otomatis terpisah.
 9. Setiap regu memilih **kontrak waktu**: 3 / 3,5 / 4 jam. Kontrak dipilih per
    regu, sehingga satu kloter bisa berisi regu dengan kontrak berbeda-beda.
@@ -541,7 +541,7 @@ Jalur lomba    tiap lomba punya jurinya sendiri
    5. Kertas dimasukkan ke **kotak penilaian** di pos itu.
    6. Kotaknya diserahkan ke tim IT untuk diinput.
    7. Tim IT **mengurutkan kertasnya menurut nomor dada** — 001 sampai 500
-      untuk Eksternal, lalu 1001 sampai 1250 untuk Intern (migrasi `0116`) —
+      untuk Eksternal, lalu 1001 sampai 1250 untuk Internal (migrasi `0116`) —
       lalu memasukkannya berurutan.
 
    Bentuk ini bukan selera, melainkan tuntutan dua hal yang terjadi bersamaan.
@@ -868,7 +868,7 @@ Jalur lomba    tiap lomba punya jurinya sendiri
 
 ### Pengurangan lain di luar penalti waktu
 
-Ketiga pengurangan di bawah **tidak berlaku bagi regu Intern** (migrasi
+Ketiga pengurangan di bawah **tidak berlaku bagi regu Internal** (migrasi
 `0091`): mereka hanya menerima poin lomba soal tulis dikurangi penalti waktu.
 
 7. **Belum tercatat tiba** di meja Kedatangan: tetap ditampilkan di Live Score

--- a/docs/desain-sistem.md
+++ b/docs/desain-sistem.md
@@ -42,7 +42,7 @@ Ringkasan dari `alur-lomba.md` — setiap kandidat dipetakan ke daftar ini:
 | R1 | Form pendaftaran online (identitas regu, golongan, barak), link sama untuk online & offline |
 | R2 | Verifikasi pembayaran manual → kwitansi + kode pembayaran |
 | R3 | Daftar ulang 2–3 meja paralel: kode → nomor dada, diambil **per sekolah sekaligus**, tanpa nomor ganda |
-| R4 | Kloter otomatis FIFO saat itu juga: 5 Eksternal + 3 Intern, 75 kloter dengan headroom untuk perkiraan 300+50 regu; set manual tanpa batas |
+| R4 | Kloter otomatis FIFO saat itu juga: 5 Eksternal + 3 Internal, 75 kloter dengan headroom untuk perkiraan 300+50 regu; set manual tanpa batas |
 | R5 | Layar garis start: antrean 4 tahap, konfirmasi kontrak waktu, jam berangkat per kloter + ceklis per regu |
 | R6 | Input nilai per pos: link + akun/password sendiri per pos; input manual **dan** upload massal Excel/CSV dengan layar preview yang memvalidasi |
 | R7 | Mesin skor yang bisa dikonfigurasi panitia tanpa programmer: 6 bentuk konversi, bobot pos, rumus penalti, pengurangan lain |

--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -242,7 +242,7 @@ kainnya benda fisik di meja, dan yang ada di tangan petugas belum tentu nomor
 terkecil yang tersedia.
 
 **Dua deret, satu kunci** (migrasi `0116`). Kain dicetak dalam dua set yang
-sama-sama mulai dari 001, jadi Intern diketik **1001–1250** sementara
+sama-sama mulai dari 001, jadi Internal diketik **1001–1250** sementara
 Eksternal tetap **1–500**. Yang membedakannya bukan kolom baru: `nomor_dada`
 tetap satu integer unik, dan yang menjaga deretnya `nomor_dada_sesuai_deret()`
 di **dua** pintu — `daftar_ulang_batch` dan `tukar_nomor_dada`. Batas
@@ -253,7 +253,7 @@ deret di kotaknya sendiri, dan pesannya menyebut rentang yang benar.
 
 **Kainnya ikut diberi angka 1 di depan** — keputusan pemilik acara,
 27 Agustus 2026. Ini bukan kerapian: juri di pos menulis nomor dada dengan
-tangan dari kain di dada regu, jadi kain Intern yang polos bertulis 001 akan
+tangan dari kain di dada regu, jadi kain Internal yang polos bertulis 001 akan
 menghasilkan blangko yang ambigu, dan tidak ada baris SQL yang bisa
 memulihkannya. Dengan angka 1 di depan, kain dan sistem menyebut angka yang
 sama dan tidak ada terjemahan di kepala siapa pun.
@@ -538,7 +538,7 @@ bisa dipercaya.
 
 Penyebutnya adalah regu lunas, tidak batal, sudah punya nomor dada, dan memang
 memiliki komponen yang berlaku di pos itu. `komponen_berlaku()` menjadi satu
-aturan bersama untuk penilaian dan kelengkapan sejak `0096`: regu Intern
+aturan bersama untuk penilaian dan kelengkapan sejak `0096`: regu Internal
 dihitung di lima Soal Tulis yang mereka ikuti, tetapi tidak menjadi regu
 "kosong" abadi di lomba lapangan yang memang tidak mereka ikuti.
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -54,7 +54,7 @@
 >   Seluruh bagian 3 menggambarkan mekanisme yang sudah diganti.
 > - **Golongan ada enam, bukan empat** (0091): empat Eksternal ditambah
 >   `intern_pa` dan `intern_pi`. Papan panitia memakai keenamnya; papan
->   PESERTA tetap empat, karena Intern dibuang di batas penerbitan.
+>   PESERTA tetap empat, karena Internal dibuang di batas penerbitan.
 > - **Fase live ada lima, bukan tiga** (0145 `top10`, 0163 `juara`).
 > - **Akun panitia bisa dibuat dari layar Akun** (`#/account`) lewat gateway
 >   Worker, dan dari HP lewat `provision-accounts.yml`. Kalimat "dari SPA
@@ -134,7 +134,7 @@ penyelesaiannya dicatat di bagian 11.
 
 | Tabel | Isi | Contoh edisi 37 |
 | --- | --- | --- |
-| `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | Kuota otomatis 5 Eksternal + 3 Intern, perkiraan 300 Eksternal + 50 Intern, `kloter_maks=75`, jendela 07:00–10:00 |
+| `edisi` | Metadata + semua angka tunggal musim; tepat satu `aktif` | Kuota otomatis 5 Eksternal + 3 Internal, perkiraan 300 Eksternal + 50 Internal, `kloter_maks=75`, jendela 07:00–10:00 |
 | `pos` | Daftar pos dinilai + bobot | 5 baris, `bobot=1.00` semua (aturan 9.2) |
 | `wahana` | Satu baris per komponen nilai (wahana **atau** soal, kolom `jenis` — di database `type` sejak 0014): bentuk konversi (`bentuk`, di database `form`) + parameter + rentang wajar | `kode='lari_zigzag', bentuk='kecil_baik', poin_maks=100, raw_terbaik=20, raw_terburuk=90` → raw 40 detik = 71,4 poin |
 | `kontrak_opsi` | Pilihan kontrak waktu | `('3 jam',180), ('3,5 jam',210), ('4 jam',240)` |
@@ -195,9 +195,9 @@ Postgres — layar tidak pernah menulis "setengah jadi":
 | RPC | Menjamin |
 | --- | --- |
 | `submit_pendaftaran` | Buat sekolah (bila baru) + batch + N baris regu + kode pembayaran unik, sekali jalan; validasi ulang rincian golongan = total di server |
-| `verifikasi_pembayaran` | Cek nominal = `tagihan_pendaftaran()` = jumlah `biaya_regu(golongan)` seluruh regu yang belum dibatalkan — Intern memakai `biaya_per_regu_intern`, golongan lain `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
+| `verifikasi_pembayaran` | Cek nominal = `tagihan_pendaftaran()` = jumlah `biaya_regu(golongan)` seluruh regu yang belum dibatalkan — Internal memakai `biaya_per_regu_intern`, golongan lain `biaya_per_regu`; tolak batch yang bukan `menunggu_pembayaran`; terbit kwitansi; `UNIQUE` menolak verifikasi dobel |
 | `batalkan_verifikasi` | Jalan mundur yang sah untuk salah verifikasi (meja di hari yang sama, admin kapan pun) — dengan alasan, terekam riwayat |
-| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → terima pasangan regu→nomor dada **yang diketik petugas** (`p_nomor` jsonb; wajib lengkap satu batch, nomor divalidasi ada di stok / belum pensiun / belum dipakai, baris stoknya dikunci) → **satu gerbang `pg_advisory_xact_lock`** → tempatkan FIFO ke kloter paling awal yang belum berangkat dengan kuota 5 Eksternal + 3 Intern → tulis semuanya sekaligus. Regu `batal` dilewati. |
+| `daftar_ulang_batch` | **Transaksi terpenting**: kunci batch lunas → terima pasangan regu→nomor dada **yang diketik petugas** (`p_nomor` jsonb; wajib lengkap satu batch, nomor divalidasi ada di stok / belum pensiun / belum dipakai, baris stoknya dikunci) → **satu gerbang `pg_advisory_xact_lock`** → tempatkan FIFO ke kloter paling awal yang belum berangkat dengan kuota 5 Eksternal + 3 Internal → tulis semuanya sekaligus. Regu `batal` dilewati. |
 | `tukar_nomor_dada` | Nomor dada rusak/salah pasang: tukar dengan stok tersedia, terekam riwayat |
 | `konfirmasi_kontrak` | Validasi pilihan terhadap `kontrak_opsi` (bukan hardcode); boleh dikoreksi selama kloter belum berangkat |
 | `berangkatkan_kloter` | Jam berangkat **wajib dari argumen** (diketik) — fungsi tidak mengenal `now()`; menolak bila ada regu ter-ceklis berangkat yang belum punya kontrak (daftarnya ditampilkan layar) |
@@ -502,7 +502,7 @@ dikerjakan**: lembar Umum yang tercetak hari ini tidak punya kotak itu.
 | --- | --- | --- |
 | Login | semua | Username + password; akhiran email ditambah otomatis |
 | Beranda meja | meja | Pemilih fungsi + lencana angka dari data nyata (batch menunggu verifikasi, batch lunas belum bernomor, regu belum closing) |
-| Form pendaftaran | publik | Bagian 3 alur, **satu halaman** (bukan wizard — lihat 10.4): 7 bagian bernomor dinamis (Peserta, Asal sekolah, Menginap, Jumlah regu, Identitas regu, Contact Person, Pembayaran; bagian Menginap dilewati untuk Intern), autocomplete sekolah dari master (dimuat sekali, difilter di browser), blok per regu muncul mengikuti stepper, tombol Kirim menempel di bawah dengan total hidup; hasil akhir menampilkan kode pembayaran besar-besar |
+| Form pendaftaran | publik | Bagian 3 alur, **satu halaman** (bukan wizard — lihat 10.4): 7 bagian bernomor dinamis (Peserta, Asal sekolah, Menginap, Jumlah regu, Identitas regu, Contact Person, Pembayaran; bagian Menginap dilewati untuk Internal), autocomplete sekolah dari master (dimuat sekali, difilter di browser), blok per regu muncul mengikuti stepper, tombol Kirim menempel di bawah dengan total hidup; hasil akhir menampilkan kode pembayaran besar-besar |
 | Meja pembayaran | meja | Ketik kode → kartu batch → "Tandai Lunas" → panel sukses langsung menawarkan "Cetak Kwitansi" (satu alur, bukan dua); "Batalkan (salah)" memanggil `batalkan_verifikasi` |
 | Meja daftar ulang | meja | Cari kode/sekolah → buka "Isi N Nomor Dada" → **ketik nomor dari kain fisik per regu** (nama regu + kategori + ketua terlihat, Enter = regu berikutnya) → satu tombol "Simpan N Nomor Dada" → kloter terisi otomatis dan dibacakan; jalur "Tukar nomor" untuk stok rusak |
 | Garis start | meja | Papan 4 kolom **turunan otomatis** dari kloter terakhir yang berangkat: N berangkat / N+1–N+2 siap / N+3 konfirmasi kontrak. Operator hanya punya dua aksi: ceklis regu + tombol besar "BERANGKATKAN" (jam diketik). Papan bergeser sendiri — operator tidak pernah memutuskan apa yang maju |
@@ -611,7 +611,7 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
    lagi diperlukan. Kodenya ikut menyusut, sejalan dengan CLAUDE.md §6.
 4. Yang tetap dijaga meski satu halaman:
    - Bagian **bernomor**, sekarang 1–7 dan dihitung dinamis supaya pendaftar
-     Intern yang melewati bagian menginap tetap membaca urutan tanpa lubang.
+     Internal yang melewati bagian menginap tetap membaca urutan tanpa lubang.
    - Tombol Kirim **menempel di bawah layar** dengan ringkasan hidup
      ("3 regu · Rp 525.000") — pada form panjang, aksi utama tidak boleh
      tenggelam di ujung gulungan.
@@ -662,7 +662,7 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
 1. **Bentuk formula total** (Σ pos − penalti) adalah kode (satu view);
    angka-angkanya konfigurasi. Bentuk yang benar-benar baru = pemilik
    mengedit satu view SQL. Batas yang sama berlaku di semua kandidat.
-2. **Kuota otomatis 5 Eksternal + 3 Intern** ditegakkan RPC; set manual tidak
+2. **Kuota otomatis 5 Eksternal + 3 Internal** ditegakkan RPC; set manual tidak
    dibatasi kuota maupun jumlah, dan `urutan_kloter` hanya wajib positif.
 3. **.xlsx tidak di-parse** — paste dari Excel menutup kebutuhan yang sama
    tanpa dependensi parser.
@@ -730,7 +730,7 @@ dibaca dengan koreksi ini:
    rombongan sebelum memecah; menggabung tetap jalan terakhir. Jumlah
    pendamping bisa diisi dari form dan dikoreksi meja (`ubah_pendamping`).
 10. **Penempatan kloter otomatis FIFO**: kloter paling awal diisi sampai kuota
-    5 Eksternal + 3 Intern; sekolah tidak menjadi faktor penempatan.
+    5 Eksternal + 3 Internal; sekolah tidak menjadi faktor penempatan.
 11. **Audit menempel juga di** `akun_panitia` (peta otorisasi), `sekolah`,
     `ruangan`, `nomor_dada_pensiun`; simpan-ulang tanpa perubahan tidak
     menulis apa pun sehingga riwayat tidak banjir dan kepengarangan tidak

--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=66">
+  <link rel="stylesheet" href="style.css?v=67">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>
@@ -78,6 +78,6 @@
        mendadak. Skrip biasa, bukan modul: ia cuma menaruh satu objek global.
   -->
   <script src="config.js"></script>
-  <script type="module" src="live.js?v=19"></script>
+  <script type="module" src="live.js?v=20"></script>
 </body>
 </html>

--- a/live/js/api.js
+++ b/live/js/api.js
@@ -886,13 +886,13 @@ export async function lembarPos(pos) {
  *  yang mungkin muncul di kotak penilaian. */
 /** Kedua deret nomor dada, dari `v_rentang_nomor_dada` (migrasi 0116).
  *
- *  Kain nomor dada dicetak dua set yang sama-sama mulai dari 001, jadi Intern
+ *  Kain nomor dada dicetak dua set yang sama-sama mulai dari 001, jadi Internal
  *  diketik 1001-1250 sementara Eksternal tetap 1-500. Yang dibaca di sini
  *  UJUNG-UJUNGNYA saja, bukan seluruh 750 baris stok: layar cuma perlu tahu
  *  nomor mana milik deret mana, dan meja daftar ulang bekerja di jaringan
  *  yang sama dengan lima pos.
  *
- *  Nol berarti deretnya kosong — stok Intern yang belum pernah diisi admin.
+ *  Nol berarti deretnya kosong — stok Internal yang belum pernah diisi admin.
  *  Layar yang memakainya harus tetap jalan dalam keadaan itu, bukan menolak
  *  semua nomor. */
 export async function rentangNomorDada() {
@@ -960,7 +960,7 @@ export const simpanKejuaraanTerjauh = (sekolahId) =>
 
 /* ========================== FOTO BUKU SAKTI ============================= */
 
-/* Gambar contoh di dalam Buku Sakti: kain nomor dada Intern, blangko A5, rupa
+/* Gambar contoh di dalam Buku Sakti: kain nomor dada Internal, blangko A5, rupa
    satu layar. Bucket-nya `buku` dan sengaja PUBLIK, tidak seperti `lembar` dan
    `bukti` yang privat dan dilayani lewat tautan bertanda tangan.
 

--- a/live/js/daftar.js
+++ b/live/js/daftar.js
@@ -207,7 +207,7 @@ const labelGolongan = k => golonganForm().find(g => g.kode === k)?.label
 
 const NAMA_MAKS = 25;
 
-/* Kelas / organisasi (jalur Intern). Sama dengan batas kolomnya di database
+/* Kelas / organisasi (jalur Internal). Sama dengan batas kolomnya di database
    (migrasi 0133), jadi yang lolos di layar juga lolos di sana — pembina tidak
    pernah menemui penolakan yang tidak bisa ia lihat sebabnya. */
 const KELAS_MAKS = 80;
@@ -227,7 +227,7 @@ const KELAS_MAKS = 80;
 const POLA_KELAS = /^[A-Za-z0-9 ]*$/;
 const rapatSpasi = (t) => String(t || "").replace(/\s+/g, " ").trim();
 
-/* Kelas / organisasi: WAJIB di jalur Intern, tidak ada sama sekali di jalur
+/* Kelas / organisasi: WAJIB di jalur Internal, tidak ada sama sekali di jalur
    Eksternal. Satu tempat yang memutuskan, dipakai cekRegu() maupun periksa().
    Dua aturan untuk satu kotak berarti kotak yang merah tapi tetap bisa
    dikirim, atau sebaliknya.
@@ -349,7 +349,7 @@ function halaman() {
     </section>
 
     <!-- Identitas regu. Judulnya bukan lagi "Nama tiap regu" karena jalur
-         Intern mengisi lebih dari nama di sini: kelas atau organisasi asal
+         Internal mengisi lebih dari nama di sini: kelas atau organisasi asal
          tiap regu ikut, dan itu justru yang membedakan mereka. -->
     <section class="card" id="bagian-regu">
       <h2><span class="section-number">${nomorRegu}</span> Identitas regu</h2>
@@ -811,7 +811,7 @@ function sinkronRegu() {
 
 function perbaruiTotal() {
   const total = jawab.regu.length;
-  // Regu Intern berharga lain (migrasi 0110). Form ini tidak pernah mencampur
+  // Regu Internal berharga lain (migrasi 0110). Form ini tidak pernah mencampur
   // keduanya — jenis peserta dipilih sekali di atas dan menentukan seluruh
   // pilihan golongan — jadi "N × harga" masih benar dan harganya diambil dari
   // regu pertama. Yang DIJUMLAHKAN tetap per regu, supaya angka besarnya tetap
@@ -858,8 +858,8 @@ function gambarRegu() {
           <input type="text" id="r-anggota-${i}-${k}" value="${a}"
                  style="margin-top:.35rem"
                  placeholder="Nama Anggota ${k + 1}">`).join("");
-    /* Kelas / organisasi HANYA di jalur Intern, dan di ATAS nama regunya.
-       Regu Eksternal sudah dibedakan oleh sekolahnya; regu Intern semuanya
+    /* Kelas / organisasi HANYA di jalur Internal, dan di ATAS nama regunya.
+       Regu Eksternal sudah dibedakan oleh sekolahnya; regu Internal semuanya
        dari satu sekolah, jadi inilah satu-satunya yang membedakan mereka —
        dan yang dibaca lebih dulu saat memanggil regu di lapangan.
 
@@ -969,7 +969,7 @@ function gambarRegu() {
     const kotakAnggota = document.getElementById(`r-anggota-galat-${i}`);
     if (kotakAnggota) kotakAnggota.hidden = !salahAnggota;
 
-    // Kotaknya cuma ada di jalur Intern; di Eksternal keduanya null dan
+    // Kotaknya cuma ada di jalur Internal; di Eksternal keduanya null dan
     // baris ini tidak melakukan apa-apa.
     const salahKelas = masalahKelas(i);
     const inpKelas = document.getElementById(`r-kelas-${i}`);
@@ -1025,7 +1025,7 @@ function gambarRegu() {
     // sudah mengisi belasan kotak dan harus mencari yang mana, dan aturan yang
     // baru muncul di ujung terbaca seperti penolakan yang mengada-ada.
     //
-    // Kotaknya cuma ada di jalur Intern, dan gambarRegu() menggambar ulang
+    // Kotaknya cuma ada di jalur Internal, dan gambarRegu() menggambar ulang
     // seluruh kartunya saat jenis peserta berganti, jadi tidak ada listener
     // yang menggantung ke kotak yang sudah tidak ada.
     const inpKelas = document.getElementById(`r-kelas-${i}`);

--- a/live/js/util.js
+++ b/live/js/util.js
@@ -46,7 +46,7 @@ export function bacaAnggotaHadir(teks, badInput = false) {
 /** Cari kotak pada kolom tabel dan slot yang sama di baris berikutnya.
  *
  * Baris Input Pos tidak selalu punya kotak yang sama: komponen Eksternal
- * digambar sebagai tanda mati pada baris Intern, dan sebaliknya. Karena itu
+ * digambar sebagai tanda mati pada baris Internal, dan sebaliknya. Karena itu
  * indeks di antara seluruh input satu baris tidak menunjukkan kolom tabel.
  * `data-slot` membedakan pasangan Benar/Salah di dalam satu sel. */
 export function kotakBerikutnyaDalamKolom(baris, kotak) {
@@ -1185,7 +1185,7 @@ export function petunjukKolom(k) {
  *
  * Kalau minimal satu baris bernama sama dibatasi golongan, SEMUA baris dengan
  * nama itu adalah varian satu kolom — termasuk baris asal yang golongannya
- * null. Ini menyatukan pasangan umum + Intern tanpa menurunkan hubungan dari
+ * null. Ini menyatukan pasangan umum + Internal tanpa menurunkan hubungan dari
  * akhiran `kode`, yang hanya kebiasaan penamaan dan bukan kontrak data. */
 export function kolomPos(komponen) {
   const namaBervarian = new Set(
@@ -1209,10 +1209,10 @@ export function kolomPos(komponen) {
 /** Varian mana dari satu kolom yang berlaku untuk satu regu — atau null.
  *
  *  Pasangan sisi layar dari `komponen_berlaku()` di database (migrasi 0091),
- *  dan seperti fungsi itu ia TIDAK simetris: regu Intern hanya menerima
+ *  dan seperti fungsi itu ia TIDAK simetris: regu Internal hanya menerima
  *  komponen bertanda `intern` atau golongannya sendiri, sedangkan golongan
  *  Eksternal menerima baris umum (`golongan` null) maupun baris golongannya.
- *  Komponen umum tidak otomatis berlaku untuk Intern — kalau iya, seluruh
+ *  Komponen umum tidak otomatis berlaku untuk Internal — kalau iya, seluruh
  *  lomba lapangan ikut tergambar untuk regu yang tidak mengikutinya.
  *
  *  Tempatnya di util.js bersama kolomPos(), bukan di app.js, karena papan
@@ -1419,7 +1419,7 @@ export function periksaJawabSimpan(jumlahKirim, jawab) {
  *  `berlaku === 0` berarti lomba ini memang bukan untuk golongan regu itu.
  *  Itu keadaan sah, bukan konfigurasi rusak: Tebak Simpul Penegak tidak ada
  *  urusannya dengan regu Penggalang, dan seluruh lomba lapangan tidak ada
- *  urusannya dengan regu Intern (migrasi 0091). */
+ *  urusannya dengan regu Internal (migrasi 0091). */
 export function ringkasLomba(lomba, golongan, pos, peta) {
   let berlaku = 0, terisi = 0, jumlah = 0;
   for (const kol of lomba.kolom) {
@@ -1495,7 +1495,7 @@ export const URUT_GOLONGAN =
  *  di layar mana pun yang bisa memperbaikinya.
  *
  *  Tagihan satu batch adalah PENJUMLAHAN nilai ini per regu, bukan perkalian:
- *  satu pendaftaran boleh memuat regu Eksternal dan Intern sekaligus.
+ *  satu pendaftaran boleh memuat regu Eksternal dan Internal sekaligus.
  *
  *  HARGA INTERN YANG TIDAK ADA JATUH KE HARGA BIASA, dan itu yang membuat
  *  urutan rilis tidak penting. Situs terbit tiap kali PR di-merge sedangkan
@@ -1503,7 +1503,7 @@ export const URUT_GOLONGAN =
  *  ketika layar baru ini membaca `v_edisi_publik` yang belum punya kolomnya.
  *  Dengan jatuh ke `biaya_per_regu` layar menghitung persis seperti server
  *  yang belum dimigrasi — angkanya cocok, pembayaran jalan. Kalau ia jatuh ke
- *  nol, regu Intern akan tampil Rp 0 di Meja Pembayaran dan setiap
+ *  nol, regu Internal akan tampil Rp 0 di Meja Pembayaran dan setiap
  *  pembayarannya ditolak, tanpa satu pun galat yang menyebut sebabnya. */
 export const biayaRegu = (edisi, golongan) =>
   golongan === "intern_pa" || golongan === "intern_pi"

--- a/live/live.js
+++ b/live/live.js
@@ -70,7 +70,7 @@ import {
 
 const GOLONGAN = GOLONGAN_LABEL;
 
-/* Live Score peserta hanya mengumumkan golongan Eksternal. Intern tetap ada
+/* Live Score peserta hanya mengumumkan golongan Eksternal. Internal tetap ada
    di sumber bersama karena layar panitia memang perlu menilainya, tetapi tidak
    mendapat tab atau baris di halaman publik. Diturunkan dari daftar bersama
    supaya urutan dan label golongan tidak ditulis ulang di sini. */
@@ -81,9 +81,9 @@ const golonganPeserta = g => URUT_GOLONGAN_PESERTA.includes(g);
 /* MENGHITUNG PENDAFTAR itu pertanyaan lain dari MENYUSUN KLASEMEN, dan sejak
    28 Agustus 2026 keduanya tidak lagi memakai daftar yang sama.
 
-   Yang di atas menjawab "siapa yang muncul di papan" — Intern tidak, dan itu
+   Yang di atas menjawab "siapa yang muncul di papan" — Internal tidak, dan itu
    tetap. Yang di sini menjawab "berapa regu sudah mendaftar", dan jawabannya
-   SELURUHNYA, karena regu Intern sama-sama mendaftar, sama-sama membayar, dan
+   SELURUHNYA, karena regu Internal sama-sama mendaftar, sama-sama membayar, dan
    sama-sama berangkat pagi itu. Angka yang menghilangkan 64 di antaranya
    bukan angka yang lebih sopan, cuma angka yang salah.
 
@@ -205,14 +205,14 @@ async function ambilRingkasDb() {
 /** Ringkasan yang berlaku: database kalau terbaca, berkas kalau tidak. */
 const ringkasBerlaku = () => RINGKAS_DB || (META && META.ringkas) || {};
 
-/** Regu yang sudah mendaftar, SELURUHNYA — Intern ikut, sama dengan yang
+/** Regu yang sudah mendaftar, SELURUHNYA — Internal ikut, sama dengan yang
  *  diumumkan pil golongan di bawahnya. Sampai 28 Agustus 2026 angka ini
  *  menjumlahkan golongan Eksternal saja, memakai ulang saringan klasemen
  *  padahal pertanyaannya berbeda.
  *
  *  Cadangan `jumlah_regu_daftar` menjaga live.json lama yang belum punya
  *  `per_golongan` tetap tergambar — dan kebetulan ia MEMANG sudah berisi
- *  total dengan Intern, jadi kedua jalur kini menjawab hal yang sama. */
+ *  total dengan Internal, jadi kedua jalur kini menjawab hal yang sama. */
 const jumlahPesertaPra = () => {
   const r = ringkasBerlaku();
   const per = r.per_golongan || {};
@@ -520,9 +520,9 @@ function pasangCetakSkor() {
 let golAktif = URUT_GOLONGAN_PESERTA[0];
 
 function barisPapan(klasemenTerbuka, top10 = false) {
-  /* Penyaring ini tetap ada walau workflow penerbitan juga membuang Intern.
+  /* Penyaring ini tetap ada walau workflow penerbitan juga membuang Internal.
      Dengan begitu berkas lama yang masih tersimpan di cache tidak sempat
-     menampilkan Intern setelah kode halaman yang baru sudah ter-deploy. */
+     menampilkan Internal setelah kode halaman yang baru sudah ter-deploy. */
   const progres = ((REKAP && REKAP.progres) || [])
     .filter(b => golonganPeserta(b.golongan));
   const klasemen = ((REKAP && REKAP.klasemen) || [])

--- a/live/style.css
+++ b/live/style.css
@@ -355,7 +355,7 @@ input.jam-ketik {
 
    Keempat kolomnya dipatok 25% di bawah `table-layout: fixed` — kolom yang
    tidak dipatok mendapat NOL, bukan sisanya (pasal 15.3), dan kolom yang
-   lebarnya ikut isinya membuat "Intern" jauh lebih sempit daripada "Total
+   lebarnya ikut isinya membuat "Internal" jauh lebih sempit daripada "Total
    Kloter" sehingga angkanya tidak lagi berjarak sama.
 
    Rantai anak, bukan selektor keturunan (pasal 15.5): kartu ini tidak
@@ -1746,7 +1746,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      yang 13,04mm satu baris. Terlihat di lembar tercetak — judulnya tidak
      pernah membungkus, padahal 10mm mestinya memaksanya. */
   /* 12mm, naik dari 10mm sejak nomor dada bisa EMPAT digit (migrasi 0116:
-     Intern 1001-1250). Diukur pada tiruan lembar Pos 3 melintang 277mm,
+     Internal 1001-1250). Diukur pada tiruan lembar Pos 3 melintang 277mm,
      kondisi terlebar:
 
        "1250" pada 11pt      8,85mm tinta

--- a/supabase/checks/kloter_dari_stok.sql
+++ b/supabase/checks/kloter_dari_stok.sql
@@ -5,10 +5,10 @@
 -- angka bulat yang dipilih waktu edisi dibuka.
 --
 --     kloter dibutuhkan = maks( kain Eksternal / kuota Eksternal per kloter,
---                               kain Intern    / kuota Intern per kloter )
+--                               kain Internal    / kuota Internal per kloter )
 --     kloter dipasang   = kloter dibutuhkan + CADANGAN
 --
--- HRCD XXXVII: 250 kain Eksternal / 5 = 50 kloter, 100 kain Intern / 3 = 34
+-- HRCD XXXVII: 250 kain Eksternal / 5 = 50 kloter, 100 kain Internal / 3 = 34
 -- kloter, jadi 50 yang menentukan.
 --
 -- ---------------------------------------------------------------------------
@@ -75,7 +75,7 @@ begin
 
   raise notice 'kloter: kain % Eksternal / % per kloter = % kloter',
                v_kain_ext, v_q_ext, ceil(v_kain_ext::numeric / v_q_ext);
-  raise notice 'kloter: kain % Intern    / % per kloter = % kloter',
+  raise notice 'kloter: kain % Internal    / % per kloter = % kloter',
                v_kain_int, v_q_int, ceil(v_kain_int::numeric / v_q_int);
   raise notice 'kloter: dibutuhkan %, cadangan %, dipasang % (sebelumnya %)',
                v_butuh, v_cadangan, v_pasang, v_lama;

--- a/supabase/checks/simulasi_end_to_end.sql
+++ b/supabase/checks/simulasi_end_to_end.sql
@@ -259,7 +259,7 @@ begin
       select kode_pembayaran from pendaftaran where status = 'menunggu_pembayaran'
     loop
       -- tagihan_pendaftaran(), bukan jumlah_regu * biaya_per_regu: sejak
-      -- migrasi 0110 regu Intern berharga lain, jadi perkalian lama meleset
+      -- migrasi 0110 regu Internal berharga lain, jadi perkalian lama meleset
       -- pada batch mana pun yang memuatnya dan simulasi berhenti di
       -- "nominal tidak sama dengan tagihan".
       perform verifikasi_pembayaran(

--- a/supabase/checks/stok_nomor_dada.sql
+++ b/supabase/checks/stok_nomor_dada.sql
@@ -6,7 +6,7 @@
 -- HRCD XXXVII:
 --
 --     Eksternal   001 - 250
---     Intern     1001 - 1100
+--     Internal     1001 - 1100
 --
 -- ---------------------------------------------------------------------------
 -- KENAPA BUKAN MIGRASI
@@ -50,7 +50,7 @@ drop table if exists stok_kain;
 create temporary table stok_kain (jenis text, dari integer, sampai integer);
 insert into stok_kain (jenis, dari, sampai) values
   ('Eksternal',    1,  250),
-  ('Intern',    1001, 1100);
+  ('Internal',    1001, 1100);
 
 -- ---------------------------------------------------------------------------
 -- 1. Keadaan sekarang, sebelum disentuh.
@@ -126,7 +126,7 @@ do $blok$
 declare r record;
 begin
   select * into r from v_rentang_nomor_dada;
-  raise notice 'stok: SEKARANG Eksternal % - %, Intern % - %.',
+  raise notice 'stok: SEKARANG Eksternal % - %, Internal % - %.',
                r.eksternal_mulai, r.eksternal_sampai, r.intern_mulai, r.intern_sampai;
   raise notice 'stok: lembar cadangan "form tabel" akan mencetak % baris.',
                (select count(*) from nomor_dada_stok);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -63,7 +63,7 @@ insert into status_acara (id) values (true);
 -- tests/run.sh menjalankannya di TENGAH daftar migrasi, sementara
 -- tests/dev_database.sh menjalankannya SESUDAH semuanya — dan beberapa
 -- migrasi memasukkan baris yang sama (0093, 0105, 0119 untuk kloter; 0116
--- untuk stok nomor dada Intern, yang memang sudah memakai penjaga yang sama).
+-- untuk stok nomor dada Internal, yang memang sudah memakai penjaga yang sama).
 --
 -- Tanpa penjaga ini, seed berhenti dengan "duplicate key" pada urutan kedua,
 -- dan yang gagal bukan cuma seed-nya: seluruh langkah sesudahnya tidak
@@ -74,7 +74,7 @@ insert into kloter (nomor) select generate_series(1, 40)
 on conflict (nomor) do nothing;
 
 -- Stok nomor dada fisik. DUA deret, karena kainnya dicetak dua set yang
--- sama-sama mulai dari 001: Eksternal 1-500, Intern 1001-1250 (migrasi 0116).
+-- sama-sama mulai dari 001: Eksternal 1-500, Internal 1001-1250 (migrasi 0116).
 -- Batas antaranya `edisi.nomor_dada_intern_mulai`.
 insert into nomor_dada_stok (nomor) select generate_series(1, 500)
 on conflict (nomor) do nothing;

--- a/tests/concurrency_test.py
+++ b/tests/concurrency_test.py
@@ -86,7 +86,7 @@ def siapkan():
         k = h["kode_pembayaran"]
         # Nominalnya diambil dari yang sudah dihitung submit_pendaftaran, bukan
         # dari REGU_PER_SEKOLAH * biaya_per_regu. Batch ini CAMPURAN Eksternal
-        # dan Intern, dan sejak migrasi 0110 keduanya berharga lain — perkalian
+        # dan Internal, dan sejak migrasi 0110 keduanya berharga lain — perkalian
         # itu meleset dan verifikasi_pembayaran menolak seluruh fixture.
         jalankan("select verifikasi_pembayaran(%s,%s,%s)",
                  (k, h["total_tagihan"], "tunai"),
@@ -98,9 +98,9 @@ def siapkan():
 def stok_tersedia(jumlah, intern=False):
     """Nomor dada yang masih boleh dipakai, urut kecil ke besar.
 
-    DUA DERET sejak migrasi 0116: kain Intern dicetak set sendiri yang juga
-    mulai dari 001, jadi Intern diketik 1001-1250 dan nomor Eksternal untuk
-    regu Intern ditolak database. Batasnya dibaca dari `edisi`, tidak ditulis
+    DUA DERET sejak migrasi 0116: kain Internal dicetak set sendiri yang juga
+    mulai dari 001, jadi Internal diketik 1001-1250 dan nomor Eksternal untuk
+    regu Internal ditolak database. Batasnya dibaca dari `edisi`, tidak ditulis
     di sini — tes yang mematok 1001 akan gugur diam-diam begitu panitia tahun
     depan menggesernya.
     """
@@ -151,7 +151,7 @@ def serbu(kode):
     if len(stok_ext) < butuh_ext or len(stok_int) < butuh_int:
         raise SystemExit(
             f"stok nomor dada kurang: butuh {butuh_ext} Eksternal / {butuh_int} "
-            f"Intern, ada {len(stok_ext)} / {len(stok_int)}")
+            f"Internal, ada {len(stok_ext)} / {len(stok_int)}")
     # Disiapkan SEBELUM barrier supaya yang diadu murni transaksinya, bukan
     # waktu menyusun JSON di Python.
     bawaan = {k: pasangan(k,
@@ -229,7 +229,7 @@ def periksa(hasil, galat):
         group by k.nomor
         having count(r.id) > (select maks_intern_per_kloter from edisi where is_active)
     """, uid=MEJA[2])
-    cek("tidak ada kloter melebihi kuota Intern", not penuh_intern,
+    cek("tidak ada kloter melebihi kuota Internal", not penuh_intern,
         str(penuh_intern[:3]))
 
     urutan = jalankan("""

--- a/tests/departure_calculator.test.mjs
+++ b/tests/departure_calculator.test.mjs
@@ -71,7 +71,7 @@ test("isi kloter tetap FIFO dengan dua kuota terpisah", () => {
   assert.deepEqual(hasil[0], {
     kloter: 1, jumlahEksternal: 5, jumlahIntern: 3, waktuBerangkat: "07:00",
   });
-  // Intern habis di kloter ke-17: 50 dibagi 3 menyisakan 2.
+  // Internal habis di kloter ke-17: 50 dibagi 3 menyisakan 2.
   assert.equal(hasil[16].jumlahEksternal, 5);
   assert.equal(hasil[16].jumlahIntern, 2);
   assert.equal(hasil[17].jumlahIntern, 0);

--- a/tests/dev_database.sh
+++ b/tests/dev_database.sh
@@ -273,7 +273,7 @@ run supabase/migrations/0024_komponen_pos.sql
 #     yang lebih muda. Sebelum menambahkan satu ke daftar ini, cari migrasi
 #     sesudahnya yang menyentuh kolom yang sama.
 #   * 0091 harus SESUDAH 0076 agar lima komponen Soal Tulis yang disalin untuk
-#     Intern sudah ada. 0093 menyiapkan 60 kloter setelah edisi aktif lahir;
+#     Internal sudah ada. 0093 menyiapkan 60 kloter setelah edisi aktif lahir;
 #     0105 menambah headroom-nya menjadi 75, dan ia HARUS ikut diulang di
 #     sini: di glob ia berjalan sebelum edisi aktif lahir, jadi
 #     `select kloter_maks from edisi where is_active` tidak menemukan apa
@@ -285,7 +285,7 @@ run supabase/migrations/0024_komponen_pos.sql
 #     assert 0118 memeriksa sebaran jamnya atas jumlah yang benar.
 #   * 0169 harus SESUDAH 0076 dan 0091, karena keduanya yang memasang
 #     `judul_isian = 'Benar'` pada baris soal — 0076 untuk kelimanya, 0091
-#     untuk salinan Intern-nya. Alasan yang sama persis dengan 0168 di bawah.
+#     untuk salinan Internal-nya. Alasan yang sama persis dengan 0168 di bawah.
 #   * 0168 harus SESUDAH 0039, dan itu satu-satunya alasan ia ada di daftar
 #     ini. 0039 memasang judul isian Menaksir "Selisih Taksir" dan 0168
 #     menggantinya dengan "Hasil Taksir"; di glob urutannya benar, tapi 0039

--- a/tests/input_pos_navigation.test.mjs
+++ b/tests/input_pos_navigation.test.mjs
@@ -18,7 +18,7 @@ function rangkai(...barisDaftar) {
   }
 }
 
-test("Enter mengikuti kolom tabel melewati batas Intern dan Eksternal", () => {
+test("Enter mengikuti kolom tabel melewati batas Internal dan Eksternal", () => {
   const asal = kotak();
   asal.closest = () => ({ cellIndex: 3 });
 
@@ -27,7 +27,7 @@ test("Enter mengikuti kolom tabel melewati batas Intern dan Eksternal", () => {
   const tujuan = kotak();
   const pertama = baris([]);
   const disaring = baris([sel(), sel(), sel(), sel(tersembunyi)], true);
-  // Baris Intern tidak punya lomba pada kolom 3. Ia punya input pada kolom 0,
+  // Baris Internal tidak punya lomba pada kolom 3. Ia punya input pada kolom 0,
   // tetapi input itu tidak boleh dianggap sebagai kolom yang sama.
   const intern = baris([sel(salahKolom), sel(), sel(), sel()]);
   const eksternal = baris([sel(), sel(), sel(), sel(tujuan)]);

--- a/tests/kloter_departure_label.test.mjs
+++ b/tests/kloter_departure_label.test.mjs
@@ -119,20 +119,20 @@ test("layar planning tanpa judul dan tanpa paragraf penjelas", () => {
 });
 
 
-test("jumlah Eksternal dan Intern tetap ada, sebagai kolom mendatar", () => {
+test("jumlah Eksternal dan Internal tetap ada, sebagai kolom mendatar", () => {
   // Yang dijaga ANGKANYA tetap terbit, bukan bentuk tabelnya: keempatnya
   // dibalik jadi mendatar 27 Agustus 2026 supaya kotak jam dan tombol Cetak
   // di bawahnya tidak terdorong keluar layar HP.
-  assert.match(layar, /<th>Eksternal<\/th><th>Intern<\/th>/);
+  assert.match(layar, /<th>Eksternal<\/th><th>Internal<\/th>/);
   assert.match(layar, /<td class="angka">\$\{jumlahEksternal\}<\/td>/);
   assert.match(layar, /<td class="angka">\$\{jumlahIntern\}<\/td>/);
   // Kepala kolom dan angkanya harus berurutan sama. Tertukar, "Eksternal 0
-  // Intern 6" terbaca meyakinkan dan salah total.
+  // Internal 6" terbaca meyakinkan dan salah total.
   const kepala = layar.match(/<th>Total Kloter<\/th>[\s\S]*?<\/tr>/)[0];
   const isi = layar.match(/<tbody>[\s\S]*?<\/tbody>/)[0];
   assert.deepEqual(
     [...kepala.matchAll(/<th>([^<]+)<\/th>/g)].map(m => m[1]),
-    ["Total Kloter", "Total Regu", "Eksternal", "Intern"]);
+    ["Total Kloter", "Total Regu", "Eksternal", "Internal"]);
   assert.deepEqual(
     [...isi.matchAll(/\$\{(\w+)/g)].map(m => m[1]),
     ["perKloter", "baris", "jumlahEksternal", "jumlahIntern"]);

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -36,9 +36,9 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 /** Nomor versi yang sedang tertulis di index.html, beserta sidik jari isi
  *  berkas saat nomor itu dipasang. Ubah KEDUANYA bersama-sama. */
 const BERKAS = {
-  "live.js": { versi: 19, sidik: "3a694d058cbc" },
+  "live.js": { versi: 20, sidik: "0cec1e3dde68" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 66, sidik: "973cf984cb96" },
+  "style.css": { versi: 67, sidik: "8b9143b2f4b2" },
 };
 
 const sidikIsi = (teks) =>

--- a/tests/live_score_per_lomba.test.mjs
+++ b/tests/live_score_per_lomba.test.mjs
@@ -23,7 +23,7 @@ const live = await readFile(new URL("live/live.js", akar), "utf8");
 
 /* Konfigurasi Pos 3 yang sebenarnya (dibaca dari `wahana` edisi 37): lima
    kriteria Pembidaian di bawah satu `lomba`, KIM Lihat dan KIM Cium sebagai
-   lomba tersendiri sejak 0087, dan Logika dengan varian Intern-nya. */
+   lomba tersendiri sejak 0087, dan Logika dengan varian Internal-nya. */
 const POS3 = [
   { kode: "bidai_diagnosis", name: "Diagnosis dan Penanganan Awal", lomba: "Pembidaian", golongan: null },
   { kode: "bidai_teknik", name: "Teknik Bidai", lomba: "Pembidaian", golongan: null },
@@ -86,13 +86,13 @@ test("terisi sebagian dilaporkan sebagian, bukan lengkap dan bukan kosong", () =
 
 
 test("lomba yang tidak berlaku untuk golongannya dilaporkan berlaku=0", () => {
-  // Regu Intern hanya dinilai Soal Tulis dan ketepatan waktu (0091); seluruh
+  // Regu Internal hanya dinilai Soal Tulis dan ketepatan waktu (0091); seluruh
   // lomba lapangan tidak berlaku untuknya. Itu keadaan sah, dan papan harus
   // membedakannya dari "nilainya belum masuk".
   const [pembidaian, , , logika] = lombaPos(POS3);
   assert.equal(ringkasLomba(pembidaian, "intern_pa", 3, {}).berlaku, 0);
 
-  // Logika punya varian Intern, jadi ia TETAP berlaku — dan yang dibaca
+  // Logika punya varian Internal, jadi ia TETAP berlaku — dan yang dibaca
   // varian internnya, bukan baris umum.
   const r = ringkasLomba(logika, "intern_pa", 3, { "3.logika_intern": 80, "3.logika": 55 });
   assert.equal(r.berlaku, 1);

--- a/tests/nomor_dada_series.test.mjs
+++ b/tests/nomor_dada_series.test.mjs
@@ -4,7 +4,7 @@
 // DUA DERET NOMOR DADA, DAN LAYAR HARUS MENOLAK YANG SALAH SEBELUM SERVER.
 //
 // Panitia mencetak kain nomor dada dalam dua set yang sama-sama mulai dari
-// 001, jadi Intern diketik 1001-1250. Pagar sesungguhnya ada di database
+// 001, jadi Internal diketik 1001-1250. Pagar sesungguhnya ada di database
 // (tes SQL 78); yang diuji di sini pagar di kotaknya — petugas meja mengisi
 // belasan kotak sebelum menekan Simpan, dan ditolak server berarti mencari
 // sendiri kotak mana yang salah.
@@ -41,8 +41,8 @@ test("golongan Intern dikenali dari awalannya, bukan dari daftar nama", () => {
 });
 
 
-test("nomor Eksternal untuk regu Intern ditolak, dan sebaliknya", () => {
-  // Kekeliruan yang PASTI terjadi kalau tidak ditolak: kain Intern bertulis
+test("nomor Eksternal untuk regu Internal ditolak, dan sebaliknya", () => {
+  // Kekeliruan yang PASTI terjadi kalau tidak ditolak: kain Internal bertulis
   // 001, dan mengetik apa yang terbaca adalah hal paling wajar sedunia.
   assert.equal(deretCocok(HRCD37, "intern_pa", 1), false);
   assert.equal(deretCocok(HRCD37, "intern_pa", 250), false);
@@ -69,7 +69,7 @@ test("batasnya dari rentang, bukan dari angka 1001 yang dipatok", () => {
 
 
 test("deret yang kosong tidak menghakimi apa pun", () => {
-  // Stok Intern yang belum diisi admin: layar berhenti menilai deret dan
+  // Stok Internal yang belum diisi admin: layar berhenti menilai deret dan
   // membiarkan database yang memutuskan. Menolak semua nomor di keadaan ini
   // akan mematikan meja daftar ulang untuk seluruh peserta.
   const belum = { eksternalMulai: 1, eksternalSampai: 500, internMulai: 0, internSampai: 0 };
@@ -80,7 +80,7 @@ test("deret yang kosong tidak menghakimi apa pun", () => {
 
 test("lembar cadangan memuat kedua deret dan TIDAK memuat lubang di antaranya", () => {
   // Inilah yang dulu salah: lembar dicetak 1..batas, dan batas adalah nomor
-  // tertinggi di stok. Dengan deret Intern 1001-1250 itu berarti 500 baris
+  // tertinggi di stok. Dengan deret Internal 1001-1250 itu berarti 500 baris
   // kosong bernomor 501-1000 — nomor yang tidak pernah dibawa siapa pun, dan
   // tiap barisnya menyuruh petugas mencari slip yang tidak ada.
   const nomor = nomorStok(HRCD37);
@@ -94,7 +94,7 @@ test("lembar cadangan memuat kedua deret dan TIDAK memuat lubang di antaranya", 
 });
 
 
-test("stok yang belum punya deret Intern tetap mencetak deret Eksternal", () => {
+test("stok yang belum punya deret Internal tetap mencetak deret Eksternal", () => {
   const belum = { eksternalMulai: 1, eksternalSampai: 3, internMulai: 0, internSampai: 0 };
   assert.deepEqual(nomorStok(belum), [1, 2, 3]);
 });
@@ -113,7 +113,7 @@ test("pesannya menyebut deret yang BENAR, bukan cuma bahwa nomornya salah", () =
 });
 
 
-test("batch Intern dikenali dari golongan regunya", () => {
+test("batch Internal dikenali dari golongan regunya", () => {
   assert.equal(deretIntern([{ golongan: "penggalang_pa" }, { golongan: "intern_pi" }]), true);
   assert.equal(deretIntern([{ golongan: "penggalang_pa" }]), false);
   assert.equal(deretIntern([]), false);

--- a/tests/public_board_columns.test.mjs
+++ b/tests/public_board_columns.test.mjs
@@ -43,12 +43,12 @@ test("varian bergolongan digabung jadi satu kolom bernama sama", () => {
 });
 
 
-test("varianUntuk tidak simetris: Intern tidak menerima komponen umum", () => {
+test("varianUntuk tidak simetris: Internal tidak menerima komponen umum", () => {
   const [kol] = kolomPos([
     { kode: "semaphore", name: "Semaphore", golongan: null },
   ]);
   assert.equal(varianUntuk(kol, "penegak_pa").kode, "semaphore");
-  // Kalau baris umum ikut berlaku untuk Intern, seluruh lomba lapangan
+  // Kalau baris umum ikut berlaku untuk Internal, seluruh lomba lapangan
   // tergambar untuk regu yang tidak mengikutinya (migrasi 0091).
   assert.equal(varianUntuk(kol, "intern_pa"), null);
 

--- a/tests/public_registration_headline.test.mjs
+++ b/tests/public_registration_headline.test.mjs
@@ -27,7 +27,7 @@ test("headline pra menjumlahkan golongan yang sama dengan pill", () => {
   // membantah pil di bawahnya.
   //
   // Versi pertama memaku `URUT_GOLONGAN_PESERTA` apa adanya, lalu gagal saat
-  // penghitung pendaftar dipindahkan ke daftar yang memuat Intern — padahal
+  // penghitung pendaftar dipindahkan ke daftar yang memuat Internal — padahal
   // pilnya ikut pindah dan keduanya tetap sepakat. Tes yang memaku ejaan
   // menghukum perubahan yang benar, lalu diabaikan.
   const headline = jumlahHelper.match(
@@ -47,26 +47,26 @@ test("headline pra menjumlahkan golongan yang sama dengan pill", () => {
 });
 
 
-test("jumlah pendaftar memuat Intern; klasemen tetap tanpa Intern", () => {
+test("jumlah pendaftar memuat Internal; klasemen tetap tanpa Internal", () => {
   // Dua pertanyaan yang berbeda, dan sejak 28 Agustus 2026 dua daftar yang
   // berbeda:
   //
-  //   "berapa regu sudah mendaftar"  -> SELURUHNYA. Regu Intern sama-sama
+  //   "berapa regu sudah mendaftar"  -> SELURUHNYA. Regu Internal sama-sama
   //                                     mendaftar, membayar, dan berangkat.
   //   "siapa yang muncul di papan"   -> Eksternal saja, dan itu tetap.
   //
-  // Sebelumnya keduanya memakai satu daftar, jadi 64 regu Intern hilang dari
+  // Sebelumnya keduanya memakai satu daftar, jadi 64 regu Internal hilang dari
   // hitungan pendaftar tanpa ada yang memutuskannya.
   assert.match(live, /const URUT_GOLONGAN_DAFTAR = URUT_GOLONGAN;/,
-    "daftar penghitung pendaftar bukan lagi daftar penuh — Intern akan hilang "
+    "daftar penghitung pendaftar bukan lagi daftar penuh — Internal akan hilang "
     + "lagi dari angka pendaftar");
 
   const saringan = live.match(
     /const URUT_GOLONGAN_PESERTA =\s*URUT_GOLONGAN\.filter\(g => !g\.startsWith\("intern_"\)\);/);
-  assert.ok(saringan, "saringan klasemen tidak lagi membuang Intern");
+  assert.ok(saringan, "saringan klasemen tidak lagi membuang Internal");
 
   // Papan klasemen — tab, kartu, dan golongan aktif — tetap memakai saringan
-  // Eksternal. Kalau salah satunya berpindah ke daftar penuh, Intern mendapat
+  // Eksternal. Kalau salah satunya berpindah ke daftar penuh, Internal mendapat
   // tab di papan publik, dan itu keputusan yang berbeda sama sekali.
   const papan = live.slice(live.indexOf("let golAktif ="));
   for (const pemakai of ["let golAktif = URUT_GOLONGAN_PESERTA[0]",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -388,7 +388,7 @@ run tests/sql/51_reset_event_times.sql
 run supabase/migrations/0091_intern_golongan.sql
 run tests/sql/52_intern_golongan.sql
 # 0092 mengganti penyebaran sekolah per dua kloter dengan FIFO berkategori:
-# otomatis 5 Eksternal + 3 Intern, manual tanpa batas, 300+50 regu dalam 60
+# otomatis 5 Eksternal + 3 Internal, manual tanpa batas, 300+50 regu dalam 60
 # kloter yang perkiraannya dibagi rata sepanjang 07:00-10:00.
 run supabase/migrations/0092_fifo_kloter_eksternal_intern.sql
 run supabase/migrations/0093_configure_fifo_capacity.sql
@@ -408,7 +408,7 @@ run supabase/migrations/0095_lembar_pos_jawaban_benar.sql
 run tests/sql/56_lembar_pos_sama_dengan_klasemen.sql
 # 0096 membuat penyebut kelengkapan memakai komponen_berlaku(), aturan golongan
 # yang sama dengan penilaian — 0091 mengubah aturannya dan melewatkan salinan
-# di komponen_pos_golongan(), jadi regu Intern tidak pernah bisa terhitung
+# di komponen_pos_golongan(), jadi regu Internal tidak pernah bisa terhitung
 # lengkap dan di Pos 4/5 dihitung kosong selamanya. Tes 57 menguji kesamaan
 # aturannya, bukan angkanya.
 run supabase/migrations/0096_kelengkapan_mengenal_intern.sql
@@ -443,7 +443,7 @@ run tests/sql/63_daftar_ulang_after_print.sql
 run supabase/migrations/0103_restore_pos_last_entry.sql
 run tests/sql/64_pos_last_entry.sql
 # Halaman peserta hanya menerbitkan regu Eksternal, jadi penghitung kelengkapan
-# publik harus memakai populasi yang sama. Papan panitia tetap menghitung Intern.
+# publik harus memakai populasi yang sama. Papan panitia tetap menghitung Internal.
 run supabase/migrations/0104_public_completeness_external_only.sql
 run tests/sql/65_public_completeness_external.sql
 # Enam puluh kloter hanya memberi tepat 300 tempat Eksternal. Tambahkan 15
@@ -471,7 +471,7 @@ run tests/sql/70_anggota_hadir_publik.sql
 # keadaan yang harus dikerjakannya.
 run supabase/migrations/0109_kontrak_waktu_tiga_pilihan.sql
 run tests/sql/71_kontrak_waktu_tiga_pilihan.sql
-# 0110 memberi regu Intern harganya sendiri, jadi tagihan berhenti jadi
+# 0110 memberi regu Internal harganya sendiri, jadi tagihan berhenti jadi
 # perkalian dan menjadi penjumlahan per regu. Tes 72 memakai batch CAMPURAN —
 # satu-satunya bentuk yang membedakan kedua rumus — dan menempati kursi Meja
 # Pembayaran untuk membuktikan server menolak nominal rumus lama.
@@ -510,13 +510,13 @@ run supabase/migrations/0114_nama_anggota_regu.sql
 # tanpa galat dan pagar akhirnya tidak menyala di daftar kurasi.
 run supabase/migrations/0115_sekolah_baku_dua_baris.sql
 
-# 0116 memecah nomor dada jadi dua deret: Eksternal 1-500, Intern 1001-1250.
-# Tes 78 menempati kursinya — memberi regu Intern nomor Eksternal harus
+# 0116 memecah nomor dada jadi dua deret: Eksternal 1-500, Internal 1001-1250.
+# Tes 78 menempati kursinya — memberi regu Internal nomor Eksternal harus
 # ditolak, dan sebaliknya, lewat KEDUA pintu yang memberi nomor.
 run supabase/migrations/0116_nomor_dada_intern_seribu.sql
 run tests/sql/78_deret_nomor_dada_intern.sql
 
-# 0117 membetulkan lpad(...,3) yang MEMOTONG nomor Intern empat digit jadi
+# 0117 membetulkan lpad(...,3) yang MEMOTONG nomor Internal empat digit jadi
 # tiga — dan tiga digit itu regu Eksternal yang benar-benar ada. Tes 79
 # membaca pesan yang keluar, bukan definisi fungsinya.
 run supabase/migrations/0117_dada_empat_digit_berangkat.sql
@@ -615,7 +615,7 @@ run supabase/migrations/0129_impor_pendaftaran_xxxvii.sql
 # tempatnya tepat di belakangnya, bukan di kelompok migrasi mana pun.
 run supabase/migrations/0130_bukti_transfer_link_drive.sql
 
-# 0133 memberi regu kolom kelas/organisasi, dipakai jalur Intern. Pagar di
+# 0133 memberi regu kolom kelas/organisasi, dipakai jalur Internal. Pagar di
 # dalamnya MENGIRIM dua pendaftaran uji lewat submit_pendaftaran lalu
 # menghapusnya lagi — salah satunya untuk membuktikan kiriman TANPA kunci
 # baru itu tetap diterima.

--- a/tests/score_columns.test.mjs
+++ b/tests/score_columns.test.mjs
@@ -1,6 +1,6 @@
 // ============================================================================
 // hrcd-rekap : tests/score_columns.test.mjs
-// Varian umum dan Intern dari satu penilaian tetap satu kolom layar.
+// Varian umum dan Internal dari satu penilaian tetap satu kolom layar.
 // ============================================================================
 
 import assert from "node:assert/strict";
@@ -13,7 +13,7 @@ const komponen = (kode, name, golongan = null) => ({
   rentang_mentah_min: 0, rentang_mentah_maks: 10,
 });
 
-test("pasangan umum dan Intern bergabung berdasarkan nama", () => {
+test("pasangan umum dan Internal bergabung berdasarkan nama", () => {
   const kolom = kolomPos([
     komponen("semaphore", "Semaphore"),
     komponen("menaksir", "Menaksir"),

--- a/tests/sql/52_intern_golongan.sql
+++ b/tests/sql/52_intern_golongan.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- hrcd-rekap : tests/sql/52_intern_golongan.sql
--- Intern adalah dua golongan tersendiri dan hanya mengikuti Soal Tulis.
+-- Internal adalah dua golongan tersendiri dan hanya mengikuti Soal Tulis.
 -- ============================================================================
 
 do $blok$
@@ -24,7 +24,7 @@ begin
 
   select count(*) into v_n from wahana
   where edisi = edisi_aktif() and golongan = 'intern';
-  assert v_n = 5, format('Intern mendapat %s komponen, seharusnya 5 Soal Tulis', v_n);
+  assert v_n = 5, format('Internal mendapat %s komponen, seharusnya 5 Soal Tulis', v_n);
 
   select count(*) into v_n from wahana
   where edisi = edisi_aktif() and golongan = 'intern'
@@ -72,12 +72,12 @@ begin
 
   select total into v_total from v_total_skor where regu_id = v_regu;
   assert v_total = 300,
-         format('Intern bernilai Soal Tulis penuh harus mendapat 300, bukan %s', v_total);
+         format('Internal bernilai Soal Tulis penuh harus mendapat 300, bukan %s', v_total);
 
   select penalti_checkout + penalti_anggota into v_total
   from v_total_skor where regu_id = v_regu;
   assert v_total = 0,
-         format('Intern terkena %s penalti selain waktu', v_total);
+         format('Internal terkena %s penalti selain waktu', v_total);
 
   select n.nomor into v_nomor from nomor_dada_stok n
   where not exists (select 1 from regu r where r.nomor_dada = n.nomor)
@@ -102,10 +102,10 @@ begin
                      '00000000-0000-0000-0000-00000000000a', true);
   select count(*) into v_n from v_lembar_pos where regu_id = v_regu;
   assert v_n = 3,
-         format('Intern muncul di %s pos; seharusnya hanya tiga pos Soal Tulis', v_n);
+         format('Internal muncul di %s pos; seharusnya hanya tiga pos Soal Tulis', v_n);
   select sum(jumlah_komponen) into v_n from v_lembar_pos where regu_id = v_regu;
   assert v_n = 5,
-         format('form Intern memuat %s komponen; seharusnya lima Soal Tulis', v_n);
+         format('form Internal memuat %s komponen; seharusnya lima Soal Tulis', v_n);
   reset role;
 
   update kloter set jam_berangkat = '2026-08-29 07:00:00+07'
@@ -116,7 +116,7 @@ begin
     (regu_id, jam_datang, anggota_hadir, recorded_by, note)
   values
     (v_regu, '2026-08-29 11:03:00+07', 3,
-     (select id from auth.users order by id limit 1), 'uji Intern');
+     (select id from auth.users order by id limit 1), 'uji Internal');
 
   select total into v_total from v_total_skor where regu_id = v_regu;
   assert v_total = 297,
@@ -124,7 +124,7 @@ begin
   select penalti_checkout + penalti_anggota into v_total
   from v_total_skor where regu_id = v_regu;
   assert v_total = 0,
-         format('Intern terkena %s penalti checkout/anggota setelah closing', v_total);
+         format('Internal terkena %s penalti checkout/anggota setelah closing', v_total);
   select peringkat into v_n from v_klasemen where regu_id = v_regu;
   assert v_n = 1, format('Intern PA harus memulai klasemennya sendiri di peringkat %s', v_n);
 

--- a/tests/sql/53_fifo_kloter_eksternal_intern.sql
+++ b/tests/sql/53_fifo_kloter_eksternal_intern.sql
@@ -1,5 +1,5 @@
 -- ============================================================================
--- 0092: FIFO, kuota 5 Eksternal + 3 Intern, manual tanpa batas, dan 60 kloter.
+-- 0092: FIFO, kuota 5 Eksternal + 3 Internal, manual tanpa batas, dan 60 kloter.
 -- ============================================================================
 
 do $blok$
@@ -23,7 +23,7 @@ begin
 
   assert (select maks_eksternal_per_kloter = 5 and maks_intern_per_kloter = 3
           from edisi where is_active),
-         'kuota otomatis bukan 5 Eksternal + 3 Intern';
+         'kuota otomatis bukan 5 Eksternal + 3 Internal';
   assert (select kloter_maks >= 60 from edisi where is_active),
          '300 Eksternal membutuhkan sedikitnya 60 kloter';
   assert (select count(*) from kloter where nomor between 1 and 60) = 60,
@@ -41,12 +41,12 @@ begin
   values (v_sekolah, 'UJI-FIFO-0092', 13, '081200000092', 'lunas')
   returning id into v_daftar;
 
-  -- Delapan Eksternal lalu lima Intern dalam satu transaksi. Urutan nama
+  -- Delapan Eksternal lalu lima Internal dalam satu transaksi. Urutan nama
   -- sengaja memastikan Eksternal diproses lebih dahulu; kuota tiap jenis tetap
   -- harus menghasilkan K1=5+3 dan K2=3+2.
   for v_i in 1..13 loop
     insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
-    values (v_daftar, format('%s %s', case when v_i <= 8 then 'A Ext' else 'B Intern' end,
+    values (v_daftar, format('%s %s', case when v_i <= 8 then 'A Ext' else 'B Internal' end,
                     chr(64 + v_i)),
             'Ketua Uji', case when v_i <= 8 then 'penggalang_pa' else 'intern_pa' end)
     returning id into v_regu;
@@ -65,7 +65,7 @@ begin
   assert v_jumlah = 5, format('K1 berisi %s Eksternal, seharusnya 5', v_jumlah);
   select count(*) into v_jumlah from regu r where r.pendaftaran_id = v_daftar
     and r.kloter_nomor = 1 and r.golongan like 'intern_%';
-  assert v_jumlah = 3, format('K1 berisi %s Intern, seharusnya 3', v_jumlah);
+  assert v_jumlah = 3, format('K1 berisi %s Internal, seharusnya 3', v_jumlah);
   select count(*) into v_jumlah from regu r where r.pendaftaran_id = v_daftar
     and r.kloter_nomor = 2;
   assert v_jumlah = 5, format('sisa FIFO di K2 berjumlah %s, seharusnya 5', v_jumlah);
@@ -127,4 +127,4 @@ begin
   raise notice '53: FIFO 5+3, lewati kloter berangkat, manual tanpa batas, dan perkiraan 60 kloter teruji.';
 end $blok$;
 
-\echo '53 FIFO kloter Eksternal/Intern: LULUS'
+\echo '53 FIFO kloter Eksternal/Internal: LULUS'

--- a/tests/sql/57_kelengkapan_intern.sql
+++ b/tests/sql/57_kelengkapan_intern.sql
@@ -7,14 +7,14 @@
 -- Ada dua salinan aturan itu di sistem: `komponen_berlaku()` yang dipakai
 -- v_lembar_pos dan simpan_nilai_massal, dan satu lagi yang dulu diketik ulang
 -- di dalam `komponen_pos_golongan()`. 0091 mengubah yang pertama dan
--- melewatkan yang kedua, jadi regu Intern tidak pernah bisa terhitung lengkap
+-- melewatkan yang kedua, jadi regu Internal tidak pernah bisa terhitung lengkap
 -- di pos mana pun — dan di Pos 4 dan Pos 5, tempat mereka memang tidak
 -- berlomba, mereka dihitung 'kosong' selamanya lalu ikut jadi 'hilang'
 -- sesudah checkout.
 --
 -- Yang diuji di sini bukan angkanya, melainkan KESAMAAN aturannya: penyebut
 -- kelengkapan harus sama persis dengan apa yang boleh diisi juri. Tes ini
--- bersandar pada regu Intern yang dibuat tes 52.
+-- bersandar pada regu Internal yang dibuat tes 52.
 -- ============================================================================
 
 \echo '--- 57. penyebut kelengkapan mengikuti aturan golongan penilaian'
@@ -23,7 +23,7 @@ do $blok$
 declare
   v_regu    uuid;
   v_gol     text;
-  v_pos_ada smallint;   -- pos tempat regu Intern memang berlomba
+  v_pos_ada smallint;   -- pos tempat regu Internal memang berlomba
   v_pos_tak smallint;   -- pos tempat ia tidak punya komponen sama sekali
   v_wajib   int;
   v_terisi  int;
@@ -48,7 +48,7 @@ begin
     and d.status = 'lunas'
   order by r.nomor_dada limit 1;
   assert v_regu is not null,
-    '57 GAGAL: tidak ada regu Intern bernomor dada — tes 52 seharusnya membuatnya';
+    '57 GAGAL: tidak ada regu Internal bernomor dada — tes 52 seharusnya membuatnya';
 
   -- ---------------------------------------------------------------------
   -- 57.1 Penyebutnya = jumlah komponen yang BOLEH diisi juri untuk regu itu.
@@ -73,7 +73,7 @@ begin
   raise notice '57.1 OK — penyebut tiap pos sama dengan komponen yang berlaku untuk %.', v_gol;
 
   -- ---------------------------------------------------------------------
-  -- 57.2 Regu Intern yang sudah mengisi seluruh komponennya TERHITUNG
+  -- 57.2 Regu Internal yang sudah mengisi seluruh komponennya TERHITUNG
   --      lengkap.
   --
   --      Dibaca dua kali dengan satu baris nilai dihapus di antaranya —
@@ -88,7 +88,7 @@ begin
     format('57 GAGAL: %s tidak berlomba di pos mana pun', v_gol);
 
   -- Nilainya diisi DI SINI, bukan diwarisi dari tes sebelumnya: beberapa tes
-  -- membuat regu Intern untuk keperluan lain (tes 53 mengujinya sebagai kuota
+  -- membuat regu Internal untuk keperluan lain (tes 53 mengujinya sebagai kuota
   -- FIFO) dan mana yang kebetulan sudah dinilai bukan sesuatu yang boleh
   -- diandalkan. Yang ditambahkan di sini dibongkar lagi di akhir.
   select array_agg(w.id) into v_tambah
@@ -113,7 +113,7 @@ begin
   where n.regu_id = v_regu and w.pos = v_pos_ada and w.edisi = edisi_aktif()
   limit 1;
   assert v_wahana is not null,
-    format('57 GAGAL: regu Intern belum punya nilai di Pos %s', v_pos_ada);
+    format('57 GAGAL: regu Internal belum punya nilai di Pos %s', v_pos_ada);
 
   delete from nilai_mentah where regu_id = v_regu and wahana_id = v_wahana;
   select lengkap into v_sesudah from v_kelengkapan_pos where pos = v_pos_ada;
@@ -121,10 +121,10 @@ begin
   values (v_regu, v_wahana, v_n1, v_n2, v_sumber, v_oleh);
 
   assert v_lengkap - v_sesudah = 1,
-    format('57.2 GAGAL: menghapus satu nilai regu Intern mengubah "lengkap" '
-           'Pos %s dari %s jadi %s — seharusnya turun satu. Regu Intern tidak '
+    format('57.2 GAGAL: menghapus satu nilai regu Internal mengubah "lengkap" '
+           'Pos %s dari %s jadi %s — seharusnya turun satu. Regu Internal tidak '
            'ikut terhitung lengkap.', v_pos_ada, v_lengkap, v_sesudah);
-  raise notice '57.2 OK — regu Intern terhitung lengkap di Pos %.', v_pos_ada;
+  raise notice '57.2 OK — regu Internal terhitung lengkap di Pos %.', v_pos_ada;
 
   -- ---------------------------------------------------------------------
   -- 57.3 Di pos yang tidak ia ikuti, ia tidak dihitung sama sekali.
@@ -138,7 +138,7 @@ begin
   where p.jumlah_komponen > 0 and komponen_pos_golongan(p.nomor, v_gol) = 0
   order by p.nomor limit 1;
   assert v_pos_tak is not null,
-    '57 GAGAL: tidak ada pos yang tidak diikuti Intern — fikstur tes berubah, '
+    '57 GAGAL: tidak ada pos yang tidak diikuti Internal — fikstur tes berubah, '
     'tes 57.3 tidak lagi memeriksa apa pun';
 
   select regu_total into v_total from v_kelengkapan_pos where pos = v_pos_tak;
@@ -156,10 +156,10 @@ begin
   where not r.is_cancelled and d.status = 'lunas' and r.nomor_dada is not null
     and r.golongan in ('intern_pa', 'intern_pi');
   assert v_intern > 0,
-    '57.3 GAGAL: tidak ada regu Intern yang dikecualikan, jadi angka di atas '
+    '57.3 GAGAL: tidak ada regu Internal yang dikecualikan, jadi angka di atas '
     'sama saja dengan sebelum perbaikan';
 
-  raise notice '57.3 OK — Pos % menghitung % regu, % regu Intern dikecualikan.',
+  raise notice '57.3 OK — Pos % menghitung % regu, % regu Internal dikecualikan.',
     v_pos_tak, v_total, v_intern;
 
   -- Nilai yang ditambahkan tes ini dibongkar lagi.
@@ -169,4 +169,4 @@ begin
 end;
 $blok$;
 
-\echo '57 kelengkapan mengenal Intern: LULUS'
+\echo '57 kelengkapan mengenal Internal: LULUS'

--- a/tests/sql/65_public_completeness_external.sql
+++ b/tests/sql/65_public_completeness_external.sql
@@ -21,7 +21,7 @@ begin
   select fase_live into v_fase_sebelumnya from status_acara;
   update status_acara set fase_live = 'progres' where id = true;
 
-  -- Pilih pos yang benar-benar diikuti Intern agar tes tidak bisa lulus hanya
+  -- Pilih pos yang benar-benar diikuti Internal agar tes tidak bisa lulus hanya
   -- karena 0096 memang sudah mengeluarkan mereka dari Pos 4/5.
   select p.nomor into v_pos
   from v_pos p
@@ -35,7 +35,7 @@ begin
   limit 1;
 
   assert v_pos is not null,
-    '65 GAGAL: tidak ada pos yang diikuti Intern; fikstur tidak menguji boundary publik';
+    '65 GAGAL: tidak ada pos yang diikuti Internal; fikstur tidak menguji boundary publik';
 
   select regu_total into v_publik
   from v_kelengkapan_publik where pos = v_pos;
@@ -60,7 +60,7 @@ begin
     and komponen_pos_golongan(v_pos, r.golongan) > 0;
 
   assert v_semua > v_eksternal,
-    '65 GAGAL: tidak ada regu Intern yang membedakan hitungan publik dan panitia';
+    '65 GAGAL: tidak ada regu Internal yang membedakan hitungan publik dan panitia';
   assert v_publik = v_eksternal,
     format('65 GAGAL: publik menghitung %s regu di Pos %s, seharusnya %s Eksternal',
            v_publik, v_pos, v_eksternal);

--- a/tests/sql/72_biaya_intern.sql
+++ b/tests/sql/72_biaya_intern.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- hrcd-rekap : tests/sql/72_biaya_intern.sql
--- Regu Intern ditagih Rp 100.000, Eksternal Rp 175.000, dan yang menghitung
+-- Regu Internal ditagih Rp 100.000, Eksternal Rp 175.000, dan yang menghitung
 -- tagihan adalah PENJUMLAHAN — bukan lagi perkalian.
 --
 -- Kenapa penjumlahan itu yang diuji, bukan angkanya: harga berganti tiap
@@ -45,7 +45,7 @@ begin
   assert v_eksternal = 175000,
     format('72.1: biaya Eksternal %s, harusnya 175000', v_eksternal);
   assert v_intern = 100000,
-    format('72.1: biaya Intern %s, harusnya 100000', v_intern);
+    format('72.1: biaya Internal %s, harusnya 100000', v_intern);
 
   foreach v_g in array array['penegak_pa', 'penegak_pi',
                              'penggalang_pa', 'penggalang_pi'] loop
@@ -56,7 +56,7 @@ begin
 
   foreach v_g in array array['intern_pa', 'intern_pi'] loop
     assert biaya_regu(v_g) = v_intern,
-      format('72.1: biaya_regu(%s) = %s, harusnya harga Intern %s',
+      format('72.1: biaya_regu(%s) = %s, harusnya harga Internal %s',
              v_g, biaya_regu(v_g), v_intern);
   end loop;
 end $$;
@@ -91,14 +91,14 @@ begin
 
   select hasil into strict v from uji72 where label = 'int';
   assert (v ->> 'total_tagihan')::int = 3 * v_intern,
-    format('72.2: tagihan 3 regu Intern %s, harusnya %s',
+    format('72.2: tagihan 3 regu Internal %s, harusnya %s',
            v ->> 'total_tagihan', 3 * v_intern);
 end $$;
 
 -- ---------------------------------------------------------------------------
 -- 72.3 Batch campuran: di sinilah perkalian lama dan penjumlahan baru berbeda.
 --
---      Dua Eksternal + dua Intern. Perkalian lama memberi 4 x Eksternal, dan
+--      Dua Eksternal + dua Internal. Perkalian lama memberi 4 x Eksternal, dan
 --      pesan gagalnya menyebutkan angka itu supaya siapa pun yang membuat tes
 --      ini merah tahu persis apa yang kembali.
 -- ---------------------------------------------------------------------------
@@ -201,7 +201,7 @@ begin
   where pendaftaran_id = v_id and nama_regu = 'Ujibiaya Bataltiga';
 
   assert tagihan_pendaftaran(v_id) = 2 * v_eksternal,
-    format('72.5: regu Intern yang dibatalkan masih ditagih — %s, harusnya %s',
+    format('72.5: regu Internal yang dibatalkan masih ditagih — %s, harusnya %s',
            tagihan_pendaftaran(v_id), 2 * v_eksternal);
 
   assert verifikasi_pembayaran(v_kode, 2 * v_eksternal, 'tunai')
@@ -225,7 +225,7 @@ begin
   assert v.biaya_per_regu = 175000,
     format('72.6: anon membaca biaya Eksternal %s', v.biaya_per_regu);
   assert v.biaya_per_regu_intern = 100000,
-    format('72.6: anon membaca biaya Intern %s', v.biaya_per_regu_intern);
+    format('72.6: anon membaca biaya Internal %s', v.biaya_per_regu_intern);
 end $$;
 
 reset role;

--- a/tests/sql/78_deret_nomor_dada_intern.sql
+++ b/tests/sql/78_deret_nomor_dada_intern.sql
@@ -3,7 +3,7 @@
 -- Dua deret nomor dada, dan KEDUA pintu yang memberi nomor harus menjaganya.
 --
 -- Kain nomor dada dicetak dalam dua set yang sama-sama mulai dari 001, jadi
--- Intern diketik 1001-1250. Yang diuji di sini bukan bahwa nomornya tersimpan
+-- Internal diketik 1001-1250. Yang diuji di sini bukan bahwa nomornya tersimpan
 -- — itu sudah dijaga unique sejak 0001 — melainkan bahwa nomor dari deret yang
 -- SALAH ditolak, dan bahwa pesannya menyebut deret yang benar. Petugas yang
 -- salah ketik butuh tahu harus mengetik apa.
@@ -13,7 +13,7 @@
 -- Menutup yang pertama saja meninggalkan pintu samping yang terbuka lebar.
 -- ============================================================================
 
-\echo '--- 78. dua deret nomor dada: Eksternal dan Intern'
+\echo '--- 78. dua deret nomor dada: Eksternal dan Internal'
 \set ON_ERROR_STOP on
 
 begin;
@@ -39,10 +39,10 @@ begin
   -- ---------------------------------------------------------------------
   assert (select intern_mulai = 1001 and intern_sampai = 1250
           from v_rentang_nomor_dada),
-    '78.0 GAGAL: stok Intern bukan 1001-1250';
+    '78.0 GAGAL: stok Internal bukan 1001-1250';
   assert (select eksternal_sampai < 1001 and eksternal_mulai = 1
           from v_rentang_nomor_dada),
-    '78.0 GAGAL: deret Eksternal bocor ke wilayah Intern';
+    '78.0 GAGAL: deret Eksternal bocor ke wilayah Internal';
 
   -- Nomor bebas dari masing-masing deret. Diambil dari stok, bukan ditulis
   -- angkanya: tes yang mematok 7 dan 1001 akan gugur setiap kali fixture di
@@ -74,23 +74,23 @@ begin
   returning id into v_regu_intern;
 
   -- ---------------------------------------------------------------------
-  -- 78.1 Regu Intern + nomor Eksternal: DITOLAK, dan pesannya menyebut
+  -- 78.1 Regu Internal + nomor Eksternal: DITOLAK, dan pesannya menyebut
   --      1001-1250. Inilah kekeliruan yang benar-benar akan terjadi di meja
-  --      — kain Intern bertulis 001, dan mengetik apa yang terbaca adalah
+  --      — kain Internal bertulis 001, dan mengetik apa yang terbaca adalah
   --      hal paling wajar sedunia.
   -- ---------------------------------------------------------------------
   v_tolak := false;
   begin
     perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
       jsonb_build_object('regu_id', v_regu_intern, 'nomor_dada', v_eks)));
-    raise exception 'GAGAL: regu Intern menerima nomor dari deret Eksternal (%)', v_eks;
+    raise exception 'GAGAL: regu Internal menerima nomor dari deret Eksternal (%)', v_eks;
   exception when others then
     if sqlerrm like 'GAGAL:%' then raise; end if;
     v_tolak := true; v_pesan := sqlerrm;
   end;
-  assert v_tolak, '78.1 GAGAL: nomor Eksternal untuk regu Intern tidak ditolak';
+  assert v_tolak, '78.1 GAGAL: nomor Eksternal untuk regu Internal tidak ditolak';
   assert v_pesan like '%1001 - 1250%',
-    format('78.1 GAGAL: pesan tidak menyebut deret Intern yang benar: %s', v_pesan);
+    format('78.1 GAGAL: pesan tidak menyebut deret Internal yang benar: %s', v_pesan);
   assert v_pesan like '%intern%',
     format('78.1 GAGAL: pesan tidak menyebut deret mana yang dimaksud: %s', v_pesan);
 
@@ -103,26 +103,26 @@ begin
   perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
     jsonb_build_object('regu_id', v_regu_intern, 'nomor_dada', v_intern)));
   assert (select nomor_dada = v_intern from regu where id = v_regu_intern),
-    '78.2 GAGAL: nomor Intern yang sah ikut ditolak';
+    '78.2 GAGAL: nomor Internal yang sah ikut ditolak';
 
   -- ---------------------------------------------------------------------
   -- 78.3 Arah sebaliknya. Aturannya satu kalimat dibaca dari dua sisi, jadi
   --      menguji satu sisi saja membiarkan separuhnya tanpa kursi.
   -- ---------------------------------------------------------------------
   insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
-  values (v_daftar, 'DERET EKSTERN UJI', 'Ketua Uji', 'penggalang_pa')
+  values (v_daftar, 'DERET EKSTERNAL UJI', 'Ketua Uji', 'penggalang_pa')
   returning id into v_regu_ext;
 
   v_tolak := false;
   begin
     perform * from daftar_ulang_batch('UJI-DERET-0116', jsonb_build_array(
       jsonb_build_object('regu_id', v_regu_ext, 'nomor_dada', v_intern_lain)));
-    raise exception 'GAGAL: regu Eksternal menerima nomor dari deret Intern (%)', v_intern_lain;
+    raise exception 'GAGAL: regu Eksternal menerima nomor dari deret Internal (%)', v_intern_lain;
   exception when others then
     if sqlerrm like 'GAGAL:%' then raise; end if;
     v_tolak := true; v_pesan := sqlerrm;
   end;
-  assert v_tolak, '78.3 GAGAL: nomor Intern untuk regu Eksternal tidak ditolak';
+  assert v_tolak, '78.3 GAGAL: nomor Internal untuk regu Eksternal tidak ditolak';
   assert v_pesan like '%eksternal%',
     format('78.3 GAGAL: pesan tidak menyebut deret Eksternal: %s', v_pesan);
 
@@ -132,13 +132,13 @@ begin
     '78.3 GAGAL: nomor Eksternal yang sah ikut ditolak';
 
   -- ---------------------------------------------------------------------
-  -- 78.4 Pintu kedua: tukar kain sobek. Regu Intern tidak boleh berpindah ke
+  -- 78.4 Pintu kedua: tukar kain sobek. Regu Internal tidak boleh berpindah ke
   --      deret Eksternal lewat jalur ini.
   -- ---------------------------------------------------------------------
   v_tolak := false;
   begin
     perform tukar_nomor_dada(v_regu_intern, v_eks_lain, 'uji 78: kain sobek');
-    raise exception 'GAGAL: tukar memindahkan regu Intern ke deret Eksternal (%)', v_eks_lain;
+    raise exception 'GAGAL: tukar memindahkan regu Internal ke deret Eksternal (%)', v_eks_lain;
   exception when others then
     if sqlerrm like 'GAGAL:%' then raise; end if;
     v_tolak := true; v_pesan := sqlerrm;
@@ -147,14 +147,14 @@ begin
   assert v_pesan like '%1001 - 1250%',
     format('78.4 GAGAL: pesan tukar tidak menyebut deret yang benar: %s', v_pesan);
 
-  -- 78.5 Tukar ke sesama deret Intern tetap jalan — pagarnya menyaring deret,
+  -- 78.5 Tukar ke sesama deret Internal tetap jalan — pagarnya menyaring deret,
   --      bukan mematikan penukaran.
   perform tukar_nomor_dada(v_regu_intern, v_intern_lain, 'uji 78: kain sobek');
   assert (select nomor_dada = v_intern_lain from regu where id = v_regu_intern),
-    '78.5 GAGAL: tukar sesama deret Intern ikut ditolak';
+    '78.5 GAGAL: tukar sesama deret Internal ikut ditolak';
 
   perform set_config('app.uid', '', true);
-  raise notice '78 OK — Eksternal % / %, Intern % / % diuji dua arah, dua pintu.',
+  raise notice '78 OK — Eksternal % / %, Internal % / % diuji dua arah, dua pintu.',
                v_eks, v_eks_lain, v_intern, v_intern_lain;
 end;
 $blok$;

--- a/tests/sql/79_dada_empat_digit.sql
+++ b/tests/sql/79_dada_empat_digit.sql
@@ -33,7 +33,7 @@ begin
    where s.nomor >= 1001
      and not exists (select 1 from regu r where r.nomor_dada = s.nomor)
      and not exists (select 1 from nomor_dada_pensiun p where p.nomor = s.nomor);
-  assert v_nomor >= 1001, '79.0: tidak ada nomor Intern bebas di stok';
+  assert v_nomor >= 1001, '79.0: tidak ada nomor Internal bebas di stok';
 
   -- Kloter kosong yang belum berangkat, dan tidak boleh ada kloter berisi
   -- sebelum ia — `berangkatkan_kloter` menolak yang melompati.

--- a/tests/sql/81_migrasi_terlewat.sql
+++ b/tests/sql/81_migrasi_terlewat.sql
@@ -22,7 +22,7 @@ do $blok$
 declare
   v_jumlah int;
 begin
-  -- 81.1 (0091) Golongan Intern sah di tabel regu. Inilah yang gagal di
+  -- 81.1 (0091) Golongan Internal sah di tabel regu. Inilah yang gagal di
   -- lapangan: constraint 0001 hanya mengenal empat golongan eksternal.
   assert exists (select 1 from pg_constraint
                  where conname = 'regu_golongan_check'
@@ -34,7 +34,7 @@ begin
                    and pg_get_constraintdef(oid) like '%intern_pa%'),
     '81.1 GAGAL: wahana_golongan_check belum mengenal golongan intern';
 
-  -- 81.2 (0091) Sebuah regu Intern benar-benar bisa masuk, bukan hanya lolos
+  -- 81.2 (0091) Sebuah regu Internal benar-benar bisa masuk, bukan hanya lolos
   -- pembacaan constraint. Di-rollback supaya tidak meninggalkan baris uji.
   assert exists (select 1 from pendaftaran),
     '81.2 GAGAL: tidak ada pendaftaran untuk disisipi — tes ini akan lulus '
@@ -45,31 +45,31 @@ begin
     from pendaftaran limit 1;
     get diagnostics v_jumlah = row_count;
     assert v_jumlah = 1,
-      format('81.2 GAGAL: %s baris regu Intern masuk, seharusnya 1', v_jumlah);
+      format('81.2 GAGAL: %s baris regu Internal masuk, seharusnya 1', v_jumlah);
   exception when others then
     if sqlerrm like '81.2 GAGAL%' then raise; end if;
-    raise exception '81.2 GAGAL: regu Intern ditolak database — %', sqlerrm;
+    raise exception '81.2 GAGAL: regu Internal ditolak database — %', sqlerrm;
   end;
 
-  -- 81.3 (0091) Komponen Intern: lima Soal Tulis punya varian sendiri, dan
+  -- 81.3 (0091) Komponen Internal: lima Soal Tulis punya varian sendiri, dan
   -- komponen umum TIDAK otomatis berlaku bagi mereka.
   select count(*) into v_jumlah
   from wahana where edisi = edisi_aktif() and kode like '%\_intern';
   assert v_jumlah = 5,
-    format('81.3 GAGAL: varian wahana Intern ada %s, seharusnya 5', v_jumlah);
+    format('81.3 GAGAL: varian wahana Internal ada %s, seharusnya 5', v_jumlah);
 
   assert komponen_berlaku('intern', 'intern_pa'),
     '81.3 GAGAL: komponen bertanda intern tidak berlaku untuk Intern PA';
   assert not komponen_berlaku(null, 'intern_pa'),
-    '81.3 GAGAL: komponen umum ikut berlaku untuk Intern — lomba lapangan '
+    '81.3 GAGAL: komponen umum ikut berlaku untuk Internal — lomba lapangan '
     'akan muncul di lembar mereka';
 
-  -- 81.4 (0091) Klasemen Intern hanya Soal Tulis dikurangi penalti waktu.
+  -- 81.4 (0091) Klasemen Internal hanya Soal Tulis dikurangi penalti waktu.
   assert exists (select 1 from pg_class c
                  join pg_namespace n on n.oid = c.relnamespace
                  where n.nspname = 'public' and c.relname = 'v_total_skor'
                    and pg_get_viewdef(c.oid) like '%intern_pa%'),
-    '81.4 GAGAL: v_total_skor masih mengenakan penalti lapangan ke Intern';
+    '81.4 GAGAL: v_total_skor masih mengenakan penalti lapangan ke Internal';
 
   -- 81.5 (0098) Layar Keberangkatan hanya memegang hak `keberangkatan`.
   assert exists (select 1 from pg_proc p
@@ -107,7 +107,7 @@ begin
                  join pg_namespace n on n.oid = c.relnamespace
                  where n.nspname = 'public' and c.relname = 'v_kelengkapan_publik'
                    and pg_get_viewdef(c.oid) like '%intern_pa%'),
-    '81.9 GAGAL: v_kelengkapan_publik masih ikut menghitung regu Intern';
+    '81.9 GAGAL: v_kelengkapan_publik masih ikut menghitung regu Internal';
 
   -- 81.10 (0105) 75 kloter tersedia, dan barisnya benar-benar ada.
   select kloter_maks into v_jumlah from edisi where is_active;

--- a/tests/sql/82_nama_regu_tiga_huruf.sql
+++ b/tests/sql/82_nama_regu_tiga_huruf.sql
@@ -15,7 +15,7 @@
 -- Diuji untuk KEDUA jenis peserta. Constraint-nya memang tidak menyebut
 -- golongan, tetapi "berlaku untuk semua" adalah persis jenis kalimat yang
 -- benar saat ditulis dan diam-diam berhenti benar nanti — pos, kelengkapan,
--- dan penalti semuanya sudah pernah bercabang untuk Intern.
+-- dan penalti semuanya sudah pernah bercabang untuk Internal.
 --
 -- Dan constraint-nya NOT VALID: empat baris satu huruf yang sudah ada di
 -- produksi sengaja dibiarkan. Yang dijaga tes terakhir adalah bahwa
@@ -72,7 +72,7 @@ begin
              v_nama);
   end loop;
 
-  -- 82.3 Nama Intern yang cukup panjang tetap masuk — supaya 82.1 tidak
+  -- 82.3 Nama Internal yang cukup panjang tetap masuk — supaya 82.1 tidak
   -- lulus hanya karena golongan Intern kebetulan ditolak oleh hal lain.
   begin
     insert into regu (pendaftaran_id, nama_regu, nama_ketua, golongan)
@@ -82,8 +82,8 @@ begin
     v_diterima := false;
   end;
   assert v_diterima,
-    '82.3 GAGAL: regu Intern bernama "Cakrawala" ditolak — 82.1 tidak '
-    'membuktikan apa pun kalau semua Intern memang ditolak';
+    '82.3 GAGAL: regu Internal bernama "Cakrawala" ditolak — 82.1 tidak '
+    'membuktikan apa pun kalau semua Internal memang ditolak';
 
   -- 82.4 Constraint-nya NOT VALID: baris lama dibiarkan, baris baru tidak.
   -- Kalau suatu saat ia divalidasi, keempat nama satu huruf di produksi harus

--- a/tests/sql/92_peserta_terbanyak_eksternal.sql
+++ b/tests/sql/92_peserta_terbanyak_eksternal.sql
@@ -35,7 +35,7 @@ begin
   reset role;
 
   assert v_pemenang = 'SEKOLAH EKSTERNAL UJI 92',
-    format('92 GAGAL: dua regu Intern ikut dihitung; pemenang = %s', v_pemenang);
+    format('92 GAGAL: dua regu Internal ikut dihitung; pemenang = %s', v_pemenang);
 
   delete from regu where pendaftaran_id in (v_daftar_eksternal, v_daftar_intern);
   delete from pendaftaran where id in (v_daftar_eksternal, v_daftar_intern);

--- a/tests/sql/93_kejuaraan_tanpa_intern.sql
+++ b/tests/sql/93_kejuaraan_tanpa_intern.sql
@@ -29,9 +29,9 @@ begin
 
   begin
     perform simpan_kejuaraan_manual('kostum', v_intern);
-    assert false, '93.1 GAGAL: regu Intern dapat dipilih';
+    assert false, '93.1 GAGAL: regu Internal dapat dipilih';
   exception when others then
-    assert sqlerrm like '%termasuk Intern',
+    assert sqlerrm like '%termasuk Internal',
       format('93.1 GAGAL: penolakannya salah: %s', sqlerrm);
   end;
 

--- a/tests/sql/94_simulasi_pemenang_kejuaraan.sql
+++ b/tests/sql/94_simulasi_pemenang_kejuaraan.sql
@@ -1,4 +1,4 @@
--- Simulasi 24 pemenang Eksternal dan 12 regu Intern. Dua sekolah Penegak
+-- Simulasi 24 pemenang Eksternal dan 12 regu Internal. Dua sekolah Penegak
 -- sengaja sama-sama mendapat lima gelar agar bobot Juara I-Harapan III diuji;
 -- sekolah Juara Umum tetap ditentukan pertama-tama dari jumlah gelar.
 
@@ -111,7 +111,7 @@ cross join lateral (
     and kode = 'kepramukaan_keagamaan'
 ) w;
 
--- Intern sengaja mendapat nilai Pos 5 sempurna; satu-satunya nilai Pos 5
+-- Internal sengaja mendapat nilai Pos 5 sempurna; satu-satunya nilai Pos 5
 -- Eksternal hanya 50. Juara Yel-Yel tetap harus jatuh ke nomor 301.
 insert into nilai_mentah
   (regu_id, wahana_id, nilai_1, nilai_2, source, created_by)
@@ -162,12 +162,12 @@ begin
   select nomor_dada into v_nomor from hasil_simulasi_kejuaraan
   where kode = 'yel_yel';
   assert v_nomor = 301,
-    format('94.5 GAGAL: Intern memengaruhi Juara Yel-Yel; nomor dada = %s', v_nomor);
+    format('94.5 GAGAL: Internal memengaruhi Juara Yel-Yel; nomor dada = %s', v_nomor);
 
   select count(*) into v_salah from hasil_simulasi_kejuaraan
   where golongan like 'intern_%';
   assert v_salah = 0,
-    format('94.6 GAGAL: %s gelar diberikan kepada Intern', v_salah);
+    format('94.6 GAGAL: %s gelar diberikan kepada Internal', v_salah);
 end;
 $blok$;
 

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=61">
+  <link rel="stylesheet" href="style.css?v=62">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -886,13 +886,13 @@ export async function lembarPos(pos) {
  *  yang mungkin muncul di kotak penilaian. */
 /** Kedua deret nomor dada, dari `v_rentang_nomor_dada` (migrasi 0116).
  *
- *  Kain nomor dada dicetak dua set yang sama-sama mulai dari 001, jadi Intern
+ *  Kain nomor dada dicetak dua set yang sama-sama mulai dari 001, jadi Internal
  *  diketik 1001-1250 sementara Eksternal tetap 1-500. Yang dibaca di sini
  *  UJUNG-UJUNGNYA saja, bukan seluruh 750 baris stok: layar cuma perlu tahu
  *  nomor mana milik deret mana, dan meja daftar ulang bekerja di jaringan
  *  yang sama dengan lima pos.
  *
- *  Nol berarti deretnya kosong — stok Intern yang belum pernah diisi admin.
+ *  Nol berarti deretnya kosong — stok Internal yang belum pernah diisi admin.
  *  Layar yang memakainya harus tetap jalan dalam keadaan itu, bukan menolak
  *  semua nomor. */
 export async function rentangNomorDada() {
@@ -960,7 +960,7 @@ export const simpanKejuaraanTerjauh = (sekolahId) =>
 
 /* ========================== FOTO BUKU SAKTI ============================= */
 
-/* Gambar contoh di dalam Buku Sakti: kain nomor dada Intern, blangko A5, rupa
+/* Gambar contoh di dalam Buku Sakti: kain nomor dada Internal, blangko A5, rupa
    satu layar. Bucket-nya `buku` dan sengaja PUBLIK, tidak seperti `lembar` dan
    `bukti` yang privat dan dilayani lewat tautan bertanda tangan.
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -745,7 +745,7 @@ async function layarPengaturanKloter() {
                  min="0" value="${eksternalAwal}">
         </div>
         <div class="field">
-          <label for="kloter-jumlah-intern">Regu Intern</label>
+          <label for="kloter-jumlah-intern">Regu Internal</label>
           <input type="number" id="kloter-jumlah-intern" inputmode="numeric"
                  min="0" value="${internAwal}">
         </div>
@@ -760,7 +760,7 @@ async function layarPengaturanKloter() {
           <thead><tr>
             <th>Kloter</th>
             <th>Eksternal</th>
-            <th>Intern</th>
+            <th>Internal</th>
             <th>Waktu Berangkat</th>
           </tr></thead>
           <tbody id="kloter-rekomendasi-baris"></tbody>
@@ -1257,7 +1257,7 @@ async function layarDataPeserta() {
         saringan: [
           { kode: "semua", label: "Semua" },
           { kode: "eksternal", label: "Eksternal", pendek: "Luar" },
-          { kode: "intern", label: "Intern" },
+          { kode: "intern", label: "Internal" },
         ],
         saringAktif: "semua",
         jumlah: semua.length,
@@ -1359,7 +1359,7 @@ async function layarDataPeserta() {
      dari kelima, bukan orang keenam. Kotak "Anggota 5" karena itu tidak ada —
      constraint regu_anggota_maks_empat menolaknya.
 
-     Kelas hanya untuk regu Intern; regu Eksternal dibedakan oleh sekolahnya
+     Kelas hanya untuk regu Internal; regu Eksternal dibedakan oleh sekolahnya
      dan kotaknya tidak digambar sama sekali. */
   const barisRegu = (r, i) => {
     const id = esc(r.id);
@@ -1548,7 +1548,7 @@ async function layarPembayaran() {
 
     tbody.replaceChildren(h(baris.map(b => {
       const aktif = reguAktif(b);
-      // PENJUMLAHAN per regu, bukan perkalian: regu Intern berharga lain
+      // PENJUMLAHAN per regu, bukan perkalian: regu Internal berharga lain
       // (migrasi 0110), dan satu pendaftaran boleh memuat kedua jenis.
       // Angka ini dikirim apa adanya sebagai nominal ke verifikasi_pembayaran,
       // yang menghitung ulang dengan rumus yang sama di server dan menolak
@@ -1903,7 +1903,7 @@ function cetakKwitansi(daftar) {
            · <strong>Cara bayar:</strong> ${esc(bayar.method || "—")}<br>
            <span class="receipt-date"><strong>Tanggal:</strong>
              ${esc(tanggal(bayar.verified_at))}</span></p>
-        <!-- Dulu baris ini berbunyi "N regu @ Rp X". Sejak regu Intern punya
+        <!-- Dulu baris ini berbunyi "N regu @ Rp X". Sejak regu Internal punya
              harganya sendiri (migrasi 0110) tidak ada lagi SATU harga satuan
              yang benar untuk setiap batch, dan menuliskan salah satunya di
              kwitansi yang dipegang pembina lebih buruk daripada tidak
@@ -2090,7 +2090,7 @@ async function layarDaftarUlang() {
                      style.css. -->
                 <tr><th>Regu</th><th>Kategori</th><th>Ketua</th>
                     <th>Nomor dada${deretIntern(menunggu) && rentang
-                      ? `<span class="sub">Intern ${rentang.internMulai}–${rentang.internSampai}</span>`
+                      ? `<span class="sub">Internal ${rentang.internMulai}–${rentang.internSampai}</span>`
                       : ""}</th>
                     <th class="kol-imbang"></th></tr>
               </thead>
@@ -2199,8 +2199,8 @@ async function layarDaftarUlang() {
     // berikutnya, dan di regu terakhir langsung menyimpan — satu sekolah
     // selesai tanpa memegang mouse.
     // Deret yang salah memerah SAMBIL DIKETIK, tidak menunggu tombol Simpan.
-    // Kain Intern bertulis 001 sama seperti kain Eksternal, jadi mengetik tiga
-    // angka untuk regu Intern adalah kekeliruan yang paling mungkin terjadi di
+    // Kain Internal bertulis 001 sama seperti kain Eksternal, jadi mengetik tiga
+    // angka untuk regu Internal adalah kekeliruan yang paling mungkin terjadi di
     // meja — dan menahannya sampai Simpan berarti petugas sudah mengetik
     // sepuluh nomor sebelum tahu yang pertama salah.
     const tandaiDeret = (inp) => {
@@ -2254,7 +2254,7 @@ async function layarDaftarUlang() {
             keluhan = keluhan || `Nomor ${angka} diketik untuk dua regu.`;
             continue;
           }
-          // Kain Intern bertulis 001 sama seperti kain Eksternal, dan
+          // Kain Internal bertulis 001 sama seperti kain Eksternal, dan
           // mengetik apa yang terbaca adalah hal paling wajar sedunia —
           // karena itu yang ditolak di sini bukan salah ketik, melainkan
           // kekeliruan yang PASTI terjadi kalau tidak ditolak.
@@ -2762,7 +2762,7 @@ async function layarKeberangkatan() {
  *  `Number(value)`, dan `Number("001")` tetap 1 — tidak ada satu pun
  *  pencarian, penyimpanan, atau perbandingan yang perlu tahu soal ini.
  *
- *  Nomor Intern empat digit tidak dipotong: dada3() melewatkan apa pun di atas
+ *  Nomor Internal empat digit tidak dipotong: dada3() melewatkan apa pun di atas
  *  999 apa adanya (migrasi 0116), jadi 1000 tetap 1000.
  *
  *  ANGKA NOL MENGOSONGKAN KOTAKNYA, dan itu bukan kebetulan melainkan
@@ -2856,7 +2856,7 @@ async function layarCetakKloter() {
         <thead>
           <tr>
             <th>Total Kloter</th><th>Total Regu</th>
-            <th>Eksternal</th><th>Intern</th>
+            <th>Eksternal</th><th>Internal</th>
           </tr>
         </thead>
         <tbody>
@@ -9132,7 +9132,7 @@ async function gambarLombaNilai(l) {
    *  varianUntuk() yang memilihnya, sama seperti layar lama — Tebak Simpul
    *  punya empat baris wahana dan regu ini cuma berhak atas satu. Lomba yang
    *  tidak punya varian untuk golongan itu bukan konfigurasi rusak: lomba
-   *  lapangan memang tidak berlaku untuk regu Intern (migrasi 0091). */
+   *  lapangan memang tidak berlaku untuk regu Internal (migrasi 0091). */
   function gambarIsian(r) {
     const dipakai = l.kolom
       .map(kol => ({ kol, k: varianUntuk(kol, r.golongan) }))

--- a/web/js/buku-sakti.mjs
+++ b/web/js/buku-sakti.mjs
@@ -55,7 +55,7 @@
    dimuat, karena buku panduan paling dibutuhkan saat ada yang rusak.
 
    Akibatnya satu: tulis keterangannya supaya utuh dibaca TANPA gambarnya.
-   "Contoh: kain Intern bertulis 1001, angka 1 di depan ikut disablon" bekerja
+   "Contoh: kain Internal bertulis 1001, angka 1 di depan ikut disablon" bekerja
    di dua keadaan; "Contoh: seperti di gambar" tidak bekerja di satu pun.
 
    SATU BAB PUNYA DUA NAMA, dan keduanya wajib.
@@ -203,14 +203,14 @@ const BAB_TUTORIAL = {
         },
         {
           jenis: "p",
-          teks: "Yang pertama dan paling sering keliru: nomor dada punya DUA deret, dan keduanya dipakai berdampingan di lomba yang sama. Regu Eksternal dan regu Intern dinilai di pos yang sama, oleh juri yang sama, di blangko yang sama.",
+          teks: "Yang pertama dan paling sering keliru: nomor dada punya DUA deret, dan keduanya dipakai berdampingan di lomba yang sama. Regu Eksternal dan regu Internal dinilai di pos yang sama, oleh juri yang sama, di blangko yang sama.",
         },
         {
           jenis: "tabel",
           kepala: ["Deret", "Angka di sistem", "Yang harus tertulis di kain"],
           baris: [
             ["Eksternal", "1 sampai 500", "sama persis dengan angka di sistem"],
-            ["Intern", "1001 sampai 1250", "1001, bukan 001; angka 1 di depan ikut disablon"],
+            ["Internal", "1001 sampai 1250", "1001, bukan 001; angka 1 di depan ikut disablon"],
           ],
         },
         {
@@ -220,15 +220,15 @@ const BAB_TUTORIAL = {
         {
           jenis: "foto",
           berkas: "kain-nomor-dada-dua-deret.jpg",
-          teks: "Contoh: dua kain berdampingan. Yang kiri Eksternal, angkanya polos. Yang kanan Intern, angka 1 di depan ikut disablon jadi 1001 — bukan 001.",
+          teks: "Contoh: dua kain berdampingan. Yang kiri Eksternal, angkanya polos. Yang kanan Internal, angka 1 di depan ikut disablon jadi 1001 — bukan 001.",
         },
         {
           jenis: "poin",
           butir: [
-            "Kain Intern yang polos bertulis 001 melahirkan blangko yang ambigu: juri menyalin apa yang dilihatnya di dada regu, dan 001 bisa dibaca sebagai Eksternal 1. Tidak ada satu baris SQL pun yang bisa memulihkan blangko seperti itu, karena kertasnya tidak menyimpan nama regu.",
+            "Kain Internal yang polos bertulis 001 melahirkan blangko yang ambigu: juri menyalin apa yang dilihatnya di dada regu, dan 001 bisa dibaca sebagai Eksternal 1. Tidak ada satu baris SQL pun yang bisa memulihkan blangko seperti itu, karena kertasnya tidak menyimpan nama regu.",
             "Blangko penilaian memang HANYA memuat nomor dada, tanpa nama regu. Satu angka yang salah memindahkan seluruh nilai satu regu ke regu lain, dan tidak ada apa pun di kertas yang memperlihatkannya.",
             "Nomor yang ditukar karena kainnya rusak DIPENSIUNKAN permanen. Kalau petugas pos melihat nomor yang sudah pensiun di lapangan, itu dilaporkan ke Sekretariat, bukan dinilai diam-diam.",
-            "Penalti pos terlewat dan penalti anggota TIDAK berlaku bagi regu Intern. Umumkan ini sebelum papan dibaca, kalau tidak ada yang menyimpulkan sistemnya salah hitung.",
+            "Penalti pos terlewat dan penalti anggota TIDAK berlaku bagi regu Internal. Umumkan ini sebelum papan dibaca, kalau tidak ada yang menyimpulkan sistemnya salah hitung.",
             "Samakan jam tangan seluruh panitia ke satu jam acuan pada apel pagi. Jam berangkat dan jam datang diketik dari jam sungguhan, dan penaltinya satu poin per menit ke dua arah. Dua jam tangan yang selisih tiga menit berarti tiga poin bagi regu yang tidak salah apa-apa.",
           ],
         },
@@ -255,7 +255,7 @@ const BAB_TUTORIAL = {
           nama: "Kalkulator Keberangkatan",
           hash: "#/pengaturan-kloter",
           fitur: "pengaturan",
-          teks: "Isi Waktu Berangkat Pertama, Waktu Berangkat Terakhir, jumlah regu Eksternal dan Intern; layar ini menghitung rekomendasi berapa kloter yang terbentuk beserta jam berangkat tiap kloter. Dipakai untuk memastikan seluruh kloter masih masuk jendela sebelum angkanya dikunci.",
+          teks: "Isi Waktu Berangkat Pertama, Waktu Berangkat Terakhir, jumlah regu Eksternal dan Internal; layar ini menghitung rekomendasi berapa kloter yang terbentuk beserta jam berangkat tiap kloter. Dipakai untuk memastikan seluruh kloter masih masuk jendela sebelum angkanya dikunci.",
         },
         {
           jenis: "langkah",
@@ -264,7 +264,7 @@ const BAB_TUTORIAL = {
             "Tetapkan jendela keberangkatan 07:00 sampai 10:00 dan jeda MAKSIMAL antar keberangkatan 5 menit sebagai konfigurasi edisi, bukan sebagai angka tetap. Jeda itu batas atas: kalau kloternya sedikit, yang terakhir berangkat jauh sebelum ujung jendela.",
             "Isi daftar pos, lomba, dan penilaian beserta poin maksimalnya. Bobot sebuah pos tidak pernah ditulis di mana pun: ia adalah jumlah poin maksimal seluruh wahana di pos itu.",
             "Isi pilihan kontrak waktu (3 jam, 3,5 jam, 4 jam) dan konfigurasi penalti.",
-            "Isi stok nomor dada dua deret: Eksternal 1 sampai 500, Intern 1001 sampai 1250.",
+            "Isi stok nomor dada dua deret: Eksternal 1 sampai 500, Internal 1001 sampai 1250.",
             "Buka Kalkulator Keberangkatan dan pastikan kloter terakhir masih berangkat sebelum 10:00.",
             "Sesudah PR mendarat, jalankan workflow Apply migration to Supabase untuk tiap berkas migration, satu per satu, lalu baca notice yang keluar.",
             "Jalankan supabase/checks/status_migrasi.sql lewat workflow yang sama untuk membuktikan migration-nya benar-benar hidup di database.",
@@ -272,7 +272,7 @@ const BAB_TUTORIAL = {
         },
         {
           jenis: "kenapa",
-          teks: "Migration tidak pernah ikut merge. Berkas yang di-merge tapi tidak pernah dijalankan tidak menimbulkan satu galat pun: CI tetap hijau dan layar tetap menyala. Sepuluh migration pernah menganggur enam hari seperti itu, dan yang menemukannya adalah seorang pembina yang ditolak saat mendaftarkan regu Intern.",
+          teks: "Migration tidak pernah ikut merge. Berkas yang di-merge tapi tidak pernah dijalankan tidak menimbulkan satu galat pun: CI tetap hijau dan layar tetap menyala. Sepuluh migration pernah menganggur enam hari seperti itu, dan yang menemukannya adalah seorang pembina yang ditolak saat mendaftarkan regu Internal.",
         },
         {
           jenis: "poin",
@@ -492,8 +492,8 @@ const BAB_TUTORIAL = {
           jenis: "poin",
           butir: [
             "Nomor dada DIKETIK petugas, tidak diterbitkan sistem. Sistem hanya memeriksa: ada di stok, belum dipensiunkan, belum dipakai, dan berada di deret yang benar.",
-            "Ada DUA deret. Eksternal 1 sampai 500. Intern 1001 sampai 1250.",
-            "Kain Intern bertulis 001 diketik 1001, dan angka 1001 itulah yang tampil di seluruh layar, kertas, dan papan peserta. Kain barunya diberi angka 1 di depan supaya tidak ada terjemahan di kepala siapa pun.",
+            "Ada DUA deret. Eksternal 1 sampai 500. Internal 1001 sampai 1250.",
+            "Kain Internal bertulis 001 diketik 1001, dan angka 1001 itulah yang tampil di seluruh layar, kertas, dan papan peserta. Kain barunya diberi angka 1 di depan supaya tidak ada terjemahan di kepala siapa pun.",
             "Kloter ditentukan SISTEM saat nomor dada tersimpan. Petugas tidak memilih kloter di layar ini.",
             "Tidak ada tanda tangan dan tidak ada centang konfirmasi di sistem. Konsekuensinya tidak ada catatan siapa mengonfirmasi apa dan kapan, jadi konfirmasi lisannya harus benar-benar dilakukan.",
           ],
@@ -522,7 +522,7 @@ const BAB_TUTORIAL = {
         {
           jenis: "poin",
           butir: [
-            "Kuota otomatis per kloter: 5 Eksternal dan 3 Intern, dihitung TERPISAH.",
+            "Kuota otomatis per kloter: 5 Eksternal dan 3 Internal, dihitung TERPISAH.",
             "Urutannya FIFO murni. Yang lebih dahulu menyelesaikan daftar ulang mendapat kloter lebih awal.",
             "Sekolah tidak memengaruhi apa pun. Tidak ada pengacakan dan tidak ada lompatan kloter. Dua regu satu sekolah boleh sekloter kalau memang FIFO menempatkan mereka di sana.",
             "Pengacakan otomatis MELEWATI kloter yang sudah berangkat. Tanda cetak tidak menutup kloter untuk penambahan regu.",
@@ -770,7 +770,7 @@ const BAB_TUTORIAL = {
           butir: [
             "Jam datang adalah jam saat tombol ditekan di laptop panitia, BUKAN timestamp server saat datanya sampai. Kalau server yang menandai waktunya sendiri, regu yang dicatat dua puluh menit setelah tiba dihukum atas keterlambatan yang tidak pernah terjadi.",
             "Karena itu jam datang tetap boleh diubah manual untuk pencatatan susulan dari kertas.",
-            "Penalti pos terlewat dan penalti anggota TIDAK berlaku bagi regu Intern.",
+            "Penalti pos terlewat dan penalti anggota TIDAK berlaku bagi regu Internal.",
             "Regu yang belum tercatat tiba tetap tampil di Live Score tanpa peringkat, tidak bisa masuk enam besar, dan tidak dikenai pengurangan apa pun. Ia hilang dari klasemen resmi tanpa satu galat pun muncul.",
           ],
         },
@@ -1215,7 +1215,7 @@ const BAB_SEKSI = {
         {
           jenis: "poin",
           butir: [
-            "Menetapkan tanggal lomba dan biaya pendaftaran per regu, DUA angka, satu untuk Eksternal dan satu untuk Intern.",
+            "Menetapkan tanggal lomba dan biaya pendaftaran per regu, DUA angka, satu untuk Eksternal dan satu untuk Internal.",
             "Menunjuk koordinator tiap seksi, dan menunjuk seksi mana yang memegang akun admin.",
             "Memutuskan yang tidak boleh diputuskan petugas meja: pembatalan keberangkatan, penyisipan regu terlambat ke kloter, dan sanksi.",
             "Memutuskan kapan fase live dinaikkan, lalu memberitahukannya ke pemegang admin, bukan sebaliknya.",
@@ -1652,7 +1652,7 @@ const BAB_SEKSI = {
           butir: [
             "Mengurus izin dan pembagian ruang barak, memisahkan putra dan putri, dan menempel denahnya.",
             "Menyediakan alat tiap lomba sesuai daftar Koordinator Lapangan, beserta cadangannya.",
-            "Menyiapkan nomor dada kain dua deret sesuai stok yang dipasang di sistem: Eksternal polos, Intern disablon 1001 ke atas dan bukan 001.",
+            "Menyiapkan nomor dada kain dua deret sesuai stok yang dipasang di sistem: Eksternal polos, Internal disablon 1001 ke atas dan bukan 001.",
             "Menyiapkan tiska sejumlah PESERTA beserta cadangan, dan menyerahkannya ke meja daftar ulang, bukan ke garis finish. Tiska bukti keikutsertaan, jadi hitungannya per kepala, bukan per regu.",
             "Menggandakan blangko di mesin fotokopi. Yang dicetak dari layar cuma satu master per lomba, bukan setumpuk.",
             "Menyiapkan piala dan hadiah, dan memastikan namanya sesuai kategori juara.",
@@ -2155,8 +2155,8 @@ const BAB_KENAPA = {
           jenis: "poin",
           butir: [
             "Ditolak sistem memberi nomor terkecil yang tersedia: petugas jadi harus mencari kain nomor tertentu di tumpukan, sementara antrean berdiri di depannya.",
-            "Sejak migration 0116 ada dua deret dari satu kunci yang sama: Eksternal 1 sampai 500, Intern 1001 sampai 1250.",
-            "Deret Intern itu keputusan pemilik acara, 27 Agustus 2026, dan ia menutup jalur sistemnya saja. Jalur kertasnya ikut menuntut. Kain Intern harus ditandai 1xxx, karena juri menyalin nomor dari kain di dada regu. Kain polos bertulis 001 menghasilkan blangko ambigu, dan itu tidak bisa dipulihkan satu baris SQL pun.",
+            "Sejak migration 0116 ada dua deret dari satu kunci yang sama: Eksternal 1 sampai 500, Internal 1001 sampai 1250.",
+            "Deret Internal itu keputusan pemilik acara, 27 Agustus 2026, dan ia menutup jalur sistemnya saja. Jalur kertasnya ikut menuntut. Kain Internal harus ditandai 1xxx, karena juri menyalin nomor dari kain di dada regu. Kain polos bertulis 001 menghasilkan blangko ambigu, dan itu tidak bisa dipulihkan satu baris SQL pun.",
             "Efek sampingnya menjatuhkan satu bug tidur: pemformat tiga digit memotong 1001 jadi 100. Diperbaiki di migration 0117.",
           ],
         },
@@ -2194,7 +2194,7 @@ const BAB_KENAPA = {
       isi: [
         {
           jenis: "p",
-          teks: "Pembagian kloter otomatis mengisi kloter paling awal yang belum berangkat, urut siapa yang lebih dulu menyelesaikan daftar ulang. Paling banyak 5 Eksternal dan 3 Intern per kloter, kuotanya dihitung terpisah. Sekolah tidak berpengaruh sama sekali. Tapi kloter yang kertasnya sudah dicetak TETAP boleh ditambah regu secara manual.",
+          teks: "Pembagian kloter otomatis mengisi kloter paling awal yang belum berangkat, urut siapa yang lebih dulu menyelesaikan daftar ulang. Paling banyak 5 Eksternal dan 3 Internal per kloter, kuotanya dihitung terpisah. Sekolah tidak berpengaruh sama sekali. Tapi kloter yang kertasnya sudah dicetak TETAP boleh ditambah regu secara manual.",
         },
         {
           jenis: "poin",
@@ -2617,7 +2617,7 @@ export const SPRINT = [
       { kode: "s2-tanggal", seksi: "Ketua Pelaksana", layar: null,
         teks: "TETAPKAN TANGGAL LOMBA bersama kepala sekolah dan pembina, lalu tulis di notulen. Seluruh tenggat di sprint berikutnya dihitung mundur dari tanggal ini." },
       { kode: "s2-tema", seksi: "Ketua Pelaksana", layar: null,
-        teks: "Tetapkan tema, kuota regu, dan biaya pendaftaran per regu, termasuk biaya regu Intern yang memang berbeda." },
+        teks: "Tetapkan tema, kuota regu, dan biaya pendaftaran per regu, termasuk biaya regu Internal yang memang berbeda." },
       { kode: "s2-rab", seksi: "Bendahara", layar: null,
         teks: "Susun anggaran kasar dan hitung titik impasnya dari uang pendaftaran SAJA. Acara harus tetap jalan kalau sponsor nol." },
       { kode: "s2-izin-prinsip", seksi: "Sekretaris", layar: null,
@@ -2727,7 +2727,7 @@ export const SPRINT = [
       { kode: "s5-edaran", seksi: "Humas", layar: null,
         teks: "Minta Kwartir Cabang menerbitkan surat edaran ke gudep SMP dan SMA se-kabupaten. Ini alat publikasi paling ampuh dan tidak berbiaya." },
       { kode: "s5-migrasi-edisi", seksi: "Sekretariat", layar: null,
-        teks: "Susun migration edisi baru: nomor, nama, tahun, tanggal lomba, biaya per regu Eksternal dan Intern, jam mulai dan batas berangkat, serta jeda maksimal antar kloter." },
+        teks: "Susun migration edisi baru: nomor, nama, tahun, tanggal lomba, biaya per regu Eksternal dan Internal, jam mulai dan batas berangkat, serta jeda maksimal antar kloter." },
       { kode: "s5-kalkulator", seksi: "Sekretariat", layar: "#/pengaturan-kloter",
         teks: "Buka Kalkulator Keberangkatan dan pastikan kloter terakhir masih berangkat sebelum jam sepuluh dengan perkiraan jumlah regu tahun ini." },
     ],
@@ -2853,13 +2853,13 @@ export const SPRINT = [
       { kode: "s9-medis", seksi: "Kesehatan", layar: null,
         teks: "Ajukan permohonan tenaga medis dan ambulans ke Puskesmas kecamatan dan PMI, lalu sepakati rumah sakit rujukan beserta nomor IGD-nya." },
       { kode: "s9-nomor-dada", seksi: "Akomodasi dan Logistik", layar: null,
-        teks: "Pesan kain nomor dada beserta cadangan sepuluh persen. Deret Intern disablon 1001 dan seterusnya, BUKAN 001, supaya angka yang disalin juri dari dada regu tidak bentrok dengan Eksternal. Sablon butuh dua minggu kerja. Kalau pendaftaran belum ditutup, pesan sejumlah KUOTA, bukan sejumlah pendaftar." },
+        teks: "Pesan kain nomor dada beserta cadangan sepuluh persen. Deret Internal disablon 1001 dan seterusnya, BUKAN 001, supaya angka yang disalin juri dari dada regu tidak bentrok dengan Eksternal. Sablon butuh dua minggu kerja. Kalau pendaftaran belum ditutup, pesan sejumlah KUOTA, bukan sejumlah pendaftar." },
       { kode: "s9-tiska", seksi: "Akomodasi dan Logistik", layar: null,
         teks: "Pesan tiska beserta cadangan. Hitungannya per PESERTA, bukan per regu, jadi angkanya berlipat kira-kira delapan kali jumlah regu — pastikan Bendahara memakai angka itu, bukan angka regu." },
       { kode: "s9-pinjam", seksi: "Akomodasi dan Logistik", layar: null,
         teks: "Kirim surat peminjaman tenda, terpal, meja-kursi, sound system, HT, genset, dan lampu sorot." },
       { kode: "s9-stok-dada", seksi: "Sekretariat", layar: null,
-        teks: "Samakan stok nomor dada di sistem dengan kain yang benar-benar dipesan: dua deret, Eksternal dan Intern. Pagar nomor dada membaca angkanya dari sana." },
+        teks: "Samakan stok nomor dada di sistem dengan kain yang benar-benar dipesan: dua deret, Eksternal dan Internal. Pagar nomor dada membaca angkanya dari sana." },
       { kode: "s9-danus-preorder", seksi: "Dana Usaha", layar: null,
         teks: "Tutup pre-order kaos dan merchandise sekarang, supaya barangnya jadi sebelum hari-H, bukan sesudahnya." },
     ],
@@ -2959,7 +2959,7 @@ export const SPRINT = [
       { kode: "s12-pasang-rambu", seksi: "Akomodasi dan Logistik", layar: null,
         teks: "Pasang penunjuk arah sehari sebelum acara, sore hari, jangan lebih awal. Rambu yang dipasang seminggu sebelumnya hilang, dicabut, atau berpindah arah." },
       { kode: "s12-daftar-ulang", seksi: "Sekretariat", layar: "#/daftar-ulang",
-        teks: "H-1: buka meja daftar ulang. Cari batch lewat kode pembayaran, isi nomor dada seluruh regu sekolah itu sekaligus, tukar nomor yang kainnya rusak, dan serahkan kain beserta tiskanya. Jangan menomori kloter sendiri: urutan FIFO dan kuota lima Eksternal serta tiga Intern dijaga di dalam sistem." },
+        teks: "H-1: buka meja daftar ulang. Cari batch lewat kode pembayaran, isi nomor dada seluruh regu sekolah itu sekaligus, tukar nomor yang kainnya rusak, dan serahkan kain beserta tiskanya. Jangan menomori kloter sendiri: urutan FIFO dan kuota lima Eksternal serta tiga Internal dijaga di dalam sistem." },
       { kode: "s12-cetak-kloter", seksi: "Sekretariat", layar: "#/cetak-kloter",
         teks: "Cetak Daftar Kloter untuk Petugas dan untuk Peserta sesudah seluruh regu bernomor dada, lalu tempel lembar peserta di barak dan titik kumpul malam itu juga." },
       { kode: "s12-berangkat", seksi: "Seksi Acara", layar: "#/keberangkatan",

--- a/web/js/departure-calculator.mjs
+++ b/web/js/departure-calculator.mjs
@@ -89,7 +89,7 @@ export function jadwalPlanning(nomorKloter, waktuPertama, waktuTerakhir,
 }
 
 /**
- * Isi kloter FIFO dengan kuota terpisah Eksternal dan Intern, lalu sebarkan
+ * Isi kloter FIFO dengan kuota terpisah Eksternal dan Internal, lalu sebarkan
  * jam K1 sampai kloter terakhir merata di seluruh jendela.
  */
 export function hitungRekomendasiKloter({

--- a/web/js/nomor-dada-series.mjs
+++ b/web/js/nomor-dada-series.mjs
@@ -5,13 +5,13 @@
    aturan yang sama bisa diuji di Node dan dipakai layar.
 
    Kain nomor dada dicetak dalam DUA set yang sama-sama mulai dari 001, jadi
-   Intern diketik 1001-1250 sementara Eksternal tetap 1-500. Batasnya tidak
+   Internal diketik 1001-1250 sementara Eksternal tetap 1-500. Batasnya tidak
    ditulis di berkas ini — ia datang dari `v_rentang_nomor_dada`, karena yang
    menyatakan "sampai berapa" adalah stok kain yang benar-benar dibawa
    panitia. Panitia tahun depan mengubah stoknya, bukan kodenya.
 
    Dipakai dua layar. Meja Daftar Ulang menolak nomor dari deret yang salah
-   sebelum dikirim — kain Intern bertulis 001 sama seperti kain Eksternal, dan
+   sebelum dikirim — kain Internal bertulis 001 sama seperti kain Eksternal, dan
    mengetik apa yang terbaca adalah hal paling wajar sedunia. Input Pos
    mencetak lembar cadangan hanya pada nomor yang benar-benar ada; tanpa itu
    ia mencetak 500 baris kosong di antara 500 dan 1001, nomor yang tidak
@@ -24,8 +24,8 @@
 
 export const golonganIntern = (golongan) => String(golongan || "").startsWith("intern_");
 
-/** Daftar regu ini memberi nomor kepada Intern? Satu pendaftaran selalu satu
- *  jenis peserta, jadi praktisnya ini "batch Intern" — tetapi yang diperiksa
+/** Daftar regu ini memberi nomor kepada Internal? Satu pendaftaran selalu satu
+ *  jenis peserta, jadi praktisnya ini "batch Internal" — tetapi yang diperiksa
  *  tetap golongan REGUNYA, patokan yang sama dengan pagar di database. */
 export const deretIntern = (daftar) => daftar.some(r => golonganIntern(r.golongan));
 

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -46,7 +46,7 @@ export function bacaAnggotaHadir(teks, badInput = false) {
 /** Cari kotak pada kolom tabel dan slot yang sama di baris berikutnya.
  *
  * Baris Input Pos tidak selalu punya kotak yang sama: komponen Eksternal
- * digambar sebagai tanda mati pada baris Intern, dan sebaliknya. Karena itu
+ * digambar sebagai tanda mati pada baris Internal, dan sebaliknya. Karena itu
  * indeks di antara seluruh input satu baris tidak menunjukkan kolom tabel.
  * `data-slot` membedakan pasangan Benar/Salah di dalam satu sel. */
 export function kotakBerikutnyaDalamKolom(baris, kotak) {
@@ -1185,7 +1185,7 @@ export function petunjukKolom(k) {
  *
  * Kalau minimal satu baris bernama sama dibatasi golongan, SEMUA baris dengan
  * nama itu adalah varian satu kolom — termasuk baris asal yang golongannya
- * null. Ini menyatukan pasangan umum + Intern tanpa menurunkan hubungan dari
+ * null. Ini menyatukan pasangan umum + Internal tanpa menurunkan hubungan dari
  * akhiran `kode`, yang hanya kebiasaan penamaan dan bukan kontrak data. */
 export function kolomPos(komponen) {
   const namaBervarian = new Set(
@@ -1209,10 +1209,10 @@ export function kolomPos(komponen) {
 /** Varian mana dari satu kolom yang berlaku untuk satu regu — atau null.
  *
  *  Pasangan sisi layar dari `komponen_berlaku()` di database (migrasi 0091),
- *  dan seperti fungsi itu ia TIDAK simetris: regu Intern hanya menerima
+ *  dan seperti fungsi itu ia TIDAK simetris: regu Internal hanya menerima
  *  komponen bertanda `intern` atau golongannya sendiri, sedangkan golongan
  *  Eksternal menerima baris umum (`golongan` null) maupun baris golongannya.
- *  Komponen umum tidak otomatis berlaku untuk Intern — kalau iya, seluruh
+ *  Komponen umum tidak otomatis berlaku untuk Internal — kalau iya, seluruh
  *  lomba lapangan ikut tergambar untuk regu yang tidak mengikutinya.
  *
  *  Tempatnya di util.js bersama kolomPos(), bukan di app.js, karena papan
@@ -1419,7 +1419,7 @@ export function periksaJawabSimpan(jumlahKirim, jawab) {
  *  `berlaku === 0` berarti lomba ini memang bukan untuk golongan regu itu.
  *  Itu keadaan sah, bukan konfigurasi rusak: Tebak Simpul Penegak tidak ada
  *  urusannya dengan regu Penggalang, dan seluruh lomba lapangan tidak ada
- *  urusannya dengan regu Intern (migrasi 0091). */
+ *  urusannya dengan regu Internal (migrasi 0091). */
 export function ringkasLomba(lomba, golongan, pos, peta) {
   let berlaku = 0, terisi = 0, jumlah = 0;
   for (const kol of lomba.kolom) {
@@ -1495,7 +1495,7 @@ export const URUT_GOLONGAN =
  *  di layar mana pun yang bisa memperbaikinya.
  *
  *  Tagihan satu batch adalah PENJUMLAHAN nilai ini per regu, bukan perkalian:
- *  satu pendaftaran boleh memuat regu Eksternal dan Intern sekaligus.
+ *  satu pendaftaran boleh memuat regu Eksternal dan Internal sekaligus.
  *
  *  HARGA INTERN YANG TIDAK ADA JATUH KE HARGA BIASA, dan itu yang membuat
  *  urutan rilis tidak penting. Situs terbit tiap kali PR di-merge sedangkan
@@ -1503,7 +1503,7 @@ export const URUT_GOLONGAN =
  *  ketika layar baru ini membaca `v_edisi_publik` yang belum punya kolomnya.
  *  Dengan jatuh ke `biaya_per_regu` layar menghitung persis seperti server
  *  yang belum dimigrasi — angkanya cocok, pembayaran jalan. Kalau ia jatuh ke
- *  nol, regu Intern akan tampil Rp 0 di Meja Pembayaran dan setiap
+ *  nol, regu Internal akan tampil Rp 0 di Meja Pembayaran dan setiap
  *  pembayarannya ditolak, tanpa satu pun galat yang menyebut sebabnya. */
 export const biayaRegu = (edisi, golongan) =>
   golongan === "intern_pa" || golongan === "intern_pi"

--- a/web/style.css
+++ b/web/style.css
@@ -355,7 +355,7 @@ input.jam-ketik {
 
    Keempat kolomnya dipatok 25% di bawah `table-layout: fixed` — kolom yang
    tidak dipatok mendapat NOL, bukan sisanya (pasal 15.3), dan kolom yang
-   lebarnya ikut isinya membuat "Intern" jauh lebih sempit daripada "Total
+   lebarnya ikut isinya membuat "Internal" jauh lebih sempit daripada "Total
    Kloter" sehingga angkanya tidak lagi berjarak sama.
 
    Rantai anak, bukan selektor keturunan (pasal 15.5): kartu ini tidak
@@ -1746,7 +1746,7 @@ input[aria-invalid="true"] { border-color: var(--bahaya); background: var(--baha
      yang 13,04mm satu baris. Terlihat di lembar tercetak — judulnya tidak
      pernah membungkus, padahal 10mm mestinya memaksanya. */
   /* 12mm, naik dari 10mm sejak nomor dada bisa EMPAT digit (migrasi 0116:
-     Intern 1001-1250). Diukur pada tiruan lembar Pos 3 melintang 277mm,
+     Internal 1001-1250). Diukur pada tiruan lembar Pos 3 melintang 277mm,
      kondisi terlebar:
 
        "1250" pada 11pt      8,85mm tinta


### PR DESCRIPTION
## What

Where a regu comes from, and which lane it registers through, now reads
**Eksternal** or **Internal** everywhere a person sees it: the Data Peserta
filter, the Kalkulator Keberangkatan columns and labels, the nomor dada
series, the kloter quota, Buku Sakti, `docs/`, and this repository's own
guidance files. The peserta registration form already said Internal, so
this is the rest of the system catching up to the word pembina were
already given.

The **golongan category keeps its familiar spelling**: `Intern PA` and
`Intern PI` stay as they are in `GOLONGAN_LABEL`, on the registration
form's golongan choice, and in the klasemen. Naming the origin and naming
the category are two different acts, and panitia say them differently.

267 words in 50 files, then 31 of them put back where the word named the
category. One `EKSTERN` in a SQL fixture became `EKSTERNAL`.

## Why

The system used three spellings for two ideas. A pembina choosing
"Internal" on the form then appeared as "Intern" on every panitia screen,
which reads like a different thing rather than the same regu.

## Notes

**Nothing in the database moved.** Every stored value is lower case —
`intern`, `intern_pa`, `intern_pi` — so a capitalised whole-word
replacement cannot reach a column, a value, a constraint, or a comparison.
The SQL that changed is comment text, `\echo` output, assertion messages,
and fixture names; every changed non-comment SQL line was checked to be
inside a quoted string.

**`supabase/migrations/` is deliberately untouched.** A migration file
records what actually ran in production, and rewording one afterwards
makes the record disagree with the run. Around 60 occurrences remain
there, all inside comments.

The SQL suite was not run for this branch. 470 node tests pass, the four
shared-file pairs are still byte-identical, and the Data Peserta filter,
Kalkulator Keberangkatan, and `GOLONGAN_LABEL` were read off a rendered
screen rather than off the source.

Asset versions rise accordingly: `style.css` to v67 for peserta and v62
for panitia, `live.js` to v20, with the fingerprints in
`tests/live_asset_version.test.mjs`.
