### PR TITLE
fix: serve /nama-regu-dipakai from the dev server

### DIFF
--- a/tests/dev_rpc_parity.test.mjs
+++ b/tests/dev_rpc_parity.test.mjs
@@ -23,6 +23,26 @@ test("setiap RPC API tersedia di dev server", () => {
 });
 
 
+// Pasangan tes di atas, untuk jalur BACA. RPC sudah dijaga sejak lama dan
+// rute baca() tidak, jadi /nama-regu-dipakai bisa hilang sejak hari pertama
+// tanpa satu pun tanda: pemanggilnya menelan galatnya, dan layarnya cuma
+// berhenti memperingatkan. CLAUDE.md 17.6 menyebut alat pembuka layar yang
+// rusak sebagai bug prioritas tinggi justru karena bentuknya seperti ini.
+test("setiap rute baca() API tersedia di dev server", () => {
+  const apiRoutes = new Set(
+    [...api.matchAll(/\bbaca\(\s*[`"']\/([a-z0-9-]+)/g)].map((match) => match[1]),
+  );
+  assert.ok(apiRoutes.size > 20,
+    `cuma ${apiRoutes.size} rute terbaca — polanya tidak lagi cocok`);
+
+  const missing = [...apiRoutes]
+    .filter((route) => !devServer.includes(`u.path == "/${route}"`))
+    .sort();
+
+  assert.deepEqual(missing, [], `rute baca() tanpa rute dev: ${missing.join(", ")}`);
+});
+
+
 test("hapus foto memakai wrapper RPC dan cast UUID di dev", () => {
   const awal = api.indexOf("export async function hapusFotoLembar");
   const akhir = api.indexOf("export async function kuotaFoto", awal);

--- a/tests/dev_server.py
+++ b/tests/dev_server.py
@@ -255,6 +255,29 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self._kirim(200, q(
                     "select id, name, address from sekolah order by name",
                     role="anon"))
+            elif u.path == "/nama-regu-dipakai":
+                # Pasangan dev untuk RPC nama_regu_dipakai (0051). Rute ini
+                # TIDAK ADA sampai sekarang, dan tidak ada yang tahu: satu-
+                # satunya pemanggilnya membungkus panggilannya dengan
+                # `catch { /* diam */ }` -- benar untuk produksi, karena
+                # jaringan yang putus sekejap tidak boleh memotong pembina
+                # yang sedang mengetik. Di dev artinya peringatan nama regu
+                # kembar tidak pernah muncul dan tidak pernah menyebut sebab,
+                # jadi form-nya tampak bekerja.
+                #
+                # role anon: form pendaftaran memang tanpa login, dan
+                # fungsinya di-grant ke anon.
+                #
+                # Jawabannya BOOLEAN TELANJANG, sama dengan yang dikembalikan
+                # PostgREST untuk RPC ini. Membungkusnya jadi
+                # {"dipakai": true} akan lulus tanpa suara dan salah selalu:
+                # pemanggilnya menyimpan jawabannya apa adanya ke peta
+                # namaTerpakai, dan objek apa pun truthy -- jadi SETIAP nama
+                # akan terbaca "sudah dipakai".
+                self._kirim(200, q(
+                    "select nama_regu_dipakai(%s) as dipakai",
+                    (p.get("nama") or "",),
+                    role="anon", fetch="one")["dipakai"])
             elif u.path == "/centang-sprint":
                 # Papan sprint Buku Sakti (migrasi 0170). Layarnya sengaja
                 # tetap terbuka walau ini gagal, jadi yang penting di sini


### PR DESCRIPTION
## What

`api.js` splits every read into a dev route and a production route. The
production side of `namaReguDipakai` resolves — `nama_regu_dipakai` exists as
an RPC. The dev side asked for `/nama-regu-dipakai`, which
`tests/dev_server.py` never implemented, so in dev the request 404s and `kirim`
throws.

Checked: every other route `api.js` asks the dev server for is implemented.
This was the only gap.

## Why it was invisible

The one caller swallows it, in `live/js/daftar.js`:

```js
try { namaTerpakai.set(n, await namaReguDipakai(n)); } catch { /* diam */ }
```

The `catch` is right for production — a network blip while a pembina is typing
must not interrupt the form. In dev it means the check never runs, never warns,
and never says why. **The form looks like it is working.**

## Why it matters

The screen this disabled is the registration form, which CLAUDE.md 9.8 names
the exception that proves the rule: "a pembina fills it once, has had no
training, and has nobody to ask." Nama regu is globally unique (18.3), and
catching a duplicate at submit is too late — by then five regu have been
filled in.

Section 17.2 asks that the screen be opened before merging, and 17.6 is
explicit that a broken tool for opening it is itself high priority. Anyone
following 17.2 today typed a duplicate, saw no warning, and could not tell
whether the feature was broken or the dev server simply did not serve it.

Closes #847.

## Notes

**The answer is a bare boolean**, the same shape PostgREST returns for this
RPC. Wrapping it as `{"dipakai": true}` would pass quietly and be wrong every
time: the caller stores the answer as-is into `namaTerpakai` and any object is
truthy, so every name would read as taken. The comment on the route says so.

**Parity check extended**, as the issue suggests. `dev_rpc_parity.test.mjs` now
checks `baca()` routes the way it already checks RPCs. Both directions:

- On this tree — 3 tests pass.
- Against the route removed — `rute baca() tanpa rute dev: nama-regu-dipakai`,
  exactly one, exactly the right one.

**Screen opened** against `hrcd_dev` (17.2), not just the tests: typing
`GARUDA`, which exists, shows *"Nama ini sudah dipakai regu lain. Pilih nama
yang berbeda."*; replacing it with a fresh name clears the warning. No console
errors. The route also matches the RPC on case and repeated spaces —
`garuda` and `  Garuda  ` both answer `true` — the same comparison as the
`regu_nama_unik` index.

`live/config.js` was switched to `"dev"` to do that and switched back; it is
not in this commit.