### PR TITLE
test: check every migration's fingerprint against the final schema

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -783,4 +783,16 @@ run supabase/migrations/0171_lembar_pos_jawaban_benar_kembali.sql
 # ada migrasi baru, ia masuk di ATAS baris ini.
 run supabase/checks/live_json.sql
 
+# Jejak tiap migrasi, diperiksa terhadap SKEMA AKHIR. Barisnya harus tetap
+# yang terakhir, dan alasannya sama dengan alasan live_json.sql di atas: yang
+# diperiksa keadaan sesudah semuanya mendarat, bukan keadaan pada barisnya.
+#
+# Seluruh tes lain di berkas ini membuktikan invariannya pada saat invarian
+# itu dibuat lalu tidak pernah memeriksanya lagi, jadi migrasi yang membangun
+# ulang objek milik migrasi lebih tua bisa melanggarnya sambil suite tetap
+# hijau. Itulah yang terjadi pada v_lembar_pos: tes 56 duduk 320 baris di atas
+# migrasi yang mematahkannya. Yang di bawah ini menutup kelas itu untuk 117
+# jejak sekaligus — rinciannya di kepala berkasnya.
+run tests/sql/121_jejak_migrasi_akhir.sql
+
 echo "SEMUA TES LULUS"

--- a/tests/sql/121_jejak_migrasi_akhir.sql
+++ b/tests/sql/121_jejak_migrasi_akhir.sql
@@ -1,0 +1,86 @@
+-- ============================================================================
+-- hrcd-rekap : tests/sql/121_jejak_migrasi_akhir.sql
+--
+-- SATU-SATUNYA TES YANG MEMERIKSA SKEMA AKHIR, BUKAN SKEMA PADA BARISNYA.
+--
+-- tests/run.sh menyelang migrasi dan tes menurut urutan, jadi setiap tes
+-- membuktikan invariannya terhadap skema SEBAGAIMANA ADANYA DI BARIS ITU.
+-- Tidak ada yang menjalankannya lagi sesudahnya. Migrasi yang membangun ulang
+-- objek yang dijaga tes lebih tua karena itu bisa melanggar invariannya sambil
+-- suite tetap hijau.
+--
+-- Itu bukan dugaan; begitulah #843 masuk:
+--
+--   run.sh baris 407  0095_lembar_pos_jawaban_benar.sql memasang invariannya
+--   run.sh baris 408  56_lembar_pos_sama_dengan_klasemen.sql membuktikannya
+--   run.sh baris 728  0166_gembok_per_lomba.sql membangun ulang v_lembar_pos
+--                     dan menjatuhkan argumen ke-11 hitung_poin()
+--
+-- Tes 56 ada persis supaya "rebuild berikutnya yang lupa satu argumen jatuh di
+-- CI". Ia tidak bisa: ia sudah selesai 320 baris sebelumnya. Yang menemukannya
+-- supabase/checks/status_migrasi.sql, satu-satunya berkas yang membaca skema
+-- sesudah semuanya mendarat — dan berkas itu cuma jalan kalau ada yang
+-- men-dispatch-nya dengan tangan (CLAUDE.md 16.5), jadi tidak ada yang
+-- memunculkannya selama seminggu.
+--
+-- ---------------------------------------------------------------------------
+-- KENAPA status_migrasi, BUKAN MENJALANKAN ULANG TES 56 DI SINI
+--
+-- Menjalankan ulang tes 56 di kaki run.sh adalah jalan yang paling terpikir,
+-- dan ia TIDAK JALAN: tes itu memasang komponennya sendiri tetapi meminjam
+-- regu yang sudah ada — lunas, bernomor dada, tidak batal — dan di kaki
+-- run.sh regu seperti itu sudah habis dihapus tes "Bersihkan data" di
+-- atasnya. Dicoba: `56 GAGAL: tidak ada regu lunas bernomor dada untuk
+-- diuji`. Membuatkannya regu sendiri berarti menulis ulang setengah tesnya
+-- di tempat kedua yang akan menyimpang dari yang pertama.
+--
+-- Yang di bawah ini lebih murah DAN lebih luas. Di atas database yang
+-- dibangun dari NOL, sebuah baris BELUM di bagian 1 hanya bisa berarti satu
+-- hal: migrasi yang lebih muda menulis ulang objek milik migrasi yang lebih
+-- tua dan tidak membawa serta keputusannya. Itu persis kelas kerusakan yang
+-- dijaga di sini, dan diperiksa untuk 117 jejak sekaligus, bukan satu
+-- invarian pilihan tangan.
+--
+-- Di PRODUKSI arti BELUM berbeda — di sana ia bisa berarti berkasnya memang
+-- belum pernah dijalankan, dan itulah sebab berkas checks-nya melapor alih-
+-- alih gagal. Di sini seluruh migrasi baru saja dijalankan berurutan oleh
+-- run.sh, jadi kemungkinan itu tertutup dan BELUM boleh menggagalkan.
+--
+-- Kalau kelak sebuah migrasi memang SENGAJA membuang objek milik migrasi
+-- lama, yang benar bukan melonggarkan tes ini: pindahkan nomor migrasi tua
+-- itu dari bagian 1 ke bagian 2 status_migrasi.sql, di commit yang sama —
+-- karena memang tidak ada lagi yang tersisa untuk diperiksa.
+-- ============================================================================
+
+\echo '--- 121. Jejak tiap migrasi masih berdiri sesudah seluruh migrasi'
+
+-- Laporannya sendiri. Ia mengisi tabel sementara status_migrasi_hasil, dan
+-- karena \ir berjalan di sesi psql YANG SAMA, blok di bawah bisa membacanya.
+\ir ../../supabase/checks/status_migrasi.sql
+
+do $blok$
+declare
+  v_hilang text;
+  v_jumlah int;
+begin
+  select count(*) into v_jumlah from status_migrasi_hasil;
+  assert v_jumlah > 100,
+    format('121 GAGAL: status_migrasi cuma memeriksa %s jejak — bagian 1 '
+           'tidak terisi, jadi tes ini tidak membuktikan apa pun', v_jumlah);
+
+  select string_agg(nomor || ' (' || jejak || ')', E'\n           '
+                    order by nomor)
+    into v_hilang
+    from status_migrasi_hasil where not ada;
+
+  assert v_hilang is null,
+    format('121 GAGAL: jejak migrasi berikut TIDAK berdiri di skema akhir. '
+           'Database ini dibangun dari nol dan seluruh migrasi baru saja '
+           'dijalankan, jadi ini bukan migrasi terlewat — ini migrasi yang '
+           'lebih muda menulis ulang objeknya dan menjatuhkan keputusan '
+           'migrasi yang lebih tua:%s           %s',
+           E'\n           ', v_hilang);
+
+  raise notice '121.1 LULUS: % jejak migrasi masih berdiri di skema akhir.',
+    v_jumlah;
+end $blok$;


