### PR TITLE
fix: v_lembar_pos calls hitung_poin with jawaban_benar again

### DIFF
--- a/supabase/checks/status_migrasi.sql
+++ b/supabase/checks/status_migrasi.sql
@@ -27,7 +27,7 @@
 -- menutup pertanyaannya.
 --
 -- Sekarang keduanya disebutkan: 117 migrasi punya jejak yang diperiksa
--- (bagian 1), dan 53 tidak punya (bagian 2). 117 + 53 = 170, yaitu SELURUH
+-- (bagian 1), dan 54 tidak punya (bagian 2). 117 + 54 = 171, yaitu SELURUH
 -- migrasi yang ada — dan angka itu yang harus dijaga tiap kali berkas migrasi
 -- baru mendarat. Yang di bagian 2 bukan berarti belum diterapkan — berarti
 -- tidak ada yang tersisa untuk diperiksa.
@@ -424,7 +424,14 @@ select nomor, berkas from (values
   ('0151', 'skor_juara_umum_enam_besar'),
   ('0162', 'lebur_smp_al_fadliliyah'),
   ('0168', 'judul_isian_menaksir'),
-  ('0169', 'judul_isian_soal')
+  ('0169', 'judul_isian_soal'),
+  -- 0171 mengembalikan argumen ke-11 `w.jawaban_benar` yang 0166 jatuhkan
+  -- dari v_lembar_pos. Jejaknya BUKAN jejak baru: yang membuktikannya persis
+  -- jejak 0085 di bagian 1, yang memuat panggilan hitung_poin sebelas argumen
+  -- di dalam v_lembar_pos. Alasan yang sama menempatkan 0095 di daftar ini.
+  -- Kalau 0085 melapor BELUM di atas database yang dibangun dari nol, yang
+  -- dilaporkannya bukan migrasi terlewat melainkan regresi itu, lagi.
+  ('0171', 'lembar_pos_jawaban_benar_kembali')
 ) as t(nomor, berkas)
 order by nomor;
 

