### PR TITLE
feat: the date is the one timeline item that cannot wait

### DIFF
--- a/web/js/buku-sakti.mjs
+++ b/web/js/buku-sakti.mjs
@@ -1941,8 +1941,12 @@ const BAB_KENAPA = {
     },
     {
       kode: "kenapa-februari-maret",
-      judul: "Lombanya Februari atau Maret, dan tanggalnya dikunci September",
+      judul: "Menetapkan tanggal adalah tugas utama, dan bulannya Februari atau Maret",
       isi: [
+        {
+          jenis: "p",
+          teks: "Dari seluruh papan sprint, satu tugas yang tidak boleh mundur: menetapkan tanggal. Logo, surat, susunan acara, lapangan, dan hadiah boleh menyusul, karena semuanya masih bisa dikejar. Tanggal tidak bisa dikejar, karena yang menunggunya bukan panitia melainkan peserta.",
+        },
         {
           jenis: "p",
           teks: "Tanggal lomba ditetapkan di Sprint 2, sekitar lima bulan sebelum harinya, bersama kepala sekolah dan pembina lalu ditulis di notulen. Bulan yang dianjurkan Februari atau Maret. Dua-duanya keputusan yang saling mengunci: tanggal yang jatuh di Februari berarti hitungan mundurnya dimulai September, dan itulah kenapa papan sprint di buku ini berbentuk seperti sekarang.",
@@ -1950,6 +1954,8 @@ const BAB_KENAPA = {
         {
           jenis: "poin",
           butir: [
+            "Lomba tidak bisa mendadak. Regu berlatih, sekolah mengurus izin dan biaya, dan pembina menyusun jadwalnya sendiri. Semua itu berangkat dari tanggal, bukan dari pengumuman sebulan sebelumnya.",
+            "Pertanyaannya selalu datang lebih dulu. Tiap tahun ada pembina dan peserta yang menanyakan kapan HRCD berikutnya digelar, kadang sebelum panitianya sendiri terbentuk. Tanggal adalah satu-satunya jawaban yang mereka butuhkan saat itu.",
             "Ditolak Agustus. Sekolah, desa, dan kwartir sama-sama penuh acara Agustusan, jadi panitia, lahan, dan izin keramaian semuanya berebut dengan lomba yang sudah ada lebih dulu. Peserta pun begitu: sekolah yang diundang sedang menyiapkan acaranya sendiri.",
             "Februari dan Maret memberi Kelas X tempat. Mereka sudah masuk sejak Juli, sudah kenal ambalan, dan sudah bisa dipercaya memegang pekerjaan sungguhan. Digelar lebih awal, mereka baru penonton.",
             "Itu sekaligus kaderisasi, bukan cuma tambahan tenaga. Yang jadi panitia sebagai Kelas X adalah yang memimpin edisi berikutnya, dan mereka sudah pernah melihat seluruh alurnya sekali.",
@@ -1958,7 +1964,7 @@ const BAB_KENAPA = {
         },
         {
           jenis: "kenapa",
-          teks: "Kalau lombanya digeser ke Agustus, panitia inti mengerjakan dua acara sekaligus dan Kelas X kehilangan satu-satunya edisi yang bisa mereka ikuti sebelum memimpinnya. Kalau tanggalnya dibiarkan menggantung sampai Oktober, yang hilang bukan waktu persiapan melainkan tempat di antrean izin.",
+          teks: "Kalau lombanya digeser ke Agustus, panitia inti mengerjakan dua acara sekaligus dan Kelas X kehilangan satu-satunya edisi yang bisa mereka ikuti sebelum memimpinnya. Kalau tanggalnya dibiarkan menggantung sampai Oktober, yang hilang bukan waktu persiapan panitia melainkan tempat di antrean izin, dan waktu latihan peserta yang tidak pernah bisa diganti.",
         },
       ],
     },
@@ -2654,7 +2660,7 @@ export const SPRINT = [
       { kode: "s2-danus-target", seksi: "Dana Usaha", layar: null,
         teks: "Tetapkan target rupiah dana usaha bersama Bendahara, dan bagi caranya: jualan berkala, pre-order, atau bazar." },
     ],
-    jangan: "Jangan menunda penetapan tanggal ke bulan depan. Setiap minggu tanggal belum pasti adalah satu minggu yang hilang dari antrean izin keramaian, dan antrean itu tidak bisa dipercepat dengan cara apa pun.",
+    jangan: "Jangan menunda penetapan tanggal ke bulan depan, dan jangan menunggu logo, surat, atau lapangan selesai dulu. Semua itu bisa menyusul; tanggal tidak. Setiap minggu tanggal belum pasti adalah satu minggu yang hilang dari antrean izin keramaian, dan satu minggu latihan yang hilang dari regu yang sudah menanyakannya.",
   },
 
   {


### PR DESCRIPTION
## What

The Kenapa section about the date now leads with the point that matters
most, and its title says so: **Menetapkan tanggal adalah tugas utama, dan
bulannya Februari atau Maret.**

- Logo, surat, susunan acara, lapangan, and hadiah may all follow. Every
  one of them can still be caught up; the date cannot.
- A lomba cannot be sudden. Regu train, schools arrange permission and
  money, and pembina build their own calendar — all of it starts from a
  date, not from an announcement a month ahead.
- The question arrives before the panitia do. Pembina and peserta ask when
  the next HRCD will be held, sometimes before the kepanitiaan exists, and
  the date is the only answer that helps them then.

Sprint 2's warning carries both halves now: do not push the date to next
month, and do not wait for the logo, the letters, or the field first.

## Why

The previous version explained which month and why, but left the
impression that the date is one Sprint 2 task among eight. It is not — it
is the one item whose delay costs someone outside the kepanitiaan.

## Notes

Content only, one file. 470 node tests pass, and the section was read off
the rendered screen: 982px tall, still inside the range of the sections
around it.
