### PR TITLE
docs: say why web/_headers has no /live.json rule, correctly

### DIFF
--- a/web/_headers
+++ b/web/_headers
@@ -22,10 +22,15 @@
   Cache-Control: no-cache
   Content-Type: text/css; charset=utf-8
 
-# Aturan untuk /live.json sengaja BELUM ada di sini. Halaman live publik
-# (live.html + live.json) baru rencana — lihat docs/rancangan-b.md bagian 7 —
-# dan berkasnya tidak pernah dibuat. Aturan cache-nya sempat ditulis lebih dulu
-# beserta komentar yang menyatakan "diperbarui GitHub Actions tiap beberapa
-# menit", padahal workflow itu tidak ada; aturan untuk berkas yang tidak ada
-# hanya menyesatkan pembaca berikutnya. Tambahkan kembali saat halamannya
-# benar-benar dibangun.
+# TIDAK ADA ATURAN /live.json DI SINI, DAN JANGAN DITAMBAHKAN.
+#
+# Berkas ini mengatur situs PANITIA, dan situs panitia tidak menyajikan
+# live.json maupun rekap.json sama sekali. Keduanya milik situs PESERTA, di
+# domainnya sendiri, dan aturan cache-nya ada di live/_headers — di sana
+# live.json no-store karena di-poll tiap menit, sementara rekap.json disimpan
+# lama karena alamatnya sudah memuat versinya. Alasan lengkapnya, termasuk
+# kenapa berkas itu tidak punya aturan `/*`, ditulis di kepala berkas itu.
+#
+# Yang perlu diketahui sebelum menyentuh cache halaman peserta: tempatnya
+# live/_headers, bukan sini. Aturan yang ditulis di berkas ini tidak akan
+# mengubah apa pun di HP peserta, dan diamnya sulit dibedakan dari berhasil.


### PR DESCRIPTION
## What

`web/_headers` closed with a note saying the peserta live page was only a plan,
that `live.html` and `live.json` were never built, and that the workflow which
would update them did not exist. Every claim is out of date:

- `live/live.json` has been committed since 15 August, as has `live/index.html`.
- The workflow it says does not exist is `publish-live.yml`, running since #235
  — `paths: live/**` plus the event cron.
- The page is `live/index.html`, served from the peserta site's own root, not
  `live.html`.

## Why fix it rather than leave it

The missing `/live.json` rule in **this** file is correct and stays missing:
`web/` is the panitia site and does not serve `live.json` at all — checked,
there is no JSON in `web/`. The peserta site has its own `live/_headers`, and
that one is carefully reasoned.

So the rule is right and the reason given for it was wrong, which is the
combination most likely to mislead. A reader taking the comment at face value
concludes the peserta live page does not exist yet — and the next person to
touch caching for that page could reasonably add a `/live.json` rule *here*, in
the file that governs the wrong site, and see no effect. Silence is hard to
tell from success.

The comment's own closing sentence was the argument for correcting it:
"aturan untuk berkas yang tidak ada hanya menyesatkan pembaca berikutnya."

Closes #848.

## Notes

Comments only — `git diff` shows no rule line changed. The replacement points
at `live/_headers` and says what happens to a rule written here instead.