### PR TITLE
fix: the centang on the peserta board is the boldest thing again, not the thinnest

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -31,7 +31,7 @@
        peserta: kepala hijau, kartu, tabel klasemen, dan dua override yang
        disengaja. Urutannya penting — yang belakangan menang. -->
   <link rel="stylesheet" href="style.css?v=68">
-  <link rel="stylesheet" href="live.css?v=7">
+  <link rel="stylesheet" href="live.css?v=8">
 </head>
 <body>
   <header class="kepala">

--- a/live/live.css
+++ b/live/live.css
@@ -147,9 +147,21 @@ main { max-width: 1200px; margin: 0 auto; padding: 1rem .7rem 2rem; }
    dan Rekapitulasi lewat `.kolom-petunjuk` di web/style.css. */
 .tabel th.kol-komponen { font-size: .72rem; font-weight: 600; white-space: normal;
   line-height: 1.15; }
-.tabel td.pos { text-align: center; }
-.tabel td.pos.ada { font-weight: 700; }
-.tabel td.pos.belum { color: #9aa3ad; }
+
+/* Gaya sel pos TIDAK ditulis di sini. Satu-satunya tempatnya blok "Centang
+   pos" di bawah — cari `.tabel td.pos`.
+
+   Dulu ada blok kedua persis di baris ini, dan itu membalik yang dimaksudnya.
+   Selektornya sama persis dengan yang di bawah dan kekhususannya sama, jadi
+   yang menang cuma ditentukan urutan baris: `color: #9aa3ad` di sini kalah
+   oleh `#c7c7c2` di bawah dan tidak pernah berlaku sedetik pun, sementara
+   `font-weight: 700` pada `.ada` JUSTRU menang — kekhususannya lebih tinggi
+   daripada `.tabel td.pos` milik blok bawah. Hasil terukurnya: sel yang SUDAH
+   dicentang tergambar 700 dan sel yang MASIH kosong 800, jadi centangnya
+   lebih tipis daripada strip kosong di sebelahnya — kebalikan dari maksud
+   blok bawah, yang menyebut centang "yang paling besar dan paling berwarna".
+   Tidak ada yang merah, tidak ada aturan yang terlihat salah (CLAUDE.md
+   15.6). */
 
 .tabel { width: 100%; border-collapse: collapse; font-size: .9rem; white-space: nowrap; }
 .tabel th {

--- a/tests/live_asset_version.test.mjs
+++ b/tests/live_asset_version.test.mjs
@@ -37,7 +37,7 @@ const halaman = await readFile(new URL("../live/index.html", import.meta.url), "
  *  berkas saat nomor itu dipasang. Ubah KEDUANYA bersama-sama. */
 const BERKAS = {
   "live.js": { versi: 20, sidik: "0cec1e3dde68" },
-  "live.css": { versi: 7, sidik: "3edc52a93ca9" },
+  "live.css": { versi: 8, sidik: "49d72f12ce8f" },
   "style.css": { versi: 68, sidik: "fc1fce32700b" },
 };
 


### PR DESCRIPTION
## What

`live/live.css` held **two** blocks styling the same pos cells with identical
selectors. At equal specificity only line order decides, and the block added
later (`626ad9f`) sits *earlier* in the file — so its two declarations went
opposite ways:

| Declaration | Outcome |
| --- | --- |
| `color: #9aa3ad` on `.belum` | **lost** to `#c7c7c2` below — never applied once |
| `font-weight: 700` on `.ada` | **won** — `.tabel td.pos.ada` outranks the `.tabel td.pos` carrying `font-weight: 800` |

Measured in a browser rather than reasoned about (CLAUDE.md 15.9), with both
stylesheets loaded the way `live/index.html` loads them:

```
before   td.pos.ada    weight=700   <- has a centang
         td.pos.belum  weight=800   <- empty
```

**The centang was thinner than the dash meaning "nothing yet."** That is the
reverse of what the surviving block exists for — its own comment calls the
centang "yang paling besar dan paling berwarna", and it is the one thing
people open this page to look for during the lomba.

## Fix

The stale block is removed, leaving one place where pos cells are styled.
Measured after:

```
after    td.pos.ada    weight=800  color=rgb(46,125,50)  bg=rgb(232,245,233)
         td.pos.belum  weight=800  color=rgb(199,199,194)
```

`.belum` is **identical to what it rendered before**, so the cells nobody was
looking at do not move; the centang gains the weight it was always supposed to
have, and the emphasis now comes from colour and background rather than from
being accidentally lighter than its neighbour.

A comment stands where the removed block was — the next person adding a pos
rule will reach for that spot for exactly the reason the last one did.

## Notes

Same class as #841 and precisely what CLAUDE.md 15.6 warns about: *"Selektor
yang sama persis, di media query yang sama, dua kali = yang belakangan menang
tanpa suara."* Found by scanning every stylesheet for duplicate selectors whose
blocks set the same property to different values — it was the only real
conflict in `live.css`, and `web/style.css`'s one hit (`.kemajuan`) is harmless
because `.terbuka` re-declares it.

`live.css?v=7` → `v=8`, with the fingerprint in
`tests/live_asset_version.test.mjs`. That guard is what caught the missing
bump. Whole node suite afterwards: **471 tests, 471 pass**. The four shared
`web/` ↔ `live/` pairs are untouched and still identical — `live.css` is not
one of them.