### PR TITLE
fix: keep Supabase awake daily from Cloudflare, and record that this repo is public

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,24 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
 
 ## 7. Repository facts
 
-1. Remote: `https://github.com/ciradyka/hrcd-rekap` (private).
+1. Remote: `https://github.com/ciradyka/hrcd-rekap` — **PUBLIC**. This clause
+   said "private" until 6 September 2026 and it was never checked;
+   `gh repo view` reports `"visibility": "PUBLIC"`. Two things follow, and
+   both were being reasoned about backwards:
+   - **GitHub disables scheduled workflows in a PUBLIC repo after 60 days with
+     no repository activity**, and only new commits reset that clock. After
+     the lomba this repo goes quiet, so every cron here stops on its own —
+     see 16.9.
+   - **Actions minutes on standard runners are free and unlimited for public
+     repos.** The 2,000-a-month allowance section 16 keeps arithmetic against
+     is the PRIVATE-repo number and does not apply. Running a check twice
+     costs nothing in money; it still costs wall-clock, which is a reason to
+     prefer local, but it is not the reason section 16 gives.
+
+   Nothing about the anon key changes: `web/config.js` is served verbatim to
+   every browser already, and the service key lives only in Actions secrets
+   and `wrangler secret`. Being public is not a leak — but it should be a
+   deliberate choice, so confirm it is.
 2. Default branch: `main`. It has **no** branch protection, and squash and
    rebase merges are still enabled on the repo — section 4 is a convention, not
    something GitHub enforces. Follow it deliberately.
@@ -873,11 +890,22 @@ Pernah menyimpang, dan itulah kenapa aturan sinkron di atas ditulis: AGENTS.md s
    spaced requests. GitHub bills per JOB rounded up to a whole minute, not per
    request, so the second and third requests cost nothing.
 
-   Re-priced accordingly: 365 runs a year, so ~31 billed minutes a month
-   against the 2,000 a month a private repo gets on Free — about 1.5%, still
-   nothing beside the 288 minutes A DAY that `*/5 * * * *` would cost. Do not
-   quietly take it back to weekly to save four minutes a month; what that buys
-   is a project that pauses.
+   Re-priced accordingly: 365 runs a year. This repo is PUBLIC (7.1), so
+   standard-runner minutes are free and unlimited and the money cost is zero;
+   even on the private-repo allowance it would be ~31 of 2,000 minutes a
+   month. Either way, do not quietly take it back to weekly to save a few
+   minutes — what that buys is a project that pauses.
+
+   **The GitHub cron is the SECOND layer, not the one to rely on for years.**
+   Scheduled workflows in a public repo are disabled after 60 days with no
+   repository activity, and only new commits reset that clock — which is
+   exactly what this repo stops producing once the edition is over. The
+   keep-alive that survives that is the Cloudflare one:
+   `workers/gateway/wrangler.toml` carries `crons = ["0 3 * * *"]` and the
+   `scheduled()` handler in `worker.js` beside it. It depends on no repo
+   activity, no Actions minutes, and no GitHub state at all. Keep BOTH — two
+   providers failing the same week is the case worth paying nothing to cover —
+   but if only one may live, it is the Cloudflare one.
 
    **A failing run here is not a flaky check, it is the alarm.** GitHub emails
    on a failed scheduled workflow, and that email is the only warning this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,24 @@ Guidance for Claude Code when working in this repository.
 
 ## 7. Repository facts
 
-1. Remote: `https://github.com/ciradyka/hrcd-rekap` (private).
+1. Remote: `https://github.com/ciradyka/hrcd-rekap` — **PUBLIC**. This clause
+   said "private" until 6 September 2026 and it was never checked;
+   `gh repo view` reports `"visibility": "PUBLIC"`. Two things follow, and
+   both were being reasoned about backwards:
+   - **GitHub disables scheduled workflows in a PUBLIC repo after 60 days with
+     no repository activity**, and only new commits reset that clock. After
+     the lomba this repo goes quiet, so every cron here stops on its own —
+     see 16.9.
+   - **Actions minutes on standard runners are free and unlimited for public
+     repos.** The 2,000-a-month allowance section 16 keeps arithmetic against
+     is the PRIVATE-repo number and does not apply. Running a check twice
+     costs nothing in money; it still costs wall-clock, which is a reason to
+     prefer local, but it is not the reason section 16 gives.
+
+   Nothing about the anon key changes: `web/config.js` is served verbatim to
+   every browser already, and the service key lives only in Actions secrets
+   and `wrangler secret`. Being public is not a leak — but it should be a
+   deliberate choice, so confirm it is.
 2. Default branch: `main`. It has **no** branch protection, and squash and
    rebase merges are still enabled on the repo — section 4 is a convention, not
    something GitHub enforces. Follow it deliberately.
