### PR TITLE
feat: one REST request a week keeps the Supabase project from pausing

### DIFF
--- a/.github/workflows/keep-supabase-awake.yml
+++ b/.github/workflows/keep-supabase-awake.yml
@@ -1,0 +1,88 @@
+name: Keep Supabase awake
+
+# ============================================================================
+# hrcd-rekap : keep-supabase-awake.yml — satu permintaan REST tiap minggu,
+# supaya project Supabase gratis tidak di-pause karena menganggur.
+#
+# KENAPA BERKAS INI ADA
+#
+# Project free tier di-pause kalau tidak ada aktivitas selama sepekan.
+# `docs/rancangan-b.md` bagian 12.5 sudah merencanakan keep-alive sejak awal
+# dan mencatat sendiri bahwa ia TIDAK PERNAH DIBUAT; yang tersisa cuma
+# jendela pemulihan satu tahun. Selama arsip edisi belum ditarik keluar
+# lewat `tools/arsip_edisi.py`, satu-satunya salinan hasil HRCD ada di
+# project itu — dan project yang ter-pause di luar jendela pemulihan adalah
+# hasil lomba yang hilang.
+#
+# TAGIHANNYA, dihitung lebih dulu seperti yang dituntut CLAUDE.md 16.9:
+# mingguan = 52 run setahun. GitHub membulatkan tiap JOB ke menit penuh, jadi
+# 52 menit setahun. Bandingkan dengan `*/5 * * * *` yang 288 menit SEHARI.
+# Ini cron ketiga di repo, dan satu-satunya yang tidak terkunci ke tanggal
+# lomba — memang disengaja, karena yang dijaganya juga tidak terikat tanggal.
+#
+# TANPA SECRET SATU PUN. Alamat dan anon key dibaca dari `web/config.js`,
+# yang memang publik dan disajikan apa adanya ke tiap browser panitia. Satu
+# sumber, jadi project yang pindah tidak meninggalkan workflow yang basi.
+#
+# YANG DIBACA sengaja `v_edisi_publik`: view paling ringan yang terbuka untuk
+# anon, dipakai halaman peserta, dan tidak memuat satu pun data pribadi.
+#
+# BOLEH DIMATIKAN. Begitu arsipnya keluar dan tersimpan di Drive, project
+# ini tidak perlu dijaga hidup lagi — hapus berkas ini, dan biarkan
+# Supabase melakukan apa yang mau dilakukannya.
+# ============================================================================
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Senin 08:00 WIB = 01:00 UTC. Harinya tidak penting; yang penting
+    # jaraknya tidak pernah lebih dari tujuh hari.
+    - cron: "0 1 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: keep-supabase-awake
+  cancel-in-progress: false
+
+jobs:
+  sentuh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Baca alamat dan anon key dari web/config.js
+        id: cfg
+        run: |
+          set -euo pipefail
+          url=$(grep -oE 'supabaseUrl:[[:space:]]*"[^"]+"' web/config.js \
+                | head -1 | sed 's/.*"\(.*\)"/\1/')
+          key=$(grep -oE 'anonKey:[[:space:]]*"[^"]+"' web/config.js \
+                | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ -z "$url" ] || [ -z "$key" ]; then
+            echo "GAGAL: supabaseUrl atau anonKey tidak terbaca dari web/config.js." >&2
+            echo "Kalau bentuk berkas itu berubah, perbaiki pembacanya DI SINI." >&2
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          # Anon key memang publik, tapi tetap tidak perlu tercetak di log.
+          echo "::add-mask::$key"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Sentuh REST API
+        run: |
+          set -euo pipefail
+          # Yang membuktikan project masih hidup bukan HTTP 200 saja
+          # melainkan jawaban yang benar-benar berisi baris edisi. Project
+          # yang ter-pause menjawab galat, bukan JSON.
+          jawab=$(curl -fsS --max-time 30 \
+            -H "apikey: ${{ steps.cfg.outputs.key }}" \
+            -H "Authorization: Bearer ${{ steps.cfg.outputs.key }}" \
+            "${{ steps.cfg.outputs.url }}/rest/v1/v_edisi_publik?select=name&limit=1")
+          echo "jawaban: $jawab"
+          case "$jawab" in
+            \[*\]) echo "Supabase menjawab; project masih hidup." ;;
+            *) echo "GAGAL: jawaban bukan JSON array — project mungkin ter-pause." >&2
+               exit 1 ;;
+          esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -836,12 +836,21 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
-   run from their phones. There are two event-only exceptions, both on
-   29 August 2026 and both between 06:00 and 18:59 WIB: `publish-live.yml`
-   every 15 minutes, and `refresh-live-score.yml` every 10. Cron has no year
-   field, so each one's first step rejects every scheduled run outside that
-   exact date before reading the database or deploying. Do not widen either
-   window or remove those year guards.
+   run from their phones. Two crons are event-only, both on 29 August 2026 and
+   both between 06:00 and 18:59 WIB: `publish-live.yml` every 15 minutes, and
+   `refresh-live-score.yml` every 10. Cron has no year field, so each one's
+   first step rejects every scheduled run outside that exact date before
+   reading the database or deploying. Do not widen either window or remove
+   those year guards.
+
+   **The third cron is the only standing one, and it was priced before it was
+   enabled.** `keep-supabase-awake.yml` makes one REST request a week so the
+   free-tier project is not paused for idleness — 52 runs a year, so 52 billed
+   minutes, against the 288 minutes A DAY that `*/5 * * * *` would cost. It
+   carries no secret: the address and anon key are read out of
+   `web/config.js`, which is public anyway. Delete the file once the edition's
+   results have been pulled out with `tools/arsip_edisi.py`; what it protects
+   is the last copy of those results, not the project itself.
 
 ## 17. Selama acara berjalan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -834,12 +834,21 @@ Guidance for Claude Code when working in this repository.
    a day, which empties a private repo's monthly allowance in a week. Multiply
    it out before enabling one, and remember that an exhausted allowance stops
    EVERY workflow — including `apply-migration.yml` and the ones the panitia
