### PR TITLE
docs: carry the architecture checkpoint to 0171

### DIFF
--- a/docs/final-architecture.md
+++ b/docs/final-architecture.md
@@ -8,7 +8,7 @@ sebelum sistemnya dibangun.
 Terakhir diperiksa terhadap kode secara menyeluruh: **27 Agustus 2026**,
 sampai migrasi `0136`. Disegarkan 30 Agustus 2026 sampai migrasi `0164`, lalu
 2 September 2026 sampai migrasi `0169`, lalu 5 September 2026
-sampai migrasi `0170`.
+sampai migrasi `0170`, lalu 6 September 2026 sampai migrasi `0171`.
 
 Dokumen ini sengaja TIDAK memuat jumlah view, RPC, policy, check, atau pemicu.
 Angka-angka itu berubah tiap beberapa migrasi, tidak ada satu tes pun yang
@@ -40,7 +40,11 @@ menurunkan "Jumlah benar" sendiri, sama seperti Semaphore; `0170` memberi
 papan sprint Buku Sakti tabel centangnya (`centang_sprint`,
 `set_centang_sprint()`, `v_centang_sprint`) — satu-satunya tabel yang boleh
 ditulis SETIAP panitia tanpa centang fitur, dan alasannya ada di kepala
-berkas migrasinya.
+berkas migrasinya; `0171` mengembalikan argumen ke-11 `jawaban_benar` ke
+panggilan `hitung_poin()` di dalam `v_lembar_pos`, yang dijatuhkan `0166`
+saat membangun ulang view itu — ketiga kalinya argumen itu hilang lewat
+`create or replace view`, dan sekarang migrasinya sendiri berhenti keras
+kalau definisi terpasangnya tidak membawanya.
 
 Bersamaan dengan `0169`, bentuk pengisian "soal" DIBUANG dari Input Nilai Pos
 v2 — `jenisLomba()` di `web/js/util.js` tinggal "waktu" dan "nilai", dan
@@ -116,7 +120,7 @@ Mengganti `name` di `web/wrangler.toml` tidak menyentuh gateway sama sekali.
 
 ## 2. Database
 
-170 migrasi, `0001` sampai `0170`, dijalankan berurutan tanpa lubang penomoran.
+171 migrasi, `0001` sampai `0171`, dijalankan berurutan tanpa lubang penomoran.
 `supabase/migrations/` adalah satu-satunya sumber kebenaran skema — tidak ada
 perubahan yang dilakukan lewat dashboard.
 


### PR DESCRIPTION
## What

`docs/final-architecture.md` still read *"170 migrasi, `0001` sampai `0170`"*,
so `tests/final_architecture.test.mjs` went red as soon as `0171` (#850)
landed. That test exists for exactly this — a document claiming to be the
reference must not quietly fall behind the tree.

Updated: the checkpoint date and migration, the count in section 2, and a line
in the migration narrative recording what `0171` did — the eleventh
`hitung_poin()` argument restored to `v_lembar_pos` after `0166` dropped it,
and the guard that now stops the migration if the installed definition does not
carry it.

## Notes

Caught by running the node suite over the merged tree rather than per-branch,
which is how it should have been caught before #850 merged.

Whole node suite afterwards: **471 tests, 471 pass, 0 fail.**