### PR TITLE
fix: two CSS declarations that could never take effect

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -30,7 +30,7 @@
        live.css tinggal sesudahnya, dan isinya hanya yang memang milik halaman
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
-  <link rel="stylesheet" href="style.css?v=67">
+  <link rel="stylesheet" href="style.css?v=68">
   <link rel="stylesheet" href="live.css?v=7">
 </head>
 <body>

--- a/live/style.css
+++ b/live/style.css
@@ -4123,7 +4123,10 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Hijau, bukan abu: gembok tertutup berarti "sudah diperiksa dan benar",
    sekelas dengan centang hijau di baris yang sama — bukan berarti mati. */
 .table-pos tbody tr.baris-terkunci .gembok { color: var(--utama); }
-.gembok { color: var(--tinta-lembut); background: none; border: 0; cursor: pointer; }
+/* Hanya WARNA di sini. Latar, garis, dan kursornya sudah ditetapkan aturan
+   .gembok di bagian lembar pos; mengulanginya membuat dua tempat untuk satu
+   jawaban, dan yang belakangan menang tanpa suara (CLAUDE.md 15.6). */
+.gembok { color: var(--tinta-lembut); }
 /* Lambang, bukan tombol: sejak 0166 menggembok pindah ke layar Cek Nilai.
    Kursornya dikembalikan ke bawaan supaya ia tidak mengaku bisa diketuk. */
 .gembok-tanda { cursor: default; display: inline-flex; align-items: center; }
@@ -5948,7 +5951,6 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   .isi.cek .cek-identitas .card-identity .nama { font-size: 1.1rem; }
   .isi.cek .cek-identitas .card-identity .detail { font-size: .85rem; }
-  .isi.cek .cek-identitas .card-identity { flex: 1 1 auto; }
 
   #cek-isi { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: .6rem; }
   /* Wadah lomba mengisi sisa tinggi, dan ISINYA yang menyesuaikan — bukan

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -38,7 +38,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
 const BERKAS = {
   "live.js": { versi: 20, sidik: "0cec1e3dde68" },
   "live.css": { versi: 7, sidik: "3edc52a93ca9" },
-  "style.css": { versi: 67, sidik: "8b9143b2f4b2" },
+  "style.css": { versi: 68, sidik: "fc1fce32700b" },
 };
 
 const sidikIsi = (teks) =>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
        peserta, dan dua tab bernama sama membuat panitia mengetik nilai ke tab
        yang salah. -->
   <title>Sistem Panitia — HRCD</title>
-  <link rel="stylesheet" href="style.css?v=62">
+  <link rel="stylesheet" href="style.css?v=63">
 </head>
 <body>
   <header class="header" id="kepala" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -4123,7 +4123,10 @@ button.pill-number:hover { filter: brightness(.95); }
 /* Hijau, bukan abu: gembok tertutup berarti "sudah diperiksa dan benar",
    sekelas dengan centang hijau di baris yang sama — bukan berarti mati. */
 .table-pos tbody tr.baris-terkunci .gembok { color: var(--utama); }
-.gembok { color: var(--tinta-lembut); background: none; border: 0; cursor: pointer; }
+/* Hanya WARNA di sini. Latar, garis, dan kursornya sudah ditetapkan aturan
+   .gembok di bagian lembar pos; mengulanginya membuat dua tempat untuk satu
+   jawaban, dan yang belakangan menang tanpa suara (CLAUDE.md 15.6). */
+.gembok { color: var(--tinta-lembut); }
 /* Lambang, bukan tombol: sejak 0166 menggembok pindah ke layar Cek Nilai.
    Kursornya dikembalikan ke bawaan supaya ia tidak mengaku bisa diketuk. */
 .gembok-tanda { cursor: default; display: inline-flex; align-items: center; }
@@ -5948,7 +5951,6 @@ button.pill-number:hover { filter: brightness(.95); }
   }
   .isi.cek .cek-identitas .card-identity .nama { font-size: 1.1rem; }
   .isi.cek .cek-identitas .card-identity .detail { font-size: .85rem; }
-  .isi.cek .cek-identitas .card-identity { flex: 1 1 auto; }
 
   #cek-isi { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: .6rem; }
   /* Wadah lomba mengisi sisa tinggi, dan ISINYA yang menyesuaikan — bukan


### PR DESCRIPTION
## What

A sweep for selectors repeated inside one context found **22**; three
declared the same property twice. Two were dead and are now gone.

- **`.gembok`** is written beside the pos sheet and again 1.400 lines
  later. The second only needed to add a colour but repeated `background`,
  `border`, and `cursor` with identical values. It now sets colour alone.
- **`.isi.cek .cek-identitas .card-identity`** declares `flex: 1 1 auto`
  and then, five lines below in the same media query, declares it again
  with the same value. The second line said nothing.

The third is **not** a bug and stays: `.kemajuan` lays itself out as a flex
list and is then collapsed to `display: none`, with `.kemajuan.terbuka`
restoring it. Base, then default-closed, is the intent.

## Why

Section 15.6 records a real failure from exactly this shape — a
`display: flex` block that never applied for 160 lines because an identical
selector below it won, with no error anywhere. Two places holding one
answer is the trap; removing the dead half is what closes it.

## Notes

**Measured, not read** — section 15.9. Both stylesheets were loaded into
iframes over identical markup and every computed property compared:
`background-color`, `border-top-width`, `cursor`, `color`, `font-size`,
`padding-top`, `border-radius`, and all three flex components, on a bare
`.gembok`, a `.gembok` inside `tr.baris-terkunci`, and the
`.card-identity`. **Zero differences.**

Both stylesheets stay byte-identical; `style.css` goes to v68 for peserta
and v63 for panitia with the fingerprint updated. 470 node tests pass.