--- a/supabase/migrations/0171_lembar_pos_jawaban_benar_kembali.sql
+++ b/supabase/migrations/0171_lembar_pos_jawaban_benar_kembali.sql
@@ -1,0 +1,126 @@
+-- ============================================================================
+-- hrcd-rekap : 0171_lembar_pos_jawaban_benar_kembali.sql
+-- Kembalikan argumen ke-11 `w.jawaban_benar` ke panggilan hitung_poin() di
+-- dalam v_lembar_pos. Ini KETIGA KALINYA hilang.
+--
+-- APA YANG SALAH
+--
+-- Sesudah seluruh migrasi diterapkan berurutan, dua jalur yang menghitung
+-- Nilai Pos memanggil hitung_poin() dengan cara BERBEDA:
+--
+--   v_lembar_pos   argumennya sepuluh   -> layar Input Nilai Pos (juri)
+--   v_poin_wahana  argumennya sebelas   -> klasemen, Rekap, Live Score
+--
+-- Argumen ke-11 `p_jawaban_benar` punya `default null`, jadi panggilan yang
+-- melupakannya TIDAK gagal: migrasinya berhasil, view-nya terbaca, cuma
+-- angkanya yang berubah. Tidak ada yang merah dan tidak ada yang kosong --
+-- dua layar hanya menyebut dua angka untuk regu yang sama.
+--
+-- YANG TERASA DI LAPANGAN
+--
+-- Hanya komponen `bertingkat` yang punya `jawaban_benar` yang terkena, dan
+-- di konfigurasi produksi itu cuma Menaksir (jawaban_benar 855 cm, tangga
+-- 100/200/300/400/500 cm). Contoh dari kepala 0095, masih berlaku persis:
+--
+--   taksiran 830 cm  ->  klasemen  : |830-855| = 25 cm  -> 100 poin
+--                        layar juri: 830 dibaca apa adanya, lewat seluruh
+--                                    anak tangga            ->   0 poin
+--
+-- Juri melihat 0 untuk regu yang sebenarnya mendapat angka penuh, lalu
+-- mengetik ulang nilai yang sudah benar.
+--
+-- KENAPA HILANG LAGI
+--
+-- 0085 menambahkan argumennya. 0091 menulis ulang v_lembar_pos dari badan
+-- yang lebih tua dan menjatuhkannya; 0095 mengembalikannya. Sekarang 0166
+-- melakukan hal yang sama: ia membangun ulang view ini supaya `terkunci`
+-- jadi per lomba, dan badan yang disalinnya mendahului 0095.
+--
+-- Ini bukan kecerobohan satu orang, melainkan bentuk yang berulang: setiap
+-- `create or replace view` menuliskan ULANG seluruh badan view, jadi tiap
+-- migrasi yang menyentuh satu kolom harus membawa serta setiap keputusan
+-- yang pernah dibuat pada kolom lain. Yang menahan itu cuma pemeriksaan,
+-- dan pemeriksaannya tidak berjalan pada tempat yang tepat -- lihat bawah.
+--
+-- YANG TIDAK BERUBAH
+--
+-- SELURUH sisanya milik 0166 dan dibiarkan apa adanya: `v_lomba_pos`,
+-- kolom `lomba_terkunci`, `nilai_tergembok()` di kolom `terkunci`, dan
+-- pagar hak di klausa `where`. Badan di bawah adalah SALINAN PERSIS badan
+-- 0166 dengan SATU kata ditambahkan.
+--
+-- KENAPA PAGARNYA TIDAK MENANGKAP
+--
+-- 0095 memasang tests/sql/56_lembar_pos_sama_dengan_klasemen.sql tepat untuk
+-- ini, dan tes itu bekerja -- tetapi ia berjalan di tests/run.sh baris 408,
+-- sesaat sesudah 0095. Migrasi 0166 berjalan 320 baris di bawahnya, jadi
+-- invarian itu dibuktikan pada saat ia dibuat lalu tidak pernah diperiksa
+-- lagi terhadap skema akhir. Suite hijau, skema akhirnya melanggar.
+--
+-- Yang menemukannya supabase/checks/status_migrasi.sql, satu-satunya yang
+-- membaca skema SESUDAH semuanya mendarat: jejak 0085 melapor BELUM di atas
+-- database yang dibangun dari nol. Itu bukan migrasi yang terlewat -- itu
+-- regresi ini, muncul sebagai jejak yang tidak lagi berdiri.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Salinan persis v_lembar_pos milik 0166, dengan `w.jawaban_benar` sebagai
+-- argumen ke-11 hitung_poin() -- sama seperti v_poin_wahana (0085)
+-- memanggilnya, dan itulah seluruh isi perubahan ini.
+-- ---------------------------------------------------------------------------
+create or replace view v_lembar_pos as
+select p.nomor as pos,
+    p.name as nama_pos,
+    p.bayangan,
+    r.id as regu_id,
+    r.nomor_dada,
+    r.nama_regu,
+    s.name as nama_sekolah,
+    r.golongan,
+    coalesce((select jsonb_object_agg(w.kode, jsonb_build_object('nilai_1', n.nilai_1, 'nilai_2', n.nilai_2))
+           from nilai_mentah n join wahana w on w.id = n.wahana_id
+          where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor), '{}'::jsonb) as nilai,
+    ((select count(*) from nilai_mentah n join wahana w on w.id = n.wahana_id
+          where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor))::integer as jumlah_terisi,
+    ((select count(*) from wahana w
+          where w.edisi = p.edisi and w.pos = p.nomor and komponen_berlaku(w.golongan, r.golongan)))::integer as jumlah_komponen,
+    round(coalesce((select sum(hitung_poin(w.form, n.nilai_1, n.nilai_2, w.poin_maks, w.raw_terbaik, w.raw_terburuk, w.poin_benar, w.poin_salah, w.total_soal, w.tingkat, w.jawaban_benar))
+           from nilai_mentah n join wahana w on w.id = n.wahana_id
+          where n.regu_id = r.id and w.edisi = p.edisi and w.pos = p.nomor), 0::numeric) * p.bobot, 2) as nilai_pos,
+    nilai_tergembok(r.id, p.nomor) as terkunci,
+    coalesce((select array_agg(t.kode_lomba order by t.kode_lomba)
+           from nilai_terkunci t
+          where t.regu_id = r.id and t.pos = p.nomor), '{}'::text[]) as lomba_terkunci
+   from regu r
+     join pendaftaran d on d.id = r.pendaftaran_id
+     join sekolah s on s.id = d.sekolah_id
+     cross join pos p
+  where p.edisi = edisi_aktif() and not r.is_cancelled and d.status = 'lunas'::text
+    and r.nomor_dada is not null and boleh('pos'::text)
+    and (pos_saya() is null or p.nomor = pos_saya())
+    and (exists (select 1 from wahana w
+          where w.edisi = p.edisi and w.pos = p.nomor and komponen_berlaku(w.golongan, r.golongan)));
+
+-- ---------------------------------------------------------------------------
+-- Penjaga: gagal keras kalau badannya tidak membawa argumen ke-11.
+--
+-- Bukan hiasan. Tiga kali argumen ini hilang lewat `create or replace view`
+-- yang menuliskan ulang seluruh badan, dan tiga-tiganya berhasil diterapkan
+-- tanpa satu pun galat. Yang diperiksa di sini definisi yang BENAR-BENAR
+-- terpasang, bukan yang baru saja diketik di atas -- kalau suatu hari
+-- migrasi ini dijalankan ulang sesudah migrasi lain menulis ulang view-nya,
+-- di sinilah ia berhenti.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from pg_views
+    where schemaname = 'public' and viewname = 'v_lembar_pos'
+      and position('w.total_soal, w.tingkat, w.jawaban_benar' in definition) > 0)
+  then
+    raise exception
+      '0171: v_lembar_pos tidak memanggil hitung_poin dengan w.jawaban_benar';
+  end if;
+  raise notice
+    '0171: v_lembar_pos memanggil hitung_poin dengan w.jawaban_benar lagi.';
+end $$;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -744,6 +744,13 @@ run supabase/migrations/0169_judul_isian_soal.sql
 # sama sekali (CLAUDE.md 7.5).
 run supabase/migrations/0170_centang_sprint.sql
 run tests/sql/120_centang_sprint.sql
