### PR TITLE
feat: Buku Sakti is limited to the pengaturan centang for now

### DIFF
--- a/tests/buku_sakti.test.mjs
+++ b/tests/buku_sakti.test.mjs
@@ -638,25 +638,38 @@ test("tidak ada backtick di komentar HTML milik layar ini", () => {
   }
 });
 
-test("layar Buku Sakti tidak dipagari hak akses", () => {
-  // Sengaja, dan didokumentasikan di kepala bagiannya: yang paling butuh
-  // membaca buku ini justru yang haknya paling sempit. Tes ini menahan
-  // "kerapian" yang suatu hari menambahkan pagar seperti layar lain.
+test("layar Buku Sakti dipagari centang, dan pintunya ikut pagar itu", () => {
+  // KEBALIKAN dari tes yang berdiri di sini sebelum 5 September 2026. Dulu ia
+  // menahan pagar apa pun, karena buku ini terbuka untuk semua akun panitia.
+  // Sekarang pemilik acara menutupnya sementara: isinya masih ditulis ulang,
+  // dan panduan yang berubah tiap jam menyesatkan lebih banyak daripada
+  // menolong.
+  //
+  // Yang diuji BUKAN sekadar adanya pagar, melainkan pagar yang dipasang
+  // dengan mekanisme yang benar. Menuliskan nama akun akan patah begitu
+  // username diganti dari layar Akun, dan tidak akan kelihatan di matriks
+  // centang tempat panitia mengurus hak (CLAUDE.md 13.1).
   const awal = app.indexOf("function layarBukuSakti() {");
   const akhir = app.indexOf("function blokBukuCetak(", awal);
   assert.ok(awal >= 0 && akhir > awal, "layarBukuSakti tidak ditemukan");
   const badan = tanpaKomentar(app.slice(awal, akhir));
-  /* Yang dicari BENTUK pagarnya, bukan satu kalimat tertentu. Layar lain
-     memakai kalimat yang berbeda-beda ("Akun ini tidak berhak membuka X"),
-     jadi tes yang mencocokkan satu kalimat akan diam terhadap pagar yang
-     ditulis dengan kalimat kedua. Yang menandai pagar dengan pasti dua hal:
-     kartu galat, dan bolehLihat() yang mengembalikan lebih awal. */
-  assert.ok(!badan.includes("kartuGalat("),
-    "Buku Sakti tidak boleh punya kartu galat hak akses — lihat komentar di atasnya");
-  assert.ok(!/if\s*\(!\s*bolehLihat\(/.test(badan),
-    "Buku Sakti tidak boleh menolak lewat bolehLihat() — lihat komentar di atasnya");
-});
 
+  assert.match(badan, /if\s*\(!\s*bolehLihat\("pengaturan"\)\)/,
+    "Buku Sakti harus menolak lewat bolehLihat(\"pengaturan\")");
+  assert.ok(badan.includes("kartuGalat("),
+    "penolakannya harus berupa kartu galat, seperti layar lain");
+  assert.ok(!/admin\.ciradyka|username\s*===/.test(tanpaKomentar(app)),
+    "pagar tidak boleh memakai nama akun — pakai centang (CLAUDE.md 13.1)");
+
+  // Pintu masuknya dua: kartu galat sesi dan papan Home. Tautan yang tetap
+  // tergambar untuk akun tanpa centang cuma mengantar orang ke kartu
+  // \"tidak berhak\" — itu bukan pagar, itu jebakan.
+  const pintu = app.split('<a class="bs-pintu" href="#/buku-sakti">').length - 1;
+  assert.equal(pintu, 2, `pintu Buku Sakti ada ${pintu}, seharusnya 2`);
+  const berpagar = app.split('${bolehLihat("pengaturan") ? `').length - 1;
+  assert.ok(berpagar >= 2,
+    "kedua pintu Buku Sakti harus dibungkus bolehLihat(\"pengaturan\")");
+});
 // ---------------------------------------------------------------------------
 // 9. Aturan kertas (CLAUDE.md bagian 8)
 // ---------------------------------------------------------------------------

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -539,6 +539,7 @@ async function layarHome() {
           <div class="function-name">${ikonKotak("trophy", "jingga")} Kejuaraan</div>
         </a>` : ""}
       </div>
+      ${bolehLihat("pengaturan") ? `
       <a class="bs-pintu" href="#/buku-sakti">
         ${ikon("book-open", "ikon bs-pintu-ikon")}
         <span class="bs-pintu-teks">
@@ -553,6 +554,7 @@ async function layarHome() {
             seksi, dan timeline satu edisi.</span>
         </span>
       </a>
+      ` : ""}
 `));
     return;
   }
@@ -679,6 +681,7 @@ async function layarHome() {
          ubin yang tangan panitia sudah hafal letaknya. Hak aksesnya sengaja
          tidak diperiksa — alasannya di kepala bagian BUKU SAKTI. -->
 
+      ${bolehLihat("pengaturan") ? `
       <a class="bs-pintu" href="#/buku-sakti">
         ${ikon("book-open", "ikon bs-pintu-ikon")}
         <span class="bs-pintu-teks">
@@ -693,6 +696,7 @@ async function layarHome() {
             seksi, dan timeline satu edisi.</span>
         </span>
       </a>
+      ` : ""}
   `));
 }
 
@@ -11072,6 +11076,24 @@ function layarBukuSakti() {
      satu halaman, dan itu terbaca seperti tata letak yang rusak, bukan
      seperti kolom bacaan. */
   pasangKepala("Buku Sakti");
+  /* DIPAGARI SEMENTARA, dan ini kebalikan dari niat aslinya.
+
+     Buku ini dulu terbuka untuk semua akun panitia, karena yang paling butuh
+     membacanya justru yang haknya paling sempit. Sejak 5 September 2026 ia
+     dipagari centang `pengaturan` atas permintaan pemilik acara: isinya masih
+     ditulis ulang, dan buku panduan yang berubah tiap jam menyesatkan
+     pembacanya lebih banyak daripada menolongnya.
+
+     Yang dipakai centang, BUKAN nama akun (CLAUDE.md 13.1). Menuliskan
+     "admin.ciradyka" di sini akan patah begitu username itu diganti — layar
+     Akun bisa menggantinya — dan pagarnya tidak akan kelihatan di matriks
+     centang tempat panitia mengurus hak. Membukanya kembali untuk seluruh
+     panitia nanti cukup mengembalikan baris ini beserta FITUR_LAYAR. */
+  if (!bolehLihat("pengaturan")) {
+    LAYAR.replaceChildren(h(kartuGalat(
+      "Akun ini tidak berhak membuka Buku Sakti.")));
+    return;
+  }
   const diminta = ekorRute(location.hash);
   const bab = BUKU_SAKTI.find(b => b.kode === diminta) || BUKU_SAKTI[0];
 

--- a/web/js/buku-sakti.mjs
+++ b/web/js/buku-sakti.mjs
@@ -127,7 +127,7 @@ export const FITUR_SAH = Object.keys(FITUR_NAMA);
 export const FITUR_LAYAR = {
   "#/home":              null,
   "#/ganti-password":    null,
-  "#/buku-sakti":        null,
+  "#/buku-sakti":        "pengaturan",
   "#/data-peserta":      "pendaftaran",
   "#/pembayaran":        "pembayaran",
   "#/daftar-ulang":      "daftar_ulang",


### PR DESCRIPTION
## What

`layarBukuSakti()` now refuses accounts without the **pengaturan** centang,
with the same error card every other gated screen uses, and
`FITUR_LAYAR["#/buku-sakti"]` says so. Both entrances — the session error
card and the Home board — are wrapped in the same check, so nobody is shown
a link that only leads to a refusal.

## Why

The book was deliberately open to every panitia account: whoever needs it
most is usually whoever holds the fewest rights. That is suspended at the
event owner's request while its contents are still being rewritten. A
handbook that changes every hour misleads more readers than it helps.

## Notes

**The gate is a centang, not an account name.** Writing `admin.ciradyka`
into `app.js` would break the moment that username is changed from the Akun
screen — which is a feature this system has — and the gate would be
invisible in the matrix where panitia actually manage rights (CLAUDE.md
13.1). Today `pengaturan` is the admin's, which gives the requested effect;
widening or narrowing it later is a checkbox, not a deploy.

Reopening it for everyone is two lines back: the guard in
`layarBukuSakti()` and the `FITUR_LAYAR` entry.

The test that used to forbid any gate here now requires this one. It was
checked by removing the guard: the test fails. It also fails if the gate is
written against a username, or if either entrance stops following it.

470 node tests pass, and both paths were read on a rendered screen:
`admin.ciradyka` sees the door and the book; `meja1hrcd37` sees no door on
Home, and the direct address returns "Akun ini tidak berhak membuka Buku
Sakti." with zero sections drawn.