-   run from their phones. There are two event-only exceptions, both on
-   29 August 2026 and both between 06:00 and 18:59 WIB: `publish-live.yml`
-   every 15 minutes, and `refresh-live-score.yml` every 10. Cron has no year
-   field, so each one's first step rejects every scheduled run outside that
-   exact date before reading the database or deploying. Do not widen either
-   window or remove those year guards.
+   run from their phones. Two crons are event-only, both on 29 August 2026 and
+   both between 06:00 and 18:59 WIB: `publish-live.yml` every 15 minutes, and
+   `refresh-live-score.yml` every 10. Cron has no year field, so each one's
+   first step rejects every scheduled run outside that exact date before
+   reading the database or deploying. Do not widen either window or remove
+   those year guards.
+
+   **The third cron is the only standing one, and it was priced before it was
+   enabled.** `keep-supabase-awake.yml` makes one REST request a week so the
+   free-tier project is not paused for idleness — 52 runs a year, so 52 billed
+   minutes, against the 288 minutes A DAY that `*/5 * * * *` would cost. It
+   carries no secret: the address and anon key are read out of
+   `web/config.js`, which is public anyway. Delete the file once the edition's
+   results have been pulled out with `tools/arsip_edisi.py`; what it protects
+   is the last copy of those results, not the project itself.
 
 ## 17. Selama acara berjalan
 

--- a/docs/rancangan-b.md
+++ b/docs/rancangan-b.md
@@ -669,12 +669,19 @@ klik? Bisakah kita hanya mengisi 1 halaman form?"** — dan itu benar.
 4. **Pembayaran sebagian tidak punya bentuk data** — sesuai keputusan panitia;
    layar pembayaran menampilkan teks arahan "daftarkan batch lebih kecil".
 5. **Supabase pause**: rencananya keep-alive = cron GitHub Actions mingguan
-   yang menyentuh tabel heartbeat + ritual cek Januari. **Tidak pernah
-   dibuat** — tidak ada tabel heartbeat maupun workflow keep-alive di repo,
-   dan cron yang ada hanya `publish-live.yml` serta `refresh-live-score.yml`,
-   dua-duanya terkunci ke tanggal lomba. Yang tersisa: jendela pemulihan
-   1 tahun, jadi kelalaian tetap dapat dipulihkan. Sebelum menambah cron
-   mingguan, hitung dulu tagihannya (CLAUDE.md 16.9).
+   yang menyentuh tabel heartbeat + ritual cek Januari. **Sudah dibuat, tapi
+   bentuknya lebih kecil daripada rencananya** — `keep-supabase-awake.yml`,
+   satu permintaan REST tiap Senin ke `v_edisi_publik`. Tidak ada tabel
+   heartbeat: menyentuh API sudah menghitung sebagai aktivitas, jadi tabel
+   dan migrasinya cuma menambah dua konsep tanpa menambah jaminan. Tidak ada
+   secret juga; alamat dan anon key dibaca dari `web/config.js` yang memang
+   publik. Tagihannya dihitung lebih dulu sesuai CLAUDE.md 16.9: 52 run
+   setahun = 52 menit, lawan 288 menit SEHARI kalau `*/5 * * * *`.
+
+   Jendela pemulihan 1 tahun tetap ada sebagai jaring kedua. Dan begitu
+   arsip edisi ditarik keluar lewat `tools/arsip_edisi.py`, workflow ini
+   boleh dihapus — yang dijaganya salinan terakhir hasil lomba, bukan
+   project-nya.
 
 ## 13. Urutan implementasi
 


### PR DESCRIPTION
## What

`keep-supabase-awake.yml` makes one REST request every Monday to
`v_edisi_publik`, so the free-tier project is not paused for idleness.
`workflow_dispatch` too, for running it by hand.

Section 16.9 of CLAUDE.md and AGENTS.md now describe three crons instead of
two, and `docs/rancangan-b.md` 12.5 no longer says the keep-alive was never
built.

## Why

A free-tier project pauses after a week of idleness. Until an edition's
results have been pulled out with `tools/arsip_edisi.py`, that project holds
the **only** copy of them — git has none and the Cloudflare files are
overwritten on every republish.

## Notes

**Priced before enabling**, as 16.9 demands: weekly is 52 runs a year, so 52
billed minutes, against the 288 minutes *a day* that `*/5 * * * *` costs.
This is the third cron and the only one not locked to the race date, which
is deliberate — what it guards is not tied to a date either.

**Smaller than the plan it fulfils.** rancangan-b wanted a heartbeat table;
touching the API already counts as activity, so a table plus its migration
would have added two concepts and no guarantee.

**No secret.** Address and anon key are read out of `web/config.js`, which is
served to every browser as it is, so a project that moves cannot leave the
workflow stale. The reader fails loudly if that file's shape changes.

**It checks the answer, not the status code.** A paused project can still
return something; the step requires a JSON array.

Tested against production from this machine with the exact command in the
step: `[{"name":"HRCD XXXVII"}]`. YAML parses, the config reader returns the
right URL and a 46-character key, 470 node tests pass, and the CLAUDE.md /
AGENTS.md pair is still byte-identical.

**Delete this file once the archive is out.** Both documents say so, so it
does not calcify into a rule.