+# 0171 mengembalikan argumen ke-11 `w.jawaban_benar` ke hitung_poin() di dalam
+# v_lembar_pos, yang dijatuhkan 0166 saat membangun ulang view itu. Ia HARUS
+# berada di bawah 0166 — di atasnya, 0166-lah yang menang dan perbaikannya
+# tidak ada artinya. Berlaku untuk migrasi berikutnya juga: apa pun yang
+# menulis ulang v_lembar_pos setelah ini wajib membawa argumen ke-11 itu
+# serta, dan penjaga di kaki 0171 hanya memeriksa keadaan pada saat ia jalan.
+run supabase/migrations/0171_lembar_pos_jawaban_benar_kembali.sql
 
 # tests/sql/bentuk_lomba_produksi.sql SENGAJA TIDAK DIJALANKAN DI SINI, dan itu
 # perlu disebut karena CLAUDE.md 7.5 melatih pembaca mengharapkan sebaliknya.


### PR DESCRIPTION
## What

After every migration is applied in order, the two paths that derive Nilai Pos
called `hitung_poin()` differently:

```
v_lembar_pos   ten arguments     <- layar Input Nilai Pos (juri)
v_poin_wahana  eleven arguments  <- klasemen, Rekap, Live Score
```

`0166_gembok_per_lomba.sql` rebuilt `v_lembar_pos` to make the gembok per
lomba, and the body it wrote predates `0095` — so `w.jawaban_benar` is gone.
The argument has `default null`, so nothing fails: the apply succeeds, the view
reads fine, only the number changes.

`0171` restores it. Everything `0166` introduced is kept verbatim — `v_lomba_pos`,
the per-lomba `terkunci`, `lomba_terkunci`, the `where` guards — and one word
is added.

## Why

Only `bertingkat` components carrying a `jawaban_benar` are affected, which in
the production configuration is **Menaksir alone** (`jawaban_benar` 855 cm,
steps 100/200/300/400/500 cm):

```
taksiran 830 cm  ->  klasemen  : |830-855| = 25 cm  -> 100 poin
                     layar juri: 830 read as-is, past every step -> 0 poin
```

The juri sees 0 for a regu that actually scored full marks, and retypes a
number that was already right.

This is the third time. `0085` added the argument, `0091` dropped it, `0095`
restored it, `0166` dropped it again — every one of them through a
`create or replace view` that rewrites the whole body.

So `0171` ends with a guard that reads the **installed** definition back and
raises if the argument is not there. A future rebuild that forgets it stops in
`tests/run.sh` instead of on a juri's screen.

Closes #843.

## Notes

Verified locally, PostgreSQL 17.11 (production's major version):

- `tests/run.sh` — `SEMUA TES LULUS`, with `0171` printing its notice.
- `supabase/checks/status_migrasi.sql` against a database built from zero —
  **zero BELUM rows**. `0085`'s fingerprint, the only one that was failing,
  stands again.

`0171` is registered in `tests/run.sh` (CLAUDE.md 7.5) and named in part 2 of
`status_migrasi.sql` (7.8), for the same reason `0095` is there: what proves it
is `0085`'s fingerprint, not a new one. The file's own header count moves to
117 + 54 = 171.

The invariant that should have caught this is `tests/sql/56`, which runs 320
lines before `0166` — that is #844, and it is not fixed here.

Migration to apply after merge: `supabase/migrations/0171_lembar_pos_jawaban_benar_kembali.sql`.