@@ -871,11 +888,22 @@ Guidance for Claude Code when working in this repository.
    spaced requests. GitHub bills per JOB rounded up to a whole minute, not per
    request, so the second and third requests cost nothing.
 
-   Re-priced accordingly: 365 runs a year, so ~31 billed minutes a month
-   against the 2,000 a month a private repo gets on Free — about 1.5%, still
-   nothing beside the 288 minutes A DAY that `*/5 * * * *` would cost. Do not
-   quietly take it back to weekly to save four minutes a month; what that buys
-   is a project that pauses.
+   Re-priced accordingly: 365 runs a year. This repo is PUBLIC (7.1), so
+   standard-runner minutes are free and unlimited and the money cost is zero;
+   even on the private-repo allowance it would be ~31 of 2,000 minutes a
+   month. Either way, do not quietly take it back to weekly to save a few
+   minutes — what that buys is a project that pauses.
+
+   **The GitHub cron is the SECOND layer, not the one to rely on for years.**
+   Scheduled workflows in a public repo are disabled after 60 days with no
+   repository activity, and only new commits reset that clock — which is
+   exactly what this repo stops producing once the edition is over. The
+   keep-alive that survives that is the Cloudflare one:
+   `workers/gateway/wrangler.toml` carries `crons = ["0 3 * * *"]` and the
+   `scheduled()` handler in `worker.js` beside it. It depends on no repo
+   activity, no Actions minutes, and no GitHub state at all. Keep BOTH — two
+   providers failing the same week is the case worth paying nothing to cover —
+   but if only one may live, it is the Cloudflare one.
 
    **A failing run here is not a flaky check, it is the alarm.** GitHub emails
    on a failed scheduled workflow, and that email is the only warning this

--- a/workers/gateway/worker.js
+++ b/workers/gateway/worker.js
@@ -571,17 +571,37 @@ export default {
   // dipasang jauh sebelum lomba dan nyaris tidak disentuh sampai Januari,
   // jadi tanpa ini project sudah tertidur saat panitia membukanya.
   //
-  // Satu bacaan sepele sudah cukup dihitung sebagai aktivitas. Kalau gagal,
-  // biarkan gagal: jadwal berikutnya datang sendiri dan tidak ada yang
-  // menunggu jawabannya. Jadwalnya di wrangler.toml.
+  // TIGA bacaan, bukan satu. Dokumentasi Supabase menaruh ambangnya di
+  // "a few user requests to the database each day", dan angka pastinya tidak
+  // pernah diumumkan — jadi yang dikirim beberapa, bukan satu yang pas-pasan.
+  // Ketiganya sepele dan tidak mengubah apa pun; ongkosnya nol karena satu
+  // invocation cron sudah dibayar entah ia mem-fetch sekali atau tiga kali.
+  //
+  // Kalau gagal, biarkan gagal: jadwal berikutnya datang sendiri dan tidak ada
+  // yang menunggu jawabannya. Yang berubah cuma galatnya sekarang DICATAT —
+  // `.catch(() => {})` yang lama membuang satu-satunya petunjuk bahwa project
+  // sudah tertidur, dan Workers menyimpan log invocation-nya. Jadwalnya di
+  // wrangler.toml.
   async scheduled(event, env, ctx) {
-    ctx.waitUntil(
-      fetch(`${env.SUPABASE_URL}/rest/v1/edisi?select=nomor&limit=1`, {
-        headers: {
-          apikey: env.SUPABASE_SERVICE_KEY,
-          Authorization: `Bearer ${env.SUPABASE_SERVICE_KEY}`,
-        },
-      }).catch(() => {}),
-    );
+    ctx.waitUntil((async () => {
+      for (let i = 1; i <= 3; i++) {
+        try {
+          const r = await fetch(
+            `${env.SUPABASE_URL}/rest/v1/edisi?select=nomor&limit=1`,
+            {
+              headers: {
+                apikey: env.SUPABASE_SERVICE_KEY,
+                Authorization: `Bearer ${env.SUPABASE_SERVICE_KEY}`,
+              },
+            },
+          );
+          if (!r.ok) {
+            console.error(`keep-alive ${i}: Supabase menjawab ${r.status}`);
+          }
+        } catch (e) {
+          console.error(`keep-alive ${i}: ${e}`);
+        }
+      }
+    })());
   },
 };

