### PR TITLE
fix: a broken connection costs one photo, not the whole archive

### DIFF
--- a/.github/workflows/archive-edition.yml
+++ b/.github/workflows/archive-edition.yml
@@ -77,7 +77,12 @@ jobs:
           fi
           python tools/arsip_edisi.py --keluar arsip-keluar $bendera
 
+      # SELALU, walau langkah di atas gagal. Putaran pertama mati di satu
+      # foto yang koneksinya putus, dan karena unggahan dilewati, seluruh
+      # unduhan setengah jalan ikut terbuang. Yang setengah pun berharga:
+      # menjalankan ulang akan melewati yang sudah ada.
       - name: Hitung isinya
+        if: always()
         run: |
           set -euo pipefail
           echo "### Arsip selesai" >> "$GITHUB_STEP_SUMMARY"
@@ -94,6 +99,7 @@ jobs:
       # Yang kecil lebih dulu, supaya angka klasemen sudah bisa diambil
       # sementara unggahan foto masih berjalan.
       - name: Unggah data
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: arsip-data
@@ -104,10 +110,10 @@ jobs:
           if-no-files-found: error
 
       - name: Unggah lembar jawaban
-        if: inputs.sertakan_foto
+        if: always() && inputs.sertakan_foto
         uses: actions/upload-artifact@v4
         with:
           name: arsip-lembar-jawaban
           path: arsip-keluar/lembar-jawaban
           retention-days: 7
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/tools/arsip_edisi.py
+++ b/tools/arsip_edisi.py
@@ -64,6 +64,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import requests
@@ -231,6 +232,37 @@ def aman(nama):
     return re.sub(r"\s+", " ", nama) or "tanpa-nama"
 
 
+def unduh_satu(sesi, path, percobaan=3):
+    """Satu foto, dengan pengulangan. `None` kalau tetap gagal.
+
+    KENAPA MENGULANG, dan kenapa tidak boleh melempar.
+
+    Putaran pertama di Actions mati di tengah pada `IncompleteRead` — satu
+    koneksi putus di antara 2.489 permintaan, dan seluruh run ikut mati.
+    Tiga puluh menit unduhan terbuang, karena berkasnya belum sempat
+    diunggah ke mana pun.
+
+    Di jumlah sebanyak ini kegagalan sesekali bukan kemungkinan, melainkan
+    kepastian. Jadi yang gagal DIHITUNG, bukan dilempar: sisanya tetap
+    terunduh, dan menjalankan ulang perintah yang sama akan melewati yang
+    sudah ada lalu memungut yang bolong.
+    """
+    for ke in range(percobaan):
+        try:
+            r = sesi.get(f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path}",
+                         headers=kepala(), timeout=120)
+            if r.status_code != 200:
+                print(f"  ! {path}: HTTP {r.status_code}", file=sys.stderr)
+                return None
+            return r.content
+        except requests.RequestException as e:
+            if ke == percobaan - 1:
+                print(f"  ! {path}: {type(e).__name__}", file=sys.stderr)
+                return None
+            time.sleep(1 + 2 * ke)
+    return None
+
+
 def unduh_foto(keluar, foto, regu_per_dada, tenang):
     """Foto slip, satu folder per lomba, nama berkas nomor dada.
 
@@ -241,6 +273,9 @@ def unduh_foto(keluar, foto, regu_per_dada, tenang):
     """
     akar = keluar / "lembar-jawaban"
     akar.mkdir(parents=True, exist_ok=True)
+    # Satu koneksi dipakai ulang untuk seluruh unduhan. Membuka 2.489
+    # koneksi baru bukan cuma lebih lambat, ia sendiri sumber putusnya.
+    sesi = requests.Session()
 
     per_folder = {}
     for f in sorted(foto, key=lambda x: (x.get("pos") or 0,
@@ -286,15 +321,11 @@ def unduh_foto(keluar, foto, regu_per_dada, tenang):
                 dilewati += 1
                 continue
 
-            resp = requests.get(
-                f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{f['path']}",
-                headers=kepala(), timeout=120,
-            )
-            if resp.status_code != 200:
+            isi_foto = unduh_satu(sesi, f["path"])
+            if isi_foto is None:
                 gagal += 1
-                print(f"  ! gagal {f['path']}: {resp.status_code}", file=sys.stderr)
                 continue
-            berkas.write_bytes(resp.content)
+            berkas.write_bytes(isi_foto)
             sudah += 1
             if not tenang and (sudah + dilewati) % 50 == 0:
                 print(f"  foto {sudah + dilewati}/{total}")


### PR DESCRIPTION
## What

- A photo **retries three times** with a growing pause, and one that still
  will not come is **counted, not raised**.
- **One `requests.Session`** is reused for all 2.489 downloads.
- The workflow's summary and both uploads run with **`always()`**, and the
  photo upload **warns** instead of failing when there is nothing yet.

## Why

Run #33966104097 died on `ChunkedEncodingError: IncompleteRead` partway
through the downloads. One connection dropped, the script raised, and
because the upload steps only run after a successful step, **thirty minutes
of finished downloads were thrown away**.

At 2.489 requests an occasional failure is not a possibility, it is a
certainty — that should have been in the first version. Opening a fresh
connection for every one of them is also itself a source of the drops.

## Notes

The run still ends red when photos are missing, so nothing looks finished
when it is not; the difference is that the partial archive survives and
re-running resumes, since files already on disk at the right size are
skipped.

Tested with a stubbed session: a photo that drops twice then succeeds is
fetched on the third attempt; one that always drops returns `None` after
three, printing a single line rather than a traceback. `py_compile` passes
and the workflow YAML parses with the three `always()` conditions in place.