### PR DESCRIPTION
## What

`tests/run.sh` interleaves migrations and tests in order, so every test proves
its invariant against the schema **as it stood at that line**, and nothing runs
it again. A migration that rebuilds an object an earlier test guards can break
the invariant while the suite stays green.

That is how #843 got in:

| run.sh line | What runs |
| --- | --- |
| 407 | `0095_lembar_pos_jawaban_benar.sql` establishes the invariant |
| 408 | `56_lembar_pos_sama_dengan_klasemen.sql` proves it |
| 728 | `0166_gembok_per_lomba.sql` rebuilds `v_lembar_pos` and breaks it |

Test 56 exists specifically so that "rebuild berikutnya yang lupa satu argumen
jatuh di CI". It could not, because it had already finished 320 lines earlier.

`tests/sql/121_jejak_migrasi_akhir.sql` runs
`supabase/checks/status_migrasi.sql` — the only file that reads the schema
**after everything has landed** — and fails on any part-1 fingerprint reading
`BELUM`.

## Why status_migrasi and not a second run of test 56

The issue suggested test 56 as the clearest candidate, on the grounds that it
builds its own fixture. It builds its own *wahana*, but it **borrows** an
existing regu — lunas, bernomor dada, not cancelled — and by the foot of
`run.sh` the cleanup tests have deleted every one of them. Tried it:

```
56 GAGAL: tidak ada regu lunas bernomor dada untuk diuji
```

Giving it its own regu means writing half the test in a second place that will
drift from the first.

The check taken instead is cheaper **and** wider. On a database built from
zero, a `BELUM` row in part 1 can only mean one thing: a younger migration
rewrote an older one's object without carrying its decisions along. That is
exactly the class of damage this is guarding, checked for **117 fingerprints
at once** rather than one hand-picked invariant at a time.

In production `BELUM` means something else — the file may genuinely never have
run — which is why the checks file reports rather than fails. Here `run.sh`
has just applied every migration in order, so that reading is closed off and
`BELUM` is allowed to be fatal. The header records this, and records what to
do when a migration deliberately drops an old object: move that number from
part 1 to part 2 of `status_migrasi.sql`, in the same commit.

Closes #844.

## Notes

Verified locally on PostgreSQL 17.11, **both directions** — the second is the
one usually missing, and without it `select true` passes:

- Current tree: `SEMUA TES LULUS`, with
  `121.1 LULUS: 117 jejak migrasi masih berdiri di skema akhir.`
- Against a database whose `v_lembar_pos` was put back to the ten-argument
  body: `psql exit=3`, naming the culprit —
  `0085 (view v_lembar_pos: round((COALESCE(( SELECT sum(hitung_poin(w.form, n.nilai_1)`

The line sits last in `run.sh`, next to `live_json.sql`, for the same reason
that one is there.