--- a/workers/gateway/wrangler.toml
+++ b/workers/gateway/wrangler.toml
@@ -24,8 +24,24 @@ compatibility_date = "2026-08-12"
 binding = "RATE"
 id = "c344415a45044d7e9716f41715ab3d9a"
 
-# Tiap 3 hari, 03.00 UTC (10.00 WIB) — menahan project Supabase tetap bangun.
-# Supabase menjeda setelah ±7 hari menganggur; 3 hari memberi dua kesempatan
-# meleset sebelum benar-benar tertidur.
+# TIAP HARI, 03.00 UTC (10.00 WIB) — menahan project Supabase tetap bangun.
+#
+# Dulu tiap 3 hari, dan itu di bawah yang diminta dokumentasi Supabase:
+# "a few user requests to the database each day over the previous week is
+# enough to keep the project from being paused". Yang dinilai aktivitas
+# RENDAH dalam jendela 7 hari, jadi dua-tiga permintaan sepekan justru
+# berbentuk seperti calon pause. Tidak ada ambang yang diumumkan, jadi yang
+# benar bukan menebaknya melainkan duduk jauh di atasnya.
+#
+# `*/3` juga punya jebakan yang tidak kelihatan: day-of-month diulang tiap
+# bulan, jadi ia melompat 28 -> 31 -> 1 dan jaraknya tidak pernah rata.
+# `* * *` tidak punya sudut seperti itu.
+#
+# INI keep-alive yang menentukan, bukan yang di GitHub Actions. Repo ini
+# PUBLIK, dan GitHub mematikan scheduled workflow di repo publik setelah 60
+# hari tanpa aktivitas repo — sesudah lomba, repo ini memang diam. Cron
+# Cloudflare tidak punya aturan itu dan tidak bergantung pada repo sama
+# sekali. keep-supabase-awake.yml tetap ada sebagai lapis kedua, tapi yang
+# diandalkan untuk jangka tahun adalah baris di bawah ini.
 [triggers]
-crons = ["0 3 */3 * *"]
+crons = ["0 3 * * *"]


### PR DESCRIPTION
## What

Two keep-alives exist and **both sat under the bar Supabase publishes**:

> "a few user requests to the database each day over the previous week is
> enough to keep the project from being paused"
> — [Project Pausing](https://supabase.com/docs/guides/platform/free-project-pausing)

| | was | now |
| --- | --- | --- |
| `workers/gateway` cron | every 3 days, 1 request | **daily, 3 requests** |
| `keep-supabase-awake.yml` | weekly, 1 request | daily, 3 requests (#858) |

Low activity across a 7-day window is exactly what the pause looks for; two or
three requests a week is the shape of a pause candidate, not the shape of a
live project.

`*/3` also had a corner worth losing: day-of-month restarts every month, so the
gap walked 28 → 31 → 1 rather than staying even. `* * *` has no such corner.
Cost is unchanged — one cron invocation is billed whether it fetches once or
three times.

`.catch(() => {})` is gone. Failing quietly is right for the request, but it
threw away the only signal that the project had gone to sleep. Errors are
logged now and Workers keeps them.

## The bigger correction: which keep-alive actually survives

**Section 7.1 has said this repo is private since it was written, and nobody
checked.** `gh repo view` reports `"visibility": "PUBLIC"`. Two things follow,
both of which were being reasoned about backwards:

1. **GitHub disables scheduled workflows in a *public* repo after 60 days with
   no repository activity**, and only new commits reset that clock — which is
   precisely what this repo stops producing once the edition is over. So
   `keep-supabase-awake.yml` **cannot** be the thing that lasts. The Cloudflare
   cron can: it depends on no repo activity, no Actions minutes, and no GitHub
   state at all.
2. **Actions minutes on standard runners are free and unlimited for public
   repos.** Section 16 does its arithmetic against the 2,000-a-month
   *private*-repo allowance, which does not apply.

Both keep-alives stay — two providers failing in the same week is worth
covering when the cover costs nothing — but 7.1 and 16.9 now say which is the
load-bearing one.

I corrected the **facts** only. The run-locally convention in section 16 has
merits beyond billing and changing it is your call, not a side effect of a
billing correction — flagged in the clause rather than acted on.

## Notes

Nothing about key exposure changes: `web/config.js` is served verbatim to every
browser already, and the service key lives only in Actions secrets and
`wrangler secret`. Public is not a leak here — but it should be a deliberate
choice, so 7.1 now asks you to confirm it is.

Verified: `worker.js` parses as an ES module (stdin form), `wrangler.toml`
parses and reports `crons = ["0 3 * * *"]`, node suite **471/471**.
CLAUDE.md and AGENTS.md byte-identical (7.7).