### PR TITLE
docs: last edition's panitia passwords do not have to be rotated

### DIFF
--- a/web/js/buku-sakti.mjs
+++ b/web/js/buku-sakti.mjs
@@ -2623,7 +2623,7 @@ export const SPRINT = [
       { kode: "s1-akses", seksi: "Sekretariat", layar: null,
         teks: "Serahkan password akun organisasi (Supabase, Cloudflare, GitHub, email ambalan) ke minimal DUA orang, dan catat siapa memegang apa di luar sistem." },
       { kode: "s1-password", seksi: "Sekretariat", layar: "#/account",
-        teks: "Ganti password akun admin yang diwariskan, jangan dipakai apa adanya." },
+        teks: "Password akun panitia edisi lalu TIDAK perlu diganti satu per satu, dan password lama tidak perlu diburu. Tiap edisi boleh berdiri dengan akunnya sendiri, jadi yang dikerjakan cuma membuat akun untuk orang yang benar-benar bertugas sekarang." },
       { kode: "s1-evaluasi", seksi: "Ketua Pelaksana", layar: null,
         teks: "Baca ulang catatan evaluasi edisi lalu bersama-sama. Tiap keluhan yang berulang jadi calon tugas di sprint berikutnya." },
       { kode: "s1-arsip", seksi: "Sekretariat", layar: "#/live-score",


### PR DESCRIPTION
## What

Sprint 1's `s1-password` told Sekretariat to change the inherited admin
password before using it. It now says the opposite, plainly: last
edition's panitia passwords do not have to be changed one by one, and the
old ones do not have to be chased. An edition may stand on its own
accounts, so the work is building the accounts for whoever is actually on
duty now.

## Why

The rotation was a chore the event does not need. Each year the system may
be rebuilt with different accounts anyway, and a task that reads as
mandatory costs Sekretariat a morning in the sprint where the least time
exists.

## Notes

`s1-akses` is untouched: the organisation account passwords still go to at
least two people, and who holds what is still written down outside the
system. That task is about knowing those passwords, not rotating them.

Worth deciding separately: the organisation accounts — Supabase,
Cloudflare, GitHub, email ambalan — are the ones that are **not** rebuilt
each year, so a member who leaves keeps whatever they hold there. If you
want a rotation note limited to those four, say so and it goes in as its
own task rather than as a blanket instruction.

Content only, one file, 470 node tests pass.
