### PR TITLE
fix: match the rejection message test 93 asserts against

### DIFF
--- a/tests/sql/93_kejuaraan_tanpa_intern.sql
+++ b/tests/sql/93_kejuaraan_tanpa_intern.sql
@@ -31,7 +31,17 @@ begin
     perform simpan_kejuaraan_manual('kostum', v_intern);
     assert false, '93.1 GAGAL: regu Internal dapat dipilih';
   exception when others then
-    assert sqlerrm like '%termasuk Internal',
+    -- JANGAN ganti 'Intern' jadi 'Internal' di sini. Ini bukan teks yang tes
+    -- ini tulis, melainkan POLA yang dicocokkan ke pesan yang DIANGKAT
+    -- migrasinya, dan migrasinya berbunyi '...atau termasuk Intern' —
+    -- 0142, lalu 0143, 0152 dan 0153 yang menulis ulang fungsinya. Sebuah
+    -- migrasi merekam apa yang benar-benar dijalankan, jadi kata itu tidak
+    -- ikut disapu saat 'Ekstern/Intern' dibakukan jadi 'Eksternal/Internal'
+    -- di docs, layar dan tes. Menamai ulang satu sisi perbandingan saja
+    -- membuat polanya tidak pernah cocok: assert di dalam handler ini gagal,
+    -- galatnya keluar dari blok do, dan 28 tes di belakangnya tidak pernah
+    -- jalan sama sekali.
+    assert sqlerrm like '%termasuk Intern',
       format('93.1 GAGAL: penolakannya salah: %s', sqlerrm);
   end;
 


### PR DESCRIPTION
## What

`tests/sql/93_kejuaraan_tanpa_intern.sql` asserted the rejection message with

```sql
assert sqlerrm like '%termasuk Internal',
```

while every migration that defines `simpan_kejuaraan_manual` raises
`...atau termasuk Intern` — `0142`, then `0143`, `0152` and `0153`.

The pattern could never match, so the `assert` inside the exception handler
fired, its own exception propagated out of the `do` block, and `tests/run.sh`
aborted at test 93. **Tests 93 through 121 have not run since.**

This restores the pattern to the word the migration actually raises, with a
comment saying why it must not be swept again.

## Why

The word came from the `Ekstern`/`Intern` → `Eksternal`/`Internal` rename.
Leaving `supabase/migrations/` alone was right and deliberate — a migration
records what actually ran. What the sweep missed is that this particular
string is not text the test *emits*; it is a **pattern matched against text
the migration emits**. Renaming one side of a comparison is the whole bug.

Nothing on GitHub inspects a branch on its own (CLAUDE.md 16.5), so this
stayed invisible after the commit landed.

Closes #842.

## Notes

Verified locally, PostgreSQL 17.11 (production's major version):

```
PSQL=... PGPORT=5433 bash tests/run.sh
...
SEMUA TES LULUS
```

The 28 tests behind the abort now run again. One of them surfaced nothing new,
but #843 is a real regression in the final schema that this suite still cannot
see — see that issue.